### PR TITLE
Reduce unsafe lambdas in WebCore/dom

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -56,15 +56,10 @@ css/CSSValue.cpp
 css/CSSVariableReferenceValue.cpp
 css/SelectorChecker.cpp
 css/StyleRule.cpp
-dom/ContainerNode.cpp
 dom/ContentVisibilityDocumentState.cpp
 dom/CustomElementDefaultARIA.cpp
 dom/Document.cpp
-dom/MessagePort.cpp
-dom/Node.cpp
 dom/Subscriber.cpp
-dom/ViewTransition.cpp
-dom/ViewportArguments.cpp
 editing/Editor.cpp
 html/FormAssociatedCustomElement.cpp
 html/canvas/CanvasRenderingContext2DBase.cpp

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -301,7 +301,7 @@ static ContainerNode::ChildChange makeChildChangeForCloneInsertion(ClonedChildIn
 
 template<typename DOMInsertionWork>
 static ALWAYS_INLINE void executeNodeInsertionWithScriptAssertion(ContainerNode& containerNode, Node& child, Node* beforeChild,
-    ContainerNode::ChildChange::Source source, ReplacedAllChildren replacedAllChildren, DOMInsertionWork doNodeInsertion)
+    ContainerNode::ChildChange::Source source, ReplacedAllChildren replacedAllChildren, NOESCAPE const DOMInsertionWork& doNodeInsertion)
 {
     auto childChange = makeChildChangeForInsertion(containerNode, child, beforeChild, source, replacedAllChildren);
 
@@ -331,7 +331,7 @@ static ALWAYS_INLINE void executeNodeInsertionWithScriptAssertion(ContainerNode&
 }
 
 template<typename DOMInsertionWork>
-static ALWAYS_INLINE void executeParserNodeInsertionIntoIsolatedTreeWithoutNotifyingParent(ContainerNode& containerNode, Node& child, DOMInsertionWork doNodeInsertion)
+static ALWAYS_INLINE void executeParserNodeInsertionIntoIsolatedTreeWithoutNotifyingParent(ContainerNode& containerNode, Node& child, NOESCAPE const DOMInsertionWork& doNodeInsertion)
 {
     {
         WidgetHierarchyUpdatesSuspensionScope suspendWidgetHierarchyUpdates;

--- a/Source/WebCore/dom/EventListenerMap.h
+++ b/Source/WebCore/dom/EventListenerMap.h
@@ -68,14 +68,14 @@ public:
     Vector<AtomString> eventTypes() const;
 
     template<typename CallbackType>
-    void enumerateEventListenerTypes(CallbackType callback) const
+    void enumerateEventListenerTypes(NOESCAPE const CallbackType& callback) const
     {
         for (auto& entry : m_entries)
             callback(entry.first, entry.second.size());
     }
 
     template<typename CallbackType>
-    bool containsMatchingEventListener(CallbackType callback) const
+    bool containsMatchingEventListener(NOESCAPE const CallbackType& callback) const
     {
         for (auto& entry : m_entries) {
             if (callback(entry.first, m_entries))

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -152,14 +152,14 @@ public:
     }
 
     template<typename CallbackType>
-    void enumerateEventListenerTypes(CallbackType callback) const
+    void enumerateEventListenerTypes(NOESCAPE const CallbackType& callback) const
     {
         if (auto* data = eventTargetData())
             data->eventListenerMap.enumerateEventListenerTypes(callback);
     }
 
     template<typename CallbackType>
-    bool containsMatchingEventListener(CallbackType callback) const
+    bool containsMatchingEventListener(NOESCAPE const CallbackType& callback) const
     {
         if (auto* data = eventTargetData())
             return data->eventListenerMap.containsMatchingEventListener(callback);

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -2210,7 +2210,7 @@ enum EventTargetInterfaceType Node::eventTargetInterface() const
 }
 
 template <typename MoveNodeFunction, typename MoveShadowRootFunction>
-static unsigned traverseSubtreeToUpdateTreeScope(Node& root, MoveNodeFunction moveNode, MoveShadowRootFunction moveShadowRoot)
+static unsigned traverseSubtreeToUpdateTreeScope(Node& root, NOESCAPE const MoveNodeFunction& moveNode, NOESCAPE const MoveShadowRootFunction& moveShadowRoot)
 {
     unsigned count = 0;
     for (Node* node = &root; node; node = NodeTraversal::next(*node, &root)) {

--- a/Source/WebCore/dom/ViewportArguments.cpp
+++ b/Source/WebCore/dom/ViewportArguments.cpp
@@ -203,7 +203,7 @@ void restrictScaleFactorToInitialScaleIfNotUserScalable(ViewportAttributes& resu
         result.maximumScale = result.minimumScale = result.initialScale;
 }
 
-static float numericPrefix(StringView key, StringView value, const InternalViewportErrorHandler& errorHandler, bool* ok = nullptr)
+static float numericPrefix(StringView key, StringView value, NOESCAPE const InternalViewportErrorHandler& errorHandler, bool* ok = nullptr)
 {
     size_t parsedLength;
     float numericValue;
@@ -224,7 +224,7 @@ static float numericPrefix(StringView key, StringView value, const InternalViewp
     return numericValue;
 }
 
-static float findSizeValue(StringView key, StringView value, const InternalViewportErrorHandler& errorHandler, bool* valueWasExplicit = nullptr)
+static float findSizeValue(StringView key, StringView value, NOESCAPE const InternalViewportErrorHandler& errorHandler, bool* valueWasExplicit = nullptr)
 {
     // 1) Non-negative number values are translated to px lengths.
     // 2) Negative number values are translated to auto.
@@ -251,7 +251,7 @@ static float findSizeValue(StringView key, StringView value, const InternalViewp
     return sizeValue;
 }
 
-static float findScaleValue(StringView key, StringView value, const InternalViewportErrorHandler& errorHandler)
+static float findScaleValue(StringView key, StringView value, NOESCAPE const InternalViewportErrorHandler& errorHandler)
 {
     // 1) Non-negative number values are translated to <number> values.
     // 2) Negative number values are translated to auto.
@@ -279,7 +279,7 @@ static float findScaleValue(StringView key, StringView value, const InternalView
     return numericValue;
 }
 
-static bool findBooleanValue(StringView key, StringView value, const InternalViewportErrorHandler& errorHandler)
+static bool findBooleanValue(StringView key, StringView value, NOESCAPE const InternalViewportErrorHandler& errorHandler)
 {
     // yes and no are used as keywords.
     // Numbers >= 1, numbers <= -1, device-width and device-height are mapped to yes.
@@ -296,7 +296,7 @@ static bool findBooleanValue(StringView key, StringView value, const InternalVie
     return std::abs(numericPrefix(key, value, errorHandler)) >= 1;
 }
 
-static ViewportFit parseViewportFitValue(StringView key, StringView value, const InternalViewportErrorHandler& errorHandler)
+static ViewportFit parseViewportFitValue(StringView key, StringView value, NOESCAPE const InternalViewportErrorHandler& errorHandler)
 {
     if (equalLettersIgnoringASCIICase(value, "auto"_s))
         return ViewportFit::Auto;
@@ -366,7 +366,7 @@ static void reportViewportWarning(Document& document, ViewportErrorCode errorCod
     document.addConsoleMessage(MessageSource::Rendering, viewportErrorMessageLevel(errorCode), message);
 }
 
-void setViewportFeature(ViewportArguments& arguments, StringView key, StringView value, const ViewportErrorHandler& errorHandler)
+void setViewportFeature(ViewportArguments& arguments, StringView key, StringView value, NOESCAPE const ViewportErrorHandler& errorHandler)
 {
     InternalViewportErrorHandler internalErrorHandler = [&errorHandler] (ViewportErrorCode errorCode, StringView replacement1, StringView replacement2) {
         errorHandler(errorCode, viewportErrorMessage(errorCode, replacement1, replacement2));

--- a/Source/WebCore/dom/ViewportArguments.h
+++ b/Source/WebCore/dom/ViewportArguments.h
@@ -149,7 +149,7 @@ WEBCORE_EXPORT float computeMinimumScaleFactorForContentContained(const Viewport
 
 typedef Function<void(ViewportErrorCode, const String&)> ViewportErrorHandler;
 void setViewportFeature(ViewportArguments&, Document&, StringView key, StringView value);
-WEBCORE_EXPORT void setViewportFeature(ViewportArguments&, StringView key, StringView value, const ViewportErrorHandler&);
+WEBCORE_EXPORT void setViewportFeature(ViewportArguments&, StringView key, StringView value, NOESCAPE const ViewportErrorHandler&);
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const ViewportArguments&);
 


### PR DESCRIPTION
#### 7b92378a90e6a02c21193d3bb25158ca7cc6885c
<pre>
Reduce unsafe lambdas in WebCore/dom
<a href="https://bugs.webkit.org/show_bug.cgi?id=291416">https://bugs.webkit.org/show_bug.cgi?id=291416</a>

Reviewed by Chris Dumez.

As per Safer CPP Guidelines:

- <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#capture-protectedthis-or-weakthis-in-asynchronous-lambdas-where-you-need-to-use-this">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#capture-protectedthis-or-weakthis-in-asynchronous-lambdas-where-you-need-to-use-this</a>
- <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#annotate-noescape-when-a-function-uses-a-lambda-synchronously">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#annotate-noescape-when-a-function-uses-a-lambda-synchronously</a>

* Source/WebCore/Modules/cache/DOMCache.cpp:
(WebCore::DOMCache::put):
(WebCore::DOMCache::queryCache):
(WebCore::DOMCache::batchDeleteOperation):
(WebCore::DOMCache::batchPutOperation):
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::executeNodeInsertionWithScriptAssertion):
(WebCore::executeParserNodeInsertionIntoIsolatedTreeWithoutNotifyingParent):
* Source/WebCore/dom/EventListenerMap.h:
(WebCore::EventListenerMap::enumerateEventListenerTypes const):
(WebCore::EventListenerMap::containsMatchingEventListener const):
* Source/WebCore/dom/EventTarget.h:
(WebCore::EventTarget::enumerateEventListenerTypes const):
(WebCore::EventTarget::containsMatchingEventListener const):
* Source/WebCore/dom/MessagePort.cpp:
(WebCore::MessagePort::dispatchMessages):
* Source/WebCore/dom/Node.cpp:
(WebCore::traverseSubtreeToUpdateTreeScope):
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::skipViewTransition):
(WebCore::ViewTransition::callUpdateCallback):
(WebCore::ViewTransition::setupViewTransition):
(WebCore::forEachRendererInPaintOrder):
* Source/WebCore/dom/ViewportArguments.cpp:
(WebCore::numericPrefix):
(WebCore::findSizeValue):
(WebCore::findScaleValue):
(WebCore::findBooleanValue):
(WebCore::parseViewportFitValue):
(WebCore::setViewportFeature):
* Source/WebCore/dom/ViewportArguments.h:

Canonical link: <a href="https://commits.webkit.org/293625@main">https://commits.webkit.org/293625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1c65a6ff1e4474f2df8a648d710be162928e50b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99440 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9343 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104571 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50041 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101481 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19378 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27523 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75687 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32782 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102447 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89789 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56046 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14542 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7772 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49401 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84462 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7865 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106929 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26554 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84644 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26916 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84161 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28834 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6529 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20299 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16189 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26494 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31695 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26314 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29627 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27881 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->