### PR TITLE
Stop implicitly converting WTF::String to NSString* in WebCore & WebKitLegacy

### DIFF
--- a/Source/WebCore/Modules/applepay/cocoa/PaymentContactCocoa.mm
+++ b/Source/WebCore/Modules/applepay/cocoa/PaymentContactCocoa.mm
@@ -44,40 +44,40 @@ static RetainPtr<PKContact> convert(unsigned version, const ApplePayPaymentConta
 {
     auto result = adoptNS([PAL::allocPKContactInstance() init]);
 
-    NSString *familyName = nil;
-    NSString *phoneticFamilyName = nil;
+    RetainPtr<NSString> familyName;
+    RetainPtr<NSString> phoneticFamilyName;
     if (!contact.familyName.isEmpty()) {
-        familyName = contact.familyName;
+        familyName = contact.familyName.createNSString();
         if (version >= 3 && !contact.phoneticFamilyName.isEmpty())
-            phoneticFamilyName = contact.phoneticFamilyName;
+            phoneticFamilyName = contact.phoneticFamilyName.createNSString();
     }
 
-    NSString *givenName = nil;
-    NSString *phoneticGivenName = nil;
+    RetainPtr<NSString> givenName;
+    RetainPtr<NSString> phoneticGivenName;
     if (!contact.givenName.isEmpty()) {
-        givenName = contact.givenName;
+        givenName = contact.givenName.createNSString();
         if (version >= 3 && !contact.phoneticGivenName.isEmpty())
-            phoneticGivenName = contact.phoneticGivenName;
+            phoneticGivenName = contact.phoneticGivenName.createNSString();
     }
 
     if (familyName || givenName) {
-        auto name = adoptNS([[NSPersonNameComponents alloc] init]);
-        [name setFamilyName:familyName];
-        [name setGivenName:givenName];
+        RetainPtr name = adoptNS([[NSPersonNameComponents alloc] init]);
+        [name setFamilyName:familyName.get()];
+        [name setGivenName:givenName.get()];
         if (phoneticFamilyName || phoneticGivenName) {
             auto phoneticName = adoptNS([[NSPersonNameComponents alloc] init]);
-            [phoneticName setFamilyName:phoneticFamilyName];
-            [phoneticName setGivenName:phoneticGivenName];
+            [phoneticName setFamilyName:phoneticFamilyName.get()];
+            [phoneticName setGivenName:phoneticGivenName.get()];
             [name setPhoneticRepresentation:phoneticName.get()];
         }
         [result setName:name.get()];
     }
 
     if (!contact.emailAddress.isEmpty())
-        [result setEmailAddress:contact.emailAddress];
+        [result setEmailAddress:contact.emailAddress.createNSString().get()];
 
     if (!contact.phoneNumber.isEmpty())
-        [result setPhoneNumber:adoptNS([allocCNPhoneNumberInstance() initWithStringValue:contact.phoneNumber]).get()];
+        [result setPhoneNumber:adoptNS([allocCNPhoneNumberInstance() initWithStringValue:contact.phoneNumber.createNSString().get()]).get()];
 
     if (contact.addressLines && !contact.addressLines->isEmpty()) {
         auto address = adoptNS([allocCNMutablePostalAddressInstance() init]);
@@ -90,22 +90,22 @@ static RetainPtr<PKContact> convert(unsigned version, const ApplePayPaymentConta
         }
 
         // FIXME: StringBuilder should hava a toNSString() function to avoid the extra String allocation.
-        [address setStreet:builder.toString()];
+        [address setStreet:builder.toString().createNSString().get()];
 
         if (!contact.subLocality.isEmpty())
-            [address setSubLocality:contact.subLocality];
+            [address setSubLocality:contact.subLocality.createNSString().get()];
         if (!contact.locality.isEmpty())
-            [address setCity:contact.locality];
+            [address setCity:contact.locality.createNSString().get()];
         if (!contact.postalCode.isEmpty())
-            [address setPostalCode:contact.postalCode];
+            [address setPostalCode:contact.postalCode.createNSString().get()];
         if (!contact.subAdministrativeArea.isEmpty())
-            [address setSubAdministrativeArea:contact.subAdministrativeArea];
+            [address setSubAdministrativeArea:contact.subAdministrativeArea.createNSString().get()];
         if (!contact.administrativeArea.isEmpty())
-            [address setState:contact.administrativeArea];
+            [address setState:contact.administrativeArea.createNSString().get()];
         if (!contact.country.isEmpty())
-            [address setCountry:contact.country];
+            [address setCountry:contact.country.createNSString().get()];
         if (!contact.countryCode.isEmpty())
-            [address setISOCountryCode:contact.countryCode];
+            [address setISOCountryCode:contact.countryCode.createNSString().get()];
 
         [result setPostalAddress:address.get()];
     }

--- a/Source/WebCore/Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm
+++ b/Source/WebCore/Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm
@@ -37,7 +37,7 @@ NSDecimalNumber *toDecimalNumber(const String& amount)
 {
     if (!amount)
         return [NSDecimalNumber zero];
-    return [NSDecimalNumber decimalNumberWithString:amount locale:@{ NSLocaleDecimalSeparator : @"." }];
+    return [NSDecimalNumber decimalNumberWithString:amount.createNSString().get() locale:@{ NSLocaleDecimalSeparator : @"." }];
 }
 
 static PKPaymentSummaryItemType toPKPaymentSummaryItemType(ApplePayLineItem::Type type)
@@ -88,7 +88,7 @@ static NSCalendarUnit toCalendarUnit(ApplePayRecurringPaymentDateUnit unit)
 PKRecurringPaymentSummaryItem *platformRecurringSummaryItem(const ApplePayLineItem& lineItem)
 {
     ASSERT(lineItem.paymentTiming == ApplePayPaymentTiming::Recurring);
-    PKRecurringPaymentSummaryItem *summaryItem = [PAL::getPKRecurringPaymentSummaryItemClass() summaryItemWithLabel:lineItem.label amount:toDecimalNumber(lineItem.amount) type:toPKPaymentSummaryItemType(lineItem.type)];
+    PKRecurringPaymentSummaryItem *summaryItem = [PAL::getPKRecurringPaymentSummaryItemClass() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toDecimalNumber(lineItem.amount) type:toPKPaymentSummaryItemType(lineItem.type)];
     if (!lineItem.recurringPaymentStartDate.isNaN())
         summaryItem.startDate = toDate(lineItem.recurringPaymentStartDate);
     summaryItem.intervalUnit = toCalendarUnit(lineItem.recurringPaymentIntervalUnit);
@@ -105,7 +105,7 @@ PKRecurringPaymentSummaryItem *platformRecurringSummaryItem(const ApplePayLineIt
 PKDeferredPaymentSummaryItem *platformDeferredSummaryItem(const ApplePayLineItem& lineItem)
 {
     ASSERT(lineItem.paymentTiming == ApplePayPaymentTiming::Deferred);
-    PKDeferredPaymentSummaryItem *summaryItem = [PAL::getPKDeferredPaymentSummaryItemClass() summaryItemWithLabel:lineItem.label amount:toDecimalNumber(lineItem.amount) type:toPKPaymentSummaryItemType(lineItem.type)];
+    PKDeferredPaymentSummaryItem *summaryItem = [PAL::getPKDeferredPaymentSummaryItemClass() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toDecimalNumber(lineItem.amount) type:toPKPaymentSummaryItemType(lineItem.type)];
     if (!lineItem.deferredPaymentDate.isNaN())
         summaryItem.deferredDate = toDate(lineItem.deferredPaymentDate);
     return summaryItem;
@@ -118,7 +118,7 @@ PKDeferredPaymentSummaryItem *platformDeferredSummaryItem(const ApplePayLineItem
 PKAutomaticReloadPaymentSummaryItem *platformAutomaticReloadSummaryItem(const ApplePayLineItem& lineItem)
 {
     ASSERT(lineItem.paymentTiming == ApplePayPaymentTiming::AutomaticReload);
-    PKAutomaticReloadPaymentSummaryItem *summaryItem = [PAL::getPKAutomaticReloadPaymentSummaryItemClass() summaryItemWithLabel:lineItem.label amount:toDecimalNumber(lineItem.amount) type:toPKPaymentSummaryItemType(lineItem.type)];
+    PKAutomaticReloadPaymentSummaryItem *summaryItem = [PAL::getPKAutomaticReloadPaymentSummaryItemClass() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toDecimalNumber(lineItem.amount) type:toPKPaymentSummaryItemType(lineItem.type)];
     summaryItem.thresholdAmount = toDecimalNumber(lineItem.automaticReloadPaymentThresholdAmount);
     return summaryItem;
 }
@@ -130,14 +130,14 @@ PKAutomaticReloadPaymentSummaryItem *platformAutomaticReloadSummaryItem(const Ap
 PKDisbursementSummaryItem *platformDisbursementSummaryItem(const ApplePayLineItem& lineItem)
 {
     ASSERT(lineItem.disbursementLineItemType == ApplePayLineItem::DisbursementLineItemType::Disbursement);
-    PKDisbursementSummaryItem *summaryItem = [PAL::getPKDisbursementSummaryItemClass() summaryItemWithLabel:lineItem.label amount:toDecimalNumber(lineItem.amount)];
+    PKDisbursementSummaryItem *summaryItem = [PAL::getPKDisbursementSummaryItemClass() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toDecimalNumber(lineItem.amount)];
     return summaryItem;
 }
 
 PKInstantFundsOutFeeSummaryItem *platformInstantFundsOutFeeSummaryItem(const ApplePayLineItem& lineItem)
 {
     ASSERT(lineItem.disbursementLineItemType == ApplePayLineItem::DisbursementLineItemType::InstantFundsOutFee);
-    PKInstantFundsOutFeeSummaryItem *summaryItem = [PAL::getPKInstantFundsOutFeeSummaryItemClass() summaryItemWithLabel:lineItem.label amount:toDecimalNumber(lineItem.amount)];
+    PKInstantFundsOutFeeSummaryItem *summaryItem = [PAL::getPKInstantFundsOutFeeSummaryItemClass() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toDecimalNumber(lineItem.amount)];
     return summaryItem;
 }
 
@@ -176,7 +176,7 @@ PKPaymentSummaryItem *platformSummaryItem(const ApplePayLineItem& lineItem)
 #endif
     }
 
-    return [PAL::getPKPaymentSummaryItemClass() summaryItemWithLabel:lineItem.label amount:toDecimalNumber(lineItem.amount) type:toPKPaymentSummaryItemType(lineItem.type)];
+    return [PAL::getPKPaymentSummaryItemClass() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toDecimalNumber(lineItem.amount) type:toPKPaymentSummaryItemType(lineItem.type)];
 }
 
 #if HAVE(PASSKIT_DISBURSEMENTS)

--- a/Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoaderUSD.mm
+++ b/Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoaderUSD.mm
@@ -109,7 +109,7 @@ static RetainPtr<NSURL> writeToTemporaryFile(WebCore::Model& modelSource)
     ASSERT_UNUSED(byteCount, byteCount == modelSource.data()->size());
     fileHandle = { };
 
-    return adoptNS([[NSURL alloc] initFileURLWithPath:filePath]);
+    return adoptNS([[NSURL alloc] initFileURLWithPath:filePath.createNSString().get()]);
 }
 
 Ref<SceneKitModelLoader> loadSceneKitModelUsingUSDLoader(Model& modelSource, SceneKitModelLoaderClient& client)

--- a/Source/WebCore/Modules/speech/cocoa/SpeechRecognizerCocoa.mm
+++ b/Source/WebCore/Modules/speech/cocoa/SpeechRecognizerCocoa.mm
@@ -48,7 +48,7 @@ void SpeechRecognizer::dataCaptured(const MediaTime&, const PlatformAudioData& d
 bool SpeechRecognizer::startRecognition(bool mockSpeechRecognitionEnabled, SpeechRecognitionConnectionClientIdentifier identifier, const String& localeIdentifier, bool continuous, bool interimResults, uint64_t alternatives)
 {
     auto taskClass = mockSpeechRecognitionEnabled ? [WebSpeechRecognizerTaskMock class] : [WebSpeechRecognizerTask class];
-    m_task = adoptNS([[taskClass alloc] initWithIdentifier:identifier locale:localeIdentifier doMultipleRecognitions:continuous reportInterimResults:interimResults maxAlternatives:alternatives delegateCallback:[weakThis = WeakPtr { *this }](const WebCore::SpeechRecognitionUpdate& update) {
+    m_task = adoptNS([[taskClass alloc] initWithIdentifier:identifier locale:localeIdentifier.createNSString().get() doMultipleRecognitions:continuous reportInterimResults:interimResults maxAlternatives:alternatives delegateCallback:[weakThis = WeakPtr { *this }](const WebCore::SpeechRecognitionUpdate& update) {
         if (weakThis)
             weakThis->m_delegateCallback(update);
     }]);

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -1,6 +1,5 @@
 Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm
 Modules/applepay/ApplePayLogoSystemImage.mm
-Modules/applepay/cocoa/PaymentContactCocoa.mm
 Modules/applepay/cocoa/PaymentMerchantSessionCocoa.mm
 Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm
 Modules/async-clipboard/mac/ClipboardImageReaderMac.mm
@@ -24,13 +23,11 @@ editing/cocoa/AttributedString.mm
 editing/cocoa/DataDetection.mm
 editing/cocoa/FontAttributesCocoa.mm
 editing/cocoa/HTMLConverter.mm
-editing/cocoa/WebContentReaderCocoa.mm
 loader/ContentFilter.cpp
 loader/archive/cf/LegacyWebArchive.cpp
 loader/archive/cf/LegacyWebArchiveMac.mm
 loader/cocoa/BundleResourceLoader.mm
 loader/cocoa/DiskCacheMonitorCocoa.mm
-loader/mac/LoaderNSURLExtras.mm
 page/CaptionUserPreferencesMediaAF.cpp
 page/cocoa/ResourceUsageThreadCocoa.mm
 page/mac/ChromeMac.mm
@@ -68,7 +65,6 @@ platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm
 platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
 platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
-platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm
 platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
 platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
 platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -127,7 +123,6 @@ platform/mac/CursorMac.mm
 platform/mac/DataDetectorHighlight.mm
 platform/mac/HIDDevice.cpp
 platform/mac/PasteboardMac.mm
-platform/mac/PasteboardWriter.mm
 platform/mac/PlatformEventFactoryMac.mm
 platform/mac/PlatformPasteboardMac.mm
 platform/mac/PlaybackSessionInterfaceMac.mm

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -143,7 +143,7 @@ void attributedStringSetExpandedText(NSMutableAttributedString *string, const AX
         return;
 
     if (object.supportsExpandedTextValue())
-        [string addAttribute:NSAccessibilityExpandedTextValueAttribute value:object.expandedTextValue() range:range];
+        [string addAttribute:NSAccessibilityExpandedTextValueAttribute value:object.expandedTextValue().createNSString().get() range:range];
 }
 
 void attributedStringSetNeedsSpellCheck(NSMutableAttributedString *string, const AXCoreObject& object)
@@ -339,7 +339,7 @@ bool AXCoreObject::isEmptyGroup()
     if (UNLIKELY(isRemoteFrame()))
         return false;
 
-    return [rolePlatformString() isEqual:NSAccessibilityGroupRole]
+    return [rolePlatformString().createNSString() isEqual:NSAccessibilityGroupRole]
         && !firstUnignoredChild()
         && ![renderWidgetChildren(*this) count];
 }

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -377,7 +377,7 @@ void AXObjectCache::postPlatformAnnouncementNotification(const String& message)
 #endif
 
     NSDictionary *userInfo = @{ NSAccessibilityPriorityKey: @(NSAccessibilityPriorityHigh),
-        NSAccessibilityAnnouncementKey: message,
+        NSAccessibilityAnnouncementKey: message.createNSString().get(),
     };
     NSAccessibilityPostNotificationWithUserInfo(NSApp, NSAccessibilityAnnouncementRequestedNotification, userInfo);
 

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -419,7 +419,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         return [remoteFramePlatformElement().get() accessibilityAttributeValue:NSAccessibilityRoleDescriptionAttribute];
 ALLOW_DEPRECATED_DECLARATIONS_END
 
-    NSString *axRole = rolePlatformString();
+    RetainPtr axRole = rolePlatformString().createNSString();
 
     if ([axRole isEqualToString:NSAccessibilityGroupRole]) {
         if (isOutput())

--- a/Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapMac.mm
+++ b/Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapMac.mm
@@ -97,9 +97,9 @@ static std::optional<Vector<uint8_t>> createAndStoreMasterKey()
         applicationName = [mainBundle objectForInfoDictionaryKey:bridge_cast(kCFBundleNameKey)];
     if (!applicationName)
         applicationName = [mainBundle bundleIdentifier];
-    NSString *localizedItemName = webCryptoMasterKeyKeychainLabel(applicationName);
+    RetainPtr localizedItemName = webCryptoMasterKeyKeychainLabel(applicationName).createNSString();
 #else
-    NSString *localizedItemName = webCryptoMasterKeyKeychainLabel([[NSRunningApplication currentApplication] localizedName]);
+    RetainPtr localizedItemName = webCryptoMasterKeyKeychainLabel([[NSRunningApplication currentApplication] localizedName]).createNSString();
 #endif
 
     OSStatus status;
@@ -107,7 +107,7 @@ static std::optional<Vector<uint8_t>> createAndStoreMasterKey()
 #if USE(KEYCHAIN_ACCESS_CONTROL_LISTS)
     SecAccessRef accessRef;
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    status = SecAccessCreate((__bridge CFStringRef)localizedItemName, nullptr, &accessRef);
+    status = SecAccessCreate(bridge_cast(localizedItemName.get()), nullptr, &accessRef);
 ALLOW_DEPRECATED_DECLARATIONS_END
     if (status) {
         WTFLogAlways("Cannot create a security access object for storing WebCrypto master key, error %d", (int)status);
@@ -131,7 +131,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     RetainPtr<SecTrustedApplicationRef> trustedApp = adoptCF(trustedAppRef);
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    status = SecACLSetContents(acl, (__bridge CFArrayRef)@[ (__bridge id)trustedApp.get() ], (__bridge CFStringRef)localizedItemName, kSecKeychainPromptRequirePassphase);
+    status = SecACLSetContents(acl, (__bridge CFArrayRef)@[ (__bridge id)trustedApp.get() ], bridge_cast(localizedItemName.get()), kSecKeychainPromptRequirePassphase);
 ALLOW_DEPRECATED_DECLARATIONS_END
     if (status) {
         WTFLogAlways("Cannot set ACL for WebCrypto master key, error %d", (int)status);
@@ -148,8 +148,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if USE(KEYCHAIN_ACCESS_CONTROL_LISTS)
         (id)kSecAttrAccess : (__bridge id)access.get(),
 #endif
-        (id)kSecAttrComment : webCryptoMasterKeyKeychainComment(),
-        (id)kSecAttrLabel : localizedItemName,
+        (id)kSecAttrComment : webCryptoMasterKeyKeychainComment().createNSString().get(),
+        (id)kSecAttrLabel : localizedItemName.get(),
         (id)kSecAttrAccount : masterKeyAccountNameForCurrentApplication(),
         (id)kSecValueData : toNSData(base64EncodedMasterKeyData).autorelease(),
     };

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -759,7 +759,7 @@ bool WebContentReader::readPlainText(const String& text)
     if (!m_allowPlainText)
         return false;
 
-    String precomposedString = [text precomposedStringWithCanonicalMapping];
+    String precomposedString = [text.createNSString() precomposedStringWithCanonicalMapping];
     if (RefPtr page = frame().page())
         precomposedString = page->applyLinkDecorationFiltering(precomposedString, LinkDecorationFilteringTrigger::Paste);
 
@@ -925,7 +925,7 @@ bool WebContentReader::readURL(const URL& url, const String& title)
     auto anchor = HTMLAnchorElement::create(document.get());
     anchor->setAttributeWithoutSynchronization(HTMLNames::hrefAttr, AtomString { sanitizedURLString });
 
-    NSString *linkText = title.isEmpty() ? sanitizedURLString : title;
+    RetainPtr linkText = title.isEmpty() ? sanitizedURLString.createNSString() : title.createNSString();
     anchor->appendChild(document->createTextNode([linkText precomposedStringWithCanonicalMapping]));
 
     auto newFragment = document->createDocumentFragment();

--- a/Source/WebCore/editing/mac/EditorMac.mm
+++ b/Source/WebCore/editing/mac/EditorMac.mm
@@ -230,7 +230,7 @@ String Editor::plainTextFromPasteboard(const PasteboardPlainText& text)
     // FIXME: It's not clear this is 100% correct since we know -[NSURL URLWithString:] does not handle
     // all the same cases we handle well in the URL code for creating an NSURL.
     if (text.isURL)
-        string = WTF::userVisibleString([NSURL URLWithString:string]);
+        string = WTF::userVisibleString([NSURL URLWithString:string.createNSString().get()]);
 
     // FIXME: WTF should offer a non-Mac-specific way to convert string to precomposed form so we can do it for all platforms.
     return [string.createNSString() precomposedStringWithCanonicalMapping];

--- a/Source/WebCore/loader/cocoa/BundleResourceLoader.mm
+++ b/Source/WebCore/loader/cocoa/BundleResourceLoader.mm
@@ -51,7 +51,7 @@ void loadResourceFromBundle(ResourceLoader& loader, const String& subdirectory)
     ASSERT(RunLoop::isMain());
 
     loadQueue().dispatch([protectedLoader = Ref { loader }, url = loader.request().url().isolatedCopy(), subdirectory = subdirectory.isolatedCopy()]() mutable {
-        auto *relativePath = [subdirectory stringByAppendingString: url.path().toString()];
+        auto *relativePath = [subdirectory.createNSString() stringByAppendingString: url.path().toString().createNSString().get()];
         auto *bundle = [NSBundle bundleWithIdentifier:@"com.apple.WebCore"];
         auto *path = [bundle pathForResource:relativePath ofType:nil];
         auto *data = [NSData dataWithContentsOfFile:path];

--- a/Source/WebCore/platform/cocoa/DragDataCocoa.mm
+++ b/Source/WebCore/platform/cocoa/DragDataCocoa.mm
@@ -248,7 +248,7 @@ String DragData::asPlainText() const
     // FIXME: It's not clear this is 100% correct since we know -[NSURL URLWithString:] does not handle
     // all the same cases we handle well in the URL code for creating an NSURL.
     if (text.isURL)
-        return WTF::userVisibleString([NSURL URLWithString:string]);
+        return WTF::userVisibleString([NSURL URLWithString:string.createNSString().get()]);
 
     // FIXME: WTF should offer a non-Mac-specific way to convert string to precomposed form so we can do it for all platforms.
     return [string.createNSString() precomposedStringWithCanonicalMapping];
@@ -317,7 +317,7 @@ bool DragData::containsURL(FilenameConversionPolicy) const
     Vector<String> types;
     platformStrategies()->pasteboardStrategy()->getTypes(types, m_pasteboardName, context.get());
     if (types.contains(String(legacyFilesPromisePasteboardType())) && fileNames().size() == 1)
-        return !![NSURL fileURLWithPath:fileNames().first()];
+        return !![NSURL fileURLWithPath:fileNames().first().createNSString().get()];
 #endif
 
     return false;
@@ -340,7 +340,7 @@ String DragData::asURL(FilenameConversionPolicy, String* title) const
     Vector<String> types;
     platformStrategies()->pasteboardStrategy()->getTypes(types, m_pasteboardName, context.get());
     if (types.contains(String(legacyFilesPromisePasteboardType())) && fileNames().size() == 1)
-        return [URLByCanonicalizingURL([NSURL fileURLWithPath:fileNames()[0]]) absoluteString];
+        return [URLByCanonicalizingURL([NSURL fileURLWithPath:fileNames()[0].createNSString().get()]) absoluteString];
 #endif
 
     return { };

--- a/Source/WebCore/platform/cocoa/MIMETypeRegistryCocoa.mm
+++ b/Source/WebCore/platform/cocoa/MIMETypeRegistryCocoa.mm
@@ -160,9 +160,9 @@ Vector<String> MIMETypeRegistry::extensionsForMIMEType(const String& type)
     if (type.endsWith('*'))
         return extensionsForWildcardMIMEType(type);
 
-    NSArray *extensions = [[NSURLFileTypeMappings sharedMappings] extensionsForMIMEType:type];
-    if (extensions.count)
-        return makeVector<String>(extensions);
+    RetainPtr<NSArray> extensions = [[NSURLFileTypeMappings sharedMappings] extensionsForMIMEType:type.createNSString().get()];
+    if (extensions.get().count)
+        return makeVector<String>(extensions.get());
 
     auto mapEntry = additionalExtensionsMap().find(type);
     if (mapEntry != additionalExtensionsMap().end())

--- a/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.mm
+++ b/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.mm
@@ -68,7 +68,7 @@ void NetworkExtensionContentFilter::initialize(const URL* url)
     m_queue = adoptOSObject(dispatch_queue_create("WebKit NetworkExtension Filtering", DISPATCH_QUEUE_SERIAL));
     ASSERT_UNUSED(url, !url);
     m_neFilterSource = adoptNS([[NEFilterSource alloc] initWithDecisionQueue:m_queue.get()]);
-    [m_neFilterSource setSourceAppIdentifier:applicationBundleIdentifier()];
+    [m_neFilterSource setSourceAppIdentifier:applicationBundleIdentifier().createNSString().get()];
     [m_neFilterSource setSourceAppPid:legacyPresentingApplicationPID()];
 }
 

--- a/Source/WebCore/platform/cocoa/PlatformPasteboardCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PlatformPasteboardCocoa.mm
@@ -83,14 +83,14 @@ String PlatformPasteboard::urlStringSuitableForLoading(String& title)
 #endif
 
     if (types.contains(urlPasteboardType)) {
-        NSURL *URLFromPasteboard = [NSURL URLWithString:stringForType(urlPasteboardType)];
+        NSURL *URLFromPasteboard = [NSURL URLWithString:stringForType(urlPasteboardType).createNSString().get()];
         // Cannot drop other schemes unless <rdar://problem/10562662> and <rdar://problem/11187315> are fixed.
         if (URL { URLFromPasteboard }.protocolIsInHTTPFamily())
             return [URLByCanonicalizingURL(URLFromPasteboard) absoluteString];
     }
 
     if (types.contains(stringPasteboardType)) {
-        NSURL *URLFromPasteboard = [NSURL URLWithString:stringForType(stringPasteboardType)];
+        NSURL *URLFromPasteboard = [NSURL URLWithString:stringForType(stringPasteboardType).createNSString().get()];
         // Pasteboard content is not trusted, because JavaScript code can modify it. We can sanitize it for URLs and other typed content, but not for strings.
         // The result of this function is used to initiate navigation, so we shouldn't allow arbitrary file URLs.
         // FIXME: Should we allow only http family schemes, or anything non-local?
@@ -103,10 +103,11 @@ String PlatformPasteboard::urlStringSuitableForLoading(String& title)
         Vector<String> files;
         getPathnamesForType(files, String(legacyFilenamesPasteboardType()));
         if (files.size() == 1) {
+            RetainPtr firstFile = files[0].createNSString();
             BOOL isDirectory;
-            if ([[NSFileManager defaultManager] fileExistsAtPath:files[0] isDirectory:&isDirectory] && isDirectory)
+            if ([[NSFileManager defaultManager] fileExistsAtPath:firstFile.get() isDirectory:&isDirectory] && isDirectory)
                 return String();
-            return [URLByCanonicalizingURL([NSURL fileURLWithPath:files[0]]) absoluteString];
+            return [URLByCanonicalizingURL([NSURL fileURLWithPath:firstFile.get()]) absoluteString];
         }
     }
 #endif

--- a/Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm
@@ -34,7 +34,7 @@ namespace WebCore {
 
 static bool isPublicSuffixCF(const String& domain)
 {
-    RetainPtr host = WTF::decodeHostName(domain);
+    RetainPtr host = WTF::decodeHostName(domain.createNSString().get());
     return host && _CFHostIsDomainTopLevel(bridge_cast(host.get()));
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.mm
@@ -116,11 +116,11 @@ bool AVAssetMIMETypeCache::canDecodeExtendedType(const ContentType& typeParamete
 #if HAVE(AVURLASSET_ISPLAYABLEEXTENDEDMIMETYPEWITHOPTIONS)
     if (PAL::canLoad_AVFoundation_AVURLAssetExtendedMIMETypePlayabilityTreatPlaylistMIMETypesAsISOBMFFMediaDataContainersKey()
         && [PAL::getAVURLAssetClass() respondsToSelector:@selector(isPlayableExtendedMIMEType:options:)]) {
-        if ([PAL::getAVURLAssetClass() isPlayableExtendedMIMEType:type.raw() options:@{ AVURLAssetExtendedMIMETypePlayabilityTreatPlaylistMIMETypesAsISOBMFFMediaDataContainersKey: @YES }])
+        if ([PAL::getAVURLAssetClass() isPlayableExtendedMIMEType:type.raw().createNSString().get() options:@{ AVURLAssetExtendedMIMETypePlayabilityTreatPlaylistMIMETypesAsISOBMFFMediaDataContainersKey: @YES }])
             return true;
     } else
 #endif
-    if ([PAL::getAVURLAssetClass() isPlayableExtendedMIMEType:type.raw()])
+    if ([PAL::getAVURLAssetClass() isPlayableExtendedMIMEType:type.raw().createNSString().get()])
         return true;
 
 #endif // ENABLE(VIDEO) && USE(AVFOUNDATION)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.mm
@@ -92,7 +92,7 @@ bool AVStreamDataParserMIMETypeCache::canDecodeExtendedType(const ContentType& t
     ASSERT(isAvailable());
 
     if ([PAL::getAVStreamDataParserClass() respondsToSelector:@selector(canParseExtendedMIMEType:)])
-        return [PAL::getAVStreamDataParserClass() canParseExtendedMIMEType:type.raw()];
+        return [PAL::getAVStreamDataParserClass() canParseExtendedMIMEType:type.raw().createNSString().get()];
 
     // FIXME(rdar://50502771) AVStreamDataParser does not have an -canParseExtendedMIMEType: method on this system,
     //  so just replace the container type with a valid one from AVAssetMIMETypeCache and ask that cache if it

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
@@ -210,7 +210,7 @@ void CDMSessionAVContentKeySession::releaseKeys()
             return;
 
         RetainPtr certificateData = toNSData(m_certificate->span());
-        NSArray* expiredSessions = [PAL::getAVContentKeySessionClass() pendingExpiredSessionReportsWithAppIdentifier:certificateData.get() storageDirectoryAtURL:[NSURL fileURLWithPath:storagePath]];
+        NSArray* expiredSessions = [PAL::getAVContentKeySessionClass() pendingExpiredSessionReportsWithAppIdentifier:certificateData.get() storageDirectoryAtURL:[NSURL fileURLWithPath:storagePath.createNSString().get()]];
         for (NSData* expiredSessionData in expiredSessions) {
             static const NSString *PlaybackSessionIdKey = @"PlaybackSessionID";
             NSDictionary *expiredSession = [NSPropertyListSerialization propertyListWithData:expiredSessionData options:kCFPropertyListImmutable format:nullptr error:nullptr];
@@ -260,7 +260,7 @@ bool CDMSessionAVContentKeySession::update(Uint8Array* key, RefPtr<Uint8Array>& 
         RetainPtr certificateData = toNSData(m_certificate->span());
 
         if ([PAL::getAVContentKeySessionClass() respondsToSelector:@selector(removePendingExpiredSessionReports:withAppIdentifier:storageDirectoryAtURL:)])
-            [PAL::getAVContentKeySessionClass() removePendingExpiredSessionReports:@[m_expiredSession.get()] withAppIdentifier:certificateData.get() storageDirectoryAtURL:[NSURL fileURLWithPath:storagePath]];
+            [PAL::getAVContentKeySessionClass() removePendingExpiredSessionReports:@[m_expiredSession.get()] withAppIdentifier:certificateData.get() storageDirectoryAtURL:[NSURL fileURLWithPath:storagePath.createNSString().get()]];
         m_expiredSession = nullptr;
         return true;
     }
@@ -428,7 +428,7 @@ RefPtr<Uint8Array> CDMSessionAVContentKeySession::generateKeyReleaseMessage(unsi
         return nullptr;
     }
 
-    NSArray* expiredSessions = [PAL::getAVContentKeySessionClass() pendingExpiredSessionReportsWithAppIdentifier:certificateData.get() storageDirectoryAtURL:[NSURL fileURLWithPath:storagePath]];
+    NSArray* expiredSessions = [PAL::getAVContentKeySessionClass() pendingExpiredSessionReportsWithAppIdentifier:certificateData.get() storageDirectoryAtURL:[NSURL fileURLWithPath:storagePath.createNSString().get()]];
     if (![expiredSessions count]) {
         ALWAYS_LOG(LOGIDENTIFIER, "no expired sessions found");
 
@@ -482,7 +482,7 @@ AVContentKeySession* CDMSessionAVContentKeySession::contentKeySession()
                 return nil;
         }
 
-        storageURL = [NSURL fileURLWithPath:storagePath];
+        storageURL = [NSURL fileURLWithPath:storagePath.createNSString().get()];
     }
 
 #if HAVE(AVCONTENTKEYREQUEST_COMPATABILITIY_MODE)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm
@@ -94,8 +94,8 @@ RefPtr<Uint8Array> CDMSessionAVFoundationObjC::generateKeyRequest(const String& 
     }
 
     RetainPtr certificateData = toNSData(certificate->span());
-    NSString* assetStr = keyID;
-    RetainPtr<NSData> assetID = [assetStr dataUsingEncoding:NSUTF8StringEncoding];
+    RetainPtr assetString = keyID.createNSString();
+    RetainPtr<NSData> assetID = [assetString dataUsingEncoding:NSUTF8StringEncoding];
     NSError* nsError = 0;
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     RetainPtr<NSData> keyRequest = [m_request streamingContentKeyRequestDataForApp:certificateData.get() contentIdentifier:assetID.get() options:nil error:&nsError];

--- a/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
@@ -159,7 +159,7 @@
     if (auto infoRequest = request.contentInformationRequest) {
         RefPtr parent = _parent.get();
         RELEASE_ASSERT(parent);
-        infoRequest.contentType = parent->uti();
+        infoRequest.contentType = parent->uti().createNSString().get();
         infoRequest.byteRangeAccessSupported = YES;
         infoRequest.contentLength = _complete ? _data.get().length : _expectedContentSize;
     }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
@@ -374,7 +374,7 @@ bool WebCoreAVFResourceLoader::responseReceived(const String& mimeType, int stat
     if (AVAssetResourceLoadingContentInformationRequest* contentInfo = [m_avRequest contentInformationRequest]) {
         String uti = UTIFromMIMEType(mimeType);
 
-        [contentInfo setContentType:uti];
+        [contentInfo setContentType:uti.createNSString().get()];
 
         [contentInfo setContentLength:contentRange.isValid() ? contentRange.instanceLength() : expectedContentLength];
         [contentInfo setByteRangeAccessSupported:YES];

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
@@ -165,16 +165,16 @@ PlatformCAAnimationCocoa::PlatformCAAnimationCocoa(AnimationType type, const Str
 {
     switch (type) {
     case AnimationType::Basic:
-        m_animation = [CABasicAnimation animationWithKeyPath:keyPath];
+        m_animation = [CABasicAnimation animationWithKeyPath:keyPath.createNSString().get()];
         break;
     case AnimationType::Group:
         m_animation = [CAAnimationGroup animation];
         break;
     case AnimationType::Keyframe:
-        m_animation = [CAKeyframeAnimation animationWithKeyPath:keyPath];
+        m_animation = [CAKeyframeAnimation animationWithKeyPath:keyPath.createNSString().get()];
         break;
     case AnimationType::Spring:
-        m_animation = [CASpringAnimation animationWithKeyPath:keyPath];
+        m_animation = [CASpringAnimation animationWithKeyPath:keyPath.createNSString().get()];
         break;
     }
 }

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
@@ -164,7 +164,7 @@ void PlatformCAFilters::presentationModifiers(const FilterOperations& initialFil
         case FilterOperation::Type::Contrast:
         case FilterOperation::Type::Blur: {
             auto keyValueName = makeString("filters."_s, filterName, '.', animatedFilterPropertyName(initialFilterOperation->type()));
-            presentationModifiers.append({ type, adoptNS([[CAPresentationModifier alloc] initWithKeyPath:keyValueName initialValue:filterValueForOperation(initialFilterOperation).get() additive:NO group:group.get()]) });
+            presentationModifiers.append({ type, adoptNS([[CAPresentationModifier alloc] initWithKeyPath:keyValueName.createNSString().get() initialValue:filterValueForOperation(initialFilterOperation).get() additive:NO group:group.get()]) });
             continue;
         }
         case FilterOperation::Type::AppleInvertLightness:
@@ -274,35 +274,35 @@ void PlatformCAFilters::setFiltersOnLayer(PlatformLayer* layer, const FilterOper
             const auto& colorMatrixOperation = downcast<BasicColorMatrixFilterOperation>(filterOperation);
             CAFilter *filter = [CAFilter filterWithType:kCAFilterColorMonochrome];
             [filter setValue:[NSNumber numberWithFloat:colorMatrixOperation.amount()] forKey:@"inputAmount"];
-            [filter setName:filterName];
+            [filter setName:filterName.createNSString().get()];
             return filter;
         }
         case FilterOperation::Type::Sepia: {
             RetainPtr<NSValue> colorMatrixValue = PlatformCAFilters::colorMatrixValueForFilter(filterOperation.type(), &filterOperation);
             CAFilter *filter = [CAFilter filterWithType:kCAFilterColorMatrix];
             [filter setValue:colorMatrixValue.get() forKey:@"inputColorMatrix"];
-            [filter setName:filterName];
+            [filter setName:filterName.createNSString().get()];
             return filter;
         }
         case FilterOperation::Type::Saturate: {
             const auto& colorMatrixOperation = downcast<BasicColorMatrixFilterOperation>(filterOperation);
             CAFilter *filter = [CAFilter filterWithType:kCAFilterColorSaturate];
             [filter setValue:[NSNumber numberWithFloat:colorMatrixOperation.amount()] forKey:@"inputAmount"];
-            [filter setName:filterName];
+            [filter setName:filterName.createNSString().get()];
             return filter;
         }
         case FilterOperation::Type::HueRotate: {
             const auto& colorMatrixOperation = downcast<BasicColorMatrixFilterOperation>(filterOperation);
             CAFilter *filter = [CAFilter filterWithType:kCAFilterColorHueRotate];
             [filter setValue:[NSNumber numberWithFloat:deg2rad(colorMatrixOperation.amount())] forKey:@"inputAngle"];
-            [filter setName:filterName];
+            [filter setName:filterName.createNSString().get()];
             return filter;
         }
         case FilterOperation::Type::Invert: {
             RetainPtr<NSValue> colorMatrixValue = PlatformCAFilters::colorMatrixValueForFilter(filterOperation.type(), &filterOperation);
             CAFilter *filter = [CAFilter filterWithType:kCAFilterColorMatrix];
             [filter setValue:colorMatrixValue.get() forKey:@"inputColorMatrix"];
-            [filter setName:filterName];
+            [filter setName:filterName.createNSString().get()];
             return filter;
         }
         case FilterOperation::Type::AppleInvertLightness:
@@ -312,21 +312,21 @@ void PlatformCAFilters::setFiltersOnLayer(PlatformLayer* layer, const FilterOper
             RetainPtr<NSValue> colorMatrixValue = PlatformCAFilters::colorMatrixValueForFilter(filterOperation.type(), &filterOperation);
             CAFilter *filter = [CAFilter filterWithType:kCAFilterColorMatrix];
             [filter setValue:colorMatrixValue.get() forKey:@"inputColorMatrix"];
-            [filter setName:filterName];
+            [filter setName:filterName.createNSString().get()];
             return filter;
         }
         case FilterOperation::Type::Brightness: {
             RetainPtr<NSValue> colorMatrixValue = PlatformCAFilters::colorMatrixValueForFilter(filterOperation.type(), &filterOperation);
             CAFilter *filter = [CAFilter filterWithType:kCAFilterColorMatrix];
             [filter setValue:colorMatrixValue.get() forKey:@"inputColorMatrix"];
-            [filter setName:filterName];
+            [filter setName:filterName.createNSString().get()];
             return filter;
         }
         case FilterOperation::Type::Contrast: {
             RetainPtr<NSValue> colorMatrixValue = PlatformCAFilters::colorMatrixValueForFilter(filterOperation.type(), &filterOperation);
             CAFilter *filter = [CAFilter filterWithType:kCAFilterColorMatrix];
             [filter setValue:colorMatrixValue.get() forKey:@"inputColorMatrix"];
-            [filter setName:filterName];
+            [filter setName:filterName.createNSString().get()];
             return filter;
         }
         case FilterOperation::Type::Blur: {
@@ -348,7 +348,7 @@ void PlatformCAFilters::setFiltersOnLayer(PlatformLayer* layer, const FilterOper
                     [filter setValue:@YES forKey:@"inputHardEdges"];
 #endif
             }
-            [filter setName:filterName];
+            [filter setName:filterName.createNSString().get()];
             return filter;
         }
         case FilterOperation::Type::Passthrough:

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -564,20 +564,20 @@ void PlatformCALayerCocoa::addAnimationForKey(const String& key, PlatformCAAnima
         [propertyAnimation setDelegate:static_cast<id>(m_delegate.get())];
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    [m_layer addAnimation:propertyAnimation forKey:key];
+    [m_layer addAnimation:propertyAnimation forKey:key.createNSString().get()];
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
 void PlatformCALayerCocoa::removeAnimationForKey(const String& key)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    [m_layer removeAnimationForKey:key];
+    [m_layer removeAnimationForKey:key.createNSString().get()];
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
 RefPtr<PlatformCAAnimation> PlatformCALayerCocoa::animationForKey(const String& key)
 {
-    CAAnimation *propertyAnimation = static_cast<CAAnimation *>([m_layer animationForKey:key]);
+    CAAnimation *propertyAnimation = static_cast<CAAnimation *>([m_layer animationForKey:key.createNSString().get()]);
     if (!propertyAnimation)
         return nullptr;
     return PlatformCAAnimationCocoa::create(propertyAnimation);
@@ -958,7 +958,7 @@ void PlatformCALayerCocoa::setBlendMode(BlendMode blendMode)
 void PlatformCALayerCocoa::setName(const String& value)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    [m_layer setName:value];
+    [m_layer setName:value.createNSString().get()];
     END_BLOCK_OBJC_EXCEPTIONS
 }
 

--- a/Source/WebCore/platform/graphics/cg/UTIRegistry.mm
+++ b/Source/WebCore/platform/graphics/cg/UTIRegistry.mm
@@ -192,8 +192,8 @@ String preferredExtensionForImageType(const String& uti)
     String oldExtension = adoptCF(UTTypeCopyPreferredTagWithClass(uti.createCFString().get(), kUTTagClassFilenameExtension)).get();
     ALLOW_DEPRECATED_DECLARATIONS_END
 
-    auto *type = [UTType typeWithIdentifier:uti];
-    String extension = type.preferredFilenameExtension;
+    RetainPtr type = [UTType typeWithIdentifier:uti.createNSString().get()];
+    String extension = type.get().preferredFilenameExtension;
     if (UNLIKELY(oldExtension != extension)) {
         std::array<uint64_t, 6> values { 0, 0, 0, 0, 0, 0 };
         auto utiInfo = makeString(uti, '~', oldExtension, '~', extension);

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCocoa.mm
@@ -50,8 +50,8 @@ CFStringRef contentSizeCategory()
 {
     if (!contentSizeCategoryStorage().isNull()) {
         // The contract of this function is that it returns a +0 autoreleased object (just like [[UIApplication sharedApplication] preferredContentSizeCategory] does).
-        // String's operator NSString returns a +0 autoreleased object, so we do that here, and then cast it to CFStringRef to return it.
-        return bridge_cast(static_cast<NSString*>(contentSizeCategoryStorage()));
+        // createNSString().autorelease() returns a +0 autoreleased object, so we do that here, and then cast it to CFStringRef to return it.
+        return bridge_cast(contentSizeCategoryStorage().createNSString().autorelease());
     }
 #if PLATFORM(IOS_FAMILY)
     return static_cast<CFStringRef>([[PAL::getUIApplicationClass() sharedApplication] preferredContentSizeCategory]);

--- a/Source/WebCore/platform/graphics/cocoa/controls/ApplePayButtonCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/controls/ApplePayButtonCocoa.mm
@@ -117,7 +117,7 @@ void ApplePayButtonCocoa::draw(GraphicsContext& context, const FloatRoundedRect&
         largestCornerRadius,
         toPKPaymentButtonType(applePayButtonPart.buttonType()),
         toPKPaymentButtonStyle(applePayButtonPart.buttonStyle()),
-        applePayButtonPart.locale()
+        applePayButtonPart.locale().createNSString().get()
     );
 }
 

--- a/Source/WebCore/platform/graphics/mac/IconMac.mm
+++ b/Source/WebCore/platform/graphics/mac/IconMac.mm
@@ -49,39 +49,39 @@ RefPtr<Icon> Icon::createIconForFiles(const Vector<String>& filenames)
         if (filenames[0].isEmpty() || filenames[0][0U] != '/')
             return nullptr;
 
-        NSImage *image = [[NSWorkspace sharedWorkspace] iconForFile:filenames[0]];
+        RetainPtr image = [[NSWorkspace sharedWorkspace] iconForFile:filenames[0].createNSString().get()];
         if (!image)
             return nullptr;
 
-        return adoptRef(new Icon(image));
+        return adoptRef(new Icon(image.get()));
     }
-    NSImage *image = [NSImage imageNamed:NSImageNameMultipleDocuments];
+    RetainPtr image = [NSImage imageNamed:NSImageNameMultipleDocuments];
     if (!image)
         return nullptr;
 
-    return adoptRef(new Icon(image));
+    return adoptRef(new Icon(image.get()));
 }
 
 RefPtr<Icon> Icon::createIconForFileExtension(const String& fileExtension)
 {
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    NSImage *image = [[NSWorkspace sharedWorkspace] iconForFileType:[@"." stringByAppendingString:fileExtension]];
+    RetainPtr image = [[NSWorkspace sharedWorkspace] iconForFileType:[@"." stringByAppendingString:fileExtension.createNSString().get()]];
 ALLOW_DEPRECATED_DECLARATIONS_END
     if (!image)
         return nullptr;
 
-    return adoptRef(new Icon(image));
+    return adoptRef(new Icon(image.get()));
 }
 
-RefPtr<Icon> Icon::createIconForUTI(const String& UTI)
+RefPtr<Icon> Icon::createIconForUTI(const String& uti)
 {
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    NSImage *image = [[NSWorkspace sharedWorkspace] iconForFileType:UTI];
+    RetainPtr image = [[NSWorkspace sharedWorkspace] iconForFileType:uti.createNSString().get()];
 ALLOW_DEPRECATED_DECLARATIONS_END
     if (!image)
         return nullptr;
 
-    return adoptRef(new Icon(image));
+    return adoptRef(new Icon(image.get()));
 }
 
 }

--- a/Source/WebCore/platform/mac/PasteboardWriter.mm
+++ b/Source/WebCore/platform/mac/PasteboardWriter.mm
@@ -61,7 +61,7 @@ RetainPtr<id <NSPasteboardWriting>> createPasteboardWriter(const PasteboardWrite
     auto pasteboardItem = adoptNS([[NSPasteboardItem alloc] init]);
 
     if (auto& plainText = data.plainText()) {
-        [pasteboardItem setString:plainText->text forType:NSPasteboardTypeString];
+        [pasteboardItem setString:plainText->text.createNSString().get() forType:NSPasteboardTypeString];
         if (plainText->canSmartCopyOrDelete) {
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             auto smartPasteType = bridge_cast(adoptCF(UTTypeCreatePreferredIdentifierForTag(kUTTagClassNSPboardType, bridge_cast(_NXSmartPaste), nullptr)));
@@ -72,7 +72,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     if (auto& urlData = data.urlData()) {
         RetainPtr nsURL = urlData->url.createNSURL();
-        NSString *userVisibleString = urlData->userVisibleForm;
+        RetainPtr userVisibleString = urlData->userVisibleForm.createNSString();
         RetainPtr title = urlData->title.createNSString();
         if (!title.get().length) {
             title = nsURL.get().path.lastPathComponent;
@@ -82,7 +82,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
         // WebURLsWithTitlesPboardType.
         // FIXME: This could use StringView (the one that creates NSString) to save an allocation
-        auto paths = adoptNS([[NSArray alloc] initWithObjects:@[ @[ nsURL.get().absoluteString ] ], @[ urlData->title.trim(deprecatedIsSpaceOrNewline) ], nil]);
+        auto paths = adoptNS([[NSArray alloc] initWithObjects:@[ @[ nsURL.get().absoluteString ] ], @[ urlData->title.trim(deprecatedIsSpaceOrNewline).createNSString().get() ], nil]);
         [pasteboardItem setPropertyList:paths.get() forType:toUTI(@"WebURLsWithTitlesPboardType").get()];
 
         // NSURLPboardType.
@@ -96,14 +96,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         if (nsURL.get().fileURL)
             [pasteboardItem setString:nsURL.get().absoluteString forType:(NSString *)kUTTypeFileURL];
-        [pasteboardItem setString:userVisibleString forType:(NSString *)kUTTypeURL];
+        [pasteboardItem setString:userVisibleString.get() forType:(NSString *)kUTTypeURL];
 ALLOW_DEPRECATED_DECLARATIONS_END
 
         // WebURLNamePboardType.
         [pasteboardItem setString:title.get() forType:@"public.url-name"];
 
         // NSPasteboardTypeString.
-        [pasteboardItem setString:userVisibleString forType:NSPasteboardTypeString];
+        [pasteboardItem setString:userVisibleString.get() forType:NSPasteboardTypeString];
     }
 
     if (auto& webContent = data.webContent()) {
@@ -124,16 +124,16 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         if (webContent->dataInRTFFormat)
             [pasteboardItem setData:webContent->dataInRTFFormat->createNSData().get() forType:NSPasteboardTypeRTF];
         if (!webContent->dataInHTMLFormat.isNull())
-            [pasteboardItem setString:webContent->dataInHTMLFormat forType:NSPasteboardTypeHTML];
+            [pasteboardItem setString:webContent->dataInHTMLFormat.createNSString().get() forType:NSPasteboardTypeHTML];
         if (!webContent->dataInStringFormat.isNull())
-            [pasteboardItem setString:webContent->dataInStringFormat forType:NSPasteboardTypeString];
+            [pasteboardItem setString:webContent->dataInStringFormat.createNSString().get() forType:NSPasteboardTypeString];
 
         for (unsigned i = 0; i < webContent->clientTypesAndData.size(); ++i)
-            [pasteboardItem setData:webContent->clientTypesAndData[i].second->createNSData().get() forType:toUTIUnlessAlreadyUTI(webContent->clientTypesAndData[i].first).get()];
+            [pasteboardItem setData:webContent->clientTypesAndData[i].second->createNSData().get() forType:toUTIUnlessAlreadyUTI(webContent->clientTypesAndData[i].first.createNSString().get()).get()];
 
         PasteboardCustomData customData;
         customData.setOrigin(webContent->contentOrigin);
-        [pasteboardItem setData:customData.createSharedBuffer()->createNSData().get() forType:toUTIUnlessAlreadyUTI(String(PasteboardCustomData::cocoaType())).get()];
+        [pasteboardItem setData:customData.createSharedBuffer()->createNSData().get() forType:toUTIUnlessAlreadyUTI(PasteboardCustomData::cocoaType().createNSString().get()).get()];
     }
 
     return pasteboardItem;

--- a/Source/WebCore/platform/mac/ValidationBubbleMac.mm
+++ b/Source/WebCore/platform/mac/ValidationBubbleMac.mm
@@ -63,7 +63,7 @@ ValidationBubble::ValidationBubble(NSView* view, const String& message, const Se
     [label setEditable:NO];
     [label setDrawsBackground:NO];
     [label setBordered:NO];
-    [label setStringValue:message];
+    [label setStringValue:message.createNSString().get()];
     m_fontSize = std::max(settings.minimumFontSize, 13.0);
     [label setFont:[NSFont systemFontOfSize:m_fontSize]];
     [label setMaximumNumberOfLines:4];

--- a/Source/WebCore/platform/mac/WebCoreFullScreenPlaceholderView.mm
+++ b/Source/WebCore/platform/mac/WebCoreFullScreenPlaceholderView.mm
@@ -62,7 +62,7 @@
     _exitWarning.get().editable = NO;
     _exitWarning.get().font = [NSFont systemFontOfSize:27];
     _exitWarning.get().selectable = NO;
-    _exitWarning.get().stringValue = WebCore::clickToExitFullScreenText();
+    _exitWarning.get().stringValue = WebCore::clickToExitFullScreenText().createNSString().get();
     _exitWarning.get().textColor = [NSColor tertiaryLabelColor];
     [_exitWarning sizeToFit];
 

--- a/Source/WebCore/platform/mac/WebPlaybackControlsManager.mm
+++ b/Source/WebCore/platform/mac/WebPlaybackControlsManager.mm
@@ -264,7 +264,7 @@ static AVTouchBarMediaSelectionOptionType toAVTouchBarMediaSelectionOptionType(M
 static RetainPtr<NSArray> mediaSelectionOptions(const Vector<MediaSelectionOption>& options)
 {
     return createNSArray(options, [] (auto& option) {
-        return adoptNS([allocAVTouchBarMediaSelectionOptionInstance() initWithTitle:option.displayName type:toAVTouchBarMediaSelectionOptionType(option.legibleType)]);
+        return adoptNS([allocAVTouchBarMediaSelectionOptionInstance() initWithTitle:option.displayName.createNSString().get() type:toAVTouchBarMediaSelectionOptionType(option.legibleType)]);
     });
 }
 

--- a/Source/WebCore/platform/network/cocoa/CredentialCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/CredentialCocoa.mm
@@ -91,7 +91,7 @@ NSURLCredential *Credential::nsCredential() const
     if (CredentialBase::isEmpty())
         return nil;
 
-    m_nsCredential = adoptNS([[NSURLCredential alloc] initWithUser:user() password:password() persistence:toNSURLCredentialPersistence(persistence())]);
+    m_nsCredential = adoptNS([[NSURLCredential alloc] initWithUser:user().createNSString().get() password:password().createNSString().get() persistence:toNSURLCredentialPersistence(persistence())]);
 
     return m_nsCredential.get();
 }

--- a/Source/WebCore/platform/network/cocoa/ProtectionSpaceCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ProtectionSpaceCocoa.mm
@@ -182,9 +182,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
 
     if (proxyType)
-        lazyInitialize(m_nsSpace, adoptNS([[NSURLProtectionSpace alloc] initWithProxyHost:host() port:port() type:proxyType.get() realm:realm() authenticationMethod:method]));
+        lazyInitialize(m_nsSpace, adoptNS([[NSURLProtectionSpace alloc] initWithProxyHost:host().createNSString().get() port:port() type:proxyType.get() realm:realm().createNSString().get() authenticationMethod:method]));
     else
-        lazyInitialize(m_nsSpace, adoptNS([[NSURLProtectionSpace alloc] initWithHost:host() port:port() protocol:protocol.get() realm:realm() authenticationMethod:method]));
+        lazyInitialize(m_nsSpace, adoptNS([[NSURLProtectionSpace alloc] initWithHost:host().createNSString().get() port:port() protocol:protocol.get() realm:realm().createNSString().get() authenticationMethod:method]));
 
     return m_nsSpace.get();
 }

--- a/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
@@ -302,7 +302,7 @@ void ResourceRequest::doUpdatePlatformRequest()
 
     [nsRequest setMainDocumentURL:firstPartyForCookies().createNSURL().get()];
     if (!httpMethod().isEmpty())
-        [nsRequest setHTTPMethod:httpMethod()];
+        [nsRequest setHTTPMethod:httpMethod().createNSString().get()];
     [nsRequest setHTTPShouldHandleCookies:allowCookies()];
 
     [nsRequest _setProperty:siteForCookies(m_requestData.m_sameSiteDisposition, [nsRequest URL]) forKey:@"_kCFHTTPCookiePolicyPropertySiteForCookies"];
@@ -312,8 +312,8 @@ void ResourceRequest::doUpdatePlatformRequest()
     for (NSString *oldHeaderName in [nsRequest allHTTPHeaderFields])
         [nsRequest setValue:nil forHTTPHeaderField:oldHeaderName];
     for (const auto& header : httpHeaderFields()) {
-        auto encodedValue = httpHeaderValueUsingSuitableEncoding(header);
-        [nsRequest setValue:(__bridge NSString *)encodedValue.get() forHTTPHeaderField:header.key];
+        RetainPtr encodedValue = httpHeaderValueUsingSuitableEncoding(header);
+        [nsRequest setValue:bridge_cast(encodedValue.get()) forHTTPHeaderField:header.key.createNSString().get()];
     }
 
     [nsRequest setContentDispositionEncodingFallbackArray:createNSArray(m_requestData.m_responseContentDispositionEncodingFallbackArray, [] (auto& name) -> NSNumber * {

--- a/Source/WebCore/platform/network/mac/ResourceHandleMac.mm
+++ b/Source/WebCore/platform/network/mac/ResourceHandleMac.mm
@@ -529,8 +529,8 @@ bool ResourceHandle::tryHandlePasswordBasedAuthentication(const AuthenticationCh
         return false;
 
     if (!d->m_user.isEmpty() || !d->m_password.isEmpty()) {
-        auto credential = adoptNS([[NSURLCredential alloc] initWithUser:d->m_user
-            password:d->m_password persistence:NSURLCredentialPersistenceForSession]);
+        auto credential = adoptNS([[NSURLCredential alloc] initWithUser:d->m_user.createNSString().get()
+            password:d->m_password.createNSString().get() persistence:NSURLCredentialPersistenceForSession]);
         d->m_currentMacChallenge = challenge.nsURLAuthenticationChallenge();
         d->m_currentWebChallenge = challenge;
         receivedCredential(challenge, Credential(credential.get()));

--- a/Source/WebCore/platform/network/mac/UTIUtilities.mm
+++ b/Source/WebCore/platform/network/mac/UTIUtilities.mm
@@ -48,7 +48,7 @@ namespace WebCore {
 
 String MIMETypeFromUTI(const String& uti)
 {
-    RetainPtr type = [UTType typeWithIdentifier:uti];
+    RetainPtr type = [UTType typeWithIdentifier:uti.createNSString().get()];
     return type.get().preferredMIMEType;
 }
 
@@ -118,7 +118,7 @@ public:
         if (auto type = UTIFromPotentiallyUnknownMIMEType(mimeType))
             return type;
 
-        if (RetainPtr type = [UTType typeWithMIMEType:mimeType])
+        if (RetainPtr type = [UTType typeWithMIMEType:mimeType.createNSString().get()])
             return type.get().identifier;
 
         return @"";
@@ -140,9 +140,9 @@ String UTIFromMIMEType(const String& mimeType)
     return cacheUTIFromMIMEType().get(mimeType).get();
 }
 
-bool isDeclaredUTI(const String& UTI)
+bool isDeclaredUTI(const String& uti)
 {
-    RetainPtr type = [UTType typeWithIdentifier:UTI];
+    RetainPtr type = [UTType typeWithIdentifier:uti.createNSString().get()];
     return type.get().isDeclared;
 }
 

--- a/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
+++ b/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
@@ -78,7 +78,7 @@ LocaleCocoa::LocaleCocoa(const AtomString& locale)
     // NSLocale returns a lower case NSLocaleLanguageCode so we don't have care about case.
     NSString* language = [m_locale objectForKey:NSLocaleLanguageCode];
     if ([availableLanguages indexOfObject:language] == NSNotFound)
-        m_locale = adoptNS([[NSLocale alloc] initWithLocaleIdentifier:defaultLanguage()]);
+        m_locale = adoptNS([[NSLocale alloc] initWithLocaleIdentifier:defaultLanguage().createNSString().get()]);
     [m_gregorianCalendar setLocale:m_locale.get()];
 }
 

--- a/Source/WebCore/rendering/AttachmentLayout.mm
+++ b/Source/WebCore/rendering/AttachmentLayout.mm
@@ -349,8 +349,8 @@ void AttachmentLayout::buildWrappedLines(String& text, CTFontRef font, NSDiction
     if (text.isEmpty())
         return;
     
-    auto attributedText = adoptNS([[NSAttributedString alloc] initWithString:text attributes:textAttributes]);
-    auto framesetter = adoptCF(CTFramesetterCreateWithAttributedString((CFAttributedStringRef)attributedText.get()));
+    RetainPtr attributedText = adoptNS([[NSAttributedString alloc] initWithString:text.createNSString().get() attributes:textAttributes]);
+    RetainPtr framesetter = adoptCF(CTFramesetterCreateWithAttributedString((CFAttributedStringRef)attributedText.get()));
     
     CFRange fitRange;
     auto textSize = CTFramesetterSuggestFrameSizeWithConstraints(framesetter.get(), CFRangeMake(0, 0), nullptr, CGSizeMake(wrappingWidth, CGFLOAT_MAX), &fitRange);
@@ -396,8 +396,8 @@ void AttachmentLayout::buildSingleLine(const String& text, CTFontRef font, NSDic
 {
     if (text.isEmpty())
         return;
-    RetainPtr<NSAttributedString> attributedText = adoptNS([[NSAttributedString alloc] initWithString:text attributes:textAttributes]);
-    
+
+    RetainPtr attributedText = adoptNS([[NSAttributedString alloc] initWithString:text.createNSString().get() attributes:textAttributes]);
     addLine(font, adoptCF(CTLineCreateWithAttributedString((CFAttributedStringRef)attributedText.get())).get(), true);
 }
 

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -255,7 +255,7 @@ String RenderThemeCocoa::mediaControlsBase64StringForIconNameAndType(const Strin
 {
     NSString *directory = @"modern-media-controls/images";
     NSBundle *bundle = [NSBundle bundleForClass:[WebCoreRenderThemeBundle class]];
-    return [[NSData dataWithContentsOfFile:[bundle pathForResource:iconName ofType:iconType inDirectory:directory]] base64EncodedStringWithOptions:0];
+    return [[NSData dataWithContentsOfFile:[bundle pathForResource:iconName.createNSString().get() ofType:iconType.createNSString().get() inDirectory:directory]] base64EncodedStringWithOptions:0];
 }
 
 String RenderThemeCocoa::mediaControlsFormattedStringForDuration(const double durationInSeconds)

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -1319,7 +1319,7 @@ String RenderThemeMac::fileListNameForWidth(const FileList* fileList, const Font
     if (fileList->isEmpty())
         strToTruncate = fileListDefaultLabel(multipleFilesAllowed);
     else if (fileList->length() == 1)
-        strToTruncate = [[NSFileManager defaultManager] displayNameAtPath:(fileList->item(0)->path())];
+        strToTruncate = [[NSFileManager defaultManager] displayNameAtPath:fileList->item(0)->path().createNSString().get()];
     else
         return StringTruncator::rightTruncate(multipleFileUploadText(fileList->length()), width, font);
 
@@ -1384,8 +1384,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         LOG_ATTACHMENT("-> No icon for filename! Will fallback to title...");
     }
 
-    NSString *cocoaTitle = title;
-    if (auto fileExtension = cocoaTitle.pathExtension; fileExtension.length) {
+    RetainPtr nsTitle = title.createNSString();
+    if (auto fileExtension = nsTitle.get().pathExtension; fileExtension.length) {
         if (auto icon = Icon::createIconForFileExtension(fileExtension)) {
             LOG_ATTACHMENT("-> Got icon for title file extension '%s'", String(fileExtension).utf8().data());
             return icon;

--- a/Source/WebCore/testing/Internals.mm
+++ b/Source/WebCore/testing/Internals.mm
@@ -198,9 +198,9 @@ bool Internals::privatePlayerMuted(const HTMLMediaElement& element)
 
 String Internals::encodedPreferenceValue(const String& domain, const String& key)
 {
-    auto userDefaults = adoptNS([[NSUserDefaults alloc] initWithSuiteName:domain]);
-    id value = [userDefaults objectForKey:key];
-    auto data = retainPtr([NSKeyedArchiver archivedDataWithRootObject:value requiringSecureCoding:YES error:nullptr]);
+    RetainPtr userDefaults = adoptNS([[NSUserDefaults alloc] initWithSuiteName:domain.createNSString().get()]);
+    RetainPtr value = [userDefaults objectForKey:key.createNSString().get()];
+    RetainPtr data = retainPtr([NSKeyedArchiver archivedDataWithRootObject:value.get() requiringSecureCoding:YES error:nullptr]);
     return [data base64EncodedStringWithOptions:0];
 }
 
@@ -267,7 +267,7 @@ RetainPtr<VKCImageAnalysis> Internals::fakeImageAnalysisResultForTesting(const V
             fullText.append(newlineCharacter);
     }
 
-    return adoptNS((id)[[FakeImageAnalysisResult alloc] initWithString:fullText.toString()]);
+    return adoptNS((id)[[FakeImageAnalysisResult alloc] initWithString:fullText.toString().createNSString().get()]);
 }
 
 #endif // ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)

--- a/Source/WebKitLegacy/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -49,9 +49,7 @@ mac/Panels/WebPanelAuthenticationHandler.m
 mac/Plugins/WebBasePluginPackage.mm
 mac/Plugins/WebPluginController.mm
 mac/Plugins/WebPluginDatabase.mm
-mac/Storage/WebDatabaseProvider.mm
 mac/Storage/WebStorageManager.mm
-mac/WebCoreSupport/CorrectionPanel.mm
 mac/WebCoreSupport/PopupMenuMac.mm
 mac/WebCoreSupport/WebChromeClient.mm
 mac/WebCoreSupport/WebContextMenuClient.mm
@@ -69,7 +67,6 @@ mac/WebView/WebDelegateImplementationCaching.mm
 mac/WebView/WebDynamicScrollBarsView.mm
 mac/WebView/WebFrame.mm
 mac/WebView/WebFrameView.mm
-mac/WebView/WebHTMLRepresentation.mm
 mac/WebView/WebHTMLView.mm
 mac/WebView/WebImmediateActionController.mm
 mac/WebView/WebJSPDFDoc.mm

--- a/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.mm
+++ b/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.mm
@@ -39,7 +39,7 @@ WebCore::ResourceError WebResourceLoadScheduler::pluginWillHandleLoadError(const
 
 WebCore::ResourceError WebResourceLoadScheduler::pluginWillHandleLoadErrorFromResponse(const WebCore::ResourceResponse& response)
 {
-    return [[[NSError alloc] _initWithPluginErrorCode:WebKitErrorPlugInWillHandleLoad contentURL:response.url().createNSURL().get() pluginPageURL:nil pluginName:nil MIMEType:response.mimeType()] autorelease];
+    return [[[NSError alloc] _initWithPluginErrorCode:WebKitErrorPlugInWillHandleLoad contentURL:response.url().createNSURL().get() pluginPageURL:nil pluginName:nil MIMEType:response.mimeType().createNSString().get()] autorelease];
 }
 
 WebCore::ResourceError WebResourceLoadScheduler::cancelledError(const WebCore::ResourceRequest& request) const

--- a/Source/WebKitLegacy/mac/DOM/DOMAttr.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMAttr.mm
@@ -46,7 +46,7 @@
 - (NSString *)name
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->name();
+    return IMPL->name().createNSString().autorelease();
 }
 
 - (BOOL)specified
@@ -58,7 +58,7 @@
 - (NSString *)value
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->value();
+    return IMPL->value().createNSString().autorelease();
 }
 
 - (void)setValue:(NSString *)newValue

--- a/Source/WebKitLegacy/mac/DOM/DOMBlob.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMBlob.mm
@@ -59,7 +59,7 @@
 - (NSString *)type
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->type();
+    return IMPL->type().createNSString().autorelease();
 }
 
 @end

--- a/Source/WebKitLegacy/mac/DOM/DOMCSSImportRule.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMCSSImportRule.mm
@@ -46,7 +46,7 @@
 - (NSString *)href
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->href();
+    return IMPL->href().createNSString().autorelease();
 }
 
 - (DOMMediaList *)media

--- a/Source/WebKitLegacy/mac/DOM/DOMCSSPageRule.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMCSSPageRule.mm
@@ -45,7 +45,7 @@
 - (NSString *)selectorText
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->selectorText();
+    return IMPL->selectorText().createNSString().autorelease();
 }
 
 - (void)setSelectorText:(NSString *)newSelectorText

--- a/Source/WebKitLegacy/mac/DOM/DOMCSSPrimitiveValue.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMCSSPrimitiveValue.mm
@@ -72,7 +72,7 @@
 - (NSString *)getStringValue
 {
     WebCore::JSMainThreadNullState state;
-    return raiseOnDOMError(IMPL->getStringValue());
+    return raiseOnDOMError(IMPL->getStringValue()).createNSString().autorelease();
 }
 
 - (DOMCounter *)getCounterValue

--- a/Source/WebKitLegacy/mac/DOM/DOMCSSRule.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMCSSRule.mm
@@ -62,7 +62,7 @@
 - (NSString *)cssText
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->cssText();
+    return IMPL->cssText().createNSString().autorelease();
 }
 
 - (void)setCssText:(NSString *)newCssText

--- a/Source/WebKitLegacy/mac/DOM/DOMCSSStyleDeclaration.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMCSSStyleDeclaration.mm
@@ -58,7 +58,7 @@
 - (NSString *)cssText
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->cssText();
+    return IMPL->cssText().createNSString().autorelease();
 }
 
 - (void)setCssText:(NSString *)newCssText
@@ -82,7 +82,7 @@
 - (NSString *)getPropertyValue:(NSString *)propertyName
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getPropertyValue(propertyName);
+    return IMPL->getPropertyValue(propertyName).createNSString().autorelease();
 }
 
 - (DOMCSSValue *)getPropertyCSSValue:(NSString *)propertyName
@@ -94,13 +94,13 @@
 - (NSString *)removeProperty:(NSString *)propertyName
 {
     WebCore::JSMainThreadNullState state;
-    return raiseOnDOMError(IMPL->removeProperty(propertyName));
+    return raiseOnDOMError(IMPL->removeProperty(propertyName)).createNSString().autorelease();
 }
 
 - (NSString *)getPropertyPriority:(NSString *)propertyName
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getPropertyPriority(propertyName);
+    return IMPL->getPropertyPriority(propertyName).createNSString().autorelease();
 }
 
 - (void)setProperty:(NSString *)propertyName value:(NSString *)value priority:(NSString *)priority
@@ -112,13 +112,13 @@
 - (NSString *)item:(unsigned)index
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->item(index);
+    return IMPL->item(index).createNSString().autorelease();
 }
 
 - (NSString *)getPropertyShorthand:(NSString *)propertyName
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getPropertyShorthand(propertyName);
+    return IMPL->getPropertyShorthand(propertyName).createNSString().autorelease();
 }
 
 - (BOOL)isPropertyImplicit:(NSString *)propertyName

--- a/Source/WebKitLegacy/mac/DOM/DOMCSSStyleRule.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMCSSStyleRule.mm
@@ -45,7 +45,7 @@
 - (NSString *)selectorText
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->selectorText();
+    return IMPL->selectorText().createNSString().autorelease();
 }
 
 - (void)setSelectorText:(NSString *)newSelectorText

--- a/Source/WebKitLegacy/mac/DOM/DOMCSSValue.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMCSSValue.mm
@@ -53,7 +53,7 @@
 - (NSString *)cssText
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->cssText();
+    return IMPL->cssText().createNSString().autorelease();
 }
 
 - (void)setCssText:(NSString *)newCssText

--- a/Source/WebKitLegacy/mac/DOM/DOMCharacterData.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMCharacterData.mm
@@ -43,7 +43,7 @@
 - (NSString *)data
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->data();
+    return IMPL->data().createNSString().autorelease();
 }
 
 - (void)setData:(NSString *)newData
@@ -73,7 +73,7 @@
 - (NSString *)substringData:(unsigned)offset length:(unsigned)inLength
 {
     WebCore::JSMainThreadNullState state;
-    return raiseOnDOMError(IMPL->substringData(offset, inLength));
+    return raiseOnDOMError(IMPL->substringData(offset, inLength)).createNSString().autorelease();
 }
 
 - (void)appendData:(NSString *)inData

--- a/Source/WebKitLegacy/mac/DOM/DOMCounter.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMCounter.mm
@@ -53,19 +53,19 @@
 - (NSString *)identifier
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->identifier();
+    return IMPL->identifier().createNSString().autorelease();
 }
 
 - (NSString *)listStyle
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->listStyle();
+    return IMPL->listStyle().createNSString().autorelease();
 }
 
 - (NSString *)separator
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->separator();
+    return IMPL->separator().createNSString().autorelease();
 }
 
 @end

--- a/Source/WebKitLegacy/mac/DOM/DOMDocument.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMDocument.mm
@@ -122,13 +122,13 @@
 - (NSString *)xmlEncoding
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->xmlEncoding();
+    return IMPL->xmlEncoding().createNSString().autorelease();
 }
 
 - (NSString *)xmlVersion
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->xmlVersion();
+    return IMPL->xmlVersion().createNSString().autorelease();
 }
 
 - (void)setXmlVersion:(NSString *)newXmlVersion
@@ -152,7 +152,7 @@
 - (NSString *)documentURI
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->documentURI();
+    return IMPL->documentURI().createNSString().autorelease();
 }
 
 - (void)setDocumentURI:(NSString *)newDocumentURI
@@ -176,13 +176,13 @@
 - (NSString *)contentType
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->contentType();
+    return IMPL->contentType().createNSString().autorelease();
 }
 
 - (NSString *)title
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->title();
+    return IMPL->title().createNSString().autorelease();
 }
 
 - (void)setTitle:(NSString *)newTitle
@@ -194,7 +194,7 @@
 - (NSString *)dir
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->dir();
+    return IMPL->dir().createNSString().autorelease();
 }
 
 - (void)setDir:(NSString *)newDir
@@ -206,25 +206,25 @@
 - (NSString *)referrer
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->referrer();
+    return IMPL->referrer().createNSString().autorelease();
 }
 
 - (NSString *)domain
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->domain();
+    return IMPL->domain().createNSString().autorelease();
 }
 
 - (NSString *)URL
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->urlForBindings().string();
+    return IMPL->urlForBindings().string().createNSString().autorelease();
 }
 
 - (NSString *)cookie
 {
     WebCore::JSMainThreadNullState state;
-    return raiseOnDOMError(IMPL->cookie());
+    return raiseOnDOMError(IMPL->cookie()).createNSString().autorelease();
 }
 
 - (void)setCookie:(NSString *)newCookie
@@ -284,7 +284,7 @@
 - (NSString *)lastModified
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->lastModified();
+    return IMPL->lastModified().createNSString().autorelease();
 }
 
 - (NSString *)charset
@@ -301,7 +301,7 @@
 
 - (NSString *)defaultCharset
 {
-    return IMPL->defaultCharsetForLegacyBindings();
+    return IMPL->defaultCharsetForLegacyBindings().createNSString().autorelease();
 }
 
 - (NSString *)readyState
@@ -349,7 +349,7 @@
 - (NSString *)compatMode
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->compatMode();
+    return IMPL->compatMode().createNSString().autorelease();
 }
 
 #if ENABLE(FULLSCREEN_API)
@@ -415,7 +415,7 @@
 - (NSString *)origin
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->securityOrigin().toString();
+    return IMPL->securityOrigin().toString().createNSString().autorelease();
 }
 
 - (DOMElement *)scrollingElement
@@ -662,7 +662,7 @@ static RefPtr<WebCore::XPathNSResolver> wrap(id <DOMXPathNSResolver> resolver)
 {
     WebCore::JSMainThreadNullState state;
     auto result = IMPL->queryCommandValue(command);
-    return result.hasException() ? String() : result.returnValue();
+    return result.hasException() ? @"" : result.returnValue().createNSString().autorelease();
 }
 
 - (DOMNodeList *)getElementsByName:(NSString *)elementName

--- a/Source/WebKitLegacy/mac/DOM/DOMDocumentType.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMDocumentType.mm
@@ -43,7 +43,7 @@
 - (NSString *)name
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->name();
+    return IMPL->name().createNSString().autorelease();
 }
 
 - (DOMNamedNodeMap *)entities
@@ -59,13 +59,13 @@
 - (NSString *)publicId
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->publicId();
+    return IMPL->publicId().createNSString().autorelease();
 }
 
 - (NSString *)systemId
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->systemId();
+    return IMPL->systemId().createNSString().autorelease();
 }
 
 - (NSString *)internalSubset

--- a/Source/WebKitLegacy/mac/DOM/DOMElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMElement.mm
@@ -67,7 +67,7 @@ DOMElement *kit(WebCore::Element* value)
 - (NSString *)tagName
 {
     WebCore::JSMainThreadNullState state;
-    return unwrap(*self).tagName();
+    return unwrap(*self).tagName().createNSString().autorelease();
 }
 
 - (DOMCSSStyleDeclaration *)style
@@ -170,7 +170,7 @@ DOMElement *kit(WebCore::Element* value)
 - (NSString *)innerHTML
 {
     WebCore::JSMainThreadNullState state;
-    return unwrap(*self).innerHTML();
+    return unwrap(*self).innerHTML().createNSString().autorelease();
 }
 
 - (void)setInnerHTML:(NSString *)newInnerHTML
@@ -182,7 +182,7 @@ DOMElement *kit(WebCore::Element* value)
 - (NSString *)outerHTML
 {
     WebCore::JSMainThreadNullState state;
-    return unwrap(*self).outerHTML();
+    return unwrap(*self).outerHTML().createNSString().autorelease();
 }
 
 - (void)setOuterHTML:(NSString *)newOuterHTML
@@ -194,7 +194,7 @@ DOMElement *kit(WebCore::Element* value)
 - (NSString *)className
 {
     WebCore::JSMainThreadNullState state;
-    return unwrap(*self).getAttribute(WebCore::HTMLNames::classAttr);
+    return unwrap(*self).getAttribute(WebCore::HTMLNames::classAttr).createNSString().autorelease();
 }
 
 - (void)setClassName:(NSString *)newClassName
@@ -212,13 +212,13 @@ DOMElement *kit(WebCore::Element* value)
 - (NSString *)innerText
 {
     WebCore::JSMainThreadNullState state;
-    return unwrap(*self).innerText();
+    return unwrap(*self).innerText().createNSString().autorelease();
 }
 
 - (NSString *)uiactions
 {
     WebCore::JSMainThreadNullState state;
-    return unwrap(*self).getAttribute(WebCore::HTMLNames::uiactionsAttr);
+    return unwrap(*self).getAttribute(WebCore::HTMLNames::uiactionsAttr).createNSString().autorelease();
 }
 
 - (void)setUiactions:(NSString *)newUiactions
@@ -275,7 +275,7 @@ DOMElement *kit(WebCore::Element* value)
 - (NSString *)getAttribute:(NSString *)name
 {
     WebCore::JSMainThreadNullState state;
-    return unwrap(*self).getAttribute(name);
+    return unwrap(*self).getAttribute(name).createNSString().autorelease();
 }
 
 - (void)setAttribute:(NSString *)name value:(NSString *)value
@@ -325,7 +325,7 @@ DOMElement *kit(WebCore::Element* value)
 - (NSString *)getAttributeNS:(NSString *)namespaceURI localName:(NSString *)localName
 {
     WebCore::JSMainThreadNullState state;
-    return unwrap(*self).getAttributeNS(namespaceURI, localName);
+    return unwrap(*self).getAttributeNS(namespaceURI, localName).createNSString().autorelease();
 }
 
 - (void)setAttributeNS:(NSString *)namespaceURI qualifiedName:(NSString *)qualifiedName value:(NSString *)value

--- a/Source/WebKitLegacy/mac/DOM/DOMFile.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMFile.mm
@@ -42,7 +42,7 @@
 - (NSString *)name
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->name();
+    return IMPL->name().createNSString().autorelease();
 }
 
 - (long long)lastModified

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLAnchorElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLAnchorElement.mm
@@ -189,7 +189,7 @@
 - (NSString *)text
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->text();
+    return IMPL->text().createNSString().autorelease();
 }
 
 - (NSURL *)absoluteLinkURL
@@ -207,7 +207,7 @@
 - (NSString *)href
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getURLAttribute(WebCore::HTMLNames::hrefAttr).string();
+    return IMPL->getURLAttribute(WebCore::HTMLNames::hrefAttr).string().createNSString().autorelease();
 }
 
 - (void)setHref:(NSString *)newHref
@@ -219,49 +219,49 @@
 - (NSString *)origin
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->origin();
+    return IMPL->origin().createNSString().autorelease();
 }
 
 - (NSString *)protocol
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->protocol();
+    return IMPL->protocol().createNSString().autorelease();
 }
 
 - (NSString *)host
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->host();
+    return IMPL->host().createNSString().autorelease();
 }
 
 - (NSString *)hostname
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->hostname();
+    return IMPL->hostname().createNSString().autorelease();
 }
 
 - (NSString *)port
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->port();
+    return IMPL->port().createNSString().autorelease();
 }
 
 - (NSString *)pathname
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->pathname();
+    return IMPL->pathname().createNSString().autorelease();
 }
 
 - (NSString *)search
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->search();
+    return IMPL->search().createNSString().autorelease();
 }
 
 - (NSString *)hashName
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->hash();
+    return IMPL->hash().createNSString().autorelease();
 }
 
 @end

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLAreaElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLAreaElement.mm
@@ -154,7 +154,7 @@
 - (NSString *)href
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getURLAttribute(WebCore::HTMLNames::hrefAttr).string();
+    return IMPL->getURLAttribute(WebCore::HTMLNames::hrefAttr).string().createNSString().autorelease();
 }
 
 - (void)setHref:(NSString *)newHref
@@ -166,49 +166,49 @@
 - (NSString *)origin
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->origin();
+    return IMPL->origin().createNSString().autorelease();
 }
 
 - (NSString *)protocol
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->protocol();
+    return IMPL->protocol().createNSString().autorelease();
 }
 
 - (NSString *)host
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->host();
+    return IMPL->host().createNSString().autorelease();
 }
 
 - (NSString *)hostname
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->hostname();
+    return IMPL->hostname().createNSString().autorelease();
 }
 
 - (NSString *)port
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->port();
+    return IMPL->port().createNSString().autorelease();
 }
 
 - (NSString *)pathname
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->pathname();
+    return IMPL->pathname().createNSString().autorelease();
 }
 
 - (NSString *)search
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->search();
+    return IMPL->search().createNSString().autorelease();
 }
 
 - (NSString *)hashName
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->hash();
+    return IMPL->hash().createNSString().autorelease();
 }
 
 @end

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLBaseElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLBaseElement.mm
@@ -42,7 +42,7 @@
 - (NSString *)href
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->href();
+    return IMPL->href().createNSString().autorelease();
 }
 
 - (void)setHref:(NSString *)newHref

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLCanvasElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLCanvasElement.mm
@@ -71,7 +71,7 @@
     if (exceptionOrReturnValue.hasException())
         raiseDOMErrorException(exceptionOrReturnValue.releaseException());
 
-    return exceptionOrReturnValue.releaseReturnValue().string;
+    return exceptionOrReturnValue.releaseReturnValue().string.createNSString().autorelease();
 }
 
 @end

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLDocument.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLDocument.mm
@@ -83,7 +83,7 @@
 - (NSString *)designMode
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->designMode();
+    return IMPL->designMode().createNSString().autorelease();
 }
 
 - (void)setDesignMode:(NSString *)newDesignMode
@@ -95,13 +95,13 @@
 - (NSString *)compatMode
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->compatMode();
+    return IMPL->compatMode().createNSString().autorelease();
 }
 
 - (NSString *)bgColor
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->bgColor();
+    return IMPL->bgColor().createNSString().autorelease();
 }
 
 - (void)setBgColor:(NSString *)newBgColor
@@ -113,7 +113,7 @@
 - (NSString *)fgColor
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->fgColor();
+    return IMPL->fgColor().createNSString().autorelease();
 }
 
 - (void)setFgColor:(NSString *)newFgColor
@@ -125,7 +125,7 @@
 - (NSString *)alinkColor
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->alinkColor();
+    return IMPL->alinkColor().createNSString().autorelease();
 }
 
 - (void)setAlinkColor:(NSString *)newAlinkColor
@@ -137,7 +137,7 @@
 - (NSString *)linkColor
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->linkColorForBindings();
+    return IMPL->linkColorForBindings().createNSString().autorelease();
 }
 
 - (void)setLinkColor:(NSString *)newLinkColor
@@ -149,7 +149,7 @@
 - (NSString *)vlinkColor
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->vlinkColor();
+    return IMPL->vlinkColor().createNSString().autorelease();
 }
 
 - (void)setVlinkColor:(NSString *)newVlinkColor

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLElement.mm
@@ -156,7 +156,7 @@
 - (NSString *)innerText
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->innerText();
+    return IMPL->innerText().createNSString().autorelease();
 }
 
 - (void)setInnerText:(NSString *)newInnerText
@@ -168,7 +168,7 @@
 - (NSString *)outerText
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->outerText();
+    return IMPL->outerText().createNSString().autorelease();
 }
 
 - (void)setOuterText:(NSString *)newOuterText
@@ -180,7 +180,7 @@
 - (NSString *)contentEditable
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->contentEditable();
+    return IMPL->contentEditable().createNSString().autorelease();
 }
 
 - (void)setContentEditable:(NSString *)newContentEditable
@@ -228,7 +228,7 @@
 - (NSString *)titleDisplayString
 {
     WebCore::JSMainThreadNullState state;
-    return WebCore::displayString(IMPL->title(), core(self));
+    return WebCore::displayString(IMPL->title(), core(self)).createNSString().autorelease();
 }
 
 - (DOMElement *)insertAdjacentElement:(NSString *)where element:(DOMElement *)element

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLEmbedElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLEmbedElement.mm
@@ -78,7 +78,7 @@
 - (NSString *)src
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getURLAttribute(WebCore::HTMLNames::srcAttr).string();
+    return IMPL->getURLAttribute(WebCore::HTMLNames::srcAttr).string().createNSString().autorelease();
 }
 
 - (void)setSrc:(NSString *)newSrc

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLFormElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLFormElement.mm
@@ -57,7 +57,7 @@
 - (NSString *)action
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getURLAttribute(WebCore::HTMLNames::actionAttr).string();
+    return IMPL->getURLAttribute(WebCore::HTMLNames::actionAttr).string().createNSString().autorelease();
 }
 
 - (void)setAction:(NSString *)newAction
@@ -81,7 +81,7 @@
 - (NSString *)enctype
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->enctype();
+    return IMPL->enctype().createNSString().autorelease();
 }
 
 - (void)setEnctype:(NSString *)newEnctype
@@ -93,7 +93,7 @@
 - (NSString *)encoding
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->enctype();
+    return IMPL->enctype().createNSString().autorelease();
 }
 
 - (void)setEncoding:(NSString *)newEncoding
@@ -105,7 +105,7 @@
 - (NSString *)method
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->method();
+    return IMPL->method().createNSString().autorelease();
 }
 
 - (void)setMethod:(NSString *)newMethod

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLFrameElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLFrameElement.mm
@@ -131,7 +131,7 @@
 - (NSString *)src
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getURLAttribute(WebCore::HTMLNames::srcAttr).string();
+    return IMPL->getURLAttribute(WebCore::HTMLNames::srcAttr).string().createNSString().autorelease();
 }
 
 - (void)setSrc:(NSString *)newSrc

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLHtmlElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLHtmlElement.mm
@@ -53,7 +53,7 @@
 
 - (NSString *)manifest
 {
-    return nullString();
+    return @"";
 }
 
 - (void)setManifest:(NSString *)newManifest

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLIFrameElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLIFrameElement.mm
@@ -154,7 +154,7 @@
 - (NSString *)src
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getURLAttribute(WebCore::HTMLNames::srcAttr).string();
+    return IMPL->getURLAttribute(WebCore::HTMLNames::srcAttr).string().createNSString().autorelease();
 }
 
 - (void)setSrc:(NSString *)newSrc
@@ -166,7 +166,7 @@
 - (NSString *)srcdoc
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::srcdocAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::srcdocAttr).createNSString().autorelease();
 }
 
 - (void)setSrcdoc:(NSString *)newSrcdoc

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLImageElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLImageElement.mm
@@ -81,7 +81,7 @@
 - (NSString *)border
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::borderAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::borderAttr).createNSString().autorelease();
 }
 
 - (void)setBorder:(NSString *)newBorder
@@ -93,7 +93,7 @@
 - (NSString *)crossOrigin
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->crossOrigin();
+    return IMPL->crossOrigin().createNSString().autorelease();
 }
 
 - (void)setCrossOrigin:(NSString *)newCrossOrigin
@@ -141,7 +141,7 @@
 - (NSString *)longDesc
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getURLAttribute(WebCore::HTMLNames::longdescAttr).string();
+    return IMPL->getURLAttribute(WebCore::HTMLNames::longdescAttr).string().createNSString().autorelease();
 }
 
 - (void)setLongDesc:(NSString *)newLongDesc
@@ -153,7 +153,7 @@
 - (NSString *)src
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getURLAttribute(WebCore::HTMLNames::srcAttr).string();
+    return IMPL->getURLAttribute(WebCore::HTMLNames::srcAttr).string().createNSString().autorelease();
 }
 
 - (void)setSrc:(NSString *)newSrc
@@ -189,7 +189,7 @@
 - (NSString *)currentSrc
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->currentSrc().string();
+    return IMPL->currentSrc().string().createNSString().autorelease();
 }
 
 - (NSString *)useMap
@@ -237,7 +237,7 @@
 - (NSString *)lowsrc
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getURLAttribute(WebCore::HTMLNames::lowsrcAttr).string();
+    return IMPL->getURLAttribute(WebCore::HTMLNames::lowsrcAttr).string().createNSString().autorelease();
 }
 
 - (void)setLowsrc:(NSString *)newLowsrc
@@ -273,7 +273,7 @@
 - (NSString *)altDisplayString
 {
     WebCore::JSMainThreadNullState state;
-    return WebCore::displayString(IMPL->alt(), core(self));
+    return WebCore::displayString(IMPL->alt(), core(self)).createNSString().autorelease();
 }
 
 - (NSURL *)absoluteImageURL

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLInputElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLInputElement.mm
@@ -99,7 +99,7 @@
 - (NSString *)autocomplete
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->autocomplete();
+    return IMPL->autocomplete().createNSString().autorelease();
 }
 
 - (void)setAutocomplete:(NSString *)newAutocomplete
@@ -191,7 +191,7 @@
 - (NSString *)formAction
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->formAction();
+    return IMPL->formAction().createNSString().autorelease();
 }
 
 - (void)setFormAction:(NSString *)newFormAction
@@ -203,7 +203,7 @@
 - (NSString *)formEnctype
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->formEnctype();
+    return IMPL->formEnctype().createNSString().autorelease();
 }
 
 - (void)setFormEnctype:(NSString *)newFormEnctype
@@ -215,7 +215,7 @@
 - (NSString *)formMethod
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->formMethod();
+    return IMPL->formMethod().createNSString().autorelease();
 }
 
 - (void)setFormMethod:(NSString *)newFormMethod
@@ -389,7 +389,7 @@
 - (NSString *)size
 {
     WebCore::JSMainThreadNullState state;
-    return WTF::String::number(IMPL->size());
+    return WTF::String::number(IMPL->size()).createNSString().autorelease();
 }
 
 - (void)setSize:(NSString *)newSize
@@ -401,7 +401,7 @@
 - (NSString *)src
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getURLAttribute(WebCore::HTMLNames::srcAttr).string();
+    return IMPL->getURLAttribute(WebCore::HTMLNames::srcAttr).string().createNSString().autorelease();
 }
 
 - (void)setSrc:(NSString *)newSrc
@@ -449,7 +449,7 @@
 - (NSString *)value
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->value();
+    return IMPL->value().createNSString().autorelease();
 }
 
 - (void)setValue:(NSString *)newValue
@@ -503,7 +503,7 @@
 - (NSString *)validationMessage
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->validationMessage();
+    return IMPL->validationMessage().createNSString().autorelease();
 }
 
 - (DOMNodeList *)labels
@@ -596,7 +596,7 @@
 - (NSString *)altDisplayString
 {
     WebCore::JSMainThreadNullState state;
-    return WebCore::displayString(IMPL->alt(), core(self));
+    return WebCore::displayString(IMPL->alt(), core(self)).createNSString().autorelease();
 }
 
 - (NSURL *)absoluteImageURL

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLLinkElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLLinkElement.mm
@@ -72,7 +72,7 @@
 - (NSString *)href
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getURLAttribute(WebCore::HTMLNames::hrefAttr).string();
+    return IMPL->getURLAttribute(WebCore::HTMLNames::hrefAttr).string().createNSString().autorelease();
 }
 
 - (void)setHref:(NSString *)newHref
@@ -168,7 +168,7 @@
 - (NSString *)crossOrigin
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->crossOrigin();
+    return IMPL->crossOrigin().createNSString().autorelease();
 }
 
 - (void)setCrossOrigin:(NSString *)newCrossOrigin

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLMediaElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLMediaElement.mm
@@ -57,7 +57,7 @@
 - (NSString *)src
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getURLAttribute(WebCore::HTMLNames::srcAttr).string();
+    return IMPL->getURLAttribute(WebCore::HTMLNames::srcAttr).string().createNSString().autorelease();
 }
 
 - (void)setSrc:(NSString *)newSrc
@@ -69,13 +69,13 @@
 - (NSString *)currentSrc
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->currentSrc().string();
+    return IMPL->currentSrc().string().createNSString().autorelease();
 }
 
 - (NSString *)crossOrigin
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->crossOrigin();
+    return IMPL->crossOrigin().createNSString().autorelease();
 }
 
 - (void)setCrossOrigin:(NSString *)newCrossOrigin
@@ -93,7 +93,7 @@
 - (NSString *)preload
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->preload();
+    return IMPL->preload().createNSString().autorelease();
 }
 
 - (void)setPreload:(NSString *)newPreload
@@ -309,7 +309,7 @@
 - (NSString *)canPlayType:(NSString *)type
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->canPlayType(type);
+    return IMPL->canPlayType(type).createNSString().autorelease();
 }
 
 - (NSTimeInterval)getStartDate

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLModElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLModElement.mm
@@ -42,7 +42,7 @@
 - (NSString *)cite
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getURLAttribute(WebCore::HTMLNames::citeAttr).string();
+    return IMPL->getURLAttribute(WebCore::HTMLNames::citeAttr).string().createNSString().autorelease();
 }
 
 - (void)setCite:(NSString *)newCite

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLObjectElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLObjectElement.mm
@@ -127,7 +127,7 @@
 - (NSString *)data
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getURLAttribute(WebCore::HTMLNames::dataAttr).string();
+    return IMPL->getURLAttribute(WebCore::HTMLNames::dataAttr).string().createNSString().autorelease();
 }
 
 - (void)setData:(NSString *)newData

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLOptionElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLOptionElement.mm
@@ -63,7 +63,7 @@
 - (NSString *)label
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->label();
+    return IMPL->label().createNSString().autorelease();
 }
 
 - (void)setLabel:(NSString *)newLabel
@@ -99,7 +99,7 @@
 - (NSString *)value
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->value();
+    return IMPL->value().createNSString().autorelease();
 }
 
 - (void)setValue:(NSString *)newValue
@@ -111,7 +111,7 @@
 - (NSString *)text
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->text();
+    return IMPL->text().createNSString().autorelease();
 }
 
 - (int)index

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLQuoteElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLQuoteElement.mm
@@ -42,7 +42,7 @@
 - (NSString *)cite
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getURLAttribute(WebCore::HTMLNames::citeAttr).string();
+    return IMPL->getURLAttribute(WebCore::HTMLNames::citeAttr).string().createNSString().autorelease();
 }
 
 - (void)setCite:(NSString *)newCite

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLScriptElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLScriptElement.mm
@@ -43,7 +43,7 @@
 - (NSString *)text
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->text();
+    return IMPL->text().createNSString().autorelease();
 }
 
 - (void)setText:(NSString *)newText
@@ -115,7 +115,7 @@
 - (NSString *)src
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getURLAttribute(WebCore::HTMLNames::srcAttr).string();
+    return IMPL->getURLAttribute(WebCore::HTMLNames::srcAttr).string().createNSString().autorelease();
 }
 
 - (void)setSrc:(NSString *)newSrc
@@ -139,7 +139,7 @@
 - (NSString *)crossOrigin
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->crossOrigin();
+    return IMPL->crossOrigin().createNSString().autorelease();
 }
 
 - (void)setCrossOrigin:(NSString *)newCrossOrigin

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLSelectElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLSelectElement.mm
@@ -151,7 +151,7 @@
 - (NSString *)value
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->value();
+    return IMPL->value().createNSString().autorelease();
 }
 
 - (void)setValue:(NSString *)newValue

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLTextAreaElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLTextAreaElement.mm
@@ -201,7 +201,7 @@ DOMHTMLTextAreaElement *kit(WebCore::HTMLTextAreaElement* value)
 - (NSString *)defaultValue
 {
     WebCore::JSMainThreadNullState state;
-    return unwrap(*self).defaultValue();
+    return unwrap(*self).defaultValue().createNSString().autorelease();
 }
 
 - (void)setDefaultValue:(NSString *)newDefaultValue
@@ -213,7 +213,7 @@ DOMHTMLTextAreaElement *kit(WebCore::HTMLTextAreaElement* value)
 - (NSString *)value
 {
     WebCore::JSMainThreadNullState state;
-    return unwrap(*self).value();
+    return unwrap(*self).value().createNSString().autorelease();
 }
 
 - (void)setValue:(NSString *)newValue
@@ -291,7 +291,7 @@ DOMHTMLTextAreaElement *kit(WebCore::HTMLTextAreaElement* value)
 - (NSString *)autocomplete
 {
     WebCore::JSMainThreadNullState state;
-    return unwrap(*self).autocomplete();
+    return unwrap(*self).autocomplete().createNSString().autorelease();
 }
 
 - (void)setAutocomplete:(NSString *)newAutocomplete

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLTitleElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLTitleElement.mm
@@ -41,7 +41,7 @@
 - (NSString *)text
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->text();
+    return IMPL->text().createNSString().autorelease();
 }
 
 - (void)setText:(NSString *)newText

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLVideoElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLVideoElement.mm
@@ -82,7 +82,7 @@
 - (NSString *)poster
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getURLAttribute(WebCore::HTMLNames::posterAttr).string();
+    return IMPL->getURLAttribute(WebCore::HTMLNames::posterAttr).string().createNSString().autorelease();
 }
 
 - (void)setPoster:(NSString *)newPoster

--- a/Source/WebKitLegacy/mac/DOM/DOMMediaList.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMMediaList.mm
@@ -55,7 +55,7 @@
 - (NSString *)mediaText
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->mediaText();
+    return IMPL->mediaText().createNSString().autorelease();
 }
 
 - (void)setMediaText:(NSString *)newMediaText
@@ -73,7 +73,7 @@
 - (NSString *)item:(unsigned)index
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->item(index);
+    return IMPL->item(index).createNSString().autorelease();
 }
 
 - (void)deleteMedium:(NSString *)oldMedium

--- a/Source/WebKitLegacy/mac/DOM/DOMMutationEvent.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMMutationEvent.mm
@@ -49,19 +49,19 @@
 - (NSString *)prevValue
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->prevValue();
+    return IMPL->prevValue().createNSString().autorelease();
 }
 
 - (NSString *)newValue
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->newValue();
+    return IMPL->newValue().createNSString().autorelease();
 }
 
 - (NSString *)attrName
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->attrName();
+    return IMPL->attrName().createNSString().autorelease();
 }
 
 - (unsigned short)attrChange

--- a/Source/WebKitLegacy/mac/DOM/DOMNode.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMNode.mm
@@ -86,13 +86,13 @@ DOMNode *kit(Node* value)
 - (NSString *)nodeName
 {
     JSMainThreadNullState state;
-    return unwrap(*self).nodeName();
+    return unwrap(*self).nodeName().createNSString().autorelease();
 }
 
 - (NSString *)nodeValue
 {
     JSMainThreadNullState state;
-    return unwrap(*self).nodeValue();
+    return unwrap(*self).nodeValue().createNSString().autorelease();
 }
 
 - (void)setNodeValue:(NSString *)newNodeValue
@@ -182,13 +182,13 @@ DOMNode *kit(Node* value)
 - (NSString *)baseURI
 {
     JSMainThreadNullState state;
-    return unwrap(*self).baseURI().string();
+    return unwrap(*self).baseURI().string().createNSString().autorelease();
 }
 
 - (NSString *)textContent
 {
     JSMainThreadNullState state;
-    return unwrap(*self).textContent();
+    return unwrap(*self).textContent().createNSString().autorelease();
 }
 
 - (void)setTextContent:(NSString *)newTextContent

--- a/Source/WebKitLegacy/mac/DOM/DOMProcessingInstruction.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMProcessingInstruction.mm
@@ -43,7 +43,7 @@
 - (NSString *)target
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->target();
+    return IMPL->target().createNSString().autorelease();
 }
 
 - (DOMStyleSheet *)sheet

--- a/Source/WebKitLegacy/mac/DOM/DOMRange.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMRange.mm
@@ -95,7 +95,7 @@
     WebCore::JSMainThreadNullState state;
     auto range = makeSimpleRange(*IMPL);
     range.start.document().updateLayout();
-    return plainText(range);
+    return plainText(range).createNSString().autorelease();
 }
 
 - (void)setStart:(DOMNode *)refNode offset:(int)offset
@@ -219,7 +219,7 @@
 - (NSString *)toString
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->toString();
+    return IMPL->toString().createNSString().autorelease();
 }
 
 - (void)detach

--- a/Source/WebKitLegacy/mac/DOM/DOMStyleSheet.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMStyleSheet.mm
@@ -58,7 +58,7 @@
 - (NSString *)type
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->type();
+    return IMPL->type().createNSString().autorelease();
 }
 
 - (BOOL)disabled
@@ -88,13 +88,13 @@
 - (NSString *)href
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->href();
+    return IMPL->href().createNSString().autorelease();
 }
 
 - (NSString *)title
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->title();
+    return IMPL->title().createNSString().autorelease();
 }
 
 - (DOMMediaList *)media

--- a/Source/WebKitLegacy/mac/DOM/DOMText.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMText.mm
@@ -41,7 +41,7 @@
 - (NSString *)wholeText
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->wholeText();
+    return IMPL->wholeText().createNSString().autorelease();
 }
 
 - (DOMText *)splitText:(unsigned)offset

--- a/Source/WebKitLegacy/mac/DOM/DOMTextEvent.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMTextEvent.mm
@@ -44,7 +44,7 @@
 - (NSString *)data
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->data();
+    return IMPL->data().createNSString().autorelease();
 }
 
 - (void)initTextEvent:(NSString *)typeArg canBubbleArg:(BOOL)canBubbleArg cancelableArg:(BOOL)cancelableArg viewArg:(DOMAbstractView *)viewArg dataArg:(NSString *)dataArg

--- a/Source/WebKitLegacy/mac/DOM/DOMXPathResult.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMXPathResult.mm
@@ -66,7 +66,7 @@
 - (NSString *)stringValue
 {
     WebCore::JSMainThreadNullState state;
-    return raiseOnDOMError(IMPL->stringValue());
+    return raiseOnDOMError(IMPL->stringValue()).createNSString().autorelease();
 }
 
 - (BOOL)booleanValue

--- a/Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm
+++ b/Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm
@@ -142,7 +142,7 @@ using namespace JSC;
     if (nodeType != Node::DOCUMENT_NODE && nodeType != Node::DOCUMENT_TYPE_NODE)
         markupString = makeString(documentTypeString(node.document()), markupString);
 
-    return markupString;
+    return markupString.createNSString().autorelease();
 }
 
 - (NSRect)_renderRect:(bool *)isReplaced
@@ -193,7 +193,7 @@ using namespace JSC;
 - (NSString *)markupString
 {
     auto range = makeSimpleRange(*core(self));
-    return makeString(documentTypeString(range.start.document()), serializePreservingVisualAppearance(range, nullptr, AnnotateForInterchange::Yes));
+    return makeString(documentTypeString(range.start.document()), serializePreservingVisualAppearance(range, nullptr, AnnotateForInterchange::Yes)).createNSString().autorelease();
 }
 
 @end

--- a/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
@@ -214,7 +214,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (NSUInteger)hash
 {
-    return [(NSString*)core(_private)->urlString() hash];
+    return [core(_private)->urlString().createNSString() hash];
 }
 
 - (BOOL)isEqual:(id)anObject
@@ -228,7 +228,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (NSString *)description
 {
     HistoryItem* coreItem = core(_private);
-    NSMutableString *result = [NSMutableString stringWithFormat:@"%@ %@", [super description], (NSString*)coreItem->urlString()];
+    NSMutableString *result = [NSMutableString stringWithFormat:@"%@ %@", [super description], coreItem->urlString().createNSString().get()];
     if (!coreItem->target().isEmpty()) {
         NSString *target = coreItem->target();
         [result appendFormat:@" in \"%@\"", target];
@@ -400,11 +400,11 @@ WebHistoryItem *kit(HistoryItem* item)
     HistoryItem* coreItem = core(_private);
     
     if (!coreItem->urlString().isEmpty())
-        [dict setObject:(NSString*)coreItem->urlString() forKey:@""];
+        [dict setObject:coreItem->urlString().createNSString().get() forKey:@""];
     if (!coreItem->title().isEmpty())
-        [dict setObject:(NSString*)coreItem->title() forKey:titleKey];
+        [dict setObject:coreItem->title().createNSString().get() forKey:titleKey];
     if (!coreItem->alternateTitle().isEmpty())
-        [dict setObject:(NSString*)coreItem->alternateTitle() forKey:displayTitleKey];
+        [dict setObject:coreItem->alternateTitle().createNSString().get() forKey:displayTitleKey];
     if (_private->_lastVisitedTime) {
         // Store as a string to maintain backward compatibility. (See 3245793)
         [dict setObject:[NSString stringWithFormat:@"%.1lf", _private->_lastVisitedTime]

--- a/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
@@ -261,7 +261,7 @@ static RetainPtr<NSCountedSet> createNSCountedSet(const HashCountedSet<ASCIILite
 
 - (NSString *)renderTreeAsExternalRepresentationForPrinting
 {
-    return externalRepresentation(_private->coreFrame, { RenderAsTextFlag::PrintingMode });
+    return externalRepresentation(_private->coreFrame, { RenderAsTextFlag::PrintingMode }).createNSString().autorelease();
 }
 
 static OptionSet<RenderAsTextFlag> toRenderAsTextFlags(WebRenderTreeAsTextOptions options)
@@ -286,7 +286,7 @@ static OptionSet<RenderAsTextFlag> toRenderAsTextFlags(WebRenderTreeAsTextOption
 
 - (NSString *)renderTreeAsExternalRepresentationWithOptions:(WebRenderTreeAsTextOptions)options
 {
-    return externalRepresentation(_private->coreFrame, toRenderAsTextFlags(options));
+    return externalRepresentation(_private->coreFrame, toRenderAsTextFlags(options)).createNSString().autorelease();
 }
 
 - (int)numberOfPagesWithPageWidth:(float)pageWidthInPixels pageHeight:(float)pageHeightInPixels

--- a/Source/WebKitLegacy/mac/Misc/WebElementDictionary.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebElementDictionary.mm
@@ -183,13 +183,13 @@ static void cacheValueForKey(const void *key, const void *value, void *self)
     return [[[self _domNode] ownerDocument] webFrame];
 }
 
-// String's NSString* operator converts null Strings to empty NSStrings for compatibility
+// String::createNSString() converts null Strings to empty NSStrings for compatibility
 // with AppKit. We need to work around that here.
 static NSString* NSStringOrNil(String coreString)
 {
     if (coreString.isNull())
         return nil;
-    return coreString;
+    return coreString.createNSString().autorelease();
 }
 
 - (NSString *)_altDisplayString

--- a/Source/WebKitLegacy/mac/Misc/WebNSPasteboardExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebNSPasteboardExtras.mm
@@ -267,14 +267,14 @@ static CachedImage* imageFromElement(DOMElement *domElement)
 {
     ASSERT(self == [NSPasteboard pasteboardWithName:NSPasteboardNameDrag]);
 
-    NSString *extension = @"";
+    RetainPtr<NSString> extension = @"";
     RetainPtr<NSMutableArray> types = adoptNS([[NSMutableArray alloc] initWithObjects:legacyFilesPromisePasteboardType(), nil]);
-    NSString *originIdentifier = core(element)->document().originIdentifierForPasteboard();
+    RetainPtr originIdentifier = core(element)->document().originIdentifierForPasteboard().createNSString();
     RetainPtr<NSData> customDataBuffer;
-    if (originIdentifier.length) {
+    if (originIdentifier.get().length) {
         [types addObject:@(PasteboardCustomData::cocoaType().characters())];
         PasteboardCustomData customData;
-        customData.setOrigin(originIdentifier);
+        customData.setOrigin(originIdentifier.get());
         customDataBuffer = customData.createSharedBuffer()->createNSData();
     }
 
@@ -282,7 +282,7 @@ static CachedImage* imageFromElement(DOMElement *domElement)
         if (is<RenderImage>(*renderer)) {
             if (auto* image = downcast<RenderImage>(*renderer).cachedImage()) {
                 // FIXME: This doesn't check errorOccured the way imageFromElement does.
-                extension = image->image()->filenameExtension();
+                extension = image->image()->filenameExtension().createNSString();
                 if (![extension length])
                     return nullptr;
                 [types addObjectsFromArray:[NSPasteboard _web_writableTypesForImageIncludingArchive:(archive != nil)]];
@@ -303,7 +303,7 @@ static CachedImage* imageFromElement(DOMElement *domElement)
     if (customDataBuffer)
         [self setData:customDataBuffer.get() forType:@(PasteboardCustomData::cocoaType().characters())];
 
-    [self setPropertyList:@[extension] forType:legacyFilesPromisePasteboardType()];
+    [self setPropertyList:@[extension.get()] forType:legacyFilesPromisePasteboardType()];
 
     return source;
 }

--- a/Source/WebKitLegacy/mac/Misc/WebNSURLExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebNSURLExtras.mm
@@ -185,7 +185,7 @@
 
 - (NSString *)_webkit_stringByReplacingValidPercentEscapes
 {
-    return PAL::decodeURLEscapeSequences(String(self));
+    return PAL::decodeURLEscapeSequences(String(self)).createNSString().autorelease();
 }
 
 - (NSString *)_webkit_scriptIfJavaScriptURL

--- a/Source/WebKitLegacy/mac/Misc/WebNSUserDefaultsExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebNSUserDefaultsExtras.mm
@@ -35,7 +35,7 @@
 
 + (NSString *)_webkit_preferredLanguageCode
 {
-    return defaultLanguage();
+    return defaultLanguage().createNSString().autorelease();
 }
 
 @end

--- a/Source/WebKitLegacy/mac/Misc/WebStringTruncator.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebStringTruncator.mm
@@ -64,7 +64,7 @@ static WebCore::FontCascade& fontFromNSFont(NSFont *font)
     if (!menuFont.get())
         return nil;
 
-    return WebCore::StringTruncator::centerTruncate(string, maxWidth, fontFromNSFont(menuFont.get().get()));
+    return WebCore::StringTruncator::centerTruncate(string, maxWidth, fontFromNSFont(menuFont.get().get())).createNSString().autorelease();
 }
 
 + (NSString *)centerTruncateString:(NSString *)string toWidth:(float)maxWidth withFont:(NSFont *)font
@@ -72,7 +72,7 @@ static WebCore::FontCascade& fontFromNSFont(NSFont *font)
     if (!font)
         return nil;
 
-    return WebCore::StringTruncator::centerTruncate(string, maxWidth, fontFromNSFont(font));
+    return WebCore::StringTruncator::centerTruncate(string, maxWidth, fontFromNSFont(font)).createNSString().autorelease();
 }
 
 + (NSString *)rightTruncateString:(NSString *)string toWidth:(float)maxWidth withFont:(NSFont *)font
@@ -80,7 +80,7 @@ static WebCore::FontCascade& fontFromNSFont(NSFont *font)
     if (!font)
         return nil;
 
-    return WebCore::StringTruncator::rightTruncate(string, maxWidth, fontFromNSFont(font));
+    return WebCore::StringTruncator::rightTruncate(string, maxWidth, fontFromNSFont(font)).createNSString().autorelease();
 }
 
 + (float)widthOfString:(NSString *)string font:(NSFont *)font

--- a/Source/WebKitLegacy/mac/Misc/WebUserContentURLPattern.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebUserContentURLPattern.mm
@@ -68,12 +68,12 @@ using namespace WebCore;
 
 - (NSString *)scheme
 {
-    return _private->pattern.scheme();
+    return _private->pattern.scheme().createNSString().autorelease();
 }
 
 - (NSString *)host
 {
-    return _private->pattern.host();
+    return _private->pattern.host().createNSString().autorelease();
 }
 
 - (BOOL)matchesSubdomains

--- a/Source/WebKitLegacy/mac/Plugins/WebBasePluginPackage.mm
+++ b/Source/WebKitLegacy/mac/Plugins/WebBasePluginPackage.mm
@@ -76,7 +76,7 @@ static constexpr auto QuickTimeCocoaPluginIdentifier = "com.apple.quicktime.webp
         return nil;
     
     path = [pluginPath stringByResolvingSymlinksInPath];
-    cfBundle = adoptCF(CFBundleCreate(kCFAllocatorDefault, (CFURLRef)[NSURL fileURLWithPath:path]));
+    cfBundle = adoptCF(CFBundleCreate(kCFAllocatorDefault, (CFURLRef)[NSURL fileURLWithPath:path.createNSString().get()]));
 
     if (!cfBundle) {
         [self release];
@@ -158,7 +158,7 @@ static constexpr auto QuickTimeCocoaPluginIdentifier = "com.apple.quicktime.webp
         pluginInfo.mimes.append(mimeClassInfo);
     }
 
-    NSString *filename = [(NSString *)path lastPathComponent];
+    NSString *filename = [path.createNSString() lastPathComponent];
     pluginInfo.file = filename;
 
     NSString *theName = [self _objectForInfoDictionaryKey:WebPluginNameKey];

--- a/Source/WebKitLegacy/mac/Plugins/WebPluginDatabase.mm
+++ b/Source/WebKitLegacy/mac/Plugins/WebPluginDatabase.mm
@@ -405,9 +405,9 @@ static RetainPtr<NSArray>& additionalWebPlugInPaths()
 - (void)_addPlugin:(WebBasePluginPackage *)plugin
 {
     ASSERT(plugin);
-    NSString *pluginPath = [plugin path];
+    RetainPtr pluginPath = [plugin path].createNSString();
     ASSERT(pluginPath);
-    [plugins setObject:plugin forKey:pluginPath];
+    [plugins setObject:plugin forKey:pluginPath.get()];
     [plugin wasAddedToPluginDatabase:self];
 }
 
@@ -428,10 +428,10 @@ static RetainPtr<NSArray>& additionalWebPlugInPaths()
     }
 
     // Remove plug-in from database
-    NSString *pluginPath = [plugin path];
+    RetainPtr pluginPath = [plugin path].createNSString();
     ASSERT(pluginPath);
     auto protectedPlugin = retainPtr(plugin);
-    [plugins removeObjectForKey:pluginPath];
+    [plugins removeObjectForKey:pluginPath.get()];
     [plugin wasRemovedFromPluginDatabase:self];
 }
 

--- a/Source/WebKitLegacy/mac/Plugins/WebPluginPackage.mm
+++ b/Source/WebKitLegacy/mac/Plugins/WebPluginPackage.mm
@@ -45,7 +45,7 @@ NSString *WebPlugInContainingElementKey =       @"WebPlugInContainingElementKey"
     if (!(self = [super initWithPath:pluginPath]))
         return nil;
 
-    nsBundle = [[NSBundle alloc] initWithPath:path];
+    nsBundle = [[NSBundle alloc] initWithPath:path.createNSString().get()];
 
     if (!nsBundle) {
         [self release];
@@ -105,7 +105,7 @@ NSString *WebPlugInContainingElementKey =       @"WebPlugInContainingElementKey"
     
 #if !LOG_DISABLED
     CFAbsoluteTime duration = CFAbsoluteTimeGetCurrent() - start;
-    LOG(Plugins, "principalClass took %f seconds for: %@", duration, (NSString *)[self pluginInfo].name);
+    LOG(Plugins, "principalClass took %f seconds for: %@", duration, [self pluginInfo].name.createNSString().get());
 #endif
     return [super load];
 }

--- a/Source/WebKitLegacy/mac/Scripts/PreferencesTemplates/WebPreferencesDefinitions.h.erb
+++ b/Source/WebKitLegacy/mac/Scripts/PreferencesTemplates/WebPreferencesDefinitions.h.erb
@@ -63,7 +63,7 @@
 #if <%= @pref.condition %>
 <%-   end -%>
 <%- if @pref.type == "String" -%>
-#define INITIALIZE_DEFAULT_PREFERENCES_FOR_<%= @pref.name %> (NSString *)DEFAULT_VALUE_FOR_<%= @pref.name %>, @"<%= @pref.preferenceKey %>",
+#define INITIALIZE_DEFAULT_PREFERENCES_FOR_<%= @pref.name %> DEFAULT_VALUE_FOR_<%= @pref.name %>.createNSString().get(), @"<%= @pref.preferenceKey %>",
 <%- else -%>
 #define INITIALIZE_DEFAULT_PREFERENCES_FOR_<%= @pref.name %> @(DEFAULT_VALUE_FOR_<%= @pref.name %>), @"<%= @pref.preferenceKey %>",
 <%- end -%>

--- a/Source/WebKitLegacy/mac/Storage/WebDatabaseManager.mm
+++ b/Source/WebKitLegacy/mac/Storage/WebDatabaseManager.mm
@@ -111,7 +111,7 @@ static NSString *databasesDirectoryPath();
         return nil;
 
     return @{
-        WebDatabaseDisplayNameKey: details.displayName().isEmpty() ? databaseIdentifier : (NSString *)details.displayName(),
+        WebDatabaseDisplayNameKey: details.displayName().isEmpty() ? databaseIdentifier : details.displayName().createNSString().get(),
         WebDatabaseExpectedSizeKey: @(details.expectedUsage()),
         WebDatabaseUsageKey: @(details.currentUsage()),
     };

--- a/Source/WebKitLegacy/mac/Storage/WebDatabaseManagerClient.mm
+++ b/Source/WebKitLegacy/mac/Storage/WebDatabaseManagerClient.mm
@@ -138,7 +138,7 @@ void WebDatabaseManagerClient::dispatchDidModifyDatabase(const SecurityOriginDat
     }
 
     auto webSecurityOrigin = adoptNS([[WebSecurityOrigin alloc] _initWithWebCoreSecurityOrigin:origin.securityOrigin().ptr()]);
-    auto userInfo = adoptNS([[NSDictionary alloc] initWithObjectsAndKeys:(NSString *)databaseIdentifier, WebDatabaseIdentifierKey, nil]);
+    auto userInfo = adoptNS([[NSDictionary alloc] initWithObjectsAndKeys:databaseIdentifier.createNSString().get(), WebDatabaseIdentifierKey, nil]);
     [[NSNotificationCenter defaultCenter] postNotificationName:WebDatabaseDidModifyDatabaseNotification object:webSecurityOrigin.get() userInfo:userInfo.get()];
 }
 

--- a/Source/WebKitLegacy/mac/Storage/WebDatabaseProvider.mm
+++ b/Source/WebKitLegacy/mac/Storage/WebDatabaseProvider.mm
@@ -27,15 +27,16 @@
 #import "WebDatabaseManagerPrivate.h"
 
 #import <wtf/FileSystem.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 String WebDatabaseProvider::indexedDatabaseDirectoryPath()
 {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    NSString *databasesDirectory = [defaults objectForKey:WebDatabaseDirectoryDefaultsKey];
-    if (!databasesDirectory || ![databasesDirectory isKindOfClass:[NSString class]])
-        databasesDirectory = FileSystem::pathByAppendingComponent("~/Library/WebKit/Databases/___IndexedDB"_s, String([[NSBundle mainBundle] bundleIdentifier]));
+    RetainPtr defaults = [NSUserDefaults standardUserDefaults];
+    RetainPtr databasesDirectory = dynamic_objc_cast<NSString>([defaults objectForKey:WebDatabaseDirectoryDefaultsKey]);
+    if (!databasesDirectory)
+        databasesDirectory = FileSystem::pathByAppendingComponent("~/Library/WebKit/Databases/___IndexedDB"_s, String([[NSBundle mainBundle] bundleIdentifier])).createNSString();
     else
-        databasesDirectory = FileSystem::pathByAppendingComponent(String(databasesDirectory), "___IndexedDB"_s);
+        databasesDirectory = FileSystem::pathByAppendingComponent(String(databasesDirectory.get()), "___IndexedDB"_s).createNSString();
     
     return [databasesDirectory stringByStandardizingPath];
 }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/CorrectionPanel.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/CorrectionPanel.mm
@@ -51,8 +51,8 @@ void CorrectionPanel::show(WebView* view, AlternativeTextType type, const FloatR
     if (!view)
         return;
 
-    NSString* replacedStringAsNSString = replacedString;
-    NSString* replacementStringAsNSString = replacementString;
+    RetainPtr replacedStringAsNSString = replacedString.createNSString();
+    RetainPtr replacementStringAsNSString = replacementString.createNSString();
     m_view = view;
     NSCorrectionIndicatorType indicatorType = correctionIndicatorType(type);
     
@@ -60,8 +60,8 @@ void CorrectionPanel::show(WebView* view, AlternativeTextType type, const FloatR
     if (!alternativeReplacementStrings.isEmpty())
         alternativeStrings = createNSArray(alternativeReplacementStrings);
 
-    [[NSSpellChecker sharedSpellChecker] showCorrectionIndicatorOfType:indicatorType primaryString:replacementStringAsNSString alternativeStrings:alternativeStrings.get() forStringInRect:[view _convertRectFromRootView:boundingBoxOfReplacedString] view:m_view.get() completionHandler:^(NSString* acceptedString) {
-        handleAcceptedReplacement(acceptedString, replacedStringAsNSString, replacementStringAsNSString, indicatorType);
+    [[NSSpellChecker sharedSpellChecker] showCorrectionIndicatorOfType:indicatorType primaryString:replacementStringAsNSString.get() alternativeStrings:alternativeStrings.get() forStringInRect:[view _convertRectFromRootView:boundingBoxOfReplacedString] view:m_view.get() completionHandler:^(NSString* acceptedString) {
+        handleAcceptedReplacement(acceptedString, replacedStringAsNSString.get(), replacementStringAsNSString.get(), indicatorType);
     }];
 }
 
@@ -84,7 +84,7 @@ String CorrectionPanel::dismissInternal(ReasonForDismissingAlternativeText reaso
 
 void CorrectionPanel::recordAutocorrectionResponse(NSInteger spellCheckerDocumentTag, NSCorrectionResponse response, const String& replacedString, const String& replacementString)
 {
-    [[NSSpellChecker sharedSpellChecker] recordResponse:response toCorrection:replacementString forWord:replacedString language:nil inSpellDocumentWithTag:spellCheckerDocumentTag];
+    [[NSSpellChecker sharedSpellChecker] recordResponse:response toCorrection:replacementString.createNSString().get() forWord:replacedString.createNSString().get() language:nil inSpellDocumentWithTag:spellCheckerDocumentTag];
 }
 
 void CorrectionPanel::handleAcceptedReplacement(NSString* acceptedReplacement, NSString* replaced, NSString* proposedReplacement,  NSCorrectionIndicatorType correctionIndicatorType)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm
@@ -105,7 +105,7 @@ void PopupMenuMac::populate()
 
         // FIXME: Add support for styling the foreground and background colors.
         // FIXME: Find a way to customize text color when an item is highlighted.
-        RetainPtr<NSAttributedString> string = adoptNS([[NSAttributedString alloc] initWithString:m_client->itemText(i) attributes:attributes.get()]);
+        RetainPtr<NSAttributedString> string = adoptNS([[NSAttributedString alloc] initWithString:m_client->itemText(i).createNSString().get() attributes:attributes.get()]);
 
         [m_popup addItemWithTitle:@""];
         NSMenuItem *menuItem = [m_popup lastItem];
@@ -114,14 +114,14 @@ void PopupMenuMac::populate()
         // but typeahead will use the non-attributed string that doesn't contain any leading or trailing whitespace.
         [menuItem setTitle:[[string string] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]]];
         [menuItem setEnabled:m_client->itemIsEnabled(i)];
-        [menuItem setToolTip:m_client->itemToolTip(i)];
+        [menuItem setToolTip:m_client->itemToolTip(i).createNSString().get()];
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         // Allow the accessible text of the item to be overridden if necessary.
         if (AXObjectCache::accessibilityEnabled()) {
-            NSString *accessibilityOverride = m_client->itemAccessibilityText(i);
+            RetainPtr accessibilityOverride = m_client->itemAccessibilityText(i).createNSString();
             if ([accessibilityOverride length])
-                [menuItem accessibilitySetOverrideValue:accessibilityOverride forAttribute:NSAccessibilityDescriptionAttribute];
+                [menuItem accessibilitySetOverrideValue:accessibilityOverride.get() forAttribute:NSAccessibilityDescriptionAttribute];
         }
 ALLOW_DEPRECATED_DECLARATIONS_END
     }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -478,10 +478,10 @@ void WebChromeClient::addMessageToConsole(MessageSource source, MessageLevel lev
 
     NSString *messageSource = stringForMessageSource(source);
     auto dictionary = @{
-        @"message": (NSString *)message,
+        @"message": message.createNSString().get(),
         @"lineNumber": @(lineNumber),
         @"columnNumber": @(columnNumber),
-        @"sourceURL": (NSString *)sourceURL,
+        @"sourceURL": sourceURL.createNSString().get(),
         @"MessageSource": messageSource,
         @"MessageLevel": stringForMessageLevel(level),
     };
@@ -504,7 +504,7 @@ bool WebChromeClient::canRunBeforeUnloadConfirmPanel()
 
 bool WebChromeClient::runBeforeUnloadConfirmPanel(const String& message, LocalFrame& frame)
 {
-    return CallUIDelegateReturningBoolean(true, m_webView, @selector(webView:runBeforeUnloadConfirmPanelWithMessage:initiatedByFrame:), message, kit(&frame));
+    return CallUIDelegateReturningBoolean(true, m_webView, @selector(webView:runBeforeUnloadConfirmPanelWithMessage:initiatedByFrame:), message.createNSString().get(), kit(&frame));
 }
 
 void WebChromeClient::closeWindow()
@@ -532,14 +532,14 @@ void WebChromeClient::runJavaScriptAlert(LocalFrame& frame, const String& messag
     id delegate = [m_webView UIDelegate];
     SEL selector = @selector(webView:runJavaScriptAlertPanelWithMessage:initiatedByFrame:);
     if ([delegate respondsToSelector:selector]) {
-        CallUIDelegate(m_webView, selector, message, kit(&frame));
+        CallUIDelegate(m_webView, selector, message.createNSString().get(), kit(&frame));
         return;
     }
 
     // Call the old version of the delegate method if it is implemented.
     selector = @selector(webView:runJavaScriptAlertPanelWithMessage:);
     if ([delegate respondsToSelector:selector]) {
-        CallUIDelegate(m_webView, selector, message);
+        CallUIDelegate(m_webView, selector, message.createNSString().get());
         return;
     }
 }
@@ -549,12 +549,12 @@ bool WebChromeClient::runJavaScriptConfirm(LocalFrame& frame, const String& mess
     id delegate = [m_webView UIDelegate];
     SEL selector = @selector(webView:runJavaScriptConfirmPanelWithMessage:initiatedByFrame:);
     if ([delegate respondsToSelector:selector])
-        return CallUIDelegateReturningBoolean(NO, m_webView, selector, message, kit(&frame));
+        return CallUIDelegateReturningBoolean(NO, m_webView, selector, message.createNSString().get(), kit(&frame));
 
     // Call the old version of the delegate method if it is implemented.
     selector = @selector(webView:runJavaScriptConfirmPanelWithMessage:);
     if ([delegate respondsToSelector:selector])
-        return CallUIDelegateReturningBoolean(NO, m_webView, selector, message);
+        return CallUIDelegateReturningBoolean(NO, m_webView, selector, message.createNSString().get());
 
     return NO;
 }
@@ -563,20 +563,20 @@ bool WebChromeClient::runJavaScriptPrompt(LocalFrame& frame, const String& promp
 {
     id delegate = [m_webView UIDelegate];
     SEL selector = @selector(webView:runJavaScriptTextInputPanelWithPrompt:defaultText:initiatedByFrame:);
-    NSString *defaultString = defaultText;
+    RetainPtr defaultString = defaultText.createNSString();
     if ([delegate respondsToSelector:selector]) {
-        result = (NSString *)CallUIDelegate(m_webView, selector, prompt, defaultString, kit(&frame));
+        result = (NSString *)CallUIDelegate(m_webView, selector, prompt.createNSString().get(), defaultString.get(), kit(&frame));
         return !result.isNull();
     }
 
     // Call the old version of the delegate method if it is implemented.
     selector = @selector(webView:runJavaScriptTextInputPanelWithPrompt:defaultText:);
     if ([delegate respondsToSelector:selector]) {
-        result = (NSString *)CallUIDelegate(m_webView, selector, prompt, defaultString);
+        result = (NSString *)CallUIDelegate(m_webView, selector, prompt.createNSString().get(), defaultString.get());
         return !result.isNull();
     }
 
-    result = [[WebDefaultUIDelegate sharedUIDelegate] webView:m_webView runJavaScriptTextInputPanelWithPrompt:prompt defaultText:defaultString initiatedByFrame:kit(&frame)];
+    result = [[WebDefaultUIDelegate sharedUIDelegate] webView:m_webView runJavaScriptTextInputPanelWithPrompt:prompt.createNSString().get() defaultText:defaultString.get() initiatedByFrame:kit(&frame)];
     return !result.isNull();
 }
 
@@ -682,7 +682,7 @@ void WebChromeClient::setToolTip(const String& toolTip)
 {
     NSView<WebDocumentView> *documentView = [[[m_webView _selectedOrMainFrame] frameView] documentView];
     if ([documentView isKindOfClass:[WebHTMLView class]])
-        [(WebHTMLView *)documentView _setToolTip:toolTip];
+        [(WebHTMLView *)documentView _setToolTip:toolTip.createNSString().get()];
 }
 
 void WebChromeClient::print(LocalFrame& frame, const StringWithDirection&)
@@ -699,7 +699,7 @@ void WebChromeClient::exceededDatabaseQuota(LocalFrame& frame, const String& dat
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
     auto webOrigin = adoptNS([[WebSecurityOrigin alloc] _initWithWebCoreSecurityOrigin:&frame.document()->securityOrigin()]);
-    CallUIDelegate(m_webView, @selector(webView:frame:exceededDatabaseQuotaForSecurityOrigin:database:), kit(&frame), webOrigin.get(), (NSString *)databaseName);
+    CallUIDelegate(m_webView, @selector(webView:frame:exceededDatabaseQuotaForSecurityOrigin:database:), kit(&frame), webOrigin.get(), databaseName.createNSString().get());
 
     END_BLOCK_OBJC_EXCEPTIONS
 }
@@ -1128,7 +1128,7 @@ void WebChromeClient::setMockMediaPlaybackTargetPickerEnabled(bool enabled)
 
 void WebChromeClient::setMockMediaPlaybackTargetPickerState(const String& name, MediaPlaybackTargetContext::MockState state)
 {
-    [m_webView _setMockMediaPlaybackTargetPickerName:name state:state];
+    [m_webView _setMockMediaPlaybackTargetPickerName:name.createNSString().get() state:state];
 }
 
 void WebChromeClient::mockMediaPlaybackTargetPickerDismissPopup()

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
@@ -112,7 +112,7 @@ bool WebContextMenuClient::isSpeaking() const
 
 void WebContextMenuClient::speak(const String& string)
 {
-    [NSApp speakString:(NSString *)string];
+    [NSApp speakString:string.createNSString().get()];
 }
 
 void WebContextMenuClient::stopSpeaking()

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
@@ -134,7 +134,7 @@ OptionSet<WebCore::DragSourceAction> WebDragClient::dragSourceActionMaskForPoint
 
 void WebDragClient::willPerformDragSourceAction(WebCore::DragSourceAction action, const WebCore::IntPoint& mouseDownPoint, WebCore::DataTransfer& dataTransfer)
 {
-    [[m_webView _UIDelegateForwarder] webView:m_webView willPerformDragSourceAction:kit(action) fromPoint:mouseDownPoint withPasteboard:[NSPasteboard pasteboardWithName:dataTransfer.pasteboard().name()]];
+    [[m_webView _UIDelegateForwarder] webView:m_webView willPerformDragSourceAction:kit(action) fromPoint:mouseDownPoint withPasteboard:[NSPasteboard pasteboardWithName:dataTransfer.pasteboard().name().createNSString().get()]];
 }
 
 void WebDragClient::startDrag(DragItem dragItem, DataTransfer& dataTransfer, Frame& frame)
@@ -155,7 +155,7 @@ void WebDragClient::startDrag(DragItem dragItem, DataTransfer& dataTransfer, Fra
     RetainPtr<WebHTMLView> topViewProtector = topHTMLView;
     
     [topHTMLView _stopAutoscrollTimer];
-    NSPasteboard *pasteboard = [NSPasteboard pasteboardWithName:dataTransfer.pasteboard().name()];
+    NSPasteboard *pasteboard = [NSPasteboard pasteboardWithName:dataTransfer.pasteboard().name().createNSString().get()];
 
     NSImage *dragNSImage = dragImage.get().get();
     WebHTMLView *sourceHTMLView = htmlView.get();
@@ -205,7 +205,7 @@ void WebDragClient::beginDrag(DragItem dragItem, LocalFrame& frame, const IntPoi
 void WebDragClient::declareAndWriteDragImage(const String& pasteboardName, Element& element, const URL& url, const String& title, WebCore::LocalFrame* frame)
 {
     ASSERT(pasteboardName);
-    [[NSPasteboard pasteboardWithName:pasteboardName] _web_declareAndWriteDragImageForElement:kit(&element) URL:url.createNSURL().get() title:title archive:[kit(&element) webArchive] source:getTopHTMLView(frame)];
+    [[NSPasteboard pasteboardWithName:pasteboardName.createNSString().get()] _web_declareAndWriteDragImageForElement:kit(&element) URL:url.createNSURL().get() title:title.createNSString().get() archive:[kit(&element) webArchive] source:getTopHTMLView(frame)];
 }
 
 #elif !PLATFORM(IOS_FAMILY) || !ENABLE(DRAG_SUPPORT)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
@@ -298,7 +298,7 @@ bool WebEditorClient::shouldEndEditing(const SimpleRange& range)
 bool WebEditorClient::shouldInsertText(const String& text, const std::optional<SimpleRange>& range, EditorInsertAction action)
 {
     WebView* webView = m_webView;
-    return [[webView _editingDelegateForwarder] webView:webView shouldInsertText:text replacingDOMRange:kit(range) givenAction:kit(action)];
+    return [[webView _editingDelegateForwarder] webView:webView shouldInsertText:text.createNSString().get() replacingDOMRange:kit(range) givenAction:kit(action)];
 }
 
 bool WebEditorClient::shouldChangeSelectedRange(const std::optional<SimpleRange>& fromRange, const std::optional<SimpleRange>& toRange, Affinity selectionAffinity, bool stillSelecting)
@@ -482,7 +482,7 @@ void _WebCreateFragment(Document& document, NSAttributedString *string, Fragment
 void WebEditorClient::setInsertionPasteboard(const String& pasteboardName)
 {
 #if !PLATFORM(IOS_FAMILY)
-    NSPasteboard *pasteboard = pasteboardName.isEmpty() ? nil : [NSPasteboard pasteboardWithName:pasteboardName];
+    NSPasteboard *pasteboard = pasteboardName.isEmpty() ? nil : [NSPasteboard pasteboardWithName:pasteboardName.createNSString().get()];
     [m_webView _setInsertionPasteboard:pasteboard];
 #endif
 }
@@ -596,10 +596,10 @@ void WebEditorClient::registerUndoOrRedoStep(UndoStep& step, bool isRedo)
         return;
 #endif
 
-    NSString *actionName = step.label();
+    RetainPtr actionName = step.label().createNSString();
     [undoManager registerUndoWithTarget:m_undoTarget.get() selector:(isRedo ? @selector(redoEditing:) : @selector(undoEditing:)) object:[WebUndoStep stepWithUndoStep:step]];
     if (actionName)
-        [undoManager setActionName:actionName];
+        [undoManager setActionName:actionName.get()];
     m_haveUndoRedoOperations = YES;
 }
 
@@ -912,12 +912,12 @@ bool WebEditorClient::shouldEraseMarkersAfterChangeSelection(TextCheckingType ty
 
 void WebEditorClient::ignoreWordInSpellDocument(const String& text)
 {
-    [[NSSpellChecker sharedSpellChecker] ignoreWord:text inSpellDocumentWithTag:spellCheckerDocumentTag()];
+    [[NSSpellChecker sharedSpellChecker] ignoreWord:text.createNSString().get() inSpellDocumentWithTag:spellCheckerDocumentTag()];
 }
 
 void WebEditorClient::learnWord(const String& text)
 {
-    [[NSSpellChecker sharedSpellChecker] learnWord:text];
+    [[NSSpellChecker sharedSpellChecker] learnWord:text.createNSString().get()];
 }
 
 void WebEditorClient::checkSpellingOfString(StringView text, int* misspellingLocation, int* misspellingLength)
@@ -1051,15 +1051,15 @@ void WebEditorClient::updateSpellingUIWithGrammarString(const String& badGrammar
 {
     auto dictionary = @{
         NSGrammarRange: [NSValue valueWithRange:grammarDetail.range],
-        NSGrammarUserDescription: grammarDetail.userDescription,
+        NSGrammarUserDescription: grammarDetail.userDescription.createNSString().get(),
         NSGrammarCorrections: createNSArray(grammarDetail.guesses).get(),
     };
-    [[NSSpellChecker sharedSpellChecker] updateSpellingPanelWithGrammarString:badGrammarPhrase detail:dictionary];
+    [[NSSpellChecker sharedSpellChecker] updateSpellingPanelWithGrammarString:badGrammarPhrase.createNSString().get() detail:dictionary];
 }
 
 void WebEditorClient::updateSpellingUIWithMisspelledWord(const String& misspelledWord)
 {
-    [[NSSpellChecker sharedSpellChecker] updateSpellingPanelWithMisspelledWord:misspelledWord];
+    [[NSSpellChecker sharedSpellChecker] updateSpellingPanelWithMisspelledWord:misspelledWord.createNSString().get()];
 }
 
 void WebEditorClient::showSpellingUI(bool show)
@@ -1079,15 +1079,16 @@ bool WebEditorClient::spellingUIIsShowing()
 void WebEditorClient::getGuessesForWord(const String& word, const String& context, const WebCore::VisibleSelection& currentSelection, Vector<String>& guesses)
 {
     guesses.clear();
-    NSString *language = nil;
+    RetainPtr<NSString> language;
     NSOrthography* orthography = nil;
     NSSpellChecker *checker = [NSSpellChecker sharedSpellChecker];
     NSDictionary *options = @{ NSTextCheckingInsertionPointKey : @(insertionPointFromCurrentSelection(currentSelection)) };
     if (context.length()) {
-        [checker checkString:context range:NSMakeRange(0, context.length()) types:NSTextCheckingTypeOrthography options:options inSpellDocumentWithTag:spellCheckerDocumentTag() orthography:&orthography wordCount:0];
-        language = [checker languageForWordRange:NSMakeRange(0, context.length()) inString:context orthography:orthography];
+        RetainPtr nsContext = context.createNSString();
+        [checker checkString:nsContext.get() range:NSMakeRange(0, context.length()) types:NSTextCheckingTypeOrthography options:options inSpellDocumentWithTag:spellCheckerDocumentTag() orthography:&orthography wordCount:0];
+        language = [checker languageForWordRange:NSMakeRange(0, context.length()) inString:nsContext.get() orthography:orthography];
     }
-    NSArray *stringsArray = [checker guessesForWordRange:NSMakeRange(0, word.length()) inString:word language:language inSpellDocumentWithTag:spellCheckerDocumentTag()];
+    NSArray *stringsArray = [checker guessesForWordRange:NSMakeRange(0, word.length()) inString:word.createNSString().get() language:language.get() inSpellDocumentWithTag:spellCheckerDocumentTag()];
     if (stringsArray.count)
         guesses = makeVector<String>(stringsArray);
 }
@@ -1118,10 +1119,10 @@ void WebEditorClient::requestCandidatesForSelection(const VisibleSelection& sele
     auto selectionStartOffsetInParagraph = characterCount(*makeSimpleRange(startOfParagraph(selectionStart), selectionStart));
     auto selectionLength = characterCount(*makeSimpleRange(selectionStart, selection.visibleEnd()));
     auto contextRangeForCandidateRequest = frame->editor().contextRangeForCandidateRequest();
-    String contextForCandidateReqeuest = contextRangeForCandidateRequest ? plainText(*contextRangeForCandidateRequest) : String();
+    String contextForCandidateRequest = contextRangeForCandidateRequest ? plainText(*contextRangeForCandidateRequest) : String();
 
     m_rangeForCandidates = NSMakeRange(selectionStartOffsetInParagraph, selectionLength);
-    m_paragraphContextForCandidateRequest = contextForCandidateReqeuest;
+    m_paragraphContextForCandidateRequest = contextForCandidateRequest.createNSString();
 
     NSTextCheckingTypes checkingTypes = NSTextCheckingTypeSpelling | NSTextCheckingTypeReplacement | NSTextCheckingTypeCorrection;
     WeakPtr weakEditor { *this };
@@ -1252,7 +1253,7 @@ void WebEditorClient::requestCheckingOfString(TextCheckingRequest& request, cons
     WeakPtr weakThis { *this };
     NSDictionary *options = @{ NSTextCheckingInsertionPointKey : [NSNumber numberWithUnsignedInteger:insertionPointFromCurrentSelection(currentSelection)] };
     NSTextCheckingType types = NSTextCheckingTypeSpelling | NSTextCheckingTypeGrammar | NSTextCheckingTypeLink | NSTextCheckingTypeQuote | NSTextCheckingTypeDash | NSTextCheckingTypeReplacement | NSTextCheckingTypeCorrection;
-    [[NSSpellChecker sharedSpellChecker] requestCheckingOfString:request.data().text() range:range types:types options:options inSpellDocumentWithTag:0 completionHandler:^(NSInteger, NSArray *results, NSOrthography *, NSInteger) {
+    [[NSSpellChecker sharedSpellChecker] requestCheckingOfString:request.data().text().createNSString().get() range:range types:types options:options inSpellDocumentWithTag:0 completionHandler:^(NSInteger, NSArray *results, NSOrthography *, NSInteger) {
         RetainPtr<WebEditorSpellCheckResponder> responder = adoptNS([[WebEditorSpellCheckResponder alloc] initWithClient:weakThis identifier:identifier results:results]);
         [currentLoop performBlock:^{
             [responder perform];

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -563,7 +563,7 @@ void WebFrameLoaderClient::dispatchDidDispatchOnloadEvents()
 
 void WebFrameLoaderClient::dispatchDidReceiveServerRedirectForProvisionalLoad()
 {
-    m_webFrame->_private->provisionalURL = core(m_webFrame.get())->loader().provisionalDocumentLoader()->url().string();
+    m_webFrame->_private->provisionalURL = core(m_webFrame.get())->loader().provisionalDocumentLoader()->url().string().createNSString();
 
     WebView *webView = getWebView(m_webFrame.get());
     WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
@@ -591,7 +591,7 @@ void WebFrameLoaderClient::dispatchWillPerformClientRedirect(const URL& url, dou
 
 void WebFrameLoaderClient::dispatchDidChangeLocationWithinPage()
 {
-    m_webFrame->_private->url = core(m_webFrame.get())->document()->url().string();
+    m_webFrame->_private->url = core(m_webFrame.get())->document()->url().string().createNSString();
 
     WebView *webView = getWebView(m_webFrame.get());
     WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
@@ -604,7 +604,7 @@ void WebFrameLoaderClient::dispatchDidChangeLocationWithinPage()
 
 void WebFrameLoaderClient::dispatchDidPushStateWithinPage()
 {
-    m_webFrame->_private->url = core(m_webFrame.get())->document()->url().string();
+    m_webFrame->_private->url = core(m_webFrame.get())->document()->url().string().createNSString();
 
     WebView *webView = getWebView(m_webFrame.get());
     WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
@@ -614,7 +614,7 @@ void WebFrameLoaderClient::dispatchDidPushStateWithinPage()
 
 void WebFrameLoaderClient::dispatchDidReplaceStateWithinPage()
 {
-    m_webFrame->_private->url = core(m_webFrame.get())->document()->url().string();
+    m_webFrame->_private->url = core(m_webFrame.get())->document()->url().string().createNSString();
 
     WebView *webView = getWebView(m_webFrame.get());
     WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
@@ -624,7 +624,7 @@ void WebFrameLoaderClient::dispatchDidReplaceStateWithinPage()
 
 void WebFrameLoaderClient::dispatchDidPopStateWithinPage()
 {
-    m_webFrame->_private->url = core(m_webFrame.get())->document()->url().string();
+    m_webFrame->_private->url = core(m_webFrame.get())->document()->url().string().createNSString();
 
     WebView *webView = getWebView(m_webFrame.get());
     WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
@@ -646,7 +646,7 @@ void WebFrameLoaderClient::dispatchWillClose()
 void WebFrameLoaderClient::dispatchDidStartProvisionalLoad()
 {
     ASSERT(!m_webFrame->_private->provisionalURL);
-    m_webFrame->_private->provisionalURL = core(m_webFrame.get())->loader().provisionalDocumentLoader()->url().string();
+    m_webFrame->_private->provisionalURL = core(m_webFrame.get())->loader().provisionalDocumentLoader()->url().string().createNSString();
 
     WebView *webView = getWebView(m_webFrame.get());
 #if !PLATFORM(IOS_FAMILY)
@@ -672,7 +672,7 @@ void WebFrameLoaderClient::dispatchDidReceiveTitle(const WebCore::StringWithDire
     WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
     if (implementations->didReceiveTitleForFrameFunc) {
         // FIXME: Use direction of title.
-        CallFrameLoadDelegate(implementations->didReceiveTitleForFrameFunc, webView, @selector(webView:didReceiveTitle:forFrame:), (NSString *)truncatedTitle.string, m_webFrame.get());
+        CallFrameLoadDelegate(implementations->didReceiveTitleForFrameFunc, webView, @selector(webView:didReceiveTitle:forFrame:), truncatedTitle.string.createNSString().get(), m_webFrame.get());
     }
 }
 
@@ -850,7 +850,7 @@ void WebFrameLoaderClient::dispatchDecidePolicyForResponse(const WebCore::Resour
     WebView *webView = getWebView(m_webFrame.get());
 
     [[webView _policyDelegateForwarder] webView:webView
-        decidePolicyForMIMEType:response.mimeType()
+        decidePolicyForMIMEType:response.mimeType().createNSString().get()
         request:request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody)
         frame:m_webFrame.get()
         decisionListener:setUpPolicyListener(WTFMove(function), WebCore::PolicyAction::Use, nil, nil).get()];
@@ -892,7 +892,7 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const WebCore:
     [[webView _policyDelegateForwarder] webView:webView
         decidePolicyForNewWindowAction:actionDictionary(action, formState)
         request:request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody)
-        newFrameName:frameName
+        newFrameName:frameName.createNSString().get()
         decisionListener:setUpPolicyListener(WTFMove(function), WebCore::PolicyAction::Ignore, appLinkURL.get(), referrerURL.get()).get()];
 }
 
@@ -938,7 +938,7 @@ static NSDictionary *makeFormFieldValuesDictionary(WebCore::FormState& formState
     size_t size = textFieldValues.size();
     auto dictionary = adoptNS([[NSMutableDictionary alloc] initWithCapacity:size]);
     for (auto& value : textFieldValues)
-        [dictionary setObject:value.second forKey:value.first];
+        [dictionary setObject:value.second.createNSString().get() forKey:value.first.createNSString().get()];
     return dictionary.autorelease();
 }
 
@@ -1025,7 +1025,7 @@ static inline NSString *nilOrNSString(const String& string)
 {
     if (string.isNull())
         return nil;
-    return string;
+    return string.createNSString().autorelease();
 }
 
 void WebFrameLoaderClient::updateGlobalHistory()
@@ -1040,12 +1040,12 @@ void WebFrameLoaderClient::updateGlobalHistory()
     if ([view historyDelegate]) {
         WebHistoryDelegateImplementationCache* implementations = WebViewGetHistoryDelegateImplementations(view);
         if (implementations->navigatedFunc) {
-            auto data = adoptNS([[WebNavigationData alloc] initWithURLString:loader->url().string()
+            auto data = adoptNS([[WebNavigationData alloc] initWithURLString:loader->url().string().createNSString().get()
                 title:nilOrNSString(loader->title().string)
                 originalRequest:loader->originalRequestCopy().nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody)
                 response:loader->response().nsURLResponse()
                 hasSubstituteData:loader->substituteData().isValid()
-                clientRedirectSource:loader->clientRedirectSourceForHistory()]);
+                clientRedirectSource:loader->clientRedirectSourceForHistory().createNSString().get()]);
 
             CallHistoryDelegate(implementations->navigatedFunc, view, @selector(webView:didNavigateWithNavigationData:inFrame:), data.get(), m_webFrame.get());
         }
@@ -1053,7 +1053,7 @@ void WebFrameLoaderClient::updateGlobalHistory()
         return;
     }
 
-    [[WebHistory optionalSharedHistory] _visitedURL:loader->urlForHistory().createNSURL().get() withTitle:loader->title().string method:loader->originalRequestCopy().httpMethod() wasFailure:loader->urlForHistoryReflectsFailure()];
+    [[WebHistory optionalSharedHistory] _visitedURL:loader->urlForHistory().createNSURL().get() withTitle:loader->title().string.createNSString().get() method:loader->originalRequestCopy().httpMethod().createNSString().get() wasFailure:loader->urlForHistoryReflectsFailure()];
 }
 
 static void addRedirectURL(WebHistoryItem *item, const String& url)
@@ -1079,9 +1079,9 @@ void WebFrameLoaderClient::updateGlobalHistoryRedirectLinks()
         if (implementations) {
             if (implementations->clientRedirectFunc) {
                 CallHistoryDelegate(implementations->clientRedirectFunc, view, @selector(webView:didPerformClientRedirectFromURL:toURL:inFrame:), 
-                    m_webFrame->_private->url.get(), loader->clientRedirectDestinationForHistory(), m_webFrame.get());
+                    m_webFrame->_private->url.get(), loader->clientRedirectDestinationForHistory().createNSString().get(), m_webFrame.get());
             }
-        } else if (WebHistoryItem *item = [[WebHistory optionalSharedHistory] _itemForURLString:loader->clientRedirectSourceForHistory()])
+        } else if (WebHistoryItem *item = [[WebHistory optionalSharedHistory] _itemForURLString:loader->clientRedirectSourceForHistory().createNSString().get()])
             addRedirectURL(item, loader->clientRedirectDestinationForHistory());
     }
 
@@ -1089,9 +1089,9 @@ void WebFrameLoaderClient::updateGlobalHistoryRedirectLinks()
         if (implementations) {
             if (implementations->serverRedirectFunc) {
                 CallHistoryDelegate(implementations->serverRedirectFunc, view, @selector(webView:didPerformServerRedirectFromURL:toURL:inFrame:), 
-                    loader->serverRedirectSourceForHistory(), loader->serverRedirectDestinationForHistory(), m_webFrame.get());
+                    loader->serverRedirectSourceForHistory().createNSString().get(), loader->serverRedirectDestinationForHistory().createNSString().get(), m_webFrame.get());
             }
-        } else if (WebHistoryItem *item = [[WebHistory optionalSharedHistory] _itemForURLString:loader->serverRedirectSourceForHistory()])
+        } else if (WebHistoryItem *item = [[WebHistory optionalSharedHistory] _itemForURLString:loader->serverRedirectSourceForHistory().createNSString().get()])
             addRedirectURL(item, loader->serverRedirectDestinationForHistory());
     }
 }
@@ -1145,12 +1145,12 @@ bool WebFrameLoaderClient::canHandleRequest(const WebCore::ResourceRequest& requ
 
 bool WebFrameLoaderClient::canShowMIMEType(const String& MIMEType) const
 {
-    return [getWebView(m_webFrame.get()) _canShowMIMEType:MIMEType];
+    return [getWebView(m_webFrame.get()) _canShowMIMEType:MIMEType.createNSString().get()];
 }
 
 bool WebFrameLoaderClient::canShowMIMETypeAsHTML(const String& MIMEType) const
 {
-    return [WebView canShowMIMETypeAsHTML:MIMEType];
+    return [WebView canShowMIMETypeAsHTML:MIMEType.createNSString().get()];
 }
 
 bool WebFrameLoaderClient::representationExistsForURLScheme(StringView URLScheme) const
@@ -1294,10 +1294,10 @@ void WebFrameLoaderClient::setTitle(const WebCore::StringWithDirection& title, c
         WebHistoryDelegateImplementationCache* implementations = WebViewGetHistoryDelegateImplementations(view);
         // FIXME: Use direction of title.
         if (implementations->setTitleFunc)
-            CallHistoryDelegate(implementations->setTitleFunc, view, @selector(webView:updateHistoryTitle:forURL:inFrame:), (NSString *)title.string, (NSString *)url.string(), m_webFrame.get());
+            CallHistoryDelegate(implementations->setTitleFunc, view, @selector(webView:updateHistoryTitle:forURL:inFrame:), title.string.createNSString().get(), url.string().createNSString().get(), m_webFrame.get());
         else if (implementations->deprecatedSetTitleFunc) {
             IGNORE_WARNINGS_BEGIN("undeclared-selector")
-            CallHistoryDelegate(implementations->deprecatedSetTitleFunc, view, @selector(webView:updateHistoryTitle:forURL:), (NSString *)title.string, (NSString *)url.string());
+            CallHistoryDelegate(implementations->deprecatedSetTitleFunc, view, @selector(webView:updateHistoryTitle:forURL:), title.string.createNSString().get(), url.string().createNSString().get());
             IGNORE_WARNINGS_END
         }
         return;
@@ -1311,7 +1311,7 @@ void WebFrameLoaderClient::setTitle(const WebCore::StringWithDirection& title, c
     if ([[nsURL absoluteString] isEqualToString:@"about:blank"])
         return;
 #endif
-    [[[WebHistory optionalSharedHistory] itemForURL:nsURL.get()] setTitle:title.string];
+    [[[WebHistory optionalSharedHistory] itemForURL:nsURL.get()] setTitle:title.string.createNSString().get()];
 }
 
 void WebFrameLoaderClient::savePlatformDataToCachedFrame(WebCore::CachedFrame* cachedFrame)
@@ -1610,7 +1610,7 @@ WebCore::ObjectContentType WebFrameLoaderClient::objectContentType(const URL& ur
         return WebCore::ObjectContentType::Frame; // Go ahead and hope that we can display the content.
 
     WebCore::ObjectContentType plugInType = WebCore::ObjectContentType::None;
-    if ([getWebView(m_webFrame.get()) _pluginForMIMEType:type])
+    if ([getWebView(m_webFrame.get()) _pluginForMIMEType:type.createNSString().get()])
         plugInType = WebCore::ObjectContentType::PlugIn;
 
     if (WebCore::MIMETypeRegistry::isSupportedImageMIMEType(type))
@@ -1619,7 +1619,7 @@ WebCore::ObjectContentType WebFrameLoaderClient::objectContentType(const URL& ur
     if (plugInType != WebCore::ObjectContentType::None)
         return plugInType;
 
-    if ([m_webFrame->_private->webFrameView _viewClassForMIMEType:type])
+    if ([m_webFrame->_private->webFrameView _viewClassForMIMEType:type.createNSString().get()])
         return WebCore::ObjectContentType::Frame;
     
     return WebCore::ObjectContentType::None;
@@ -1739,14 +1739,13 @@ RefPtr<WebCore::Widget> WebFrameLoaderClient::createPlugin(WebCore::HTMLPlugInEl
     }
 #endif
 
-    NSString *MIMEType;
+    RetainPtr<NSString> MIMEType;
     WebBasePluginPackage *pluginPackage;
-    if (mimeType.isEmpty()) {
-        MIMEType = nil;
+    if (mimeType.isEmpty())
         pluginPackage = nil;
-    } else {
-        MIMEType = mimeType;
-        pluginPackage = [webView _pluginForMIMEType:mimeType];
+    else {
+        MIMEType = mimeType.createNSString();
+        pluginPackage = [webView _pluginForMIMEType:MIMEType.get()];
     }
 
     NSString *extension = [[pluginURL path] pathExtension];
@@ -1759,9 +1758,9 @@ RefPtr<WebCore::Widget> WebFrameLoaderClient::createPlugin(WebCore::HTMLPlugInEl
     {
         pluginPackage = [webView _pluginForExtension:extension];
         if (pluginPackage) {
-            NSString *newMIMEType = [pluginPackage MIMETypeForExtension:extension];
+            RetainPtr newMIMEType = [pluginPackage MIMETypeForExtension:extension];
             if ([newMIMEType length] != 0)
-                MIMEType = newMIMEType;
+                MIMEType = WTFMove(newMIMEType);
         }
     }
 
@@ -1788,9 +1787,9 @@ RefPtr<WebCore::Widget> WebFrameLoaderClient::createPlugin(WebCore::HTMLPlugInEl
             URL pluginPageURL = document->completeURL(parameterValue(paramNames, paramValues, "pluginspage"_s));
             if (!pluginPageURL.protocolIsInHTTPFamily())
                 pluginPageURL = URL();
-            NSString *pluginName = pluginPackage ? (NSString *)[pluginPackage pluginInfo].name : nil;
+            RetainPtr pluginName = pluginPackage ? [pluginPackage pluginInfo].name.createNSString() : nil;
 
-            RetainPtr error = adoptNS([[NSError alloc] _initWithPluginErrorCode:errorCode contentURL:pluginURL.get() pluginPageURL:pluginPageURL.createNSURL().get() pluginName:pluginName MIMEType:MIMEType]);
+            RetainPtr error = adoptNS([[NSError alloc] _initWithPluginErrorCode:errorCode contentURL:pluginURL.get() pluginPageURL:pluginPageURL.createNSURL().get() pluginName:pluginName.get() MIMEType:MIMEType.get()]);
             CallResourceLoadDelegate(implementations->plugInFailedWithErrorFunc, [m_webFrame.get() webView],
                                      @selector(webView:plugInFailedWithError:dataSource:), error.get(), [m_webFrame.get() _dataSource]);
         }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
@@ -377,7 +377,7 @@ void WebInspectorFrontendClient::logDiagnosticEvent(const String& eventName, con
 
 void WebInspectorFrontendClient::updateWindowTitle() const
 {
-    NSString *title = [NSString stringWithFormat:UI_STRING_INTERNAL("Web Inspector — %@", "Web Inspector window title"), (NSString *)m_inspectedURL];
+    NSString *title = [NSString stringWithFormat:UI_STRING_INTERNAL("Web Inspector — %@", "Web Inspector window title"), m_inspectedURL.createNSString().get()];
     [[m_frontendWindowController.get() window] setTitle:title];
 }
 
@@ -406,7 +406,7 @@ void WebInspectorFrontendClient::save(Vector<InspectorFrontendClient::SaveData>&
 
     NSURL *platformURL = m_suggestedToActualURLMap.get(suggestedURL).get();
     if (!platformURL) {
-        platformURL = [NSURL URLWithString:suggestedURL];
+        platformURL = [NSURL URLWithString:suggestedURL.createNSString().get()];
         // The user must confirm new filenames before we can save to them.
         forceSaveAs = true;
     }
@@ -432,7 +432,7 @@ void WebInspectorFrontendClient::save(Vector<InspectorFrontendClient::SaveData>&
             RetainPtr dataContent = toNSData(decodedData->span());
             [dataContent writeToURL:actualURL atomically:YES];
         } else
-            [contentCopy writeToURL:actualURL atomically:YES encoding:NSUTF8StringEncoding error:NULL];
+            [contentCopy.createNSString() writeToURL:actualURL atomically:YES encoding:NSUTF8StringEncoding error:NULL];
     };
 
     if (!forceSaveAs) {

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebSecurityOrigin.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebSecurityOrigin.mm
@@ -64,17 +64,17 @@ using namespace WebCore;
 
 - (NSString *)protocol
 {
-    return reinterpret_cast<SecurityOrigin*>(_private)->protocol();
+    return reinterpret_cast<SecurityOrigin*>(_private)->protocol().createNSString().autorelease();
 }
 
 - (NSString *)host
 {
-    return reinterpret_cast<SecurityOrigin*>(_private)->host();
+    return reinterpret_cast<SecurityOrigin*>(_private)->host().createNSString().autorelease();
 }
 
 - (NSString *)databaseIdentifier
 {
-    return reinterpret_cast<SecurityOrigin*>(_private)->data().databaseIdentifier();
+    return reinterpret_cast<SecurityOrigin*>(_private)->data().databaseIdentifier().createNSString().autorelease();
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -86,7 +86,7 @@ using namespace WebCore;
 
 - (NSString *)stringValue
 {
-    return reinterpret_cast<SecurityOrigin*>(_private)->toString();
+    return reinterpret_cast<SecurityOrigin*>(_private)->toString().createNSString().autorelease();
 }
 
 - (unsigned short)port

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebValidationMessageClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebValidationMessageClient.mm
@@ -60,7 +60,7 @@ void WebValidationMessageClient::showValidationMessage(const Element& anchor, co
 
     m_currentAnchor = &anchor;
     m_currentAnchorRect = anchor.boundingBoxInRootViewCoordinates();
-    [m_view showFormValidationMessage:message withAnchorRect:m_currentAnchorRect];
+    [m_view showFormValidationMessage:message.createNSString().get() withAnchorRect:m_currentAnchorRect];
 }
 
 void WebValidationMessageClient::hideValidationMessage(const Element& anchor)

--- a/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
@@ -500,10 +500,10 @@ void addTypesFromClass(NSMutableDictionary *allTypes, Class objCClass, NSArray *
 
 - (NSString *)textEncodingName
 {
-    NSString *textEncodingName = toPrivate(_private)->loader->overrideEncoding();
+    RetainPtr textEncodingName = toPrivate(_private)->loader->overrideEncoding().createNSString();
     if (!textEncodingName)
         textEncodingName = [[self response] textEncodingName];
-    return textEncodingName;
+    return textEncodingName.autorelease();
 }
 
 - (BOOL)isLoading

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -601,14 +601,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (NSString *)_selectedString
 {
-    return _private->coreFrame->displayStringModifiedByEncoding(_private->coreFrame->editor().selectedText());
+    return _private->coreFrame->displayStringModifiedByEncoding(_private->coreFrame->editor().selectedText()).createNSString().autorelease();
 }
 
 - (NSString *)_stringForRange:(DOMRange *)range
 {
     if (!range)
         return @"";
-    return plainText(makeSimpleRange(*core(range)), { }, true);
+    return plainText(makeSimpleRange(*core(range)), { }, true).createNSString().autorelease();
 }
 
 - (OptionSet<WebCore::PaintBehavior>)_paintBehaviorForDestinationContext:(CGContextRef)context
@@ -723,7 +723,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     auto* lexicalGlobalObject = _private->coreFrame->script().globalObject(WebCore::mainThreadNormalWorldSingleton());
     JSC::JSLockHolder lock(lexicalGlobalObject);
 #endif
-    return result.toWTFString(lexicalGlobalObject);
+    return result.toWTFString(lexicalGlobalObject).createNSString().autorelease();
 }
 
 - (NSRect)_caretRectAtPosition:(const WebCore::Position&)pos affinity:(NSSelectionAffinity)affinity
@@ -2105,7 +2105,7 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
 
     auto* lexicalGlobalObject = anyWorldGlobalObject;
     JSC::JSLockHolder lock(lexicalGlobalObject);
-    return result.toWTFString(lexicalGlobalObject);
+    return result.toWTFString(lexicalGlobalObject).createNSString().autorelease();
 }
 
 - (JSGlobalContextRef)_globalContextForScriptWorld:(WebScriptWorld *)world
@@ -2171,13 +2171,13 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
     WebCore::AXObjectCache::setEnhancedUserInterfaceAccessibility(enable);
 }
 
-- (NSString*)_layerTreeAsText
+- (NSString *)_layerTreeAsText
 {
     auto coreFrame = _private->coreFrame;
     if (!coreFrame)
         return @"";
 
-    return coreFrame->contentRenderer()->compositor().layerTreeAsText();
+    return coreFrame->contentRenderer()->compositor().layerTreeAsText().createNSString().autorelease();
 }
 
 - (id)accessibilityRoot

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -3473,75 +3473,75 @@ static RetainPtr<NSArray> fixMenusReceivedFromOldClients(NSArray *delegateSuppli
         if (tag == WebMenuItemTagOther) {
             // Restore the specific tag for items on which we temporarily set WebMenuItemTagOther to match old behavior.
             NSString *title = [item title];
-            if ([title isEqualToString:contextMenuItemTagOpenLink()])
+            if ([title isEqualToString:contextMenuItemTagOpenLink().createNSString().get()])
                 modernTag = WebMenuItemTagOpenLink;
-            else if ([title isEqualToString:contextMenuItemTagIgnoreGrammar()])
+            else if ([title isEqualToString:contextMenuItemTagIgnoreGrammar().createNSString().get()])
                 modernTag = WebMenuItemTagIgnoreGrammar;
-            else if ([title isEqualToString:contextMenuItemTagSpellingMenu()])
+            else if ([title isEqualToString:contextMenuItemTagSpellingMenu().createNSString().get()])
                 modernTag = WebMenuItemTagSpellingMenu;
-            else if ([title isEqualToString:contextMenuItemTagShowSpellingPanel(true)] || [title isEqualToString:contextMenuItemTagShowSpellingPanel(false)])
+            else if ([title isEqualToString:contextMenuItemTagShowSpellingPanel(true).createNSString().get()] || [title isEqualToString:contextMenuItemTagShowSpellingPanel(false).createNSString().get()])
                 modernTag = WebMenuItemTagShowSpellingPanel;
-            else if ([title isEqualToString:contextMenuItemTagCheckSpelling()])
+            else if ([title isEqualToString:contextMenuItemTagCheckSpelling().createNSString().get()])
                 modernTag = WebMenuItemTagCheckSpelling;
-            else if ([title isEqualToString:contextMenuItemTagCheckSpellingWhileTyping()])
+            else if ([title isEqualToString:contextMenuItemTagCheckSpellingWhileTyping().createNSString().get()])
                 modernTag = WebMenuItemTagCheckSpellingWhileTyping;
-            else if ([title isEqualToString:contextMenuItemTagCheckGrammarWithSpelling()])
+            else if ([title isEqualToString:contextMenuItemTagCheckGrammarWithSpelling().createNSString().get()])
                 modernTag = WebMenuItemTagCheckGrammarWithSpelling;
-            else if ([title isEqualToString:contextMenuItemTagFontMenu()])
+            else if ([title isEqualToString:contextMenuItemTagFontMenu().createNSString().get()])
                 modernTag = WebMenuItemTagFontMenu;
-            else if ([title isEqualToString:contextMenuItemTagShowFonts()])
+            else if ([title isEqualToString:contextMenuItemTagShowFonts().createNSString().get()])
                 modernTag = WebMenuItemTagShowFonts;
-            else if ([title isEqualToString:contextMenuItemTagBold()])
+            else if ([title isEqualToString:contextMenuItemTagBold().createNSString().get()])
                 modernTag = WebMenuItemTagBold;
-            else if ([title isEqualToString:contextMenuItemTagItalic()])
+            else if ([title isEqualToString:contextMenuItemTagItalic().createNSString().get()])
                 modernTag = WebMenuItemTagItalic;
-            else if ([title isEqualToString:contextMenuItemTagUnderline()])
+            else if ([title isEqualToString:contextMenuItemTagUnderline().createNSString().get()])
                 modernTag = WebMenuItemTagUnderline;
-            else if ([title isEqualToString:contextMenuItemTagOutline()])
+            else if ([title isEqualToString:contextMenuItemTagOutline().createNSString().get()])
                 modernTag = WebMenuItemTagOutline;
-            else if ([title isEqualToString:contextMenuItemTagStyles()])
+            else if ([title isEqualToString:contextMenuItemTagStyles().createNSString().get()])
                 modernTag = WebMenuItemTagStyles;
-            else if ([title isEqualToString:contextMenuItemTagShowColors()])
+            else if ([title isEqualToString:contextMenuItemTagShowColors().createNSString().get()])
                 modernTag = WebMenuItemTagShowColors;
-            else if ([title isEqualToString:contextMenuItemTagSpeechMenu()])
+            else if ([title isEqualToString:contextMenuItemTagSpeechMenu().createNSString().get()])
                 modernTag = WebMenuItemTagSpeechMenu;
-            else if ([title isEqualToString:contextMenuItemTagStartSpeaking()])
+            else if ([title isEqualToString:contextMenuItemTagStartSpeaking().createNSString().get()])
                 modernTag = WebMenuItemTagStartSpeaking;
-            else if ([title isEqualToString:contextMenuItemTagStopSpeaking()])
+            else if ([title isEqualToString:contextMenuItemTagStopSpeaking().createNSString().get()])
                 modernTag = WebMenuItemTagStopSpeaking;
-            else if ([title isEqualToString:contextMenuItemTagWritingDirectionMenu()])
+            else if ([title isEqualToString:contextMenuItemTagWritingDirectionMenu().createNSString().get()])
                 modernTag = WebMenuItemTagWritingDirectionMenu;
-            else if ([title isEqualToString:contextMenuItemTagDefaultDirection()])
+            else if ([title isEqualToString:contextMenuItemTagDefaultDirection().createNSString().get()])
                 modernTag = WebMenuItemTagDefaultDirection;
-            else if ([title isEqualToString:contextMenuItemTagLeftToRight()])
+            else if ([title isEqualToString:contextMenuItemTagLeftToRight().createNSString().get()])
                 modernTag = WebMenuItemTagLeftToRight;
-            else if ([title isEqualToString:contextMenuItemTagRightToLeft()])
+            else if ([title isEqualToString:contextMenuItemTagRightToLeft().createNSString().get()])
                 modernTag = WebMenuItemTagRightToLeft;
-            else if ([title isEqualToString:contextMenuItemTagInspectElement()])
+            else if ([title isEqualToString:contextMenuItemTagInspectElement().createNSString().get()])
                 modernTag = WebMenuItemTagInspectElement;
-            else if ([title isEqualToString:contextMenuItemTagCorrectSpellingAutomatically()])
+            else if ([title isEqualToString:contextMenuItemTagCorrectSpellingAutomatically().createNSString().get()])
                 modernTag = WebMenuItemTagCorrectSpellingAutomatically;
-            else if ([title isEqualToString:contextMenuItemTagSubstitutionsMenu()])
+            else if ([title isEqualToString:contextMenuItemTagSubstitutionsMenu().createNSString().get()])
                 modernTag = WebMenuItemTagSubstitutionsMenu;
-            else if ([title isEqualToString:contextMenuItemTagShowSubstitutions(true)] || [title isEqualToString:contextMenuItemTagShowSubstitutions(false)])
+            else if ([title isEqualToString:contextMenuItemTagShowSubstitutions(true).createNSString().get()] || [title isEqualToString:contextMenuItemTagShowSubstitutions(false).createNSString().get()])
                 modernTag = WebMenuItemTagShowSubstitutions;
-            else if ([title isEqualToString:contextMenuItemTagSmartCopyPaste()])
+            else if ([title isEqualToString:contextMenuItemTagSmartCopyPaste().createNSString().get()])
                 modernTag = WebMenuItemTagSmartCopyPaste;
-            else if ([title isEqualToString:contextMenuItemTagSmartQuotes()])
+            else if ([title isEqualToString:contextMenuItemTagSmartQuotes().createNSString().get()])
                 modernTag = WebMenuItemTagSmartQuotes;
-            else if ([title isEqualToString:contextMenuItemTagSmartDashes()])
+            else if ([title isEqualToString:contextMenuItemTagSmartDashes().createNSString().get()])
                 modernTag = WebMenuItemTagSmartDashes;
-            else if ([title isEqualToString:contextMenuItemTagSmartLinks()])
+            else if ([title isEqualToString:contextMenuItemTagSmartLinks().createNSString().get()])
                 modernTag = WebMenuItemTagSmartLinks;
-            else if ([title isEqualToString:contextMenuItemTagTextReplacement()])
+            else if ([title isEqualToString:contextMenuItemTagTextReplacement().createNSString().get()])
                 modernTag = WebMenuItemTagTextReplacement;
-            else if ([title isEqualToString:contextMenuItemTagTransformationsMenu()])
+            else if ([title isEqualToString:contextMenuItemTagTransformationsMenu().createNSString().get()])
                 modernTag = WebMenuItemTagTransformationsMenu;
-            else if ([title isEqualToString:contextMenuItemTagMakeUpperCase()])
+            else if ([title isEqualToString:contextMenuItemTagMakeUpperCase().createNSString().get()])
                 modernTag = WebMenuItemTagMakeUpperCase;
-            else if ([title isEqualToString:contextMenuItemTagMakeLowerCase()])
+            else if ([title isEqualToString:contextMenuItemTagMakeLowerCase().createNSString().get()])
                 modernTag = WebMenuItemTagMakeLowerCase;
-            else if ([title isEqualToString:contextMenuItemTagCapitalize()])
+            else if ([title isEqualToString:contextMenuItemTagCapitalize().createNSString().get()])
                 modernTag = WebMenuItemTagCapitalize;
             else {
             // We don't expect WebMenuItemTagOther for any items other than the ones we explicitly handle.
@@ -3595,8 +3595,8 @@ static RetainPtr<NSMenuItem> createShareMenuItem(const WebCore::HitTestResult& h
     }
 
     if (!hitTestResult.selectedText().isEmpty()) {
-        NSString *selectedText = hitTestResult.selectedText();
-        [items addObject:selectedText];
+        RetainPtr selectedText = hitTestResult.selectedText().createNSString();
+        [items addObject:selectedText.get()];
     }
 
     if (![items count])
@@ -3630,7 +3630,7 @@ static RetainPtr<NSMenuItem> createMenuItem(const WebCore::HitTestResult& hitTes
     switch (item.type()) {
     case WebCore::ContextMenuItemType::Action:
     case WebCore::ContextMenuItemType::CheckableAction: {
-        auto menuItem = adoptNS([[NSMenuItem alloc] initWithTitle:item.title() action:@selector(forwardContextMenuAction:) keyEquivalent:@""]);
+        RetainPtr menuItem = adoptNS([[NSMenuItem alloc] initWithTitle:item.title().createNSString().get() action:@selector(forwardContextMenuAction:) keyEquivalent:@""]);
 
         if (auto tag = toTag(item.action()))
             [menuItem setTag:*tag];
@@ -3652,7 +3652,7 @@ static RetainPtr<NSMenuItem> createMenuItem(const WebCore::HitTestResult& hitTes
                 [menu addItem:menuItem];
         }
 
-        auto menuItem = adoptNS([[NSMenuItem alloc] initWithTitle:item.title() action:nullptr keyEquivalent:@""]);
+        RetainPtr menuItem = adoptNS([[NSMenuItem alloc] initWithTitle:item.title().createNSString().get() action:nullptr keyEquivalent:@""]);
 
         if (auto tag = toTag(item.action()))
             [menuItem setTag:*tag];
@@ -4365,9 +4365,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
             draggingElementURL = [response URL];
             wrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:buffer->makeContiguous()->createNSData().get()]);
             NSString* filename = [response suggestedFilename];
-            NSString* trueExtension(tiffResource->image()->filenameExtension());
-            if (!matchesExtensionOrEquivalent(filename, trueExtension))
-                filename = [[filename stringByAppendingString:@"."] stringByAppendingString:trueExtension];
+            RetainPtr trueExtension = tiffResource->image()->filenameExtension().createNSString();
+            if (!matchesExtensionOrEquivalent(filename, trueExtension.get()))
+                filename = [[filename stringByAppendingString:@"."] stringByAppendingString:trueExtension.get()];
             [wrapper setPreferredFilename:filename];
         }
     }
@@ -5975,11 +5975,11 @@ static BOOL writingDirectionKeyBindingsEnabled()
     for (size_t i = 0; i < commands.size(); ++i) {
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         if (commands[i].commandName == "insertText:"_s)
-            [self insertText:commands[i].text];
+            [self insertText:commands[i].text.createNSString().get()];
         else if (commands[i].commandName == "noop:"_s)
             ; // Do nothing. This case can be removed once <rdar://problem/9025012> is fixed.
         else
-            [self doCommandBySelector:NSSelectorFromString(commands[i].commandName)];
+            [self doCommandBySelector:NSSelectorFromString(commands[i].commandName.createNSString().get())];
 ALLOW_DEPRECATED_DECLARATIONS_END
     }
     parameters->event->keypressCommands().clear();
@@ -6035,7 +6035,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         // (e.g. Tab that inserts a Tab character, or Enter).
         bool haveTextInsertionCommands = false;
         for (size_t i = 0; i < commands.size(); ++i) {
-            if ([self coreCommandBySelector:NSSelectorFromString(commands[i].commandName)].isTextInsertion())
+            if ([self coreCommandBySelector:NSSelectorFromString(commands[i].commandName.createNSString().get())].isTextInsertion())
                 haveTextInsertionCommands = true;
         }
         // If there are no text insertion commands, default keydown handler is the right time to execute the commands.

--- a/Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm
@@ -498,7 +498,7 @@ static WebCore::IntRect elementBoundingBoxInWindowCoordinatesFromNode(WebCore::N
 
     [_currentActionContext setHighlightFrame:[_webView.window convertRectToScreen:elementBoundingBoxInWindowCoordinatesFromNode(_hitTestResult.URLElement())]];
 
-    NSArray *menuItems = [[PAL::getDDActionsManagerClass() sharedManager] menuItemsForTargetURL:_hitTestResult.absoluteLinkURL().string() actionContext:_currentActionContext.get()];
+    NSArray *menuItems = [[PAL::getDDActionsManagerClass() sharedManager] menuItemsForTargetURL:_hitTestResult.absoluteLinkURL().string().createNSString().get() actionContext:_currentActionContext.get()];
     if (menuItems.count != 1)
         return nil;
     

--- a/Source/WebKitLegacy/mac/WebView/WebNotification.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebNotification.mm
@@ -81,7 +81,7 @@ using namespace WebCore;
 - (NSString *)title
 {
 #if ENABLE(NOTIFICATIONS)
-    return _private->_internal->title;
+    return _private->_internal->title.createNSString().autorelease();
 #else
     return nil;
 #endif
@@ -90,7 +90,7 @@ using namespace WebCore;
 - (NSString *)body
 {
 #if ENABLE(NOTIFICATIONS)
-    return _private->_internal->body;
+    return _private->_internal->body.createNSString().autorelease();
 #else
     return nil;
 #endif
@@ -99,7 +99,7 @@ using namespace WebCore;
 - (NSString *)tag
 {
 #if ENABLE(NOTIFICATIONS)
-    return _private->_internal->tag;
+    return _private->_internal->tag.createNSString().autorelease();
 #else
     return nil;
 #endif
@@ -108,7 +108,7 @@ using namespace WebCore;
 - (NSString *)iconURL
 {
 #if ENABLE(NOTIFICATIONS)
-    return _private->_internal->iconURL;
+    return _private->_internal->iconURL.createNSString().autorelease();
 #else
     return nil;
 #endif
@@ -117,7 +117,7 @@ using namespace WebCore;
 - (NSString *)lang
 {
 #if ENABLE(NOTIFICATIONS)
-    return _private->_internal->language;
+    return _private->_internal->language.createNSString().autorelease();
 #else
     return nil;
 #endif
@@ -142,7 +142,7 @@ using namespace WebCore;
 - (WebSecurityOrigin *)origin
 {
 #if ENABLE(NOTIFICATIONS)
-    return adoptNS([[WebSecurityOrigin alloc] _initWithString:_private->_internal->originString]).autorelease();
+    return adoptNS([[WebSecurityOrigin alloc] _initWithString:_private->_internal->originString.createNSString().get()]).autorelease();
 #else
     return nil;
 #endif
@@ -151,7 +151,7 @@ using namespace WebCore;
 - (NSString *)notificationID
 {
 #if ENABLE(NOTIFICATIONS)
-    return _private->_internal->notificationID.toString();
+    return _private->_internal->notificationID.toString().createNSString().autorelease();
 #else
     return 0;
 #endif

--- a/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
@@ -1618,7 +1618,7 @@ public:
 + (void)_setInitialDefaultTextEncodingToSystemEncoding
 {
     [[NSUserDefaults standardUserDefaults] registerDefaults:
-        @{ WebKitDefaultTextEncodingNamePreferenceKey: PAL::defaultTextEncodingNameForSystemLanguage() }];
+        @{ WebKitDefaultTextEncodingNamePreferenceKey: PAL::defaultTextEncodingNameForSystemLanguage().createNSString().get() }];
 }
 
 static RetainPtr<NSString>& classIBCreatorID()

--- a/Source/WebKitLegacy/mac/WebView/WebResource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebResource.mm
@@ -167,22 +167,24 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
 
     RetainPtr<NSData> data;
     RetainPtr<NSURL> url;
-    NSString *mimeType = nil, *textEncoding = nil, *frameName = nil;
+    RetainPtr<NSString> mimeType;
+    RetainPtr<NSString> textEncoding;
+    RetainPtr<NSString> frameName;
     NSURLResponse *response = nil;
 
     if (resource) {
         data = resource->data().makeContiguous()->createNSData();
         url = resource->url().createNSURL();
-        mimeType = resource->mimeType();
-        textEncoding = resource->textEncoding();
-        frameName = resource->frameName();
+        mimeType = resource->mimeType().createNSString();
+        textEncoding = resource->textEncoding().createNSString();
+        frameName = resource->frameName().createNSString();
         response = resource->response().nsURLResponse();
     }
     [encoder encodeObject:data.get() forKey:WebResourceDataKey];
     [encoder encodeObject:url.get() forKey:WebResourceURLKey];
-    [encoder encodeObject:mimeType forKey:WebResourceMIMETypeKey];
-    [encoder encodeObject:textEncoding forKey:WebResourceTextEncodingNameKey];
-    [encoder encodeObject:frameName forKey:WebResourceFrameNameKey];
+    [encoder encodeObject:mimeType.get() forKey:WebResourceMIMETypeKey];
+    [encoder encodeObject:textEncoding.get() forKey:WebResourceTextEncodingNameKey];
+    [encoder encodeObject:frameName.get() forKey:WebResourceFrameNameKey];
     [encoder encodeObject:response forKey:WebResourceResponseKey];
 }
 
@@ -221,8 +223,7 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
 
     if (!_private->coreResource)
         return nil;
-    NSString *mimeType = _private->coreResource->mimeType();
-    return mimeType;
+    return _private->coreResource->mimeType().createNSString().autorelease();
 }
 
 - (NSString *)textEncodingName
@@ -231,8 +232,7 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
 
     if (!_private->coreResource)
         return nil;
-    NSString *textEncodingName = _private->coreResource->textEncoding();
-    return textEncodingName;
+    return _private->coreResource->textEncoding().createNSString().autorelease();
 }
 
 - (NSString *)frameName
@@ -241,8 +241,7 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
 
     if (!_private->coreResource)
         return nil;
-    NSString *frameName = _private->coreResource->frameName();
-    return frameName;
+    return _private->coreResource->frameName().createNSString().autorelease();
 }
 
 - (NSString *)description
@@ -332,8 +331,7 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
 
     if (!_private->coreResource)
         return nil;
-    NSString *suggestedFilename = _private->coreResource->response().suggestedFilename();
-    return suggestedFilename;
+    return _private->coreResource->response().suggestedFilename().createNSString().autorelease();
 }
 
 #if !PLATFORM(IOS_FAMILY)
@@ -371,7 +369,7 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
     RefPtr coreData = _private->coreResource ? &_private->coreResource->data() : nullptr;
     if (!coreData)
         return @"";
-    return encoding.decode(coreData->makeContiguous()->span());
+    return encoding.decode(coreData->makeContiguous()->span()).createNSString().autorelease();
 }
 
 @end

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -990,7 +990,7 @@ static const NSUInteger orderedListSegment = 2;
 
     _webView = webView;
 
-    NSSegmentedControl *insertListControl = [NSSegmentedControl segmentedControlWithLabels:@[ WebCore::insertListTypeNone(), WebCore::insertListTypeBulleted(), WebCore::insertListTypeNumbered() ] trackingMode:NSSegmentSwitchTrackingSelectOne target:self action:@selector(_selectList:)];
+    NSSegmentedControl *insertListControl = [NSSegmentedControl segmentedControlWithLabels:@[ WebCore::insertListTypeNone().createNSString().get(), WebCore::insertListTypeBulleted().createNSString().get(), WebCore::insertListTypeNumbered().createNSString().get() ] trackingMode:NSSegmentSwitchTrackingSelectOne target:self action:@selector(_selectList:)];
     [insertListControl setWidth:listControlSegmentWidth forSegment:noListSegment];
     [insertListControl setWidth:listControlSegmentWidth forSegment:unorderedListSegment];
     [insertListControl setWidth:listControlSegmentWidth forSegment:orderedListSegment];
@@ -1000,9 +1000,9 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     id segmentElement = NSAccessibilityUnignoredDescendant(insertListControl);
     NSArray *segments = [segmentElement accessibilityAttributeValue:NSAccessibilityChildrenAttribute];
     ASSERT(segments.count == 3);
-    [segments[noListSegment] accessibilitySetOverrideValue:WebCore::insertListTypeNone() forAttribute:NSAccessibilityDescriptionAttribute];
-    [segments[unorderedListSegment] accessibilitySetOverrideValue:WebCore::insertListTypeBulletedAccessibilityTitle() forAttribute:NSAccessibilityDescriptionAttribute];
-    [segments[orderedListSegment] accessibilitySetOverrideValue:WebCore::insertListTypeNumberedAccessibilityTitle() forAttribute:NSAccessibilityDescriptionAttribute];
+    [segments[noListSegment] accessibilitySetOverrideValue:WebCore::insertListTypeNone().createNSString().get() forAttribute:NSAccessibilityDescriptionAttribute];
+    [segments[unorderedListSegment] accessibilitySetOverrideValue:WebCore::insertListTypeBulletedAccessibilityTitle().createNSString().get() forAttribute:NSAccessibilityDescriptionAttribute];
+    [segments[orderedListSegment] accessibilitySetOverrideValue:WebCore::insertListTypeNumberedAccessibilityTitle().createNSString().get() forAttribute:NSAccessibilityDescriptionAttribute];
 ALLOW_DEPRECATED_DECLARATIONS_END
 
     self.view = insertListControl;
@@ -1212,7 +1212,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)_webChangeColor:(id)sender
 {
     _textColor = self.colorPickerItem.color;
-    [_webView _executeCoreCommandByName:@"ForeColor" value:WebCore::serializationForHTML(WebCore::colorFromCocoaColor(_textColor.get()))];
+    [_webView _executeCoreCommandByName:@"ForeColor" value:WebCore::serializationForHTML(WebCore::colorFromCocoaColor(_textColor.get())).createNSString().get()];
 }
 
 - (NSViewController *)textListViewController
@@ -1280,7 +1280,7 @@ static RetainPtr<CFMutableSetRef>& allWebViewsSet()
 
 + (NSString *)_standardUserAgentWithApplicationName:(NSString *)applicationName
 {
-    return WebCore::standardUserAgentWithApplicationName(applicationName);
+    return WebCore::standardUserAgentWithApplicationName(applicationName).createNSString().autorelease();
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -3270,7 +3270,7 @@ IGNORE_WARNINGS_END
 + (NSString *)_decodeData:(NSData *)data
 {
     WebCore::HTMLNames::init(); // this method is used for importing bookmarks at startup, so HTMLNames are likely to be uninitialized yet
-    return WebCore::TextResourceDecoder::create("text/html"_s)->decodeAndFlush(span(data)); // bookmark files are HTML
+    return WebCore::TextResourceDecoder::create("text/html"_s)->decodeAndFlush(span(data)).createNSString().autorelease(); // bookmark files are HTML
 }
 
 - (void)_pushPerformingProgrammaticFocus
@@ -4169,7 +4169,7 @@ IGNORE_WARNINGS_END
         auto* validationBubble = _private->formValidationBubble.get();
         String message = validationBubble ? validationBubble->message() : emptyString();
         double fontSize = validationBubble ? validationBubble->fontSize() : 0;
-        return @{ userInterfaceItem: @{ @"message": (NSString *)message, @"fontSize": @(fontSize) } };
+        return @{ userInterfaceItem: @{ @"message": message.createNSString().get(), @"fontSize": @(fontSize) } };
     }
 
     return nil;
@@ -6132,7 +6132,7 @@ static bool needsWebViewInitThreadWorkaround()
 {
     if (!_private->userAgentOverridden)
         return nil;
-    return _private->userAgent;
+    return _private->userAgent.createNSString().autorelease();
 }
 
 - (void)setMediaStyle:(NSString *)mediaStyle
@@ -6225,7 +6225,7 @@ static bool needsWebViewInitThreadWorkaround()
 // Get the appropriate user-agent string for a particular URL.
 - (NSString *)userAgentForURL:(NSURL *)url
 {
-    return [self _userAgentString];
+    return [self _userAgentString].createNSString().autorelease();
 }
 
 - (void)setHostWindow:(NSWindow *)hostWindow
@@ -6568,7 +6568,7 @@ static WebFrame *incrementFrame(WebFrame *frame, WebFindOptions options = 0)
 {
     if (!_private->page)
         return nil;
-    return _private->page->groupName();
+    return _private->page->groupName().createNSString().autorelease();
 }
 
 - (double)estimatedProgress
@@ -7448,7 +7448,7 @@ static NSAppleEventDescriptor* aeDescFromJSValue(JSC::JSGlobalObject* lexicalGlo
     if (jsValue.isBoolean())
         return [NSAppleEventDescriptor descriptorWithBoolean:jsValue.asBoolean()];
     if (jsValue.isString())
-        return [NSAppleEventDescriptor descriptorWithString:asString(jsValue)->value(lexicalGlobalObject).data];
+        return [NSAppleEventDescriptor descriptorWithString:asString(jsValue)->value(lexicalGlobalObject).data.createNSString().get()];
     if (jsValue.isNumber()) {
         double value = jsValue.asNumber();
         int intValue = value;
@@ -9604,7 +9604,7 @@ static NSTextAlignment nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle
     }
 
     auto translationViewController = adoptNS([PAL::allocLTUITranslationViewControllerInstance() init]);
-    [translationViewController setText:adoptNS([[NSAttributedString alloc] initWithString:info.text]).get()];
+    [translationViewController setText:adoptNS([[NSAttributedString alloc] initWithString:info.text.createNSString().get()]).get()];
     if (info.mode == WebCore::TranslationContextMenuMode::Editable) {
         [translationViewController setIsSourceEditable:YES];
         [translationViewController setReplacementHandler:[weakSelf = WeakObjCPtr<WebView>(self)](NSAttributedString *string) {
@@ -9740,7 +9740,7 @@ static NSTextAlignment nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle
         return 0;
     JSContextRef context = [[self mainFrame] globalContext];
     auto* notification = WebCore::JSNotification::toWrapped(toJS(context)->vm(), toJS(toJS(context), jsNotification));
-    return notification->identifier().toString();
+    return notification->identifier().toString().createNSString().autorelease();
 #else
     return nil;
 #endif


### PR DESCRIPTION
#### 4327dfcbd97710b17f067d60d59c4492aed5fe06
<pre>
Stop implicitly converting WTF::String to NSString* in WebCore &amp; WebKitLegacy
<a href="https://bugs.webkit.org/show_bug.cgi?id=291406">https://bugs.webkit.org/show_bug.cgi?id=291406</a>

Reviewed by Geoffrey Garen.

Stop implicitly converting WTF::String to NSString* in WebCore &amp; WebKitLegacy.
Use String::createNSString() instead, which makes it clearer we are allocating
a new string object and which returns a RetainPtr instead of an autoreleased
value.

* Source/WebCore/Modules/applepay/cocoa/PaymentContactCocoa.mm:
(WebCore::convert):
* Source/WebCore/Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm:
(WebCore::toDecimalNumber):
(WebCore::platformRecurringSummaryItem):
(WebCore::platformDeferredSummaryItem):
(WebCore::platformAutomaticReloadSummaryItem):
(WebCore::platformDisbursementSummaryItem):
(WebCore::platformInstantFundsOutFeeSummaryItem):
(WebCore::platformSummaryItem):
* Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoaderUSD.mm:
(WebCore::writeToTemporaryFile):
* Source/WebCore/Modules/speech/cocoa/SpeechRecognizerCocoa.mm:
(WebCore::SpeechRecognizer::startRecognition):
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::attributedStringSetExpandedText):
(WebCore::AXCoreObject::isEmptyGroup):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::postPlatformAnnouncementNotification):
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
(WebCore::AccessibilityObject::rolePlatformDescription):
* Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapMac.mm:
(WebCore::createAndStoreMasterKey):
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::WebContentReader::readPlainText):
(WebCore::WebContentReader::readURL):
* Source/WebCore/editing/mac/EditorMac.mm:
(WebCore::Editor::plainTextFromPasteboard):
* Source/WebCore/loader/cocoa/BundleResourceLoader.mm:
(WebCore::BundleResourceLoader::loadResourceFromBundle):
* Source/WebCore/loader/mac/LoaderNSURLExtras.mm:
(suggestedFilenameWithMIMEType):
* Source/WebCore/platform/cocoa/DragDataCocoa.mm:
(WebCore::DragData::asPlainText const):
(WebCore::DragData::containsURL const):
(WebCore::DragData::asURL const):
* Source/WebCore/platform/cocoa/MIMETypeRegistryCocoa.mm:
(WebCore::MIMETypeRegistry::extensionsForMIMEType):
* Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.mm:
(WebCore::NetworkExtensionContentFilter::initialize):
* Source/WebCore/platform/cocoa/PlatformPasteboardCocoa.mm:
(WebCore::PlatformPasteboard::urlStringSuitableForLoading):
* Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm:
(WebCore::isPublicSuffixCF):
* Source/WebCore/platform/cocoa/SearchPopupMenuCocoa.mm:
(WebCore::typeCheckedRecentSearchesRemovingRecentSearchesAddedAfterDate):
(WebCore::saveRecentSearchesToFile):
(WebCore::loadRecentSearchesFromFile):
(WebCore::removeRecentlyModifiedRecentSearchesFromFile):
* Source/WebCore/platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.mm:
(WebCore::AVAssetMIMETypeCache::canDecodeExtendedType):
* Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.mm:
(WebCore::AVStreamDataParserMIMETypeCache::canDecodeExtendedType):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm:
(WebCore::CDMSessionAVContentKeySession::releaseKeys):
(WebCore::CDMSessionAVContentKeySession::update):
(WebCore::CDMSessionAVContentKeySession::generateKeyReleaseMessage):
(WebCore::CDMSessionAVContentKeySession::contentKeySession):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm:
(WebCore::CDMSessionAVFoundationObjC::generateKeyRequest):
* Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm:
(-[WebCoreSharedBufferResourceLoaderDelegate fulfillRequest:]):
* Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm:
(WebCore::WebCoreAVFResourceLoader::responseReceived):
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm:
(WebCore::PlatformCAAnimationCocoa::PlatformCAAnimationCocoa):
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm:
(WebCore::PlatformCAFilters::presentationModifiers):
(WebCore::PlatformCAFilters::setFiltersOnLayer):
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayerCocoa::addAnimationForKey):
(WebCore::PlatformCALayerCocoa::removeAnimationForKey):
(WebCore::PlatformCALayerCocoa::animationForKey):
(WebCore::PlatformCALayerCocoa::setName):
* Source/WebCore/platform/graphics/cg/UTIRegistry.mm:
(WebCore::preferredExtensionForImageType):
* Source/WebCore/platform/graphics/cocoa/FontCacheCocoa.mm:
(WebCore::contentSizeCategory):
* Source/WebCore/platform/graphics/cocoa/controls/ApplePayButtonCocoa.mm:
(WebCore::ApplePayButtonCocoa::draw):
* Source/WebCore/platform/graphics/mac/IconMac.mm:
(WebCore::Icon::createIconForFiles):
(WebCore::Icon::createIconForFileExtension):
(WebCore::Icon::createIconForUTI):
* Source/WebCore/platform/mac/PasteboardMac.mm:
(WebCore::writeURLForTypes):
(WebCore::cocoaTypeFromHTMLClipboardType):
(WebCore::Pasteboard::readPlatformValuesAsStrings):
(WebCore::Pasteboard::writeString):
* Source/WebCore/platform/mac/PasteboardWriter.mm:
(WebCore::createPasteboardWriter):
* Source/WebCore/platform/mac/PlatformPasteboardMac.mm:
(WebCore::isFilePasteboardType):
(WebCore::PlatformPasteboard::PlatformPasteboard):
(WebCore::PlatformPasteboard::bufferForType const):
(WebCore::PlatformPasteboard::getPathnamesForType const):
(WebCore::PlatformPasteboard::stringForType const):
(WebCore::PlatformPasteboard::allStringsForType const):
(WebCore::PlatformPasteboard::write):
(WebCore::PlatformPasteboard::copy):
(WebCore::PlatformPasteboard::setBufferForType):
(WebCore::PlatformPasteboard::setURL):
(WebCore::PlatformPasteboard::setStringForType):
(WebCore::PlatformPasteboard::readBuffer const):
(WebCore::PlatformPasteboard::readString const):
(WebCore::createPasteboardItem):
* Source/WebCore/platform/mac/ValidationBubbleMac.mm:
(WebCore::ValidationBubble::ValidationBubble):
* Source/WebCore/platform/mac/WebCoreFullScreenPlaceholderView.mm:
(-[WebCoreFullScreenPlaceholderView initWithFrame:]):
* Source/WebCore/platform/mac/WebPlaybackControlsManager.mm:
(mediaSelectionOptions):
* Source/WebCore/platform/network/cocoa/CredentialCocoa.mm:
(WebCore::Credential::nsCredential const):
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::parseDOMCookie):
(WebCore::NetworkStorageSession::domCookiesForHost):
* Source/WebCore/platform/network/cocoa/ProtectionSpaceCocoa.mm:
(WebCore::ProtectionSpace::nsSpace const):
* Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm:
(WebCore::ResourceRequest::doUpdatePlatformRequest):
* Source/WebCore/platform/network/mac/ResourceErrorMac.mm:
(WebCore::createNSErrorFromResourceErrorBase):
(WebCore::ResourceError::errorRecoveryMethod const):
* Source/WebCore/platform/network/mac/ResourceHandleMac.mm:
(WebCore::ResourceHandle::tryHandlePasswordBasedAuthentication):
* Source/WebCore/platform/network/mac/UTIUtilities.mm:
(WebCore::MIMETypeFromUTI):
(WebCore::UTIFromMIMETypeCachePolicy::createValueForKey):
(WebCore::isDeclaredUTI):
* Source/WebCore/platform/text/cocoa/LocaleCocoa.mm:
(WebCore::LocaleCocoa::LocaleCocoa):
* Source/WebCore/rendering/AttachmentLayout.mm:
(WebCore::AttachmentLayout::buildWrappedLines):
(WebCore::AttachmentLayout::buildSingleLine):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::mediaControlsBase64StringForIconNameAndType):
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::RenderThemeMac::fileListNameForWidth const):
(WebCore::iconForAttachment):
* Source/WebCore/testing/Internals.mm:
(WebCore::Internals::encodedPreferenceValue):
(WebCore::Internals::fakeImageAnalysisResultForTesting):
* Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.mm:
(WebResourceLoadScheduler::pluginWillHandleLoadErrorFromResponse):
* Source/WebKitLegacy/mac/DOM/DOMAttr.mm:
(-[DOMAttr name]):
(-[DOMAttr value]):
* Source/WebKitLegacy/mac/DOM/DOMBlob.mm:
(-[DOMBlob type]):
* Source/WebKitLegacy/mac/DOM/DOMCSSImportRule.mm:
(-[DOMCSSImportRule href]):
* Source/WebKitLegacy/mac/DOM/DOMCSSPageRule.mm:
(-[DOMCSSPageRule selectorText]):
* Source/WebKitLegacy/mac/DOM/DOMCSSPrimitiveValue.mm:
(-[DOMCSSPrimitiveValue getStringValue]):
* Source/WebKitLegacy/mac/DOM/DOMCSSRule.mm:
(-[DOMCSSRule cssText]):
* Source/WebKitLegacy/mac/DOM/DOMCSSStyleDeclaration.mm:
(-[DOMCSSStyleDeclaration cssText]):
(-[DOMCSSStyleDeclaration getPropertyValue:]):
(-[DOMCSSStyleDeclaration removeProperty:]):
(-[DOMCSSStyleDeclaration getPropertyPriority:]):
(-[DOMCSSStyleDeclaration item:]):
(-[DOMCSSStyleDeclaration getPropertyShorthand:]):
* Source/WebKitLegacy/mac/DOM/DOMCSSStyleRule.mm:
(-[DOMCSSStyleRule selectorText]):
* Source/WebKitLegacy/mac/DOM/DOMCSSValue.mm:
(-[DOMCSSValue cssText]):
* Source/WebKitLegacy/mac/DOM/DOMCharacterData.mm:
(-[DOMCharacterData data]):
(-[DOMCharacterData substringData:length:]):
* Source/WebKitLegacy/mac/DOM/DOMCounter.mm:
(-[DOMCounter identifier]):
(-[DOMCounter listStyle]):
(-[DOMCounter separator]):
* Source/WebKitLegacy/mac/DOM/DOMDocument.mm:
(-[DOMDocument xmlEncoding]):
(-[DOMDocument xmlVersion]):
(-[DOMDocument documentURI]):
(-[DOMDocument contentType]):
(-[DOMDocument title]):
(-[DOMDocument dir]):
(-[DOMDocument referrer]):
(-[DOMDocument domain]):
(-[DOMDocument URL]):
(-[DOMDocument cookie]):
(-[DOMDocument lastModified]):
(-[DOMDocument defaultCharset]):
(-[DOMDocument compatMode]):
(-[DOMDocument origin]):
(-[DOMDocument queryCommandValue:]):
* Source/WebKitLegacy/mac/DOM/DOMDocumentType.mm:
(-[DOMDocumentType name]):
(-[DOMDocumentType publicId]):
(-[DOMDocumentType systemId]):
* Source/WebKitLegacy/mac/DOM/DOMElement.mm:
(-[DOMElement tagName]):
(-[DOMElement innerHTML]):
(-[DOMElement outerHTML]):
(-[DOMElement className]):
(-[DOMElement innerText]):
(-[DOMElement uiactions]):
(-[DOMElement getAttribute:]):
(-[DOMElement getAttributeNS:localName:]):
* Source/WebKitLegacy/mac/DOM/DOMFile.mm:
(-[DOMFile name]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLAnchorElement.mm:
(-[DOMHTMLAnchorElement text]):
(-[DOMHTMLAnchorElement href]):
(-[DOMHTMLAnchorElement origin]):
(-[DOMHTMLAnchorElement protocol]):
(-[DOMHTMLAnchorElement host]):
(-[DOMHTMLAnchorElement hostname]):
(-[DOMHTMLAnchorElement port]):
(-[DOMHTMLAnchorElement pathname]):
(-[DOMHTMLAnchorElement search]):
(-[DOMHTMLAnchorElement hashName]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLAreaElement.mm:
(-[DOMHTMLAreaElement href]):
(-[DOMHTMLAreaElement origin]):
(-[DOMHTMLAreaElement protocol]):
(-[DOMHTMLAreaElement host]):
(-[DOMHTMLAreaElement hostname]):
(-[DOMHTMLAreaElement port]):
(-[DOMHTMLAreaElement pathname]):
(-[DOMHTMLAreaElement search]):
(-[DOMHTMLAreaElement hashName]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLBaseElement.mm:
(-[DOMHTMLBaseElement href]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLCanvasElement.mm:
(-[DOMHTMLCanvasElement toDataURL:]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLDocument.mm:
(-[DOMHTMLDocument designMode]):
(-[DOMHTMLDocument compatMode]):
(-[DOMHTMLDocument bgColor]):
(-[DOMHTMLDocument fgColor]):
(-[DOMHTMLDocument alinkColor]):
(-[DOMHTMLDocument linkColor]):
(-[DOMHTMLDocument vlinkColor]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLElement.mm:
(-[DOMHTMLElement innerText]):
(-[DOMHTMLElement outerText]):
(-[DOMHTMLElement contentEditable]):
(-[DOMHTMLElement titleDisplayString]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLEmbedElement.mm:
(-[DOMHTMLEmbedElement src]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLFormElement.mm:
(-[DOMHTMLFormElement action]):
(-[DOMHTMLFormElement enctype]):
(-[DOMHTMLFormElement encoding]):
(-[DOMHTMLFormElement method]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLFrameElement.mm:
(-[DOMHTMLFrameElement src]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLHtmlElement.mm:
(-[DOMHTMLHtmlElement manifest]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLIFrameElement.mm:
(-[DOMHTMLIFrameElement src]):
(-[DOMHTMLIFrameElement srcdoc]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLImageElement.mm:
(-[DOMHTMLImageElement border]):
(-[DOMHTMLImageElement crossOrigin]):
(-[DOMHTMLImageElement longDesc]):
(-[DOMHTMLImageElement src]):
(-[DOMHTMLImageElement currentSrc]):
(-[DOMHTMLImageElement lowsrc]):
(-[DOMHTMLImageElement altDisplayString]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLInputElement.mm:
(-[DOMHTMLInputElement autocomplete]):
(-[DOMHTMLInputElement formAction]):
(-[DOMHTMLInputElement formEnctype]):
(-[DOMHTMLInputElement formMethod]):
(-[DOMHTMLInputElement size]):
(-[DOMHTMLInputElement src]):
(-[DOMHTMLInputElement value]):
(-[DOMHTMLInputElement validationMessage]):
(-[DOMHTMLInputElement altDisplayString]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLLinkElement.mm:
(-[DOMHTMLLinkElement href]):
(-[DOMHTMLLinkElement crossOrigin]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLMediaElement.mm:
(-[DOMHTMLMediaElement src]):
(-[DOMHTMLMediaElement currentSrc]):
(-[DOMHTMLMediaElement crossOrigin]):
(-[DOMHTMLMediaElement preload]):
(-[DOMHTMLMediaElement canPlayType:]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLModElement.mm:
(-[DOMHTMLModElement cite]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLObjectElement.mm:
(-[DOMHTMLObjectElement data]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLOptionElement.mm:
(-[DOMHTMLOptionElement label]):
(-[DOMHTMLOptionElement value]):
(-[DOMHTMLOptionElement text]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLQuoteElement.mm:
(-[DOMHTMLQuoteElement cite]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLScriptElement.mm:
(-[DOMHTMLScriptElement text]):
(-[DOMHTMLScriptElement src]):
(-[DOMHTMLScriptElement crossOrigin]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLSelectElement.mm:
(-[DOMHTMLSelectElement value]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLTextAreaElement.mm:
(-[DOMHTMLTextAreaElement defaultValue]):
(-[DOMHTMLTextAreaElement value]):
(-[DOMHTMLTextAreaElement autocomplete]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLTitleElement.mm:
(-[DOMHTMLTitleElement text]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLVideoElement.mm:
(-[DOMHTMLVideoElement poster]):
* Source/WebKitLegacy/mac/DOM/DOMMediaList.mm:
(-[DOMMediaList mediaText]):
(-[DOMMediaList item:]):
* Source/WebKitLegacy/mac/DOM/DOMMutationEvent.mm:
(-[DOMMutationEvent prevValue]):
(-[DOMMutationEvent newValue]):
(-[DOMMutationEvent attrName]):
* Source/WebKitLegacy/mac/DOM/DOMNode.mm:
(-[DOMNode nodeName]):
(-[DOMNode nodeValue]):
(-[DOMNode baseURI]):
(-[DOMNode textContent]):
* Source/WebKitLegacy/mac/DOM/DOMProcessingInstruction.mm:
(-[DOMProcessingInstruction target]):
* Source/WebKitLegacy/mac/DOM/DOMRange.mm:
(-[DOMRange text]):
(-[DOMRange toString]):
* Source/WebKitLegacy/mac/DOM/DOMStyleSheet.mm:
(-[DOMStyleSheet type]):
(-[DOMStyleSheet href]):
(-[DOMStyleSheet title]):
* Source/WebKitLegacy/mac/DOM/DOMText.mm:
(-[DOMText wholeText]):
* Source/WebKitLegacy/mac/DOM/DOMTextEvent.mm:
(-[DOMTextEvent data]):
* Source/WebKitLegacy/mac/DOM/DOMXPathResult.mm:
(-[DOMXPathResult stringValue]):
* Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm:
(-[DOMNode markupString]):
(-[DOMRange markupString]):
* Source/WebKitLegacy/mac/History/WebHistoryItem.mm:
(-[WebHistoryItem hash]):
(-[WebHistoryItem description]):
* Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm:
(-[WebFrame renderTreeAsExternalRepresentationForPrinting]):
(-[WebFrame renderTreeAsExternalRepresentationWithOptions:]):
* Source/WebKitLegacy/mac/Misc/WebElementDictionary.mm:
(NSStringOrNil):
* Source/WebKitLegacy/mac/Misc/WebNSPasteboardExtras.mm:
(-[NSPasteboard _web_declareAndWriteDragImageForElement:URL:title:archive:source:]):
* Source/WebKitLegacy/mac/Misc/WebNSURLExtras.mm:
(-[NSString _webkit_stringByReplacingValidPercentEscapes]):
* Source/WebKitLegacy/mac/Misc/WebNSUserDefaultsExtras.mm:
(+[NSUserDefaults _webkit_preferredLanguageCode]):
* Source/WebKitLegacy/mac/Misc/WebStringTruncator.mm:
(+[WebStringTruncator centerTruncateString:toWidth:]):
(+[WebStringTruncator centerTruncateString:toWidth:withFont:]):
(+[WebStringTruncator rightTruncateString:toWidth:withFont:]):
* Source/WebKitLegacy/mac/Misc/WebUserContentURLPattern.mm:
(-[WebUserContentURLPattern scheme]):
(-[WebUserContentURLPattern host]):
* Source/WebKitLegacy/mac/Plugins/WebBasePluginPackage.mm:
(-[WebBasePluginPackage initWithPath:]):
(-[WebBasePluginPackage getPluginInfoFromPLists]):
* Source/WebKitLegacy/mac/Plugins/WebPluginDatabase.mm:
(-[WebPluginDatabase _addPlugin:]):
(-[WebPluginDatabase _removePlugin:]):
* Source/WebKitLegacy/mac/Plugins/WebPluginPackage.mm:
(-[WebPluginPackage initWithPath:]):
(-[WebPluginPackage load]):
* Source/WebKitLegacy/mac/Scripts/PreferencesTemplates/WebPreferencesDefinitions.h.erb:
* Source/WebKitLegacy/mac/Storage/WebDatabaseManager.mm:
(-[WebDatabaseManager detailsForDatabase:withOrigin:]):
* Source/WebKitLegacy/mac/Storage/WebDatabaseManagerClient.mm:
(WebKit::WebDatabaseManagerClient::dispatchDidModifyDatabase):
* Source/WebKitLegacy/mac/Storage/WebDatabaseProvider.mm:
(WebDatabaseProvider::indexedDatabaseDirectoryPath):
* Source/WebKitLegacy/mac/WebCoreSupport/CorrectionPanel.mm:
(CorrectionPanel::show):
(CorrectionPanel::recordAutocorrectionResponse):
* Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm:
(PopupMenuMac::populate):
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm:
(WebChromeClient::addMessageToConsole):
(WebChromeClient::runBeforeUnloadConfirmPanel):
(WebChromeClient::runJavaScriptAlert):
(WebChromeClient::runJavaScriptConfirm):
(WebChromeClient::runJavaScriptPrompt):
(WebChromeClient::setToolTip):
(WebChromeClient::exceededDatabaseQuota):
(WebChromeClient::setMockMediaPlaybackTargetPickerState):
* Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm:
(WebContextMenuClient::speak):
* Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm:
(WebDragClient::willPerformDragSourceAction):
(WebDragClient::startDrag):
(WebDragClient::declareAndWriteDragImage):
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm:
(WebEditorClient::shouldInsertText):
(WebEditorClient::setInsertionPasteboard):
(WebEditorClient::registerUndoOrRedoStep):
(WebEditorClient::ignoreWordInSpellDocument):
(WebEditorClient::learnWord):
(WebEditorClient::updateSpellingUIWithGrammarString):
(WebEditorClient::updateSpellingUIWithMisspelledWord):
(WebEditorClient::getGuessesForWord):
(WebEditorClient::requestCandidatesForSelection):
(WebEditorClient::requestCheckingOfString):
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::dispatchDidReceiveServerRedirectForProvisionalLoad):
(WebFrameLoaderClient::dispatchDidChangeLocationWithinPage):
(WebFrameLoaderClient::dispatchDidPushStateWithinPage):
(WebFrameLoaderClient::dispatchDidReplaceStateWithinPage):
(WebFrameLoaderClient::dispatchDidPopStateWithinPage):
(WebFrameLoaderClient::dispatchDidStartProvisionalLoad):
(WebFrameLoaderClient::dispatchDidReceiveTitle):
(WebFrameLoaderClient::dispatchDecidePolicyForResponse):
(WebFrameLoaderClient::dispatchDecidePolicyForNewWindowAction):
(makeFormFieldValuesDictionary):
(nilOrNSString):
(WebFrameLoaderClient::updateGlobalHistory):
(WebFrameLoaderClient::updateGlobalHistoryRedirectLinks):
(WebFrameLoaderClient::canShowMIMEType const):
(WebFrameLoaderClient::canShowMIMETypeAsHTML const):
(WebFrameLoaderClient::setTitle):
(WebFrameLoaderClient::objectContentType):
(WebFrameLoaderClient::createPlugin):
* Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm:
(WebInspectorFrontendClient::updateWindowTitle const):
(WebInspectorFrontendClient::save):
* Source/WebKitLegacy/mac/WebCoreSupport/WebSecurityOrigin.mm:
(-[WebSecurityOrigin protocol]):
(-[WebSecurityOrigin host]):
(-[WebSecurityOrigin databaseIdentifier]):
(-[WebSecurityOrigin stringValue]):
* Source/WebKitLegacy/mac/WebCoreSupport/WebValidationMessageClient.mm:
(WebValidationMessageClient::showValidationMessage):
* Source/WebKitLegacy/mac/WebView/WebDataSource.mm:
(-[WebDataSource textEncodingName]):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _selectedString]):
(-[WebFrame _stringForRange:]):
(-[WebFrame _stringByEvaluatingJavaScriptFromString:forceUserGesture:]):
(-[WebFrame _stringByEvaluatingJavaScriptFromString:withGlobalObject:inScriptWorld:]):
(-[WebFrame _layerTreeAsText]):
* Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm:
(-[WebHTMLRepresentation documentSource]):
(searchForLabelsBeforeElement):
(matchLabelsAgainstString):
(matchLabelsAgainstElement):
(-[WebHTMLRepresentation searchForLabels:beforeElement:resultDistance:resultIsInCellAbove:]):
(-[WebHTMLRepresentation matchLabels:againstElement:]):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(fixMenusReceivedFromOldClients):
(createShareMenuItem):
(createMenuItem):
(-[WebHTMLView namesOfPromisedFilesDroppedAtDestination:]):
(-[WebHTMLView _executeSavedKeypressCommands]):
(-[WebHTMLView _interpretKeyEvent:savingCommands:]):
* Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm:
(-[WebImmediateActionController _animationControllerForDataDetectedLink]):
* Source/WebKitLegacy/mac/WebView/WebNotification.mm:
(-[WebNotification title]):
(-[WebNotification body]):
(-[WebNotification tag]):
(-[WebNotification iconURL]):
(-[WebNotification lang]):
(-[WebNotification origin]):
(-[WebNotification notificationID]):
* Source/WebKitLegacy/mac/WebView/WebPreferences.mm:
(+[WebPreferences _setInitialDefaultTextEncodingToSystemEncoding]):
* Source/WebKitLegacy/mac/WebView/WebResource.mm:
(-[WebResource encodeWithCoder:]):
(-[WebResource MIMEType]):
(-[WebResource textEncodingName]):
(-[WebResource frameName]):
(-[WebResource _suggestedFilename]):
(-[WebResource _stringValue]):
* Source/WebKitLegacy/mac/WebView/WebScriptDebugger.mm:
(toNSString):
(WebScriptDebugger::sourceParsed):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebTextListTouchBarViewController initWithWebView:]):
(-[WebTextTouchBarItemController _webChangeColor:]):
(+[WebView _standardUserAgentWithApplicationName:]):
(+[WebView _decodeData:]):
(-[WebView _contentsOfUserInterfaceItem:]):
(-[WebView customUserAgent]):
(-[WebView userAgentForURL:]):
(-[WebView groupName]):
(aeDescFromJSValue):
(-[WebView _handleContextMenuTranslation:]):
(-[WebView _notificationIDForTesting:]):

Canonical link: <a href="https://commits.webkit.org/293616@main">https://commits.webkit.org/293616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53f06887b06c1188373749cbf4f2a4fb95c7e3e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99337 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104468 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49938 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19275 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75601 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32709 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102344 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14652 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89686 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55961 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14446 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7667 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49298 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84371 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7754 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106825 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26451 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84562 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26813 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85888 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84074 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28744 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6430 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20191 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16183 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26391 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31591 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26211 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29524 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27778 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->