### PR TITLE
[Page color sampling] Fixed-position color extension views disappear when rubber-banding

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-while-rubber-banding-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-while-rubber-banding-expected.txt
@@ -1,0 +1,12 @@
+PASS colorsBeforeScrolling.top is "rgb(250, 60, 0)"
+PASS colorsBeforeScrolling.left is null
+PASS colorsBeforeScrolling.right is null
+PASS colorsBeforeScrolling.bottom is null
+PASS colorsAfterScrolling.top is "rgb(250, 60, 0)"
+PASS colorsAfterScrolling.left is null
+PASS colorsAfterScrolling.right is null
+PASS colorsAfterScrolling.bottom is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/page-color-sampling/color-sampling-while-rubber-banding.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-while-rubber-banding.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+    body, html {
+        width: 100%;
+        margin: 0;
+        font-family: system-ui;
+        background: #eee;
+    }
+
+    header {
+        position: fixed;
+        top: 0;
+        width: 100%;
+        height: 50px;
+        z-index: 100;
+        background: rgb(250, 60, 0);
+    }
+
+    .tall {
+        width: 10px;
+        height: 5000px;
+    }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    window.internals?.settings.setAllowUnclampedScrollPosition(true);
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(100, 0, 0, 0);
+        await UIHelper.ensurePresentationUpdate();
+        colorsBeforeScrolling = await UIHelper.fixedContainerEdgeColors();
+        shouldBeEqualToString("colorsBeforeScrolling.top", "rgb(250, 60, 0)");
+        shouldBeNull("colorsBeforeScrolling.left");
+        shouldBeNull("colorsBeforeScrolling.right");
+        shouldBeNull("colorsBeforeScrolling.bottom");
+
+        scrollTo(0, -200);
+        await UIHelper.ensurePresentationUpdate();
+
+        colorsAfterScrolling = await UIHelper.fixedContainerEdgeColors();
+        shouldBeEqualToString("colorsAfterScrolling.top", "rgb(250, 60, 0)");
+        shouldBeNull("colorsAfterScrolling.left");
+        shouldBeNull("colorsAfterScrolling.right");
+        shouldBeNull("colorsAfterScrolling.bottom");
+
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+    <header></header>
+    <div class="tall"></div>
+</body>
+</html>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1933,23 +1933,53 @@ FixedContainerEdges LocalFrameView::fixedContainerEdges(BoxSideSet sides) const
         Color backgroundColor;
     };
 
-    auto fixedRect = rectForFixedPositionLayout();
+    auto unclampedFixedRect = rectForFixedPositionLayout();
+    auto fixedRect = unclampedFixedRect;
+    if (CheckedPtr view = renderView())
+        fixedRect.intersect(view->unscaledDocumentRect());
     fixedRect.contract({ sampleRectMargin });
+    unclampedFixedRect.contract({ sampleRectMargin });
 
-    auto hitTestLocationForSide = [&](BoxSide side) -> LayoutPoint {
+    auto midpointOnSide = [&](BoxSide side, const LayoutRect& rect) -> LayoutPoint {
         switch (side) {
         case BoxSide::Top:
-            return { (fixedRect.x() + fixedRect.maxX()) / 2, fixedRect.y() };
+            return { (rect.x() + rect.maxX()) / 2, rect.y() };
         case BoxSide::Left:
-            return { fixedRect.x(), (fixedRect.y() + fixedRect.maxY()) / 2 };
+            return { rect.x(), (rect.y() + rect.maxY()) / 2 };
         case BoxSide::Right:
-            return { fixedRect.maxX(), (fixedRect.y() + fixedRect.maxY()) / 2 };
+            return { rect.maxX(), (fixedRect.y() + rect.maxY()) / 2 };
         case BoxSide::Bottom:
-            return { (fixedRect.x() + fixedRect.maxX()) / 2, fixedRect.maxY() };
+            return { (rect.x() + rect.maxX()) / 2, rect.maxY() };
         default:
             ASSERT_NOT_REACHED();
             return { };
         }
+    };
+
+    auto hitTestLocationForSide = [&](BoxSide side) -> HitTestLocation {
+        auto target = midpointOnSide(side, fixedRect);
+        auto unclampedTarget = midpointOnSide(side, unclampedFixedRect);
+        LayoutRect hitTestRect {
+            LayoutPoint { std::min(target.x(), unclampedTarget.x()), std::min(target.y(), unclampedTarget.y()) },
+            LayoutPoint { std::max(target.x(), unclampedTarget.x()), std::max(target.y(), unclampedTarget.y()) },
+        };
+
+        if (hitTestRect.size().maxDimension() <= sampleRectMargin)
+            return { target };
+
+        LayoutUnit hitTestRectThickness = 1;
+        switch (side) {
+        case BoxSide::Top:
+        case BoxSide::Bottom:
+            hitTestRect.inflateX(hitTestRectThickness / 2);
+            break;
+        case BoxSide::Left:
+        case BoxSide::Right:
+            hitTestRect.inflateY(hitTestRectThickness / 2);
+            break;
+        }
+
+        return { hitTestRect };
     };
 
     auto primaryBackgroundColorForRenderer = [](const RenderElement& renderer) -> Color {
@@ -1990,7 +2020,7 @@ FixedContainerEdges LocalFrameView::fixedContainerEdges(BoxSideSet sides) const
 
     auto findFixedContainer = [&](BoxSide side) -> FixedContainerResult {
         using enum HitTestRequest::Type;
-        static constexpr OptionSet hitTestOptions {
+        static constexpr OptionSet commonHitTestOptions {
             ReadOnly,
             DisallowUserAgentShadowContent,
             IgnoreClipping,
@@ -1998,10 +2028,13 @@ FixedContainerEdges LocalFrameView::fixedContainerEdges(BoxSideSet sides) const
         };
 
         HitTestResult result { hitTestLocationForSide(side) };
-        if (!document->hitTest({ HitTestSource::User, hitTestOptions }, result))
-            return { };
+        auto hitTestOptions = commonHitTestOptions;
+        if (result.isRectBasedTest())
+            hitTestOptions.add(CollectMultipleElements);
 
-        RefPtr hitNode = result.innerNonSharedNode();
+        document->hitTest({ HitTestSource::User, hitTestOptions }, result);
+
+        RefPtr hitNode = result.isRectBasedTest() ? result.listBasedTestResult().first().ptr() : result.innerNonSharedNode();
         if (!hitNode)
             return { };
 


### PR DESCRIPTION
#### 3a37a9d2664db026cc7d29b4d656eadd6e81f3d6
<pre>
[Page color sampling] Fixed-position color extension views disappear when rubber-banding
<a href="https://bugs.webkit.org/show_bug.cgi?id=291399">https://bugs.webkit.org/show_bug.cgi?id=291399</a>
<a href="https://rdar.apple.com/148840634">rdar://148840634</a>

Reviewed by Abrar Rahman Protyasha.

Teach `fixedContainerEdges` to handle rubber-banding on macOS, without failing to hit-test to fixed-
position elements on the rubber-banded edge. Currently, the `hitTest` fails and returns `false`, due
to the fact that the `rectForFixedPositionLayout` gets pushed outside of the document rect (e.g.
when scrolling against the top, the origin has a negative `y`). Simply intersecting this rect for
fixed-position layout with the document rect is insufficient, as the hit-test will still fail and
hit the body if the rubber-banding distance is large enough that the fixed container&apos;s layer bounds
lie outside of the document rect.

As a workaround, when rubber-banding, we can instead hit-test using a rect that extends from the
midpoint of the rect edge on the rect for fixed-position layout, to the midpoint of the document
rect (with a slight inset margin). This allows hit-testing to properly find fixed-position elements
whose clip rects lie outside of the document bounds when rubber-banding.

* LayoutTests/fast/page-color-sampling/color-sampling-while-rubber-banding-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-while-rubber-banding.html: Added.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):

Canonical link: <a href="https://commits.webkit.org/293575@main">https://commits.webkit.org/293575@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c21af690d3fbec111d6bb96d0ea9598fcae6afb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104446 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49916 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101356 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19253 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27398 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75584 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32689 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102322 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14630 "Found 1 new test failure: fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89667 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55944 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14424 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7648 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49276 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84349 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7735 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106803 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26429 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19272 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84543 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26791 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85869 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84055 "Found 1 new API test failure: /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21325 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28723 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6411 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20161 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26369 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31569 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26189 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29502 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27756 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->