### PR TITLE
[JSC] `export async function` changes prototype to Function instead of AsyncFunction

### DIFF
--- a/JSTests/modules/exported-async-function-shape-check.js
+++ b/JSTests/modules/exported-async-function-shape-check.js
@@ -1,0 +1,32 @@
+export async function a() {}
+
+async function b() {}
+async function c() {}
+
+if (Object.getPrototypeOf(a) !== Object.getPrototypeOf(c)) {
+    throw new Error("Expected export declaration & export function to have same prototype");
+}
+
+if (Object.getPrototypeOf(a) !== Object.getPrototypeOf(b)) {
+    throw new Error("Expected export & non-exported functions to have same prototype");
+}
+
+if (Object.getPrototypeOf(a).constructor !== Object.getPrototypeOf(c).constructor) {
+    throw new Error("Expected export declaration & export function to have same constructor");
+}
+
+if (Object.getPrototypeOf(a).constructor !== Object.getPrototypeOf(b).constructor) {
+    throw new Error("Expected export & non-exported functions to have same constructor");
+}
+
+if (Object.getPrototypeOf(a).constructor.name !== "AsyncFunction") {
+    throw new Error("Expected AsyncFunction");
+}
+globalThis.print ??= console.log;
+
+const AsyncFunction = Object.getPrototypeOf(a).constructor;
+
+// This should not throw
+new AsyncFunction("await 42")();
+
+export { c };

--- a/JSTests/modules/exported-functions-check.js
+++ b/JSTests/modules/exported-functions-check.js
@@ -1,0 +1,19 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+export async function exportedAsyncFunction() {}
+export async function *exportedAsyncGeneratorFunction() {}
+export function *exportedGeneratorFunction() {}
+export function exportedFunction() {}
+
+async function nonExportedAsyncFunction() {}
+async function *nonExportedAsyncGeneratorFunction() {}
+function *nonExportedGeneratorFunction() {}
+function nonExportedFunction() {}
+
+shouldBe(Object.getPrototypeOf(exportedAsyncFunction), Object.getPrototypeOf(nonExportedAsyncFunction));
+shouldBe(Object.getPrototypeOf(exportedAsyncGeneratorFunction), Object.getPrototypeOf(nonExportedAsyncGeneratorFunction));
+shouldBe(Object.getPrototypeOf(exportedGeneratorFunction), Object.getPrototypeOf(nonExportedGeneratorFunction));
+shouldBe(Object.getPrototypeOf(exportedFunction), Object.getPrototypeOf(nonExportedFunction));


### PR DESCRIPTION
#### 910c1b00a197143b37d1ed46773e35070349483b
<pre>
[JSC] `export async function` changes prototype to Function instead of AsyncFunction
<a href="https://bugs.webkit.org/show_bug.cgi?id=291255">https://bugs.webkit.org/show_bug.cgi?id=291255</a>
<a href="https://rdar.apple.com/149083588">rdar://149083588</a>

Reviewed by Keith Miller.

Module&apos;s declaration insertion should appropriately materialize
functions with their specific constructors.

* JSTests/modules/exported-async-function-shape-check.js: Added.
(export.async a):
(async b):
(async c):
(Object.getPrototypeOf.a.Object.getPrototypeOf):
(Object.getPrototypeOf):
* JSTests/modules/exported-functions-check.js: Added.
(shouldBe):
(export.async exportedAsyncFunction):
(export.async exportedAsyncGeneratorFunction):
(export.exportedGeneratorFunction):
(export.exportedFunction):
(async nonExportedAsyncFunction):
(async nonExportedAsyncGeneratorFunction):
(nonExportedGeneratorFunction):
(nonExportedFunction):
* Source/JavaScriptCore/runtime/JSModuleRecord.cpp:
(JSC::JSModuleRecord::instantiateDeclarations):

Canonical link: <a href="https://commits.webkit.org/293602@main">https://commits.webkit.org/293602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8d3459888549e9b20bba524d1ab22b075703b1a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104508 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49978 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75632 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32736 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89727 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55991 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14480 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7710 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49338 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92060 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84406 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106865 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97996 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26491 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84591 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26853 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84104 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28779 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6471 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20234 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16176 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26431 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31632 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121612 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26251 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33965 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29564 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27818 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->