### PR TITLE
Prepare to switch from std::variant to WTF::Variant

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCorePrefix.h
+++ b/Source/JavaScriptCore/JavaScriptCorePrefix.h
@@ -68,6 +68,7 @@
 #include <typeinfo>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/Variant.h>
 #endif
 
 #ifdef __cplusplus

--- a/Source/JavaScriptCore/disassembler/Disassembler.cpp
+++ b/Source/JavaScriptCore/disassembler/Disassembler.cpp
@@ -27,7 +27,6 @@
 #include "Disassembler.h"
 
 #include "MacroAssemblerCodeRef.h"
-#include <variant>
 #include <wtf/Condition.h>
 #include <wtf/DataLog.h>
 #include <wtf/Deque.h>

--- a/Source/JavaScriptCore/interpreter/Interpreter.h
+++ b/Source/JavaScriptCore/interpreter/Interpreter.h
@@ -33,7 +33,6 @@
 #include "MacroAssemblerCodeRef.h"
 #include "NativeFunction.h"
 #include "Opcode.h"
-#include <variant>
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -46,7 +46,6 @@
 #include "TagRegistersMode.h"
 #include "TypeofType.h"
 #include "VM.h"
-#include <variant>
 #include <wtf/TZoneMalloc.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/JavaScriptCore/jit/SnippetReg.h
+++ b/Source/JavaScriptCore/jit/SnippetReg.h
@@ -27,7 +27,6 @@
 #pragma once
 
 #include "Reg.h"
-#include <variant>
 
 #if ENABLE(JIT)
 

--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -32,7 +32,6 @@
 #include "ParseInt.h"
 #include <limits.h>
 #include <string.h>
-#include <variant>
 #include <wtf/Assertions.h>
 #include <wtf/HexNumber.h>
 #include <wtf/dtoa.h>

--- a/Source/JavaScriptCore/parser/VariableEnvironment.h
+++ b/Source/JavaScriptCore/parser/VariableEnvironment.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "Identifier.h"
-#include <variant>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/IteratorRange.h>

--- a/Source/JavaScriptCore/runtime/BytecodeCacheError.h
+++ b/Source/JavaScriptCore/runtime/BytecodeCacheError.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "ParserError.h"
-#include <variant>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/CachePayload.h
+++ b/Source/JavaScriptCore/runtime/CachePayload.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "VM.h"
-#include <variant>
 #include <wtf/MallocSpan.h>
 #include <wtf/MappedFileData.h>
 

--- a/Source/JavaScriptCore/runtime/CacheUpdate.h
+++ b/Source/JavaScriptCore/runtime/CacheUpdate.h
@@ -28,7 +28,6 @@
 #include "CachePayload.h"
 #include "CachedTypes.h"
 #include "CodeSpecializationKind.h"
-#include <variant>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/TemporalObject.h
+++ b/Source/JavaScriptCore/runtime/TemporalObject.h
@@ -22,7 +22,6 @@
 #pragma once
 
 #include "JSObject.h"
-#include <variant>
 #include <wtf/Int128.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/runtime/TemporalTimeZone.h
+++ b/Source/JavaScriptCore/runtime/TemporalTimeZone.h
@@ -28,7 +28,6 @@
 #include "ISO8601.h"
 #include "IntlObject.h"
 #include "JSObject.h"
-#include <variant>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -64,7 +64,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "WasmContext.h"
 #include "WeakGCMap.h"
 #include "WriteBarrier.h"
-#include <variant>
 #include <wtf/BumpPointerAllocator.h>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/DoublyLinkedList.h>

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -38,7 +38,6 @@
 #include "WasmFunctionIPIntMetadataGenerator.h"
 #include "WasmFunctionParser.h"
 #include "WasmGeneratorTraits.h"
-#include <variant>
 #include <wtf/Assertions.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/RefPtr.h>

--- a/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -38,7 +38,6 @@
 #include "WasmFunctionCodeBlockGenerator.h"
 #include "WasmFunctionParser.h"
 #include "WasmGeneratorTraits.h"
-#include <variant>
 #include <wtf/CompletionHandler.h>
 #include <wtf/RefPtr.h>
 #include <wtf/text/MakeString.h>

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <variant>
-
 #if ENABLE(WEBASSEMBLY)
 
 #include "JITCompilation.h"

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -915,6 +915,7 @@
 		EBEE51132D2DF488004FEC23 /* ContinuousApproximateTime.h in Headers */ = {isa = PBXBuildFile; fileRef = EBEE51112D2DF488004FEC23 /* ContinuousApproximateTime.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EBEE51142D2DF488004FEC23 /* ContinuousApproximateTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EBEE51122D2DF488004FEC23 /* ContinuousApproximateTime.cpp */; };
 		FA0C387B2BEAD56B00583842 /* SmallMap.h in Headers */ = {isa = PBXBuildFile; fileRef = FA0C387A2BEAD56B00583842 /* SmallMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FA864D602DA9809F006820D3 /* Variant.h in Headers */ = {isa = PBXBuildFile; fileRef = FA864D5F2DA9809F006820D3 /* Variant.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FAC31B9D2D80083D006CCA20 /* CoroutineUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = FAC31B9C2D80083D006CCA20 /* CoroutineUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE032AD22463E43B0012D7C7 /* WTFConfig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE032AD02463E43B0012D7C7 /* WTFConfig.cpp */; };
 		FE03831C2ABC04F700A576A2 /* TZoneMallocInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FE03831A2ABC04F700A576A2 /* TZoneMallocInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1961,6 +1962,7 @@
 		F6D67D3226F90142006E0349 /* Int128.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Int128.h; sourceTree = "<group>"; };
 		F72BBDB107FA424886178B9E /* SymbolImpl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SymbolImpl.cpp; sourceTree = "<group>"; };
 		FA0C387A2BEAD56B00583842 /* SmallMap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SmallMap.h; sourceTree = "<group>"; };
+		FA864D5F2DA9809F006820D3 /* Variant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Variant.h; sourceTree = "<group>"; };
 		FAC31B9C2D80083D006CCA20 /* CoroutineUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoroutineUtilities.h; sourceTree = "<group>"; };
 		FE032AD02463E43B0012D7C7 /* WTFConfig.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WTFConfig.cpp; sourceTree = "<group>"; };
 		FE032AD12463E43B0012D7C7 /* WTFConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WTFConfig.h; sourceTree = "<group>"; };
@@ -2668,6 +2670,7 @@
 				7AFEC6AE1EB22AC600DADE36 /* UUID.h */,
 				A8A47311151A825B004123FG /* ValidatedReinterpretCast.h */,
 				A8A4736F151A825B004123FF /* ValueCheck.h */,
+				FA864D5F2DA9809F006820D3 /* Variant.h */,
 				BCE0DFAA2D18670B003F0349 /* VariantExtras.h */,
 				BCEA08032CCFDB33000AC148 /* VariantList.h */,
 				BC05ACA52CEA70E500750CB1 /* VariantListOperations.h */,
@@ -3805,6 +3808,7 @@
 				DD3DC8C227A4BF8E007E5B61 /* UUID.h in Headers */,
 				DD3DC98127A4BF8E007E5B62 /* ValidatedReinterpretCast.h in Headers */,
 				DD3DC86D27A4BF8E007E5B61 /* ValueCheck.h in Headers */,
+				FA864D602DA9809F006820D3 /* Variant.h in Headers */,
 				BCE0DFAB2D18670B003F0349 /* VariantExtras.h in Headers */,
 				BCEA08042CCFDB33000AC148 /* VariantList.h in Headers */,
 				BC05ACA62CEA70E500750CB1 /* VariantListOperations.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -367,6 +367,7 @@ set(WTF_PUBLIC_HEADERS
     VMTags.h
     ValidatedReinterpretCast.h
     ValueCheck.h
+    Variant.h
     VariantExtras.h
     VariantList.h
     VariantListOperations.h

--- a/Source/WTF/wtf/CompactVariantOperations.h
+++ b/Source/WTF/wtf/CompactVariantOperations.h
@@ -29,9 +29,9 @@
 #include <concepts>
 #include <functional>
 #include <type_traits>
-#include <variant>
 #include <wtf/GetPtr.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/Variant.h>
 #include <wtf/VariantExtras.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/CrossThreadCopier.h
+++ b/Source/WTF/wtf/CrossThreadCopier.h
@@ -33,7 +33,6 @@
 
 #include <tuple>
 #include <type_traits>
-#include <variant>
 #include <wtf/Assertions.h>
 #include <wtf/Expected.h>
 #include <wtf/Forward.h>
@@ -42,6 +41,7 @@
 #include <wtf/RefPtr.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/TypeTraits.h>
+#include <wtf/Variant.h>
 #include <wtf/text/WTFString.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/Expected.h
+++ b/Source/WTF/wtf/Expected.h
@@ -182,11 +182,11 @@ inline namespace fundamentals_v3 {
 #include <optional>
 #include <type_traits>
 #include <utility>
-#include <variant>
 #include <wtf/Assertions.h>
 #include <wtf/Compiler.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Unexpected.h>
+#include <wtf/Variant.h>
 
 namespace std {
 namespace experimental {

--- a/Source/WTF/wtf/FlatteningVariantAdaptor.h
+++ b/Source/WTF/wtf/FlatteningVariantAdaptor.h
@@ -24,10 +24,10 @@
 
 #pragma once
 
-#include <variant>
 #include <wtf/Brigand.h>
 #include <wtf/CompactVariant.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/Variant.h>
 #include <wtf/VariantExtras.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/GenericHashKey.h
+++ b/Source/WTF/wtf/GenericHashKey.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <variant>
 #include <wtf/Forward.h>
 #include <wtf/HashTraits.h>
+#include <wtf/Variant.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/Hasher.h
+++ b/Source/WTF/wtf/Hasher.h
@@ -21,12 +21,12 @@
 #pragma once
 
 #include <optional>
-#include <variant>
 #include <wtf/CheckedPtr.h>
 #include <wtf/Int128.h>
 #include <wtf/RefPtr.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/URL.h>
+#include <wtf/Variant.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/SuperFastHash.h>
 

--- a/Source/WTF/wtf/LikelyDenseUnsignedIntegerSet.h
+++ b/Source/WTF/wtf/LikelyDenseUnsignedIntegerSet.h
@@ -25,13 +25,13 @@
 
 #pragma once
 
-#include <variant>
 #include <wtf/Assertions.h>
 #include <wtf/BitVector.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/HashFunctions.h>
 #include <wtf/HashSet.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/Variant.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/SmallMap.h
+++ b/Source/WTF/wtf/SmallMap.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include <variant>
 #include <wtf/HashMap.h>
 #include <wtf/ScopedLambda.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/Variant.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -39,7 +39,6 @@
 #include <span>
 #include <type_traits>
 #include <utility>
-#include <variant>
 #include <wtf/Assertions.h>
 #include <wtf/Brigand.h>
 #include <wtf/CheckedArithmetic.h>
@@ -50,6 +49,7 @@
 #include <wtf/StringExtras.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/TypeTraits.h>
+#include <wtf/Variant.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/WTF/wtf/Variant.h
+++ b/Source/WTF/wtf/Variant.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,21 +25,4 @@
 
 #pragma once
 
-#if ENABLE(GPU_PROCESS)
-
-#include <WebCore/WebGPUIntegralTypes.h>
-#include <optional>
-#include <wtf/Vector.h>
-
-namespace WebKit::WebGPU {
-
-struct Origin2DDict {
-    WebCore::WebGPU::IntegerCoordinate x { 0 };
-    WebCore::WebGPU::IntegerCoordinate y { 0 };
-};
-
-using Origin2D = std::variant<Vector<WebCore::WebGPU::IntegerCoordinate>, Origin2DDict>;
-
-} // namespace WebKit::WebGPU
-
-#endif // ENABLE(GPU_PROCESS)
+#include <variant>

--- a/Source/WTF/wtf/VariantExtras.h
+++ b/Source/WTF/wtf/VariantExtras.h
@@ -24,8 +24,8 @@
 
 #pragma once
 
-#include <variant>
 #include <wtf/StdLibExtras.h>
+#include <wtf/Variant.h>
 #include <wtf/VectorTraits.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/VariantList.h
+++ b/Source/WTF/wtf/VariantList.h
@@ -26,8 +26,8 @@
 
 #include <array>
 #include <span>
-#include <variant>
 #include <wtf/StdLibExtras.h>
+#include <wtf/Variant.h>
 #include <wtf/VariantListOperations.h>
 #include <wtf/Vector.h>
 

--- a/Source/WTF/wtf/text/TextBreakIterator.h
+++ b/Source/WTF/wtf/text/TextBreakIterator.h
@@ -23,8 +23,8 @@
 
 #include <mutex>
 #include <optional>
-#include <variant>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/Variant.h>
 #include <wtf/text/StringView.h>
 #include <wtf/text/icu/TextBreakIteratorICU.h>
 

--- a/Source/WebCore/Modules/WebGPU/GPUBindGroupEntry.h
+++ b/Source/WebCore/Modules/WebGPU/GPUBindGroupEntry.h
@@ -32,7 +32,6 @@
 #include "GPUTextureView.h"
 #include "WebGPUBindGroupEntry.h"
 #include <utility>
-#include <variant>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/WebGPU/GPUColorDict.h
+++ b/Source/WebCore/Modules/WebGPU/GPUColorDict.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "WebGPUColor.h"
-#include <variant>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/Modules/WebGPU/GPUError.h
+++ b/Source/WebCore/Modules/WebGPU/GPUError.h
@@ -28,7 +28,6 @@
 #include "GPUInternalError.h"
 #include "GPUOutOfMemoryError.h"
 #include "GPUValidationError.h"
-#include <variant>
 #include <wtf/RefPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/WebGPU/GPUExtent3DDict.h
+++ b/Source/WebCore/Modules/WebGPU/GPUExtent3DDict.h
@@ -27,7 +27,6 @@
 
 #include "GPUIntegralTypes.h"
 #include "WebGPUExtent3D.h"
-#include <variant>
 #include <wtf/Vector.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/WebGPU/GPUImageCopyExternalImage.h
+++ b/Source/WebCore/Modules/WebGPU/GPUImageCopyExternalImage.h
@@ -35,7 +35,6 @@
 #include "WebCodecsVideoFrame.h"
 #include "WebGPUImageCopyExternalImage.h"
 #include <optional>
-#include <variant>
 #include <wtf/RefPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/WebGPU/GPUOrigin2DDict.h
+++ b/Source/WebCore/Modules/WebGPU/GPUOrigin2DDict.h
@@ -27,7 +27,6 @@
 
 #include "GPUIntegralTypes.h"
 #include "WebGPUOrigin2D.h"
-#include <variant>
 #include <wtf/Vector.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/WebGPU/GPUOrigin3DDict.h
+++ b/Source/WebCore/Modules/WebGPU/GPUOrigin3DDict.h
@@ -27,7 +27,6 @@
 
 #include "GPUIntegralTypes.h"
 #include "WebGPUOrigin3D.h"
-#include <variant>
 #include <wtf/Vector.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/WebGPU/GPUPipelineDescriptorBase.h
+++ b/Source/WebCore/Modules/WebGPU/GPUPipelineDescriptorBase.h
@@ -30,7 +30,6 @@
 #include "GPUPipelineLayout.h"
 #include "WebGPUPipelineDescriptorBase.h"
 
-#include <variant>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassColorAttachment.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassColorAttachment.h
@@ -31,7 +31,6 @@
 #include "GPUStoreOp.h"
 #include "GPUTextureView.h"
 #include "WebGPURenderPassColorAttachment.h"
-#include <variant>
 #include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
 

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassDepthStencilAttachment.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassDepthStencilAttachment.h
@@ -30,7 +30,6 @@
 #include "GPUStoreOp.h"
 #include "GPUTextureView.h"
 #include "WebGPURenderPassDepthStencilAttachment.h"
-#include <variant>
 #include <wtf/RefPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroupEntry.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroupEntry.h
@@ -31,7 +31,6 @@
 #include "WebGPUSampler.h"
 #include "WebGPUTextureView.h"
 #include <functional>
-#include <variant>
 
 namespace WebCore::WebGPU {
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUColor.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUColor.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <variant>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUError.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUError.h
@@ -28,7 +28,6 @@
 #include "WebGPUInternalError.h"
 #include "WebGPUOutOfMemoryError.h"
 #include "WebGPUValidationError.h"
-#include <variant>
 #include <wtf/Ref.h>
 
 namespace WebCore::WebGPU {

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUExtent3D.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUExtent3D.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "WebGPUIntegralTypes.h"
-#include <variant>
 #include <wtf/Vector.h>
 
 namespace WebCore::WebGPU {

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUImageCopyExternalImage.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUImageCopyExternalImage.h
@@ -27,7 +27,6 @@
 
 #include "WebGPUOrigin2D.h"
 #include <optional>
-#include <variant>
 
 namespace WebCore::WebGPU {
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUOrigin2D.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUOrigin2D.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "WebGPUIntegralTypes.h"
-#include <variant>
 #include <wtf/Vector.h>
 
 namespace WebCore::WebGPU {

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUOrigin3D.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUOrigin3D.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "WebGPUIntegralTypes.h"
-#include <variant>
 #include <wtf/Vector.h>
 
 namespace WebCore::WebGPU {

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassColorAttachment.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassColorAttachment.h
@@ -30,7 +30,6 @@
 #include "WebGPULoadOp.h"
 #include "WebGPUStoreOp.h"
 #include "WebGPUTextureView.h"
-#include <variant>
 #include <wtf/Ref.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakRef.h>

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassDepthStencilAttachment.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassDepthStencilAttachment.h
@@ -29,7 +29,6 @@
 #include "WebGPULoadOp.h"
 #include "WebGPUStoreOp.h"
 #include "WebGPUTextureView.h"
-#include <variant>
 #include <wtf/Ref.h>
 #include <wtf/WeakRef.h>
 

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h
@@ -28,7 +28,6 @@
 #include "ClipboardItemDataSource.h"
 #include "ExceptionCode.h"
 #include "FileReaderLoaderClient.h"
-#include <variant>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 

--- a/Source/WebCore/Modules/fetch/FetchBody.h
+++ b/Source/WebCore/Modules/fetch/FetchBody.h
@@ -35,7 +35,6 @@
 #include "FormData.h"
 #include "ReadableStream.h"
 #include "URLSearchParams.h"
-#include <variant>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/fetch/FetchHeaders.h
+++ b/Source/WebCore/Modules/fetch/FetchHeaders.h
@@ -31,7 +31,6 @@
 #include "ExceptionOr.h"
 #include "FetchHeadersGuard.h"
 #include "HTTPHeaderMap.h"
-#include <variant>
 #include <wtf/HashTraits.h>
 #include <wtf/Vector.h>
 

--- a/Source/WebCore/Modules/indexeddb/IDBCursor.h
+++ b/Source/WebCore/Modules/indexeddb/IDBCursor.h
@@ -33,7 +33,6 @@
 #include "IDBValue.h"
 #include "JSValueInWrappedObject.h"
 #include <JavaScriptCore/Strong.h>
-#include <variant>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/indexeddb/IDBGetAllResult.h
+++ b/Source/WebCore/Modules/indexeddb/IDBGetAllResult.h
@@ -29,7 +29,6 @@
 #include "IDBKeyPath.h"
 #include "IDBValue.h"
 #include "IndexedDB.h"
-#include <variant>
 #include <wtf/ArgumentCoder.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/Modules/indexeddb/IDBKey.h
+++ b/Source/WebCore/Modules/indexeddb/IDBKey.h
@@ -27,7 +27,6 @@
 
 #include "IndexedDB.h"
 #include "ThreadSafeDataBuffer.h"
-#include <variant>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/Modules/indexeddb/IDBKeyData.h
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyData.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "IDBKey.h"
-#include <variant>
 #include <wtf/Hasher.h>
 #include <wtf/StdSet.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/Modules/indexeddb/IDBKeyPath.h
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyPath.h
@@ -26,7 +26,6 @@
 
 #pragma once
 
-#include <variant>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
@@ -46,7 +46,6 @@
 #include "ThreadSafeDataBuffer.h"
 #include "WebCoreOpaqueRoot.h"
 #include <JavaScriptCore/StrongInlines.h>
-#include <variant>
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -68,7 +68,6 @@
 #include "VTTCue.h"
 #include "VoidCallback.h"
 #include <JavaScriptCore/JSCJSValueInlines.h>
-#include <variant>
 #include <wtf/Function.h>
 #include <wtf/JSONValues.h>
 #include <wtf/Scope.h>

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
@@ -29,7 +29,6 @@
 
 #include "HTMLMediaElement.h"
 #include "MediaSession.h"
-#include <variant>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>

--- a/Source/WebCore/Modules/mediastream/MediaTrackConstraints.h
+++ b/Source/WebCore/Modules/mediastream/MediaTrackConstraints.h
@@ -28,7 +28,6 @@
 
 #include "DoubleRange.h"
 #include "LongRange.h"
-#include <variant>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/Modules/mediastream/RTCIceServer.h
+++ b/Source/WebCore/Modules/mediastream/RTCIceServer.h
@@ -27,7 +27,6 @@
 
 #if ENABLE(WEB_RTC)
 
-#include <variant>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.h
@@ -30,7 +30,6 @@
 #include "JSValueInWrappedObject.h"
 #include "PaymentRequestUpdateEvent.h"
 #include <JavaScriptCore/Strong.h>
-#include <variant>
 #include <wtf/text/WTFString.h>
 
 namespace JSC {

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.h
@@ -35,7 +35,6 @@
 #include "PaymentMethodChangeEvent.h"
 #include "PaymentOptions.h"
 #include "PaymentResponse.h"
-#include <variant>
 #include <wtf/URL.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/push-api/PushEventInit.h
+++ b/Source/WebCore/Modules/push-api/PushEventInit.h
@@ -27,7 +27,6 @@
 
 #include "ExtendableEventInit.h"
 #include <JavaScriptCore/ArrayBuffer.h>
-#include <variant>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/push-api/PushSubscription.h
+++ b/Source/WebCore/Modules/push-api/PushSubscription.h
@@ -33,7 +33,6 @@
 #include "PushSubscriptionJSON.h"
 
 #include <optional>
-#include <variant>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/Modules/push-api/PushSubscriptionOptionsInit.h
+++ b/Source/WebCore/Modules/push-api/PushSubscriptionOptionsInit.h
@@ -27,7 +27,6 @@
 
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <optional>
-#include <variant>
 #include <wtf/RefCounted.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/speech/SpeechRecognitionUpdate.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionUpdate.h
@@ -28,7 +28,6 @@
 #include "SpeechRecognitionConnectionClientIdentifier.h"
 #include "SpeechRecognitionError.h"
 #include "SpeechRecognitionResultData.h"
-#include <variant>
 #include <wtf/ArgumentCoder.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/webaudio/AudioContextOptions.h
+++ b/Source/WebCore/Modules/webaudio/AudioContextOptions.h
@@ -29,7 +29,6 @@
 
 #include "AudioContextLatencyCategory.h"
 #include <optional>
-#include <variant>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/webaudio/AudioNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioNode.h
@@ -29,7 +29,6 @@
 #include "ChannelInterpretation.h"
 #include "EventTarget.h"
 #include "ExceptionOr.h"
-#include <variant>
 #include <wtf/Forward.h>
 #include <wtf/LoggerHelper.h>
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataAlgorithms.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataAlgorithms.h
@@ -32,7 +32,6 @@
 
 #include <ExceptionOr.h>
 #include <span>
-#include <variant>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -46,7 +46,6 @@
 #include "WebCodecsUtilities.h"
 #include "WebCodecsVideoFrame.h"
 #include "WebCodecsVideoFrameOutputCallback.h"
-#include <variant>
 #include <wtf/ASCIICType.h>
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.h
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.h
@@ -34,7 +34,6 @@
 #include "GraphicsTypesGL.h"
 #include "PlatformXR.h"
 #include "WebXRLayer.h"
-#include <variant>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/WebCorePrefix.h
+++ b/Source/WebCore/WebCorePrefix.h
@@ -75,6 +75,7 @@
 #include <new>
 #include <string>
 #include <typeinfo>
+#include <wtf/Variant.h>
 #endif
 
 #if defined(__APPLE__)

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -37,7 +37,6 @@
 #include "TextIteratorBehavior.h"
 #include "VisibleSelection.h"
 #include "Widget.h"
-#include <variant>
 #include <wtf/HashSet.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/ProcessID.h>

--- a/Source/WebCore/accessibility/AXTreeStore.h
+++ b/Source/WebCore/accessibility/AXTreeStore.h
@@ -26,7 +26,6 @@
 
 #include "AXCoreObject.h"
 #include "ActivityState.h"
-#include <variant>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -34,7 +34,6 @@
 #include "LayoutRect.h"
 #include "Path.h"
 #include "RenderStyleConstants.h"
-#include <variant>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/RefPtr.h>

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h
@@ -30,7 +30,6 @@
 #import "CocoaAccessibilityConstants.h"
 #import "FontPlatformData.h"
 #import <CoreGraphics/CoreGraphics.h>
-#import <variant>
 #import <wtf/Markable.h>
 #import <wtf/RefPtr.h>
 #import <wtf/WeakPtr.h>

--- a/Source/WebCore/animation/AnimationEffect.h
+++ b/Source/WebCore/animation/AnimationEffect.h
@@ -37,7 +37,6 @@
 #include "TimingFunction.h"
 #include "WebAnimation.h"
 #include "WebAnimationUtilities.h"
-#include <variant>
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>

--- a/Source/WebCore/animation/EffectTiming.h
+++ b/Source/WebCore/animation/EffectTiming.h
@@ -29,7 +29,6 @@
 #include "CommonAtomStrings.h"
 #include "FillMode.h"
 #include "PlaybackDirection.h"
-#include <variant>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {

--- a/Source/WebCore/animation/OptionalEffectTiming.h
+++ b/Source/WebCore/animation/OptionalEffectTiming.h
@@ -28,7 +28,6 @@
 #include "FillMode.h"
 #include "PlaybackDirection.h"
 #include "WebAnimationTypes.h"
-#include <variant>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {

--- a/Source/WebCore/bindings/IDLTypes.h
+++ b/Source/WebCore/bindings/IDLTypes.h
@@ -29,7 +29,6 @@
 #include "StringAdaptors.h"
 #include <JavaScriptCore/HandleTypes.h>
 #include <JavaScriptCore/Strong.h>
-#include <variant>
 #include <wtf/Brigand.h>
 #include <wtf/Compiler.h>
 #include <wtf/Markable.h>

--- a/Source/WebCore/bindings/js/BufferSource.h
+++ b/Source/WebCore/bindings/js/BufferSource.h
@@ -29,7 +29,6 @@
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <JavaScriptCore/ArrayBufferView.h>
 #include <span>
-#include <variant>
 #include <wtf/Compiler.h>
 #include <wtf/RefPtr.h>
 

--- a/Source/WebCore/bindings/js/JSDOMConvertUnion.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertUnion.h
@@ -35,7 +35,6 @@
 #include "JSDOMConvertUndefined.h"
 #include <JavaScriptCore/IteratorOperations.h>
 #include <JavaScriptCore/JSArrayBufferViewInlines.h>
-#include <variant>
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/JSValueInWrappedObject.h
+++ b/Source/WebCore/bindings/js/JSValueInWrappedObject.h
@@ -29,7 +29,6 @@
 #include <JavaScriptCore/JSCJSValueInlines.h>
 #include <JavaScriptCore/SlotVisitor.h>
 #include <JavaScriptCore/WeakInlines.h>
-#include <variant>
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -701,7 +701,7 @@ sub AddToIncludesForIDLType
     }
 
     if ($type->isUnion) {
-        AddToIncludes("<variant>", $includesRef, $conditional);
+        AddToIncludes("<wtf/Variant.h>", $includesRef, $conditional);
         AddToIncludes("JSDOMConvertUnion.h", $includesRef, $conditional);
 
         foreach my $memberType (@{$type->subtypes}) {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallTracer.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallTracer.cpp
@@ -53,10 +53,10 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
-#include <variant>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
 #include <wtf/URL.h>
+#include <wtf/Variant.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp
@@ -31,7 +31,7 @@
 #include "JSTestCallbackFunction.h"
 #include "JSTestDictionary.h"
 #include "ScriptExecutionContext.h"
-#include <variant>
+#include <wtf/Variant.h>
 
 
 namespace WebCore {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -104,11 +104,11 @@
 #include <JavaScriptCore/PropertyNameArray.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
-#include <variant>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
 #include <wtf/SortedArrayMap.h>
 #include <wtf/URL.h>
+#include <wtf/Variant.h>
 #include <wtf/Vector.h>
 #include <wtf/text/MakeString.h>
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp
@@ -37,9 +37,9 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSString.h>
 #include <JavaScriptCore/ObjectConstructor.h>
-#include <variant>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/SortedArrayMap.h>
+#include <wtf/Variant.h>
 
 
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestTypedefs.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestTypedefs.cpp
@@ -60,10 +60,10 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
-#include <variant>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
 #include <wtf/URL.h>
+#include <wtf/Variant.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {

--- a/Source/WebCore/crypto/CryptoAlgorithm.h
+++ b/Source/WebCore/crypto/CryptoAlgorithm.h
@@ -33,7 +33,6 @@
 #include "ExceptionOr.h"
 #include "JsonWebKey.h"
 #include <pal/crypto/CryptoDigest.h>
-#include <variant>
 #include <wtf/Function.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Vector.h>

--- a/Source/WebCore/crypto/CryptoKey.h
+++ b/Source/WebCore/crypto/CryptoKey.h
@@ -32,7 +32,6 @@
 #include "CryptoKeyData.h"
 #include "CryptoRsaHashedKeyAlgorithm.h"
 #include "CryptoRsaKeyAlgorithm.h"
-#include <variant>
 #include <wtf/Forward.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/TypeCasts.h>

--- a/Source/WebCore/crypto/SubtleCrypto.h
+++ b/Source/WebCore/crypto/SubtleCrypto.h
@@ -28,7 +28,6 @@
 #include "ContextDestructionObserver.h"
 #include "CryptoKeyFormat.h"
 #include <JavaScriptCore/Strong.h>
-#include <variant>
 #include <wtf/Ref.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/WeakPtr.h>

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESKW.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESKW.cpp
@@ -28,7 +28,6 @@
 
 #include "CryptoAlgorithmAesKeyParams.h"
 #include "CryptoKeyAES.h"
-#include <variant>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.cpp
@@ -29,7 +29,6 @@
 #include "CryptoAlgorithmHmacKeyParams.h"
 #include "CryptoKeyHMAC.h"
 #include "ScriptExecutionContext.h"
-#include <variant>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSASSA_PKCS1_v1_5.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSASSA_PKCS1_v1_5.cpp
@@ -30,7 +30,6 @@
 #include "CryptoAlgorithmRsaHashedKeyGenParams.h"
 #include "CryptoKeyPair.h"
 #include "CryptoKeyRSA.h"
-#include <variant>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_OAEP.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_OAEP.cpp
@@ -31,7 +31,6 @@
 #include "CryptoAlgorithmRsaOaepParams.h"
 #include "CryptoKeyPair.h"
 #include "CryptoKeyRSA.h"
-#include <variant>
 #include <wtf/CrossThreadCopier.h>
 
 namespace WebCore {

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_PSS.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_PSS.cpp
@@ -33,7 +33,6 @@
 #include "CryptoAlgorithmRsaPssParams.h"
 #include "CryptoKeyPair.h"
 #include "CryptoKeyRSA.h"
-#include <variant>
 #include <wtf/CrossThreadCopier.h>
 
 namespace WebCore {

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmEcdsaParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmEcdsaParams.h
@@ -28,7 +28,6 @@
 #include "CryptoAlgorithmParameters.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
-#include <variant>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmHmacKeyParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmHmacKeyParams.h
@@ -28,7 +28,6 @@
 #include "CryptoAlgorithmParameters.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
-#include <variant>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedImportParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedImportParams.h
@@ -28,7 +28,6 @@
 #include "CryptoAlgorithmParameters.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
-#include <variant>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedKeyGenParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedKeyGenParams.h
@@ -28,7 +28,6 @@
 #include "CryptoAlgorithmRsaKeyGenParams.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
-#include <variant>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmX25519Params.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmX25519Params.h
@@ -24,7 +24,6 @@
 #include "CryptoKey.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
-#include <variant>
 
 namespace WebCore {
 

--- a/Source/WebCore/css/CSSFontFaceSet.h
+++ b/Source/WebCore/css/CSSFontFaceSet.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "CSSFontFace.h"
-#include <variant>
 #include <wtf/HashMap.h>
 #include <wtf/Observer.h>
 #include <wtf/Vector.h>

--- a/Source/WebCore/css/CSSStyleProperties.cpp
+++ b/Source/WebCore/css/CSSStyleProperties.cpp
@@ -45,7 +45,6 @@
 #include "StyleProperties.h"
 #include "StyleSheetContents.h"
 #include "StyledElement.h"
-#include <variant>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/ParsingUtilities.h>

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -27,7 +27,6 @@
 #include "MediaQuery.h"
 #include "StyleSheet.h"
 #include <memory>
-#include <variant>
 #include <wtf/CheckedPtr.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TypeCasts.h>

--- a/Source/WebCore/css/DOMMatrixReadOnly.h
+++ b/Source/WebCore/css/DOMMatrixReadOnly.h
@@ -30,7 +30,6 @@
 #include "ScriptWrappable.h"
 #include "TransformationMatrix.h"
 #include <JavaScriptCore/Forward.h>
-#include <variant>
 #include <wtf/NoVirtualDestructorBase.h>
 #include <wtf/RefCounted.h>
 #include <wtf/Vector.h>

--- a/Source/WebCore/css/FontFace.h
+++ b/Source/WebCore/css/FontFace.h
@@ -30,7 +30,6 @@
 #include "CSSPropertyNames.h"
 #include "ExceptionOr.h"
 #include "IDLTypes.h"
-#include <variant>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakPtr.h>
 

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -31,7 +31,6 @@
 #include "MediaQuery.h"
 #include "StyleRuleType.h"
 #include <map>
-#include <variant>
 #include <wtf/NoVirtualDestructorBase.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>

--- a/Source/WebCore/css/calc/CSSCalcTree.h
+++ b/Source/WebCore/css/calc/CSSCalcTree.h
@@ -30,7 +30,6 @@
 #include "CSSPrimitiveNumericRange.h"
 #include "CSSUnits.h"
 #include "CSSValueKeywords.h"
-#include <variant>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>

--- a/Source/WebCore/css/typedom/CSSNumericValue.h
+++ b/Source/WebCore/css/typedom/CSSNumericValue.h
@@ -27,7 +27,6 @@
 
 #include "CSSNumericType.h"
 #include "CSSStyleValue.h"
-#include <variant>
 #include <wtf/HashMap.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
@@ -36,7 +36,6 @@
 #include "CSSTokenizer.h"
 #include "CSSVariableReferenceValue.h"
 #include "ExceptionOr.h"
-#include <variant>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>

--- a/Source/WebCore/css/typedom/CSSUnparsedValue.h
+++ b/Source/WebCore/css/typedom/CSSUnparsedValue.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "CSSStyleValue.h"
-#include <variant>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/values/CSSValueAggregates.h
+++ b/Source/WebCore/css/values/CSSValueAggregates.h
@@ -30,7 +30,6 @@
 #include <optional>
 #include <tuple>
 #include <utility>
-#include <variant>
 #include <wtf/Markable.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>

--- a/Source/WebCore/css/values/color/CSSAbsoluteColorSerialization.h
+++ b/Source/WebCore/css/values/color/CSSAbsoluteColorSerialization.h
@@ -28,7 +28,6 @@
 #include "CSSColorDescriptors.h"
 #include "ColorSerialization.h"
 #include <optional>
-#include <variant>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/values/color/CSSColor.h
+++ b/Source/WebCore/css/values/color/CSSColor.h
@@ -31,7 +31,6 @@
 #include "CSSKeywordColor.h"
 #include "CSSResolvedColor.h"
 #include "CSSValueTypes.h"
-#include <variant>
 #include <wtf/Markable.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/values/color/CSSColorDescriptors.h
+++ b/Source/WebCore/css/values/color/CSSColorDescriptors.h
@@ -34,7 +34,6 @@
 #include "ColorTypes.h"
 #include "StylePrimitiveNumericTypes.h"
 #include <optional>
-#include <variant>
 #include <wtf/Brigand.h>
 #include <wtf/OptionSet.h>
 #include <wtf/StdLibExtras.h>

--- a/Source/WebCore/css/values/color/CSSRelativeColor.h
+++ b/Source/WebCore/css/values/color/CSSRelativeColor.h
@@ -31,7 +31,6 @@
 #include "CSSPrimitiveNumericTypes+EvaluateCalc.h"
 #include "CSSRelativeColorResolver.h"
 #include "CSSRelativeColorSerialization.h"
-#include <variant>
 #include <wtf/Forward.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/values/color/CSSRelativeColorSerialization.h
+++ b/Source/WebCore/css/values/color/CSSRelativeColorSerialization.h
@@ -29,7 +29,6 @@
 #include "CSSPrimitiveNumericTypes+Serialization.h"
 #include "ColorSerialization.h"
 #include <optional>
-#include <variant>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/values/filter-effects/CSSFilterFunction.h
+++ b/Source/WebCore/css/values/filter-effects/CSSFilterFunction.h
@@ -35,7 +35,6 @@
 #include "CSSOpacityFunction.h"
 #include "CSSSaturateFunction.h"
 #include "CSSSepiaFunction.h"
-#include <variant>
 
 namespace WebCore {
 namespace CSS {

--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
@@ -27,7 +27,6 @@
 #include "CSSPrimitiveNumericConcepts.h"
 #include "CSSValueTypes.h"
 #include <optional>
-#include <variant>
 #include <wtf/Forward.h>
 #include <wtf/IterationStatus.h>
 #include <wtf/Ref.h>

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -64,7 +64,6 @@
 #include "StaticNodeList.h"
 #include "TemplateContentDocumentFragment.h"
 #include <algorithm>
-#include <variant>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/DocumentMarker.h
+++ b/Source/WebCore/dom/DocumentMarker.h
@@ -22,7 +22,6 @@
 
 #include "DictationContext.h"
 #include "SimpleRange.h"
-#include <variant>
 #include <wtf/Forward.h>
 #include <wtf/OptionSet.h>
 #include <wtf/UUID.h>

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -36,7 +36,6 @@
 #include "ExceptionOr.h"
 #include "ScriptWrappable.h"
 #include <memory>
-#include <variant>
 #include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/dom/MessageEvent.h
+++ b/Source/WebCore/dom/MessageEvent.h
@@ -33,7 +33,6 @@
 #include "SerializedScriptValue.h"
 #include "ServiceWorker.h"
 #include "WindowProxy.h"
-#include <variant>
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -90,7 +90,6 @@
 #include "XMLNSNames.h"
 #include "XMLNames.h"
 #include <JavaScriptCore/HeapInlines.h>
-#include <variant>
 #include <wtf/HexNumber.h>
 #include <wtf/RefCountedLeakCounter.h>
 #include <wtf/SHA1.h>

--- a/Source/WebCore/editing/AlternativeTextController.h
+++ b/Source/WebCore/editing/AlternativeTextController.h
@@ -29,7 +29,6 @@
 #include "DocumentMarker.h"
 #include "EventLoop.h"
 #include "Position.h"
-#include <variant>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>

--- a/Source/WebCore/fileapi/Blob.h
+++ b/Source/WebCore/fileapi/Blob.h
@@ -39,7 +39,6 @@
 #include "SecurityOriginData.h"
 #include "URLKeepingBlobAlive.h"
 #include "URLRegistry.h"
-#include <variant>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 

--- a/Source/WebCore/fileapi/NetworkSendQueue.h
+++ b/Source/WebCore/fileapi/NetworkSendQueue.h
@@ -28,7 +28,6 @@
 #include "ContextDestructionObserver.h"
 #include "ExceptionCode.h"
 #include <span>
-#include <variant>
 #include <wtf/Deque.h>
 #include <wtf/Function.h>
 #include <wtf/UniqueRef.h>

--- a/Source/WebCore/html/DOMFormData.h
+++ b/Source/WebCore/html/DOMFormData.h
@@ -32,7 +32,6 @@
 
 #include "File.h"
 #include <pal/text/TextEncoding.h>
-#include <variant>
 #include <wtf/RefCounted.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/html/HTMLAllCollection.cpp
+++ b/Source/WebCore/html/HTMLAllCollection.cpp
@@ -30,7 +30,6 @@
 #include "Element.h"
 #include "NodeRareDataInlines.h"
 #include <JavaScriptCore/Identifier.h>
-#include <variant>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -54,7 +54,6 @@
 #include "WebCodecsVideoFrame.h"
 #include "WorkerClient.h"
 #include "WorkerGlobalScope.h"
-#include <variant>
 #include <wtf/Scope.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/html/ImageDataArray.h
+++ b/Source/WebCore/html/ImageDataArray.h
@@ -32,7 +32,6 @@
 #include <JavaScriptCore/Float16Array.h>
 #include <JavaScriptCore/Uint8ClampedArray.h>
 #include <optional>
-#include <variant>
 #include <wtf/JSONValues.h>
 
 namespace WebCore {

--- a/Source/WebCore/html/URLSearchParams.h
+++ b/Source/WebCore/html/URLSearchParams.h
@@ -26,7 +26,6 @@
 
 #include "ExceptionOr.h"
 #include "ScriptExecutionContext.h"
-#include <variant>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/html/canvas/CanvasPath.h
+++ b/Source/WebCore/html/canvas/CanvasPath.h
@@ -30,7 +30,6 @@
 
 #include "ExceptionOr.h"
 #include "Path.h"
-#include <variant>
 #include <wtf/Forward.h>
 
 namespace WebCore {

--- a/Source/WebCore/html/canvas/CanvasStyle.h
+++ b/Source/WebCore/html/canvas/CanvasStyle.h
@@ -31,7 +31,6 @@
 #include "Color.h"
 #include "ColorSerialization.h"
 #include <optional>
-#include <variant>
 
 namespace WebCore {
 

--- a/Source/WebCore/html/canvas/GPUCanvasContext.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.h
@@ -27,7 +27,6 @@
 
 #include "ExceptionOr.h"
 #include "GPUBasedCanvasRenderingContext.h"
-#include <variant>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -36,7 +36,6 @@
 #include "IOSurface.h"
 #include "OffscreenCanvas.h"
 #include "PlatformCALayer.h"
-#include <variant>
 #include <wtf/MachSendRight.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>

--- a/Source/WebCore/html/canvas/WebGLFramebuffer.h
+++ b/Source/WebCore/html/canvas/WebGLFramebuffer.h
@@ -28,7 +28,6 @@
 #if ENABLE(WEBGL)
 
 #include "WebGLObject.h"
-#include <variant>
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
 #include <wtf/Vector.h>

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -89,7 +89,6 @@
 #include <JavaScriptCore/IdentifiersFactory.h>
 #include <JavaScriptCore/ScriptCallStackFactory.h>
 #include <JavaScriptCore/TypedArrays.h>
-#include <variant>
 #include <wtf/Function.h>
 #include <wtf/RefPtr.h>
 #include <wtf/Scope.h>

--- a/Source/WebCore/inspector/InspectorCanvas.h
+++ b/Source/WebCore/inspector/InspectorCanvas.h
@@ -30,7 +30,6 @@
 #include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <JavaScriptCore/ScriptCallFrame.h>
 #include <JavaScriptCore/ScriptCallStack.h>
-#include <variant>
 #include <wtf/HashSet.h>
 #include <wtf/WeakRef.h>
 

--- a/Source/WebCore/inspector/InspectorCanvasCallTracer.cpp
+++ b/Source/WebCore/inspector/InspectorCanvasCallTracer.cpp
@@ -63,7 +63,6 @@
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <JavaScriptCore/ArrayBufferView.h>
 #include <JavaScriptCore/TypedArrays.h>
-#include <variant>
 #include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -71,7 +71,6 @@
 #include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/TypedArrays.h>
-#include <variant>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBox.h
@@ -27,7 +27,6 @@
 
 #include "InlineIteratorBoxLegacyPath.h"
 #include "InlineIteratorBoxModernPath.h"
-#include <variant>
 
 namespace WebCore {
 

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
@@ -29,7 +29,6 @@
 #include "InlineIteratorLineBoxLegacyPath.h"
 #include "InlineIteratorLineBoxModernPath.h"
 #include "RenderBlockFlow.h"
-#include <variant>
 
 namespace WebCore {
 

--- a/Source/WebCore/loader/ResourceLoaderOptions.h
+++ b/Source/WebCore/loader/ResourceLoaderOptions.h
@@ -43,7 +43,6 @@
 #include "ServiceWorkerTypes.h"
 #include "SharedWorkerIdentifier.h"
 #include "StoredCredentialsPolicy.h"
-#include <variant>
 #include <wtf/HashSet.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/page/DiagnosticLoggingClient.h
+++ b/Source/WebCore/page/DiagnosticLoggingClient.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "DiagnosticLoggingDomain.h"
-#include <variant>
 #include <wtf/CheckedPtr.h>
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/HashMap.h>

--- a/Source/WebCore/page/IntersectionObserver.h
+++ b/Source/WebCore/page/IntersectionObserver.h
@@ -30,7 +30,6 @@
 #include "IntersectionObserverCallback.h"
 #include "LengthBox.h"
 #include "ReducedResolutionSeconds.h"
-#include <variant>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -134,7 +134,6 @@
 #include <JavaScriptCore/ScriptCallStackFactory.h>
 #include <algorithm>
 #include <memory>
-#include <variant>
 #include <wtf/Language.h>
 #include <wtf/MainThread.h>
 #include <wtf/MathExtras.h>

--- a/Source/WebCore/page/Performance.h
+++ b/Source/WebCore/page/Performance.h
@@ -39,7 +39,6 @@
 #include "ReducedResolutionSeconds.h"
 #include "ScriptExecutionContext.h"
 #include "Timer.h"
-#include <variant>
 #include <wtf/ListHashSet.h>
 
 namespace JSC {

--- a/Source/WebCore/page/PerformanceMeasureOptions.h
+++ b/Source/WebCore/page/PerformanceMeasureOptions.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <JavaScriptCore/JSCJSValue.h>
-#include <variant>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -35,7 +35,6 @@
 #include "ScrollingCoordinatorTypes.h"
 #include "UserInterfaceLayoutDirection.h"
 #include "WheelEventTestMonitor.h"
-#include <variant>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>

--- a/Source/WebCore/platform/Cursor.h
+++ b/Source/WebCore/platform/Cursor.h
@@ -27,7 +27,6 @@
 
 #include "Image.h"
 #include "IntPoint.h"
-#include <variant>
 #include <wtf/Assertions.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/platform/PasteboardCustomData.h
+++ b/Source/WebCore/platform/PasteboardCustomData.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <variant>
 #include <wtf/Function.h>
 #include <wtf/HashMap.h>
 #include <wtf/Vector.h>

--- a/Source/WebCore/platform/ProcessIdentity.h
+++ b/Source/WebCore/platform/ProcessIdentity.h
@@ -31,7 +31,6 @@
 #include <wtf/ArgumentCoder.h>
 #include <wtf/MachSendRight.h>
 #else
-#include <variant>
 #endif
 
 namespace WebCore {

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -29,7 +29,6 @@
 #include <JavaScriptCore/Forward.h>
 #include <span>
 #include <utility>
-#include <variant>
 #include <wtf/FileSystem.h>
 #include <wtf/Forward.h>
 #include <wtf/Function.h>

--- a/Source/WebCore/platform/audio/AudioStreamDescription.h
+++ b/Source/WebCore/platform/audio/AudioStreamDescription.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <variant>
 
 typedef struct AudioStreamBasicDescription AudioStreamBasicDescription;
 

--- a/Source/WebCore/platform/calc/CalculationTree.h
+++ b/Source/WebCore/platform/calc/CalculationTree.h
@@ -27,7 +27,6 @@
 #include "CalculationOperator.h"
 #include <optional>
 #include <tuple>
-#include <variant>
 #include <wtf/Ref.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>

--- a/Source/WebCore/platform/graphics/ColorInterpolationMethod.h
+++ b/Source/WebCore/platform/graphics/ColorInterpolationMethod.h
@@ -28,7 +28,6 @@
 #include "AlphaPremultiplication.h"
 #include "ColorTypes.h"
 #include <optional>
-#include <variant>
 #include <wtf/Hasher.h>
 
 namespace WTF {

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -28,7 +28,6 @@
 #include "GlyphMetricsMap.h"
 #include "GlyphPage.h"
 #include "RenderingResourceIdentifier.h"
-#include <variant>
 #include <wtf/BitVector.h>
 #include <wtf/Hasher.h>
 #include <wtf/WeakPtr.h>

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.h
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.h
@@ -26,7 +26,6 @@
 
 #include "CSSValueKeywords.h"
 #include "FontDescription.h"
-#include <variant>
 #include <wtf/RefCountedFixedVector.h>
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/platform/graphics/FontPalette.h
+++ b/Source/WebCore/platform/graphics/FontPalette.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <variant>
 #include <wtf/Hasher.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/TextStream.h>

--- a/Source/WebCore/platform/graphics/FontPaletteValues.h
+++ b/Source/WebCore/platform/graphics/FontPaletteValues.h
@@ -27,7 +27,6 @@
 
 #include "Color.h"
 #include "Gradient.h"
-#include <variant>
 #include <wtf/HashFunctions.h>
 #include <wtf/Vector.h>
 #include <wtf/text/AtomString.h>

--- a/Source/WebCore/platform/graphics/FontSizeAdjust.h
+++ b/Source/WebCore/platform/graphics/FontSizeAdjust.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "FontMetrics.h"
-#include <variant>
 #include <wtf/Markable.h>
 #include <wtf/text/TextStream.h>
 

--- a/Source/WebCore/platform/graphics/Gradient.h
+++ b/Source/WebCore/platform/graphics/Gradient.h
@@ -33,7 +33,6 @@
 #include "GradientColorStops.h"
 #include "GraphicsTypes.h"
 #include "RenderingResource.h"
-#include <variant>
 #include <wtf/Vector.h>
 
 #if USE(SKIA)

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayerDelegatedContents.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayerDelegatedContents.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "RenderingResourceIdentifier.h"
-#include <variant>
 #include <wtf/MachSendRight.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/ObjectIdentifier.h>

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParser.h
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParser.h
@@ -31,7 +31,6 @@
 #include "SourceBufferPrivateClient.h"
 #include <JavaScriptCore/Forward.h>
 #include <pal/spi/cocoa/MediaToolboxSPI.h>
-#include <variant>
 #include <wtf/Expected.h>
 #include <wtf/RefCounted.h>
 #include <wtf/ThreadSafeWeakPtr.h>

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
@@ -34,7 +34,6 @@
 #include "SourceBufferParser.h"
 #include <CoreAudio/CoreAudioTypes.h>
 #include <pal/spi/cf/CoreMediaSPI.h>
-#include <variant>
 #include <webm/callback.h>
 #include <webm/common/vp9_header_parser.h>
 #include <webm/status.h>

--- a/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.h
+++ b/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.h
@@ -29,7 +29,6 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <CoreText/CoreText.h>
 #include <optional>
-#include <variant>
 #include <wtf/RetainPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "RenderingResourceIdentifier.h"
-#include <variant>
 #include <wtf/OptionSet.h>
 
 namespace WTF {

--- a/Source/WebCore/platform/network/DNS.h
+++ b/Source/WebCore/platform/network/DNS.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <optional>
-#include <variant>
 #include <wtf/Forward.h>
 #include <wtf/HashTraits.h>
 #include <wtf/StdLibExtras.h>

--- a/Source/WebCore/platform/network/FormData.h
+++ b/Source/WebCore/platform/network/FormData.h
@@ -20,7 +20,6 @@
 #pragma once
 
 #include "BlobData.h"
-#include <variant>
 #include <wtf/ArgumentCoder.h>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>

--- a/Source/WebCore/platform/sql/SQLValue.h
+++ b/Source/WebCore/platform/sql/SQLValue.h
@@ -28,7 +28,6 @@
 
 #pragma once
 
-#include <variant>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/sql/SQLiteStatement.cpp
+++ b/Source/WebCore/platform/sql/SQLiteStatement.cpp
@@ -30,7 +30,6 @@
 #include "SQLValue.h"
 #include "SQLiteDatabaseTracker.h"
 #include <sqlite3.h>
-#include <variant>
 #include <wtf/Assertions.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/platform/text/TextFlags.h
+++ b/Source/WebCore/platform/text/TextFlags.h
@@ -27,7 +27,6 @@
 
 #include "FontTaggedSettings.h"
 #include <optional>
-#include <variant>
 #include <vector>
 #include <wtf/Hasher.h>
 #include <wtf/Markable.h>

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -25,7 +25,6 @@
 #include "IntRect.h"
 #include "IntSize.h"
 #include <memory>
-#include <variant>
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashMap.h>
 #include <wtf/Ref.h>

--- a/Source/WebCore/rendering/style/StyleGridData.h
+++ b/Source/WebCore/rendering/style/StyleGridData.h
@@ -29,7 +29,6 @@
 #include "GridTrackSize.h"
 #include "RenderStyleConstants.h"
 #include "StyleContentAlignmentData.h"
-#include <variant>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 #include <wtf/Vector.h>

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePaintServer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePaintServer.h
@@ -21,7 +21,6 @@
 
 #include "Color.h"
 #include "RenderSVGResourceContainer.h"
-#include <variant>
 
 namespace WebCore {
 

--- a/Source/WebCore/style/values/StyleValueTypes.h
+++ b/Source/WebCore/style/values/StyleValueTypes.h
@@ -30,7 +30,6 @@
 #include <optional>
 #include <tuple>
 #include <utility>
-#include <variant>
 #include <wtf/StdLibExtras.h>
 
 namespace WebCore {

--- a/Source/WebCore/testing/TypeConversions.h
+++ b/Source/WebCore/testing/TypeConversions.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "Node.h"
-#include <variant>
 #include <wtf/RefCounted.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/workers/FetchingWorkerIdentifier.h
+++ b/Source/WebCore/workers/FetchingWorkerIdentifier.h
@@ -27,7 +27,6 @@
 
 #include "ServiceWorkerIdentifier.h"
 #include "SharedWorkerIdentifier.h"
-#include <variant>
 
 namespace WebCore {
 

--- a/Source/WebCore/workers/WorkerInspectorProxy.h
+++ b/Source/WebCore/workers/WorkerInspectorProxy.h
@@ -27,7 +27,6 @@
 
 #include "PageIdentifier.h"
 #include "ScriptExecutionContextIdentifier.h"
-#include <variant>
 #include <wtf/CheckedPtr.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/FastMalloc.h>

--- a/Source/WebCore/workers/service/ExtendableMessageEvent.h
+++ b/Source/WebCore/workers/service/ExtendableMessageEvent.h
@@ -31,7 +31,6 @@
 #include "MessagePort.h"
 #include "ServiceWorker.h"
 #include "ServiceWorkerClient.h"
-#include <variant>
 
 namespace JSC {
 class CallFrame;

--- a/Source/WebCore/workers/service/ServiceWorkerRoute.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRoute.h
@@ -32,7 +32,6 @@
 #include "RouterSourceEnum.h"
 #include "RunningStatus.h"
 #include <optional>
-#include <variant>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/workers/service/ServiceWorkerTypes.h
+++ b/Source/WebCore/workers/service/ServiceWorkerTypes.h
@@ -30,7 +30,6 @@
 #include "ScriptBuffer.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include "ServiceWorkerIdentifier.h"
-#include <variant>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/URLHash.h>

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -33,7 +33,6 @@
 #include <wtf/URL.h>
 #include "XMLHttpRequestEventTarget.h"
 #include "XMLHttpRequestProgressEventThrottle.h"
-#include <variant>
 #include <wtf/CancellableTask.h>
 #include <wtf/text/StringBuilder.h>
 

--- a/Source/WebGPU/WGSL/WGSL.h
+++ b/Source/WebGPU/WGSL/WGSL.h
@@ -32,11 +32,11 @@
 #include <cinttypes>
 #include <cstdint>
 #include <memory>
-#include <variant>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/OptionSet.h>
 #include <wtf/UniqueRef.h>
+#include <wtf/Variant.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebKit/GPUProcess/ShapeDetection/ShapeDetectionObjectHeap.h
+++ b/Source/WebKit/GPUProcess/ShapeDetection/ShapeDetectionObjectHeap.h
@@ -30,7 +30,6 @@
 #include "ScopedActiveMessageReceiveQueue.h"
 #include "ShapeDetectionIdentifier.h"
 #include <functional>
-#include <variant>
 #include <wtf/HashMap.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.h
@@ -31,7 +31,6 @@
 #include "WebGPUConvertFromBackingContext.h"
 #include "WebGPUIdentifier.h"
 #include <functional>
-#include <variant>
 #include <wtf/HashMap.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
@@ -32,7 +32,6 @@
 #include <WebCore/FetchOptions.h>
 #include <WebCore/NetworkLoadInformation.h>
 #include <pal/SessionID.h>
-#include <variant>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
@@ -44,7 +44,6 @@
 #endif
 
 #if USE(CURL)
-#include <variant>
 #include <wtf/Box.h>
 #endif
 

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -30,7 +30,6 @@
 #include "Encoder.h"
 #include "GeneratedSerializers.h"
 #include <utility>
-#include <variant>
 #include <wtf/ArgumentCoder.h>
 #include <wtf/Box.h>
 #include <wtf/CheckedArithmetic.h>

--- a/Source/WebKit/Platform/IPC/MessageReceiveQueueMap.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiveQueueMap.h
@@ -27,7 +27,6 @@
 
 #include "Decoder.h"
 #include "MessageReceiveQueue.h"
-#include <variant>
 #include <wtf/HashMap.h>
 
 namespace IPC {

--- a/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.h
+++ b/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.h
@@ -30,7 +30,6 @@
 #include "CoreIPCAVOutputContext.h"
 #include <WebCore/MediaPlaybackTargetCocoa.h>
 #include <WebCore/MediaPlaybackTargetMock.h>
-#include <variant>
 
 namespace WebKit {
 

--- a/Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesStoreDefaultsMap.cpp.erb
+++ b/Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesStoreDefaultsMap.cpp.erb
@@ -31,7 +31,6 @@
 #include "WebKit2Initialize.h"
 #include "WebPreferencesDefinitions.h"
 #include "WebPreferencesKeys.h"
-#include <variant>
 #include <wtf/NeverDestroyed.h>
 
 // FIXME: These should added via options in WebPreferences.yaml, rather than hardcoded.

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -880,7 +880,7 @@ def class_template_headers(template_string):
         'std::optional': {'headers': ['<optional>'], 'argument_coder_headers': ['"ArgumentCoders.h"']},
         'std::pair': {'headers': ['<utility>'], 'argument_coder_headers': ['"ArgumentCoders.h"']},
         'std::span': {'headers': ['<span>'], 'argument_coder_headers': ['"ArgumentCoders.h"']},
-        'std::variant': {'headers': ['<variant>'], 'argument_coder_headers': ['"ArgumentCoders.h"']},
+        'std::variant': {'headers': ['<wtf/Variant.h>'], 'argument_coder_headers': ['"ArgumentCoders.h"']},
         'IPC::ArrayReferenceTuple': {'headers': ['"ArrayReferenceTuple.h"'], 'argument_coder_headers': ['"ArgumentCoders.h"']},
         'Ref': {'headers': ['<wtf/Ref.h>'], 'argument_coder_headers': ['"ArgumentCoders.h"']},
         'RefPtr': {'headers': ['<wtf/RefCounted.h>'], 'argument_coder_headers': ['"ArgumentCoders.h"']},

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -239,7 +239,7 @@ header: <wtf/MemoryPressureHandler.h>
     Critical,
 }
 
-header: <variant>
+header: <wtf/Variant.h>
 [AdditionalEncoder=StreamConnectionEncoder, Nested] struct std::monostate {
 }
 

--- a/Source/WebKit/Shared/WebCompiledContentRuleListData.h
+++ b/Source/WebKit/Shared/WebCompiledContentRuleListData.h
@@ -29,7 +29,6 @@
 
 #include <WebCore/SharedBuffer.h>
 #include <WebCore/SharedMemory.h>
-#include <variant>
 #include <wtf/RefPtr.h>
 
 namespace WebKit {

--- a/Source/WebKit/Shared/WebFoundTextRange.h
+++ b/Source/WebKit/Shared/WebFoundTextRange.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "ArgumentCoders.h"
-#include <variant>
 #include <wtf/HashTraits.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebKit/Shared/WebGPU/WebGPUColor.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUColor.h
@@ -28,7 +28,6 @@
 #if ENABLE(GPU_PROCESS)
 
 #include <optional>
-#include <variant>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebKit/Shared/WebGPU/WebGPUError.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUError.h
@@ -30,7 +30,6 @@
 #include "WebGPUInternalError.h"
 #include "WebGPUOutOfMemoryError.h"
 #include "WebGPUValidationError.h"
-#include <variant>
 
 namespace WebKit::WebGPU {
 

--- a/Source/WebKit/Shared/WebGPU/WebGPUExtent3D.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUExtent3D.h
@@ -29,7 +29,6 @@
 
 #include <WebCore/WebGPUIntegralTypes.h>
 #include <optional>
-#include <variant>
 #include <wtf/Vector.h>
 
 namespace WebKit::WebGPU {

--- a/Source/WebKit/Shared/WebGPU/WebGPUImageCopyExternalImage.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUImageCopyExternalImage.h
@@ -29,7 +29,6 @@
 
 #include "WebGPUOrigin2D.h"
 #include <optional>
-#include <variant>
 
 namespace WebKit::WebGPU {
 

--- a/Source/WebKit/Shared/WebGPU/WebGPUOrigin3D.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUOrigin3D.h
@@ -29,7 +29,6 @@
 
 #include <WebCore/WebGPUIntegralTypes.h>
 #include <optional>
-#include <variant>
 #include <wtf/Vector.h>
 
 namespace WebKit::WebGPU {

--- a/Source/WebKit/Shared/WebGPU/WebGPURenderPassColorAttachment.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPURenderPassColorAttachment.h
@@ -33,7 +33,6 @@
 #include <WebCore/WebGPULoadOp.h>
 #include <WebCore/WebGPUStoreOp.h>
 #include <optional>
-#include <variant>
 #include <wtf/Ref.h>
 #include <wtf/Vector.h>
 

--- a/Source/WebKit/Shared/WebGPU/WebGPURenderPassDepthStencilAttachment.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPURenderPassDepthStencilAttachment.h
@@ -32,7 +32,6 @@
 #include <WebCore/WebGPULoadOp.h>
 #include <WebCore/WebGPUStoreOp.h>
 #include <optional>
-#include <variant>
 #include <wtf/Ref.h>
 
 namespace WebKit::WebGPU {

--- a/Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.h
+++ b/Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.h
@@ -29,7 +29,6 @@
 
 #include "APIObject.h"
 #include <WebCore/AuthenticatorTransport.h>
-#include <variant>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -40,7 +40,6 @@
 #import "_WKAttachmentInternal.h"
 #import "_WKWebViewPrintFormatterInternal.h"
 #import <pal/spi/cocoa/WritingToolsSPI.h>
-#import <variant>
 #import <wtf/BlockPtr.h>
 #import <wtf/CompletionHandler.h>
 #import <wtf/HashMap.h>

--- a/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp
+++ b/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp
@@ -34,7 +34,6 @@
 #include "WebAutomationSessionMacros.h"
 #include "WebPageProxy.h"
 #include <WebCore/PointerEventTypeNames.h>
-#include <variant>
 
 #if ENABLE(WEBDRIVER_KEYBOARD_GRAPHEME_CLUSTERS)
 #include <wtf/text/TextBreakIterator.h>

--- a/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.h
+++ b/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.h
@@ -29,7 +29,6 @@
 
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/IntPoint.h>
-#include <variant>
 #include <wtf/CompletionHandler.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/RunLoop.h>

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h
@@ -27,7 +27,6 @@
 
 #if HAVE(APP_SSO)
 
-#include <variant>
 #include "FrameLoadState.h"
 #include "NavigationSOAuthorizationSession.h"
 #include <WebCore/FrameIdentifier.h>

--- a/Source/WebKit/UIProcess/Cocoa/_WKWarningView.h
+++ b/Source/WebKit/UIProcess/Cocoa/_WKWarningView.h
@@ -25,7 +25,6 @@
 
 #import "WKFoundation.h"
 #import <WebCore/ColorCocoa.h>
-#import <variant>
 #import <wtf/CompletionHandler.h>
 #import <wtf/RefPtr.h>
 #import <wtf/RetainPtr.h>

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -51,7 +51,6 @@
 #include <WebCore/TextAnimationTypes.h>
 #include <WebCore/UserInterfaceLayoutDirection.h>
 #include <WebCore/ValidationBubble.h>
-#include <variant>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationRequestData.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationRequestData.h
@@ -36,7 +36,6 @@
 #include <WebCore/PublicKeyCredentialCreationOptions.h>
 #include <WebCore/PublicKeyCredentialRequestOptions.h>
 #include <WebCore/WebAuthenticationConstants.h>
-#include <variant>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 

--- a/Source/WebKit/WebKit2Prefix.h
+++ b/Source/WebKit/WebKit2Prefix.h
@@ -66,6 +66,7 @@
 #include <string>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/Variant.h>
 #endif
 
 #ifdef __OBJC__

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferBackendHandle.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferBackendHandle.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <WebCore/ShareableBitmap.h>
-#include <variant>
 #include <wtf/MachSendRight.h>
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLOptionsCollection.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLOptionsCollection.mm
@@ -37,7 +37,6 @@
 #import <WebCore/ThreadCheck.h>
 #import <WebCore/WebCoreObjCExtras.h>
 #import <WebCore/WebScriptObjectPrivate.h>
-#import <variant>
 #import <wtf/GetPtr.h>
 #import <wtf/URL.h>
 

--- a/Tools/TestWebKitAPI/Tests/WTF/CrossThreadCopierTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CrossThreadCopierTests.cpp
@@ -26,9 +26,9 @@
 #include "config.h"
 
 #include "Test.h"
-#include <variant>
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/URL.h>
+#include <wtf/Variant.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FrameTreeChecks.h
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FrameTreeChecks.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <variant>
+#include <wtf/Variant.h>
 #include <wtf/Vector.h>
 
 namespace TestWebKitAPI {


### PR DESCRIPTION
#### 7f62a88a674a810b02784b2d141a23839416215b
<pre>
Prepare to switch from std::variant to WTF::Variant
<a href="https://rdar.apple.com/149072846">rdar://149072846</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291432">https://bugs.webkit.org/show_bug.cgi?id=291432</a>

Reviewed by Keith Miller.

libcpp&apos;s std::variant implementation generates suboptimal code.
See <a href="https://github.com/llvm/llvm-project/issues/62648">https://github.com/llvm/llvm-project/issues/62648</a>
We have partially mitigated this in <a href="https://commits.webkit.org/283806@main">https://commits.webkit.org/283806@main</a>
and <a href="https://commits.webkit.org/289736@main">https://commits.webkit.org/289736@main</a> by making our own std::visit
replacements, but that doesn&apos;t help std::variant&apos;s destructor or copy
constructor.

This patch adds a &lt;wtf/Variant.h&gt; header that simply includes &lt;variant&gt;.
This is step 1 of at least 3 to replace our use of std::variant.
Step 2 will be to add &quot;using Variant = std::variant&quot; and replace our
uses of std::variant with Variant, which will initially not change anything
because it will be just an alias, then step 3 will be to replace the alias
with our own implementation.

While I was at it, I put wtf/Variant.h into precompiled headers.  That
saved me from needing to realphabetize ~150 includes to meet WebKit style
and it also will speed up build time.

* Source/JavaScriptCore/JavaScriptCorePrefix.h:
* Source/JavaScriptCore/disassembler/Disassembler.cpp:
* Source/JavaScriptCore/interpreter/Interpreter.h:
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
* Source/JavaScriptCore/jit/SnippetReg.h:
* Source/JavaScriptCore/parser/Lexer.cpp:
* Source/JavaScriptCore/parser/VariableEnvironment.h:
* Source/JavaScriptCore/runtime/BytecodeCacheError.h:
* Source/JavaScriptCore/runtime/CachePayload.h:
* Source/JavaScriptCore/runtime/CacheUpdate.h:
* Source/JavaScriptCore/runtime/TemporalObject.h:
* Source/JavaScriptCore/runtime/TemporalTimeZone.h:
* Source/JavaScriptCore/runtime/VM.h:
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/CompactVariantOperations.h:
* Source/WTF/wtf/CrossThreadCopier.h:
* Source/WTF/wtf/Expected.h:
* Source/WTF/wtf/FlatteningVariantAdaptor.h:
* Source/WTF/wtf/GenericHashKey.h:
* Source/WTF/wtf/Hasher.h:
* Source/WTF/wtf/LikelyDenseUnsignedIntegerSet.h:
* Source/WTF/wtf/SmallMap.h:
* Source/WTF/wtf/StdLibExtras.h:
* Source/WTF/wtf/Variant.h: Copied from Source/WebCore/workers/FetchingWorkerIdentifier.h.
* Source/WTF/wtf/VariantExtras.h:
* Source/WTF/wtf/VariantList.h:
* Source/WTF/wtf/text/TextBreakIterator.h:
* Source/WebCore/Modules/WebGPU/GPUBindGroupEntry.h:
* Source/WebCore/Modules/WebGPU/GPUColorDict.h:
* Source/WebCore/Modules/WebGPU/GPUError.h:
* Source/WebCore/Modules/WebGPU/GPUExtent3DDict.h:
* Source/WebCore/Modules/WebGPU/GPUImageCopyExternalImage.h:
* Source/WebCore/Modules/WebGPU/GPUOrigin2DDict.h:
* Source/WebCore/Modules/WebGPU/GPUOrigin3DDict.h:
* Source/WebCore/Modules/WebGPU/GPUPipelineDescriptorBase.h:
* Source/WebCore/Modules/WebGPU/GPURenderPassColorAttachment.h:
* Source/WebCore/Modules/WebGPU/GPURenderPassDepthStencilAttachment.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroupEntry.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUColor.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUError.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUExtent3D.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUImageCopyExternalImage.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUOrigin2D.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUOrigin3D.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassColorAttachment.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassDepthStencilAttachment.h:
* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h:
* Source/WebCore/Modules/fetch/FetchBody.h:
* Source/WebCore/Modules/fetch/FetchHeaders.h:
* Source/WebCore/Modules/indexeddb/IDBCursor.h:
* Source/WebCore/Modules/indexeddb/IDBGetAllResult.h:
* Source/WebCore/Modules/indexeddb/IDBKey.h:
* Source/WebCore/Modules/indexeddb/IDBKeyData.h:
* Source/WebCore/Modules/indexeddb/IDBKeyPath.h:
* Source/WebCore/Modules/indexeddb/IDBRequest.cpp:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.h:
* Source/WebCore/Modules/mediastream/MediaTrackConstraints.h:
* Source/WebCore/Modules/mediastream/RTCIceServer.h:
* Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.h:
* Source/WebCore/Modules/paymentrequest/PaymentRequest.h:
* Source/WebCore/Modules/push-api/PushEventInit.h:
* Source/WebCore/Modules/push-api/PushSubscription.h:
* Source/WebCore/Modules/push-api/PushSubscriptionOptionsInit.h:
* Source/WebCore/Modules/speech/SpeechRecognitionUpdate.h:
* Source/WebCore/Modules/webaudio/AudioContextOptions.h:
* Source/WebCore/Modules/webaudio/AudioNode.h:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDataAlgorithms.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
* Source/WebCore/Modules/webxr/WebXRWebGLLayer.h:
* Source/WebCore/WebCorePrefix.h:
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXTreeStore.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h:
* Source/WebCore/animation/AnimationEffect.h:
* Source/WebCore/animation/EffectTiming.h:
* Source/WebCore/animation/OptionalEffectTiming.h:
* Source/WebCore/bindings/IDLTypes.h:
* Source/WebCore/bindings/js/BufferSource.h:
* Source/WebCore/bindings/js/JSDOMConvertUnion.h:
* Source/WebCore/bindings/js/JSValueInWrappedObject.h:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(AddToIncludesForIDLType):
* Source/WebCore/crypto/CryptoAlgorithm.h:
* Source/WebCore/crypto/CryptoKey.h:
* Source/WebCore/crypto/SubtleCrypto.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESKW.cpp:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.cpp:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmRSASSA_PKCS1_v1_5.cpp:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_OAEP.cpp:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_PSS.cpp:
* Source/WebCore/crypto/parameters/CryptoAlgorithmEcdsaParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmHmacKeyParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedImportParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedKeyGenParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmX25519Params.h:
* Source/WebCore/css/CSSFontFaceSet.h:
* Source/WebCore/css/CSSStyleProperties.cpp:
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/css/DOMMatrixReadOnly.h:
* Source/WebCore/css/FontFace.h:
* Source/WebCore/css/StyleRule.h:
* Source/WebCore/css/calc/CSSCalcTree.h:
* Source/WebCore/css/typedom/CSSNumericValue.h:
* Source/WebCore/css/typedom/CSSUnparsedValue.cpp:
* Source/WebCore/css/typedom/CSSUnparsedValue.h:
* Source/WebCore/css/values/CSSValueAggregates.h:
* Source/WebCore/css/values/color/CSSAbsoluteColorSerialization.h:
* Source/WebCore/css/values/color/CSSColor.h:
* Source/WebCore/css/values/color/CSSColorDescriptors.h:
* Source/WebCore/css/values/color/CSSRelativeColor.h:
* Source/WebCore/css/values/color/CSSRelativeColorSerialization.h:
* Source/WebCore/css/values/filter-effects/CSSFilterFunction.h:
* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h:
* Source/WebCore/dom/ContainerNode.cpp:
* Source/WebCore/dom/DocumentMarker.h:
* Source/WebCore/dom/EventTarget.h:
* Source/WebCore/dom/MessageEvent.h:
* Source/WebCore/dom/Node.cpp:
* Source/WebCore/editing/AlternativeTextController.h:
* Source/WebCore/fileapi/Blob.h:
* Source/WebCore/fileapi/NetworkSendQueue.h:
* Source/WebCore/html/DOMFormData.h:
* Source/WebCore/html/HTMLAllCollection.cpp:
* Source/WebCore/html/ImageBitmap.cpp:
* Source/WebCore/html/ImageDataArray.h:
* Source/WebCore/html/URLSearchParams.h:
* Source/WebCore/html/canvas/CanvasPath.h:
* Source/WebCore/html/canvas/CanvasStyle.h:
* Source/WebCore/html/canvas/GPUCanvasContext.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/WebGLFramebuffer.h:
* Source/WebCore/inspector/InspectorCanvas.cpp:
* Source/WebCore/inspector/InspectorCanvas.h:
* Source/WebCore/inspector/InspectorCanvasCallTracer.cpp:
* Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp:
* Source/WebCore/layout/integration/inline/InlineIteratorBox.h:
* Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h:
* Source/WebCore/loader/ResourceLoaderOptions.h:
* Source/WebCore/page/DiagnosticLoggingClient.h:
* Source/WebCore/page/IntersectionObserver.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
* Source/WebCore/page/Performance.h:
* Source/WebCore/page/PerformanceMeasureOptions.h:
* Source/WebCore/page/scrolling/ScrollingCoordinator.h:
* Source/WebCore/platform/Cursor.h:
* Source/WebCore/platform/PasteboardCustomData.h:
* Source/WebCore/platform/ProcessIdentity.h:
* Source/WebCore/platform/SharedBuffer.h:
* Source/WebCore/platform/audio/AudioStreamDescription.h:
* Source/WebCore/platform/calc/CalculationTree.h:
* Source/WebCore/platform/graphics/ColorInterpolationMethod.h:
* Source/WebCore/platform/graphics/Font.h:
* Source/WebCore/platform/graphics/FontCascadeDescription.h:
* Source/WebCore/platform/graphics/FontPalette.h:
* Source/WebCore/platform/graphics/FontPaletteValues.h:
* Source/WebCore/platform/graphics/FontSizeAdjust.h:
* Source/WebCore/platform/graphics/Gradient.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayerDelegatedContents.h:
* Source/WebCore/platform/graphics/cocoa/SourceBufferParser.h:
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h:
* Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListItem.h:
* Source/WebCore/platform/network/DNS.h:
* Source/WebCore/platform/network/FormData.h:
* Source/WebCore/platform/sql/SQLValue.h:
* Source/WebCore/platform/sql/SQLiteStatement.cpp:
* Source/WebCore/platform/text/TextFlags.h:
* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebCore/rendering/style/StyleGridData.h:
* Source/WebCore/rendering/svg/RenderSVGResourcePaintServer.h:
* Source/WebCore/style/values/StyleValueTypes.h:
* Source/WebCore/testing/TypeConversions.h:
* Source/WebCore/workers/FetchingWorkerIdentifier.h:
* Source/WebCore/workers/WorkerInspectorProxy.h:
* Source/WebCore/workers/service/ExtendableMessageEvent.h:
* Source/WebCore/workers/service/ServiceWorkerRoute.h:
* Source/WebCore/workers/service/ServiceWorkerTypes.h:
* Source/WebCore/xml/XMLHttpRequest.h:
* Source/WebGPU/WGSL/WGSL.h:
* Source/WebKit/GPUProcess/ShapeDetection/ShapeDetectionObjectHeap.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.h:
* Source/WebKit/NetworkProcess/NetworkLoadChecker.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheData.h:
* Source/WebKit/Platform/IPC/ArgumentCoders.h:
* Source/WebKit/Platform/IPC/MessageReceiveQueueMap.h:
* Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.h:
* Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesStoreDefaultsMap.cpp.erb:
* Source/WebKit/Scripts/webkit/messages.py:
(class_template_headers):
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebCompiledContentRuleListData.h:
* Source/WebKit/Shared/WebFoundTextRange.h:
* Source/WebKit/Shared/WebGPU/WebGPUColor.h:
* Source/WebKit/Shared/WebGPU/WebGPUError.h:
* Source/WebKit/Shared/WebGPU/WebGPUExtent3D.h:
* Source/WebKit/Shared/WebGPU/WebGPUImageCopyExternalImage.h:
* Source/WebKit/Shared/WebGPU/WebGPUOrigin2D.h:
* Source/WebKit/Shared/WebGPU/WebGPUOrigin3D.h:
* Source/WebKit/Shared/WebGPU/WebGPURenderPassColorAttachment.h:
* Source/WebKit/Shared/WebGPU/WebGPURenderPassDepthStencilAttachment.h:
* Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp:
* Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h:
* Source/WebKit/UIProcess/Cocoa/_WKWarningView.h:
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationRequestData.h:
* Source/WebKit/WebKit2Prefix.h:
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferBackendHandle.h:
* Source/WebKitLegacy/mac/DOM/DOMHTMLOptionsCollection.mm:
* Tools/TestWebKitAPI/Tests/WTF/CrossThreadCopierTests.cpp:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FrameTreeChecks.h:

Canonical link: <a href="https://commits.webkit.org/293592@main">https://commits.webkit.org/293592@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fb079bc0efb09e4a8785f307fffe2d036470a7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104513 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/49983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101423 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27465 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/75639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/49983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102389 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/14693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/89728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/55998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/98855 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/14487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/7711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49343 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/92065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/7798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/106870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/98001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/26496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/106870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/26858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/85932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/106870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/6472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/20239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16169 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/26436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/31637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121617 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/26256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/29569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/27823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->