### PR TITLE
Reduce unsafe lambdas in WebCore/svg and WTF

### DIFF
--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -333,12 +333,12 @@ public:
     static WTF_EXPORT_PRIVATE Expected<size_t, UTF8ConversionError> utf8ForCharactersIntoBuffer(std::span<const UChar> characters, ConversionMode, Vector<char8_t, 1024>&);
 
     template<typename Func>
-    static Expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8ConversionError> tryGetUTF8ForCharacters(const Func&, std::span<const LChar> characters);
+    static Expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8ConversionError> tryGetUTF8ForCharacters(NOESCAPE const Func&, std::span<const LChar> characters);
     template<typename Func>
-    static Expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8ConversionError> tryGetUTF8ForCharacters(const Func&, std::span<const UChar> characters, ConversionMode = LenientConversion);
+    static Expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8ConversionError> tryGetUTF8ForCharacters(NOESCAPE const Func&, std::span<const UChar> characters, ConversionMode = LenientConversion);
 
     template<typename Func>
-    Expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8ConversionError> tryGetUTF8(const Func&, ConversionMode = LenientConversion) const;
+    Expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8ConversionError> tryGetUTF8(NOESCAPE const Func&, ConversionMode = LenientConversion) const;
     WTF_EXPORT_PRIVATE Expected<CString, UTF8ConversionError> tryGetUTF8(ConversionMode = LenientConversion) const;
     WTF_EXPORT_PRIVATE CString utf8(ConversionMode = LenientConversion) const;
 
@@ -1373,7 +1373,7 @@ inline Ref<StringImpl> StringImpl::createByReplacingInCharacters(std::span<const
 }
 
 template<typename Func>
-inline Expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8ConversionError> StringImpl::tryGetUTF8(const Func& function, ConversionMode mode) const
+inline Expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8ConversionError> StringImpl::tryGetUTF8(NOESCAPE const Func& function, ConversionMode mode) const
 {
     if (is8Bit())
         return tryGetUTF8ForCharacters(function, span8());
@@ -1387,7 +1387,7 @@ static inline std::span<const char8_t> nonNullEmptyUTF8Span()
 }
 
 template<typename Func>
-inline Expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8ConversionError> StringImpl::tryGetUTF8ForCharacters(const Func& function, std::span<const LChar> characters)
+inline Expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8ConversionError> StringImpl::tryGetUTF8ForCharacters(NOESCAPE const Func& function, std::span<const LChar> characters)
 {
     if (characters.empty())
         return function(nonNullEmptyUTF8Span());
@@ -1425,7 +1425,7 @@ inline Expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8Conver
 }
 
 template<typename Func>
-inline Expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8ConversionError> StringImpl::tryGetUTF8ForCharacters(const Func& function, std::span<const UChar> characters, ConversionMode mode)
+inline Expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8ConversionError> StringImpl::tryGetUTF8ForCharacters(NOESCAPE const Func& function, std::span<const UChar> characters, ConversionMode mode)
 {
     if (characters.empty())
         return function(nonNullEmptyUTF8Span());

--- a/Source/WTF/wtf/text/StringParsingBuffer.h
+++ b/Source/WTF/wtf/text/StringParsingBuffer.h
@@ -125,7 +125,7 @@ private:
     std::span<const CharacterType> m_data;
 };
 
-template<typename StringType, typename Function> decltype(auto) readCharactersForParsing(StringType&& string, Function&& functor)
+template<typename StringType, typename Function> decltype(auto) readCharactersForParsing(StringType&& string, NOESCAPE const Function& functor)
 {
     if (string.is8Bit())
         return functor(StringParsingBuffer { string.span8() });

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -319,7 +319,7 @@ inline Vector<String> String::splitInternal(StringView separator) const
 }
 
 template<bool allowEmptyEntries>
-inline void String::splitInternal(UChar separator, const SplitFunctor& functor) const
+inline void String::splitInternal(UChar separator, NOESCAPE const SplitFunctor& functor) const
 {
     StringView view(*this);
 
@@ -345,7 +345,7 @@ inline Vector<String> String::splitInternal(UChar separator) const
     return result;
 }
 
-void String::split(UChar separator, const SplitFunctor& functor) const
+void String::split(UChar separator, NOESCAPE const SplitFunctor& functor) const
 {
     splitInternal<false>(separator, functor);
 }
@@ -360,7 +360,7 @@ Vector<String> String::split(StringView separator) const
     return splitInternal<false>(separator);
 }
 
-void String::splitAllowingEmptyEntries(UChar separator, const SplitFunctor& functor) const
+void String::splitAllowingEmptyEntries(UChar separator, NOESCAPE const SplitFunctor& functor) const
 {
     splitInternal<true>(separator, functor);
 }

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -120,7 +120,7 @@ public:
     WTF_EXPORT_PRIVATE CString utf8(ConversionMode = LenientConversion) const;
 
     template<typename Func>
-    Expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8ConversionError> tryGetUTF8(const Func&, ConversionMode = LenientConversion) const;
+    Expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8ConversionError> tryGetUTF8(NOESCAPE const Func&, ConversionMode = LenientConversion) const;
     WTF_EXPORT_PRIVATE Expected<CString, UTF8ConversionError> tryGetUTF8(ConversionMode) const;
     WTF_EXPORT_PRIVATE Expected<CString, UTF8ConversionError> tryGetUTF8() const;
 
@@ -214,11 +214,11 @@ public:
 
     using SplitFunctor = WTF::Function<void(StringView)>;
 
-    WTF_EXPORT_PRIVATE void split(UChar separator, const SplitFunctor&) const;
+    WTF_EXPORT_PRIVATE void split(UChar separator, NOESCAPE const SplitFunctor&) const;
     WTF_EXPORT_PRIVATE Vector<String> WARN_UNUSED_RETURN split(UChar separator) const;
     WTF_EXPORT_PRIVATE Vector<String> WARN_UNUSED_RETURN split(StringView separator) const;
 
-    WTF_EXPORT_PRIVATE void splitAllowingEmptyEntries(UChar separator, const SplitFunctor&) const;
+    WTF_EXPORT_PRIVATE void splitAllowingEmptyEntries(UChar separator, NOESCAPE const SplitFunctor&) const;
     WTF_EXPORT_PRIVATE Vector<String> WARN_UNUSED_RETURN splitAllowingEmptyEntries(UChar separator) const;
     WTF_EXPORT_PRIVATE Vector<String> WARN_UNUSED_RETURN splitAllowingEmptyEntries(StringView separator) const;
 
@@ -308,7 +308,7 @@ public:
     static constexpr unsigned MaxLength = StringImpl::MaxLength;
 
 private:
-    template<bool allowEmptyEntries> void splitInternal(UChar separator, const SplitFunctor&) const;
+    template<bool allowEmptyEntries> void splitInternal(UChar separator, NOESCAPE const SplitFunctor&) const;
     template<bool allowEmptyEntries> Vector<String> splitInternal(UChar separator) const;
     template<bool allowEmptyEntries> Vector<String> splitInternal(StringView separator) const;
 
@@ -498,7 +498,7 @@ inline String String::substring(unsigned position, unsigned length) const
 }
 
 template<typename Func>
-inline Expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8ConversionError> String::tryGetUTF8(const Func& function, ConversionMode mode) const
+inline Expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8ConversionError> String::tryGetUTF8(NOESCAPE const Func& function, ConversionMode mode) const
 {
     if (!m_impl)
         return function(nonNullEmptyUTF8Span());

--- a/Source/WTF/wtf/text/WYHash.h
+++ b/Source/WTF/wtf/text/WYHash.h
@@ -251,7 +251,7 @@ private:
     }
 
     template<typename T, typename Read8Functor>
-    ALWAYS_INLINE static constexpr void consume24Characters(const T* p, const Read8Functor& wyr8, uint64_t& seed, uint64_t& see1, uint64_t& see2)
+    ALWAYS_INLINE static constexpr void consume24Characters(const T* p, NOESCAPE const Read8Functor& wyr8, uint64_t& seed, uint64_t& see1, uint64_t& see2)
     {
         seed = wymix(wyr8(p) ^ secret[1], wyr8(p + 4) ^ seed);
         see1 = wymix(wyr8(p + 8) ^ secret[2], wyr8(p + 12) ^ see1);
@@ -268,7 +268,7 @@ private:
     }
 
     template<typename T, typename Read8Functor>
-    ALWAYS_INLINE static constexpr void handleGreaterThan8CharactersCase(T*& p, unsigned& i, const Read8Functor& wyr8, uint64_t& seed, uint64_t see1, uint64_t see2)
+    ALWAYS_INLINE static constexpr void handleGreaterThan8CharactersCase(T*& p, unsigned& i, NOESCAPE const Read8Functor& wyr8, uint64_t& seed, uint64_t see1, uint64_t see2)
     {
         if (UNLIKELY(i > 24)) {
             do {

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -122,9 +122,6 @@ style/ElementRuleCollector.cpp
 style/StyleBuilderConverter.h
 style/StyleTreeResolver.cpp
 style/Styleable.cpp
-svg/SVGAnimationElement.cpp
-svg/SVGViewSpec.cpp
-svg/properties/SVGPropertyOwnerRegistry.h
 testing/MockMediaSessionCoordinator.cpp
 workers/Worker.cpp
 workers/WorkerMessagingProxy.cpp

--- a/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
+++ b/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
@@ -180,7 +180,7 @@ public:
     // Enumerate all the SVGMemberAccessors recursively. The functor will be called and will
     // be given the pair<QualifiedName, SVGMemberAccessor> till the functor returns false.
     template<typename Functor>
-    static bool enumerateRecursively(const Functor& functor)
+    static bool enumerateRecursively(NOESCAPE const Functor& functor)
     {
         for (const auto& entry : attributeNameToAccessorMap()) {
             if (!functor(entry))
@@ -190,7 +190,7 @@ public:
     }
 
     template<typename Functor>
-    static bool lookupRecursivelyAndApply(const QualifiedName& attributeName, const Functor& functor)
+    static bool lookupRecursivelyAndApply(const QualifiedName& attributeName, NOESCAPE const Functor& functor)
     {
         if (auto* accessor = findAccessor(attributeName)) {
             functor(*accessor);
@@ -359,11 +359,11 @@ private:
     // from enumerateRecursively(). It returns true and is enable_if<I == sizeof...(BaseTypes)>. So it is mainly for
     // breaking the recursion.
     template<typename Functor, size_t I = 0>
-    static typename std::enable_if<I == sizeof...(BaseTypes), bool>::type enumerateRecursivelyBaseTypes(const Functor&) { return true; }
+    static typename std::enable_if<I == sizeof...(BaseTypes), bool>::type enumerateRecursivelyBaseTypes(NOESCAPE const Functor&) { return true; }
 
     // This version of animatedTypesBaseTypes() is enable_if<I < sizeof...(BaseTypes)>.
     template<typename Functor, size_t I = 0>
-    static typename std::enable_if<I < sizeof...(BaseTypes), bool>::type enumerateRecursivelyBaseTypes(const Functor& functor)
+    static typename std::enable_if<I < sizeof...(BaseTypes), bool>::type enumerateRecursivelyBaseTypes(NOESCAPE const Functor& functor)
     {
         // Get the base type at index 'I' using std::tuple and std::tuple_element.
         using BaseType = typename std::tuple_element<I, typename std::tuple<BaseTypes...>>::type;
@@ -380,10 +380,10 @@ private:
     }
 
     template<typename Functor, size_t I = 0>
-    static typename std::enable_if<I == sizeof...(BaseTypes), bool>::type lookupRecursivelyAndApplyBaseTypes(const QualifiedName&, const Functor&) { return false; }
+    static typename std::enable_if<I == sizeof...(BaseTypes), bool>::type lookupRecursivelyAndApplyBaseTypes(const QualifiedName&, NOESCAPE const Functor&) { return false; }
 
     template<typename Functor, size_t I = 0>
-    static typename std::enable_if<I < sizeof...(BaseTypes), bool>::type lookupRecursivelyAndApplyBaseTypes(const QualifiedName& attributeName, const Functor& functor)
+    static typename std::enable_if<I < sizeof...(BaseTypes), bool>::type lookupRecursivelyAndApplyBaseTypes(const QualifiedName& attributeName, NOESCAPE const Functor& functor)
     {
         // Get the base type at index 'I' using std::tuple and std::tuple_element.
         using BaseType = typename std::tuple_element<I, typename std::tuple<BaseTypes...>>::type;


### PR DESCRIPTION
#### 0613e80a48f9dab83f8649085fa78aac732c1769
<pre>
Reduce unsafe lambdas in WebCore/svg and WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=291418">https://bugs.webkit.org/show_bug.cgi?id=291418</a>

Reviewed by Chris Dumez.

* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::tryGetUTF8 const):
(WTF::StringImpl::tryGetUTF8ForCharacters):
* Source/WTF/wtf/text/StringParsingBuffer.h:
(WTF::readCharactersForParsing):
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::splitInternal const):
(WTF::String::split const):
(WTF::String::splitAllowingEmptyEntries const):
* Source/WTF/wtf/text/WTFString.h:
(WTF::String::tryGetUTF8 const):
* Source/WTF/wtf/text/WYHash.h:
(WTF::WYHash::consume24Characters):
(WTF::WYHash::handleGreaterThan8CharactersCase):
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h:
(WebCore::SVGPropertyOwnerRegistry::enumerateRecursively):
(WebCore::SVGPropertyOwnerRegistry::lookupRecursivelyAndApply):
(WebCore::SVGPropertyOwnerRegistry::enumerateRecursivelyBaseTypes):
(WebCore::SVGPropertyOwnerRegistry::lookupRecursivelyAndApplyBaseTypes):

Canonical link: <a href="https://commits.webkit.org/293582@main">https://commits.webkit.org/293582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f9b29e36daaac945ae53cd647214407c8d5d351

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19000 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9251 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/104482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49952 "Failed to checkout and rebase branch from PR 43949") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101392 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27434 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/104482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/49952 "Failed to checkout and rebase branch from PR 43949") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102358 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/14665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/89699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/104482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/14459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/7681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/49312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92034 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/7768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/106839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97970 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26465 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/106839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26827 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/85902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/106839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/28756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/6443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20208 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16160 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26405 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/31605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121586 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26225 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29538 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27792 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->