### PR TITLE
Reduce unsafe lambdas in WebCore/html

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -67,15 +67,7 @@ dom/ViewTransition.cpp
 dom/ViewportArguments.cpp
 editing/Editor.cpp
 html/FormAssociatedCustomElement.cpp
-html/HTMLImageElement.cpp
-html/HTMLMediaElement.cpp
-html/HTMLTextFormControlElement.cpp
-html/HTMLTrackElement.cpp
-html/NumberInputType.cpp
 html/canvas/CanvasRenderingContext2DBase.cpp
-html/canvas/CanvasStyle.cpp
-html/canvas/GPUCanvasContextCocoa.mm
-html/track/LoadableTextTrack.cpp
 html/track/TrackBase.cpp
 inspector/InspectorOverlay.cpp
 inspector/agents/page/PageDOMDebuggerAgent.cpp

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.h
@@ -68,7 +68,7 @@ WebCore::Color consumeColorRaw(CSSParserTokenRange&, CSS::PropertyParserState&, 
 WEBCORE_EXPORT WebCore::Color parseColorRawSlow(const String&, const CSSParserContext&, const CSSColorParsingOptions&, CSS::PlatformColorResolutionState&);
 
 // NOTE: Callers must include CSSPropertyParserConsumer+ColorInlines.h to use this.
-template<typename F> WebCore::Color parseColorRaw(const String&, const CSSParserContext&, F&& lazySlowPathOptionsFunctor);
+template<typename F> WebCore::Color parseColorRaw(const String&, const CSSParserContext&, NOESCAPE const F& lazySlowPathOptionsFunctor);
 
 // FIXME: All callers are not getting the right Settings, keyword resolution and calc resolution
 // when using this function and should switch to parseColorRaw().

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorInlines.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorInlines.h
@@ -33,7 +33,7 @@ namespace CSSPropertyParserHelpers {
 
 // MARK: <color> parsing (raw)
 
-template<typename F> WebCore::Color parseColorRaw(const String& string, const CSSParserContext& context, F&& lazySlowPathOptionsFunctor)
+template<typename F> WebCore::Color parseColorRaw(const String& string, const CSSParserContext& context, NOESCAPE const F& lazySlowPathOptionsFunctor)
 {
     if (auto color = CSSParserFastPaths::parseSimpleColor(string, context))
         return *color;

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1079,7 +1079,7 @@ private:
     bool ensureMediaControls();
 
     using JSSetupFunction = Function<bool(JSDOMGlobalObject&, JSC::JSGlobalObject&, ScriptController&, DOMWrapperWorld&)>;
-    bool setupAndCallJS(const JSSetupFunction&);
+    bool setupAndCallJS(NOESCAPE const JSSetupFunction&);
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     void prepareForDocumentSuspension() final;

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -804,7 +804,7 @@ String HTMLTextFormControlElement::valueWithHardLineBreaks() const
     if (!renderer)
         return value();
 
-    Node* breakNode = nullptr;
+    RefPtr<Node> breakNode;
     unsigned breakOffset = 0;
     auto currentLineBox = InlineIterator::firstLineBoxFor(*renderer);
     if (!currentLineBox)

--- a/Source/WebCore/html/HTMLTrackElement.cpp
+++ b/Source/WebCore/html/HTMLTrackElement.cpp
@@ -190,39 +190,39 @@ void HTMLTrackElement::scheduleLoad()
 
     // 4. Run the remainder of these steps asynchronously, allowing whatever caused these steps to run to continue.
     m_loadPending = true;
-    scheduleTask([this]() mutable {
+    scheduleTask([](auto& track) mutable {
 
-        SetForScope loadPending { m_loadPending, true, false };
+        SetForScope loadPending { track.m_loadPending, true, false };
 
-        if (!hasAttributeWithoutSynchronization(srcAttr)) {
-            track().removeAllCues();
+        if (!track.hasAttributeWithoutSynchronization(srcAttr)) {
+            track.track().removeAllCues();
             return;
         }
 
         // 6. Set the text track readiness state to loading.
-        setReadyState(HTMLTrackElement::LOADING);
+        track.setReadyState(HTMLTrackElement::LOADING);
 
         // 7. Let URL be the track URL of the track element.
-        URL trackURL = getNonEmptyURLAttribute(srcAttr);
+        URL trackURL = track.getNonEmptyURLAttribute(srcAttr);
 
         // ... if URL is the empty string, then queue a task to first change the text track readiness state
         // to failed to load and then fire an event named error at the track element.
         // 8. If the track element's parent is a media element then let CORS mode be the state of the parent media
         // element's crossorigin content attribute. Otherwise, let CORS mode be No CORS.
-        if (!canLoadURL(trackURL)) {
-            track().removeAllCues();
-            didCompleteLoad(HTMLTrackElement::Failure);
+        if (!track.canLoadURL(trackURL)) {
+            track.track().removeAllCues();
+            track.didCompleteLoad(HTMLTrackElement::Failure);
             return;
         }
 
-        m_track->scheduleLoad(trackURL);
+        track.m_track->scheduleLoad(trackURL);
     });
 }
 
-void HTMLTrackElement::scheduleTask(Function<void()>&& task)
+void HTMLTrackElement::scheduleTask(Function<void(HTMLTrackElement&)>&& task)
 {
-    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [task = WTFMove(task)](auto&) mutable {
-        task();
+    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [task = WTFMove(task)](auto& track) mutable {
+        task(track);
     });
 }
 

--- a/Source/WebCore/html/HTMLTrackElement.h
+++ b/Source/WebCore/html/HTMLTrackElement.h
@@ -72,7 +72,7 @@ public:
     RefPtr<HTMLMediaElement> mediaElement() const;
     const AtomString& mediaElementCrossOriginAttribute() const;
 
-    void scheduleTask(Function<void()>&&);
+    void scheduleTask(Function<void(HTMLTrackElement&)>&&);
 
 private:
     HTMLTrackElement(const QualifiedName&, Document&);

--- a/Source/WebCore/html/NumberInputType.cpp
+++ b/Source/WebCore/html/NumberInputType.cpp
@@ -147,11 +147,11 @@ StepRange NumberInputType::createStepRange(AnyStepHandling anyStepHandling) cons
     const Decimal stepBase = findStepBase(numberDefaultStepBase);
 
     const Decimal doubleMax = Decimal::doubleMax();
-    const Element& element = *this->element();
+    Ref element = *this->element();
 
     RangeLimitations rangeLimitations = RangeLimitations::Invalid;
     auto extractBound = [&] (const QualifiedName& attributeName, const Decimal& defaultValue) -> Decimal {
-        const AtomString& attributeValue = element.attributeWithoutSynchronization(attributeName);
+        const AtomString& attributeValue = element->attributeWithoutSynchronization(attributeName);
         Decimal valueFromAttribute = parseToNumberOrNaN(attributeValue);
         if (valueFromAttribute.isFinite()) {
             rangeLimitations = RangeLimitations::Valid;
@@ -162,7 +162,7 @@ StepRange NumberInputType::createStepRange(AnyStepHandling anyStepHandling) cons
     Decimal minimum = extractBound(minAttr, -doubleMax);
     Decimal maximum = extractBound(maxAttr, doubleMax);
 
-    const Decimal step = StepRange::parseStep(anyStepHandling, stepDescription, element.attributeWithoutSynchronization(stepAttr));
+    const Decimal step = StepRange::parseStep(anyStepHandling, stepDescription, element->attributeWithoutSynchronization(stepAttr));
     return StepRange(stepBase, rangeLimitations, minimum, maximum, step, stepDescription);
 }
 

--- a/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
@@ -294,7 +294,7 @@ static ImageCandidate pickBestImageCandidate(float deviceScaleFactor, Vector<Ima
     return imageCandidates[winner];
 }
 
-ImageCandidate bestFitSourceForImageAttributes(float deviceScaleFactor, const AtomString& srcAttribute, StringView srcsetAttribute, float sourceSize, Function<bool(const ImageCandidate&)>&& shouldIgnoreCandidateCallback)
+ImageCandidate bestFitSourceForImageAttributes(float deviceScaleFactor, const AtomString& srcAttribute, StringView srcsetAttribute, float sourceSize, NOESCAPE const Function<bool(const ImageCandidate&)>& shouldIgnoreCandidateCallback)
 {
     if (srcsetAttribute.isNull()) {
         if (srcAttribute.isNull())

--- a/Source/WebCore/html/parser/HTMLSrcsetParser.h
+++ b/Source/WebCore/html/parser/HTMLSrcsetParser.h
@@ -108,7 +108,7 @@ struct ImageCandidate {
     OriginAttribute originAttribute;
 };
 
-ImageCandidate bestFitSourceForImageAttributes(float deviceScaleFactor, const AtomString& srcAttribute, StringView srcsetAttribute, float sourceSize, Function<bool(const ImageCandidate&)>&& shouldIgnoreCandidateCallback = { });
+ImageCandidate bestFitSourceForImageAttributes(float deviceScaleFactor, const AtomString& srcAttribute, StringView srcsetAttribute, float sourceSize, NOESCAPE const Function<bool(const ImageCandidate&)>& shouldIgnoreCandidateCallback = { });
 
 Vector<ImageCandidate> parseImageCandidatesFromSrcsetAttribute(StringView attribute);
 void getURLsFromSrcsetAttribute(const Element&, StringView attribute, ListHashSet<URL>&);

--- a/Source/WebCore/html/track/LoadableTextTrack.cpp
+++ b/Source/WebCore/html/track/LoadableTextTrack.cpp
@@ -77,7 +77,7 @@ void LoadableTextTrack::scheduleLoad(const URL& url)
     
     // 3. Asynchronously run the remaining steps, while continuing with whatever task
     // was responsible for creating the text track or changing the text track mode.
-    m_trackElement->scheduleTask([this]() mutable {
+    m_trackElement->scheduleTask([this, protectedThis = Ref { *this }](auto&) mutable {
         SetForScope loadPending { m_loadPending, true, false };
 
         if (m_loader)


### PR DESCRIPTION
#### 96237f350480d4ad040b00c3f780a242d015138e
<pre>
Reduce unsafe lambdas in WebCore/html
<a href="https://bugs.webkit.org/show_bug.cgi?id=291355">https://bugs.webkit.org/show_bug.cgi?id=291355</a>

Reviewed by Chris Dumez.

As per Safer CPP Guidelines:

- <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#capture-protectedthis-or-weakthis-in-asynchronous-lambdas-where-you-need-to-use-this">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#capture-protectedthis-or-weakthis-in-asynchronous-lambdas-where-you-need-to-use-this</a>
- <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#annotate-noescape-when-a-function-uses-a-lambda-synchronously">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#annotate-noescape-when-a-function-uses-a-lambda-synchronously</a>

* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorInlines.h:
(WebCore::CSSPropertyParserHelpers::parseColorRaw):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::loadResource):
(WebCore::HTMLMediaElement::updateActiveTextTrackCues):
(WebCore::HTMLMediaElement::setNetworkState):
(WebCore::HTMLMediaElement::progressEventTimerFired):
(WebCore::HTMLMediaElement::setupAndCallJS):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::valueWithHardLineBreaks const):
* Source/WebCore/html/HTMLTrackElement.cpp:
(WebCore::HTMLTrackElement::scheduleLoad):
(WebCore::HTMLTrackElement::scheduleTask):
* Source/WebCore/html/HTMLTrackElement.h:
* Source/WebCore/html/NumberInputType.cpp:
(WebCore::NumberInputType::createStepRange const):
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::surfaceBufferToImageBuffer):
(WebCore::GPUCanvasContextCocoa::prepareForDisplay):
* Source/WebCore/html/parser/HTMLSrcsetParser.cpp:
(WebCore::bestFitSourceForImageAttributes):
* Source/WebCore/html/parser/HTMLSrcsetParser.h:
(WebCore::bestFitSourceForImageAttributes):
* Source/WebCore/html/track/LoadableTextTrack.cpp:
(WebCore::LoadableTextTrack::scheduleLoad):

Canonical link: <a href="https://commits.webkit.org/293583@main">https://commits.webkit.org/293583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d433e412848139bb4af0850c882adb9d6f37f0fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9255 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/104486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/49956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101396 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27438 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/104486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/49956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102362 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/14669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/89703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/104486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/14463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/7685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/49316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/7772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/106843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26469 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/106843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26831 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/85906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/106843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/28760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/6447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/20212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16161 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/26409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/31609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/26229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/29542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/27796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->