### PR TITLE
[GTK][WPE] Make Damage iterable

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperDamageVisualizer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperDamageVisualizer.cpp
@@ -52,7 +52,7 @@ void TextureMapperDamageVisualizer::paintDamage(TextureMapper& textureMapper, co
         return;
 
     const auto color = Color::red.colorWithAlphaByte(200);
-    for (const auto& rect : damage->rects())
+    for (const auto& rect : *damage)
         textureMapper.drawSolidColor(rect + m_margin, { }, color, true);
 }
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -504,17 +504,13 @@ void TextureMapperLayer::collectDamageSelf(TextureMapperPaintOptions& options, D
     // layer-level operations such as resizes, transformations, etc.
     const auto& clipBounds = options.textureMapper.clipBounds();
     if (m_damageInGlobalCoordinateSpace) {
-        for (const auto& rect : m_damageInGlobalCoordinateSpace->rects()) {
-            if (!rect.isEmpty())
-                damage.add(intersection(rect, clipBounds));
-        }
+        for (const auto& rect : *m_damageInGlobalCoordinateSpace)
+            damage.add(intersection(rect, clipBounds));
     }
 
     if (m_damageInLayerCoordinateSpace) {
-        for (const auto& rect : m_damageInLayerCoordinateSpace->rects()) {
-            if (!rect.isEmpty())
-                damage.add(intersection(transformRectFromLayerToGlobalCoordinateSpace(rect, transform, options), clipBounds));
-        }
+        for (const auto& rect : *m_damageInLayerCoordinateSpace)
+            damage.add(intersection(transformRectFromLayerToGlobalCoordinateSpace(rect, transform, options), clipBounds));
     }
 }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
@@ -91,11 +91,9 @@ void CoordinatedBackingStore::paintToTextureMapper(TextureMapper& textureMapper,
             // area significantly in many cases.
             const auto tileIntRect = enclosingIntRect(tile.rect());
             Damage tileDamage(tileIntRect);
-            for (const auto& damageRect : frameDamage->rects()) {
-                if (damageRect.isEmpty())
-                    continue;
+            for (const auto& damageRect : *frameDamage)
                 tileDamage.add(intersection(tileIntRect, damageRect));
-            }
+
             for (const auto& tileDamageRect : tileDamage.rectsForPainting()) {
                 const auto sourceRect = FloatRect { FloatPoint { tileDamageRect.location() - tile.rect().location() }, tileDamageRect.size() };
                 textureMapper.drawTextureFragment(tile.texture(), sourceRect, tileDamageRect);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -552,12 +552,8 @@ void CoordinatedPlatformLayer::setContentsTilePhase(const FloatSize& contentsTil
 void CoordinatedPlatformLayer::setDirtyRegion(Damage&& damage)
 {
     ASSERT(m_lock.isHeld());
-    // FIXME: add a way to remove the empty rects from Damage class.
-    auto dirtyRegion = WTF::compactMap(damage.rects(), [](const auto& value) -> std::optional<IntRect> {
-        if (value.isEmpty())
-            return std::nullopt;
-        return value;
-    });
+
+    auto dirtyRegion = damage.copyToVector();
     if (m_dirtyRegion != dirtyRegion) {
         m_dirtyRegion = WTFMove(dirtyRegion);
         notifyCompositionRequired();

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
@@ -681,7 +681,7 @@ void AcceleratedSurfaceDMABuf::didRenderFrame()
 #if ENABLE(DAMAGE_TRACKING)
     m_target->setDamage(WebCore::Damage(m_size));
     if (m_frameDamage) {
-        damageRects = m_frameDamage->rects();
+        damageRects = m_frameDamage->copyToVector();
         m_frameDamage = std::nullopt;
     }
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
@@ -36,7 +36,7 @@ TEST(Damage, Basics)
 {
     Damage damage(IntSize { 2048, 1024 });
     EXPECT_TRUE(damage.isEmpty());
-    EXPECT_EQ(damage.rects().size(), 0);
+    EXPECT_EQ(damage.size(), 0);
 }
 
 TEST(Damage, Mode)
@@ -47,7 +47,7 @@ TEST(Damage, Mode)
     EXPECT_TRUE(rectsDamage.add(IntRect { 100, 100, 200, 200 }));
     EXPECT_TRUE(rectsDamage.add(IntRect { 300, 300, 200, 200 }));
     EXPECT_FALSE(rectsDamage.isEmpty());
-    EXPECT_EQ(rectsDamage.rects().size(), 2);
+    EXPECT_EQ(rectsDamage.size(), 2);
     EXPECT_EQ(rectsDamage.bounds().x(), 100);
     EXPECT_EQ(rectsDamage.bounds().y(), 100);
     EXPECT_EQ(rectsDamage.bounds().width(), 400);
@@ -59,8 +59,8 @@ TEST(Damage, Mode)
     EXPECT_TRUE(bboxDamage.add(IntRect { 100, 100, 200, 200 }));
     EXPECT_TRUE(bboxDamage.add(IntRect { 300, 300, 200, 200 }));
     EXPECT_FALSE(bboxDamage.isEmpty());
-    EXPECT_EQ(bboxDamage.rects().size(), 1);
-    EXPECT_EQ(bboxDamage.rects()[0], bboxDamage.bounds());
+    EXPECT_EQ(bboxDamage.size(), 1);
+    EXPECT_EQ(bboxDamage[0], bboxDamage.bounds());
     EXPECT_EQ(bboxDamage.bounds().x(), 100);
     EXPECT_EQ(bboxDamage.bounds().y(), 100);
     EXPECT_EQ(bboxDamage.bounds().width(), 400);
@@ -72,8 +72,8 @@ TEST(Damage, Mode)
     EXPECT_FALSE(fullDamage.add(IntRect { 100, 100, 200, 200 }));
     EXPECT_FALSE(fullDamage.add(IntRect { 300, 300, 200, 200 }));
     EXPECT_FALSE(fullDamage.isEmpty());
-    EXPECT_EQ(fullDamage.rects().size(), 1);
-    EXPECT_EQ(fullDamage.rects()[0], fullDamage.bounds());
+    EXPECT_EQ(fullDamage.size(), 1);
+    EXPECT_EQ(fullDamage[0], fullDamage.bounds());
     EXPECT_EQ(fullDamage.bounds().x(), 0);
     EXPECT_EQ(fullDamage.bounds().y(), 0);
     EXPECT_EQ(fullDamage.bounds().width(), 1024);
@@ -85,8 +85,8 @@ TEST(Damage, Mode)
     fullDamage.makeFull();
     EXPECT_TRUE(fullDamage.mode() == Damage::Mode::Full);
     EXPECT_FALSE(fullDamage.isEmpty());
-    EXPECT_EQ(fullDamage.rects().size(), 1);
-    EXPECT_EQ(fullDamage.rects()[0], fullDamage.bounds());
+    EXPECT_EQ(fullDamage.size(), 1);
+    EXPECT_EQ(fullDamage[0], fullDamage.bounds());
     EXPECT_EQ(fullDamage.bounds().x(), 0);
     EXPECT_EQ(fullDamage.bounds().y(), 0);
     EXPECT_EQ(fullDamage.bounds().width(), 1024);
@@ -98,7 +98,7 @@ TEST(Damage, Mode)
     EXPECT_TRUE(fullDamage.add(IntRect { 0, 0, 1024, 768 }));
     EXPECT_TRUE(fullDamage.mode() == Damage::Mode::Full);
     EXPECT_FALSE(fullDamage.isEmpty());
-    EXPECT_EQ(fullDamage.rects().size(), 1);
+    EXPECT_EQ(fullDamage.size(), 1);
     EXPECT_EQ(fullDamage.bounds().x(), 0);
     EXPECT_EQ(fullDamage.bounds().y(), 0);
     EXPECT_EQ(fullDamage.bounds().width(), 1024);
@@ -110,7 +110,7 @@ TEST(Damage, Mode)
     EXPECT_TRUE(fullDamage.add(IntRect { 0, 0, 2048, 1024 }));
     EXPECT_TRUE(fullDamage.mode() == Damage::Mode::Full);
     EXPECT_FALSE(fullDamage.isEmpty());
-    EXPECT_EQ(fullDamage.rects().size(), 1);
+    EXPECT_EQ(fullDamage.size(), 1);
     EXPECT_EQ(fullDamage.bounds().x(), 0);
     EXPECT_EQ(fullDamage.bounds().y(), 0);
     EXPECT_EQ(fullDamage.bounds().width(), 1024);
@@ -126,7 +126,7 @@ TEST(Damage, Mode)
     }));
     EXPECT_TRUE(fullDamage.mode() == Damage::Mode::Full);
     EXPECT_FALSE(fullDamage.isEmpty());
-    EXPECT_EQ(fullDamage.rects().size(), 1);
+    EXPECT_EQ(fullDamage.size(), 1);
     EXPECT_EQ(fullDamage.bounds().x(), 0);
     EXPECT_EQ(fullDamage.bounds().y(), 0);
     EXPECT_EQ(fullDamage.bounds().width(), 1024);
@@ -145,7 +145,7 @@ TEST(Damage, Mode)
     }));
     EXPECT_TRUE(fullDamage.mode() == Damage::Mode::Full);
     EXPECT_FALSE(fullDamage.isEmpty());
-    EXPECT_EQ(fullDamage.rects().size(), 1);
+    EXPECT_EQ(fullDamage.size(), 1);
     EXPECT_EQ(fullDamage.bounds().x(), 0);
     EXPECT_EQ(fullDamage.bounds().y(), 0);
     EXPECT_EQ(fullDamage.bounds().width(), 512);
@@ -158,7 +158,7 @@ TEST(Damage, Mode)
     EXPECT_TRUE(fullDamage.add(fullDamage2));
     EXPECT_TRUE(fullDamage.mode() == Damage::Mode::Full);
     EXPECT_FALSE(fullDamage.isEmpty());
-    EXPECT_EQ(fullDamage.rects().size(), 1);
+    EXPECT_EQ(fullDamage.size(), 1);
     EXPECT_EQ(fullDamage.bounds().x(), 0);
     EXPECT_EQ(fullDamage.bounds().y(), 0);
     EXPECT_EQ(fullDamage.bounds().width(), 1024);
@@ -171,7 +171,7 @@ TEST(Damage, Move)
     EXPECT_TRUE(damage.add(IntRect { 100, 100, 200, 200 }));
     EXPECT_TRUE(damage.add(IntRect { 300, 300, 200, 200 }));
     EXPECT_FALSE(damage.isEmpty());
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
     EXPECT_EQ(damage.bounds().x(), 100);
     EXPECT_EQ(damage.bounds().y(), 100);
     EXPECT_EQ(damage.bounds().width(), 400);
@@ -179,13 +179,13 @@ TEST(Damage, Move)
 
     Damage other = WTFMove(damage);
     EXPECT_FALSE(other.isEmpty());
-    EXPECT_EQ(other.rects().size(), 2);
+    EXPECT_EQ(other.size(), 2);
     EXPECT_EQ(other.bounds().x(), 100);
     EXPECT_EQ(other.bounds().y(), 100);
     EXPECT_EQ(other.bounds().width(), 400);
     EXPECT_EQ(other.bounds().height(), 400);
     EXPECT_TRUE(damage.isEmpty());
-    EXPECT_EQ(damage.rects().size(), 0);
+    EXPECT_EQ(damage.size(), 0);
     EXPECT_EQ(damage.bounds().x(), 100);
     EXPECT_EQ(damage.bounds().y(), 100);
     EXPECT_EQ(damage.bounds().width(), 400);
@@ -196,7 +196,7 @@ TEST(Damage, AddRect)
 {
     Damage damage(IntSize { 2048, 1024 });
     EXPECT_TRUE(damage.add(IntRect { 100, 100, 200, 200 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
 
     // When there's only one rect, that should be the bounds.
     EXPECT_EQ(damage.bounds().x(), 100);
@@ -207,15 +207,15 @@ TEST(Damage, AddRect)
     // When there's only one rect, adding a rect already contained
     // by the bounding box does nothing.
     EXPECT_FALSE(damage.add(IntRect { 150, 150, 100, 100 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
 
     // Adding an empty rect does nothing.
     EXPECT_FALSE(damage.add(IntRect { }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
 
     // Adding a new rect not contained by previous one adds it to the list.
     EXPECT_TRUE(damage.add(IntRect { 300, 300, 200, 200 }));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
 
     // Now the bounding box contains the two rectangles.
     EXPECT_EQ(damage.bounds().x(), 100);
@@ -225,7 +225,7 @@ TEST(Damage, AddRect)
 
     // Adding a rect containing the bounds makes it the only rect.
     EXPECT_TRUE(damage.add(IntRect { 50, 50, 500, 500 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_EQ(damage.bounds().x(), 50);
     EXPECT_EQ(damage.bounds().y(), 50);
     EXPECT_EQ(damage.bounds().width(), 500);
@@ -233,31 +233,31 @@ TEST(Damage, AddRect)
 
     // Adding FloatRect takes the enclosingIntRect
     EXPECT_TRUE(damage.add(FloatRect { 1024.50, 1024.25, 50.32, 25.75 }));
-    EXPECT_EQ(damage.rects().size(), 2);
-    EXPECT_EQ(damage.rects().last().x(), 1024);
-    EXPECT_EQ(damage.rects().last().y(), 1024);
-    EXPECT_EQ(damage.rects().last().width(), 51);
-    EXPECT_EQ(damage.rects().last().height(), 26);
+    EXPECT_EQ(damage.size(), 2);
+    EXPECT_EQ(damage[1].x(), 1024);
+    EXPECT_EQ(damage[1].y(), 1024);
+    EXPECT_EQ(damage[1].width(), 51);
+    EXPECT_EQ(damage[1].height(), 26);
 
     // Adding an empty FloatRect does nothing.
     EXPECT_FALSE(damage.add(FloatRect { 1024.50, 1024.25, 0, 0 }));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
 }
 
 TEST(Damage, AddRects)
 {
     Damage damage(IntSize { 2048, 1024 });
     EXPECT_TRUE(damage.add(Vector<IntRect, 1> { { 100, 100, 200, 200 } }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_EQ(damage.bounds(), IntRect(100, 100, 200, 200));
 
     // Adding an empty Vector does nothing.
     EXPECT_FALSE(damage.add(Vector<IntRect, 1> { }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
 
     // Adding a Vector with empty rets does nothing.
     EXPECT_FALSE(damage.add(Vector<IntRect, 1> { { }, { } }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
 
     // Adding more than 4 rectangles will unite.
     damage = Damage(IntSize { 512, 512 });
@@ -268,8 +268,8 @@ TEST(Damage, AddRects)
         { 200, 200, 4, 4 },
         { 128, 128, 4, 4 }
     }));
-    EXPECT_EQ(damage.rects().size(), 4);
-    EXPECT_EQ(damage.rects()[0], damage.bounds());
+    EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage[0], damage.bounds());
 
     // Adding more than 4 rectangles to a non empty damage should unite too.
     damage = Damage(IntSize { 512, 512 });
@@ -280,20 +280,20 @@ TEST(Damage, AddRects)
         { 500, 200, 4, 4 },
         { 384, 128, 4, 4 }
     }));
-    EXPECT_EQ(damage.rects().size(), 4);
-    EXPECT_EQ(damage.rects()[1], damage.bounds());
+    EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage[0], damage.bounds());
 
     // Adding more than 4 empty rectangles does nothing.
     damage = Damage(IntSize { 512, 512 });
     EXPECT_FALSE(damage.add(Vector<IntRect, 1> { { }, { }, { }, { }, { } }));
-    EXPECT_EQ(damage.rects().size(), 0);
+    EXPECT_EQ(damage.size(), 0);
 
     // Adding more than 4 empty rectangles to a non empty damage does nothing too.
     damage = Damage(IntSize { 512, 512 });
     EXPECT_TRUE(damage.add(IntRect { 300, 0, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_FALSE(damage.add(Vector<IntRect, 1> { { }, { }, { }, { }, { } }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
 
     // Adding a Vector to damage in BoundingBox mode always unite damage in bounds.
     damage = Damage(IntSize { 1024, 768 }, Damage::Mode::BoundingBox);
@@ -301,8 +301,8 @@ TEST(Damage, AddRects)
         { 100, 100, 200, 200 },
         { 300, 300, 200, 200 }
     }));
-    EXPECT_EQ(damage.rects().size(), 1);
-    EXPECT_EQ(damage.rects()[0], damage.bounds());
+    EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage[0], damage.bounds());
     EXPECT_EQ(damage.bounds(), IntRect(100, 100, 400, 400));
 
     // Adding a Vector to damage in Full mode does nothing.
@@ -311,8 +311,8 @@ TEST(Damage, AddRects)
         { 100, 100, 200, 200 },
         { 300, 300, 200, 200 }
     }));
-    EXPECT_EQ(damage.rects().size(), 1);
-    EXPECT_EQ(damage.rects()[0], damage.bounds());
+    EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage[0], damage.bounds());
     EXPECT_EQ(damage.bounds(), IntRect(0, 0, 1024, 768));
 }
 
@@ -320,18 +320,18 @@ TEST(Damage, AddDamage)
 {
     Damage damage(IntSize { 2048, 1024 });
     EXPECT_TRUE(damage.add(IntRect { 100, 100, 200, 200 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
 
     // Adding empty Damage does nothing.
     Damage other(IntSize { 2048, 1024 });
     EXPECT_FALSE(damage.add(other));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
 
     // Adding a valid Damage adds its rectangles.
     EXPECT_TRUE(other.add(IntRect { 300, 300, 200, 200 }));
-    EXPECT_EQ(other.rects().size(), 1);
+    EXPECT_EQ(other.size(), 1);
     EXPECT_TRUE(damage.add(other));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
     EXPECT_EQ(damage.bounds().x(), 100);
     EXPECT_EQ(damage.bounds().y(), 100);
     EXPECT_EQ(damage.bounds().width(), 400);
@@ -340,14 +340,14 @@ TEST(Damage, AddDamage)
     // It's possible to add one Damage to another with different rectangle.
     damage = Damage(IntSize { 1024, 768 });
     EXPECT_TRUE(damage.add(IntRect { 100, 100, 200, 200 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     other = Damage(IntSize { 800, 600 });
     EXPECT_TRUE(other.add(IntRect { 300, 300, 200, 200 }));
-    EXPECT_EQ(other.rects().size(), 1);
+    EXPECT_EQ(other.size(), 1);
     EXPECT_TRUE(damage.add(other));
-    EXPECT_EQ(damage.rects().size(), 2);
-    EXPECT_EQ(damage.rects()[0], IntRect(100, 100, 200, 200));
-    EXPECT_EQ(damage.rects()[1], IntRect(300, 300, 200, 200));
+    EXPECT_EQ(damage.size(), 2);
+    EXPECT_EQ(damage[0], IntRect(100, 100, 200, 200));
+    EXPECT_EQ(damage[1], IntRect(300, 300, 200, 200));
 
     // Adding a Damage already united with the same rectangle, just unites every rectangle in the grid.
     damage = Damage(IntSize { 512, 512 });
@@ -358,11 +358,11 @@ TEST(Damage, AddDamage)
         { 300, 300, 4, 4 },
         { 128, 128, 4, 4 }
     }));
-    EXPECT_EQ(damage.rects().size(), 4);
-    EXPECT_EQ(damage.rects()[0], IntRect(0, 0, 132, 132));
-    EXPECT_EQ(damage.rects()[1], IntRect(300, 0, 4, 4));
-    EXPECT_EQ(damage.rects()[2], IntRect(0, 300, 4, 4));
-    EXPECT_EQ(damage.rects()[3], IntRect(300, 300, 4, 4));
+    EXPECT_EQ(damage.size(), 4);
+    EXPECT_EQ(damage[0], IntRect(0, 0, 132, 132));
+    EXPECT_EQ(damage[1], IntRect(300, 0, 4, 4));
+    EXPECT_EQ(damage[2], IntRect(0, 300, 4, 4));
+    EXPECT_EQ(damage[3], IntRect(300, 300, 4, 4));
     other = Damage(IntSize { 512, 512 });
     EXPECT_TRUE(other.add(Vector<IntRect, 1> {
         { 10, 10, 4, 4 },
@@ -371,17 +371,17 @@ TEST(Damage, AddDamage)
         { 310, 310, 4, 4 },
         { 384, 384, 4, 4 }
     }));
-    EXPECT_EQ(other.rects().size(), 4);
-    EXPECT_EQ(other.rects()[0], IntRect(10, 10, 4, 4));
-    EXPECT_EQ(other.rects()[1], IntRect(310, 10, 4, 4));
-    EXPECT_EQ(other.rects()[2], IntRect(10, 310, 4, 4));
-    EXPECT_EQ(other.rects()[3], IntRect(310, 310, 78, 78));
+    EXPECT_EQ(other.size(), 4);
+    EXPECT_EQ(other[0], IntRect(10, 10, 4, 4));
+    EXPECT_EQ(other[1], IntRect(310, 10, 4, 4));
+    EXPECT_EQ(other[2], IntRect(10, 310, 4, 4));
+    EXPECT_EQ(other[3], IntRect(310, 310, 78, 78));
     EXPECT_TRUE(damage.add(other));
-    EXPECT_EQ(damage.rects().size(), 4);
-    EXPECT_EQ(damage.rects()[0], IntRect(0, 0, 132, 132));
-    EXPECT_EQ(damage.rects()[1], IntRect(300, 0, 14, 14));
-    EXPECT_EQ(damage.rects()[2], IntRect(0, 300, 14, 14));
-    EXPECT_EQ(damage.rects()[3], IntRect(300, 300, 88, 88));
+    EXPECT_EQ(damage.size(), 4);
+    EXPECT_EQ(damage[0], IntRect(0, 0, 132, 132));
+    EXPECT_EQ(damage[1], IntRect(300, 0, 14, 14));
+    EXPECT_EQ(damage[2], IntRect(0, 300, 14, 14));
+    EXPECT_EQ(damage[3], IntRect(300, 300, 88, 88));
 }
 
 TEST(Damage, Unite)
@@ -389,159 +389,149 @@ TEST(Damage, Unite)
     // Add several rects to the first tile.
     Damage damage(IntSize { 512, 512 });
     EXPECT_TRUE(damage.add(IntRect { 0, 0, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 200, 0, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
     EXPECT_TRUE(damage.add(IntRect { 0, 200, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 3);
+    EXPECT_EQ(damage.size(), 3);
     EXPECT_TRUE(damage.add(IntRect { 200, 200, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 128, 128, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
-    EXPECT_FALSE(damage.rects()[0].isEmpty());
-    EXPECT_TRUE(damage.rects()[1].isEmpty());
-    EXPECT_TRUE(damage.rects()[2].isEmpty());
-    EXPECT_TRUE(damage.rects()[3].isEmpty());
-    EXPECT_EQ(damage.rects()[0], damage.bounds());
+    EXPECT_EQ(damage.size(), 1);
+    EXPECT_FALSE(damage[0].isEmpty());
+    EXPECT_EQ(damage[0], damage.bounds());
 
     // Add several rects to the second tile.
     damage = Damage(IntSize { 512, 512 });
     EXPECT_TRUE(damage.add(IntRect { 300, 0, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 500, 0, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
     EXPECT_TRUE(damage.add(IntRect { 300, 200, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 3);
+    EXPECT_EQ(damage.size(), 3);
     EXPECT_TRUE(damage.add(IntRect { 500, 200, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 384, 128, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
-    EXPECT_TRUE(damage.rects()[0].isEmpty());
-    EXPECT_FALSE(damage.rects()[1].isEmpty());
-    EXPECT_TRUE(damage.rects()[2].isEmpty());
-    EXPECT_TRUE(damage.rects()[3].isEmpty());
-    EXPECT_EQ(damage.rects()[1], damage.bounds());
+    EXPECT_EQ(damage.size(), 1);
+    EXPECT_FALSE(damage[0].isEmpty());
+    EXPECT_EQ(damage[0], damage.bounds());
 
     // Add several rects to the third tile.
     damage = Damage(IntSize { 512, 512 });
     EXPECT_TRUE(damage.add(IntRect { 0, 300, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 200, 300, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
     EXPECT_TRUE(damage.add(IntRect { 0, 500, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 3);
+    EXPECT_EQ(damage.size(), 3);
     EXPECT_TRUE(damage.add(IntRect { 200, 500, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 128, 384, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
-    EXPECT_TRUE(damage.rects()[0].isEmpty());
-    EXPECT_TRUE(damage.rects()[1].isEmpty());
-    EXPECT_FALSE(damage.rects()[2].isEmpty());
-    EXPECT_TRUE(damage.rects()[3].isEmpty());
-    EXPECT_EQ(damage.rects()[2], damage.bounds());
+    EXPECT_EQ(damage.size(), 1);
+    EXPECT_FALSE(damage[0].isEmpty());
+    EXPECT_EQ(damage[0], damage.bounds());
 
     // Add several rects to the fourth tile.
     damage = Damage(IntSize { 512, 512 });
     EXPECT_TRUE(damage.add(IntRect { 300, 300, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 500, 300, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
     EXPECT_TRUE(damage.add(IntRect { 300, 500, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 3);
+    EXPECT_EQ(damage.size(), 3);
     EXPECT_TRUE(damage.add(IntRect { 500, 500, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 384, 384, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
-    EXPECT_TRUE(damage.rects()[0].isEmpty());
-    EXPECT_TRUE(damage.rects()[1].isEmpty());
-    EXPECT_TRUE(damage.rects()[2].isEmpty());
-    EXPECT_FALSE(damage.rects()[3].isEmpty());
-    EXPECT_EQ(damage.rects()[3], damage.bounds());
+    EXPECT_EQ(damage.size(), 1);
+    EXPECT_FALSE(damage[0].isEmpty());
+    EXPECT_EQ(damage[0], damage.bounds());
 
     // Add one rect per tile.
     damage = Damage(IntSize { 512, 512 });
     EXPECT_TRUE(damage.add(IntRect { 0, 0, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 300, 0, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
     EXPECT_TRUE(damage.add(IntRect { 0, 300, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 3);
+    EXPECT_EQ(damage.size(), 3);
     EXPECT_TRUE(damage.add(IntRect { 300, 300, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
-    EXPECT_FALSE(damage.rects()[0].isEmpty());
-    EXPECT_EQ(damage.rects()[0].x(), 0);
-    EXPECT_EQ(damage.rects()[0].y(), 0);
-    EXPECT_EQ(damage.rects()[0].width(), 4);
-    EXPECT_EQ(damage.rects()[0].height(), 4);
-    EXPECT_FALSE(damage.rects()[1].isEmpty());
-    EXPECT_EQ(damage.rects()[1].x(), 300);
-    EXPECT_EQ(damage.rects()[1].y(), 0);
-    EXPECT_EQ(damage.rects()[1].width(), 4);
-    EXPECT_EQ(damage.rects()[1].height(), 4);
-    EXPECT_FALSE(damage.rects()[2].isEmpty());
-    EXPECT_EQ(damage.rects()[2].x(), 0);
-    EXPECT_EQ(damage.rects()[2].y(), 300);
-    EXPECT_EQ(damage.rects()[2].width(), 4);
-    EXPECT_EQ(damage.rects()[2].height(), 4);
-    EXPECT_FALSE(damage.rects()[3].isEmpty());
-    EXPECT_EQ(damage.rects()[3].x(), 300);
-    EXPECT_EQ(damage.rects()[3].y(), 300);
-    EXPECT_EQ(damage.rects()[3].width(), 4);
-    EXPECT_EQ(damage.rects()[3].height(), 4);
+    EXPECT_EQ(damage.size(), 4);
+    EXPECT_TRUE(damage.add(IntRect { 384, 384, 4, 4 }));
+    EXPECT_EQ(damage.size(), 4);
+    EXPECT_FALSE(damage[0].isEmpty());
+    EXPECT_EQ(damage[0].x(), 0);
+    EXPECT_EQ(damage[0].y(), 0);
+    EXPECT_EQ(damage[0].width(), 4);
+    EXPECT_EQ(damage[0].height(), 4);
+    EXPECT_FALSE(damage[1].isEmpty());
+    EXPECT_EQ(damage[1].x(), 300);
+    EXPECT_EQ(damage[1].y(), 0);
+    EXPECT_EQ(damage[1].width(), 4);
+    EXPECT_EQ(damage[1].height(), 4);
+    EXPECT_FALSE(damage[2].isEmpty());
+    EXPECT_EQ(damage[2].x(), 0);
+    EXPECT_EQ(damage[2].y(), 300);
+    EXPECT_EQ(damage[2].width(), 4);
+    EXPECT_EQ(damage[2].height(), 4);
+    EXPECT_FALSE(damage[3].isEmpty());
+    EXPECT_EQ(damage[3].x(), 300);
+    EXPECT_EQ(damage[3].y(), 300);
+    EXPECT_EQ(damage[3].width(), 88);
+    EXPECT_EQ(damage[3].height(), 88);
 
     // Add rects with points off the grid area.
     damage = Damage(IntSize { 512, 512 });
     EXPECT_TRUE(damage.add(IntRect { -2, 0, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 50, -2, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
     EXPECT_TRUE(damage.add(IntRect { 550, 0, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 3);
+    EXPECT_EQ(damage.size(), 3);
     EXPECT_TRUE(damage.add(IntRect { 300, -2, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.add(IntRect { -2, 300, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 3);
     EXPECT_TRUE(damage.add(IntRect { 50, 550, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 3);
     EXPECT_TRUE(damage.add(IntRect { 300, 550, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 550, 300, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
-    EXPECT_FALSE(damage.rects()[0].isEmpty());
-    EXPECT_EQ(damage.rects()[0].x(), -2);
-    EXPECT_EQ(damage.rects()[0].y(), -2);
-    EXPECT_EQ(damage.rects()[0].width(), 56);
-    EXPECT_EQ(damage.rects()[0].height(), 6);
-    EXPECT_FALSE(damage.rects()[1].isEmpty());
-    EXPECT_EQ(damage.rects()[1].x(), 300);
-    EXPECT_EQ(damage.rects()[1].y(), -2);
-    EXPECT_EQ(damage.rects()[1].width(), 254);
-    EXPECT_EQ(damage.rects()[1].height(), 6);
-    EXPECT_FALSE(damage.rects()[2].isEmpty());
-    EXPECT_EQ(damage.rects()[2].x(), -2);
-    EXPECT_EQ(damage.rects()[2].y(), 300);
-    EXPECT_EQ(damage.rects()[2].width(), 56);
-    EXPECT_EQ(damage.rects()[2].height(), 254);
-    EXPECT_FALSE(damage.rects()[3].isEmpty());
-    EXPECT_EQ(damage.rects()[3].x(), 300);
-    EXPECT_EQ(damage.rects()[3].y(), 300);
-    EXPECT_EQ(damage.rects()[3].width(), 254);
-    EXPECT_EQ(damage.rects()[3].height(), 254);
+    EXPECT_EQ(damage.size(), 4);
+    EXPECT_FALSE(damage[0].isEmpty());
+    EXPECT_EQ(damage[0].x(), -2);
+    EXPECT_EQ(damage[0].y(), -2);
+    EXPECT_EQ(damage[0].width(), 56);
+    EXPECT_EQ(damage[0].height(), 6);
+    EXPECT_FALSE(damage[1].isEmpty());
+    EXPECT_EQ(damage[1].x(), 300);
+    EXPECT_EQ(damage[1].y(), -2);
+    EXPECT_EQ(damage[1].width(), 254);
+    EXPECT_EQ(damage[1].height(), 6);
+    EXPECT_FALSE(damage[2].isEmpty());
+    EXPECT_EQ(damage[2].x(), -2);
+    EXPECT_EQ(damage[2].y(), 300);
+    EXPECT_EQ(damage[2].width(), 56);
+    EXPECT_EQ(damage[2].height(), 254);
+    EXPECT_FALSE(damage[3].isEmpty());
+    EXPECT_EQ(damage[3].x(), 300);
+    EXPECT_EQ(damage[3].y(), 300);
+    EXPECT_EQ(damage[3].width(), 254);
+    EXPECT_EQ(damage[3].height(), 254);
 
     // Add several rects and check that unite works for single tile grid.
     damage = Damage(IntSize { 128, 128 });
     EXPECT_TRUE(damage.add(IntRect { 10, 10, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 60, 60, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 70, 10, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 120, 60, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 10, 70, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 120, 120, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
 
     // Grid size should be ceiled.
     damage = Damage(IntSize { 512, 333 });
@@ -549,13 +539,13 @@ TEST(Damage, Unite)
     EXPECT_TRUE(damage.add(IntRect { 1, 1, 1, 1 }));
     EXPECT_TRUE(damage.add(IntRect { 2, 2, 1, 1 }));
     EXPECT_TRUE(damage.add(IntRect { 3, 3, 1, 1 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
 
     // Grid size should be ceiled with high precision.
     damage = Damage(IntSize { 257, 50 });
     EXPECT_TRUE(damage.add(IntRect { 0, 0, 1, 1 }));
     EXPECT_TRUE(damage.add(IntRect { 1, 1, 1, 1 }));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
 
     // Unification should work correctly when grid does not start and { 0, 0 }.
     damage = Damage(IntRect { 256, 256, 512, 512 });
@@ -563,28 +553,29 @@ TEST(Damage, Unite)
     EXPECT_TRUE(damage.add(IntRect { 600, 300, 1, 1 }));
     EXPECT_TRUE(damage.add(IntRect { 300, 600, 1, 1 }));
     EXPECT_TRUE(damage.add(IntRect { 600, 600, 1, 1 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 301, 301, 1, 1 }));
-    EXPECT_EQ(damage.rects().size(), 4);
-    EXPECT_EQ(damage.rects()[0], IntRect(300, 300, 2, 2));
-    EXPECT_EQ(damage.rects()[1], IntRect(600, 300, 1, 1));
-    EXPECT_EQ(damage.rects()[2], IntRect(300, 600, 1, 1));
-    EXPECT_EQ(damage.rects()[3], IntRect(600, 600, 1, 1));
+    EXPECT_EQ(damage.size(), 4);
+    EXPECT_EQ(damage[0], IntRect(300, 300, 2, 2));
+    EXPECT_EQ(damage[1], IntRect(600, 300, 1, 1));
+    EXPECT_EQ(damage[2], IntRect(300, 600, 1, 1));
+    EXPECT_EQ(damage[3], IntRect(600, 600, 1, 1));
 
     // Adding a rect covering the current bounding box makes the Damage no longer unified.
     damage = Damage(IntSize { 512, 512 });
+    EXPECT_TRUE(damage.add(IntRect { 0, 0, 4, 4 }));
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 300, 0, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
-    EXPECT_TRUE(damage.add(IntRect { 500, 0, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 2);
-    EXPECT_TRUE(damage.add(IntRect { 300, 200, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 3);
-    EXPECT_TRUE(damage.add(IntRect { 500, 200, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
-    EXPECT_TRUE(damage.add(IntRect { 384, 128, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
-    EXPECT_TRUE(damage.add(IntRect { 250, 0, 254, 254 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 2);
+    EXPECT_TRUE(damage.add(IntRect { 0, 300, 4, 4 }));
+    EXPECT_EQ(damage.size(), 3);
+    EXPECT_TRUE(damage.add(IntRect { 300, 300, 4, 4 }));
+    EXPECT_EQ(damage.size(), 4);
+    EXPECT_TRUE(damage.add(IntRect { 384, 384, 4, 4 }));
+    EXPECT_EQ(damage.size(), 4);
+    EXPECT_TRUE(damage.add(IntRect { 0, 0, 400, 400 }));
+    EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage.bounds(), IntRect(0, 0, 400, 400));
 }
 
 TEST(Damage, RectsForPainting)
@@ -602,17 +593,6 @@ TEST(Damage, RectsForPainting)
     ASSERT_EQ(damage.rectsForPainting().size(), 1);
     EXPECT_EQ(damage.rectsForPainting()[0], IntRect(0, 0, 150, 150));
 
-    // The function should remove empty rects.
-    damage = Damage(IntSize { 512, 512 });
-    EXPECT_TRUE(damage.add(IntRect { 0, 0, 10, 10 }));
-    EXPECT_TRUE(damage.add(IntRect { 10, 10, 10, 10 }));
-    EXPECT_TRUE(damage.add(IntRect { 20, 20, 10, 10 }));
-    EXPECT_TRUE(damage.add(IntRect { 30, 30, 10, 10 }));
-    EXPECT_TRUE(damage.add(IntRect { 40, 40, 10, 10 }));
-    EXPECT_EQ(damage.rects().size(), 4);
-    ASSERT_EQ(damage.rectsForPainting().size(), 1);
-    EXPECT_EQ(damage.rectsForPainting()[0], IntRect(0, 0, 50, 50));
-
     // The function should clip the rects.
     damage = Damage(IntSize { 512, 512 });
     EXPECT_TRUE(damage.add(IntRect { -2, -2, 10, 10 }));
@@ -628,8 +608,13 @@ TEST(Damage, RectsForPainting)
     EXPECT_TRUE(damage.add(IntRect { 0, 256, 10, 10 }));
     EXPECT_TRUE(damage.add(IntRect { 256, 0, 10, 10 }));
     EXPECT_TRUE(damage.add(IntRect { 256, 256, 10, 10 }));
-    EXPECT_EQ(damage.rects().size(), 4);
-    EXPECT_EQ(damage.rects(), damage.rectsForPainting());
+    EXPECT_EQ(damage.size(), 4);
+    auto rectsForPainting = damage.rectsForPainting();
+    EXPECT_EQ(rectsForPainting.size(), damage.size());
+    EXPECT_EQ(rectsForPainting[0], damage[0]);
+    EXPECT_EQ(rectsForPainting[1], damage[1]);
+    EXPECT_EQ(rectsForPainting[2], damage[2]);
+    EXPECT_EQ(rectsForPainting[3], damage[3]);
 
     // The function should preserve the layout of cells when unification is enabled
     // and the grid does not start at { 0, 0 }.
@@ -639,18 +624,24 @@ TEST(Damage, RectsForPainting)
     EXPECT_TRUE(damage.add(IntRect { 256, 256 + 256, 10, 10 }));
     EXPECT_TRUE(damage.add(IntRect { 256 + 256, 256, 10, 10 }));
     EXPECT_TRUE(damage.add(IntRect { 256 + 256, 256 + 256, 10, 10 }));
-    EXPECT_EQ(damage.rects().size(), 4);
-    EXPECT_EQ(damage.rects(), damage.rectsForPainting());
+    EXPECT_EQ(damage.size(), 4);
+    rectsForPainting = damage.rectsForPainting();
+    EXPECT_EQ(rectsForPainting.size(), damage.size());
+    EXPECT_EQ(rectsForPainting[0], damage[0]);
+    EXPECT_EQ(rectsForPainting[1], damage[1]);
+    EXPECT_EQ(rectsForPainting[2], damage[2]);
+    EXPECT_EQ(rectsForPainting[3], damage[3]);
 
     // The function should split a rect spanning multiple cells.
     damage = Damage(IntSize { 512, 512 });
     EXPECT_TRUE(damage.add(IntRect { 250, 250, 12, 12 }));
     EXPECT_TRUE(damage.add(IntRect { 249, 249, 1, 1 }));
-    ASSERT_EQ(damage.rectsForPainting().size(), 4);
-    EXPECT_EQ(damage.rectsForPainting()[0], IntRect(249, 249, 7, 7));
-    EXPECT_EQ(damage.rectsForPainting()[1], IntRect(256, 250, 6, 6));
-    EXPECT_EQ(damage.rectsForPainting()[2], IntRect(250, 256, 6, 6));
-    EXPECT_EQ(damage.rectsForPainting()[3], IntRect(256, 256, 6, 6));
+    rectsForPainting = damage.rectsForPainting();
+    ASSERT_EQ(rectsForPainting.size(), 4);
+    EXPECT_EQ(rectsForPainting[0], IntRect(249, 249, 7, 7));
+    EXPECT_EQ(rectsForPainting[1], IntRect(256, 250, 6, 6));
+    EXPECT_EQ(rectsForPainting[2], IntRect(250, 256, 6, 6));
+    EXPECT_EQ(rectsForPainting[3], IntRect(256, 256, 6, 6));
 
     // The function should just return original rects when mode != Mode::Rectangles.
     damage = Damage(IntRect { 1024, 512, 512, 512 }, Damage::Mode::BoundingBox);
@@ -658,9 +649,13 @@ TEST(Damage, RectsForPainting)
     EXPECT_TRUE(damage.add(IntRect { 1285, 678, 5, 341 }));
     EXPECT_FALSE(damage.add(IntRect { 1279, 678, 9, 341 }));
     EXPECT_TRUE(damage.add(IntRect { 1286, 678, 5, 341 }));
-    EXPECT_EQ(damage.rects(), damage.rectsForPainting());
+    rectsForPainting = damage.rectsForPainting();
+    ASSERT_EQ(rectsForPainting.size(), 1);
+    EXPECT_EQ(rectsForPainting[0], damage.bounds());
     damage = Damage(IntRect { 1024, 512, 512, 512 }, Damage::Mode::Full);
-    EXPECT_EQ(damage.rects(), damage.rectsForPainting());
+    rectsForPainting = damage.rectsForPainting();
+    ASSERT_EQ(rectsForPainting.size(), 1);
+    EXPECT_EQ(rectsForPainting[0], IntRect(1024, 512, 512, 512));
 }
 
 TEST(Damage, MaxRectangles)
@@ -672,9 +667,9 @@ TEST(Damage, MaxRectangles)
         { 0, 300, 4, 4 },
         { 300, 300, 4, 4 }
     }));
-    EXPECT_EQ(damage.rects().size(), 2);
-    EXPECT_EQ(damage.rects()[0], IntRect(0, 0, 4, 304));
-    EXPECT_EQ(damage.rects()[1], IntRect(300, 0, 4, 304));
+    EXPECT_EQ(damage.size(), 2);
+    EXPECT_EQ(damage[0], IntRect(0, 0, 4, 304));
+    EXPECT_EQ(damage[1], IntRect(300, 0, 4, 304));
 
     damage = Damage(IntSize { 2048, 1024 }, Damage::Mode::Rectangles, 3);
     EXPECT_TRUE(damage.add(Vector<IntRect, 1> {
@@ -683,10 +678,10 @@ TEST(Damage, MaxRectangles)
         { 1400, 700, 200, 200 },
         { 1800, 800, 200, 200 }
     }));
-    EXPECT_EQ(damage.rects().size(), 3);
-    EXPECT_EQ(damage.rects()[0], IntRect(100, 100, 200, 200));
-    EXPECT_EQ(damage.rects()[1], IntRect(700, 500, 200, 200));
-    EXPECT_EQ(damage.rects()[2], IntRect(1400, 700, 600, 300));
+    EXPECT_EQ(damage.size(), 3);
+    EXPECT_EQ(damage[0], IntRect(100, 100, 200, 200));
+    EXPECT_EQ(damage[1], IntRect(700, 500, 200, 200));
+    EXPECT_EQ(damage[2], IntRect(1400, 700, 600, 300));
 
     // Using MaxRectangles = 0 means no maximum so default fixed cell size is used
     damage = Damage(IntSize { 512, 512 }, Damage::Mode::Rectangles, 0);
@@ -697,11 +692,11 @@ TEST(Damage, MaxRectangles)
         { 300, 300, 4, 4 },
         { 384, 384, 4, 4 }
     }));
-    EXPECT_EQ(damage.rects().size(), 4);
-    EXPECT_EQ(damage.rects()[0], IntRect(0, 0, 4, 4));
-    EXPECT_EQ(damage.rects()[1], IntRect(300, 0, 4, 4));
-    EXPECT_EQ(damage.rects()[2], IntRect(0, 300, 4, 4));
-    EXPECT_EQ(damage.rects()[3], IntRect(300, 300, 88, 88));
+    EXPECT_EQ(damage.size(), 4);
+    EXPECT_EQ(damage[0], IntRect(0, 0, 4, 4));
+    EXPECT_EQ(damage[1], IntRect(300, 0, 4, 4));
+    EXPECT_EQ(damage[2], IntRect(0, 300, 4, 4));
+    EXPECT_EQ(damage[3], IntRect(300, 300, 88, 88));
 
     // Passing MaxRectangles = 1 always unifies.
     damage = Damage(IntSize { 512, 512 }, Damage::Mode::Rectangles, 1);
@@ -712,8 +707,8 @@ TEST(Damage, MaxRectangles)
         { 300, 300, 4, 4 },
         { 384, 384, 4, 4 }
     }));
-    EXPECT_EQ(damage.rects().size(), 1);
-    EXPECT_EQ(damage.rects()[0], damage.bounds());
+    EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage[0], damage.bounds());
     EXPECT_EQ(damage.bounds(), IntRect(0, 0, 388, 388));
 
     // Passing MaxRectangles with BoundingBode mode ignores it.
@@ -723,8 +718,8 @@ TEST(Damage, MaxRectangles)
         { 200, 200, 200, 200 },
         { 300, 300, 200, 200 }
     }));
-    EXPECT_EQ(damage.rects().size(), 1);
-    EXPECT_EQ(damage.rects()[0], damage.bounds());
+    EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage[0], damage.bounds());
     EXPECT_EQ(damage.bounds(), IntRect(100, 100, 400, 400));
 
     // Passing MaxRectangles with Full mode ignores it.
@@ -733,8 +728,8 @@ TEST(Damage, MaxRectangles)
         { 100, 100, 200, 200 },
         { 300, 300, 200, 200 }
     }));
-    EXPECT_EQ(damage.rects().size(), 1);
-    EXPECT_EQ(damage.rects()[0], damage.bounds());
+    EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage[0], damage.bounds());
     EXPECT_EQ(damage.bounds(), IntRect(0, 0, 1024, 768));
 }
 


### PR DESCRIPTION
#### 63ebc0af1d9d8bb676eced504beba71393363392
<pre>
[GTK][WPE] Make Damage iterable
<a href="https://bugs.webkit.org/show_bug.cgi?id=291358">https://bugs.webkit.org/show_bug.cgi?id=291358</a>

Reviewed by Alejandro G. Castro.

Instead of exposing the internal vector we use for dirty rects, that can
contain empty rectangles after uniting, we can make Damage iterable and
always return the actual rectangles.

* Source/WebCore/platform/graphics/Damage.h:
(WebCore::Damage::size const):
(WebCore::Damage::isEmpty const):
(WebCore::Damage::bounds const):
(WebCore::Damage::iterator::iterator):
(WebCore::Damage::iterator::operator*):
(WebCore::Damage::iterator::operator++):
(WebCore::Damage::iterator::operator== const):
(WebCore::Damage::begin const):
(WebCore::Damage::end const):
(WebCore::Damage::copyToVector const):
(WebCore::Damage::rectsForPainting const):
(WebCore::Damage::makeFull):
(WebCore::Damage::add):
(WebCore::Damage::initialize):
(WebCore::Damage::uniteExistingRects):
(WebCore::Damage::cellIndexForRect const):
(WebCore::Damage::unite):
(WebCore::FrameDamageHistory::addDamage):
(WebCore::operator&lt;&lt;):
(WebCore::Damage::rects const): Deleted.
* Source/WebCore/platform/graphics/texmap/TextureMapperDamageVisualizer.cpp:
(WebCore::TextureMapperDamageVisualizer::paintDamage const):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::collectDamageSelf):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp:
(WebCore::CoordinatedBackingStore::paintToTextureMapper):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::setDirtyRegion):
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::didRenderFrame):
* Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp:
(TestWebKitAPI::TEST(Damage, Basics)):
(TestWebKitAPI::TEST(Damage, Mode)):
(TestWebKitAPI::TEST(Damage, Move)):
(TestWebKitAPI::TEST(Damage, AddRect)):
(TestWebKitAPI::TEST(Damage, AddRects)):
(TestWebKitAPI::TEST(Damage, AddDamage)):
(TestWebKitAPI::TEST(Damage, Unite)):
(TestWebKitAPI::TEST(Damage, RectsForPainting)):
(TestWebKitAPI::TEST(Damage, MaxRectangles)):

Canonical link: <a href="https://commits.webkit.org/294236@main">https://commits.webkit.org/294236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3ff4311a8ee8e4c1cfe84cf9d4e455153a2ad01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100290 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105420 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50873 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102331 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20244 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76364 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33420 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90589 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56720 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15315 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8588 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50241 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85227 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107779 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27403 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20095 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85316 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27766 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84854 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29533 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7272 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21309 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16463 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27340 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32573 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27151 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30467 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28710 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->