### PR TITLE
perf issues with rowspan="0" on huge complex tables

### DIFF
--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug30332-1-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug30332-1-expected.txt
@@ -12,7 +12,7 @@ layer at (0,0) size 800x600
         RenderTable {TABLE} at (0,0) size 784x38 [border: (5px outset #000000)]
           RenderTableSection {TBODY} at (5,5) size 774x28
             RenderTableRow {TR} at (0,2) size 774x0
-              RenderTableCell {TD} at (2,3) size 375x22 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+              RenderTableCell {TD} at (2,3) size 375x22 [border: (1px inset #000000)] [r=0 c=0 rs=3 cs=1]
                 RenderText {#text} at (2,3) size 27x18
                   text run at (2,2) width 27: "One"
             RenderTableRow {TR} at (0,4) size 774x22

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug30332-2-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug30332-2-expected.txt
@@ -12,7 +12,7 @@ layer at (0,0) size 800x222
         RenderTable {TABLE} at (0,0) size 784x38 [border: (5px outset #000000)]
           RenderTableSection {TBODY} at (5,5) size 774x28
             RenderTableRow {TR} at (0,2) size 774x0
-              RenderTableCell {TD} at (2,3) size 375x22 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+              RenderTableCell {TD} at (2,3) size 375x22 [border: (1px inset #000000)] [r=0 c=0 rs=3 cs=1]
                 RenderText {#text} at (2,3) size 27x18
                   text run at (2,2) width 27: "One"
             RenderTableRow {TR} at (0,4) size 774x22

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug9879-1-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug9879-1-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x348
       RenderTable {TABLE} at (0,0) size 158x52 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 156x50
           RenderTableRow {TR} at (0,2) size 156x22
-            RenderTableCell {TD} at (2,14) size 71x22 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+            RenderTableCell {TD} at (2,14) size 71x22 [border: (1px inset #000000)] [r=0 c=0 rs=3 cs=1]
               RenderText {#text} at (2,14) size 67x18
                 text run at (2,2) width 67: "rowspan 0"
             RenderTableCell {TD} at (74,2) size 66x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
@@ -81,7 +81,7 @@ layer at (0,0) size 800x348
             RenderTableCell {TD} at (2,2) size 32x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x18
                 text run at (2,2) width 28: "auto"
-            RenderTableCell {TD} at (35,14) size 71x22 [border: (1px inset #000000)] [r=0 c=1 rs=65534 cs=1]
+            RenderTableCell {TD} at (35,14) size 71x22 [border: (1px inset #000000)] [r=0 c=1 rs=3 cs=1]
               RenderText {#text} at (2,14) size 67x18
                 text run at (2,2) width 67: "rowspan 0"
             RenderTableCell {TD} at (107,2) size 33x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug9879-1-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug9879-1-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x348
       RenderTable {TABLE} at (0,0) size 158x52 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 156x50
           RenderTableRow {TR} at (0,2) size 156x22
-            RenderTableCell {TD} at (2,14) size 71x22 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+            RenderTableCell {TD} at (2,14) size 71x22 [border: (1px inset #000000)] [r=0 c=0 rs=3 cs=1]
               RenderText {#text} at (2,14) size 67x18
                 text run at (2,2) width 67: "rowspan 0"
             RenderTableCell {TD} at (74,2) size 66x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
@@ -81,7 +81,7 @@ layer at (0,0) size 800x348
             RenderTableCell {TD} at (2,2) size 32x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x18
                 text run at (2,2) width 28: "auto"
-            RenderTableCell {TD} at (35,14) size 71x22 [border: (1px inset #000000)] [r=0 c=1 rs=65534 cs=1]
+            RenderTableCell {TD} at (35,14) size 71x22 [border: (1px inset #000000)] [r=0 c=1 rs=3 cs=1]
               RenderText {#text} at (2,14) size 67x18
                 text run at (2,2) width 67: "rowspan 0"
             RenderTableCell {TD} at (107,2) size 33x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]

--- a/Source/WebCore/html/HTMLTableCellElement.cpp
+++ b/Source/WebCore/html/HTMLTableCellElement.cpp
@@ -65,8 +65,8 @@ unsigned HTMLTableCellElement::rowSpan() const
     // > For this attribute, the value zero means that the cell is
     // > to span all the remaining rows in the row group.
     if (!rowSpanValue)
-        return maxRowspan;
-    return std::max(1u, rowSpanValue);
+        return 0;
+    return rowSpanValue;
 }
 
 unsigned HTMLTableCellElement::rowSpanForBindings() const

--- a/Source/WebCore/rendering/RenderTableCell.h
+++ b/Source/WebCore/rendering/RenderTableCell.h
@@ -46,6 +46,7 @@ public:
     
     unsigned colSpan() const;
     unsigned rowSpan() const;
+    unsigned parseRowSpan() const;
 
     // Called from HTMLTableCellElement.
     void colSpanOrRowSpanChanged();
@@ -228,11 +229,21 @@ inline unsigned RenderTableCell::colSpan() const
     return parseColSpanFromDOM();
 }
 
-inline unsigned RenderTableCell::rowSpan() const
+inline unsigned RenderTableCell::parseRowSpan() const
 {
     if (!m_hasRowSpan)
         return 1;
     return parseRowSpanFromDOM();
+}
+
+inline unsigned RenderTableCell::rowSpan() const
+{
+    unsigned computedRowSpan = parseRowSpan();
+    if (!computedRowSpan) {
+        ASSERT(!section()->needsCellRecalc());
+        computedRowSpan = section()->numRows() - rowIndex();
+    }
+    return std::min(computedRowSpan, maxRowIndex);
 }
 
 inline void RenderTableCell::setCol(unsigned column)

--- a/Source/WebCore/rendering/RenderTableRow.cpp
+++ b/Source/WebCore/rendering/RenderTableRow.cpp
@@ -131,7 +131,7 @@ void RenderTableRow::didInsertTableCell(RenderTableCell& child, RenderObject* be
     // Generated content can result in us having a null section so make sure to null check our parent.
     if (auto* section = this->section()) {
         section->addCell(&child, this);
-        if (beforeChild || nextRow())
+        if (beforeChild || nextRow() || !child.parseRowSpan())
             section->setNeedsCellRecalc();
     }
     if (auto* table = this->table())

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -1383,11 +1383,11 @@ void RenderTableSection::recalcCells()
     // and update its dimensions to be consistent with the table's column representation before we rebuild
     // the grid using addCell().
     m_needsCellRecalc = false;
-
     m_cCol = 0;
     m_cRow = 0;
     m_grid.clear();
 
+    bool resizedGrid = false;
     for (RenderTableRow* row = firstRow(); row; row = row->nextRow()) {
         unsigned insertionRow = m_cRow;
         m_cRow++;
@@ -1398,12 +1398,21 @@ void RenderTableSection::recalcCells()
         row->setRowIndex(insertionRow);
         setRowLogicalHeightToRowStyleLogicalHeight(m_grid[insertionRow]);
 
-        for (RenderTableCell* cell = row->firstCell(); cell; cell = cell->nextCell())
-            addCell(cell, row);
-    }
+        for (RenderTableCell* cell = row->firstCell(); cell; cell = cell->nextCell()) {
+            if (!cell->parseRowSpan() && !resizedGrid) {
+                unsigned rowPos = row->rowIndex() + 1;
+
+                for (RenderTableRow* remainingRow = row; remainingRow; remainingRow = remainingRow->nextRow())
+                    rowPos++;
+                ensureRows(rowPos);
+                resizedGrid = true;
+            }
+        addCell(cell, row);
+        }
 
     m_grid.shrinkToFit();
     setNeedsLayout();
+    }
 }
 
 void RenderTableSection::removeRedundantColumns()


### PR DESCRIPTION
#### eca3b4debf3b9045a29609cf000b3c3eec94082d
<pre>
perf issues with rowspan=&quot;0&quot; on huge complex tables
<a href="https://bugs.webkit.org/show_bug.cgi?id=291405">https://bugs.webkit.org/show_bug.cgi?id=291405</a>
<a href="https://rdar.apple.com/146056348">rdar://146056348</a>

Reviewed by NOBODY (OOPS!).

rowspan=&quot;0&quot; needs to be properly handled at the rendering stage. This
patch improves the performances bottleneck introduced in
bugs.webkit.org/b/185341 which was here to fix a layout issue. rowspan
was not doing the right thing before.

There are probably still things to improve in terms of performances.

* LayoutTests/platform/mac/tables/mozilla/bugs/bug30332-1-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug30332-2-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug9879-1-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug9879-1-expected.txt:
* Source/WebCore/html/HTMLTableCellElement.cpp:
(WebCore::HTMLTableCellElement::rowSpan const):
* Source/WebCore/rendering/RenderTableCell.h:
(WebCore::RenderTableCell::parseRowSpan const):
(WebCore::RenderTableCell::rowSpan const):
* Source/WebCore/rendering/RenderTableRow.cpp:
(WebCore::RenderTableRow::didInsertTableCell):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::recalcCells):
</pre>