### PR TITLE
[Site Isolation] Sync frame document origin between processes

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -725,6 +725,7 @@ void Document::populateDocumentSyncDataForNewlyConstructedDocument(ProcessSyncDa
     case ProcessSyncDataType::IsAutofocusProcessed:
     case ProcessSyncDataType::UserDidInteractWithPage:
     case ProcessSyncDataType::FrameCanCreatePaymentSession:
+    case ProcessSyncDataType::FrameDocumentSecurityOrigin:
         break;
     }
 }

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -134,7 +134,8 @@ public:
     WEBCORE_EXPORT void updateFrameTreeSyncData(Ref<FrameTreeSyncData>&&);
 
     virtual bool frameCanCreatePaymentSession() const;
-    FrameTreeSyncData& frameTreeSyncData() { return m_frameTreeSyncData.get(); }
+    FrameTreeSyncData& frameTreeSyncData() const { return m_frameTreeSyncData.get(); }
+    WEBCORE_EXPORT virtual RefPtr<SecurityOrigin> frameDocumentSecurityOrigin() const = 0;
 
 protected:
     Frame(Page&, FrameIdentifier, FrameType, HTMLFrameOwnerElement*, Frame* parent, Frame* opener, Ref<FrameTreeSyncData>&&);

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1539,7 +1539,14 @@ bool LocalFrame::frameCanCreatePaymentSession() const
 #else
     return false;
 #endif
+}
 
+RefPtr<SecurityOrigin> LocalFrame::frameDocumentSecurityOrigin() const
+{
+    if (RefPtr document = this->document())
+        return &document->securityOrigin();
+
+    return nullptr;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -352,6 +352,7 @@ private:
     bool preventsParentFromBeingComplete() const final;
     void changeLocation(FrameLoadRequest&&) final;
     void didFinishLoadInAnotherProcess() final;
+    RefPtr<SecurityOrigin> frameDocumentSecurityOrigin() const final;
 
     FrameView* virtualView() const final;
     void disconnectView() final;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -925,6 +925,7 @@ void Page::updateProcessSyncData(const ProcessSyncData& data)
         protectedTopDocumentSyncData()->update(data);
         break;
     case ProcessSyncDataType::FrameCanCreatePaymentSession:
+    case ProcessSyncDataType::FrameDocumentSecurityOrigin:
         ASSERT_NOT_REACHED();
     }
 }

--- a/Source/WebCore/page/ProcessSyncData.in
+++ b/Source/WebCore/page/ProcessSyncData.in
@@ -64,3 +64,4 @@ DocumentSecurityOrigin : RefPtr<WebCore::SecurityOrigin> [DocumentSyncData Heade
 DocumentClasses : OptionSet<WebCore::DocumentClass> [DocumentSyncData Header="DocumentClasses.h"]
 HasInjectedUserScript : bool [DocumentSyncData]
 FrameCanCreatePaymentSession : bool [FrameTreeSyncData]
+FrameDocumentSecurityOrigin : RefPtr<WebCore::SecurityOrigin> [FrameTreeSyncData Header="SecurityOrigin.h"]

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -167,4 +167,9 @@ void RemoteFrame::updateScrollingMode()
         m_client->updateScrollingMode(ownerElement->scrollingMode());
 }
 
+RefPtr<SecurityOrigin> RemoteFrame::frameDocumentSecurityOrigin() const
+{
+    return frameTreeSyncData().frameDocumentSecurityOrigin;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -87,6 +87,7 @@ private:
     void didFinishLoadInAnotherProcess() final;
     bool isRootFrame() const final { return false; }
     void documentURLForConsoleLog(CompletionHandler<void(const URL&)>&&) final;
+    RefPtr<SecurityOrigin> frameDocumentSecurityOrigin() const final;
 
     FrameView* virtualView() const final;
     void disconnectView() final;

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -596,7 +596,7 @@ Ref<FrameTreeSyncData> WebFrameProxy::calculateFrameTreeSyncData() const
     bool isSecureForPaymentSession = false;
 #endif
 
-    return FrameTreeSyncData::create(isSecureForPaymentSession);
+    return FrameTreeSyncData::create(isSecureForPaymentSession, WebCore::SecurityOrigin::create(url()));
 }
 
 void WebFrameProxy::broadcastFrameTreeSyncData(Ref<FrameTreeSyncData>&& data)


### PR DESCRIPTION
#### 4818e3b6275c8a4634cd7556b5fc6432383d0321
<pre>
[Site Isolation] Sync frame document origin between processes
<a href="https://bugs.webkit.org/show_bug.cgi?id=291439">https://bugs.webkit.org/show_bug.cgi?id=291439</a>
<a href="https://rdar.apple.com/147869171">rdar://147869171</a>

Reviewed by Alex Christensen.

Currently web process sends ancestor origins to network process (WebLoaderStrategy::scheduleLoadFromNetworkProcess) and
network process performs CSP check (NetworkResourceLoader::shouldInterruptLoadForCSPFrameAncestorsOrXFrameOptions) with
those origins. In existing implementation, when site isolation is enabled, subframe process does not know origin of
its remote ancestors, so it sends opaque origins that leads the CSP check to fail. To fix that, make frame&apos;s document
origin part of FrameTreeSyncData so that subframe process can compute frameAncestorOrigins correctly.

API test: SiteIsolation.IframeWithCSPHeaderForFrameAncestors

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::populateDocumentSyncDataForNewlyConstructedDocument):
* Source/WebCore/page/Frame.h:
(WebCore::Frame::frameTreeSyncData const):
(WebCore::Frame::frameTreeSyncData): Deleted.
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::frameCanCreatePaymentSession const):
(WebCore::LocalFrame::frameDocumentSecurityOrigin const):
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateProcessSyncData):
* Source/WebCore/page/ProcessSyncData.in:
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::frameDocumentSecurityOrigin const):
* Source/WebCore/page/RemoteFrame.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::calculateFrameTreeSyncData const):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, IframeWithCSPHeaderForFrameAncestors)):

Canonical link: <a href="https://commits.webkit.org/293691@main">https://commits.webkit.org/293691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1140c45e79e0d4035dd318497a54618ab7e0a02

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9510 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104732 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50199 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101642 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27684 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75820 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32919 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14877 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89937 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56179 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14675 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7923 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49562 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84616 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107091 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26715 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19505 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84780 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27078 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86141 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84297 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28966 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6676 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20510 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16215 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26655 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31859 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26475 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29789 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28041 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->