### PR TITLE
When converting DNR rules, higher numbers in priority should be higher priority

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp
@@ -123,7 +123,7 @@ IDBError MemoryObjectStore::addIndex(MemoryBackingStoreTransaction& transaction,
     auto index = MemoryIndex::create(indexInfo, *this);
     index->writeTransactionStarted(transaction);
     m_info.addExistingIndex(indexInfo);
-    transaction.addNewIndex(index.get());
+    transaction.addNewIndex(indexInfo.get());
     registerIndex(WTFMove(index));
 
     return IDBError { };


### PR DESCRIPTION
#### a3e0dfae3e63b528b5d5bdff84613c26cc002bef
<pre>
When converting DNR rules, higher numbers in priority should be higher priority
<a href="https://bugs.webkit.org/show_bug.cgi?id=291222">https://bugs.webkit.org/show_bug.cgi?id=291222</a>
<a href="https://rdar.apple.com/145570245">rdar://145570245</a>

Reviewed by Timothy Hatcher.

This is specified in the declarativeNetRequest documentation at:
<a href="https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest#rule-examples">https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest#rule-examples</a>

But we had it backwards.

While we&apos;re here, also bump the DNR translation rule version so existing DNR content blockers will
be recompiled with this change.

* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm:
(-[_WKWebExtensionDeclarativeNetRequestRule compare:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RulesSortByPriorityFromDifferentRulesets)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RulesSortWithoutExplicitPriority)):

Canonical link: https://commits.webkit.org/293546@main
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3e0dfae3e63b528b5d5bdff84613c26cc002bef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99256 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18903 "Hash a3e0dfae for PR 43922 does not build (failure)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/9150 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104385 "Hash a3e0dfae for PR 43922 does not build (failure)") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/49853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101296 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/19192 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27337 "Hash a3e0dfae for PR 43922 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/104385 "Hash a3e0dfae for PR 43922 does not build (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/49853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102263 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/19192 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/9150 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/104385 "Hash a3e0dfae for PR 43922 does not build (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/19192 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/9150 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49215 "Hash a3e0dfae for PR 43922 does not build (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/19192 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/9150 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106742 "Hash a3e0dfae for PR 43922 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26369 "Hash a3e0dfae for PR 43922 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/27337 "Hash a3e0dfae for PR 43922 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/106742 "Hash a3e0dfae for PR 43922 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26732 "Hash a3e0dfae for PR 43922 does not build (failure)") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/9150 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/106742 "Hash a3e0dfae for PR 43922 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/9150 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/20094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26309 "Hash a3e0dfae for PR 43922 does not build (failure)") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/31500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/26130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29443 "Hash a3e0dfae for PR 43922 does not build (failure)") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/27697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->