### PR TITLE
Deploy more smart pointers in makeVector

### DIFF
--- a/Source/WTF/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -1,4 +1,3 @@
-WebKitBuild/Release/usr/local/include/wtf/cf/VectorCF.h
 wtf/RetainPtr.h
 wtf/cf/LanguageCF.cpp
 wtf/cf/SchedulePairCF.cpp

--- a/Source/WTF/wtf/cf/VectorCF.h
+++ b/Source/WTF/wtf/cf/VectorCF.h
@@ -130,8 +130,8 @@ template<typename VectorElementType, typename CFType> Vector<VectorElementType> 
     vector.reserveInitialCapacity(count);
     for (CFIndex i = 0; i < count; ++i) {
         constexpr const VectorElementType* typedNull = nullptr;
-        if (CFType element = dynamic_cf_cast<CFType>(CFArrayGetValueAtIndex(array, i))) {
-            if (auto vectorElement = makeVectorElement(typedNull, element))
+        if (RetainPtr element = dynamic_cf_cast<CFType>(CFArrayGetValueAtIndex(array, i))) {
+            if (auto vectorElement = makeVectorElement(typedNull, element.get()))
                 vector.append(WTFMove(*vectorElement));
         }
     }
@@ -151,8 +151,8 @@ template<typename MapLambdaType> Vector<typename LambdaTypeTraits<MapLambdaType>
     CFIndex count = CFArrayGetCount(array);
     vector.reserveInitialCapacity(count);
     for (CFIndex i = 0; i < count; ++i) {
-        if (CFType element = dynamic_cf_cast<CFType>(CFArrayGetValueAtIndex(array, i))) {
-            if (auto vectorElement = std::invoke(std::forward<MapLambdaType>(lambda), element))
+        if (RetainPtr element = dynamic_cf_cast<CFType>(CFArrayGetValueAtIndex(array, i))) {
+            if (auto vectorElement = std::invoke(std::forward<MapLambdaType>(lambda), element.get()))
                 vector.append(WTFMove(*vectorElement));
         }
     }


### PR DESCRIPTION
#### e00b6f602472b6d38c78ec086b1e5af6c1922965
<pre>
Deploy more smart pointers in makeVector
<a href="https://bugs.webkit.org/show_bug.cgi?id=291411">https://bugs.webkit.org/show_bug.cgi?id=291411</a>

Reviewed by Chris Dumez.

Fix the clang static analyzer warnings in makeVector by deploying more RetainPtr.

* Source/WTF/wtf/cf/VectorCF.h:
(WTF::makeVector):

Canonical link: <a href="https://commits.webkit.org/293595@main">https://commits.webkit.org/293595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc10a0d434ee3439bd720de026e17ace380e0cd2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99344 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18993 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104475 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49945 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27427 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75610 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32712 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102351 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89695 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55969 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14452 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7677 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49305 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92027 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106832 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97963 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26458 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19303 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84569 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26820 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84081 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28748 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6439 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20201 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16172 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26398 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31598 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121579 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26218 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33956 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29531 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27785 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->