### PR TITLE
Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml2 and libxslt headers

### DIFF
--- a/Source/WebCore/dom/TransformSource.h
+++ b/Source/WebCore/dom/TransformSource.h
@@ -22,12 +22,7 @@
 
 #if ENABLE(XSLT)
 
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
-IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/tree.h>
-IGNORE_WARNINGS_END
-IGNORE_WARNINGS_END
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/dom/TransformSourceLibxslt.cpp
+++ b/Source/WebCore/dom/TransformSourceLibxslt.cpp
@@ -28,12 +28,7 @@
 #if ENABLE(XSLT)
 #include "TransformSource.h"
 
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
-IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/tree.h>
-IGNORE_WARNINGS_END
-IGNORE_WARNINGS_END
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/xml/XMLErrors.h
+++ b/Source/WebCore/xml/XMLErrors.h
@@ -28,12 +28,7 @@
 
 #pragma once
 
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
-IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/parser.h>
-IGNORE_WARNINGS_END
-IGNORE_WARNINGS_END
 #include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringBuilder.h>

--- a/Source/WebCore/xml/XSLStyleSheet.h
+++ b/Source/WebCore/xml/XSLStyleSheet.h
@@ -26,13 +26,8 @@
 
 #include "ProcessingInstruction.h"
 #include "StyleSheet.h"
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
-IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/parser.h>
 #include <libxslt/transform.h>
-IGNORE_WARNINGS_END
-IGNORE_WARNINGS_END
 #include <wtf/Ref.h>
 #include <wtf/TypeCasts.h>
 

--- a/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
+++ b/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
@@ -34,13 +34,8 @@
 #include "XMLDocumentParserScope.h"
 #include "XSLImportRule.h"
 #include "XSLTProcessor.h"
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
-IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/uri.h>
 #include <libxslt/xsltutils.h>
-IGNORE_WARNINGS_END
-IGNORE_WARNINGS_END
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/HexNumber.h>
 #include <wtf/text/MakeString.h>
@@ -214,10 +209,7 @@ void XSLStyleSheet::loadChildSheets()
             if (IS_XSLT_ELEM(curr) && IS_XSLT_NAME(curr, "import")) {
                 xmlChar* uriRef = xsltGetNsProp(curr, (const xmlChar*)"href", XSLT_NAMESPACE);
                 loadChildSheet(String::fromUTF8((const char*)uriRef));
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
                 xmlFree(uriRef);
-IGNORE_WARNINGS_END
             } else
                 break;
             curr = curr->next;
@@ -228,10 +220,7 @@ IGNORE_WARNINGS_END
             if (curr->type == XML_ELEMENT_NODE && IS_XSLT_ELEM(curr) && IS_XSLT_NAME(curr, "include")) {
                 xmlChar* uriRef = xsltGetNsProp(curr, (const xmlChar*)"href", XSLT_NAMESPACE);
                 loadChildSheet(String::fromUTF8((const char*)uriRef));
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
                 xmlFree(uriRef);
-IGNORE_WARNINGS_END
             }
             curr = curr->next;
         }
@@ -301,11 +290,8 @@ xmlDocPtr XSLStyleSheet::locateStylesheetSubResource(xmlDocPtr parentDoc, const 
             xmlChar* base = xmlNodeGetBase(parentDoc, (xmlNodePtr)parentDoc);
             xmlChar* childURI = xmlBuildURI((const xmlChar*)importHref.data(), base);
             bool equalURIs = xmlStrEqual(uri, childURI);
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
             xmlFree(base);
             xmlFree(childURI);
-IGNORE_WARNINGS_END
             if (equalURIs) {
                 child->markAsProcessed();
                 return child->document();

--- a/Source/WebCore/xml/XSLTExtensions.cpp
+++ b/Source/WebCore/xml/XSLTExtensions.cpp
@@ -29,16 +29,11 @@
 #if ENABLE(XSLT)
 #include "XSLTExtensions.h"
 
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
-IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/xpathInternals.h>
 
 #include <libxslt/extensions.h>
 #include <libxslt/extra.h>
 #include <libxslt/xsltutils.h>
-IGNORE_WARNINGS_END
-IGNORE_WARNINGS_END
 
 namespace WebCore {
 
@@ -89,11 +84,8 @@ static void exsltNodeSetFunction(xmlXPathParserContextPtr ctxt, int nargs)
             "WebCore::exsltNodeSetFunction: Failed to create a node set object.\n");
         tctxt->state = XSLT_STATE_STOPPED;
     }
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
     if (strval != NULL)
         xmlFree(strval);
-IGNORE_WARNINGS_END
 
     valuePush(ctxt, obj);
 }

--- a/Source/WebCore/xml/XSLTProcessor.h
+++ b/Source/WebCore/xml/XSLTProcessor.h
@@ -26,13 +26,8 @@
 
 #include "Node.h"
 #include "XSLStyleSheet.h"
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
-IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/parserInternals.h>
 #include <libxslt/documents.h>
-IGNORE_WARNINGS_END
-IGNORE_WARNINGS_END
 #include <wtf/HashMap.h>
 #include <wtf/text/StringHash.h>
 

--- a/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
+++ b/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
@@ -111,10 +111,7 @@ static xmlDocPtr docLoaderFunc(const xmlChar* uri,
         xsltTransformContextPtr context = (xsltTransformContextPtr)ctxt;
         xmlChar* base = xmlNodeGetBase(context->document->doc, context->node);
         URL url(URL({ }, String::fromLatin1(byteCast<char>(base))), String::fromLatin1(byteCast<char>(uri)));
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
         xmlFree(base);
-IGNORE_WARNINGS_END
         ResourceError error;
         ResourceResponse response;
 

--- a/Source/WebCore/xml/XSLTUnicodeSort.cpp
+++ b/Source/WebCore/xml/XSLTUnicodeSort.cpp
@@ -72,10 +72,7 @@ void xsltUnicodeSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr* rawSorts,
                     number[j] = 1;
                 else
                     xsltTransformError(ctxt, nullptr, sorts[j], "xsltDoSortFunction: no support for data-type = %s\n", stype);
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
                 xmlFree(stype);
-IGNORE_WARNINGS_END
             }
         } else
             number[j] = comp->number;
@@ -89,10 +86,7 @@ IGNORE_WARNINGS_END
                     desc[j] = 1;
                 else
                     xsltTransformError(ctxt, nullptr, sorts[j], "xsltDoSortFunction: invalid value %s for order\n", order);
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
                 xmlFree(order);
-IGNORE_WARNINGS_END
             }
         } else
             desc[j] = comp->descending;
@@ -244,10 +238,7 @@ IGNORE_WARNINGS_END
         if (resultsTab[j].data()) {
             for (int i = 0; i < len; ++i)
                 xmlXPathFreeObject(resultsTab[j][i]);
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
             xmlFree(resultsTab[j].data());
-IGNORE_WARNINGS_END
         }
     }
 }

--- a/Source/WebCore/xml/parser/XMLDocumentParser.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.h
@@ -30,13 +30,8 @@
 #include "ScriptableDocumentParser.h"
 #include "SegmentedString.h"
 #include "XMLErrors.h"
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
-IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/tree.h>
 #include <libxml/xmlstring.h>
-IGNORE_WARNINGS_END
-IGNORE_WARNINGS_END
 #include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -67,13 +67,8 @@
 #include "TransformSource.h"
 #include "XMLNSNames.h"
 #include "XMLDocumentParserScope.h"
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
-IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/parser.h>
 #include <libxml/parserInternals.h>
-IGNORE_WARNINGS_END
-IGNORE_WARNINGS_END
 #include <wtf/MallocSpan.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -124,9 +119,7 @@ struct XMLMalloc {
     static void* malloc(size_t size) { return xmlMallocHelper(size); }
     static void free(void* p)
     {
-        IGNORE_WARNINGS_BEGIN("deprecated-declarations")
         xmlFree(p);
-        IGNORE_WARNINGS_END
     }
 };
 
@@ -256,8 +249,6 @@ private:
     struct PendingStartElementNSCallback : public PendingCallback {
         virtual ~PendingStartElementNSCallback()
         {
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
             xmlFree(xmlLocalName);
             xmlFree(xmlPrefix);
             xmlFree(xmlURI);
@@ -267,7 +258,6 @@ IGNORE_WARNINGS_BEGIN("deprecated-declarations")
                 for (int j = 0; j < 4; j++)
                     xmlFree(attributes[i * 5 + j]);
             }
-IGNORE_WARNINGS_END
         }
 
         void call(XMLDocumentParser* parser) override
@@ -304,11 +294,8 @@ IGNORE_WARNINGS_END
     struct PendingProcessingInstructionCallback : public PendingCallback {
         virtual ~PendingProcessingInstructionCallback()
         {
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
             xmlFree(target);
             xmlFree(data);
-IGNORE_WARNINGS_END
         }
 
         void call(XMLDocumentParser* parser) override
@@ -332,10 +319,7 @@ IGNORE_WARNINGS_END
     struct PendingCommentCallback : public PendingCallback {
         virtual ~PendingCommentCallback()
         {
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
             xmlFree(s);
-IGNORE_WARNINGS_END
         }
 
         void call(XMLDocumentParser* parser) override
@@ -349,12 +333,9 @@ IGNORE_WARNINGS_END
     struct PendingInternalSubsetCallback : public PendingCallback {
         virtual ~PendingInternalSubsetCallback()
         {
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
             xmlFree(name);
             xmlFree(externalID);
             xmlFree(systemID);
-IGNORE_WARNINGS_END
         }
 
         void call(XMLDocumentParser* parser) override
@@ -370,10 +351,7 @@ IGNORE_WARNINGS_END
     struct PendingErrorCallback: public PendingCallback {
         virtual ~PendingErrorCallback()
         {
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
             xmlFree(message);
-IGNORE_WARNINGS_END
         }
 
         void call(XMLDocumentParser* parser) override

--- a/Source/WebCore/xml/parser/XMLDocumentParserScope.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParserScope.h
@@ -25,22 +25,12 @@
 
 #pragma once
 
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
-IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/parser.h>
-IGNORE_WARNINGS_END
-IGNORE_WARNINGS_END
 #include <wtf/Noncopyable.h>
 #include <wtf/WeakPtr.h>
 
 #if ENABLE(XSLT)
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
-IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/xmlerror.h>
-IGNORE_WARNINGS_END
-IGNORE_WARNINGS_END
 #endif
 
 namespace WebCore {

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/XMLParsing.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/XMLParsing.mm
@@ -30,12 +30,7 @@
 #include <JavaScriptCore/InitializeThreading.h>
 #include <WebCore/ParserContentPolicy.h>
 #include <WebCore/ProcessIdentifier.h>
-// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
-IGNORE_WARNINGS_BEGIN("deprecated-declarations")
-IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/parser.h>
-IGNORE_WARNINGS_END
-IGNORE_WARNINGS_END
 
 namespace TestWebKitAPI {
 


### PR DESCRIPTION
#### ceb5d276f4516a6c4f225e970425df5ba757e511
<pre>
Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml2 and libxslt headers
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=286277">https://bugs.webkit.org/show_bug.cgi?id=286277</a>&gt;
&lt;<a href="https://rdar.apple.com/143284356">rdar://143284356</a>&gt;

Reviewed by Alex Christensen.

Revert 289169@main (9e7dc1e91da1) now that the header warnings have been
fixed in Apple&apos;s libxml2.

* Source/WebCore/dom/TransformSource.h:
* Source/WebCore/dom/TransformSourceLibxslt.cpp:
* Source/WebCore/xml/XMLErrors.h:
* Source/WebCore/xml/XSLStyleSheet.h:
* Source/WebCore/xml/XSLStyleSheetLibxslt.cpp:
(WebCore::XSLStyleSheet::loadChildSheets):
(WebCore::XSLStyleSheet::locateStylesheetSubResource):
* Source/WebCore/xml/XSLTExtensions.cpp:
(WebCore::exsltNodeSetFunction):
* Source/WebCore/xml/XSLTProcessor.h:
* Source/WebCore/xml/XSLTProcessorLibxslt.cpp:
(WebCore::docLoaderFunc):
* Source/WebCore/xml/XSLTUnicodeSort.cpp:
(WebCore::xsltUnicodeSortFunction):
* Source/WebCore/xml/parser/XMLDocumentParser.h:
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLMalloc::free):
(WebCore::PendingCallbacks::PendingStartElementNSCallback::~PendingStartElementNSCallback):
(WebCore::PendingCallbacks::PendingProcessingInstructionCallback::~PendingProcessingInstructionCallback):
(WebCore::PendingCallbacks::PendingCommentCallback::~PendingCommentCallback):
(WebCore::PendingCallbacks::PendingInternalSubsetCallback::~PendingInternalSubsetCallback):
* Source/WebCore/xml/parser/XMLDocumentParserScope.h:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/XMLParsing.mm:

Canonical link: <a href="https://commits.webkit.org/293580@main">https://commits.webkit.org/293580@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b80910b78e032fc935c8a3194eb4b00d29301f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99293 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104423 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49892 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101334 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27374 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75567 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32674 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102300 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14611 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89645 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55927 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14405 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7626 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49253 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84330 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7713 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106781 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26406 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19254 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84528 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26769 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85847 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84040 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28704 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6389 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20135 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16158 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26346 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31554 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26167 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29480 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27734 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->