### PR TITLE
[HDR] Implement reliable way to detect an image hasHDRContent() or not

### DIFF
--- a/Source/WebCore/platform/graphics/BitmapImageDescriptor.h
+++ b/Source/WebCore/platform/graphics/BitmapImageDescriptor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -57,8 +57,8 @@ public:
     RepetitionCount repetitionCount() const;
     DestinationColorSpace colorSpace() const;
     std::optional<Color> singlePixelSolidColor() const;
-    Headroom headroom() const;
     bool hasHDRGainMap() const;
+    bool hasHDRColorSpace() const;
 
     String uti() const;
     String filenameExtension() const;
@@ -88,14 +88,13 @@ private:
         RepetitionCount             = 1 << 6,
         ColorSpace                  = 1 << 7,
         SinglePixelSolidColor       = 1 << 8,
-        Headroom                    = 1 << 9,
-        HasHDRGainMap               = 1 << 10,
+        HasHDRGainMap               = 1 << 9,
 
-        UTI                         = 1 << 11,
-        FilenameExtension           = 1 << 12,
-        AccessibilityDescription    = 1 << 13,
-        HotSpot                     = 1 << 14,
-        MaximumSubsamplingLevel     = 1 << 15,
+        UTI                         = 1 << 10,
+        FilenameExtension           = 1 << 11,
+        AccessibilityDescription    = 1 << 12,
+        HotSpot                     = 1 << 13,
+        MaximumSubsamplingLevel     = 1 << 14,
     };
 
     template<typename MetadataType>
@@ -118,7 +117,6 @@ private:
     mutable RepetitionCount m_repetitionCount { RepetitionCountNone };
     mutable DestinationColorSpace m_colorSpace { DestinationColorSpace::SRGB() };
     mutable std::optional<Color> m_singlePixelSolidColor;
-    mutable Headroom m_headroom { Headroom::None };
     mutable bool m_hasHDRGainMap { false };
 
     mutable String m_uti;

--- a/Source/WebCore/platform/graphics/BitmapImageSource.h
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -75,6 +75,7 @@ public:
     // NativeImage
     DecodingStatus requestNativeImageAtIndexIfNeeded(unsigned index, SubsamplingLevel, ImageAnimatingState, const DecodingOptions&);
 
+    RefPtr<NativeImage> primaryNativeImageIfExists() { return frameAtIndex(primaryFrameIndex()).nativeImage(); }
     RefPtr<NativeImage> primaryNativeImage() final { return nativeImageAtIndex(primaryFrameIndex()); }
 
     // Image Metadata
@@ -160,8 +161,8 @@ private:
     ImageOrientation orientation() const final { return m_descriptor.orientation(); }
     DestinationColorSpace colorSpace() const final { return m_descriptor.colorSpace(); }
     std::optional<Color> singlePixelSolidColor() const final { return m_descriptor.singlePixelSolidColor(); }
-    bool hasHDRGainMap() const { return m_descriptor.hasHDRGainMap(); }
-    bool hasHDRContent() const final { return m_descriptor.hasHDRGainMap() || m_descriptor.headroom() > Headroom::None; }
+    bool hasHDRGainMap() const final { return m_descriptor.hasHDRGainMap(); }
+    bool hasHDRContent() const final { return m_descriptor.hasHDRGainMap() || m_descriptor.hasHDRColorSpace(); }
 
     String uti() const final { return m_descriptor.uti(); }
     String filenameExtension() const final { return m_descriptor.filenameExtension(); }

--- a/Source/WebCore/platform/graphics/DestinationColorSpace.cpp
+++ b/Source/WebCore/platform/graphics/DestinationColorSpace.cpp
@@ -170,6 +170,16 @@ bool DestinationColorSpace::usesExtendedRange() const
 #endif
 }
 
+bool DestinationColorSpace::usesITUR_2100TF() const
+{
+#if USE(CG)
+    return CGColorSpaceUsesITUR_2100TF(platformColorSpace());
+#else
+    notImplemented();
+    return false;
+#endif
+}
+
 TextStream& operator<<(TextStream& ts, const DestinationColorSpace& colorSpace)
 {
     if (colorSpace == DestinationColorSpace::SRGB())

--- a/Source/WebCore/platform/graphics/DestinationColorSpace.h
+++ b/Source/WebCore/platform/graphics/DestinationColorSpace.h
@@ -66,6 +66,7 @@ public:
     WEBCORE_EXPORT bool supportsOutput() const;
 
     bool usesExtendedRange() const;
+    bool usesITUR_2100TF() const;
 
 private:
     PlatformColorSpace m_platformColorSpace;

--- a/Source/WebCore/platform/graphics/ImageSource.h
+++ b/Source/WebCore/platform/graphics/ImageSource.h
@@ -80,9 +80,10 @@ public:
     virtual unsigned frameCount() const { return 1; }
     virtual DestinationColorSpace colorSpace() const = 0;
     virtual std::optional<Color> singlePixelSolidColor() const = 0;
+    virtual bool hasHDRGainMap() const { return false; }
     virtual bool hasHDRContent() const = 0;
 
-    ShouldDecodeToHDR shouldDecodeToHDR() const { return hasHDRContent() ? ShouldDecodeToHDR::Yes : ShouldDecodeToHDR::No; }
+    ShouldDecodeToHDR shouldDecodeToHDR() const { return hasHDRGainMap() ? ShouldDecodeToHDR::Yes : ShouldDecodeToHDR::No; }
     bool hasSolidColor() const;
 
     virtual String uti() const { return String(); }

--- a/Source/WebCore/platform/graphics/NativeImageSource.h
+++ b/Source/WebCore/platform/graphics/NativeImageSource.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,7 +39,7 @@ private:
     IntSize size(ImageOrientation = ImageOrientation::Orientation::FromImage) const final { return m_frame.size(); }
     DestinationColorSpace colorSpace() const final { return m_frame.nativeImage()->colorSpace(); }
     std::optional<Color> singlePixelSolidColor() const final { return m_frame.nativeImage()->singlePixelSolidColor(); }
-    bool hasHDRContent() const final { return m_frame.nativeImage()->headroom() > Headroom::None; }
+    bool hasHDRContent() const final { return colorSpace().usesITUR_2100TF(); }
 
     const ImageFrame& primaryImageFrame(const std::optional<SubsamplingLevel>& = std::nullopt) final { return m_frame; }
 


### PR DESCRIPTION
#### f798905acff7679506cc2693f0c572ee4fcfc13c
<pre>
[HDR] Implement reliable way to detect an image hasHDRContent() or not
<a href="https://bugs.webkit.org/show_bug.cgi?id=291431">https://bugs.webkit.org/show_bug.cgi?id=291431</a>
<a href="https://rdar.apple.com/149071262">rdar://149071262</a>

Reviewed by Simon Fraser.

It turned out using the CGImageSource frame &quot;Headroom&quot; metadata property is not
a reliable way to detect whether an image has HDR contents or not.

An image is considered to be HDR if one of these conditions is true:

1. The colorSpace of the primary frame usesITUR_2100TF()
2. The ImageDecoder detects the image has a gain map

To have the async image decoding workflow works as expected, destroy the primary
frame after getting its colorSpace only if it has not been used yet.

* Source/WebCore/platform/graphics/BitmapImageDescriptor.cpp:
(WebCore::BitmapImageDescriptor::hasHDRGainMap const):
(WebCore::BitmapImageDescriptor::hasHDRColorSpace const):
(WebCore::BitmapImageDescriptor::headroom const): Deleted.
* Source/WebCore/platform/graphics/BitmapImageDescriptor.h:
* Source/WebCore/platform/graphics/BitmapImageSource.h:
* Source/WebCore/platform/graphics/DestinationColorSpace.cpp:
(WebCore::DestinationColorSpace::usesITUR_2100TF const):
* Source/WebCore/platform/graphics/DestinationColorSpace.h:
* Source/WebCore/platform/graphics/ImageSource.h:
(WebCore::ImageSource::hasHDRGainMap const):
(WebCore::ImageSource::shouldDecodeToHDR const):
* Source/WebCore/platform/graphics/NativeImageSource.h:

Canonical link: <a href="https://commits.webkit.org/294390@main">https://commits.webkit.org/294390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8fc43aa30feddb63ec57a2ba7eefdc1f0c903f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101659 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11642 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106817 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52293 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103699 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29827 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/77418 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34447 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104666 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16716 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91807 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57755 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16542 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9824 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/51648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/86409 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/9901 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109171 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28792 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21203 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29153 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88008 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/85963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21871 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30711 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8425 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22955 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28720 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34009 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28531 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31854 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30090 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->