### PR TITLE
[Catalyst] visibilitychange event is not always dispatched when closing windows

### DIFF
--- a/Source/WebKit/UIProcess/ApplicationStateTracker.h
+++ b/Source/WebKit/UIProcess/ApplicationStateTracker.h
@@ -68,6 +68,8 @@ private:
 
     void setViewController(UIViewController *);
 
+    void setIsInBackground(bool);
+
     void applicationDidEnterBackground();
     void applicationDidFinishSnapshottingAfterEnteringBackground();
     void applicationWillEnterForeground();

--- a/Source/WebKit/UIProcess/ApplicationStateTracker.mm
+++ b/Source/WebKit/UIProcess/ApplicationStateTracker.mm
@@ -279,19 +279,24 @@ void ApplicationStateTracker::setScene(UIScene *scene)
     };
 
     if (m_scene.get() == scene) {
-        m_isInBackground = isWindowAndSceneInBackground(m_window, m_scene);
+        setIsInBackground(isWindowAndSceneInBackground(m_window, m_scene));
         return;
     }
 
     removeAllObservers();
 
+    if (!scene && m_scene && m_isInBackground) {
+        m_scene = nil;
+        return;
+    }
+
     m_scene = scene;
-    m_isInBackground = isWindowAndSceneInBackground(m_window, m_scene);
+    setIsInBackground(isWindowAndSceneInBackground(m_window, m_scene));
 
     if (!m_scene)
         return;
 
-    RELEASE_LOG(ViewState, "%p - ApplicationStateTracker::ApplicationStateTracker(): m_isInBackground=%d", this, m_isInBackground);
+    RELEASE_LOG(ViewState, "%p - ApplicationStateTracker: add observers for scene", this);
 
     NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
     m_didEnterBackgroundObserver = [notificationCenter addObserverForName:UISceneDidEnterBackgroundNotification object:scene queue:nil usingBlock:[this, weakThis = WeakPtr { *this }](NSNotification *notification) {
@@ -330,20 +335,22 @@ void ApplicationStateTracker::setViewController(UIViewController *serviceViewCon
 
     m_viewController = serviceViewController;
     if (!m_viewController) {
-        m_isInBackground = true;
+        setIsInBackground(true);
         return;
     }
 
     pid_t applicationPID = serviceViewController._hostProcessIdentifier;
     ASSERT(applicationPID);
 
-    m_isInBackground = !EndowmentStateTracker::isApplicationForeground(applicationPID);
+    bool isInBackground = !EndowmentStateTracker::isApplicationForeground(applicationPID);
 
     // Workaround for <rdar://problem/34028921>. If the host application is StoreKitUIService then it is also a ViewService
     // and is always in the background. We need to treat StoreKitUIService as foreground for the purpose of process suspension
     // or its ViewServices will get suspended.
     if ([serviceViewController._hostApplicationBundleIdentifier isEqualToString:@"com.apple.ios.StoreKitUIService"])
-        m_isInBackground = false;
+        isInBackground = false;
+
+    setIsInBackground(isInBackground);
 
     RELEASE_LOG(ProcessSuspension, "%{public}s has PID %d, host application PID=%d, isInBackground=%d", _UIApplicationIsExtension() ? "Extension" : "ViewService", getpid(), applicationPID, m_isInBackground);
 
@@ -362,9 +369,19 @@ void ApplicationStateTracker::setViewController(UIViewController *serviceViewCon
     }];
 }
 
+void ApplicationStateTracker::setIsInBackground(bool isInBackground)
+{
+    if (m_isInBackground == isInBackground)
+        return;
+
+    RELEASE_LOG(ViewState, "%p - ApplicationStateTracker::setIsInBackground: %d", this, isInBackground);
+
+    m_isInBackground = isInBackground;
+}
+
 void ApplicationStateTracker::applicationDidEnterBackground()
 {
-    m_isInBackground = true;
+    setIsInBackground(true);
     updateApplicationBackgroundState();
 
     if (auto view = m_view.get())
@@ -373,7 +390,7 @@ void ApplicationStateTracker::applicationDidEnterBackground()
 
 void ApplicationStateTracker::applicationWillEnterForeground()
 {
-    m_isInBackground = false;
+    setIsInBackground(false);
     updateApplicationBackgroundState();
 
     if (auto view = m_view.get())


### PR DESCRIPTION
#### e41237fcf56f9456c9a38994fa0adeab252ddb9b
<pre>
[Catalyst] visibilitychange event is not always dispatched when closing windows
<a href="https://bugs.webkit.org/show_bug.cgi?id=291433">https://bugs.webkit.org/show_bug.cgi?id=291433</a>
<a href="https://rdar.apple.com/148773181">rdar://148773181</a>

Reviewed by Abrar Rahman Protyasha and Tim Horton.

`visibilitychange` events correspond to the addition or removal of
`ActivityState::IsVisible` from the activity state flags. The flag is
added if `isViewVisible()` returns true. Web views that have a non-nil
`window`, and for which `-[WKWebView _isBackground]` is false, are considered
to be visible.

`-[WKWebView _isBackground]` reports the value of
`ApplicationStateTracker::isInBackground`. When a Catalyst window is closed,
`UISceneDidEnterBackgroundNotification` gets dispatched, which sets `isInBackground`
to true and schedules an activity state update. Note that the web view&apos;s window
remains non-nil.

However, in between `UISceneDidEnterBackgroundNotification` and the activity
state update dispatch, the web view&apos;s window&apos;s scene may get set to `nil`. This
is problematic due to the changes in 276009@main, which treat a web view with a
non-nil window and nil scene as &quot;foreground&quot;. `UINSSceneView` does exactly that
in Catalyst, resulting in the web view being incorrectly reported as visible,
after closing the window.

The change in 276009@main is still necessary to keep API tests passing. Fix by
avoiding an additional update to `isInBackground` when the scene was previously
non-nil. This keeps tests passing as the scene is always nil, and fixes the issue
as the value set as a result of `UISceneDidEnterBackgroundNotification` is preserved.

Add additional logging to make application state tracking issues easier to diagnose.

* Source/WebKit/UIProcess/ApplicationStateTracker.h:
* Source/WebKit/UIProcess/ApplicationStateTracker.mm:
(WebKit::ApplicationStateTracker::setScene):
(WebKit::ApplicationStateTracker::setViewController):
(WebKit::ApplicationStateTracker::setIsInBackground):

Avoid updating `m_isInBackground` if it is already true and the scene is
transitioning from non-nil to nil. This is necessary, as a view that initially
has a window and a nil scene is treated as foreground (visible), due to 276009@main.

(WebKit::ApplicationStateTracker::applicationDidEnterBackground):
(WebKit::ApplicationStateTracker::applicationWillEnterForeground):

Canonical link: <a href="https://commits.webkit.org/293743@main">https://commits.webkit.org/293743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b843e268cae849b10ea70ba0e737d30c2d1f919

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99716 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104846 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50311 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27799 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75910 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33004 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102723 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14989 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90047 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56270 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14789 "An unexpected error occured. Recent messages:Printed configuration") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49672 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84730 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107206 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26830 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19598 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84869 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27194 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86251 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84387 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29065 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6776 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20654 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16233 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26771 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31977 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26586 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29900 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28155 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->