### PR TITLE
GPUP: Frequent draw state changes spend time in Color copying

### DIFF
--- a/Source/WebCore/platform/graphics/Color.cpp
+++ b/Source/WebCore/platform/graphics/Color.cpp
@@ -40,18 +40,6 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(Color);
 static constexpr auto lightenedBlack = SRGBA<uint8_t> { 84, 84, 84 };
 static constexpr auto darkenedWhite = SRGBA<uint8_t> { 171, 171, 171 };
 
-Color::Color(const Color& other)
-    : m_colorAndFlags(other.m_colorAndFlags)
-{
-    if (isOutOfLine())
-        asOutOfLine().ref();
-}
-
-Color::Color(Color&& other)
-{
-    *this = WTFMove(other);
-}
-
 Color::Color(std::optional<ColorDataForIPC>&& colorData)
 {
     if (colorData) {
@@ -100,36 +88,6 @@ std::optional<ColorDataForIPC> Color::data() const
         } };
     };
 };
-
-Color& Color::operator=(const Color& other)
-{
-    if (*this == other)
-        return *this;
-
-    if (isOutOfLine())
-        asOutOfLine().deref();
-
-    m_colorAndFlags = other.m_colorAndFlags;
-
-    if (isOutOfLine())
-        asOutOfLine().ref();
-
-    return *this;
-}
-
-Color& Color::operator=(Color&& other)
-{
-    if (*this == other)
-        return *this;
-
-    if (isOutOfLine())
-        asOutOfLine().deref();
-
-    m_colorAndFlags = other.m_colorAndFlags;
-    other.m_colorAndFlags = invalidColorAndFlags;
-
-    return *this;
-}
 
 Color Color::lightened() const
 {

--- a/Source/WebCore/platform/graphics/Color.h
+++ b/Source/WebCore/platform/graphics/Color.h
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
@@ -84,13 +84,13 @@ public:
 
     Color() = default;
 
-    WEBCORE_EXPORT Color(SRGBA<uint8_t>, OptionSet<Flags> = { });
+    Color(SRGBA<uint8_t>, OptionSet<Flags> = { });
     Color(std::optional<SRGBA<uint8_t>>, OptionSet<Flags> = { });
     WEBCORE_EXPORT Color(std::optional<ColorDataForIPC>&&);
 
     template<typename ColorType, typename std::enable_if_t<IsColorTypeWithComponentType<ColorType, float>>* = nullptr>
     Color(const ColorType&, OptionSet<Flags> = { });
-    
+
     template<typename ColorType, typename std::enable_if_t<IsColorTypeWithComponentType<ColorType, float>>* = nullptr>
     Color(const std::optional<ColorType>&, OptionSet<Flags> = { });
 
@@ -99,11 +99,11 @@ public:
     bool isHashTableDeletedValue() const;
     bool isHashTableEmptyValue() const;
 
-    WEBCORE_EXPORT Color(const Color&);
-    WEBCORE_EXPORT Color(Color&&);
+    Color(const Color&);
+    Color(Color&&);
 
-    WEBCORE_EXPORT Color& operator=(const Color&);
-    WEBCORE_EXPORT Color& operator=(Color&&);
+    Color& operator=(const Color&);
+    Color& operator=(Color&&);
 
     ~Color();
 
@@ -391,6 +391,46 @@ inline Color::Color(WTF::HashTableEmptyValueType)
 inline Color::Color(WTF::HashTableDeletedValueType)
 {
     m_colorAndFlags = encodedFlags({ FlagsIncludingPrivate::HashTableDeletedValue });
+}
+
+inline Color::Color(const Color& other)
+    : m_colorAndFlags(other.m_colorAndFlags)
+{
+    if (isOutOfLine())
+        asOutOfLine().ref();
+}
+
+inline Color::Color(Color&& other)
+{
+    *this = WTFMove(other);
+}
+
+inline Color& Color::operator=(const Color& other)
+{
+    if (m_colorAndFlags == other.m_colorAndFlags)
+        return *this;
+
+    if (isOutOfLine())
+        asOutOfLine().deref();
+
+    m_colorAndFlags = other.m_colorAndFlags;
+
+    if (isOutOfLine())
+        asOutOfLine().ref();
+
+    return *this;
+}
+
+inline Color& Color::operator=(Color&& other)
+{
+    if (this == &other)
+        return *this;
+
+    if (isOutOfLine())
+        asOutOfLine().deref();
+
+    m_colorAndFlags = std::exchange(other.m_colorAndFlags, invalidColorAndFlags);
+    return *this;
 }
 
 inline bool Color::isHashTableDeletedValue() const


### PR DESCRIPTION
#### 778bd4f4d7c38ce8a9cb0b2882d80697abc5eb6a
<pre>
GPUP: Frequent draw state changes spend time in Color copying
<a href="https://bugs.webkit.org/show_bug.cgi?id=291360">https://bugs.webkit.org/show_bug.cgi?id=291360</a>
<a href="https://rdar.apple.com/148979107">rdar://148979107</a>

Reviewed by Sam Weinig.

Inline Color copy and move operations. They show up in traces that do
frequent drawing and state changes. GraphicsContext state holds Color
instances.

Fix a subtle bug with operator=(Color&amp;&amp;), where the moved-from source
was intended to be invalidated but in some cases was not.

Fix a bug in ColorTests where MoveAssignment test tested move
construction.

Changes the perf profile of operator=(const Color&amp;), where only
bytewise equal instances skip ref/unref. Ref/unref on equal but distinct
out-of-line pointers is guessed to be faster than deep equality compare
of out-of-line colors.

* Source/WebCore/platform/graphics/Color.cpp:
(WebCore::Color::operator=): Deleted.
* Source/WebCore/platform/graphics/Color.h:
(WebCore::Color::Color):
(WebCore::Color::operator=):
* Tools/TestWebKitAPI/Tests/WebCore/ColorTests.cpp:
(TestWebKitAPI::TEST(Color, MoveAssignment)):

Canonical link: <a href="https://commits.webkit.org/293563@main">https://commits.webkit.org/293563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a4011a7507e78d0f89a54c9a7eb7beab03b1fdc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104438 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49908 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27390 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/75579 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32682 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102314 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/14626 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89659 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55939 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/14420 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7640 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49268 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84345 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7727 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106795 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26421 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84537 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26783 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85861 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84049 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21319 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28715 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/6403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20153 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26361 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/31561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26181 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29494 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27748 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->