### PR TITLE
Crash in WebCore::forEachRendererInPaintOrder; WebCore::ViewTransition::captureNewState.

### DIFF
--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -79,6 +79,7 @@ public:
     WeakStyleable newElement;
     LayoutRect newOverflowRect;
     LayoutSize newSize;
+    RefPtr<MutableStyleProperties> newProperties;
 
     Vector<AtomString> classList;
     RefPtr<MutableStyleProperties> groupStyleProperties;
@@ -208,7 +209,7 @@ private:
     ViewTransition(Document&, Vector<AtomString>&&);
 
     Ref<MutableStyleProperties> copyElementBaseProperties(RenderLayerModelObject&, LayoutSize&, LayoutRect& overflowRect, bool& intersectsViewport);
-    bool updatePropertiesForRenderer(CapturedElement&, RenderBoxModelObject*, const AtomString&);
+    bool updatePropertiesForGroupPseudo(CapturedElement&, const AtomString&);
 
     // Setup view transition sub-algorithms.
     ExceptionOr<void> captureOldState();
@@ -218,8 +219,9 @@ private:
 
     void callUpdateCallback();
 
-    void updatePseudoElementStyles();
-    ExceptionOr<void> updatePseudoElementSizes();
+    void updatePseudoElementStylesRead();
+    void updatePseudoElementStylesWrite();
+    ExceptionOr<void> updatePseudoElementRenderers();
     ExceptionOr<void> checkForViewportSizeChange();
 
     void clearViewTransition();


### PR DESCRIPTION
#### 00b3f2deceaf36504b07ac3013698277d57dbd63
<pre>
Crash in WebCore::forEachRendererInPaintOrder; WebCore::ViewTransition::captureNewState.
<a href="https://bugs.webkit.org/show_bug.cgi?id=286109">https://bugs.webkit.org/show_bug.cgi?id=286109</a>
&lt;<a href="https://rdar.apple.com/142779342">rdar://142779342</a>&gt;

Reviewed by Tim Nguyen.

captureNewState was writing new styles while iterating the render layer tree,
and also implicitly flushing styles by reading computed values. In rare cases
the style flush could invalidate the render layer positioned list.

This change splits this into two separate passes. The first pass reads all the
computed styles from the captured elements, and then second pass generates all
the stylesheet changes. Finally we flush style, and configure the VT psuedo
renderers as needed.

* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::updatePropertiesForGroupPseudo):
(WebCore::ViewTransition::captureNewState):
(WebCore::ViewTransition::setupTransitionPseudoElements):
(WebCore::ViewTransition::activateViewTransition):
(WebCore::ViewTransition::handleTransitionFrame):
(WebCore::ViewTransition::updateNewState):
(WebCore::ViewTransition::updatePseudoElementStyles):
(WebCore::ViewTransition::updatePseudoElementRenderers):
(WebCore::ViewTransition::updatePropertiesForRenderer): Deleted.
(WebCore::ViewTransition::updatePseudoElementSizes): Deleted.
* Source/WebCore/dom/ViewTransition.h:

Originally-landed-as: 283286.634@safari-7620-branch (9ea70df86dfe). <a href="https://rdar.apple.com/148060776">rdar://148060776</a>
Canonical link: <a href="https://commits.webkit.org/293851@main">https://commits.webkit.org/293851@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99771995187a5e56efceb4d39f0e4d5e2709949b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105149 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50602 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102062 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28144 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76139 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33221 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15251 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90335 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56498 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15061 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8330 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49971 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84980 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107509 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27134 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19874 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85097 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27497 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86540 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84623 "Found 3 new API test failures: /TestWebKit:WebKit.UserMediaBasic, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/default, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mouse-target (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29300 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7033 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20970 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16288 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27071 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32300 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26882 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30198 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28441 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->