### PR TITLE
Use enum class in webaudio/AudioContext

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -153,12 +153,10 @@ void AudioContext::constructCommon()
     ASSERT(document());
     RefPtr mainFrameDocument = document()->mainFrameDocument();
     if (!mainFrameDocument || mainFrameDocument->requiresUserGestureForAudioPlayback())
-        addBehaviorRestriction(RequireUserGestureForAudioStartRestriction);
-    else
-        m_restrictions = NoRestrictions;
+        addBehaviorRestriction(BehaviorRestrictionFlags::RequireUserGestureForAudioStartRestriction);
 
 #if PLATFORM(COCOA)
-    addBehaviorRestriction(RequirePageConsentForAudioStartRestriction);
+    addBehaviorRestriction(BehaviorRestrictionFlags::RequirePageConsentForAudioStartRestriction);
 #endif
 }
 
@@ -357,7 +355,7 @@ bool AudioContext::willPausePlayback()
     if (userGestureRequiredForAudioStart()) {
         if (!document->processingUserGestureForMedia())
             return false;
-        removeBehaviorRestriction(RequireUserGestureForAudioStartRestriction);
+        removeBehaviorRestriction(BehaviorRestrictionFlags::RequireUserGestureForAudioStartRestriction);
     }
 
     if (pageConsentRequiredForAudioStart()) {
@@ -366,7 +364,7 @@ bool AudioContext::willPausePlayback()
             document->addMediaCanStartListener(*this);
             return false;
         }
-        removeBehaviorRestriction(RequirePageConsentForAudioStartRestriction);
+        removeBehaviorRestriction(BehaviorRestrictionFlags::RequirePageConsentForAudioStartRestriction);
     }
 
     return m_mediaSession->clientWillPausePlayback();
@@ -416,7 +414,7 @@ bool AudioContext::willBeginPlayback()
             ALWAYS_LOG(LOGIDENTIFIER, "returning false, not processing user gesture or capturing");
             return false;
         }
-        removeBehaviorRestriction(RequireUserGestureForAudioStartRestriction);
+        removeBehaviorRestriction(BehaviorRestrictionFlags::RequireUserGestureForAudioStartRestriction);
     }
 
     if (pageConsentRequiredForAudioStart()) {
@@ -426,7 +424,7 @@ bool AudioContext::willBeginPlayback()
             ALWAYS_LOG(LOGIDENTIFIER, "returning false, page doesn't allow media to start");
             return false;
         }
-        removeBehaviorRestriction(RequirePageConsentForAudioStartRestriction);
+        removeBehaviorRestriction(BehaviorRestrictionFlags::RequirePageConsentForAudioStartRestriction);
     }
 
     m_mediaSession->setActive(true);
@@ -654,7 +652,7 @@ const String& AudioContext::sceneIdentifier() const
 void AudioContext::mediaCanStart(Document& document)
 {
     ASSERT_UNUSED(document, &document == this->document());
-    removeBehaviorRestriction(RequirePageConsentForAudioStartRestriction);
+    removeBehaviorRestriction(BehaviorRestrictionFlags::RequirePageConsentForAudioStartRestriction);
     mayResumePlayback(true);
 }
 

--- a/Source/WebCore/Modules/webaudio/AudioContext.h
+++ b/Source/WebCore/Modules/webaudio/AudioContext.h
@@ -89,15 +89,14 @@ public:
     void isPlayingAudioDidChange();
 
     // Restrictions to change default behaviors.
-    enum BehaviorRestrictionFlags {
-        NoRestrictions = 0,
+    enum class BehaviorRestrictionFlags : uint8_t {
         RequireUserGestureForAudioStartRestriction = 1 << 0,
         RequirePageConsentForAudioStartRestriction = 1 << 1,
     };
-    typedef unsigned BehaviorRestrictions;
+    using BehaviorRestrictions = OptionSet<BehaviorRestrictionFlags>;
     BehaviorRestrictions behaviorRestrictions() const { return m_restrictions; }
-    void addBehaviorRestriction(BehaviorRestrictions restriction) { m_restrictions |= restriction; }
-    void removeBehaviorRestriction(BehaviorRestrictions restriction) { m_restrictions &= ~restriction; }
+    void addBehaviorRestriction(BehaviorRestrictions restriction) { m_restrictions.add(restriction); }
+    void removeBehaviorRestriction(BehaviorRestrictions restriction) { m_restrictions.remove(restriction); }
 
     void defaultDestinationWillBecomeConnected();
 
@@ -117,8 +116,8 @@ private:
 
     void constructCommon();
 
-    bool userGestureRequiredForAudioStart() const { return m_restrictions & RequireUserGestureForAudioStartRestriction; }
-    bool pageConsentRequiredForAudioStart() const { return m_restrictions & RequirePageConsentForAudioStartRestriction; }
+    bool userGestureRequiredForAudioStart() const { return m_restrictions.contains(BehaviorRestrictionFlags::RequireUserGestureForAudioStartRestriction); }
+    bool pageConsentRequiredForAudioStart() const { return m_restrictions.contains(BehaviorRestrictionFlags::RequirePageConsentForAudioStartRestriction); }
 
     bool willPausePlayback();
 
@@ -164,7 +163,7 @@ private:
     Ref<PlatformMediaSession> m_mediaSession;
     MediaUniqueIdentifier m_currentIdentifier;
 
-    BehaviorRestrictions m_restrictions { NoRestrictions };
+    BehaviorRestrictions m_restrictions;
 
     // [[suspended by user]] flag in the specification:
     // https://www.w3.org/TR/webaudio/#dom-audiocontext-suspended-by-user-slot
@@ -174,6 +173,16 @@ private:
 };
 
 } // WebCore
+
+namespace WTF {
+template<> struct EnumTraits<WebCore::AudioContext::BehaviorRestrictionFlags> {
+    using values = EnumValues<
+        WebCore::AudioContext::BehaviorRestrictionFlags,
+        WebCore::AudioContext::BehaviorRestrictionFlags::RequireUserGestureForAudioStartRestriction,
+        WebCore::AudioContext::BehaviorRestrictionFlags::RequirePageConsentForAudioStartRestriction
+    >;
+};
+} // namespace WTF
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::AudioContext)
     static bool isType(const WebCore::BaseAudioContext& context) { return !context.isOfflineContext(); }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5172,15 +5172,13 @@ void Internals::setAudioContextRestrictions(AudioContext& context, StringView re
     auto restrictions = context.behaviorRestrictions();
     context.removeBehaviorRestriction(restrictions);
 
-    restrictions = AudioContext::NoRestrictions;
+    restrictions = { };
 
     for (StringView restrictionString : restrictionsString.split(',')) {
-        if (equalLettersIgnoringASCIICase(restrictionString, "norestrictions"_s))
-            restrictions |= AudioContext::NoRestrictions;
         if (equalLettersIgnoringASCIICase(restrictionString, "requireusergestureforaudiostart"_s))
-            restrictions |= AudioContext::RequireUserGestureForAudioStartRestriction;
+            restrictions.add(AudioContext::BehaviorRestrictionFlags::RequireUserGestureForAudioStartRestriction);
         if (equalLettersIgnoringASCIICase(restrictionString, "requirepageconsentforaudiostart"_s))
-            restrictions |= AudioContext::RequirePageConsentForAudioStartRestriction;
+            restrictions.add(AudioContext::BehaviorRestrictionFlags::RequirePageConsentForAudioStartRestriction);
     }
     context.addBehaviorRestriction(restrictions);
 }


### PR DESCRIPTION
#### 93d411576938dfec7e6bb7aa7146936080cd78ce
<pre>
Use enum class in webaudio/AudioContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=291398">https://bugs.webkit.org/show_bug.cgi?id=291398</a>
<a href="https://rdar.apple.com/problem/149029423">rdar://problem/149029423</a>

Reviewed by Chris Dumez.

Using Safer CPP constructs to avoid type confusion, and make it easier to pass over WebKit IPC.

* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::constructCommon):
(WebCore::AudioContext::willPausePlayback):
(WebCore::AudioContext::willBeginPlayback):
(WebCore::AudioContext::mediaCanStart):
* Source/WebCore/Modules/webaudio/AudioContext.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setAudioContextRestrictions):

Canonical link: <a href="https://commits.webkit.org/293764@main">https://commits.webkit.org/293764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc0e6fcc35ae073f595253ef38ab8002c07df3da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104748 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50213 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101658 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19657 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27700 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75830 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32927 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102624 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56189 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14778 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7935 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49577 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84722 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107107 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26732 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19517 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84789 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27096 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84306 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21459 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28978 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6687 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/20523 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26672 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31875 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26491 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29803 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28057 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->