### PR TITLE
RenderInline::imageChanged repaints even when there's no layer

### DIFF
--- a/LayoutTests/fast/images/inline-with-image-no-layer-expected.txt
+++ b/LayoutTests/fast/images/inline-with-image-no-layer-expected.txt
@@ -1,0 +1,3 @@
+This test passes if WebKit does not crash
+
+PASS

--- a/LayoutTests/fast/images/inline-with-image-no-layer.html
+++ b/LayoutTests/fast/images/inline-with-image-no-layer.html
@@ -1,0 +1,24 @@
+<style>
+  * {
+        outline-offset: 1em;
+        border-image-source: url("data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==");
+    }
+</style>
+<script>
+  window.testRunner?.dumpAsText();
+  window.testRunner?.waitUntilDone();
+  function test() {
+        var00038 = label.style;
+        label.appendChild(dialog);
+        var00169 = document.execCommand("selectAll", false);
+        var00038.setProperty("position", "relative");
+        window.testRunner?.notifyDone();
+        res.append("PASS");
+    }
+</script>
+<body onload="test()">
+  <label id="label"></label>
+  <dialog id="dialog" open="true"></dialog>
+  <p>This test passes if WebKit does not crash</p>
+  <div id="res"></div>
+</body>

--- a/LayoutTests/fast/repaint/image-with-no-layer-gets-repainted-expected.txt
+++ b/LayoutTests/fast/repaint/image-with-no-layer-gets-repainted-expected.txt
@@ -1,0 +1,4 @@
+This test passes if the border image is applied and there's a repaint of the image
+
+PASS: border image applied
+Paints happened and overlap 0 0 784 18: PASS

--- a/LayoutTests/fast/repaint/image-with-no-layer-gets-repainted.html
+++ b/LayoutTests/fast/repaint/image-with-no-layer-gets-repainted.html
@@ -1,0 +1,51 @@
+<style>
+  #label {
+    border: 1px solid white;
+  }
+</style>
+<script>
+  window.testRunner?.dumpAsText();
+  //window.testRunner?.waitUntilDone();
+
+  function testRect(rects) {
+    const regex = /\(rect\s(\d+)\s(\d+)\s(\d+)\s(\d+)\)/;
+    const match = rects.match(regex);
+
+    if (match) {
+      const x = parseInt(match[1], 10);
+      const y = parseInt(match[2], 10);
+      const width = parseInt(match[3], 10);
+      const height = parseInt(match[4], 10);
+
+      if (x < 784 && (x + width) > 0 && y < 18 && (y + height) > 0) {
+        return "PASS";
+      } else {
+        return "FAIL";
+      }
+    }
+  }
+
+  function test() {
+    window.internals?.startTrackingRepaints();
+    label.style.borderImageSource = "url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==)";
+    computedStyle = getComputedStyle(label);
+    borderImageSource = computedStyle.borderImageSource;
+    var repaintRectsAfter = window.internals?.repaintRectsAsText();
+    window.internals.stopTrackingRepaints();
+
+    if (borderImageSource.includes("data:image/gif")) {
+      res.textContent = "PASS: border image applied";
+    } else {
+      res.textContent = "FAIL: border image not applied.";
+    }
+    repaints.textContent = "Paints happened and overlap 0 0 784 18: " + testRect(repaintRectsAfter);
+
+    window.testRunner?.notifyDone();
+  }
+</script>
+<body onload="test()">
+  <label id="label"></label>
+  <p>This test passes if the border image is applied and there's a repaint of the image</p>
+  <pre id="res"></pre>
+  <pre id="repaints"></pre>
+</body>

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -895,7 +895,8 @@ void RenderInline::imageChanged(WrappedImagePtr, const IntRect*)
         return;
         
     // FIXME: We can do better.
-    repaint();
+    if (hasLayer())
+        repaint();
 }
 
 namespace {


### PR DESCRIPTION
#### 0a49aa436ef6568c5567488dad7771b8a73bddec
<pre>
RenderInline::imageChanged repaints even when there&apos;s no layer
<a href="https://rdar.apple.com/147939623">rdar://147939623</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291391">https://bugs.webkit.org/show_bug.cgi?id=291391</a>

Reviewed by NOBODY (OOPS!).

Check if the RenderInline has a layer before repainting to avoid crashing
further down when we try to calculate offsets

* LayoutTests/fast/images/inline-with-image-no-layer-expected.txt: Added.
* LayoutTests/fast/images/inline-with-image-no-layer.html: Added.
* LayoutTests/fast/repaint/image-with-no-layer-gets-repainted-expected.txt: Added.
* LayoutTests/fast/repaint/image-with-no-layer-gets-repainted.html: Added.
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::imageChanged):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a49aa436ef6568c5567488dad7771b8a73bddec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99749 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19395 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9668 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104874 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50338 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101790 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27831 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75933 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33025 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15009 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90071 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56294 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14813 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8058 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49699 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84747 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8143 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107235 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26861 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19617 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84889 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27224 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84410 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29086 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6799 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/20677 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26800 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32025 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26613 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29929 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28181 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->