### PR TITLE
Add support for `SVGImageElement.decoding`

### DIFF
--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -3,7 +3,7 @@
  * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009 Rob Buis <buis@kde.org>
  * Copyright (C) 2006 Alexander Kellett <lypanov@kde.org>
  * Copyright (C) 2014 Adobe Systems Incorporated. All rights reserved.
- * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -222,6 +222,34 @@ void SVGImageElement::didMoveToNewDocument(Document& oldDocument, Document& newD
 void SVGImageElement::decode(Ref<DeferredPromise>&& promise)
 {
     return m_imageLoader.decode(WTFMove(promise));
+}
+
+void SVGImageElement::setDecoding(AtomString&& decodingMode)
+{
+    setAttributeWithoutSynchronization(SVGNames::decodingAttr, WTFMove(decodingMode));
+}
+
+String SVGImageElement::decoding() const
+{
+    switch (decodingMode()) {
+    case DecodingMode::Auto:
+        break;
+    case DecodingMode::Synchronous:
+        return "sync"_s;
+    case DecodingMode::Asynchronous:
+        return "async"_s;
+    }
+    return autoAtom();
+}
+
+DecodingMode SVGImageElement::decodingMode() const
+{
+    const AtomString& decodingMode = attributeWithoutSynchronization(SVGNames::decodingAttr);
+    if (equalLettersIgnoringASCIICase(decodingMode, "sync"_s))
+        return DecodingMode::Synchronous;
+    if (equalLettersIgnoringASCIICase(decodingMode, "async"_s))
+        return DecodingMode::Asynchronous;
+    return DecodingMode::Auto;
 }
 
 }

--- a/Source/WebCore/svg/SVGImageElement.h
+++ b/Source/WebCore/svg/SVGImageElement.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2006, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006 Rob Buis <buis@kde.org>
- * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -56,6 +56,10 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGImageElement, SVGGraphicsElement, SVGURIReference>;
 
     void decode(Ref<DeferredPromise>&&);
+
+    void setDecoding(AtomString&&);
+    String decoding() const;
+    DecodingMode decodingMode() const;
 
 private:
     SVGImageElement(const QualifiedName&, Document&);

--- a/Source/WebCore/svg/SVGImageElement.idl
+++ b/Source/WebCore/svg/SVGImageElement.idl
@@ -34,6 +34,7 @@
     readonly attribute SVGAnimatedPreserveAspectRatio preserveAspectRatio;
     [CEReactions=NotNeeded] attribute [AtomString] DOMString? crossOrigin;
 
+    [CEReactions=NotNeeded] attribute [AtomString] DOMString decoding;
     Promise<undefined> decode();
 };
 

--- a/Source/WebCore/svg/svgattrs.in
+++ b/Source/WebCore/svg/svgattrs.in
@@ -33,6 +33,7 @@ cursor
 cx
 cy
 d
+decoding
 descent
 diffuseConstant
 direction


### PR DESCRIPTION
#### eab4dc720b8b7b665a20f280406dee7b709d72b9
<pre>
Add support for `SVGImageElement.decoding`
<a href="https://bugs.webkit.org/show_bug.cgi?id=291352">https://bugs.webkit.org/show_bug.cgi?id=291352</a>
<a href="https://rdar.apple.com/148970013">rdar://148970013</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Blink / Chromium, Gecko / Firefox
and Web Specification [1]:

[1] <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-decoding">https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-decoding</a>

This patch adds `decoding` support similar to HTMLImageElement, which was
added in 196437@main (193156@main - &apos;async&apos; before rename), now for SVGImageElement.

* Source/WebCore/svg/SVGImageElement.cpp:
(WebCore::SVGImageElement::setDecoding):
(WebCore::SVGImageElement::decoding const):
(WebCore::SVGImageElement::decodingMode const):
* Source/WebCore/svg/SVGImageElement.h:
* Source/WebCore/svg/SVGImageElement.idl:
* Source/WebCore/svg/svgattrs.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eab4dc720b8b7b665a20f280406dee7b709d72b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99158 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18801 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104279 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49739 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101198 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19090 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27238 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75468 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32585 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14505 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89533 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55834 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14298 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7509 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49115 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84222 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106642 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26267 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19137 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84429 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26630 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85737 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83945 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28601 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6279 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19982 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26208 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31389 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26029 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29342 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27595 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->