### PR TITLE
Devirtualize CanvasPath::hasInvertibleTransform

### DIFF
--- a/Source/WebCore/html/canvas/CanvasPath.cpp
+++ b/Source/WebCore/html/canvas/CanvasPath.cpp
@@ -62,7 +62,7 @@ void CanvasPath::moveTo(float x, float y)
 {
     if (!std::isfinite(x) || !std::isfinite(y))
         return;
-    if (!hasInvertibleTransform())
+    if (UNLIKELY(!hasInvertibleTransform()))
         return;
     m_path.moveTo(FloatPoint(x, y));
 }
@@ -76,7 +76,7 @@ void CanvasPath::lineTo(float x, float y)
 {
     if (!std::isfinite(x) || !std::isfinite(y))
         return;
-    if (!hasInvertibleTransform())
+    if (UNLIKELY(!hasInvertibleTransform()))
         return;
 
     FloatPoint p1 = FloatPoint(x, y);
@@ -90,7 +90,7 @@ void CanvasPath::quadraticCurveTo(float cpx, float cpy, float x, float y)
 {
     if (!std::isfinite(cpx) || !std::isfinite(cpy) || !std::isfinite(x) || !std::isfinite(y))
         return;
-    if (!hasInvertibleTransform())
+    if (UNLIKELY(!hasInvertibleTransform()))
         return;
     if (m_path.isEmpty())
         m_path.moveTo(FloatPoint(cpx, cpy));
@@ -105,7 +105,7 @@ void CanvasPath::bezierCurveTo(float cp1x, float cp1y, float cp2x, float cp2y, f
 {
     if (!std::isfinite(cp1x) || !std::isfinite(cp1y) || !std::isfinite(cp2x) || !std::isfinite(cp2y) || !std::isfinite(x) || !std::isfinite(y))
         return;
-    if (!hasInvertibleTransform())
+    if (UNLIKELY(!hasInvertibleTransform()))
         return;
     if (m_path.isEmpty())
         m_path.moveTo(FloatPoint(cp1x, cp1y));
@@ -125,7 +125,7 @@ ExceptionOr<void> CanvasPath::arcTo(float x1, float y1, float x2, float y2, floa
     if (r < 0)
         return Exception { ExceptionCode::IndexSizeError };
 
-    if (!hasInvertibleTransform())
+    if (UNLIKELY(!hasInvertibleTransform()))
         return { };
 
     FloatPoint p1 = FloatPoint(x1, y1);
@@ -166,7 +166,7 @@ ExceptionOr<void> CanvasPath::arc(float x, float y, float radius, float startAng
     if (radius < 0)
         return Exception { ExceptionCode::IndexSizeError };
 
-    if (!hasInvertibleTransform())
+    if (UNLIKELY(!hasInvertibleTransform()))
         return { };
 
     normalizeAngles(startAngle, endAngle, anticlockwise);
@@ -189,7 +189,7 @@ ExceptionOr<void> CanvasPath::ellipse(float x, float y, float radiusX, float rad
     if (radiusX < 0 || radiusY < 0)
         return Exception { ExceptionCode::IndexSizeError };
 
-    if (!hasInvertibleTransform())
+    if (UNLIKELY(!hasInvertibleTransform()))
         return { };
 
     normalizeAngles(startAngle, endAngle, anticlockwise);
@@ -226,7 +226,7 @@ ExceptionOr<void> CanvasPath::ellipse(float x, float y, float radiusX, float rad
 
 void CanvasPath::rect(float x, float y, float width, float height)
 {
-    if (!hasInvertibleTransform())
+    if (UNLIKELY(!hasInvertibleTransform()))
         return;
 
     if (!std::isfinite(x) || !std::isfinite(y) || !std::isfinite(width) || !std::isfinite(height))

--- a/Source/WebCore/html/canvas/CanvasPath.h
+++ b/Source/WebCore/html/canvas/CanvasPath.h
@@ -63,11 +63,12 @@ protected:
         : m_path(path)
     { }
 
-    virtual bool hasInvertibleTransform() const { return true; }
+    bool hasInvertibleTransform() const { return m_hasInvertibleTransform; }
 
     void lineTo(FloatPoint);
 
     Path m_path;
+    bool m_hasInvertibleTransform { true };
 };
 
 }

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -406,6 +406,7 @@ private:
         DeferrableOneShotTimer evictionTimer;
     };
 
+    void setHasInvertibleTransform(bool);
     void applyLineDash() const;
     void setShadow(const FloatSize& offset, float blur, const Color&);
     void applyShadow();
@@ -485,8 +486,6 @@ private:
 #endif
     bool hasDeferredOperations() const final;
     void flushDeferredOperations() final;
-
-    bool hasInvertibleTransform() const final { return state().hasInvertibleTransform; }
 
     // The relationship between FontCascade and CanvasRenderingContext2D::FontProxy must hold certain invariants.
     // Therefore, all font operations must pass through the proxy.


### PR DESCRIPTION
#### fb95f57d2cb88a47852af04a8e49ccc36a27290f
<pre>
Devirtualize CanvasPath::hasInvertibleTransform
<a href="https://bugs.webkit.org/show_bug.cgi?id=291364">https://bugs.webkit.org/show_bug.cgi?id=291364</a>
<a href="https://rdar.apple.com/148983084">rdar://148983084</a>

Reviewed by Simon Fraser.

Frequent path drawing spends time in CanvasPath functions to add path
segments. Few of the cycles are spent in virtual dispatch to
hasInvertibleTransform.

Fix by maintaining a bool flag related to invertible transform.

* Source/WebCore/html/canvas/CanvasPath.cpp:
(WebCore::CanvasPath::moveTo):
(WebCore::CanvasPath::lineTo):
(WebCore::CanvasPath::quadraticCurveTo):
(WebCore::CanvasPath::bezierCurveTo):
(WebCore::CanvasPath::arcTo):
(WebCore::CanvasPath::arc):
(WebCore::CanvasPath::ellipse):
(WebCore::CanvasPath::rect):
* Source/WebCore/html/canvas/CanvasPath.h:
(WebCore::CanvasPath::hasInvertibleTransform const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::restore):
(WebCore::CanvasRenderingContext2DBase::setHasInvertibleTransform):
(WebCore::CanvasRenderingContext2DBase::scale):
(WebCore::CanvasRenderingContext2DBase::rotate):
(WebCore::CanvasRenderingContext2DBase::translate):
(WebCore::CanvasRenderingContext2DBase::transform):
(WebCore::CanvasRenderingContext2DBase::resetTransform):
(WebCore::CanvasRenderingContext2DBase::fillInternal):
(WebCore::CanvasRenderingContext2DBase::strokeInternal):
(WebCore::CanvasRenderingContext2DBase::clipInternal):
(WebCore::CanvasRenderingContext2DBase::isPointInPathInternal):
(WebCore::CanvasRenderingContext2DBase::isPointInStrokeInternal):
(WebCore::CanvasRenderingContext2DBase::clearRect):
(WebCore::CanvasRenderingContext2DBase::fillRect):
(WebCore::CanvasRenderingContext2DBase::strokeRect):
(WebCore::CanvasRenderingContext2DBase::drawImage):
(WebCore::CanvasRenderingContext2DBase::didDraw):
(WebCore::CanvasRenderingContext2DBase::canDrawText):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:

Canonical link: <a href="https://commits.webkit.org/293589@main">https://commits.webkit.org/293589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/799a5ddcc12a2264608ae68d4ccf98856ee5595e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99173 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18816 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9064 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104296 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49755 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101213 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27253 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75480 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32593 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14512 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89541 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55846 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14305 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7517 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49130 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84246 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106657 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26282 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19149 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84441 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26645 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83957 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21328 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28610 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6287 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20004 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26223 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31404 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26044 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29357 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27610 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->