### PR TITLE
PDF should dispatch load event

### DIFF
--- a/LayoutTests/pdf/embed-loadevent-pdf.html
+++ b/LayoutTests/pdf/embed-loadevent-pdf.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <script src="../../resources/js-test.js"></script>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+   <p id="result"> </p>
+</body>
+<script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+       
+        function onEmbedLoad() {
+            document.getElementById("result").textContent = "PASS: load event fired on embed.";
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+        
+        window.addEventListener('load', async () => {
+            const embed = document.createElement("iframe");
+            embed.src = "./resources/fullscreen.pdf";
+            embed.addEventListener("load", onEmbedLoad, false);
+            embed.width = "600";
+            embed.height = "400";
+            document.body.appendChild(embed);
+        }, false);
+    </script>
+</html>

--- a/Source/WebCore/html/PDFDocument.cpp
+++ b/Source/WebCore/html/PDFDocument.cpp
@@ -39,6 +39,7 @@
 #include "HTMLIFrameElement.h"
 #include "HTMLLinkElement.h"
 #include "HTMLNames.h"
+#include "HTMLPlugInElement.h"
 #include "HTMLScriptElement.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
@@ -227,6 +228,12 @@ void PDFDocument::finishLoadingPDF()
     if (m_script) {
         m_script->removeEventListener(eventNames().loadEvent, *m_listener, { });
         m_script = nullptr;
+    }
+
+    if (frame() && frame()->ownerElement()) {
+        RefPtr pluginElement = downcast<HTMLPlugInElement>(frame()->ownerElement());
+        if (pluginElement)
+            pluginElement->dispatchEvent(Event::create(eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No));
     }
 
     m_listener = nullptr;


### PR DESCRIPTION
#### 2e49effa72489a5ea25e4294f1da4be72a71a2cb
<pre>
PDF should dispatch load event
<a href="https://bugs.webkit.org/show_bug.cgi?id=143673">https://bugs.webkit.org/show_bug.cgi?id=143673</a>

Reviewed by NOBODY (OOPS!).

Match this behaviour with other browsers.
PDF loading was not dispatching load event after the file was loaded.

* LayoutTests/pdf/embed-loadevent-pdf.html: Added.
* Source/WebCore/html/PDFDocument.cpp:
(WebCore::PDFDocument::finishLoadingPDF):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e49effa72489a5ea25e4294f1da4be72a71a2cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104267 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49727 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101186 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19078 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27226 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75458 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32572 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102151 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14493 "Found 1 new test failure: fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89520 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55819 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14286 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7496 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49103 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84210 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7583 "Found 1 new test failure: pdf/embed-loadevent-pdf.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106630 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26255 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19125 "Found 1 new test failure: pdf/embed-loadevent-pdf.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84415 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26618 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85724 "Exiting early after 10 failures. 10 tests run. 1 missing results") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83932 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28590 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6266 "Found 1 new test failure: pdf/embed-loadevent-pdf.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19968 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26196 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31377 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26017 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29330 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27583 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->