### PR TITLE
Reduce implicit conversion of String to NSString*

### DIFF
--- a/Source/JavaScriptCore/API/JSScript.mm
+++ b/Source/JavaScriptCore/API/JSScript.mm
@@ -209,7 +209,7 @@ static bool validateBytecodeCachePath(NSURL* cachePath, NSError** error)
     String errorString { };
     [self writeCache:errorString];
     if (!errorString.isNull()) {
-        createError(errorString, error);
+        createError(errorString.createNSString().get(), error);
         return NO;
     }
 

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
@@ -487,31 +487,31 @@ RetainPtr<NSDictionary> RemoteInspector::listingForInspectionTarget(const Remote
 
     switch (target.type()) {
     case RemoteInspectionTarget::Type::ITML:
-        [listing setObject:target.name() forKey:WIRTitleKey];
-        [listing setObject:target.nameOverride() forKey:WIROverrideNameKey];
+        [listing setObject:target.name().createNSString().get() forKey:WIRTitleKey];
+        [listing setObject:target.nameOverride().createNSString().get() forKey:WIROverrideNameKey];
         [listing setObject:WIRTypeITML forKey:WIRTypeKey];
         break;
     case RemoteInspectionTarget::Type::JavaScript:
-        [listing setObject:target.name() forKey:WIRTitleKey];
-        [listing setObject:target.nameOverride() forKey:WIROverrideNameKey];
+        [listing setObject:target.name().createNSString().get() forKey:WIRTitleKey];
+        [listing setObject:target.nameOverride().createNSString().get() forKey:WIROverrideNameKey];
         [listing setObject:WIRTypeJavaScript forKey:WIRTypeKey];
         break;
     case RemoteInspectionTarget::Type::Page:
-        [listing setObject:target.url() forKey:WIRURLKey];
-        [listing setObject:target.name() forKey:WIRTitleKey];
-        [listing setObject:target.nameOverride() forKey:WIROverrideNameKey];
+        [listing setObject:target.url().createNSString().get() forKey:WIRURLKey];
+        [listing setObject:target.name().createNSString().get() forKey:WIRTitleKey];
+        [listing setObject:target.nameOverride().createNSString().get() forKey:WIROverrideNameKey];
         [listing setObject:WIRTypePage forKey:WIRTypeKey];
         break;
     case RemoteInspectionTarget::Type::ServiceWorker:
-        [listing setObject:target.url() forKey:WIRURLKey];
-        [listing setObject:target.name() forKey:WIRTitleKey];
-        [listing setObject:target.nameOverride() forKey:WIROverrideNameKey];
+        [listing setObject:target.url().createNSString().get() forKey:WIRURLKey];
+        [listing setObject:target.name().createNSString().get() forKey:WIRTitleKey];
+        [listing setObject:target.nameOverride().createNSString().get() forKey:WIROverrideNameKey];
         [listing setObject:WIRTypeServiceWorker forKey:WIRTypeKey];
         break;
     case RemoteInspectionTarget::Type::WebPage:
-        [listing setObject:target.url() forKey:WIRURLKey];
-        [listing setObject:target.name() forKey:WIRTitleKey];
-        [listing setObject:target.nameOverride() forKey:WIROverrideNameKey];
+        [listing setObject:target.url().createNSString().get() forKey:WIRURLKey];
+        [listing setObject:target.name().createNSString().get() forKey:WIRTitleKey];
+        [listing setObject:target.nameOverride().createNSString().get() forKey:WIROverrideNameKey];
         [listing setObject:WIRTypeWebPage forKey:WIRTypeKey];
         break;
     default:
@@ -542,12 +542,12 @@ RetainPtr<NSDictionary> RemoteInspector::listingForAutomationTarget(const Remote
 
     RetainPtr<NSMutableDictionary> listing = adoptNS([[NSMutableDictionary alloc] init]);
     [listing setObject:@(target.targetIdentifier()) forKey:WIRTargetIdentifierKey];
-    [listing setObject:target.name() forKey:WIRSessionIdentifierKey];
+    [listing setObject:target.name().createNSString().get() forKey:WIRSessionIdentifierKey];
     [listing setObject:WIRTypeAutomation forKey:WIRTypeKey];
     [listing setObject:@(target.isPaired()) forKey:WIRAutomationTargetIsPairedKey];
     if (m_clientCapabilities) {
-        [listing setObject:m_clientCapabilities->browserName forKey:WIRAutomationTargetNameKey];
-        [listing setObject:m_clientCapabilities->browserVersion forKey:WIRAutomationTargetVersionKey];
+        [listing setObject:m_clientCapabilities->browserName.createNSString().get() forKey:WIRAutomationTargetNameKey];
+        [listing setObject:m_clientCapabilities->browserVersion.createNSString().get() forKey:WIRAutomationTargetVersionKey];
     }
 
     if (auto connectionToTarget = m_targetConnectionMap.get(target.targetIdentifier()))

--- a/Source/WTF/wtf/cocoa/LanguageCocoa.mm
+++ b/Source/WTF/wtf/cocoa/LanguageCocoa.mm
@@ -56,7 +56,7 @@ size_t indexOfBestMatchingLanguageInList(const String& language, const Vector<St
 
 LocaleComponents parseLocale(const String& localeIdentifier)
 {
-    auto locale = retainPtr([NSLocale localeWithLocaleIdentifier:localeIdentifier]);
+    auto locale = retainPtr([NSLocale localeWithLocaleIdentifier:localeIdentifier.createNSString().get()]);
 
     return {
         locale.get().languageCode,

--- a/Source/WTF/wtf/cocoa/NSURLExtras.mm
+++ b/Source/WTF/wtf/cocoa/NSURLExtras.mm
@@ -218,7 +218,7 @@ NSURL *URLWithUserTypedString(NSString *string, NSURL *)
 
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=186057
     // We should be able to use url.createCFURL instead of using directly CFURL parsing routines.
-    RetainPtr data = dataWithUserTypedString(mappedString);
+    RetainPtr data = dataWithUserTypedString(mappedString.createNSString().get());
     if (!data)
         return [NSURL URLWithString:@""];
 
@@ -322,7 +322,7 @@ NSData *originalURLData(NSURL *URL)
 
 NSString *userVisibleString(NSURL *URL)
 {
-    return URLHelpers::userVisibleURL(span(originalURLData(URL)));
+    return URLHelpers::userVisibleURL(span(originalURLData(URL))).createNSString().autorelease();
 }
 
 BOOL isUserVisibleURL(NSString *string)

--- a/Source/WTF/wtf/mac/FileSystemMac.mm
+++ b/Source/WTF/wtf/mac/FileSystemMac.mm
@@ -37,8 +37,8 @@ namespace WTF {
 void FileSystem::setMetadataURL(const String& path, const String& metadataURLString, const String& referrer)
 {
     String urlString;
-    if (NSURL *url = URLWithUserTypedString(metadataURLString))
-        urlString = userVisibleString(URLByRemovingUserInfo(url));
+    if (RetainPtr url = URLWithUserTypedString(metadataURLString.createNSString().get()))
+        urlString = userVisibleString(URLByRemovingUserInfo(url.get()));
     else
         urlString = metadataURLString;
 
@@ -48,9 +48,9 @@ void FileSystem::setMetadataURL(const String& path, const String& metadataURLStr
         if (!item)
             return;
 
-        auto whereFromAttribute = adoptNS([[NSMutableArray alloc] initWithObjects:urlString, nil]);
+        RetainPtr whereFromAttribute = adoptNS([[NSMutableArray alloc] initWithObjects:urlString.createNSString().get(), nil]);
         if (!referrer.isNull())
-            [whereFromAttribute addObject:referrer];
+            [whereFromAttribute addObject:referrer.createNSString().get()];
 
         MDItemSetAttribute(item.get(), kMDItemWhereFroms, (__bridge CFArrayRef)whereFromAttribute.get());
         MDItemSetAttribute(item.get(), kMDItemDownloadedDate, (__bridge CFArrayRef)@[ [NSDate date] ]);

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -113,7 +113,10 @@ public:
 
 #if USE(FOUNDATION) && defined(__OBJC__)
     AtomString(NSString *);
-    operator NSString *() const { return m_string; }
+    RetainPtr<NSString> createNSString() const { return m_string.createNSString(); }
+
+    // FIXME: remove this operator and port call sites to createNSString().
+    operator NSString *() const { return m_string.createNSString().autorelease(); }
 #endif
 
 #if OS(WINDOWS)

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -30,6 +30,7 @@
 
 #ifdef __OBJC__
 #include <objc/objc.h>
+#include <wtf/RetainPtr.h>
 #endif
 
 #if OS(WINDOWS)
@@ -248,8 +249,10 @@ public:
     // This conversion converts the null string to an empty NSString rather than to nil.
     // Given Cocoa idioms, this is a more useful default. Clients that need to preserve the
     // null string can check isNull explicitly.
+    RetainPtr<NSString> createNSString() const;
+
+    // FIXME: Port call sites to createNSString() and remove this.
     operator NSString *() const;
-    WTF_EXPORT_PRIVATE RetainPtr<NSString> createNSString() const;
 #endif
 
 #if OS(WINDOWS)
@@ -509,6 +512,13 @@ inline String::operator NSString *() const
     if (!m_impl)
         return @"";
     SUPPRESS_UNCOUNTED_ARG return *m_impl;
+}
+
+inline RetainPtr<NSString> String::createNSString() const
+{
+    if (RefPtr impl = m_impl)
+        return impl->createNSString();
+    return @"";
 }
 
 inline NSString * nsStringNilIfEmpty(const String& string)

--- a/Source/WTF/wtf/text/cocoa/StringCocoa.mm
+++ b/Source/WTF/wtf/text/cocoa/StringCocoa.mm
@@ -26,13 +26,6 @@
 
 namespace WTF {
 
-RetainPtr<NSString> String::createNSString() const
-{
-    if (RefPtr impl = m_impl)
-        return impl->createNSString();
-    return @"";
-}
-
 RetainPtr<id> makeNSArrayElement(const String& vectorElement)
 {
     return bridge_cast(vectorElement.createCFString());

--- a/Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm
+++ b/Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm
@@ -141,10 +141,10 @@ static RetainPtr<id> makeNSArrayElement(const ApplePayInstallmentItem& item)
     auto installmentItem = adoptNS([PAL::allocPKPaymentInstallmentItemInstance() init]);
     [installmentItem setInstallmentItemType:platformItemType(item.type)];
     [installmentItem setAmount:toDecimalNumber(item.amount)];
-    [installmentItem setCurrencyCode:item.currencyCode];
-    [installmentItem setProgramIdentifier:item.programIdentifier];
+    [installmentItem setCurrencyCode:item.currencyCode.createNSString().get()];
+    [installmentItem setProgramIdentifier:item.programIdentifier.createNSString().get()];
     [installmentItem setApr:toDecimalNumber(item.apr)];
-    [installmentItem setProgramTerms:item.programTerms];
+    [installmentItem setProgramTerms:item.programTerms.createNSString().get()];
     return installmentItem;
 }
 
@@ -166,15 +166,15 @@ static std::optional<ApplePayInstallmentItem> makeVectorElement(const ApplePayIn
 
 static RetainPtr<NSDictionary> applicationMetadataDictionary(const ApplePayInstallmentConfiguration& configuration)
 {
-    if (NSData *applicationMetadata = [configuration.applicationMetadata dataUsingEncoding:NSUTF8StringEncoding])
-        return dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:applicationMetadata options:0 error:nil]);
+    if (RetainPtr applicationMetadata = [configuration.applicationMetadata.createNSString() dataUsingEncoding:NSUTF8StringEncoding])
+        return dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:applicationMetadata.get() options:0 error:nil]);
     return { };
 }
 
 static String applicationMetadataString(NSDictionary *dictionary)
 {
-    if (NSData *applicationMetadata = dictionary ? [NSJSONSerialization dataWithJSONObject:dictionary options:NSJSONWritingSortedKeys error:nil] : nil)
-        return adoptNS([[NSString alloc] initWithData:applicationMetadata encoding:NSUTF8StringEncoding]).get();
+    if (RetainPtr applicationMetadata = dictionary ? [NSJSONSerialization dataWithJSONObject:dictionary options:NSJSONWritingSortedKeys error:nil] : nil)
+        return adoptNS([[NSString alloc] initWithData:applicationMetadata.get() encoding:NSUTF8StringEncoding]).get();
     return { };
 }
 
@@ -188,14 +188,14 @@ static RetainPtr<PKPaymentInstallmentConfiguration> createPlatformConfiguration(
     [configuration setFeature:platformFeatureType(coreConfiguration.featureType)];
 
     [configuration setBindingTotalAmount:toDecimalNumber(coreConfiguration.bindingTotalAmount)];
-    [configuration setCurrencyCode:coreConfiguration.currencyCode];
+    [configuration setCurrencyCode:coreConfiguration.currencyCode.createNSString().get()];
     [configuration setInStorePurchase:coreConfiguration.isInStorePurchase];
     [configuration setOpenToBuyThresholdAmount:toDecimalNumber(coreConfiguration.openToBuyThresholdAmount)];
 
-    auto merchandisingImageData = adoptNS([[NSData alloc] initWithBase64EncodedString:coreConfiguration.merchandisingImageData options:0]);
+    auto merchandisingImageData = adoptNS([[NSData alloc] initWithBase64EncodedString:coreConfiguration.merchandisingImageData.createNSString().get() options:0]);
     [configuration setMerchandisingImageData:merchandisingImageData.get()];
-    [configuration setInstallmentMerchantIdentifier:coreConfiguration.merchantIdentifier];
-    [configuration setReferrerIdentifier:coreConfiguration.referrerIdentifier];
+    [configuration setInstallmentMerchantIdentifier:coreConfiguration.merchantIdentifier.createNSString().get()];
+    [configuration setReferrerIdentifier:coreConfiguration.referrerIdentifier.createNSString().get()];
 
     if (!PAL::getPKPaymentInstallmentItemClass())
         return configuration;

--- a/Source/WebCore/Modules/applepay/PaymentRequestValidator.mm
+++ b/Source/WebCore/Modules/applepay/PaymentRequestValidator.mm
@@ -101,7 +101,7 @@ ExceptionOr<void> PaymentRequestValidator::validateTotal(const ApplePayLineItem&
     if (!total.amount)
         return Exception { ExceptionCode::TypeError, "Missing total amount."_s };
 
-    double amount = [NSDecimalNumber decimalNumberWithString:total.amount locale:@{ NSLocaleDecimalSeparator : @"." }].doubleValue;
+    double amount = [NSDecimalNumber decimalNumberWithString:total.amount.createNSString().get() locale:@{ NSLocaleDecimalSeparator : @"." }].doubleValue;
 
     if (amount < 0)
         return Exception { ExceptionCode::TypeError, "Total amount must not be negative."_s };
@@ -163,8 +163,8 @@ static ExceptionOr<void> validateSupportedNetworks(const Vector<String>& support
 
 static ExceptionOr<void> validateShippingMethod(const ApplePayShippingMethod& shippingMethod)
 {
-    NSDecimalNumber *amount = [NSDecimalNumber decimalNumberWithString:shippingMethod.amount locale:@{ NSLocaleDecimalSeparator : @"." }];
-    if (amount.integerValue < 0)
+    RetainPtr amount = [NSDecimalNumber decimalNumberWithString:shippingMethod.amount.createNSString().get() locale:@{ NSLocaleDecimalSeparator : @"." }];
+    if (amount.get().integerValue < 0)
         return Exception { ExceptionCode::TypeError, "Shipping method amount must be greater than or equal to zero."_s };
 
     return { };

--- a/Source/WebCore/PAL/pal/text/mac/KillRingMac.mm
+++ b/Source/WebCore/PAL/pal/text/mac/KillRingMac.mm
@@ -61,7 +61,7 @@ void KillRing::append(const String& string)
     initializeKillRingIfNeeded();
     // Necessary to prevent an implicit new sequence if the previous command was NSPrependToKillRing.
     _NSResetKillRingOperationFlag();
-    _NSAppendToKillRing(string);
+    _NSAppendToKillRing(string.createNSString().get());
 }
 
 void KillRing::prepend(const String& string)
@@ -69,7 +69,7 @@ void KillRing::prepend(const String& string)
     initializeKillRingIfNeeded();
     // Necessary to prevent an implicit new sequence if the previous command was NSAppendToKillRing.
     _NSResetKillRingOperationFlag();
-    _NSPrependToKillRing(string);
+    _NSPrependToKillRing(string.createNSString().get());
 }
 
 String KillRing::yank()

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -24,7 +24,6 @@ editing/cocoa/AttributedString.mm
 editing/cocoa/DataDetection.mm
 editing/cocoa/FontAttributesCocoa.mm
 editing/cocoa/HTMLConverter.mm
-editing/cocoa/WebArchiveResourceFromNSAttributedString.mm
 editing/cocoa/WebContentReaderCocoa.mm
 loader/ContentFilter.cpp
 loader/archive/cf/LegacyWebArchive.cpp

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -407,7 +407,7 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
     auto extendedDescription = backingObject->extendedDescription();
     if (extendedDescription.length()) {
         accessibilityCustomContent = adoptNS([[NSMutableArray alloc] init]);
-        AXCustomContent *contentItem = [PAL::getAXCustomContentClass() customContentWithLabel:WEB_UI_STRING("description", "description detail") value:extendedDescription];
+        AXCustomContent *contentItem = [PAL::getAXCustomContentClass() customContentWithLabel:WEB_UI_STRING("description", "description detail").createNSString().get() value:extendedDescription.createNSString().get()];
         // Set this to high, so that it's always spoken.
         [contentItem setImportance:AXCustomContentImportanceHigh];
         [accessibilityCustomContent addObject:contentItem];
@@ -419,7 +419,7 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
 
 - (NSString *)baseAccessibilityHelpText
 {
-    return self.axBackingObject->helpTextAttributeValue();
+    return self.axBackingObject->helpTextAttributeValue().createNSString().autorelease();
 }
 
 struct PathConversionInfo {
@@ -620,29 +620,28 @@ std::optional<SimpleRange> makeDOMRange(Document* document, NSRange range)
                 if (!object)
                     continue;
 
-                NSString *label;
+                RetainPtr<NSString> label;
                 switch (object->roleValue()) {
                 case AccessibilityRole::StaticText:
-                    label = object->stringValue();
+                    label = object->stringValue().createNSString();
                     break;
                 case AccessibilityRole::Image: {
                     String name = object->titleAttributeValue();
                     if (name.isEmpty())
                         name = object->descriptionAttributeValue();
-                    label = name;
+                    label = name.createNSString();
                     break;
                 }
                 default:
-                    label = nil;
                     break;
                 }
 #else
-                NSString *label = static_cast<WebAccessibilityObjectWrapper *>(item).accessibilityLabel;
+                RetainPtr<NSString> label = static_cast<WebAccessibilityObjectWrapper *>(item).accessibilityLabel;
 #endif
                 if (!label)
                     continue;
 
-                auto attributedLabel = adoptNS([[NSAttributedString alloc] initWithString:label]);
+                auto attributedLabel = adoptNS([[NSAttributedString alloc] initWithString:label.get()]);
                 [text appendAttributedString:attributedLabel.get()];
             }
         }
@@ -674,7 +673,7 @@ std::optional<SimpleRange> makeDOMRange(Document* document, NSRange range)
 
 - (NSString *)ariaLandmarkRoleDescription
 {
-    return self.axBackingObject->ariaLandmarkRoleDescription();
+    return self.axBackingObject->ariaLandmarkRoleDescription().createNSString().autorelease();
 }
 
 - (NSString *)accessibilityPlatformMathSubscriptKey
@@ -804,14 +803,14 @@ static NSDictionary *dictionaryRemovingNonSupportedTypes(NSDictionary *dictionar
 - (NSString *)innerHTML
 {
     if (RefPtr<AXCoreObject> backingObject = self.axBackingObject)
-        return backingObject->innerHTML();
+        return backingObject->innerHTML().createNSString().autorelease();
     return nil;
 }
 
 - (NSString *)outerHTML
 {
     if (RefPtr<AXCoreObject> backingObject = self.axBackingObject)
-        return backingObject->outerHTML();
+        return backingObject->outerHTML().createNSString().autorelease();
     return nil;
 }
 

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -1094,37 +1094,37 @@ static NSArray *children(AXCoreObject& backingObject)
     return makeNSArray(unignoredChildren);
 }
 
-static NSString *roleString(AXCoreObject& backingObject)
+static RetainPtr<NSString> roleString(AXCoreObject& backingObject)
 {
     String roleString = backingObject.rolePlatformString();
     if (!roleString.isEmpty())
-        return roleString;
+        return roleString.createNSString();
     return NSAccessibilityUnknownRole;
 }
 
-static NSString *subroleString(AXCoreObject& backingObject)
+static RetainPtr<NSString> subroleString(AXCoreObject& backingObject)
 {
     if (backingObject.isEmptyGroup())
         return NSAccessibilityEmptyGroupSubrole;
 
     String subrole = backingObject.subrolePlatformString();
     if (!subrole.isEmpty())
-        return subrole;
+        return subrole.createNSString();
     return nil;
 }
 
-static NSString *roleDescription(AXCoreObject& backingObject)
+static RetainPtr<NSString> roleDescription(AXCoreObject& backingObject)
 {
     String roleDescription = backingObject.roleDescription();
     if (!roleDescription.isEmpty())
-        return roleDescription;
+        return roleDescription.createNSString();
 
-    NSString *axRole = roleString(backingObject);
-    NSString *subrole = subroleString(backingObject);
+    RetainPtr axRole = roleString(backingObject);
+    RetainPtr subrole = subroleString(backingObject);
     // Fallback to the system role description.
     // If we get the same string back, then as a last resort, return unknown.
-    NSString *systemRoleDescription = NSAccessibilityRoleDescription(axRole, subrole);
-    if (![systemRoleDescription isEqualToString:axRole])
+    NSString *systemRoleDescription = NSAccessibilityRoleDescription(axRole.get(), subrole.get());
+    if (![systemRoleDescription isEqualToString:axRole.get()])
         return systemRoleDescription;
     return NSAccessibilityRoleDescription(NSAccessibilityUnknownRole, nil);
 }
@@ -1173,13 +1173,13 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     }
 
     if ([attributeName isEqualToString:NSAccessibilityRoleAttribute])
-        return roleString(*backingObject);
+        return roleString(*backingObject).autorelease();
 
     if ([attributeName isEqualToString: NSAccessibilitySubroleAttribute])
-        return subroleString(*backingObject);
+        return subroleString(*backingObject).autorelease();
 
     if ([attributeName isEqualToString:NSAccessibilityRoleDescriptionAttribute])
-        return roleDescription(*backingObject);
+        return roleDescription(*backingObject).autorelease();
 
     if ([attributeName isEqualToString: NSAccessibilityParentAttribute]) {
         // This will return the parent of the AXWebArea, if this is a web area.
@@ -1253,7 +1253,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
             String selectedText = backingObject->selectedText();
             if (selectedText.isNull())
                 return nil;
-            return (NSString*)selectedText;
+            return selectedText.createNSString().autorelease();
         }
 
         if ([attributeName isEqualToString:NSAccessibilitySelectedTextRangeAttribute])
@@ -1306,7 +1306,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
                 return [attachmentView accessibilityAttributeValue:NSAccessibilityTitleAttribute];
         }
 
-        return backingObject->titleAttributeValue();
+        return backingObject->titleAttributeValue().createNSString().autorelease();
     }
 
     if ([attributeName isEqualToString:NSAccessibilityDescriptionAttribute]) {
@@ -1315,7 +1315,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
             if ([[attachmentView accessibilityAttributeNames] containsObject:NSAccessibilityDescriptionAttribute])
                 return [attachmentView accessibilityAttributeValue:NSAccessibilityDescriptionAttribute];
         }
-        return backingObject->descriptionAttributeValue();
+        return backingObject->descriptionAttributeValue().createNSString().autorelease();
     }
 
     if ([attributeName isEqualToString:NSAccessibilityValueAttribute]) {
@@ -1398,7 +1398,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     }
 
     if ([attributeName isEqualToString:NSAccessibilityEmbeddedImageDescriptionAttribute])
-        return backingObject->embeddedImageDescription();
+        return backingObject->embeddedImageDescription().createNSString().autorelease();
 
     if ([attributeName isEqualToString:NSAccessibilityWindowAttribute]
         || [attributeName isEqualToString:NSAccessibilityTopLevelUIElementAttribute])
@@ -1408,11 +1408,11 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         auto accessKey = backingObject->accessKey();
         if (accessKey.isNull())
             return nil;
-        return accessKey;
+        return accessKey.createNSString().autorelease();
     }
 
     if ([attributeName isEqualToString:NSAccessibilityLinkRelationshipTypeAttribute])
-        return backingObject->linkRelValue();
+        return backingObject->linkRelValue().createNSString().autorelease();
 
     if ([attributeName isEqualToString:NSAccessibilityTabsAttribute] && backingObject->isTabList())
         return makeNSArray(backingObject->tabChildren());
@@ -1637,7 +1637,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return [NSNumber numberWithBool:backingObject->isSelected()];
 
     if ([attributeName isEqualToString: NSAccessibilityARIACurrentAttribute])
-        return backingObject->currentValue();
+        return backingObject->currentValue().createNSString().autorelease();
 
     if ([attributeName isEqualToString:NSAccessibilityTitleUIElementAttribute]) {
         // FIXME: change to return an array instead of a single object.
@@ -1646,7 +1646,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     }
 
     if ([attributeName isEqualToString:NSAccessibilityValueDescriptionAttribute])
-        return backingObject->valueDescription();
+        return backingObject->valueDescription().createNSString().autorelease();
 
     if ([attributeName isEqualToString:NSAccessibilityOrientationAttribute]) {
         AccessibilityOrientation elementOrientation = backingObject->orientation();
@@ -1681,7 +1681,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     }
 
     if ([attributeName isEqualToString:NSAccessibilityLanguageAttribute])
-        return backingObject->languageIncludingAncestors();
+        return backingObject->languageIncludingAncestors().createNSString().autorelease();
 
     if ([attributeName isEqualToString:NSAccessibilityExpandedAttribute])
         return [NSNumber numberWithBool:backingObject->isExpanded()];
@@ -1690,7 +1690,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return [NSNumber numberWithBool:backingObject->isRequired()];
 
     if ([attributeName isEqualToString:NSAccessibilityInvalidAttribute])
-        return backingObject->invalidStatus();
+        return backingObject->invalidStatus().createNSString().autorelease();
 
     if ([attributeName isEqualToString:NSAccessibilityOwnsAttribute])
         return makeNSArray(backingObject->ownedObjects());
@@ -1707,7 +1707,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return createNSArray(backingObject->determineDropEffects()).autorelease();
 
     if ([attributeName isEqualToString:NSAccessibilityPlaceholderValueAttribute])
-        return backingObject->placeholderValue();
+        return backingObject->placeholderValue().createNSString().autorelease();
 
     if ([attributeName isEqualToString:NSAccessibilityValueAutofillAvailableAttribute])
         return @(backingObject->isValueAutofillAvailable());
@@ -1733,16 +1733,16 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return [NSNumber numberWithBool:backingObject->selfOrAncestorLinkHasPopup()];
 
     if ([attributeName isEqualToString:NSAccessibilityDatetimeValueAttribute])
-        return backingObject->datetimeAttributeValue();
+        return backingObject->datetimeAttributeValue().createNSString().autorelease();
 
     if ([attributeName isEqualToString:NSAccessibilityInlineTextAttribute])
         return @(backingObject->isInlineText());
 
     // ARIA Live region attributes.
     if ([attributeName isEqualToString:NSAccessibilityARIALiveAttribute])
-        return backingObject->liveRegionStatus();
+        return backingObject->liveRegionStatus().createNSString().autorelease();
     if ([attributeName isEqualToString:NSAccessibilityARIARelevantAttribute])
-        return backingObject->liveRegionRelevant();
+        return backingObject->liveRegionRelevant().createNSString().autorelease();
     if ([attributeName isEqualToString:NSAccessibilityARIAAtomicAttribute])
         return [NSNumber numberWithBool:backingObject->liveRegionAtomic()];
     if ([attributeName isEqualToString:NSAccessibilityElementBusyAttribute])
@@ -1775,9 +1775,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         if ([attributeName isEqualToString:NSAccessibilityMathOverAttribute])
             return (backingObject->mathOverObject()) ? backingObject->mathOverObject()->wrapper() : 0;
         if ([attributeName isEqualToString:NSAccessibilityMathFencedOpenAttribute])
-            return backingObject->mathFencedOpenString();
+            return backingObject->mathFencedOpenString().createNSString().autorelease();
         if ([attributeName isEqualToString:NSAccessibilityMathFencedCloseAttribute])
-            return backingObject->mathFencedCloseString();
+            return backingObject->mathFencedCloseString().createNSString().autorelease();
         if ([attributeName isEqualToString:NSAccessibilityMathLineThicknessAttribute])
             return [NSNumber numberWithInteger:backingObject->mathLineThickness()];
         if ([attributeName isEqualToString:NSAccessibilityMathPostscriptsAttribute])
@@ -1787,10 +1787,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     }
 
     if ([attributeName isEqualToString:NSAccessibilityExpandedTextValueAttribute])
-        return backingObject->expandedTextValue();
+        return backingObject->expandedTextValue().createNSString().autorelease();
 
     if ([attributeName isEqualToString:NSAccessibilityDOMIdentifierAttribute])
-        return backingObject->identifierAttribute();
+        return backingObject->identifierAttribute().createNSString().autorelease();
     if ([attributeName isEqualToString:NSAccessibilityDOMClassListAttribute])
         return createNSArray(backingObject->classList()).autorelease();
 
@@ -1803,10 +1803,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return [self baseAccessibilitySpeechHint];
 
     if ([attributeName isEqualToString:NSAccessibilityPopupValueAttribute])
-        return backingObject->popupValue();
+        return backingObject->popupValue().createNSString().autorelease();
 
     if ([attributeName isEqualToString:NSAccessibilityKeyShortcutsAttribute])
-        return backingObject->keyShortcuts();
+        return backingObject->keyShortcuts().createNSString().autorelease();
 
     if ([attributeName isEqualToString:NSAccessibilityIsInDescriptionListTermAttribute])
         return [NSNumber numberWithBool:backingObject->isInDescriptionListTerm()];
@@ -1815,10 +1815,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return makeNSArray(backingObject->detailedByObjects());
 
     if ([attributeName isEqualToString:NSAccessibilityBrailleLabelAttribute])
-        return backingObject->brailleLabel();
+        return backingObject->brailleLabel().createNSString().autorelease();
 
     if ([attributeName isEqualToString:NSAccessibilityBrailleRoleDescriptionAttribute])
-        return backingObject->brailleRoleDescription();
+        return backingObject->brailleRoleDescription().createNSString().autorelease();
 
     if ([attributeName isEqualToString:NSAccessibilityRelativeFrameAttribute])
         return [NSValue valueWithRect:(NSRect)backingObject->relativeFrame()];
@@ -1871,10 +1871,10 @@ id attributeValueForTesting(const RefPtr<AXCoreObject>& backingObject, NSString 
     ASSERT_WITH_MESSAGE(AXObjectCache::clientIsInTestMode(), "Should be used for testing only, not for AT clients.");
 
     if ([attributeName isEqualToString:NSAccessibilityARIARoleAttribute])
-        return backingObject->computedRoleString();
+        return backingObject->computedRoleString().createNSString().autorelease();
 
     if ([attributeName isEqualToString:NSAccessibilityStringValueAttribute])
-        return backingObject->stringValue();
+        return backingObject->stringValue().createNSString().autorelease();
 
     if ([attributeName isEqualToString:NSAccessibilityDateTimeComponentsTypeAttribute])
         return [NSNumber numberWithUnsignedShort:(uint8_t)backingObject->dateTimeComponentsType()];
@@ -1916,7 +1916,7 @@ id attributeValueForTesting(const RefPtr<AXCoreObject>& backingObject, NSString 
         return [NSNumber numberWithBool:backingObject->pressedIsPresent()];
 
     if ([attributeName isEqualToString:NSAccessibilityAutocompleteValueAttribute])
-        return backingObject->autoCompleteValue();
+        return backingObject->autoCompleteValue().createNSString().autorelease();
 
     if ([attributeName isEqualToString:NSAccessibilityClickPointAttribute])
         return [NSValue valueWithPoint:backingObject->clickPoint()];
@@ -1941,7 +1941,7 @@ id attributeValueForTesting(const RefPtr<AXCoreObject>& backingObject, NSString 
         return [NSNumber numberWithBool:backingObject->isRemoteFrame()];
 
     if ([attributeName isEqualToString:NSAccessibilityInfoStringForTestingAttribute])
-        return backingObject->infoStringForTesting();
+        return backingObject->infoStringForTesting().createNSString().autorelease();
 
     return nil;
 }
@@ -2928,8 +2928,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         });
         ASSERT(result.size() <= 1);
         if (result.size() > 0)
-            return result[0];
-        return String();
+            return result[0].createNSString().autorelease();
+        return @"";
     }
 
     if ([attribute isEqualToString:NSAccessibilitySearchTextWithCriteriaParameterizedAttribute]) {
@@ -3179,7 +3179,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     }
 
     if ([attribute isEqualToString:NSAccessibilityStringForTextMarkerRangeAttribute])
-        return AXTextMarkerRange { textMarkerRange }.toString();
+        return AXTextMarkerRange { textMarkerRange }.toString().createNSString().autorelease();
 
     if ([attribute isEqualToString:NSAccessibilityTextMarkerForPositionAttribute]) {
         if (!pointSet)
@@ -3254,21 +3254,21 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
     if ([attribute isEqualToString:NSAccessibilityStringForRangeParameterizedAttribute]) {
         if (backingObject->isTextControl())
-            return backingObject->doAXStringForRange(range);
+            return backingObject->doAXStringForRange(range).createNSString().autorelease();
 
-        return Accessibility::retrieveValueFromMainThread<String>([&range, protectedSelf = retainPtr(self)] () -> String {
+        return Accessibility::retrieveValueFromMainThread<RetainPtr<NSString>>([&range, protectedSelf = retainPtr(self)] () -> RetainPtr<NSString> {
             auto* backingObject = protectedSelf.get().axBackingObject;
             if (!backingObject)
-                return String();
+                return @"";
             auto* cache = backingObject->axObjectCache();
             if (!cache)
-                return String();
+                return @"";
 
             auto start = cache->characterOffsetForIndex(range.location, backingObject);
             auto end = cache->characterOffsetForIndex(range.location + range.length, backingObject);
             auto range = cache->rangeForUnorderedCharacterOffsets(start, end);
-            return AXTextMarkerRange { range }.toString();
-        });
+            return AXTextMarkerRange { range }.toString().createNSString().autorelease();
+        }).autorelease();
     }
 
     if ([attribute isEqualToString:NSAccessibilityAttributedStringForTextMarkerRangeAttribute])
@@ -3454,7 +3454,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         }
 
         if ([attribute isEqualToString:bridge_cast(kAXStringForRangeParameterizedAttribute)])
-            return rangeSet ? (id)backingObject->doAXStringForRange(range) : nil;
+            return rangeSet ? (id)backingObject->doAXStringForRange(range).createNSString().autorelease() : nil;
 
         if ([attribute isEqualToString:bridge_cast(kAXRangeForPositionParameterizedAttribute)]) {
             if (!pointSet)
@@ -3497,10 +3497,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     }
 
     if ([attribute isEqualToString:NSAccessibilityTextMarkerDebugDescriptionAttribute])
-        return AXTextMarker { textMarker }.debugDescription();
+        return AXTextMarker { textMarker }.debugDescription().createNSString().autorelease();
 
     if ([attribute isEqualToString:NSAccessibilityTextMarkerRangeDebugDescriptionAttribute])
-        return AXTextMarkerRange { textMarkerRange }.debugDescription();
+        return AXTextMarkerRange { textMarkerRange }.debugDescription().createNSString().autorelease();
 
 #if ENABLE(TREE_DEBUGGING)
     if ([attribute isEqualToString:AXTextMarkerNodeDebugDescriptionAttribute]) {

--- a/Source/WebCore/bridge/objc/WebScriptObject.mm
+++ b/Source/WebCore/bridge/objc/WebScriptObject.mm
@@ -584,7 +584,7 @@ static void getListFromNSArray(JSC::JSGlobalObject* lexicalGlobalObject, NSArray
     }
 
     if (value.isString())
-        return asString(value)->value(rootObject->globalObject()).data;
+        return asString(value)->value(rootObject->globalObject()).data.createNSString().autorelease();
 
     if (value.isNumber())
         return @(value.asNumber());

--- a/Source/WebCore/editing/cocoa/AttributedString.mm
+++ b/Source/WebCore/editing/cocoa/AttributedString.mm
@@ -192,7 +192,7 @@ inline static RetainPtr<NSParagraphStyle> reconstructStyle(const ParagraphStyle&
 {
     for (const auto& item : style.textLists) {
         lists.ensure(item.thisID, [&] {
-            RetainPtr list = adoptNS([[PlatformNSTextList alloc] initWithMarkerFormat:item.markerFormat options:0]);
+            RetainPtr list = adoptNS([[PlatformNSTextList alloc] initWithMarkerFormat:item.markerFormat.createNSString().get() options:0]);
             [list setStartingItemNumber:item.startingItemNumber];
             return list;
         });
@@ -296,19 +296,19 @@ static RetainPtr<NSAdaptiveImageGlyph> toWebMultiRepresentationHEICAttachment(co
             return attachment;
     }
 
-    NSString *identifier = attachmentData.identifier;
-    NSString *description = attachmentData.description;
-    if (!description.length)
+    RetainPtr identifier = attachmentData.identifier.createNSString();
+    RetainPtr description = attachmentData.description.createNSString();
+    if (!description.get().length)
         description = @"Apple Emoji";
 
 #if HAVE(NS_EMOJI_IMAGE_STRIKE_PROVENANCE)
     RetainPtr<NSMutableDictionary<NSString *, NSString *>> provenanceInfo = [NSMutableDictionary dictionaryWithCapacity:2];
 
-    NSString *credit = attachmentData.credit;
-    NSString *digitalSourceType = attachmentData.digitalSourceType;
-    if (identifier.length && digitalSourceType.length) {
-        [provenanceInfo setObject:credit forKey:(__bridge NSString *)kCGImagePropertyIPTCCredit];
-        [provenanceInfo setObject:digitalSourceType forKey:(__bridge NSString *)kCGImagePropertyIPTCExtDigitalSourceType];
+    RetainPtr credit = attachmentData.credit.createNSString();
+    RetainPtr digitalSourceType = attachmentData.digitalSourceType.createNSString();
+    if (identifier.get().length && digitalSourceType.get().length) {
+        [provenanceInfo setObject:credit.get() forKey:bridge_cast(kCGImagePropertyIPTCCredit)];
+        [provenanceInfo setObject:digitalSourceType.get() forKey:bridge_cast(kCGImagePropertyIPTCExtDigitalSourceType)];
     }
 #endif
 
@@ -328,7 +328,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (![images count])
         return nil;
 
-    RetainPtr asset = adoptNS([[CTEmojiImageAsset alloc] initWithContentIdentifier:identifier shortDescription:description strikeImages:images]);
+    RetainPtr asset = adoptNS([[CTEmojiImageAsset alloc] initWithContentIdentifier:identifier.get() shortDescription:description.get() strikeImages:images]);
     if (![asset imageData])
         return nil;
 

--- a/Source/WebCore/editing/cocoa/DictionaryLookup.mm
+++ b/Source/WebCore/editing/cocoa/DictionaryLookup.mm
@@ -280,7 +280,7 @@ std::optional<SimpleRange> DictionaryLookup::rangeForSelection(const VisibleSele
 
     auto fullCharacterRange = *makeSimpleRange(paragraphStart, paragraphEnd);
     String itemString = plainText(fullCharacterRange);
-    NSRange highlightRange = adoptNS([PAL::allocRVItemInstance() initWithText:itemString selectedRange:rangeToPass]).get().highlightRange;
+    NSRange highlightRange = adoptNS([PAL::allocRVItemInstance() initWithText:itemString.createNSString().get() selectedRange:rangeToPass]).get().highlightRange;
 
     return { { resolveCharacterRange(fullCharacterRange, highlightRange) } };
 
@@ -351,7 +351,7 @@ std::optional<SimpleRange> DictionaryLookup::rangeAtHitTestResult(const HitTestR
     NSRange selectedRange = [PAL::getRVSelectionClass() revealRangeAtIndex:hitIndex selectedRanges:@[[NSValue valueWithRange:selectionRange]] shouldUpdateSelection:nil];
 
     String itemString = plainText(*fullCharacterRange);
-    auto highlightRange = adoptNS([PAL::allocRVItemInstance() initWithText:itemString selectedRange:selectedRange]).get().highlightRange;
+    auto highlightRange = adoptNS([PAL::allocRVItemInstance() initWithText:itemString.createNSString().get() selectedRange:selectedRange]).get().highlightRange;
 
     if (highlightRange.location == NSNotFound || !highlightRange.length)
         return std::nullopt;

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -908,7 +908,7 @@ NSDictionary *HTMLConverter::computedAttributesForElement(Element& element)
     if (!font) {
         String fontName = _caches->propertyValueForNode(element, CSSPropertyFontFamily);
         if (fontName.length())
-            font = _fontForNameAndSize(fontName.convertToASCIILowercase(), fontSize, _fontCache.get());
+            font = _fontForNameAndSize(fontName.convertToASCIILowercase().createNSString().get(), fontSize, _fontCache.get());
         if (!font)
             font = [PlatformFontClass fontWithName:@"Times" size:fontSize];
 
@@ -1007,7 +1007,7 @@ NSDictionary *HTMLConverter::computedAttributesForElement(Element& element)
 
     String textShadow = _caches->propertyValueForNode(element, CSSPropertyTextShadow);
     if (textShadow.length() > 4) {
-        NSShadow *shadow = _shadowForShadowStyle(textShadow);
+        NSShadow *shadow = _shadowForShadowStyle(textShadow.createNSString().get());
         if (shadow)
             [attrs setObject:shadow forKey:NSShadowAttributeName];
     }
@@ -1621,7 +1621,7 @@ BOOL HTMLConverter::_enterElement(Element& element, BOOL embedded)
     else if ((!m_ignoreUserSelectNoneContent || !m_userSelectNoneStateCache.nodeOnlyContainsUserSelectNone(element)) && (!displayValue.length() || !(displayValue == noneAtom() || displayValue == "table-column"_s || displayValue == "table-column-group"_s))) {
         if (_caches->isBlockElement(element) && !element.hasTagName(brTag) && !(displayValue == "table-cell"_s && ![_textTables count])
             && !([_textLists count] > 0 && displayValue == "block"_s && !element.hasTagName(liTag) && !element.hasTagName(ulTag) && !element.hasTagName(olTag)))
-            _newParagraphForElement(element, element.tagName(), NO, YES);
+            _newParagraphForElement(element, element.tagName().createNSString().get(), NO, YES);
         return YES;
     }
     return NO;
@@ -1786,7 +1786,7 @@ BOOL HTMLConverter::_processElement(Element& element, NSInteger depth)
 #if ENABLE(ATTACHMENT_ELEMENT)
     } else if (RefPtr attachment = dynamicDowncast<HTMLAttachmentElement>(element)) {
         if (attachment->file()) {
-            RetainPtr url = [NSURL fileURLWithPath:attachment->file()->path()];
+            RetainPtr url = [NSURL fileURLWithPath:attachment->file()->path().createNSString().get()];
             if (url)
                 _addAttachmentForElement(element, url.get(), isBlockLevel, NO);
         }
@@ -1849,21 +1849,21 @@ BOOL HTMLConverter::_processElement(Element& element, NSInteger depth)
             if (blockElement && blockElementIsParagraph)
                 _newLineForElement(element);
             else
-                _newParagraphForElement(element, element.tagName(), YES, NO);
+                _newParagraphForElement(element, element.tagName().createNSString().get(), YES, NO);
         }
     } else if (element.hasTagName(ulTag)) {
         RetainPtr<NSTextList> list;
         String listStyleType = _caches->propertyValueForNode(element, CSSPropertyListStyleType);
         if (!listStyleType.length())
             listStyleType = @"disc";
-        list = adoptNS([[PlatformNSTextList alloc] initWithMarkerFormat:makeString("{"_s, listStyleType, "}"_s) options:0]);
+        list = adoptNS([[PlatformNSTextList alloc] initWithMarkerFormat:makeString("{"_s, listStyleType, "}"_s).createNSString().get() options:0]);
         [_textLists addObject:list.get()];
     } else if (element.hasTagName(olTag)) {
         RetainPtr<NSTextList> list;
         String listStyleType = _caches->propertyValueForNode(element, CSSPropertyListStyleType);
         if (!listStyleType.length())
             listStyleType = "decimal"_s;
-        list = adoptNS([[PlatformNSTextList alloc] initWithMarkerFormat:makeString('{', listStyleType, '}') options:0]);
+        list = adoptNS([[PlatformNSTextList alloc] initWithMarkerFormat:makeString('{', listStyleType, '}').createNSString().get() options:0]);
         if (RefPtr olElement = dynamicDowncast<HTMLOListElement>(element)) {
             auto startingItemNumber = olElement->start();
             [list setStartingItemNumber:startingItemNumber];
@@ -1977,7 +1977,7 @@ void HTMLConverter::_exitElement(Element& element, NSInteger depth, NSUInteger s
         } else if ([_textLists count] > 0 && displayValue == "block"_s && !element.hasTagName(liTag) && !element.hasTagName(ulTag) && !element.hasTagName(olTag)) {
             _newLineForElement(element);
         } else {
-            _newParagraphForElement(element, element.tagName(), (range.length == 0), YES);
+            _newParagraphForElement(element, element.tagName().createNSString().get(), !range.length, YES);
         }
     } else if ([_writingDirectionArray count] > 0) {
         String bidi = _caches->propertyValueForNode(element, CSSPropertyUnicodeBidi);
@@ -2162,7 +2162,7 @@ void HTMLConverter::_processText(Text& text)
         else if (textTransform == "lowercase"_s)
             outputString = outputString.convertToLowercaseWithoutLocale(); // FIXME: Needs locale to work correctly.
 
-        [_attrStr replaceCharactersInRange:rangeToReplace withString:outputString];
+        [_attrStr replaceCharactersInRange:rangeToReplace withString:outputString.createNSString().get()];
         rangeToReplace.length = outputString.length();
         if (rangeToReplace.length)
             [_attrStr setAttributes:aggregatedAttributesForAncestors(text) range:rangeToReplace];
@@ -2313,10 +2313,10 @@ static RetainPtr<NSFileWrapper> fileWrapperForURL(DocumentLoader* dataSource, NS
     if (dataSource) {
         if (RefPtr<ArchiveResource> resource = dataSource->subresource(URL)) {
             auto wrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:resource->data().makeContiguous()->createNSData().get()]);
-            NSString *filename = resource->response().suggestedFilename();
+            RetainPtr filename = resource->response().suggestedFilename().createNSString();
             if (!filename || ![filename length])
                 filename = suggestedFilenameWithMIMEType(resource->url().createNSURL().get(), resource->mimeType());
-            [wrapper setPreferredFilename:filename];
+            [wrapper setPreferredFilename:filename.get()];
             return wrapper;
         }
     }
@@ -2379,7 +2379,7 @@ static RetainPtr<NSFileWrapper> fileWrapperForElement(const HTMLImageElement& el
     if (CachedImage* cachedImage = element.cachedImage()) {
         if (RefPtr sharedBuffer = cachedImage->resourceBuffer()) {
             RetainPtr wrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:sharedBuffer->makeContiguous()->createNSData().get()]);
-            [wrapper setPreferredFilename:preferredFilenameForElement(element)];
+            [wrapper setPreferredFilename:preferredFilenameForElement(element).createNSString().get()];
             return wrapper;
         }
     }
@@ -2409,7 +2409,7 @@ static RetainPtr<NSFileWrapper> fileWrapperForElement(const HTMLAttachmentElemen
     // to an existing HTMLAttachmentElement.
 
     RetainPtr wrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:data.get()]);
-    [wrapper setPreferredFilename:makeString(WebContentReader::placeholderAttachmentFilenamePrefix, identifier)];
+    [wrapper setPreferredFilename:makeString(WebContentReader::placeholderAttachmentFilenamePrefix, identifier).createNSString().get()];
     return wrapper;
 }
 
@@ -2677,7 +2677,7 @@ static AttributedString editingAttributedStringInternal(const SimpleRange& range
         if (!replaceNoBreakSpaces)
             text = it.text().createNSStringWithoutCopying();
         else
-            text = makeStringByReplacingAll(it.text(), noBreakSpace, ' ');
+            text = makeStringByReplacingAll(it.text(), noBreakSpace, ' ').createNSString();
 
         [string replaceCharactersInRange:NSMakeRange(stringLength, 0) withString:text.get()];
         [string setAttributes:attributes.get() range:NSMakeRange(stringLength, currentTextLength)];

--- a/Source/WebCore/editing/cocoa/WebArchiveResourceFromNSAttributedString.mm
+++ b/Source/WebCore/editing/cocoa/WebArchiveResourceFromNSAttributedString.mm
@@ -43,14 +43,15 @@ using namespace WebCore;
         return nil;
     }
 
+    RetainPtr updatedMIMEType = MIMEType;
     if ([MIMEType isEqualToString:@"application/octet-stream"]) {
         // FIXME: This is a workaround for <rdar://problem/36074429>, and can be removed once that is fixed.
         auto mimeTypeFromURL = MIMETypeRegistry::mimeTypeForExtension(String(URL.pathExtension));
         if (!mimeTypeFromURL.isEmpty())
-            MIMEType = mimeTypeFromURL;
+            updatedMIMEType = mimeTypeFromURL.createNSString();
     }
 
-    resource = ArchiveResource::create(SharedBuffer::create(adoptNS([data copy]).get()), URL, MIMEType, textEncodingName, frameName, { });
+    resource = ArchiveResource::create(SharedBuffer::create(adoptNS([data copy]).get()), URL, updatedMIMEType.get(), textEncodingName, frameName, { });
     if (!resource) {
         [self release];
         return nil;
@@ -61,7 +62,7 @@ using namespace WebCore;
 
 - (NSString *)MIMEType
 {
-    return resource->mimeType();
+    return resource->mimeType().createNSString().autorelease();
 }
 
 - (NSURL *)URL

--- a/Source/WebCore/fileapi/FileCocoa.mm
+++ b/Source/WebCore/fileapi/FileCocoa.mm
@@ -44,7 +44,7 @@ bool File::shouldReplaceFile(const String& path)
         return false;
 
     NSError *error;
-    NSURL *pathURL = [NSURL URLByResolvingAliasFileAtURL:[NSURL fileURLWithPath:path isDirectory:NO] options:NSURLBookmarkResolutionWithoutUI error:&error];
+    RetainPtr pathURL = [NSURL URLByResolvingAliasFileAtURL:[NSURL fileURLWithPath:path.createNSString().get() isDirectory:NO] options:NSURLBookmarkResolutionWithoutUI error:&error];
     if (!pathURL) {
         LOG_ERROR("Failed to resolve alias at path %s with error %@.\n", path.utf8().data(), error);
         return false;
@@ -52,7 +52,7 @@ bool File::shouldReplaceFile(const String& path)
 
     UTType *uti;
     if (![pathURL getResourceValue:&uti forKey:NSURLContentTypeKey error:&error]) {
-        LOG_ERROR("Failed to get type identifier of resource at URL %@ with error %@.\n", pathURL, error);
+        LOG_ERROR("Failed to get type identifier of resource at URL %@ with error %@.\n", pathURL.get(), error);
         return false;
     }
 

--- a/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
@@ -134,23 +134,23 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
     // Choose the best voice, by first looking at the utterance voice, then the utterance language,
     // then choose the default language.
     RefPtr utteranceVoice = utterance->voice();
-    NSString *voiceLanguage = nil;
+    RetainPtr<NSString> voiceLanguage;
     if (!utteranceVoice || utteranceVoice->voiceURI().isEmpty()) {
         if (utterance->lang().isEmpty())
             voiceLanguage = [PAL::getAVSpeechSynthesisVoiceClass() currentLanguageCode];
         else
-            voiceLanguage = utterance->lang();
+            voiceLanguage = utterance->lang().createNSString();
     } else
-        voiceLanguage = utterance->voice()->lang();
+        voiceLanguage = utterance->voice()->lang().createNSString();
 
     AVSpeechSynthesisVoice *avVoice = nil;
     if (utteranceVoice)
-        avVoice = [PAL::getAVSpeechSynthesisVoiceClass() voiceWithIdentifier:utteranceVoice->voiceURI()];
+        avVoice = [PAL::getAVSpeechSynthesisVoiceClass() voiceWithIdentifier:utteranceVoice->voiceURI().createNSString().get()];
 
     if (!avVoice)
-        avVoice = [PAL::getAVSpeechSynthesisVoiceClass() voiceWithLanguage:voiceLanguage];
+        avVoice = [PAL::getAVSpeechSynthesisVoiceClass() voiceWithLanguage:voiceLanguage.get()];
 
-    AVSpeechUtterance *avUtterance = [PAL::getAVSpeechUtteranceClass() speechUtteranceWithString:utterance->text()];
+    AVSpeechUtterance *avUtterance = [PAL::getAVSpeechUtteranceClass() speechUtteranceWithString:utterance->text().createNSString().get()];
 
     [avUtterance setRate:[self mapSpeechRateToPlatformRate:utterance->rate()]];
     [avUtterance setVolume:utterance->volume()];

--- a/Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm
+++ b/Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm
@@ -95,16 +95,16 @@ RetainPtr<NSDictionary> SerializedPlatformDataCueValue::toNSDictionary() const
     auto dictionary = adoptNS([NSMutableDictionary new]);
 
     if (!m_data->type.isNull())
-        [dictionary setObject:m_data->type forKey:@"type"];
+        [dictionary setObject:m_data->type.createNSString().get() forKey:@"type"];
 
     for (auto& pair : m_data->otherAttributes)
-        [dictionary setObject:pair.value forKey:pair.key];
+        [dictionary setObject:pair.value.createNSString().get() forKey:pair.key.createNSString().get()];
 
     if (m_data->locale)
         [dictionary setObject:m_data->locale.get() forKey:@"locale"];
 
     if (!m_data->key.isNull())
-        [dictionary setObject:m_data->key forKey:@"key"];
+        [dictionary setObject:m_data->key.createNSString().get() forKey:@"key"];
 
     WTF::switchOn(m_data->value, [] (std::nullptr_t) {
     }, [&] (RetainPtr<NSString> string) {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -365,7 +365,7 @@ bool CDMInstanceFairPlayStreamingAVFObjC::supportsPersistentKeys()
 
 bool CDMInstanceFairPlayStreamingAVFObjC::supportsMediaCapability(const CDMMediaCapability& capability)
 {
-    if (![PAL::getAVURLAssetClass() isPlayableExtendedMIMEType:capability.contentType])
+    if (![PAL::getAVURLAssetClass() isPlayableExtendedMIMEType:capability.contentType.createNSString().get()])
         return false;
 
     // FairPlay only supports 'cbcs' encryption:
@@ -434,7 +434,7 @@ void CDMInstanceFairPlayStreamingAVFObjC::setStorageDirectory(const String& stor
             return;
     }
 
-    m_storageURL = adoptNS([[NSURL alloc] initFileURLWithPath:storagePath isDirectory:NO]);
+    m_storageURL = adoptNS([[NSURL alloc] initFileURLWithPath:storagePath.createNSString().get() isDirectory:NO]);
 }
 
 RefPtr<CDMInstanceSession> CDMInstanceFairPlayStreamingAVFObjC::createSession()
@@ -803,7 +803,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 #if HAVE(FAIRPLAYSTREAMING_CENC_INITDATA)
     else if (initDataType == InitDataRegistry::cencName()) {
         auto psshString = base64EncodeToString(initData->makeContiguous()->span());
-        initializationData = [NSJSONSerialization dataWithJSONObject:@{ @"pssh": (NSString*)psshString } options:NSJSONWritingPrettyPrinted error:nil];
+        initializationData = [NSJSONSerialization dataWithJSONObject:@{ @"pssh": psshString.createNSString().get() } options:NSJSONWritingPrettyPrinted error:nil];
     }
 #endif
 #if HAVE(FAIRPLAYSTREAMING_MTPS_INITDATA)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.mm
@@ -88,10 +88,10 @@ String InbandTextTrackPrivateAVFObjC::mediaType() const
 bool InbandTextTrackPrivateAVFObjC::hasMediaCharacteristic(const String& type) const
 {
     if (m_mediaSelectionOption)
-        return [m_mediaSelectionOption hasMediaCharacteristic:type];
+        return [m_mediaSelectionOption hasMediaCharacteristic:type.createNSString().get()];
 
     if (m_assetTrack)
-        return [m_assetTrack hasMediaCharacteristic:type];
+        return [m_assetTrack hasMediaCharacteristic:type.createNSString().get()];
 
     return false;
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -314,7 +314,7 @@ static AVAssetCache *assetCacheForPath(const String& path)
     if (path.isEmpty())
         return nil;
 
-    return [PAL::getAVAssetCacheClass() assetCacheWithURL:[NSURL fileURLWithPath:path isDirectory:YES]];
+    return [PAL::getAVAssetCacheClass() assetCacheWithURL:[NSURL fileURLWithPath:path.createNSString().get() isDirectory:YES]];
 }
 
 static AVAssetCache *ensureAssetCacheExistsForPath(const String& path)
@@ -918,11 +918,11 @@ void MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL(const URL& url, Ret
     if (!outOfBandTrackSources.isEmpty()) {
         auto outOfBandTracks = createNSArray(outOfBandTrackSources, [] (auto& trackSource) {
             return @{
-                AVOutOfBandAlternateTrackDisplayNameKey: trackSource->label(),
-                AVOutOfBandAlternateTrackExtendedLanguageTagKey: trackSource->language(),
+                AVOutOfBandAlternateTrackDisplayNameKey: trackSource->label().createNSString().get(),
+                AVOutOfBandAlternateTrackExtendedLanguageTagKey: trackSource->language().createNSString().get(),
                 AVOutOfBandAlternateTrackIsDefaultKey: trackSource->isDefault() ? @YES : @NO,
-                AVOutOfBandAlternateTrackIdentifierKey: String::number(trackSource->uniqueId()),
-                AVOutOfBandAlternateTrackSourceKey: trackSource->url(),
+                AVOutOfBandAlternateTrackIdentifierKey: String::number(trackSource->uniqueId()).createNSString().get(),
+                AVOutOfBandAlternateTrackSourceKey: trackSource->url().createNSString().get(),
                 AVOutOfBandAlternateTrackMediaCharactersticsKey: mediaDescriptionForKind(trackSource->kind()),
             };
         });
@@ -1123,7 +1123,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayer()
         if (audioOutputDeviceId.isEmpty())
             m_avPlayer.get().audioOutputDeviceUniqueID = nil;
         else
-            m_avPlayer.get().audioOutputDeviceUniqueID = audioOutputDeviceId;
+            m_avPlayer.get().audioOutputDeviceUniqueID = audioOutputDeviceId.createNSString().get();
     }
 #endif
 
@@ -1188,7 +1188,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayerItem()
         [m_avPlayerItem addObserver:m_objcObserver.get() forKeyPath:keyName options:options context:(void *)MediaPlayerAVFoundationObservationContextPlayerItem];
     }
 
-    [m_avPlayerItem setAudioTimePitchAlgorithm:MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(player->pitchCorrectionAlgorithm(), player->preservesPitch(), m_requestedRate)];
+    [m_avPlayerItem setAudioTimePitchAlgorithm:MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(player->pitchCorrectionAlgorithm(), player->preservesPitch(), m_requestedRate).createNSString().get()];
 
 #if HAVE(AVFOUNDATION_INTERSTITIAL_EVENTS)
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
@@ -1676,7 +1676,7 @@ void MediaPlayerPrivateAVFoundationObjC::setRateDouble(double rate)
 void MediaPlayerPrivateAVFoundationObjC::setPlayerRate(double rate, std::optional<MonotonicTime>&& hostTime)
 {
     if (auto player = this->player())
-        [m_avPlayerItem setAudioTimePitchAlgorithm:MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(player->pitchCorrectionAlgorithm(), player->preservesPitch(), m_requestedRate)];
+        [m_avPlayerItem setAudioTimePitchAlgorithm:MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(player->pitchCorrectionAlgorithm(), player->preservesPitch(), m_requestedRate).createNSString().get()];
 
     setShouldObserveTimeControlStatus(false);
 
@@ -1744,14 +1744,14 @@ void MediaPlayerPrivateAVFoundationObjC::setPreservesPitch(bool preservesPitch)
 {
     auto player = this->player();
     if (m_avPlayerItem && player)
-        [m_avPlayerItem setAudioTimePitchAlgorithm:MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(player->pitchCorrectionAlgorithm(), preservesPitch, m_requestedRate)];
+        [m_avPlayerItem setAudioTimePitchAlgorithm:MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(player->pitchCorrectionAlgorithm(), preservesPitch, m_requestedRate).createNSString().get()];
 }
 
 void MediaPlayerPrivateAVFoundationObjC::setPitchCorrectionAlgorithm(MediaPlayer::PitchCorrectionAlgorithm pitchCorrectionAlgorithm)
 {
     auto player = this->player();
     if (m_avPlayerItem && player)
-        [m_avPlayerItem setAudioTimePitchAlgorithm:MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(pitchCorrectionAlgorithm, player->preservesPitch(), m_requestedRate)];
+        [m_avPlayerItem setAudioTimePitchAlgorithm:MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(pitchCorrectionAlgorithm, player->preservesPitch(), m_requestedRate).createNSString().get()];
 }
 
 const PlatformTimeRanges& MediaPlayerPrivateAVFoundationObjC::platformBufferedTimeRanges() const
@@ -2172,7 +2172,7 @@ bool MediaPlayerPrivateAVFoundationObjC::shouldWaitForLoadingOfResource(AVAssetR
             return true;
         }
 
-        RetainPtr<NSData> keyURIData = [keyURI dataUsingEncoding:NSUTF8StringEncoding allowLossyConversion:YES];
+        RetainPtr keyURIData = [keyURI.createNSString() dataUsingEncoding:NSUTF8StringEncoding allowLossyConversion:YES];
         m_keyID = SharedBuffer::create(keyURIData.get());
         player->initializationDataEncountered("skd"_s, protectedKeyID()->tryCreateArrayBuffer());
         setWaitingForKey(true);
@@ -4037,7 +4037,7 @@ void MediaPlayerPrivateAVFoundationObjC::audioOutputDeviceChanged()
     if (deviceId.isEmpty())
         m_avPlayer.get().audioOutputDeviceUniqueID = nil;
     else
-        m_avPlayer.get().audioOutputDeviceUniqueID = deviceId;
+        m_avPlayer.get().audioOutputDeviceUniqueID = deviceId.createNSString().get();
 #endif
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -567,7 +567,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setRateDouble(double rate)
     if (auto player = m_player.get()) {
         auto algorithm = MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(player->pitchCorrectionAlgorithm(), player->preservesPitch(), m_rate);
         for (const auto& key : m_sampleBufferAudioRendererMap.keys())
-            [(__bridge AVSampleBufferAudioRenderer *)key.get() setAudioTimePitchAlgorithm:algorithm];
+            [(__bridge AVSampleBufferAudioRenderer *)key.get() setAudioTimePitchAlgorithm:algorithm.createNSString().get()];
     }
 
     if (shouldBePlaying())
@@ -590,7 +590,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setPreservesPitch(bool preservesPitch
     if (auto player = m_player.get()) {
         auto algorithm = MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(player->pitchCorrectionAlgorithm(), preservesPitch, m_rate);
         for (const auto& key : m_sampleBufferAudioRendererMap.keys())
-            [(__bridge AVSampleBufferAudioRenderer *)key.get() setAudioTimePitchAlgorithm:algorithm];
+            [(__bridge AVSampleBufferAudioRenderer *)key.get() setAudioTimePitchAlgorithm:algorithm.createNSString().get()];
     }
 }
 
@@ -1491,7 +1491,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     [audioRenderer setMuted:player->muted()];
     [audioRenderer setVolume:player->volume()];
     auto algorithm = MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(player->pitchCorrectionAlgorithm(), player->preservesPitch(), m_rate);
-    [audioRenderer setAudioTimePitchAlgorithm:algorithm];
+    [audioRenderer setAudioTimePitchAlgorithm:algorithm.createNSString().get()];
 #if PLATFORM(MAC)
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     if ([audioRenderer respondsToSelector:@selector(setIsUnaccompaniedByVisuals:)])
@@ -1505,7 +1505,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
         if (deviceId.isEmpty())
             audioRenderer.audioOutputDeviceUniqueID = nil;
         else
-            audioRenderer.audioOutputDeviceUniqueID = deviceId;
+            audioRenderer.audioOutputDeviceUniqueID = deviceId.createNSString().get();
     }
 #endif
 
@@ -1645,7 +1645,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::audioOutputDeviceChanged()
         if (deviceId.isEmpty())
             renderer.audioOutputDeviceUniqueID = nil;
         else
-            renderer.audioOutputDeviceUniqueID = deviceId;
+            renderer.audioOutputDeviceUniqueID = deviceId.createNSString().get();
     }
 #endif
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
@@ -211,7 +211,7 @@ MediaPlayerEnums::SupportsType SourceBufferParserAVFObjC::isContentTypeSupported
     String extendedType = type.raw();
     String outputCodecs = type.parameter(ContentType::codecsParameter());
     if (!outputCodecs.isEmpty() && [PAL::getAVStreamDataParserClass() respondsToSelector:@selector(outputMIMECodecParameterForInputMIMECodecParameter:)]) {
-        outputCodecs = [PAL::getAVStreamDataParserClass() outputMIMECodecParameterForInputMIMECodecParameter:outputCodecs];
+        outputCodecs = [PAL::getAVStreamDataParserClass() outputMIMECodecParameterForInputMIMECodecParameter:outputCodecs.createNSString().get()];
         extendedType = makeString(type.containerType(), "; codecs=\""_s, outputCodecs, "\""_s);
     }
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1453,7 +1453,7 @@ void MediaPlayerPrivateWebM::addAudioRenderer(TrackID trackId)
         if (deviceId.isEmpty())
             renderer.get().audioOutputDeviceUniqueID = nil;
         else
-            renderer.get().audioOutputDeviceUniqueID = deviceId;
+            renderer.get().audioOutputDeviceUniqueID = deviceId.createNSString().get();
     }
 #endif
 

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm
@@ -177,7 +177,7 @@ static AVMediaType toAVMediaType(MediaSelectionOption::MediaType type)
 static RetainPtr<NSArray> mediaSelectionOptions(const Vector<MediaSelectionOption>& options)
 {
     return createNSArray(options, [] (auto& option) {
-        return adoptNS([[WebAVMediaSelectionOption alloc] initWithMediaType:toAVMediaType(option.mediaType) displayName:option.displayName]);
+        return adoptNS([[WebAVMediaSelectionOption alloc] initWithMediaType:toAVMediaType(option.mediaType) displayName:option.displayName.createNSString().get()]);
     });
 }
 
@@ -206,7 +206,7 @@ void PlaybackSessionInterfaceAVKitLegacy::externalPlaybackChanged(bool enabled, 
         externalPlaybackType = AVPlayerControllerExternalPlaybackTypeTVOut;
 
     WebAVPlayerController* playerController = m_playerController.get();
-    playerController.externalPlaybackAirPlayDeviceLocalizedName = localizedDeviceName;
+    playerController.externalPlaybackAirPlayDeviceLocalizedName = localizedDeviceName.createNSString().get();
     playerController.externalPlaybackType = externalPlaybackType;
     playerController.externalPlaybackActive = enabled;
 }

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -220,7 +220,7 @@ void AVVideoCaptureSource::setUseAVCaptureDeviceRotationCoordinatorAPI(bool valu
 
 CaptureSourceOrError AVVideoCaptureSource::create(const CaptureDevice& device, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints, std::optional<PageIdentifier> pageIdentifier)
 {
-    auto *avDevice = [PAL::getAVCaptureDeviceClass() deviceWithUniqueID:device.persistentId()];
+    auto *avDevice = [PAL::getAVCaptureDeviceClass() deviceWithUniqueID:device.persistentId().createNSString().get()];
     if (!avDevice)
         return CaptureSourceOrError({ "No AVVideoCaptureSource device"_s , MediaAccessDenialReason::PermissionDenied });
 

--- a/Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm
@@ -59,7 +59,7 @@ void ResourceResponse::initNSURLResponse() const
             expectedContentLength = static_cast<NSInteger>(m_expectedContentLength);
 
         RetainPtr encodingNSString = nsStringNilIfEmpty(m_textEncodingName);
-        m_nsResponse = adoptNS([[NSURLResponse alloc] initWithURL:m_url.createNSURL().get() MIMEType:m_mimeType expectedContentLength:expectedContentLength textEncodingName:encodingNSString.get()]);
+        m_nsResponse = adoptNS([[NSURLResponse alloc] initWithURL:m_url.createNSURL().get() MIMEType:m_mimeType.createNSString().get() expectedContentLength:expectedContentLength textEncodingName:encodingNSString.get()]);
         return;
     }
 

--- a/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm
+++ b/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm
@@ -163,7 +163,7 @@ static NSDate * __nullable networkLoadMetricsDate(MonotonicTime time)
 @dynamic networkProtocolName;
 - (nullable NSString *)networkProtocolName
 {
-    return _metrics.protocol;
+    return _metrics.protocol.createNSString().autorelease();
 }
 
 @dynamic reusedConnection;

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -1285,10 +1285,10 @@ uint32_t BindGroup::dynamicOffset(uint32_t bindingIndex, const Vector<uint32_t>*
 
 void BindGroup::setLabel(String&& label)
 {
-    auto labelString = label;
-    m_vertexArgumentBuffer.label = labelString;
-    m_fragmentArgumentBuffer.label = labelString;
-    m_computeArgumentBuffer.label = labelString;
+    RetainPtr labelString = label.createNSString();
+    m_vertexArgumentBuffer.label = labelString.get();
+    m_fragmentArgumentBuffer.label = labelString.get();
+    m_computeArgumentBuffer.label = labelString.get();
 }
 
 bool BindGroup::allowedUsage(const OptionSet<BindGroupEntryUsage>& allowedUsage)

--- a/Source/WebGPU/WebGPU/BindGroupLayout.mm
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.mm
@@ -443,7 +443,7 @@ Ref<BindGroupLayout> Device::createBindGroupLayout(const WGPUBindGroupLayoutDesc
         }];
         argumentDescriptors[stage] = sortedArray;
         argumentEncoders[stage] = arguments[stage].get().count ? [m_device newArgumentEncoderWithArguments:sortedArray] : nil;
-        argumentEncoders[stage].label = label;
+        argumentEncoders[stage].label = label.createNSString().get();
         if (arguments[stage].get().count && !argumentEncoders[stage])
             return BindGroupLayout::createInvalid(*this);
     }
@@ -623,10 +623,10 @@ BindGroupLayout::~BindGroupLayout() = default;
 
 void BindGroupLayout::setLabel(String&& label)
 {
-    auto labelString = label;
-    m_vertexArgumentEncoder.label = labelString;
-    m_fragmentArgumentEncoder.label = labelString;
-    m_computeArgumentEncoder.label = labelString;
+    RetainPtr labelString = label.createNSString();
+    m_vertexArgumentEncoder.label = labelString.get();
+    m_fragmentArgumentEncoder.label = labelString.get();
+    m_computeArgumentEncoder.label = labelString.get();
 }
 
 NSUInteger BindGroupLayout::encodedLength(ShaderStage shaderStage) const

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -157,7 +157,7 @@ Ref<Buffer> Device::createBuffer(const WGPUBufferDescriptor& descriptor)
         return Buffer::createInvalid(*this);
     }
 
-    buffer.label = fromAPI(descriptor.label);
+    buffer.label = fromAPI(descriptor.label).createNSString().get();
 
     if (descriptor.mappedAtCreation)
         return Buffer::create(buffer, descriptor.size, descriptor.usage, Buffer::State::MappedAtCreation, { static_cast<size_t>(0), static_cast<size_t>(descriptor.size) }, *this);
@@ -427,7 +427,7 @@ void Buffer::unmap()
 
 void Buffer::setLabel(String&& label)
 {
-    m_buffer.label = label;
+    m_buffer.label = label.createNSString().get();
 }
 
 uint64_t Buffer::initialSize() const

--- a/Source/WebGPU/WebGPU/CommandBuffer.mm
+++ b/Source/WebGPU/WebGPU/CommandBuffer.mm
@@ -65,7 +65,7 @@ CommandBuffer::~CommandBuffer()
 
 void CommandBuffer::setLabel(String&& label)
 {
-    m_commandBuffer.label = label;
+    m_commandBuffer.label = label.createNSString().get();
 }
 
 void CommandBuffer::makeInvalid(NSString* lastError)

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -127,7 +127,7 @@ Ref<CommandEncoder> Device::createCommandEncoder(const WGPUCommandEncoderDescrip
     if (!commandBuffer)
         return CommandEncoder::createInvalid(*this);
 
-    commandBuffer.label = fromAPI(descriptor.label);
+    commandBuffer.label = fromAPI(descriptor.label).createNSString().get();
 
     auto commandEncoder = CommandEncoder::create(commandBuffer, *this, m_commandEncoderId++);
     m_commandEncoderMap.set(commandEncoder->uniqueId(), commandEncoder.ptr());
@@ -285,7 +285,7 @@ Ref<ComputePassEncoder> CommandEncoder::beginComputePass(const WGPUComputePassDe
 
     id<MTLComputeCommandEncoder> computeCommandEncoder = [m_commandBuffer computeCommandEncoderWithDescriptor:computePassDescriptor];
     setExistingEncoder(computeCommandEncoder);
-    computeCommandEncoder.label = fromAPI(descriptor.label);
+    computeCommandEncoder.label = fromAPI(descriptor.label).createNSString().get();
 
     return ComputePassEncoder::create(computeCommandEncoder, descriptor, *this, m_device);
 }
@@ -2079,7 +2079,7 @@ Ref<CommandBuffer> CommandEncoder::finish(const WGPUCommandBufferDescriptor& des
     m_commandBuffer = nil;
     m_existingCommandEncoder = nil;
 
-    commandBuffer.label = fromAPI(descriptor.label);
+    commandBuffer.label = fromAPI(descriptor.label).createNSString().get();
 
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
     if (m_managedBuffers.count || m_managedTextures.count) {
@@ -2115,7 +2115,7 @@ void CommandEncoder::insertDebugMarker(String&& markerLabel)
     finalizeBlitCommandEncoder();
 
     // There's no direct way of doing this, so we just push/pop an empty debug group.
-    [m_commandBuffer pushDebugGroup:markerLabel];
+    [m_commandBuffer pushDebugGroup:markerLabel.createNSString().get()];
     [m_commandBuffer popDebugGroup];
 }
 
@@ -2159,7 +2159,7 @@ void CommandEncoder::pushDebugGroup(String&& groupLabel)
     finalizeBlitCommandEncoder();
 
     ++m_debugGroupStackSize;
-    [m_commandBuffer pushDebugGroup:groupLabel];
+    [m_commandBuffer pushDebugGroup:groupLabel.createNSString().get()];
 }
 
 #if !ENABLE(WEBGPU_SWIFT)
@@ -2259,7 +2259,7 @@ void CommandEncoder::writeTimestamp(QuerySet& querySet, uint32_t queryIndex)
 
 void CommandEncoder::setLabel(String&& label)
 {
-    m_commandBuffer.label = label;
+    m_commandBuffer.label = label.createNSString().get();
 }
 
 void CommandEncoder::lock(bool shouldLock)

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -371,7 +371,7 @@ void ComputePassEncoder::insertDebugMarker(String&& markerLabel)
     if (!prepareTheEncoderState())
         return;
 
-    [m_computeCommandEncoder insertDebugSignpost:markerLabel];
+    [m_computeCommandEncoder insertDebugSignpost:markerLabel.createNSString().get()];
 }
 
 bool ComputePassEncoder::validatePopDebugGroup() const
@@ -427,7 +427,7 @@ void ComputePassEncoder::pushDebugGroup(String&& groupLabel)
         return;
 
     ++m_debugGroupStackSize;
-    [m_computeCommandEncoder pushDebugGroup:groupLabel];
+    [m_computeCommandEncoder pushDebugGroup:groupLabel.createNSString().get()];
 }
 
 static void setCommandEncoder(const BindGroupEntryUsageData::Resource& resource, CommandEncoder& parentEncoder)
@@ -508,7 +508,7 @@ void ComputePassEncoder::setPipeline(const ComputePipeline& pipeline)
 
 void ComputePassEncoder::setLabel(String&& label)
 {
-    m_computeCommandEncoder.label = label;
+    m_computeCommandEncoder.label = label.createNSString().get();
 }
 
 bool ComputePassEncoder::isValid() const

--- a/Source/WebGPU/WebGPU/ComputePipeline.mm
+++ b/Source/WebGPU/WebGPU/ComputePipeline.mm
@@ -91,11 +91,11 @@ std::pair<Ref<ComputePipeline>, NSString*> Device::createComputePipeline(const W
         return returnInvalidComputePipeline(*this, isAsync, @"GPUDevice.createComputePipeline: Pipeline layout is invalid");
 
     auto& deviceLimits = limits();
-    auto label = fromAPI(descriptor.label);
+    auto label = fromAPI(descriptor.label).createNSString();
     auto entryPointName = descriptor.compute.entryPoint ? fromAPI(descriptor.compute.entryPoint) : shaderModule->defaultComputeEntryPoint();
     NSError *error;
     BufferBindingSizesForPipeline minimumBufferSizes;
-    auto libraryCreationResult = createLibrary(m_device, shaderModule.get(), &pipelineLayout.get(), entryPointName, label, descriptor.compute.constantsSpan(), minimumBufferSizes, &error);
+    auto libraryCreationResult = createLibrary(m_device, shaderModule.get(), &pipelineLayout.get(), entryPointName.createNSString().get(), label.get(), descriptor.compute.constantsSpan(), minimumBufferSizes, &error);
     if (!libraryCreationResult || &pipelineLayout->device() != this)
         return returnInvalidComputePipeline(*this, isAsync, error.localizedDescription ?: @"Compute library failed creation");
 
@@ -107,7 +107,7 @@ std::pair<Ref<ComputePipeline>, NSString*> Device::createComputePipeline(const W
         return returnInvalidComputePipeline(*this, isAsync);
     WGSL::Reflection::Compute computeInformation = std::get<WGSL::Reflection::Compute>(entryPointInformation.typedEntryPoint);
 
-    auto function = createFunction(library, entryPointInformation, label);
+    auto function = createFunction(library, entryPointInformation, label.get());
     if (!function || function.functionType != MTLFunctionTypeKernel || entryPointInformation.specializationConstants.size() != wgslConstantValues.size())
         return returnInvalidComputePipeline(*this, isAsync);
 
@@ -129,11 +129,11 @@ std::pair<Ref<ComputePipeline>, NSString*> Device::createComputePipeline(const W
         auto generatedPipelineLayout = generatePipelineLayout(bindGroupEntries);
         if (!generatedPipelineLayout->isValid())
             return returnInvalidComputePipeline(*this, isAsync);
-        auto computePipelineState = createComputePipelineState(m_device, function, generatedPipelineLayout, size, label, shaderValidationState());
+        auto computePipelineState = createComputePipelineState(m_device, function, generatedPipelineLayout, size, label.get(), shaderValidationState());
         return std::make_pair(ComputePipeline::create(computePipelineState, WTFMove(generatedPipelineLayout), size, WTFMove(minimumBufferSizes), *this), nil);
     }
 
-    auto computePipelineState = createComputePipelineState(m_device, function, pipelineLayout, size, label, shaderValidationState());
+    auto computePipelineState = createComputePipelineState(m_device, function, pipelineLayout, size, label.get(), shaderValidationState());
     return std::make_pair(ComputePipeline::create(computePipelineState, WTFMove(pipelineLayout), size, WTFMove(minimumBufferSizes), *this), nil);
 }
 

--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -56,7 +56,7 @@ std::optional<LibraryCreationResult> createLibrary(id<MTLDevice> device, const S
     auto prepareResult = WGSL::prepare(*ast, entryPoint, wgslPipelineLayout ? &*wgslPipelineLayout : nullptr);
     if (std::holds_alternative<WGSL::Error>(prepareResult)) {
         auto wgslError = std::get<WGSL::Error>(prepareResult);
-        *error = [NSError errorWithDomain:@"WebGPU" code:1 userInfo:@{ NSLocalizedDescriptionKey: wgslError.message() }];
+        *error = [NSError errorWithDomain:@"WebGPU" code:1 userInfo:@{ NSLocalizedDescriptionKey: wgslError.message().createNSString().get() }];
         return std::nullopt;
     }
 
@@ -149,7 +149,7 @@ std::optional<LibraryCreationResult> createLibrary(id<MTLDevice> device, const S
 
     auto generationResult = WGSL::generate(*ast, result, wgslConstantValues);
     if (auto* generationError = std::get_if<WGSL::Error>(&generationResult)) {
-        *error = [NSError errorWithDomain:@"WebGPU" code:1 userInfo:@{ NSLocalizedDescriptionKey: generationError->message() }];
+        *error = [NSError errorWithDomain:@"WebGPU" code:1 userInfo:@{ NSLocalizedDescriptionKey: generationError->message().createNSString().get() }];
         return std::nullopt;
     }
     auto& msl = std::get<String>(generationResult);
@@ -164,7 +164,7 @@ std::optional<LibraryCreationResult> createLibrary(id<MTLDevice> device, const S
 id<MTLFunction> createFunction(id<MTLLibrary> library, const WGSL::Reflection::EntryPointInformation& entryPointInformation, NSString *label)
 {
     auto functionDescriptor = [MTLFunctionDescriptor new];
-    functionDescriptor.name = entryPointInformation.mangledName;
+    functionDescriptor.name = entryPointInformation.mangledName.createNSString().get();
     NSError *error = nil;
     id<MTLFunction> function = [library newFunctionWithDescriptor:functionDescriptor error:&error];
     if (error)

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -251,7 +251,7 @@ void PresentationContextIOSurface::configure(Device& device, const WGPUSwapChain
             textureDescriptor.usage = existingUsage;
             textureDescriptor.usage |= MTLTextureUsageShaderRead;
             id<MTLTexture> luminanceClampTexture = device.newTextureWithDescriptor(textureDescriptor);
-            luminanceClampTexture.label = fromAPI(descriptor.label);
+            luminanceClampTexture.label = fromAPI(descriptor.label).createNSString().get();
             auto viewFormats = descriptor.viewFormats;
             parentLuminanceClampTexture = Texture::create(luminanceClampTexture, wgpuTextureDescriptor, WTFMove(viewFormats), device);
             parentLuminanceClampTexture->makeCanvasBacking();
@@ -261,7 +261,7 @@ void PresentationContextIOSurface::configure(Device& device, const WGPUSwapChain
         }
 
         id<MTLTexture> texture = device.newTextureWithDescriptor(textureDescriptor, bridge_cast(iosurface));
-        texture.label = fromAPI(descriptor.label);
+        texture.label = fromAPI(descriptor.label).createNSString().get();
         auto viewFormats = descriptor.viewFormats;
         auto parentTexture = Texture::create(texture, wgpuTextureDescriptor, WTFMove(viewFormats), device);
         parentTexture->makeCanvasBacking();

--- a/Source/WebGPU/WebGPU/QuerySet.mm
+++ b/Source/WebGPU/WebGPU/QuerySet.mm
@@ -64,7 +64,7 @@ Ref<QuerySet> Device::createQuerySet(const WGPUQuerySetDescriptor& descriptor)
 #endif
     } case WGPUQueryType_Occlusion: {
         auto buffer = safeCreateBuffer(sizeof(uint64_t) * count, MTLStorageModePrivate);
-        buffer.label = fromAPI(label);
+        buffer.label = fromAPI(label).createNSString().get();
         return QuerySet::create(buffer, count, type, *this);
     }
     case WGPUQueryType_Force32:
@@ -126,7 +126,7 @@ void QuerySet::destroy()
 
 void QuerySet::setLabel(String&& label)
 {
-    m_visibilityBuffer.label = label;
+    m_visibilityBuffer.label = label.createNSString().get();
     // MTLCounterSampleBuffer's label property is read-only.
 }
 

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -1159,7 +1159,7 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint
 
 void Queue::setLabel(String&& label)
 {
-    m_commandQueue.label = label;
+    m_commandQueue.label = label.createNSString().get();
 }
 
 void Queue::scheduleWork(Instance::WorkItem&& workItem)

--- a/Source/WebGPU/WebGPU/RenderBundle.mm
+++ b/Source/WebGPU/WebGPU/RenderBundle.mm
@@ -80,7 +80,7 @@ bool RenderBundle::isValid() const
 
 void RenderBundle::setLabel(String&& label)
 {
-    m_renderBundlesResources.firstObject.indirectCommandBuffer.label = label;
+    m_renderBundlesResources.firstObject.indirectCommandBuffer.label = label.createNSString().get();
 }
 
 void RenderBundle::replayCommands(RenderPassEncoder& renderPassEncoder) const

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -1410,7 +1410,7 @@ void RenderBundleEncoder::setVertexBuffer(uint32_t slot, Buffer* optionalBuffer,
 
 void RenderBundleEncoder::setLabel(String&& label)
 {
-    m_indirectCommandBuffer.label = label;
+    m_indirectCommandBuffer.label = label.createNSString().get();
 }
 
 #undef RETURN_IF_FINISHED

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -1289,7 +1289,7 @@ void RenderPassEncoder::insertDebugMarker(String&& markerLabel)
     if (!prepareTheEncoderState())
         return;
 
-    [m_renderCommandEncoder insertDebugSignpost:markerLabel];
+    [m_renderCommandEncoder insertDebugSignpost:markerLabel.createNSString().get()];
 }
 
 bool RenderPassEncoder::validatePopDebugGroup() const
@@ -1343,7 +1343,7 @@ void RenderPassEncoder::pushDebugGroup(String&& groupLabel)
         return;
 
     ++m_debugGroupStackSize;
-    [m_renderCommandEncoder pushDebugGroup:groupLabel];
+    [m_renderCommandEncoder pushDebugGroup:groupLabel.createNSString().get()];
 }
 
 void RenderPassEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& group, std::span<const uint32_t> dynamicOffsets)
@@ -1551,7 +1551,7 @@ void RenderPassEncoder::setViewport(float x, float y, float width, float height,
 
 void RenderPassEncoder::setLabel(String&& label)
 {
-    m_renderCommandEncoder.label = label;
+    m_renderCommandEncoder.label = label.createNSString().get();
 }
 
 #undef CHECKED_SET_PSO

--- a/Source/WebGPU/WebGPU/Sampler.mm
+++ b/Source/WebGPU/WebGPU/Sampler.mm
@@ -197,7 +197,7 @@ static MTLSamplerDescriptor *createMetalDescriptorFromDescriptor(const WGPUSampl
     // https://developer.apple.com/documentation/metal/mtlsamplerdescriptor/1516164-maxanisotropy?language=objc
     // "Values must be between 1 and 16, inclusive."
     samplerDescriptor.maxAnisotropy = std::min<uint16_t>(descriptor.maxAnisotropy, 16);
-    samplerDescriptor.label = descriptor.label;
+    samplerDescriptor.label = descriptor.label.createNSString().get();
 
     return samplerDescriptor;
 }

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -94,16 +94,16 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
     // FIXME(PERFORMANCE): Run the asynchronous version of this
-    id<MTLLibrary> library = [device newLibraryWithSource:msl options:options error:error];
+    id<MTLLibrary> library = [device newLibraryWithSource:msl.createNSString().get() options:options error:error];
     if (error && *error) {
-        *error = [NSError errorWithDomain:@"WebGPU" code:1 userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to compile the shader source, generated metal:\n%@", (NSString*)msl] }];
+        *error = [NSError errorWithDomain:@"WebGPU" code:1 userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to compile the shader source, generated metal:\n%@", msl.createNSString().get()] }];
 #ifndef NDEBUG
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250442
         WTFLogAlways("MSL compilation error: %@", [*error localizedDescription]);
 #endif
         return nil;
     }
-    library.label = label;
+    library.label = label.createNSString().get();
     return library;
 }
 
@@ -784,7 +784,7 @@ void ShaderModule::getCompilationInfo(CompletionHandler<void(WGPUCompilationInfo
 void ShaderModule::setLabel(String&& label)
 {
     if (m_library)
-        m_library.label = label;
+        m_library.label = label.createNSString().get();
 }
 
 static auto wgslBindingType(WGPUBufferBindingType bindingType)

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -2642,7 +2642,7 @@ Ref<Texture> Device::createTexture(const WGPUTextureDescriptor& descriptor)
     }
 
     setOwnerWithIdentity(texture);
-    texture.label = fromAPI(descriptor.label);
+    texture.label = fromAPI(descriptor.label).createNSString().get();
 
     return Texture::create(texture, descriptor, WTFMove(viewFormats), *this);
 }
@@ -2973,7 +2973,7 @@ Ref<TextureView> Texture::createView(const WGPUTextureViewDescriptor& inputDescr
     if (!texture)
         return TextureView::createInvalid(*this, device.get());
 
-    texture.label = fromAPI(descriptor->label);
+    texture.label = fromAPI(descriptor->label).createNSString().get();
     if (!texture.label.length)
         texture.label = m_texture.label;
 
@@ -3242,7 +3242,7 @@ void Texture::destroy()
 
 void Texture::setLabel(String&& label)
 {
-    m_texture.label = label;
+    m_texture.label = label.createNSString().get();
 }
 
 WGPUExtent3D Texture::logicalMiplevelSpecificTextureExtent(uint32_t mipLevel)

--- a/Source/WebGPU/WebGPU/TextureView.mm
+++ b/Source/WebGPU/WebGPU/TextureView.mm
@@ -54,7 +54,7 @@ TextureView::~TextureView() = default;
 
 void TextureView::setLabel(String&& label)
 {
-    m_texture.label = label;
+    m_texture.label = label.createNSString().get();
 }
 
 id<MTLTexture> TextureView::parentTexture() const


### PR DESCRIPTION
#### 4ed02e53b7e088b92064523a3bdf83480904642d
<pre>
Reduce implicit conversion of String to NSString*
<a href="https://bugs.webkit.org/show_bug.cgi?id=291350">https://bugs.webkit.org/show_bug.cgi?id=291350</a>

Reviewed by Geoffrey Garen and Mike Wyrzykowski.

Reduce implicit conversion of String to NSString*. Use createNSString() instead, which makes
it clearer that we&apos;re allocating a new string and often avoid unnecessary autorelease.

* Source/JavaScriptCore/API/JSScript.mm:
(-[JSScript cacheBytecodeWithError:]):
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm:
(Inspector::RemoteInspector::listingForInspectionTarget const):
(Inspector::RemoteInspector::listingForAutomationTarget const):
* Source/WTF/wtf/cocoa/FileSystemCocoa.mm:
(WTF::FileSystemImpl::createTemporaryZipArchive):
(WTF::FileSystemImpl::extractTemporaryZipArchive):
* Source/WTF/wtf/cocoa/LanguageCocoa.mm:
(WTF::parseLocale):
* Source/WTF/wtf/cocoa/NSURLExtras.mm:
(WTF::URLWithUserTypedString):
(WTF::userVisibleString):
* Source/WTF/wtf/mac/FileSystemMac.mm:
(WTF::FileSystem::setMetadataURL):
* Source/WTF/wtf/text/AtomString.h:
* Source/WTF/wtf/text/WTFString.h:
(WTF::String::createNSString const):
* Source/WTF/wtf/text/cocoa/StringCocoa.mm:
(WTF::String::createNSString const): Deleted.
* Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm:
(WebCore::makeNSArrayElement):
(WebCore::applicationMetadataDictionary):
(WebCore::createPlatformConfiguration):
* Source/WebCore/Modules/applepay/PaymentRequestValidator.mm:
(WebCore::PaymentRequestValidator::validateTotal):
(WebCore::validateShippingMethod):
* Source/WebCore/PAL/pal/text/mac/KillRingMac.mm:
(PAL::KillRing::append):
(PAL::KillRing::prepend):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(-[WebAccessibilityObjectWrapperBase accessibilityCustomContent]):
(-[WebAccessibilityObjectWrapperBase baseAccessibilityHelpText]):
(-[WebAccessibilityObjectWrapperBase lineRectsAndText]):
(-[WebAccessibilityObjectWrapperBase ariaLandmarkRoleDescription]):
(-[WebAccessibilityObjectWrapperBase innerHTML]):
(-[WebAccessibilityObjectWrapperBase outerHTML]):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(roleString):
(subroleString):
(roleDescription):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:]):
(attributeValueForTesting):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):
* Source/WebCore/bridge/objc/WebScriptObject.mm:
(+[WebScriptObject _convertValueToObjcValue:originRootObject:rootObject:]):
* Source/WebCore/editing/cocoa/AttributedString.mm:
(WebCore::reconstructStyle):
(WebCore::toWebMultiRepresentationHEICAttachment):
* Source/WebCore/editing/cocoa/DictionaryLookup.mm:
(WebCore::DictionaryLookup::rangeForSelection):
(WebCore::DictionaryLookup::rangeAtHitTestResult):
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(HTMLConverter::computedAttributesForElement):
(HTMLConverter::_enterElement):
(HTMLConverter::_processElement):
(HTMLConverter::_exitElement):
(HTMLConverter::_processText):
(fileWrapperForURL):
(fileWrapperForElement):
(WebCore::editingAttributedStringInternal):
* Source/WebCore/editing/cocoa/WebArchiveResourceFromNSAttributedString.mm:
(WebCore::if):
(WebCore::ArchiveResource::create):
(-[WebArchiveResourceFromNSAttributedString MIMEType]):
* Source/WebCore/fileapi/FileCocoa.mm:
(WebCore::File::shouldReplaceFile):
* Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm:
(-[WebSpeechSynthesisWrapper speakUtterance:]):
* Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm:
(WebCore::SerializedPlatformDataCueValue::toNSDictionary const):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceFairPlayStreamingAVFObjC::supportsMediaCapability):
(WebCore::CDMInstanceFairPlayStreamingAVFObjC::setStorageDirectory):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::requestLicense):
* Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.mm:
(WebCore::InbandTextTrackPrivateAVFObjC::hasMediaCharacteristic const):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::assetCacheForPath):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayerItem):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setPlayerRate):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setPreservesPitch):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setPitchCorrectionAlgorithm):
(WebCore::MediaPlayerPrivateAVFoundationObjC::shouldWaitForLoadingOfResource):
(WebCore::MediaPlayerPrivateAVFoundationObjC::audioOutputDeviceChanged):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setRateDouble):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setPreservesPitch):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::audioOutputDeviceChanged):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm:
(WebCore::SourceBufferParserAVFObjC::isContentTypeSupported):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::addAudioRenderer):
* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm:
(WebCore::mediaSelectionOptions):
(WebCore::PlaybackSessionInterfaceAVKitLegacy::externalPlaybackChanged):
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::create):
* Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm:
(WebCore::ResourceResponse::initNSURLResponse const):
* Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm:
(-[WebCoreNSURLSessionTaskTransactionMetrics networkProtocolName]):
* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::BindGroup::setLabel):
* Source/WebGPU/WebGPU/BindGroupLayout.mm:
(WebGPU::Device::createBindGroupLayout):
(WebGPU::BindGroupLayout::setLabel):
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Device::createBuffer):
(WebGPU::Buffer::setLabel):
* Source/WebGPU/WebGPU/CommandBuffer.mm:
(WebGPU::CommandBuffer::setLabel):
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::Device::createCommandEncoder):
(WebGPU::CommandEncoder::beginComputePass):
(WebGPU::CommandEncoder::finish):
(WebGPU::CommandEncoder::insertDebugMarker):
(WebGPU::CommandEncoder::pushDebugGroup):
(WebGPU::CommandEncoder::setLabel):
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::insertDebugMarker):
(WebGPU::ComputePassEncoder::pushDebugGroup):
(WebGPU::ComputePassEncoder::setLabel):
* Source/WebGPU/WebGPU/ComputePipeline.mm:
* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::createLibrary):
(WebGPU::createFunction):
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::configure):
* Source/WebGPU/WebGPU/QuerySet.mm:
(WebGPU::Device::createQuerySet):
(WebGPU::QuerySet::setLabel):
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::setLabel):
* Source/WebGPU/WebGPU/RenderBundle.mm:
(WebGPU::RenderBundle::setLabel):
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::setLabel):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::insertDebugMarker):
(WebGPU::RenderPassEncoder::pushDebugGroup):
(WebGPU::RenderPassEncoder::setLabel):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
* Source/WebGPU/WebGPU/Sampler.mm:
(WebGPU::createMetalDescriptorFromDescriptor):
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::ShaderModule::createLibrary):
(WebGPU::ShaderModule::setLabel):
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Device::createTexture):
(WebGPU::Texture::createView):
(WebGPU::Texture::setLabel):
* Source/WebGPU/WebGPU/TextureView.mm:
(WebGPU::TextureView::setLabel):

Canonical link: <a href="https://commits.webkit.org/293555@main">https://commits.webkit.org/293555@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/333f4a651bccb60402254831220d11cbc586ae99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99236 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18883 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104365 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49833 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101276 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27317 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75537 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32631 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14569 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89605 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55898 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14361 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7583 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49195 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91919 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84292 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106722 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97855 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26349 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19208 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84497 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/content-with-child-with-transparent-background.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26712 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85806 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84013 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/21315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28668 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6346 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20074 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16145 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26289 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/31492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121470 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26110 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33936 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29423 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27677 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->