### PR TITLE
GPUP: Drawing spends time in obtaining refs of connection and backend for RemoteDisplayListRecorderProxy

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -53,7 +53,12 @@ public:
     RemoteDisplayListRecorderProxy(const WebCore::DestinationColorSpace&, WebCore::ContentsFormat, WebCore::RenderingMode, const WebCore::FloatRect& initialClip, const WebCore::AffineTransform&, RemoteDisplayListRecorderIdentifier, RemoteRenderingBackendProxy&);
     ~RemoteDisplayListRecorderProxy();
     RemoteDisplayListRecorderIdentifier identifier() const { return m_identifier; }
+
+    // Called when rendering backend connection is lost.
     void disconnect();
+
+    // Called when rendering backend gets discarded but reference to the owning image buffer is still referenced.
+    void abandon();
 
 
     void setClient(ThreadSafeWeakPtr<RemoteImageBufferProxy>&& client) { m_client = WTFMove(client); }
@@ -63,7 +68,6 @@ public:
 
 private:
     template<typename T> void send(T&& message);
-    RefPtr<IPC::StreamClientConnection> connection() const;
     void didBecomeUnresponsive() const;
 
     WebCore::RenderingMode renderingMode() const final;
@@ -156,6 +160,7 @@ private:
 
     const WebCore::RenderingMode m_renderingMode;
     const RemoteDisplayListRecorderIdentifier m_identifier;
+    RefPtr<IPC::StreamClientConnection> m_connection;
     WeakPtr<RemoteRenderingBackendProxy> m_renderingBackend;
     std::optional<WebCore::ContentsFormat> m_contentsFormat;
     ThreadSafeWeakPtr<RemoteImageBufferProxy> m_client;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -174,7 +174,7 @@ void RemoteImageBufferProxy::didCreateBackend(std::optional<ImageBufferBackendHa
     }
 
     if (!backend) {
-        m_context.disconnect();
+        m_context.abandon();
         if (RefPtr renderingBackend = m_renderingBackend.get()) {
             m_renderingBackend = nullptr;
             renderingBackend->releaseImageBuffer(*this);
@@ -298,6 +298,7 @@ RefPtr<PixelBuffer> RemoteImageBufferProxy::getPixelBuffer(const PixelBufferForm
 void RemoteImageBufferProxy::disconnect()
 {
     m_context.consumeHasDrawn();
+    m_context.disconnect();
     if (m_backend)
         prepareForBackingStoreChange();
     m_backend = nullptr;
@@ -387,7 +388,7 @@ std::unique_ptr<SerializedImageBuffer> RemoteImageBufferProxy::sinkIntoSerialize
     ASSERT(hasOneRef());
 
     flushDrawingContext();
-    m_context.disconnect();
+    m_context.abandon();
 
     RefPtr renderingBackend = m_renderingBackend.get();
     if (!renderingBackend)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
@@ -313,6 +313,7 @@ void RemoteImageBufferSetProxy::disconnect()
     m_prepareForDisplayIsPending = false;
     m_generation++;
     m_remoteNeedsConfigurationUpdate = true;
+    m_context = std::nullopt;
 }
 
 GraphicsContext& RemoteImageBufferSetProxy::context()


### PR DESCRIPTION
#### 1674bd87b1631d974563c1b390ad3c8c1ebbfdb4
<pre>
GPUP: Drawing spends time in obtaining refs of connection and backend for RemoteDisplayListRecorderProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=291361">https://bugs.webkit.org/show_bug.cgi?id=291361</a>
<a href="https://rdar.apple.com/148979640">rdar://148979640</a>

Reviewed by Simon Fraser.

For each function that needs RemoteRenderingBackend, convert the
weak pointer to strong one only once.

For send functions, resolve the connection once upon need and keep using
it until crash. Remove the stored connection on disconnect().

* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::send):
(WebKit::RemoteDisplayListRecorderProxy::recordResourceUse):
(WebKit::RemoteDisplayListRecorderProxy::disconnect):
(WebKit::RemoteDisplayListRecorderProxy::connection const): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp:
(WebKit::RemoteImageBufferSetProxy::disconnect):

Canonical link: <a href="https://commits.webkit.org/293678@main">https://commits.webkit.org/293678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcd7d7fd4d2c3c3710075195792ee5b90b7464f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9494 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104718 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50187 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27670 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75808 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32907 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14868 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89926 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56167 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14665 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49548 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84606 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107077 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26701 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19493 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84769 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27064 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86130 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84286 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21392 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28955 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6665 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20497 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26641 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31842 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26461 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29774 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28028 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->