### PR TITLE
Define a virtual PlatformMediaSession interface and have PlatformMediaSession derive from it

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2018,6 +2018,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/audio/NowPlayingMetadataObserver.h
     platform/audio/PlatformAudioData.h
     platform/audio/PlatformMediaSession.h
+    platform/audio/PlatformMediaSessionInterface.h
     platform/audio/PlatformMediaSessionManager.h
     platform/audio/PlatformRawAudioData.h
     platform/audio/PushPullFIFO.h

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -129,7 +129,7 @@ ExceptionOr<Ref<AudioContext>> AudioContext::create(Document& document, AudioCon
 AudioContext::AudioContext(Document& document, const AudioContextOptions& contextOptions)
     : BaseAudioContext(document)
     , m_destinationNode(makeUniqueRefWithoutRefCountedCheck<DefaultAudioDestinationNode>(*this, contextOptions.sampleRate))
-    , m_mediaSession(PlatformMediaSession::create(PlatformMediaSessionManager::singleton(), *this))
+    , m_mediaSession(PlatformMediaSession::create(*this))
     , m_currentIdentifier(MediaUniqueIdentifier::generate())
 {
     constructCommon();
@@ -594,12 +594,12 @@ std::optional<NowPlayingInfo> AudioContext::nowPlayingInfo() const
     return nowPlayingInfo;
 }
 
-WeakPtr<PlatformMediaSession> AudioContext::selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSession>>& sessions, PlatformMediaSession::PlaybackControlsPurpose purpose)
+WeakPtr<PlatformMediaSessionInterface> AudioContext::selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSessionInterface>>& sessions, PlatformMediaSession::PlaybackControlsPurpose purpose)
 {
     if (purpose != PlatformMediaSession::PlaybackControlsPurpose::NowPlaying)
         return nullptr;
 
-    WeakPtr<PlatformMediaSession> audibleSession;
+    WeakPtr<PlatformMediaSessionInterface> audibleSession;
     for (auto& session : sessions) {
         if (!isNowPlayingEligible())
             continue;

--- a/Source/WebCore/Modules/webaudio/AudioContext.h
+++ b/Source/WebCore/Modules/webaudio/AudioContext.h
@@ -53,7 +53,7 @@ class AudioContext final
 public:
     // Create an AudioContext for rendering to the audio hardware.
     static ExceptionOr<Ref<AudioContext>> create(Document&, AudioContextOptions&&);
-    ~AudioContext();
+    virtual ~AudioContext();
 
     void ref() const final { ThreadSafeRefCounted::ref(); }
     void deref() const final { ThreadSafeRefCounted::deref(); }
@@ -140,17 +140,17 @@ private:
     bool canReceiveRemoteControlCommands() const final;
     void didReceiveRemoteControlCommand(PlatformMediaSession::RemoteControlCommandType, const PlatformMediaSession::RemoteCommandArgument&) final;
     bool supportsSeeking() const final { return false; }
-    bool shouldOverrideBackgroundPlaybackRestriction(PlatformMediaSession::InterruptionType) const final;
     bool canProduceAudio() const final { return true; }
+    std::optional<MediaSessionGroupIdentifier> mediaSessionGroupIdentifier() const final;
+    void isActiveNowPlayingSessionChanged() final;
+    std::optional<ProcessID> mediaSessionPresentingApplicationPID() const final;
+    bool shouldOverrideBackgroundPlaybackRestriction(PlatformMediaSession::InterruptionType) const final;
     bool isSuspended() const final;
     bool isPlaying() const final;
     bool isAudible() const final;
-    std::optional<MediaSessionGroupIdentifier> mediaSessionGroupIdentifier() const final;
     bool isNowPlayingEligible() const final;
     std::optional<NowPlayingInfo> nowPlayingInfo() const final;
-    WeakPtr<PlatformMediaSession> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSession>>&, PlatformMediaSession::PlaybackControlsPurpose) final;
-    void isActiveNowPlayingSessionChanged() final;
-    std::optional<ProcessID> mediaSessionPresentingApplicationPID() const final;
+    WeakPtr<PlatformMediaSessionInterface> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSessionInterface>>&, PlatformMediaSession::PlaybackControlsPurpose) final;
 
     // MediaCanStartListener.
     void mediaCanStart(Document&) final;
@@ -161,7 +161,7 @@ private:
     bool virtualHasPendingActivity() const final;
 
     UniqueRef<DefaultAudioDestinationNode> m_destinationNode;
-    std::unique_ptr<PlatformMediaSession> m_mediaSession;
+    Ref<PlatformMediaSession> m_mediaSession;
     MediaUniqueIdentifier m_currentIdentifier;
 
     BehaviorRestrictions m_restrictions { NoRestrictions };

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -631,8 +631,7 @@ HTMLMediaElement::HTMLMediaElement(const QualifiedName& tagName, Document& docum
 void HTMLMediaElement::initializeMediaSession()
 {
     ASSERT(!m_mediaSession);
-    m_mediaSession = makeUnique<MediaElementSession>(*this);
-
+    m_mediaSession = MediaElementSession::create(*this);
     m_mediaSession->addBehaviorRestriction(MediaElementSession::RequireUserGestureForFullscreen);
     m_mediaSession->addBehaviorRestriction(MediaElementSession::RequirePageConsentToLoadMedia);
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
@@ -812,7 +811,7 @@ std::optional<NowPlayingInfo> HTMLMediaElement::nowPlayingInfo() const
     return m_mediaSession->computeNowPlayingInfo();
 }
 
-WeakPtr<PlatformMediaSession> HTMLMediaElement::selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSession>>& sessions, PlatformMediaSession::PlaybackControlsPurpose purpose)
+WeakPtr<PlatformMediaSessionInterface> HTMLMediaElement::selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSessionInterface>>& sessions, PlatformMediaSession::PlaybackControlsPurpose purpose)
 {
     if (!sessions.size())
         return nullptr;
@@ -5062,13 +5061,6 @@ void HTMLMediaElement::forgetResourceSpecificTracks()
         removeVideoTrack(*m_videoTracks->lastItem());
 }
 
-#if !RELEASE_LOG_DISABLED
-Ref<Logger> HTMLMediaElement::protectedLogger() const
-{
-    return *m_logger;
-}
-#endif
-
 #if ENABLE(WEB_AUDIO)
 MediaElementAudioSourceNode* HTMLMediaElement::audioSourceNode()
 {
@@ -6799,7 +6791,7 @@ bool HTMLMediaElement::virtualHasPendingActivity() const
         if (isPlaying())
             return true;
 
-        auto* mediaSession = this->mediaSessionIfExists();
+        RefPtr mediaSession = this->mediaSessionIfExists();
         if (!mediaSession)
             return false;
 
@@ -8917,14 +8909,14 @@ PlatformMediaSession::MediaType HTMLMediaElement::presentationType() const
 PlatformMediaSession::DisplayType HTMLMediaElement::displayType() const
 {
     if (m_videoFullscreenMode == VideoFullscreenModeStandard)
-        return PlatformMediaSession::Fullscreen;
+        return PlatformMediaSession::DisplayType::Fullscreen;
     if (m_videoFullscreenMode & VideoFullscreenModePictureInPicture)
-        return PlatformMediaSession::Optimized;
+        return PlatformMediaSession::DisplayType::Optimized;
     if (m_videoFullscreenMode == VideoFullscreenModeNone)
-        return PlatformMediaSession::Normal;
+        return PlatformMediaSession::DisplayType::Normal;
 
     ASSERT_NOT_REACHED();
-    return PlatformMediaSession::Normal;
+    return PlatformMediaSession::DisplayType::Normal;
 }
 
 bool HTMLMediaElement::canProduceAudio() const

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -574,7 +574,7 @@ public:
     RefPtr<VideoPlaybackQuality> getVideoPlaybackQuality() const;
 
     MediaPlayer::Preload preloadValue() const { return m_preload; }
-    MediaElementSession* mediaSessionIfExists() const { return m_mediaSession.get(); }
+    RefPtr<MediaElementSession> mediaSessionIfExists() const { return m_mediaSession.get(); }
     WEBCORE_EXPORT MediaElementSession& mediaSession() const;
 
     void pageScaleFactorChanged();
@@ -608,7 +608,7 @@ public:
 
     double playbackStartedTime() const { return m_playbackStartedTime; }
 
-    bool isTemporarilyAllowingInlinePlaybackAfterFullscreen() const {return m_temporarilyAllowingInlinePlaybackAfterFullscreen; }
+    bool isTemporarilyAllowingInlinePlaybackAfterFullscreen() const { return m_temporarilyAllowingInlinePlaybackAfterFullscreen; }
 
     void isVisibleInViewportChanged();
     void updateRateChangeRestrictions();
@@ -626,7 +626,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return *m_logger.get(); }
-    Ref<Logger> protectedLogger() const;
+    using PlatformMediaSessionClient::protectedLogger;
     uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const final { return "HTMLMediaElement"_s; }
     WTFLogChannel& logChannel() const final;
@@ -1050,7 +1050,7 @@ private:
     bool shouldOverridePauseDuringRouteChange() const final;
     bool isNowPlayingEligible() const final;
     std::optional<NowPlayingInfo> nowPlayingInfo() const final;
-    WeakPtr<PlatformMediaSession> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSession>>&, PlatformMediaSession::PlaybackControlsPurpose) final;
+    WeakPtr<PlatformMediaSessionInterface> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSessionInterface>>&, PlatformMediaSession::PlaybackControlsPurpose) final;
 
     void visibilityAdjustmentStateDidChange() final;
     void pageMutedStateDidChange() override;
@@ -1384,7 +1384,7 @@ private:
     bool m_playbackBlockedWaitingForKey { false };
 #endif
 
-    std::unique_ptr<MediaElementSession> m_mediaSession;
+    RefPtr<MediaElementSession> m_mediaSession;
     size_t m_reportedExtraMemoryCost { 0 };
 
     friend class MediaControlsHost;

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -175,7 +175,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaElementSessionObserver);
 #endif
 
 MediaElementSession::MediaElementSession(HTMLMediaElement& element)
-    : PlatformMediaSession(PlatformMediaSessionManager::singleton(), element)
+    : PlatformMediaSession(element)
     , m_element(element)
     , m_restrictions(NoRestrictions)
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)

--- a/Source/WebCore/html/MediaElementSession.h
+++ b/Source/WebCore/html/MediaElementSession.h
@@ -72,6 +72,11 @@ enum class MediaSessionPlaybackState : uint8_t;
 class MediaElementSession final : public PlatformMediaSession {
     WTF_MAKE_TZONE_ALLOCATED(MediaElementSession);
 public:
+    static Ref<MediaElementSession> create(HTMLMediaElement& element)
+    {
+        return adoptRef(*new MediaElementSession(element));
+    }
+
     explicit MediaElementSession(HTMLMediaElement&);
     virtual ~MediaElementSession();
 
@@ -276,7 +281,7 @@ struct LogArgument<WebCore::MediaPlaybackDenialReason> {
 
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::MediaElementSession)
-static bool isType(const WebCore::PlatformMediaSession& session) { return WebCore::MediaElementSession::isMediaElementSessionMediaType(session.mediaType()); }
+static bool isType(const WebCore::PlatformMediaSessionInterface& session) { return WebCore::MediaElementSession::isMediaElementSessionMediaType(session.mediaType()); }
 SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
@@ -58,8 +58,8 @@ public:
     WEBCORE_EXPORT MediaSessionManagerInterface() = default;
     WEBCORE_EXPORT virtual ~MediaSessionManagerInterface() = default;
 
-    virtual void addSession(PlatformMediaSession&) = 0;
-    virtual void removeSession(PlatformMediaSession&) = 0;
+    virtual void addSession(PlatformMediaSessionInterface&) = 0;
+    virtual void removeSession(PlatformMediaSessionInterface&) = 0;
 
     virtual bool activeAudioSessionRequired() const = 0;
     virtual bool hasActiveAudioSession() const = 0;
@@ -105,20 +105,20 @@ public:
     virtual MediaSessionRestrictions restrictions(PlatformMediaSession::MediaType) = 0;
     virtual void resetRestrictions() = 0;
 
-    virtual bool sessionWillBeginPlayback(PlatformMediaSession&) = 0;
-    virtual void sessionWillEndPlayback(PlatformMediaSession&, DelayCallingUpdateNowPlaying) = 0;
-    virtual void sessionStateChanged(PlatformMediaSession&) = 0;
-    virtual void sessionDidEndRemoteScrubbing(PlatformMediaSession&) { }
+    virtual bool sessionWillBeginPlayback(PlatformMediaSessionInterface&) = 0;
+    virtual void sessionWillEndPlayback(PlatformMediaSessionInterface&, DelayCallingUpdateNowPlaying) = 0;
+    virtual void sessionStateChanged(PlatformMediaSessionInterface&) = 0;
+    virtual void sessionDidEndRemoteScrubbing(PlatformMediaSessionInterface&) { }
     virtual void sessionCanProduceAudioChanged() = 0;
-    virtual void clientCharacteristicsChanged(PlatformMediaSession&, bool) { }
+    virtual void clientCharacteristicsChanged(PlatformMediaSessionInterface&, bool) { }
 
     virtual void configureWirelessTargetMonitoring() { }
     virtual bool hasWirelessTargetsAvailable() { return false; }
     virtual bool isMonitoringWirelessTargets() const { return false; }
-    virtual void sessionIsPlayingToWirelessPlaybackTargetChanged(PlatformMediaSession&) = 0;
+    virtual void sessionIsPlayingToWirelessPlaybackTargetChanged(PlatformMediaSessionInterface&) = 0;
 
-    virtual void setCurrentSession(PlatformMediaSession&) = 0;
-    virtual PlatformMediaSession* currentSession() const = 0;
+    virtual void setCurrentSession(PlatformMediaSessionInterface&) = 0;
+    virtual RefPtr<PlatformMediaSessionInterface> currentSession() const = 0;
 
     virtual void setIsPlayingToAutomotiveHeadUnit(bool) = 0;
     virtual bool isPlayingToAutomotiveHeadUnit() const = 0;
@@ -147,7 +147,7 @@ public:
     virtual void scheduleSessionStatusUpdate() { }
     virtual void resetSessionState() { };
 
-    virtual WeakPtr<PlatformMediaSession> bestEligibleSessionForRemoteControls(NOESCAPE const Function<bool(const PlatformMediaSession&)>&, PlatformMediaSession::PlaybackControlsPurpose) = 0;
+    virtual WeakPtr<PlatformMediaSessionInterface> bestEligibleSessionForRemoteControls(NOESCAPE const Function<bool(const PlatformMediaSessionInterface&)>&, PlatformMediaSession::PlaybackControlsPurpose) = 0;
 
     virtual void updatePresentingApplicationPIDIfNecessary(ProcessID) { }
 };

--- a/Source/WebCore/platform/audio/PlatformMediaSession.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.cpp
@@ -145,17 +145,6 @@ String convertEnumerationToString(PlatformMediaSession::RemoteControlCommandType
     return values[static_cast<size_t>(command)];
 }
 
-std::unique_ptr<PlatformMediaSession> PlatformMediaSession::create(PlatformMediaSessionManager& manager, PlatformMediaSessionClient& client)
-{
-    return std::unique_ptr<PlatformMediaSession>(new PlatformMediaSession(manager, client));
-}
-
-PlatformMediaSession::PlatformMediaSession(PlatformMediaSessionManager&, PlatformMediaSessionClient& client)
-    : m_client(client)
-    , m_mediaSessionIdentifier(MediaSessionIdentifier::generate())
-{
-}
-
 PlatformMediaSession::~PlatformMediaSession()
 {
     setActive(false);
@@ -181,7 +170,7 @@ void PlatformMediaSession::setState(State state)
     ALWAYS_LOG(LOGIDENTIFIER, state);
     m_state = state;
     if (m_state == State::Playing && canProduceAudio())
-        m_hasPlayedAudiblySinceLastInterruption = true;
+        setHasPlayedAudiblySinceLastInterruption(true);
     PlatformMediaSessionManager::singleton().sessionStateChanged(*this);
 }
 
@@ -324,71 +313,21 @@ void PlatformMediaSession::pauseSession()
     if (state() == State::Interrupted)
         m_stateToRestore = State::Paused;
 
-    m_client.suspendPlayback();
+    client().suspendPlayback();
 }
 
 void PlatformMediaSession::stopSession()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    m_client.suspendPlayback();
+    client().suspendPlayback();
     PlatformMediaSessionManager::singleton().removeSession(*this);
-}
-
-PlatformMediaSession::MediaType PlatformMediaSession::mediaType() const
-{
-    return m_client.mediaType();
-}
-
-PlatformMediaSession::MediaType PlatformMediaSession::presentationType() const
-{
-    return m_client.presentationType();
-}
-
-bool PlatformMediaSession::canReceiveRemoteControlCommands() const
-{
-    return m_client.canReceiveRemoteControlCommands();
 }
 
 void PlatformMediaSession::didReceiveRemoteControlCommand(RemoteControlCommandType command, const PlatformMediaSession::RemoteCommandArgument& argument)
 {
     ALWAYS_LOG(LOGIDENTIFIER, command);
 
-    m_client.didReceiveRemoteControlCommand(command, argument);
-}
-
-bool PlatformMediaSession::supportsSeeking() const
-{
-    return m_client.supportsSeeking();
-}
-
-bool PlatformMediaSession::isSuspended() const
-{
-    return m_client.isSuspended();
-}
-
-bool PlatformMediaSession::isPlaying() const
-{
-    return m_client.isPlaying();
-}
-
-bool PlatformMediaSession::isAudible() const
-{
-    return m_client.isAudible();
-}
-
-bool PlatformMediaSession::isEnded() const
-{
-    return m_client.isEnded();
-}
-
-MediaTime PlatformMediaSession::duration() const
-{
-    return m_client.mediaSessionDuration();
-}
-
-bool PlatformMediaSession::shouldOverrideBackgroundLoadingRestriction() const
-{
-    return m_client.shouldOverrideBackgroundLoadingRestriction();
+    client().didReceiveRemoteControlCommand(command, argument);
 }
 
 void PlatformMediaSession::isPlayingToWirelessPlaybackTargetChanged(bool isWireless)
@@ -399,11 +338,6 @@ void PlatformMediaSession::isPlayingToWirelessPlaybackTargetChanged(bool isWirel
     m_isPlayingToWirelessPlaybackTarget = isWireless;
 
     PlatformMediaSessionManager::singleton().sessionIsPlayingToWirelessPlaybackTargetChanged(*this);
-}
-
-PlatformMediaSession::DisplayType PlatformMediaSession::displayType() const
-{
-    return m_client.displayType();
 }
 
 bool PlatformMediaSession::blockedBySystemInterruption() const
@@ -418,16 +352,6 @@ bool PlatformMediaSession::activeAudioSessionRequired() const
     if (state() != PlatformMediaSession::State::Playing)
         return false;
     return canProduceAudio();
-}
-
-bool PlatformMediaSession::canProduceAudio() const
-{
-    return m_client.canProduceAudio();
-}
-
-bool PlatformMediaSession::hasMediaStreamSource() const
-{
-    return m_client.hasMediaStreamSource();
 }
 
 void PlatformMediaSession::canProduceAudioChanged()
@@ -450,7 +374,7 @@ static inline bool isPlayingAudio(PlatformMediaSession::MediaType mediaType)
 #endif
 }
 
-bool PlatformMediaSession::canPlayConcurrently(const PlatformMediaSession& otherSession) const
+bool PlatformMediaSession::canPlayConcurrently(const PlatformMediaSessionInterface& otherSession) const
 {
     auto mediaType = this->mediaType();
     auto otherMediaType = otherSession.mediaType();
@@ -462,25 +386,10 @@ bool PlatformMediaSession::canPlayConcurrently(const PlatformMediaSession& other
     if (!groupID || !otherGroupID || groupID != otherGroupID)
         return false;
 
-    return m_client.hasMediaStreamSource() || otherSession.m_client.hasMediaStreamSource();
+    return client().hasMediaStreamSource() || otherSession.client().hasMediaStreamSource();
 }
 
-bool PlatformMediaSession::shouldOverridePauseDuringRouteChange() const
-{
-    return m_client.shouldOverridePauseDuringRouteChange();
-}
-
-std::optional<NowPlayingInfo> PlatformMediaSession::nowPlayingInfo() const
-{
-    return client().nowPlayingInfo();
-}
-
-bool PlatformMediaSession::isNowPlayingEligible() const
-{
-    return client().isNowPlayingEligible();
-};
-
-WeakPtr<PlatformMediaSession> PlatformMediaSession::selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSession>>& sessions, PlaybackControlsPurpose purpose)
+WeakPtr<PlatformMediaSessionInterface> PlatformMediaSession::selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSessionInterface>>& sessions, PlaybackControlsPurpose purpose)
 {
     return client().selectBestMediaSession(sessions, purpose);
 }
@@ -492,11 +401,6 @@ void PlatformMediaSession::setActiveNowPlayingSession(bool isActiveNowPlayingSes
 
     m_isActiveNowPlayingSession = isActiveNowPlayingSession;
     client().isActiveNowPlayingSessionChanged();
-}
-
-std::optional<ProcessID> PlatformMediaSession::presentingApplicationPID() const
-{
-    return client().mediaSessionPresentingApplicationPID();
 }
 
 #if !RELEASE_LOG_DISABLED
@@ -520,16 +424,6 @@ String PlatformMediaSession::description() const
     return makeString(convertEnumerationToString(mediaType()), ", "_s, convertEnumerationToString(state()));
 }
 #endif
-
-MediaTime PlatformMediaSessionClient::mediaSessionDuration() const
-{
-    return MediaTime::invalidTime();
-}
-
-std::optional<NowPlayingInfo> PlatformMediaSessionClient::nowPlayingInfo() const
-{
-    return { };
-}
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/audio/PlatformMediaSession.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.h
@@ -25,255 +25,85 @@
 
 #pragma once
 
-#include "MediaSessionGroupIdentifier.h"
-#include "MediaSessionIdentifier.h"
-#include "Timer.h"
-#include <wtf/Logger.h>
-#include <wtf/LoggerHelper.h>
-#include <wtf/Noncopyable.h>
-#include <wtf/ProcessID.h>
-#include <wtf/TZoneMalloc.h>
-#include <wtf/WeakPtr.h>
-#include <wtf/text/WTFString.h>
-
-#if ENABLE(WIRELESS_PLAYBACK_TARGET)
-#include "MediaPlaybackTargetClient.h"
-#endif
+#include "PlatformMediaSessionInterface.h"
 
 namespace WebCore {
-class PlatformMediaSession;
-class AudioCaptureSource;
-}
-
-namespace WTF {
-class MediaTime;
-}
-
-namespace WebCore {
-
-class Document;
-class MediaPlaybackTarget;
-class PlatformMediaSessionClient;
-class PlatformMediaSessionManager;
-enum class AudioSessionCategory : uint8_t;
-enum class AudioSessionMode : uint8_t;
-enum class DelayCallingUpdateNowPlaying : bool { No, Yes };
-enum class RouteSharingPolicy : uint8_t;
-struct NowPlayingInfo;
-
-enum class PlatformMediaSessionRemoteControlCommandType : uint8_t {
-    NoCommand,
-    PlayCommand,
-    PauseCommand,
-    StopCommand,
-    TogglePlayPauseCommand,
-    BeginSeekingBackwardCommand,
-    EndSeekingBackwardCommand,
-    BeginSeekingForwardCommand,
-    EndSeekingForwardCommand,
-    SeekToPlaybackPositionCommand,
-    SkipForwardCommand,
-    SkipBackwardCommand,
-    NextTrackCommand,
-    PreviousTrackCommand,
-    BeginScrubbingCommand,
-    EndScrubbingCommand,
-};
-
-enum class PlatformMediaSessionMediaType : uint8_t {
-    None,
-    Video,
-    VideoAudio,
-    Audio,
-    WebAudio,
-};
-
-enum class PlatformMediaSessionState : uint8_t {
-    Idle,
-    Autoplaying,
-    Playing,
-    Paused,
-    Interrupted,
-};
-
-enum class PlatformMediaSessionInterruptionType : uint8_t {
-    NoInterruption,
-    SystemSleep,
-    EnteringBackground,
-    SystemInterruption,
-    SuspendedUnderLock,
-    InvisibleAutoplay,
-    ProcessInactive,
-    PlaybackSuspended,
-    PageNotVisible,
-};
-
-enum class PlatformMediaSessionEndInterruptionFlags : uint8_t {
-    NoFlags = 0,
-    MayResumePlaying = 1 << 0,
-};
-
-struct PlatformMediaSessionRemoteCommandArgument {
-    std::optional<double> time;
-    std::optional<bool> fastSeek;
-};
-
-class AudioCaptureSource : public CanMakeWeakPtr<AudioCaptureSource> {
-public:
-    virtual ~AudioCaptureSource() = default;
-    virtual bool isCapturingAudio() const = 0;
-    virtual bool wantsToCaptureAudio() const = 0;
-};
 
 class PlatformMediaSession
-    : public CanMakeCheckedPtr<PlatformMediaSession>
-    , public CanMakeWeakPtr<PlatformMediaSession>
-#if ENABLE(WIRELESS_PLAYBACK_TARGET)
-    , public MediaPlaybackTargetClient
-#endif
-#if !RELEASE_LOG_DISABLED
-    , public LoggerHelper
-#endif
+    : public PlatformMediaSessionInterface
 {
     WTF_MAKE_TZONE_ALLOCATED(PlatformMediaSession);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlatformMediaSession);
+
 public:
-    static std::unique_ptr<PlatformMediaSession> create(PlatformMediaSessionManager&, PlatformMediaSessionClient&);
+    static Ref<PlatformMediaSession> create(PlatformMediaSessionClient& client)
+    {
+        return adoptRef(*new PlatformMediaSession(client));
+    }
 
     virtual ~PlatformMediaSession();
 
-    void setActive(bool);
+    void setActive(bool) final;
 
-    using MediaType = WebCore::PlatformMediaSessionMediaType;
-    enum class PlaybackControlsPurpose { ControlsManager, NowPlaying, MediaSession };
+    State state() const  final { return m_state; }
+    void setState(State) final;
 
-    MediaType mediaType() const;
-    MediaType presentationType() const;
+    State stateToRestore() const final { return m_stateToRestore; }
 
-    using State = PlatformMediaSessionState;
+    InterruptionType interruptionType() const final;
 
-    State state() const { return m_state; }
-    void setState(State);
+    void clientCharacteristicsChanged(bool) override;
 
-    State stateToRestore() const { return m_stateToRestore; }
+    void beginInterruption(InterruptionType) final;
+    void endInterruption(OptionSet<EndInterruptionFlags>) final;
 
-    using InterruptionType = PlatformMediaSessionInterruptionType;
+    void clientWillBeginAutoplaying() override;
+    bool clientWillBeginPlayback() override;
+    bool clientWillPausePlayback() override;
 
-    InterruptionType interruptionType() const;
+    void clientWillBeDOMSuspended() final;
 
-    using EndInterruptionFlags = PlatformMediaSessionEndInterruptionFlags;
+    void pauseSession() final;
+    void stopSession() final;
 
-    virtual void clientCharacteristicsChanged(bool);
+    void didReceiveRemoteControlCommand(RemoteControlCommandType, const RemoteCommandArgument&) override;
 
-    void beginInterruption(InterruptionType);
-    void endInterruption(OptionSet<EndInterruptionFlags>);
+    bool isPlayingToWirelessPlaybackTarget() const override { return m_isPlayingToWirelessPlaybackTarget; }
+    void isPlayingToWirelessPlaybackTargetChanged(bool) final;
 
-    virtual void clientWillBeginAutoplaying();
-    virtual bool clientWillBeginPlayback();
-    virtual bool clientWillPausePlayback();
+    bool blockedBySystemInterruption() const final;
+    bool activeAudioSessionRequired() const final;
+    void canProduceAudioChanged() final;
 
-    void clientWillBeDOMSuspended();
-
-    void pauseSession();
-    void stopSession();
-
-    virtual void suspendBuffering() { }
-    virtual void resumeBuffering() { }
-
-    using RemoteCommandArgument = PlatformMediaSessionRemoteCommandArgument;
-
-    using RemoteControlCommandType = PlatformMediaSessionRemoteControlCommandType;
-    bool canReceiveRemoteControlCommands() const;
-    virtual void didReceiveRemoteControlCommand(RemoteControlCommandType, const RemoteCommandArgument&);
-    bool supportsSeeking() const;
-
-    enum DisplayType : uint8_t {
-        Normal,
-        Fullscreen,
-        Optimized,
-    };
-    DisplayType displayType() const;
-
-    bool isHidden() const;
-    bool isSuspended() const;
-    bool isPlaying() const;
-    bool isAudible() const;
-    bool isEnded() const;
-    WTF::MediaTime duration() const;
-
-    bool shouldOverrideBackgroundLoadingRestriction() const;
-
-    virtual bool isPlayingToWirelessPlaybackTarget() const { return m_isPlayingToWirelessPlaybackTarget; }
-    void isPlayingToWirelessPlaybackTargetChanged(bool);
-
-#if ENABLE(WIRELESS_PLAYBACK_TARGET)
-    // MediaPlaybackTargetClient
-    void setPlaybackTarget(Ref<MediaPlaybackTarget>&&) override { }
-    void externalOutputDeviceAvailableDidChange(bool) override { }
-    void setShouldPlayToPlaybackTarget(bool) override { }
-    void playbackTargetPickerWasDismissed() override { }
-#endif
-
-#if PLATFORM(IOS_FAMILY)
-    virtual bool requiresPlaybackTargetRouteMonitoring() const { return false; }
-#endif
-
-    bool blockedBySystemInterruption() const;
-    bool activeAudioSessionRequired() const;
-    bool canProduceAudio() const;
-    bool hasMediaStreamSource() const;
-    void canProduceAudioChanged();
-
-    virtual void resetPlaybackSessionState() { }
-    String sourceApplicationIdentifier() const;
-
-    bool hasPlayedAudiblySinceLastInterruption() const { return m_hasPlayedAudiblySinceLastInterruption; }
-    void clearHasPlayedAudiblySinceLastInterruption() { m_hasPlayedAudiblySinceLastInterruption = false; }
-
-    bool preparingToPlay() const { return m_preparingToPlay; }
+    bool preparingToPlay() const final { return m_preparingToPlay; }
 
 #if !RELEASE_LOG_DISABLED
-    const Logger& logger() const final;
-    uint64_t logIdentifier() const final;
+    const Logger& logger() const override;
+    uint64_t logIdentifier() const override;
     ASCIILiteral logClassName() const override { return "PlatformMediaSession"_s; }
-    WTFLogChannel& logChannel() const final;
+    WTFLogChannel& logChannel() const override;
 #endif
 
-    bool canPlayConcurrently(const PlatformMediaSession&) const;
-    bool shouldOverridePauseDuringRouteChange() const;
+    bool canPlayConcurrently(const PlatformMediaSessionInterface&) const final;
 
-    std::optional<NowPlayingInfo> nowPlayingInfo() const;
-    bool isNowPlayingEligible() const;
-    WeakPtr<PlatformMediaSession> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSession>>&, PlaybackControlsPurpose);
+    WeakPtr<PlatformMediaSessionInterface> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSessionInterface>>&, PlaybackControlsPurpose) final;
 
-    virtual void updateMediaUsageIfChanged() { }
-
-    virtual bool isLongEnoughForMainContent() const { return false; }
-
-    MediaSessionIdentifier mediaSessionIdentifier() const { return m_mediaSessionIdentifier; }
-
-    bool isActiveNowPlayingSession() const { return m_isActiveNowPlayingSession; }
-    void setActiveNowPlayingSession(bool);
-
-    std::optional<ProcessID> presentingApplicationPID() const;
-
-    virtual void audioSessionCategoryChanged(AudioSessionCategory, AudioSessionMode, RouteSharingPolicy) { }
+    bool isActiveNowPlayingSession() const final { return m_isActiveNowPlayingSession; }
+    void setActiveNowPlayingSession(bool) final;
 
 #if !RELEASE_LOG_DISABLED
-    virtual String description() const;
+    String description() const override;
 #endif
-
-    PlatformMediaSessionClient& client() const { return m_client; }
 
 protected:
-    PlatformMediaSession(PlatformMediaSessionManager&, PlatformMediaSessionClient&);
+    PlatformMediaSession(PlatformMediaSessionClient& client)
+        : PlatformMediaSessionInterface(client)
+    {
+    }
 
 private:
     bool processClientWillPausePlayback(DelayCallingUpdateNowPlaying);
     size_t activeInterruptionCount() const;
 
-    PlatformMediaSessionClient& m_client;
-    MediaSessionIdentifier m_mediaSessionIdentifier;
     State m_state { State::Idle };
     State m_stateToRestore { State::Idle };
     struct Interruption {
@@ -284,69 +114,8 @@ private:
     bool m_active { false };
     bool m_notifyingClient { false };
     bool m_isPlayingToWirelessPlaybackTarget { false };
-    bool m_hasPlayedAudiblySinceLastInterruption { false };
     bool m_preparingToPlay { false };
     bool m_isActiveNowPlayingSession { false };
-};
-
-class PlatformMediaSessionClient {
-    WTF_MAKE_NONCOPYABLE(PlatformMediaSessionClient);
-public:
-    PlatformMediaSessionClient() = default;
-    
-    virtual PlatformMediaSession::MediaType mediaType() const = 0;
-    virtual PlatformMediaSession::MediaType presentationType() const = 0;
-    virtual PlatformMediaSession::DisplayType displayType() const { return PlatformMediaSession::Normal; }
-
-    virtual void resumeAutoplaying() { }
-    virtual void mayResumePlayback(bool shouldResume) = 0;
-    virtual void suspendPlayback() = 0;
-
-    virtual bool canReceiveRemoteControlCommands() const = 0;
-    virtual void didReceiveRemoteControlCommand(PlatformMediaSession::RemoteControlCommandType, const PlatformMediaSession::RemoteCommandArgument&) = 0;
-    virtual bool supportsSeeking() const = 0;
-
-    virtual bool canProduceAudio() const { return false; }
-    virtual bool isSuspended() const { return false; }
-    virtual bool isPlaying() const { return false; }
-    virtual bool isAudible() const { return false; }
-    virtual bool isEnded() const { return false; }
-    virtual WTF::MediaTime mediaSessionDuration() const;
-
-    virtual bool shouldOverrideBackgroundPlaybackRestriction(PlatformMediaSession::InterruptionType) const = 0;
-    virtual bool shouldOverrideBackgroundLoadingRestriction() const { return false; }
-
-    virtual void wirelessRoutesAvailableDidChange() { }
-    virtual void setWirelessPlaybackTarget(Ref<MediaPlaybackTarget>&&) { }
-    virtual bool isPlayingToWirelessPlaybackTarget() const { return false; }
-    virtual void setShouldPlayToPlaybackTarget(bool) { }
-    virtual void playbackTargetPickerWasDismissed() { }
-
-    virtual bool isPlayingOnSecondScreen() const { return false; }
-
-    virtual std::optional<MediaSessionGroupIdentifier> mediaSessionGroupIdentifier() const = 0;
-
-    virtual bool hasMediaStreamSource() const { return false; }
-
-    virtual void processIsSuspendedChanged() { }
-
-    virtual bool shouldOverridePauseDuringRouteChange() const { return false; }
-
-    virtual bool isNowPlayingEligible() const { return false; }
-    virtual std::optional<NowPlayingInfo> nowPlayingInfo() const;
-    virtual WeakPtr<PlatformMediaSession> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSession>>&, PlatformMediaSession::PlaybackControlsPurpose) { return nullptr; }
-
-    virtual void isActiveNowPlayingSessionChanged() = 0;
-
-    virtual std::optional<ProcessID> mediaSessionPresentingApplicationPID() const = 0;
-
-#if !RELEASE_LOG_DISABLED
-    virtual const Logger& logger() const = 0;
-    virtual uint64_t logIdentifier() const = 0;
-#endif
-
-protected:
-    virtual ~PlatformMediaSessionClient() = default;
 };
 
 String convertEnumerationToString(PlatformMediaSession::State);

--- a/Source/WebCore/platform/audio/PlatformMediaSessionInterface.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionInterface.h
@@ -1,0 +1,335 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "MediaSessionGroupIdentifier.h"
+#include "MediaSessionIdentifier.h"
+#include "NowPlayingInfo.h"
+#include "Timer.h"
+#include <wtf/Logger.h>
+#include <wtf/LoggerHelper.h>
+#include <wtf/MediaTime.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/ProcessID.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/text/WTFString.h>
+
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+#include "MediaPlaybackTargetClient.h"
+#endif
+
+namespace WebCore {
+
+class AudioCaptureSource;
+class Document;
+class MediaPlaybackTarget;
+class PlatformMediaSession;
+class PlatformMediaSessionClient;
+class PlatformMediaSessionInterface;
+class PlatformMediaSessionManager;
+enum class AudioSessionCategory : uint8_t;
+enum class AudioSessionMode : uint8_t;
+enum class RouteSharingPolicy : uint8_t;
+
+enum class PlatformMediaSessionRemoteControlCommandType : uint8_t {
+    NoCommand,
+    PlayCommand,
+    PauseCommand,
+    StopCommand,
+    TogglePlayPauseCommand,
+    BeginSeekingBackwardCommand,
+    EndSeekingBackwardCommand,
+    BeginSeekingForwardCommand,
+    EndSeekingForwardCommand,
+    SeekToPlaybackPositionCommand,
+    SkipForwardCommand,
+    SkipBackwardCommand,
+    NextTrackCommand,
+    PreviousTrackCommand,
+    BeginScrubbingCommand,
+    EndScrubbingCommand,
+};
+
+enum class PlatformMediaSessionMediaType : uint8_t {
+    None,
+    Video,
+    VideoAudio,
+    Audio,
+    WebAudio,
+};
+
+enum class PlatformMediaSessionState : uint8_t {
+    Idle,
+    Autoplaying,
+    Playing,
+    Paused,
+    Interrupted,
+};
+
+enum class PlatformMediaSessionInterruptionType : uint8_t {
+    NoInterruption,
+    SystemSleep,
+    EnteringBackground,
+    SystemInterruption,
+    SuspendedUnderLock,
+    InvisibleAutoplay,
+    ProcessInactive,
+    PlaybackSuspended,
+    PageNotVisible,
+};
+
+enum class PlatformMediaSessionPlaybackControlsPurpose : uint8_t {
+    ControlsManager,
+    NowPlaying,
+    MediaSession
+};
+
+enum class PlatformMediaSessionDisplayType : uint8_t {
+    Normal,
+    Fullscreen,
+    Optimized,
+};
+
+enum class PlatformMediaSessionEndInterruptionFlags : uint8_t {
+    NoFlags = 0,
+    MayResumePlaying = 1 << 0,
+};
+
+enum class DelayCallingUpdateNowPlaying : bool {
+    No,
+    Yes
+};
+
+struct PlatformMediaSessionRemoteCommandArgument {
+    std::optional<double> time;
+    std::optional<bool> fastSeek;
+};
+
+class PlatformMediaSessionClient {
+    WTF_MAKE_NONCOPYABLE(PlatformMediaSessionClient);
+public:
+    PlatformMediaSessionClient() = default;
+
+    virtual PlatformMediaSessionMediaType mediaType() const = 0;
+    virtual PlatformMediaSessionMediaType presentationType() const = 0;
+    virtual PlatformMediaSessionDisplayType displayType() const { return PlatformMediaSessionDisplayType::Normal; }
+
+    virtual void resumeAutoplaying() { }
+    virtual void mayResumePlayback(bool shouldResume) = 0;
+    virtual void suspendPlayback() = 0;
+
+    virtual bool canReceiveRemoteControlCommands() const = 0;
+    virtual void didReceiveRemoteControlCommand(PlatformMediaSessionRemoteControlCommandType, const PlatformMediaSessionRemoteCommandArgument&) = 0;
+    virtual bool supportsSeeking() const = 0;
+
+    virtual bool canProduceAudio() const { return false; }
+    virtual bool isSuspended() const { return false; }
+    virtual bool isPlaying() const { return false; }
+    virtual bool isAudible() const { return false; }
+    virtual bool isEnded() const { return false; }
+    virtual MediaTime mediaSessionDuration() const { return MediaTime::invalidTime(); }
+
+    virtual bool shouldOverrideBackgroundPlaybackRestriction(PlatformMediaSessionInterruptionType) const = 0;
+    virtual bool shouldOverrideBackgroundLoadingRestriction() const { return false; }
+
+    virtual void wirelessRoutesAvailableDidChange() { }
+    virtual void setWirelessPlaybackTarget(Ref<MediaPlaybackTarget>&&) { }
+    virtual bool isPlayingToWirelessPlaybackTarget() const { return false; }
+    virtual void setShouldPlayToPlaybackTarget(bool) { }
+    virtual void playbackTargetPickerWasDismissed() { }
+
+    virtual bool isPlayingOnSecondScreen() const { return false; }
+
+    virtual std::optional<MediaSessionGroupIdentifier> mediaSessionGroupIdentifier() const = 0;
+
+    virtual bool hasMediaStreamSource() const { return false; }
+
+    virtual void processIsSuspendedChanged() { }
+
+    virtual bool shouldOverridePauseDuringRouteChange() const { return false; }
+
+    virtual bool isNowPlayingEligible() const { return false; }
+    virtual std::optional<NowPlayingInfo> nowPlayingInfo() const { return { }; }
+    virtual WeakPtr<PlatformMediaSessionInterface> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSessionInterface>>&, PlatformMediaSessionPlaybackControlsPurpose) { return nullptr; }
+
+    virtual void isActiveNowPlayingSessionChanged() = 0;
+
+    virtual std::optional<ProcessID> mediaSessionPresentingApplicationPID() const = 0;
+
+#if !RELEASE_LOG_DISABLED
+    virtual const Logger& logger() const = 0;
+    Ref<const Logger> protectedLogger() const { return logger(); }
+    virtual uint64_t logIdentifier() const = 0;
+#endif
+
+protected:
+    virtual ~PlatformMediaSessionClient() = default;
+};
+
+class AudioCaptureSource : public CanMakeWeakPtr<AudioCaptureSource> {
+public:
+    virtual ~AudioCaptureSource() = default;
+    virtual bool isCapturingAudio() const = 0;
+    virtual bool wantsToCaptureAudio() const = 0;
+};
+
+class PlatformMediaSessionInterface
+    : public RefCountedAndCanMakeWeakPtr<PlatformMediaSessionInterface>
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+    , public MediaPlaybackTargetClient
+#endif
+{
+public:
+    virtual ~PlatformMediaSessionInterface() = default;
+
+    virtual void setActive(bool) = 0;
+
+    using MediaType = PlatformMediaSessionMediaType;
+    virtual MediaType mediaType() const { return client().mediaType(); }
+    virtual MediaType presentationType() const { return client().presentationType(); }
+
+    using State = PlatformMediaSessionState;
+    virtual State state() const = 0;
+    virtual void setState(State) = 0;
+    virtual State stateToRestore() const = 0;
+
+    using InterruptionType = PlatformMediaSessionInterruptionType;
+    virtual InterruptionType interruptionType() const = 0;
+
+    using EndInterruptionFlags = PlatformMediaSessionEndInterruptionFlags;
+    virtual void beginInterruption(InterruptionType) = 0;
+    virtual void endInterruption(OptionSet<EndInterruptionFlags>) = 0;
+
+    virtual void clientCharacteristicsChanged(bool) = 0;
+
+    virtual void clientWillBeginAutoplaying() = 0;
+    virtual bool clientWillBeginPlayback() = 0;
+    virtual bool clientWillPausePlayback() = 0;
+
+    virtual void clientWillBeDOMSuspended() = 0;
+
+    virtual void pauseSession() = 0;
+    virtual void stopSession() = 0;
+
+    virtual void suspendBuffering() { }
+    virtual void resumeBuffering() { }
+
+    using RemoteCommandArgument = PlatformMediaSessionRemoteCommandArgument;
+    using RemoteControlCommandType = PlatformMediaSessionRemoteControlCommandType;
+    bool canReceiveRemoteControlCommands() const { return client().canReceiveRemoteControlCommands(); }
+    virtual void didReceiveRemoteControlCommand(RemoteControlCommandType, const RemoteCommandArgument&) = 0;
+
+    using DisplayType = PlatformMediaSessionDisplayType;
+    virtual DisplayType displayType() const { return client().displayType(); }
+
+    virtual bool supportsSeeking() const { return client().supportsSeeking(); }
+    virtual bool isSuspended() const { return client().isSuspended(); }
+    virtual bool isPlaying() const { return client().isPlaying(); }
+    virtual bool isAudible() const { return client().isAudible(); }
+    virtual bool isEnded() const { return client().isEnded(); }
+    virtual MediaTime duration() const { return client().mediaSessionDuration(); }
+
+    virtual bool shouldOverrideBackgroundLoadingRestriction() const { return client().shouldOverrideBackgroundLoadingRestriction(); }
+
+    virtual bool isPlayingToWirelessPlaybackTarget() const { return false; }
+    virtual void isPlayingToWirelessPlaybackTargetChanged(bool) = 0;
+
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+    // MediaPlaybackTargetClient
+    virtual void setPlaybackTarget(Ref<MediaPlaybackTarget>&&) { }
+    virtual void externalOutputDeviceAvailableDidChange(bool) { }
+    virtual void setShouldPlayToPlaybackTarget(bool) { }
+    virtual void playbackTargetPickerWasDismissed() { }
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+    virtual bool requiresPlaybackTargetRouteMonitoring() const { return false; }
+#endif
+
+    virtual bool blockedBySystemInterruption() const = 0;
+    virtual bool activeAudioSessionRequired() const = 0;
+    virtual bool canProduceAudio() const { return client().canProduceAudio(); }
+    virtual bool hasMediaStreamSource() const { return client().hasMediaStreamSource(); }
+    virtual void canProduceAudioChanged() = 0;
+
+    virtual void resetPlaybackSessionState() { }
+
+    virtual bool hasPlayedAudiblySinceLastInterruption() const { return m_hasPlayedAudiblySinceLastInterruption; }
+    virtual void setHasPlayedAudiblySinceLastInterruption(bool hasPlayed) { m_hasPlayedAudiblySinceLastInterruption = hasPlayed; }
+
+    virtual bool preparingToPlay() const = 0;
+
+    virtual bool canPlayConcurrently(const PlatformMediaSessionInterface&) const = 0;
+    virtual bool shouldOverridePauseDuringRouteChange() const { return client().shouldOverridePauseDuringRouteChange(); }
+
+    virtual std::optional<NowPlayingInfo> nowPlayingInfo() const { return client().nowPlayingInfo(); }
+    virtual bool isNowPlayingEligible() const { return client().isNowPlayingEligible(); }
+
+    using PlaybackControlsPurpose = PlatformMediaSessionPlaybackControlsPurpose;
+    virtual WeakPtr<PlatformMediaSessionInterface> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSessionInterface>>&, PlaybackControlsPurpose) = 0;
+
+    virtual void updateMediaUsageIfChanged() { }
+
+    virtual bool isLongEnoughForMainContent() const { return false; }
+
+    virtual MediaSessionIdentifier mediaSessionIdentifier() const { return m_mediaSessionIdentifier; }
+
+    virtual bool isActiveNowPlayingSession() const = 0;
+    virtual void setActiveNowPlayingSession(bool) = 0;
+
+    virtual std::optional<ProcessID> presentingApplicationPID() const { return client().mediaSessionPresentingApplicationPID(); }
+
+    virtual void audioSessionCategoryChanged(AudioSessionCategory, AudioSessionMode, RouteSharingPolicy) { }
+
+#if !RELEASE_LOG_DISABLED
+    virtual String description() const = 0;
+#endif
+
+    PlatformMediaSessionClient& client() const { return m_client; }
+
+#if !RELEASE_LOG_DISABLED
+    virtual const Logger& logger() const = 0;
+    Ref<const Logger> protectedLogger() const { return logger(); }
+    virtual uint64_t logIdentifier() const = 0;
+    virtual ASCIILiteral logClassName() const = 0;
+    virtual WTFLogChannel& logChannel() const = 0;
+#endif
+
+protected:
+    PlatformMediaSessionInterface(PlatformMediaSessionClient& client)
+        : m_client(client)
+        , m_mediaSessionIdentifier(MediaSessionIdentifier::generate())
+    {
+    }
+
+private:
+    PlatformMediaSessionClient& m_client;
+    MediaSessionIdentifier m_mediaSessionIdentifier;
+    bool m_hasPlayedAudiblySinceLastInterruption { false };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
@@ -63,10 +63,10 @@ public:
 
     virtual ~PlatformMediaSessionManager();
 
-    void addSession(PlatformMediaSession&) override;
-    void removeSession(PlatformMediaSession&) override;
-    void setCurrentSession(PlatformMediaSession&) override;
-    PlatformMediaSession* currentSession() const final;
+    void addSession(PlatformMediaSessionInterface&) override;
+    void removeSession(PlatformMediaSessionInterface&) override;
+    void setCurrentSession(PlatformMediaSessionInterface&) override;
+    RefPtr<PlatformMediaSessionInterface> currentSession() const final;
 
     bool activeAudioSessionRequired() const final;
     bool hasActiveAudioSession() const final;
@@ -99,12 +99,12 @@ public:
     WEBCORE_EXPORT MediaSessionRestrictions restrictions(PlatformMediaSession::MediaType) final;
     void resetRestrictions() override;
 
-    bool sessionWillBeginPlayback(PlatformMediaSession&) override;
-    void sessionWillEndPlayback(PlatformMediaSession&, DelayCallingUpdateNowPlaying) override;
-    void sessionStateChanged(PlatformMediaSession&) override;
+    bool sessionWillBeginPlayback(PlatformMediaSessionInterface&) override;
+    void sessionWillEndPlayback(PlatformMediaSessionInterface&, DelayCallingUpdateNowPlaying) override;
+    void sessionStateChanged(PlatformMediaSessionInterface&) override;
     void sessionCanProduceAudioChanged() override;
 
-    void sessionIsPlayingToWirelessPlaybackTargetChanged(PlatformMediaSession&) final;
+    void sessionIsPlayingToWirelessPlaybackTargetChanged(PlatformMediaSessionInterface&) final;
 
     WEBCORE_EXPORT void setIsPlayingToAutomotiveHeadUnit(bool) final;
     bool isPlayingToAutomotiveHeadUnit() const final { return m_isPlayingToAutomotiveHeadUnit; }
@@ -112,7 +112,7 @@ public:
     WEBCORE_EXPORT void setSupportsSpatialAudioPlayback(bool) final;
     std::optional<bool> supportsSpatialAudioPlaybackForConfiguration(const MediaConfiguration&) override;
 
-    void forEachMatchingSession(NOESCAPE const Function<bool(const PlatformMediaSession&)>& predicate, NOESCAPE const Function<void(PlatformMediaSession&)>& matchingCallback);
+    void forEachMatchingSession(NOESCAPE const Function<bool(const PlatformMediaSessionInterface&)>& predicate, NOESCAPE const Function<void(PlatformMediaSessionInterface&)>& matchingCallback);
 
     bool processIsSuspended() const final { return m_processIsSuspended; }
 
@@ -131,7 +131,7 @@ public:
 
     bool isApplicationInBackground() const final { return m_isApplicationInBackground; }
 
-    WeakPtr<PlatformMediaSession> bestEligibleSessionForRemoteControls(NOESCAPE const Function<bool(const PlatformMediaSession&)>&, PlatformMediaSession::PlaybackControlsPurpose) final;
+    WeakPtr<PlatformMediaSessionInterface> bestEligibleSessionForRemoteControls(NOESCAPE const Function<bool(const PlatformMediaSessionInterface&)>&, PlatformMediaSession::PlaybackControlsPurpose) final;
 
     std::optional<NowPlayingInfo> nowPlayingInfo() const override;
     WEBCORE_EXPORT void addNowPlayingMetadataObserver(const NowPlayingMetadataObserver&) final;
@@ -142,9 +142,9 @@ protected:
     static std::unique_ptr<PlatformMediaSessionManager> create();
     PlatformMediaSessionManager();
 
-    void forEachSession(NOESCAPE const Function<void(PlatformMediaSession&)>&);
-    void forEachSessionInGroup(std::optional<MediaSessionGroupIdentifier>, NOESCAPE const Function<void(PlatformMediaSession&)>&);
-    bool anyOfSessions(NOESCAPE const Function<bool(const PlatformMediaSession&)>&) const;
+    void forEachSession(NOESCAPE const Function<void(PlatformMediaSessionInterface&)>&);
+    void forEachSessionInGroup(std::optional<MediaSessionGroupIdentifier>, NOESCAPE const Function<void(PlatformMediaSessionInterface&)>&);
+    bool anyOfSessions(NOESCAPE const Function<bool(const PlatformMediaSessionInterface&)>&) const;
 
     void maybeDeactivateAudioSession();
     bool maybeActivateAudioSession();
@@ -174,8 +174,8 @@ private:
     void scheduleUpdateSessionState();
     virtual void updateSessionState() { }
 
-    Vector<WeakPtr<PlatformMediaSession>> sessionsMatching(NOESCAPE const Function<bool(const PlatformMediaSession&)>&) const;
-    WeakPtr<PlatformMediaSession> firstSessionMatching(NOESCAPE const Function<bool(const PlatformMediaSession&)>&) const;
+    Vector<WeakPtr<PlatformMediaSessionInterface>> sessionsMatching(NOESCAPE const Function<bool(const PlatformMediaSessionInterface&)>&) const;
+    WeakPtr<PlatformMediaSessionInterface> firstSessionMatching(NOESCAPE const Function<bool(const PlatformMediaSessionInterface&)>&) const;
 
 #if !RELEASE_LOG_DISABLED
     void scheduleStateLog();
@@ -183,7 +183,7 @@ private:
 #endif
 
     std::array<MediaSessionRestrictions, static_cast<unsigned>(PlatformMediaSession::MediaType::WebAudio) + 1> m_restrictions;
-    mutable Vector<WeakPtr<PlatformMediaSession>> m_sessions;
+    mutable Vector<WeakPtr<PlatformMediaSessionInterface>> m_sessions;
 
     std::optional<PlatformMediaSession::InterruptionType> m_currentInterruption;
     mutable bool m_isApplicationInBackground { false };

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
@@ -76,21 +76,21 @@ public:
 protected:
     void scheduleSessionStatusUpdate() final;
     void updateNowPlayingInfo();
-    void updateActiveNowPlayingSession(CheckedPtr<PlatformMediaSession>);
+    void updateActiveNowPlayingSession(RefPtr<PlatformMediaSessionInterface>);
 
-    void removeSession(PlatformMediaSession&) final;
-    void addSession(PlatformMediaSession&) final;
-    void setCurrentSession(PlatformMediaSession&) final;
+    void removeSession(PlatformMediaSessionInterface&) final;
+    void addSession(PlatformMediaSessionInterface&) final;
+    void setCurrentSession(PlatformMediaSessionInterface&) final;
 
-    bool sessionWillBeginPlayback(PlatformMediaSession&) override;
-    void sessionWillEndPlayback(PlatformMediaSession&, DelayCallingUpdateNowPlaying) override;
-    void sessionDidEndRemoteScrubbing(PlatformMediaSession&) final;
-    void clientCharacteristicsChanged(PlatformMediaSession&, bool) final;
+    bool sessionWillBeginPlayback(PlatformMediaSessionInterface&) override;
+    void sessionWillEndPlayback(PlatformMediaSessionInterface&, DelayCallingUpdateNowPlaying) override;
+    void sessionDidEndRemoteScrubbing(PlatformMediaSessionInterface&) final;
+    void clientCharacteristicsChanged(PlatformMediaSessionInterface&, bool) final;
     void sessionCanProduceAudioChanged() final;
 
     virtual void providePresentingApplicationPIDIfNecessary(const std::optional<ProcessID>&) { }
 
-    WeakPtr<PlatformMediaSession> nowPlayingEligibleSession();
+    WeakPtr<PlatformMediaSessionInterface> nowPlayingEligibleSession();
 
     void addSupportedCommand(PlatformMediaSession::RemoteControlCommandType) final;
     void removeSupportedCommand(PlatformMediaSession::RemoteControlCommandType) final;

--- a/Source/WebCore/platform/audio/glib/MediaSessionGLib.cpp
+++ b/Source/WebCore/platform/audio/glib/MediaSessionGLib.cpp
@@ -321,7 +321,7 @@ GVariant* MediaSessionGLib::getMetadataAsGVariant(std::optional<NowPlayingInfo> 
     return g_variant_builder_end(&builder);
 }
 
-GVariant* MediaSessionGLib::getPlaybackStatusAsGVariant(std::optional<const PlatformMediaSession*> session)
+GVariant* MediaSessionGLib::getPlaybackStatusAsGVariant(std::optional<const PlatformMediaSessionInterface*> session)
 {
     auto state = [this, session = WTFMove(session)]() -> PlatformMediaSession::State {
         if (session)
@@ -361,7 +361,7 @@ void MediaSessionGLib::emitPropertiesChanged(GRefPtr<GVariant>&& parameters)
         g_warning("Failed to emit MPRIS properties changed: %s", error->message);
 }
 
-void MediaSessionGLib::playbackStatusChanged(PlatformMediaSession& platformSession)
+void MediaSessionGLib::playbackStatusChanged(PlatformMediaSessionInterface& platformSession)
 {
     if (!m_connection)
         return;

--- a/Source/WebCore/platform/audio/glib/MediaSessionGLib.h
+++ b/Source/WebCore/platform/audio/glib/MediaSessionGLib.h
@@ -46,14 +46,14 @@ public:
 
     MediaSessionManagerGLib& manager() const { return m_manager; }
 
-    GVariant* getPlaybackStatusAsGVariant(std::optional<const PlatformMediaSession*>);
+    GVariant* getPlaybackStatusAsGVariant(std::optional<const PlatformMediaSessionInterface*>);
     GVariant* getMetadataAsGVariant(std::optional<NowPlayingInfo>);
     GVariant* getPositionAsGVariant();
     GVariant* canSeekAsGVariant();
 
     void emitPositionChanged(double time);
     void updateNowPlaying(NowPlayingInfo&);
-    void playbackStatusChanged(PlatformMediaSession&);
+    void playbackStatusChanged(PlatformMediaSessionInterface&);
 
     void unregisterMprisSession();
 

--- a/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h
+++ b/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h
@@ -52,8 +52,8 @@ public:
     void dispatch(PlatformMediaSession::RemoteControlCommandType, PlatformMediaSession::RemoteCommandArgument);
 
     const GRefPtr<GDBusNodeInfo>& mprisInterface() const { return m_mprisInterface; }
-    void setPrimarySessionIfNeeded(PlatformMediaSession&);
-    void unregisterAllOtherSessions(PlatformMediaSession&);
+    void setPrimarySessionIfNeeded(PlatformMediaSessionInterface&);
+    void unregisterAllOtherSessions(PlatformMediaSessionInterface&);
     WeakPtr<PlatformMediaSession> nowPlayingEligibleSession();
 
     void setDBusNotificationsEnabled(bool dbusNotificationsEnabled) { m_dbusNotificationsEnabled = dbusNotificationsEnabled; }
@@ -63,15 +63,15 @@ protected:
     void scheduleSessionStatusUpdate() final;
     void updateNowPlayingInfo();
 
-    void removeSession(PlatformMediaSession&) final;
-    void addSession(PlatformMediaSession&) final;
-    void setCurrentSession(PlatformMediaSession&) final;
+    void removeSession(PlatformMediaSessionInterface&) final;
+    void addSession(PlatformMediaSessionInterface&) final;
+    void setCurrentSession(PlatformMediaSessionInterface&) final;
 
-    bool sessionWillBeginPlayback(PlatformMediaSession&) override;
-    void sessionWillEndPlayback(PlatformMediaSession&, DelayCallingUpdateNowPlaying) override;
-    void sessionStateChanged(PlatformMediaSession&) override;
-    void sessionDidEndRemoteScrubbing(PlatformMediaSession&) final;
-    void clientCharacteristicsChanged(PlatformMediaSession&, bool) final;
+    bool sessionWillBeginPlayback(PlatformMediaSessionInterface&) override;
+    void sessionWillEndPlayback(PlatformMediaSessionInterface&, DelayCallingUpdateNowPlaying) override;
+    void sessionStateChanged(PlatformMediaSessionInterface&) override;
+    void sessionDidEndRemoteScrubbing(PlatformMediaSessionInterface&) final;
+    void clientCharacteristicsChanged(PlatformMediaSessionInterface&, bool) final;
     void sessionCanProduceAudioChanged() final;
 
     virtual void providePresentingApplicationPIDIfNecessary() { }

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
@@ -66,8 +66,8 @@ private:
     void configureWirelessTargetMonitoring() final;
     void providePresentingApplicationPIDIfNecessary(const std::optional<ProcessID>&) final;
     void updatePresentingApplicationPIDIfNecessary(ProcessID) final;
-    bool sessionWillBeginPlayback(PlatformMediaSession&) final;
-    void sessionWillEndPlayback(PlatformMediaSession&, DelayCallingUpdateNowPlaying) final;
+    bool sessionWillBeginPlayback(PlatformMediaSessionInterface&) final;
+    void sessionWillEndPlayback(PlatformMediaSessionInterface&, DelayCallingUpdateNowPlaying) final;
 
     // AudioSessionInterruptionObserver
     void beginAudioSessionInterruption() final { beginInterruption(PlatformMediaSession::InterruptionType::SystemInterruption); }

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
@@ -139,7 +139,7 @@ void MediaSessionManageriOS::updatePresentingApplicationPIDIfNecessary(ProcessID
 #endif
 }
 
-bool MediaSessionManageriOS::sessionWillBeginPlayback(PlatformMediaSession& session)
+bool MediaSessionManageriOS::sessionWillBeginPlayback(PlatformMediaSessionInterface& session)
 {
     if (!MediaSessionManagerCocoa::sessionWillBeginPlayback(session))
         return false;
@@ -157,7 +157,7 @@ bool MediaSessionManageriOS::sessionWillBeginPlayback(PlatformMediaSession& sess
     return true;
 }
 
-void MediaSessionManageriOS::sessionWillEndPlayback(PlatformMediaSession& session, DelayCallingUpdateNowPlaying delayCallingUpdateNowPlaying)
+void MediaSessionManageriOS::sessionWillEndPlayback(PlatformMediaSessionInterface& session, DelayCallingUpdateNowPlaying delayCallingUpdateNowPlaying)
 {
     MediaSessionManagerCocoa::sessionWillEndPlayback(session, delayCallingUpdateNowPlaying);
 
@@ -225,7 +225,7 @@ void MediaSessionManageriOS::activeVideoRouteDidChange(SupportsAirPlayVideo supp
     m_playbackTargetSupportsAirPlayVideo = supportsAirPlayVideo == SupportsAirPlayVideo::Yes;
 #endif
 
-    CheckedPtr nowPlayingSession = nowPlayingEligibleSession().get();
+    RefPtr nowPlayingSession = nowPlayingEligibleSession().get();
     if (!nowPlayingSession)
         return;
 

--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
@@ -217,7 +217,7 @@ void VideoPresentationModelVideoElement::videoInteractedWith()
     if (!videoElement)
         return;
 
-    CheckedPtr mediaSession = videoElement->mediaSessionIfExists();
+    RefPtr mediaSession = videoElement->mediaSessionIfExists();
     if (!mediaSession || (!mediaSession->mostRecentUserInteractionTime() && mediaSession->hasBehaviorRestriction(MediaElementSession::RequireUserGestureForAudioRateChange)))
         return;
 


### PR DESCRIPTION
#### 8f86af059bbbe6383dc4a6ee7e37a63e103afa71
<pre>
Define a virtual PlatformMediaSession interface and have PlatformMediaSession derive from it
<a href="https://bugs.webkit.org/show_bug.cgi?id=291374">https://bugs.webkit.org/show_bug.cgi?id=291374</a>
<a href="https://rdar.apple.com/148988705">rdar://148988705</a>

Reviewed by Andy Estes.

* Source/WebCore/Headers.cmake

* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::AudioContext):
(WebCore::AudioContext::selectBestMediaSession):
* Source/WebCore/Modules/webaudio/AudioContext.h:

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::initializeMediaSession):
(WebCore::HTMLMediaElement::selectBestMediaSession):
(WebCore::HTMLMediaElement::virtualHasPendingActivity const):
(WebCore::HTMLMediaElement::displayType const):
(WebCore::HTMLMediaElement::protectedLogger const): Deleted.
* Source/WebCore/html/HTMLMediaElement.h:
(WebCore::HTMLMediaElement::mediaSessionIfExists const):
(WebCore::HTMLMediaElement::isTemporarilyAllowingInlinePlaybackAfterFullscreen const):

* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::MediaElementSession):
* Source/WebCore/html/MediaElementSession.h:
(isType):

* Source/WebCore/platform/audio/MediaSessionManagerInterface.h:
(WebCore::MediaSessionManagerInterface::sessionDidEndRemoteScrubbing):
(WebCore::MediaSessionManagerInterface::clientCharacteristicsChanged):

* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::PlatformMediaSession::setState):
(WebCore::PlatformMediaSession::pauseSession):
(WebCore::PlatformMediaSession::stopSession):
(WebCore::PlatformMediaSession::didReceiveRemoteControlCommand):
(WebCore::PlatformMediaSession::canPlayConcurrently const):
(WebCore::PlatformMediaSession::selectBestMediaSession):
(WebCore::PlatformMediaSession::create): Deleted.
(WebCore::PlatformMediaSession::PlatformMediaSession): Deleted.
(WebCore::PlatformMediaSession::mediaType const): Deleted.
(WebCore::PlatformMediaSession::presentationType const): Deleted.
(WebCore::PlatformMediaSession::canReceiveRemoteControlCommands const): Deleted.
(WebCore::PlatformMediaSession::supportsSeeking const): Deleted.
(WebCore::PlatformMediaSession::isSuspended const): Deleted.
(WebCore::PlatformMediaSession::isPlaying const): Deleted.
(WebCore::PlatformMediaSession::isAudible const): Deleted.
(WebCore::PlatformMediaSession::isEnded const): Deleted.
(WebCore::PlatformMediaSession::duration const): Deleted.
(WebCore::PlatformMediaSession::shouldOverrideBackgroundLoadingRestriction const): Deleted.
(WebCore::PlatformMediaSession::displayType const): Deleted.
(WebCore::PlatformMediaSession::canProduceAudio const): Deleted.
(WebCore::PlatformMediaSession::hasMediaStreamSource const): Deleted.
(WebCore::PlatformMediaSession::shouldOverridePauseDuringRouteChange const): Deleted.
(WebCore::PlatformMediaSession::nowPlayingInfo const): Deleted.
(WebCore::PlatformMediaSession::isNowPlayingEligible const): Deleted.
(WebCore::PlatformMediaSession::presentingApplicationPID const): Deleted.
(WebCore::PlatformMediaSessionClient::mediaSessionDuration const): Deleted.
(WebCore::PlatformMediaSessionClient::nowPlayingInfo const): Deleted.
* Source/WebCore/platform/audio/PlatformMediaSession.h:
(WebCore::PlatformMediaSession::create):
(WebCore::PlatformMediaSession::PlatformMediaSession):
(WebCore::PlatformMediaSession::state const): Deleted.
(WebCore::PlatformMediaSession::stateToRestore const): Deleted.
(WebCore::PlatformMediaSession::suspendBuffering): Deleted.
(WebCore::PlatformMediaSession::resumeBuffering): Deleted.
(WebCore::PlatformMediaSession::isPlayingToWirelessPlaybackTarget const): Deleted.
(WebCore::PlatformMediaSession::requiresPlaybackTargetRouteMonitoring const): Deleted.
(WebCore::PlatformMediaSession::resetPlaybackSessionState): Deleted.
(WebCore::PlatformMediaSession::hasPlayedAudiblySinceLastInterruption const): Deleted.
(WebCore::PlatformMediaSession::clearHasPlayedAudiblySinceLastInterruption): Deleted.
(WebCore::PlatformMediaSession::preparingToPlay const): Deleted.
(WebCore::PlatformMediaSession::updateMediaUsageIfChanged): Deleted.
(WebCore::PlatformMediaSession::isLongEnoughForMainContent const): Deleted.
(WebCore::PlatformMediaSession::mediaSessionIdentifier const): Deleted.
(WebCore::PlatformMediaSession::isActiveNowPlayingSession const): Deleted.
(WebCore::PlatformMediaSession::audioSessionCategoryChanged): Deleted.
(WebCore::PlatformMediaSession::client const): Deleted.
(WebCore::PlatformMediaSessionClient::displayType const): Deleted.
(WebCore::PlatformMediaSessionClient::resumeAutoplaying): Deleted.
(WebCore::PlatformMediaSessionClient::canProduceAudio const): Deleted.
(WebCore::PlatformMediaSessionClient::isSuspended const): Deleted.
(WebCore::PlatformMediaSessionClient::isPlaying const): Deleted.
(WebCore::PlatformMediaSessionClient::isAudible const): Deleted.
(WebCore::PlatformMediaSessionClient::isEnded const): Deleted.
(WebCore::PlatformMediaSessionClient::shouldOverrideBackgroundLoadingRestriction const): Deleted.
(WebCore::PlatformMediaSessionClient::wirelessRoutesAvailableDidChange): Deleted.
(WebCore::PlatformMediaSessionClient::setWirelessPlaybackTarget): Deleted.
(WebCore::PlatformMediaSessionClient::isPlayingToWirelessPlaybackTarget const): Deleted.
(WebCore::PlatformMediaSessionClient::setShouldPlayToPlaybackTarget): Deleted.
(WebCore::PlatformMediaSessionClient::playbackTargetPickerWasDismissed): Deleted.
(WebCore::PlatformMediaSessionClient::isPlayingOnSecondScreen const): Deleted.
(WebCore::PlatformMediaSessionClient::hasMediaStreamSource const): Deleted.
(WebCore::PlatformMediaSessionClient::processIsSuspendedChanged): Deleted.
(WebCore::PlatformMediaSessionClient::shouldOverridePauseDuringRouteChange const): Deleted.
(WebCore::PlatformMediaSessionClient::isNowPlayingEligible const): Deleted.
(WebCore::PlatformMediaSessionClient::selectBestMediaSession): Deleted.

* Source/WebCore/platform/audio/PlatformMediaSessionInterface.h:
(WebCore::PlatformMediaSessionClient::displayType const):
(WebCore::PlatformMediaSessionClient::resumeAutoplaying):
(WebCore::PlatformMediaSessionClient::canProduceAudio const):
(WebCore::PlatformMediaSessionClient::isSuspended const):
(WebCore::PlatformMediaSessionClient::isPlaying const):
(WebCore::PlatformMediaSessionClient::isAudible const):
(WebCore::PlatformMediaSessionClient::isEnded const):
(WebCore::PlatformMediaSessionClient::mediaSessionDuration const):
(WebCore::PlatformMediaSessionClient::shouldOverrideBackgroundLoadingRestriction const):
(WebCore::PlatformMediaSessionClient::wirelessRoutesAvailableDidChange):
(WebCore::PlatformMediaSessionClient::setWirelessPlaybackTarget):
(WebCore::PlatformMediaSessionClient::isPlayingToWirelessPlaybackTarget const):
(WebCore::PlatformMediaSessionClient::setShouldPlayToPlaybackTarget):
(WebCore::PlatformMediaSessionClient::playbackTargetPickerWasDismissed):
(WebCore::PlatformMediaSessionClient::isPlayingOnSecondScreen const):
(WebCore::PlatformMediaSessionClient::hasMediaStreamSource const):
(WebCore::PlatformMediaSessionClient::processIsSuspendedChanged):
(WebCore::PlatformMediaSessionClient::shouldOverridePauseDuringRouteChange const):
(WebCore::PlatformMediaSessionClient::isNowPlayingEligible const):
(WebCore::PlatformMediaSessionClient::nowPlayingInfo const):
(WebCore::PlatformMediaSessionClient::selectBestMediaSession):
(WebCore::PlatformMediaSessionClient::protectedLogger const):
(WebCore::PlatformMediaSessionInterface::mediaType const):
(WebCore::PlatformMediaSessionInterface::presentationType const):
(WebCore::PlatformMediaSessionInterface::suspendBuffering):
(WebCore::PlatformMediaSessionInterface::resumeBuffering):
(WebCore::PlatformMediaSessionInterface::canReceiveRemoteControlCommands const):
(WebCore::PlatformMediaSessionInterface::displayType const):
(WebCore::PlatformMediaSessionInterface::supportsSeeking const):
(WebCore::PlatformMediaSessionInterface::isSuspended const):
(WebCore::PlatformMediaSessionInterface::isPlaying const):
(WebCore::PlatformMediaSessionInterface::isAudible const):
(WebCore::PlatformMediaSessionInterface::isEnded const):
(WebCore::PlatformMediaSessionInterface::duration const):
(WebCore::PlatformMediaSessionInterface::shouldOverrideBackgroundLoadingRestriction const):
(WebCore::PlatformMediaSessionInterface::isPlayingToWirelessPlaybackTarget const):
(WebCore::PlatformMediaSessionInterface::setPlaybackTarget):
(WebCore::PlatformMediaSessionInterface::externalOutputDeviceAvailableDidChange):
(WebCore::PlatformMediaSessionInterface::setShouldPlayToPlaybackTarget):
(WebCore::PlatformMediaSessionInterface::playbackTargetPickerWasDismissed):
(WebCore::PlatformMediaSessionInterface::requiresPlaybackTargetRouteMonitoring const):
(WebCore::PlatformMediaSessionInterface::canProduceAudio const):
(WebCore::PlatformMediaSessionInterface::hasMediaStreamSource const):
(WebCore::PlatformMediaSessionInterface::resetPlaybackSessionState):
(WebCore::PlatformMediaSessionInterface::hasPlayedAudiblySinceLastInterruption const):
(WebCore::PlatformMediaSessionInterface::setHasPlayedAudiblySinceLastInterruption):
(WebCore::PlatformMediaSessionInterface::shouldOverridePauseDuringRouteChange const):
(WebCore::PlatformMediaSessionInterface::nowPlayingInfo const):
(WebCore::PlatformMediaSessionInterface::isNowPlayingEligible const):
(WebCore::PlatformMediaSessionInterface::updateMediaUsageIfChanged):
(WebCore::PlatformMediaSessionInterface::isLongEnoughForMainContent const):
(WebCore::PlatformMediaSessionInterface::mediaSessionIdentifier const):
(WebCore::PlatformMediaSessionInterface::presentingApplicationPID const):
(WebCore::PlatformMediaSessionInterface::audioSessionCategoryChanged):
(WebCore::PlatformMediaSessionInterface::client const):
(WebCore::PlatformMediaSessionInterface::protectedLogger const):
(WebCore::PlatformMediaSessionInterface::PlatformMediaSessionInterface):

* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::addSession):
(WebCore::PlatformMediaSessionManager::removeSession):
(WebCore::PlatformMediaSessionManager::sessionWillBeginPlayback):
(WebCore::PlatformMediaSessionManager::sessionWillEndPlayback):
(WebCore::PlatformMediaSessionManager::sessionStateChanged):
(WebCore::PlatformMediaSessionManager::setCurrentSession):
(WebCore::PlatformMediaSessionManager::currentSession const):
(WebCore::PlatformMediaSessionManager::sessionIsPlayingToWirelessPlaybackTargetChanged):
(WebCore::PlatformMediaSessionManager::computeSupportsSeeking const):
(WebCore::PlatformMediaSessionManager::sessionsMatching const):
(WebCore::PlatformMediaSessionManager::firstSessionMatching const):
(WebCore::PlatformMediaSessionManager::forEachMatchingSession):
(WebCore::PlatformMediaSessionManager::forEachSessionInGroup):
(WebCore::PlatformMediaSessionManager::forEachSession):
(WebCore::PlatformMediaSessionManager::anyOfSessions const):
(WebCore::PlatformMediaSessionManager::bestEligibleSessionForRemoteControls):
* Source/WebCore/platform/audio/PlatformMediaSessionManager.h:

* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::beginInterruption):
(WebCore::MediaSessionManagerCocoa::sessionWillBeginPlayback):
(WebCore::MediaSessionManagerCocoa::sessionDidEndRemoteScrubbing):
(WebCore::MediaSessionManagerCocoa::addSession):
(WebCore::MediaSessionManagerCocoa::removeSession):
(WebCore::MediaSessionManagerCocoa::setCurrentSession):
(WebCore::MediaSessionManagerCocoa::sessionWillEndPlayback):
(WebCore::MediaSessionManagerCocoa::clientCharacteristicsChanged):
(WebCore::MediaSessionManagerCocoa::nowPlayingEligibleSession):
(WebCore::MediaSessionManagerCocoa::updateActiveNowPlayingSession):
(WebCore::MediaSessionManagerCocoa::updateNowPlayingInfo):

* Source/WebCore/platform/audio/glib/MediaSessionGLib.cpp:
(WebCore::MediaSessionGLib::getPlaybackStatusAsGVariant):
(WebCore::MediaSessionGLib::playbackStatusChanged):
* Source/WebCore/platform/audio/glib/MediaSessionGLib.h:

* Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp:
(WebCore::MediaSessionManagerGLib::sessionWillBeginPlayback):
(WebCore::MediaSessionManagerGLib::sessionDidEndRemoteScrubbing):
(WebCore::MediaSessionManagerGLib::addSession):
(WebCore::MediaSessionManagerGLib::removeSession):
(WebCore::MediaSessionManagerGLib::setCurrentSession):
(WebCore::MediaSessionManagerGLib::sessionWillEndPlayback):
(WebCore::MediaSessionManagerGLib::sessionStateChanged):
(WebCore::MediaSessionManagerGLib::clientCharacteristicsChanged):
(WebCore::MediaSessionManagerGLib::setPrimarySessionIfNeeded):
(WebCore::MediaSessionManagerGLib::unregisterAllOtherSessions):
* Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h:
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h:
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm:
(WebCore::MediaSessionManageriOS::sessionWillBeginPlayback):
(WebCore::MediaSessionManageriOS::sessionWillEndPlayback):
(WebCore::MediaSessionManageriOS::activeVideoRouteDidChange):

* Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm:
(WebCore::VideoPresentationModelVideoElement::videoInteractedWith):

Canonical link: <a href="https://commits.webkit.org/293547@main">https://commits.webkit.org/293547@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20591988f3caa207939a48393666ce4745ddde32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104361 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/49829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101272 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19168 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27313 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75533 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/49829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102239 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14567 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55894 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14359 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7578 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49191 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84290 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/7665 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106718 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26345 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19204 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84495 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26708 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85801 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84011 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21309 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28663 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6341 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20070 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26285 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/31470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26106 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29419 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27673 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->