### PR TITLE
Address remaining Safer CPP warnings in WebKit/UIProcess/Cocoa

### DIFF
--- a/Source/WTF/wtf/cocoa/SoftLinking.h
+++ b/Source/WTF/wtf/cocoa/SoftLinking.h
@@ -214,8 +214,8 @@ static void* lib##Library() \
     @class className; \
     static Class init##className(); \
     static Class (*get##className##Class)() = init##className; \
-    struct class##className##Wrapper { SUPPRESS_UNCOUNTED_MEMBER Class classObject; }; \
-    static class##className##Wrapper class##className; \
+    struct Class##className##Wrapper { SUPPRESS_UNCOUNTED_MEMBER Class classObject; }; \
+    static Class##className##Wrapper class##className; \
     \
     static Class className##Function() \
     { \
@@ -330,11 +330,12 @@ static void* lib##Library() \
 #define SOFT_LINK_CONSTANT_MAY_FAIL(framework, name, type) \
     static bool init##name(); \
     static type (*get##name)() = 0; \
-    static type constant##name; \
+    struct Constant##name##Wrapper { SUPPRESS_UNRETAINED_LOCAL type constant; }; \
+    static Constant##name##Wrapper constant##name; \
     \
     static type name##Function() \
     { \
-        return constant##name; \
+        return constant##name.constant; \
     } \
     \
     static bool canLoad##name() \
@@ -350,7 +351,7 @@ static void* lib##Library() \
         void* constant = dlsym(framework##Library(), auditedName); \
         if (!constant) \
             return false; \
-        constant##name = *static_cast<type const *>(constant); \
+        constant##name.constant = *static_cast<type const *>(constant); \
         get##name = name##Function; \
         return true; \
     }

--- a/Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -16,11 +16,6 @@ UIProcess/API/mac/WKWebViewMac.mm
 UIProcess/API/mac/WKWebViewTestingMac.mm
 UIProcess/Automation/cocoa/WebAutomationSessionCocoa.mm
 UIProcess/Automation/mac/WebAutomationSessionMac.mm
-UIProcess/Cocoa/WKStorageAccessAlert.mm
-UIProcess/Cocoa/WebPageProxyCocoa.mm
-UIProcess/Cocoa/WebPreferencesCocoa.mm
-UIProcess/Cocoa/WebProcessPoolCocoa.mm
-UIProcess/Cocoa/_WKWarningView.mm
 UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
 UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
 UIProcess/Gamepad/mac/UIGamepadProviderMac.mm

--- a/Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm
@@ -47,14 +47,14 @@ bool WebPreferences::platformGetStringUserValueForKey(const String& key, String&
     if (!m_identifier)
         return false;
 
-    id object = [[NSUserDefaults standardUserDefaults] objectForKey:makeKey(m_identifier, m_keyPrefix, key)];
+    RetainPtr object = [[NSUserDefaults standardUserDefaults] objectForKey:makeKey(m_identifier, m_keyPrefix, key)];
     if (!object)
         return false;
-    auto *str = dynamic_objc_cast<NSString>(object);
-    if (!str)
+    RetainPtr string = dynamic_objc_cast<NSString>(object.get());
+    if (!string)
         return false;
 
-    userValue = str;
+    userValue = string.get();
     return true;
 }
 
@@ -63,7 +63,7 @@ bool WebPreferences::platformGetBoolUserValueForKey(const String& key, bool& use
     if (!m_identifier)
         return false;
 
-    id object = [[NSUserDefaults standardUserDefaults] objectForKey:makeKey(m_identifier, m_keyPrefix, key)];
+    RetainPtr object = [[NSUserDefaults standardUserDefaults] objectForKey:makeKey(m_identifier, m_keyPrefix, key)];
     if (!object)
         return false;
     if (![object respondsToSelector:@selector(boolValue)])
@@ -78,7 +78,7 @@ bool WebPreferences::platformGetUInt32UserValueForKey(const String& key, uint32_
     if (!m_identifier)
         return false;
 
-    id object = [[NSUserDefaults standardUserDefaults] objectForKey:makeKey(m_identifier, m_keyPrefix, key)];
+    RetainPtr object = [[NSUserDefaults standardUserDefaults] objectForKey:makeKey(m_identifier, m_keyPrefix, key)];
     if (!object)
         return false;
     if (![object respondsToSelector:@selector(intValue)])
@@ -93,7 +93,7 @@ bool WebPreferences::platformGetDoubleUserValueForKey(const String& key, double&
     if (!m_identifier)
         return false;
 
-    id object = [[NSUserDefaults standardUserDefaults] objectForKey:makeKey(m_identifier, m_keyPrefix, key)];
+    RetainPtr object = [[NSUserDefaults standardUserDefaults] objectForKey:makeKey(m_identifier, m_keyPrefix, key)];
     if (!object)
         return false;
     if (![object respondsToSelector:@selector(doubleValue)])
@@ -103,10 +103,10 @@ bool WebPreferences::platformGetDoubleUserValueForKey(const String& key, double&
     return true;
 }
 
-static id debugUserDefaultsValue(const String& identifier, const String& keyPrefix, const String& globalDebugKeyPrefix, const String& key)
+static RetainPtr<id> debugUserDefaultsValue(const String& identifier, const String& keyPrefix, const String& globalDebugKeyPrefix, const String& key)
 {
-    NSUserDefaults *standardUserDefaults = [NSUserDefaults standardUserDefaults];
-    id object = nil;
+    RetainPtr standardUserDefaults = [NSUserDefaults standardUserDefaults];
+    RetainPtr<id> object;
 
     if (!identifier.isEmpty())
         object = [standardUserDefaults objectForKey:makeKey(identifier, keyPrefix, key)];
@@ -121,7 +121,7 @@ static id debugUserDefaultsValue(const String& identifier, const String& keyPref
 
 static void setDebugBoolValueIfInUserDefaults(const String& identifier, const String& keyPrefix, const String& globalDebugKeyPrefix, const String& key, WebPreferencesStore& store)
 {
-    id object = debugUserDefaultsValue(identifier, keyPrefix, globalDebugKeyPrefix, key);
+    RetainPtr object = debugUserDefaultsValue(identifier, keyPrefix, globalDebugKeyPrefix, key);
     if (!object)
         return;
     if (![object respondsToSelector:@selector(boolValue)])
@@ -132,7 +132,7 @@ static void setDebugBoolValueIfInUserDefaults(const String& identifier, const St
 
 static void setDebugUInt32ValueIfInUserDefaults(const String& identifier, const String& keyPrefix, const String& globalDebugKeyPrefix, const String& key, WebPreferencesStore& store)
 {
-    id object = debugUserDefaultsValue(identifier, keyPrefix, globalDebugKeyPrefix, key);
+    RetainPtr object = debugUserDefaultsValue(identifier, keyPrefix, globalDebugKeyPrefix, key);
     if (!object)
         return;
     if (![object respondsToSelector:@selector(unsignedIntegerValue)])

--- a/Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm
+++ b/Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm
@@ -208,7 +208,7 @@ static WebCore::CocoaColor *colorForItem(WarningItem item, ViewType *warning)
 static RetainPtr<ViewType> viewForIconImage(_WKWarningView *warningView)
 {
     NSString *symbolName;
-    WebCore::CocoaColor *color = colorForItem(WarningItem::WarningSymbol, warningView);
+    RetainPtr color = colorForItem(WarningItem::WarningSymbol, warningView);
     BOOL shouldSetTint = NO;
     CGFloat imagePointSize = fontOfSize(WarningTextSize::Title).pointSize * imageIconPointSizeMultiplier;
     WTF::switchOn(warningView.warning->data(), [&] (const WebKit::BrowsingWarning::SafeBrowsingWarningData&) {
@@ -221,10 +221,10 @@ static RetainPtr<ViewType> viewForIconImage(_WKWarningView *warningView)
     RetainPtr view = [NSImageView imageViewWithImage:[NSImage imageWithSystemSymbolName:symbolName accessibilityDescription:nil]];
     [view setSymbolConfiguration:[NSImageSymbolConfiguration configurationWithPointSize:imagePointSize weight:NSFontWeightRegular scale:NSImageSymbolScaleLarge]];
     if (shouldSetTint)
-        [view setContentTintColor:color];
+        [view setContentTintColor:color.get()];
 #else
     RetainPtr view = adoptNS([[UIImageView alloc] initWithImage:[UIImage systemImageNamed:symbolName]]);
-    [view setTintColor:color];
+    [view setTintColor:color.get()];
     [view setPreferredSymbolConfiguration:[UIImageSymbolConfiguration configurationWithPointSize:imagePointSize]];
     [view setContentMode:UIViewContentModeScaleAspectFit];
 #endif
@@ -233,7 +233,7 @@ static RetainPtr<ViewType> viewForIconImage(_WKWarningView *warningView)
 
 static ButtonType *makeButton(WarningItem item, _WKWarningView *warning, SEL action)
 {
-    NSString *title = nil;
+    RetainPtr<NSString> title;
     if (item == WarningItem::ShowDetailsButton)
         title = WEB_UI_NSSTRING(@"Show Details", "Action from safe browsing warning");
     else if (item == WarningItem::ContinueButton)
@@ -241,10 +241,10 @@ static ButtonType *makeButton(WarningItem item, _WKWarningView *warning, SEL act
     else
         title = WEB_UI_NSSTRING(@"Go Back", "Action from safe browsing warning");
 #if PLATFORM(MAC)
-    return [NSButton buttonWithTitle:title target:warning action:action];
+    return [NSButton buttonWithTitle:title.get() target:warning action:action];
 #else
     UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
-    auto attributedTitle = adoptNS([[NSAttributedString alloc] initWithString:title attributes:@{
+    auto attributedTitle = adoptNS([[NSAttributedString alloc] initWithString:title.get() attributes:@{
         NSUnderlineStyleAttributeName:@(NSUnderlineStyleSingle),
         NSUnderlineColorAttributeName:[UIColor whiteColor],
         NSForegroundColorAttributeName:colorForItem(item, warning),
@@ -356,18 +356,18 @@ static RetainPtr<ViewType> makeLabel(NSAttributedString *attributedString)
 #endif
     }]).get());
 
-    auto primaryButton = WTF::switchOn(_warning->data(), [&] (const WebKit::BrowsingWarning::SafeBrowsingWarningData&) {
+    RetainPtr primaryButton = WTF::switchOn(_warning->data(), [&] (const WebKit::BrowsingWarning::SafeBrowsingWarningData&) {
         return makeButton(WarningItem::ShowDetailsButton, self, @selector(showDetailsClicked));
     }, [&] (const WebKit::BrowsingWarning::HTTPSNavigationFailureData&) {
         return makeButton(WarningItem::ContinueButton, self, @selector(continueClicked));
     });
-    auto goBack = makeButton(WarningItem::GoBackButton, self, @selector(goBackClicked));
-    auto box = adoptNS([_WKWarningViewBox new]);
+    RetainPtr goBack = makeButton(WarningItem::GoBackButton, self, @selector(goBackClicked));
+    RetainPtr box = adoptNS([_WKWarningViewBox new]);
     _box = box.get();
     [box setWarningViewBackgroundColor:colorForItem(WarningItem::BoxBackground, self)];
     [box layer].cornerRadius = boxCornerRadius;
 
-    for (ViewType *view in @[ warningViewIcon.get(), title.get(), warning.get(), goBack, primaryButton ]) {
+    for (ViewType *view in @[ warningViewIcon.get(), title.get(), warning.get(), goBack.get(), primaryButton.get() ]) {
         view.translatesAutoresizingMaskIntoConstraints = NO;
         [box addSubview:view];
     }
@@ -403,23 +403,23 @@ static RetainPtr<ViewType> makeLabel(NSAttributedString *attributedString)
 
         [[[title trailingAnchor] anchorWithOffsetToAnchor:[box trailingAnchor]] constraintGreaterThanOrEqualToConstant:marginSize],
         [[[warning trailingAnchor] anchorWithOffsetToAnchor:[box trailingAnchor]] constraintGreaterThanOrEqualToConstant:marginSize],
-        [[goBack.trailingAnchor anchorWithOffsetToAnchor:[box trailingAnchor]] constraintEqualToConstant:marginSize],
+        [[goBack.get().trailingAnchor anchorWithOffsetToAnchor:[box trailingAnchor]] constraintEqualToConstant:marginSize],
 
-        [[[warning bottomAnchor] anchorWithOffsetToAnchor:goBack.topAnchor] constraintEqualToConstant:marginSize],
+        [[[warning bottomAnchor] anchorWithOffsetToAnchor:goBack.get().topAnchor] constraintEqualToConstant:marginSize],
     ]];
 
-    bool needsVerticalButtonLayout = buttonSize(primaryButton).width + buttonSize(goBack).width + 3 * marginSize > self.frame.size.width;
+    bool needsVerticalButtonLayout = buttonSize(primaryButton.get()).width + buttonSize(goBack.get()).width + 3 * marginSize > self.frame.size.width;
     if (needsVerticalButtonLayout) {
         [NSLayoutConstraint activateConstraints:@[
-            [[primaryButton.trailingAnchor anchorWithOffsetToAnchor:[box trailingAnchor]] constraintEqualToConstant:marginSize],
-            [[goBack.bottomAnchor anchorWithOffsetToAnchor:primaryButton.topAnchor] constraintEqualToConstant:marginSize],
-            [[goBack.bottomAnchor anchorWithOffsetToAnchor:[box bottomAnchor]] constraintEqualToConstant:marginSize * 2 + buttonSize(primaryButton).height],
+            [[primaryButton.get().trailingAnchor anchorWithOffsetToAnchor:[box trailingAnchor]] constraintEqualToConstant:marginSize],
+            [[goBack.get().bottomAnchor anchorWithOffsetToAnchor:primaryButton.get().topAnchor] constraintEqualToConstant:marginSize],
+            [[goBack.get().bottomAnchor anchorWithOffsetToAnchor:[box bottomAnchor]] constraintEqualToConstant:marginSize * 2 + buttonSize(primaryButton.get()).height],
         ]];
     } else {
         [NSLayoutConstraint activateConstraints:@[
-            [[primaryButton.trailingAnchor anchorWithOffsetToAnchor:goBack.leadingAnchor] constraintEqualToConstant:marginSize],
-            [goBack.topAnchor constraintEqualToAnchor:primaryButton.topAnchor],
-            [[goBack.bottomAnchor anchorWithOffsetToAnchor:[box bottomAnchor]] constraintEqualToConstant:marginSize],
+            [[primaryButton.get().trailingAnchor anchorWithOffsetToAnchor:goBack.get().leadingAnchor] constraintEqualToConstant:marginSize],
+            [goBack.get().topAnchor constraintEqualToAnchor:primaryButton.get().topAnchor],
+            [[goBack.get().bottomAnchor anchorWithOffsetToAnchor:[box bottomAnchor]] constraintEqualToConstant:marginSize],
         ]];
     }
 #if !PLATFORM(MAC)
@@ -435,8 +435,8 @@ static RetainPtr<ViewType> makeLabel(NSAttributedString *attributedString)
 
 - (void)showDetailsClicked
 {
-    _WKWarningViewBox *box = _box.get().get();
-    ButtonType *showDetails = box.subviews.lastObject;
+    RetainPtr box = _box.get().get();
+    RetainPtr<ButtonType> showDetails = box.get().subviews.lastObject;
     [showDetails removeFromSuperview];
 
     auto text = adoptNS([self._protectedWarning->details() mutableCopy]);
@@ -451,10 +451,10 @@ static RetainPtr<ViewType> makeLabel(NSAttributedString *attributedString)
     constexpr auto maxY = kCALayerMinXMaxYCorner | kCALayerMaxXMaxYCorner;
     constexpr auto minY = kCALayerMinXMinYCorner | kCALayerMaxXMinYCorner;
 #if PLATFORM(MAC)
-    box.layer.maskedCorners = maxY;
+    box.get().layer.maskedCorners = maxY;
     [bottom layer].maskedCorners = minY;
 #else
-    box.layer.maskedCorners = minY;
+    box.get().layer.maskedCorners = minY;
     [bottom layer].maskedCorners = maxY;
 #endif
 #endif
@@ -469,9 +469,9 @@ static RetainPtr<ViewType> makeLabel(NSAttributedString *attributedString)
     [bottom addSubview:details.get()];
 #if HAVE(SAFE_BROWSING)
     [NSLayoutConstraint activateConstraints:@[
-        [box.widthAnchor constraintEqualToAnchor:[bottom widthAnchor]],
-        [box.bottomAnchor constraintEqualToAnchor:[bottom topAnchor]],
-        [box.leadingAnchor constraintEqualToAnchor:[bottom leadingAnchor]],
+        [box.get().widthAnchor constraintEqualToAnchor:[bottom widthAnchor]],
+        [box.get().bottomAnchor constraintEqualToAnchor:[bottom topAnchor]],
+        [box.get().leadingAnchor constraintEqualToAnchor:[bottom leadingAnchor]],
         [[line widthAnchor] constraintEqualToAnchor:[bottom widthAnchor]],
         [[line leadingAnchor] constraintEqualToAnchor:[bottom leadingAnchor]],
         [[line topAnchor] constraintEqualToAnchor:[bottom topAnchor]],
@@ -612,11 +612,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     self->_warning = warning;
     self.delegate = warning;
 
-    auto *foregroundColor = colorForItem(WarningItem::MessageText, warning);
-    auto string = adoptNS([attributedString mutableCopy]);
-    [string addAttributes:@{ NSForegroundColorAttributeName : foregroundColor } range:NSMakeRange(0, [string length])];
+    RetainPtr foregroundColor = colorForItem(WarningItem::MessageText, warning);
+    RetainPtr string = adoptNS([attributedString mutableCopy]);
+    [string addAttributes:@{ NSForegroundColorAttributeName : foregroundColor.get() } range:NSMakeRange(0, [string length])];
     [self setBackgroundColor:colorForItem(WarningItem::BoxBackground, warning)];
-    [self setLinkTextAttributes:@{ NSForegroundColorAttributeName : foregroundColor }];
+    [self setLinkTextAttributes:@{ NSForegroundColorAttributeName : foregroundColor.get() }];
     [self.textStorage appendAttributedString:string.get()];
     self.editable = NO;
 #if !PLATFORM(MAC)


### PR DESCRIPTION
#### a964b1ea0d89ad3acfa7343aa26f5d26784184bf
<pre>
Address remaining Safer CPP warnings in WebKit/UIProcess/Cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=291375">https://bugs.webkit.org/show_bug.cgi?id=291375</a>

Reviewed by Geoffrey Garen and Darin Adler.

* Source/WTF/wtf/cocoa/SoftLinking.h:
* Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm:
(WebKit::presentStorageAccessAlertSSOQuirk):
(WebKit::displayStorageAccessAlert):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::beginSafeBrowsingCheck):
(WebKit::WebPageProxy::addDictationAlternative):
(WebKit::WebPageProxy::updateIconForDirectory):
(WebKit::WebPageProxy::startApplePayAMSUISession):
(WebKit::WebPageProxy::isQuarantinedAndNotUserApproved):
(WebKit::WebPageProxy::useGPUProcessForDOMRenderingEnabled const):
(WebKit::WebPageProxy::presentingApplicationBundleIdentifier const):
* Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm:
(WebKit::WebPreferences::platformGetStringUserValueForKey):
(WebKit::WebPreferences::platformGetBoolUserValueForKey):
(WebKit::WebPreferences::platformGetUInt32UserValueForKey):
(WebKit::WebPreferences::platformGetDoubleUserValueForKey):
(WebKit::debugUserDefaultsValue):
(WebKit::setDebugBoolValueIfInUserDefaults):
(WebKit::setDebugUInt32ValueIfInUserDefaults):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::registerUserDefaults):
(WebKit::WebProcessPool::setMediaAccessibilityPreferences):
(WebKit::WebProcessPool::platformInitializeWebProcess):
(WebKit::WebProcessPool::platformInitializeNetworkProcess):
(WebKit::WebProcessPool::setJavaScriptConfigurationFileEnabledFromDefaults):
(WebKit::WebProcessPool::registerNotificationObservers):
(WebKit::WebProcessPool::clearPermanentCredentialsForProtectionSpace):
(WebKit::addUserInstalledFontURLs):
* Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm:
(viewForIconImage):
(makeButton):
(-[_WKWarningView addContent]):
(-[_WKWarningView showDetailsClicked]):
(-[_WKWarningViewTextView initWithAttributedString:forWarning:]):

Canonical link: <a href="https://commits.webkit.org/293576@main">https://commits.webkit.org/293576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d548a7bb3aeab4da058009caf0563f29f9798ff1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99248 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9142 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104377 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49845 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27329 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75542 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32637 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102255 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14579 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89613 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55903 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14370 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7591 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49207 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91931 "Built successfully and passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106734 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97867 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19216 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84500 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26724 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85814 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84016 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28673 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6353 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20086 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16155 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26301 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31560 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121482 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26122 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33939 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29435 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27689 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->