### PR TITLE
Unreviewed. Update safer C++ expectations after LLVM update.

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -1,9 +1,7 @@
 API/JSObjectRef.cpp
 BytecodeStructs.h
 assembler/Printer.h
-b3/B3CaseCollection.h
 b3/B3StackmapGenerationParams.h
-b3/B3SwitchValue.h
 b3/B3Value.h
 b3/B3VariableValue.h
 b3/air/AirAllocateRegistersAndStackAndGenerateCode.h
@@ -34,7 +32,6 @@ heap/HeapInlines.h
 heap/HeapProfiler.h
 heap/HeapSnapshotBuilder.h
 heap/MarkedBlock.h
-heap/MarkingConstraintSolver.h
 heap/SlotVisitor.h
 heap/WeakImpl.h
 heap/WeakSet.h
@@ -62,19 +59,6 @@ runtime/DumpContext.h
 runtime/FunctionExecutable.h
 runtime/FunctionExecutableInlines.h
 runtime/GetPutInfo.h
-runtime/IntlCollator.cpp
-runtime/IntlDateTimeFormat.cpp
-runtime/IntlDurationFormat.cpp
-runtime/IntlListFormat.cpp
-runtime/IntlLocale.cpp
-runtime/IntlNumberFormat.cpp
-runtime/IntlNumberFormatInlines.h
-runtime/IntlObject.cpp
-runtime/IntlPluralRules.cpp
-runtime/IntlRelativeTimeFormat.cpp
-runtime/IntlSegmentIterator.cpp
-runtime/IntlSegmenter.cpp
-runtime/IntlSegments.cpp
 runtime/JSArrayBufferConstructor.cpp
 runtime/JSCConfig.h
 runtime/JSGlobalObject.h
@@ -84,7 +68,6 @@ runtime/MicrotaskQueue.h
 runtime/NumericStrings.h
 runtime/PropertySlot.h
 runtime/SmallStrings.h
-runtime/StringPrototype.cpp
 runtime/StringReplaceCache.h
 runtime/StringSplitCache.h
 runtime/Structure.h

--- a/Source/JavaScriptCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -1,7 +1,4 @@
 API/JSAPIGlobalObject.mm
-API/JSContext.mm
-API/JSManagedValue.mm
-API/JSScript.mm
 API/JSValue.mm
 API/JSVirtualMachine.mm
 API/JSWrapperMap.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -822,6 +822,7 @@ loader/ApplicationManifestLoader.cpp
 loader/CrossOriginAccessControl.cpp
 loader/CrossOriginOpenerPolicy.cpp
 loader/CrossOriginPreflightChecker.cpp
+loader/DocumentLoader.cpp
 loader/DocumentThreadableLoader.cpp
 loader/DocumentWriter.cpp
 loader/FormSubmission.cpp

--- a/Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -1,12 +1,7 @@
-<<<<<<< HEAD
-=======
->>>>>>> f1f4378deaa5 (Update safer C++ expectations.)
 Platform/IPC/Connection.h
 Platform/IPC/MessageSenderInlines.h
 Platform/classifier/cocoa/ResourceLoadStatisticsClassifierCocoa.cpp
 Platform/cocoa/WebPrivacyHelpers.h
-UIProcess/API/C/WKPage.cpp
-UIProcess/Automation/WebAutomationSession.h
 UIProcess/WebProcessPool.h
 WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
 WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp

--- a/Source/WebKitLegacy/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -2,7 +2,6 @@ Storage/StorageTracker.h
 WebCoreSupport/SocketStreamHandle.h
 ios/WebCoreSupport/PopupMenuIOS.h
 mac/DOM/DOMAbstractView.mm
-mac/DOM/DOMDocument.mm
 mac/DOM/DOMObject.mm
 mac/WebCoreSupport/PopupMenuMac.h
 mac/WebCoreSupport/WebChromeClient.mm


### PR DESCRIPTION
#### 2a30837739f7a17311b6236c5d668b07c7716742
<pre>
Unreviewed. Update safer C++ expectations after LLVM update.

* Source/JavaScriptCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/JavaScriptCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/ForwardDeclCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/293544@main">https://commits.webkit.org/293544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47e712e2cfc716f54ec7288d33d0fb86ca265185

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99243 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104372 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/49840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101283 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27324 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/75541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/49840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102250 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/14578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/89610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/55902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/14369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7588 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49202 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91926 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106729 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97862 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26356 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26719 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85811 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/84015 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/28674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/6351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/20081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16140 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26296 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/31481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121477 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26117 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33937 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29430 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27684 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->