### PR TITLE
Drop operators that are no longer necessary with C++20

### DIFF
--- a/Source/JavaScriptCore/API/JSRetainPtr.h
+++ b/Source/JavaScriptCore/API/JSRetainPtr.h
@@ -171,8 +171,3 @@ template<typename T, typename U> inline bool operator==(const JSRetainPtr<T>& a,
 { 
     return a.get() == b; 
 }
-
-template<typename T, typename U> inline bool operator==(T* a, const JSRetainPtr<U>& b) 
-{
-    return a == b.get(); 
-}

--- a/Source/JavaScriptCore/dfg/DFGEdge.h
+++ b/Source/JavaScriptCore/dfg/DFGEdge.h
@@ -231,10 +231,6 @@ inline bool operator==(Edge edge, Node* node)
 {
     return edge.node() == node;
 }
-inline bool operator==(Node* node, Edge edge)
-{
-    return edge.node() == node;
-}
 
 } } // namespace JSC::DFG
 

--- a/Source/JavaScriptCore/heap/Handle.h
+++ b/Source/JavaScriptCore/heap/Handle.h
@@ -152,9 +152,4 @@ template <typename T, typename U> inline bool operator==(const Handle<T>& a, U* 
     return a.get() == b; 
 }
 
-template <typename T, typename U> inline bool operator==(T* a, const Handle<U>& b) 
-{
-    return a == b.get(); 
-}
-
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/WeakInlines.h
+++ b/Source/JavaScriptCore/heap/WeakInlines.h
@@ -141,11 +141,6 @@ template<typename T> inline bool operator==(const Weak<T>& lhs, const T* rhs)
     return lhs.get() == rhs;
 }
 
-template<typename T> inline bool operator==(const T* lhs, const Weak<T>& rhs)
-{
-    return lhs == rhs.get();
-}
-
 // This function helps avoid modifying a weak table while holding an iterator into it. (Object allocation
 // can run a finalizer that modifies the table. We avoid that by requiring a pre-constructed object as our value.)
 template<typename Map, typename Key, typename Value> inline void weakAdd(Map& map, const Key& key, Value&& value)

--- a/Source/JavaScriptCore/runtime/JSCJSValue.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.h
@@ -740,7 +740,6 @@ ALWAYS_INLINE EncodedJSValue encodedJSValue()
 }
 
 inline bool operator==(const JSValue a, const JSCell* b) { return a == JSValue(b); }
-inline bool operator==(const JSCell* a, const JSValue b) { return JSValue(a) == b; }
 
 bool isThisValueAltered(const PutPropertySlot&, JSObject* baseObject);
 

--- a/Source/JavaScriptCore/runtime/PropertyName.h
+++ b/Source/JavaScriptCore/runtime/PropertyName.h
@@ -99,11 +99,6 @@ inline bool operator==(PropertyName a, const Identifier& b)
     return a.uid() == b.impl();
 }
 
-inline bool operator==(const Identifier& a, PropertyName b)
-{
-    return a.impl() == b.uid();
-}
-
 inline bool operator==(PropertyName a, PropertyName b)
 {
     return a.uid() == b.uid();

--- a/Source/WTF/wtf/CompactPtr.h
+++ b/Source/WTF/wtf/CompactPtr.h
@@ -227,12 +227,6 @@ inline bool operator==(const CompactPtr<T>& a, U* b)
     return a.get() == b;
 }
 
-template<typename T, typename U>
-inline bool operator==(T* a, const CompactPtr<U>& b)
-{
-    return a == b.get();
-}
-
 template <typename T>
 struct GetPtrHelper<CompactPtr<T>> {
     using PtrType = T*;

--- a/Source/WTF/wtf/Expected.h
+++ b/Source/WTF/wtf/Expected.h
@@ -390,10 +390,8 @@ template<class T, class E> constexpr bool operator==(const expected<T, E>& x, co
 template<class E> constexpr bool operator==(const expected<void, E>& x, const expected<void, E>& y) { return bool(x) == bool(y) && (x ? true : x.error() == y.error()); }
 
 template<class T, class E> constexpr bool operator==(const expected<T, E>& x, const T& y) { return x ? *x == y : false; }
-template<class T, class E> constexpr bool operator==(const T& x, const expected<T, E>& y) { return y ? x == *y : false; }
 
 template<class T, class E> constexpr bool operator==(const expected<T, E>& x, const unexpected<E>& y) { return x ? false : x.error() == y.value(); }
-template<class T, class E> constexpr bool operator==(const unexpected<E>& x, const expected<T, E>& y) { return y ? false : x.value() == y.error(); }
 
 template<typename T, typename E> void swap(expected<T, E>& x, expected<T, E>& y) { x.swap(y); }
 

--- a/Source/WTF/wtf/Float16.h
+++ b/Source/WTF/wtf/Float16.h
@@ -312,11 +312,6 @@ public:
         return m_value == other.m_value;
     }
 
-    bool operator!=(const Float16& other) const
-    {
-        return m_value != other.m_value;
-    }
-
 private:
     explicit constexpr Float16(_Float16 value)
         : m_value(value)
@@ -350,11 +345,6 @@ public:
     bool operator==(const Float16& other) const
     {
         return asDouble() == other.asDouble();
-    }
-
-    bool operator!=(const Float16& other) const
-    {
-        return asDouble() != other.asDouble();
     }
 
 private:

--- a/Source/WTF/wtf/Markable.h
+++ b/Source/WTF/wtf/Markable.h
@@ -189,8 +189,6 @@ template <typename T, typename Traits> constexpr bool operator==(const Markable<
     return x.value() == y.value();
 }
 template <typename T, typename Traits> constexpr bool operator==(const Markable<T, Traits>& x, const T& v) { return bool(x) && x.value() == v; }
-template <typename T, typename Traits> constexpr bool operator==(const T& v, const Markable<T, Traits>& x) { return bool(x) && v == x.value(); }
-
 
 } // namespace WTF
 

--- a/Source/WTF/wtf/Packed.h
+++ b/Source/WTF/wtf/Packed.h
@@ -279,12 +279,6 @@ inline bool operator==(const PackedPtr<T>& a, U* b)
     return a.get() == b;
 }
 
-template<typename T, typename U>
-inline bool operator==(T* a, const PackedPtr<U>& b)
-{
-    return a == b.get();
-}
-
 template<typename T>
 struct PackedPtrTraits {
     template<typename U> using RebindTraits = PackedPtrTraits<U>;

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -99,8 +99,6 @@ private:
     friend bool operator==(const RefPtr<T1, U, V>&, const RefPtr<X, Y, Z>&);
     template<typename T1, typename U, typename V, typename X>
     friend bool operator==(const RefPtr<T1, U, V>&, X*);
-    template<typename T1, typename X, typename Y, typename Z>
-    friend bool operator==(T1*, const RefPtr<X, Y, Z>&);
 
     enum AdoptTag { Adopt };
     RefPtr(T* ptr, AdoptTag) : m_ptr(ptr) { }
@@ -205,12 +203,6 @@ template<typename T, typename U, typename V, typename X>
 inline bool operator==(const RefPtr<T, U, V>& a, X* b)
 {
     return a.m_ptr == b;
-}
-
-template<typename T, typename X, typename Y, typename Z>
-inline bool operator==(T* a, const RefPtr<X, Y, Z>& b)
-{
-    return a == b.m_ptr;
 }
 
 template<typename T, typename U, typename V>

--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -303,11 +303,6 @@ template<typename T, typename U> constexpr bool operator==(const RetainPtr<T>& a
     return a.get() == b; 
 }
 
-template<typename T, typename U> constexpr bool operator==(T* a, const RetainPtr<U>& b)
-{
-    return a == b.get(); 
-}
-
 template<typename T> constexpr RetainPtr<RetainPtrType<T>> adoptCF(T CF_RELEASES_ARGUMENT ptr)
 {
     static_assert(!IsNSType<T>, "Don't use adoptCF with Objective-C pointer types, use adoptNS.");

--- a/Source/WTF/wtf/SortedArrayMap.h
+++ b/Source/WTF/wtf/SortedArrayMap.h
@@ -110,8 +110,6 @@ bool operator<(ComparableASCIILiteral, ComparableStringView);
 bool operator<(ComparableCaseFoldingASCIILiteral, ComparableStringView);
 bool operator<(ComparableLettersLiteral, ComparableStringView);
 
-template<typename OtherType> bool operator==(OtherType, ComparableStringView);
-
 template<typename StorageInteger, ASCIISubset> class PackedASCIISubsetLiteral {
 public:
     static_assert(std::is_unsigned_v<StorageInteger>);
@@ -333,11 +331,6 @@ inline bool operator<(ComparableStringView a, ComparableCaseFoldingASCIILiteral 
 inline bool operator<(ComparableCaseFoldingASCIILiteral a, ComparableStringView b)
 {
     return lessThanASCIICaseFolding(a.literal, b.string);
-}
-
-template<typename OtherType> inline bool operator==(OtherType a, ComparableStringView b)
-{
-    return b == a;
 }
 
 template<typename StorageInteger, ASCIISubset subset> constexpr PackedASCIISubsetLiteral<StorageInteger, subset>::PackedASCIISubsetLiteral(ASCIILiteral string)

--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -294,7 +294,6 @@ static_assert(sizeof(URL) == sizeof(String) + 8 * sizeof(unsigned), "URL should 
 
 bool operator==(const URL&, const URL&);
 bool operator==(const URL&, const String&);
-bool operator==(const String&, const URL&);
 
 WTF_EXPORT_PRIVATE bool equalIgnoringFragmentIdentifier(const URL&, const URL&);
 WTF_EXPORT_PRIVATE bool protocolHostAndPortAreEqual(const URL&, const URL&);
@@ -353,11 +352,6 @@ inline bool operator==(const URL& a, const URL& b)
 inline bool operator==(const URL& a, const String& b)
 {
     return a.string() == b;
-}
-
-inline bool operator==(const String& a, const URL& b)
-{
-    return a == b.string();
 }
 
 inline URL::URL(HashTableDeletedValueType)

--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -312,11 +312,6 @@ template<typename T, typename U, typename WeakPtrImpl, typename PtrTraits> inlin
     return a.get() == b;
 }
 
-template<typename T, typename U, typename WeakPtrImpl, typename PtrTraits> inline bool operator==(T* a, const WeakPtr<U, WeakPtrImpl, PtrTraits>& b)
-{
-    return a == b.get();
-}
-
 template<class T, typename = std::enable_if_t<!IsSmartPtr<T>::value>>
 WeakPtr(const T* value, EnableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes) -> WeakPtr<T, typename T::WeakPtrImplType>;
 

--- a/Source/WTF/wtf/cocoa/Entitlements.mm
+++ b/Source/WTF/wtf/cocoa/Entitlements.mm
@@ -88,10 +88,10 @@ bool hasEntitlementValueInArray(audit_token_t token, ASCIILiteral entitlement, A
     RetainPtr<CFArrayRef> array = static_cast<CFArrayRef>(entitlementValue);
 
     for (CFIndex i = 0; i < CFArrayGetCount(array.get()); ++i) {
-        auto element = CFArrayGetValueAtIndex(array.get(), i);
-        if (CFGetTypeID(element) != CFStringGetTypeID())
+        RetainPtr element = dynamic_cf_cast<CFStringRef>(CFArrayGetValueAtIndex(array.get(), i));
+        if (!element)
             continue;
-        CFStringRef stringElement = static_cast<CFStringRef>(element);
+        String stringElement = element.get();
         if (value == stringElement)
             return true;
     }

--- a/Source/WTF/wtf/glib/GRefPtr.h
+++ b/Source/WTF/wtf/glib/GRefPtr.h
@@ -192,26 +192,6 @@ template <typename T, typename U> inline bool operator==(const GRefPtr<T>& a, U*
     return a.get() == b;
 }
 
-template <typename T, typename U> inline bool operator==(T* a, const GRefPtr<U>& b)
-{
-    return a == b.get();
-}
-
-template <typename T, typename U> inline bool operator!=(const GRefPtr<T>& a, const GRefPtr<U>& b)
-{
-    return a.get() != b.get();
-}
-
-template <typename T, typename U> inline bool operator!=(const GRefPtr<T>& a, U* b)
-{
-    return a.get() != b;
-}
-
-template <typename T, typename U> inline bool operator!=(T* a, const GRefPtr<U>& b)
-{
-    return a != b.get();
-}
-
 template <typename T, typename U> inline GRefPtr<T> static_pointer_cast(const GRefPtr<U>& p)
 {
     return GRefPtr<T>(static_cast<T*>(p.get()));

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -152,8 +152,6 @@ inline bool operator==(const AtomString& a, const AtomString& b) { return a.impl
 inline bool operator==(const AtomString& a, ASCIILiteral b) { return WTF::equal(a.impl(), b); }
 inline bool operator==(const AtomString& a, const Vector<UChar>& b) { return a.impl() && equal(a.impl(), b.span()); }
 inline bool operator==(const AtomString& a, const String& b) { return equal(a.impl(), b.impl()); }
-inline bool operator==(const String& a, const AtomString& b) { return equal(a.impl(), b.impl()); }
-inline bool operator==(const Vector<UChar>& a, const AtomString& b) { return b == a; }
 
 bool equalIgnoringASCIICase(const AtomString&, const AtomString&);
 bool equalIgnoringASCIICase(const AtomString&, const String&);

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -262,7 +262,6 @@ bool startsWithLettersIgnoringASCIICase(StringView, ASCIILiteral);
 
 inline bool operator==(StringView a, StringView b) { return equal(a, b); }
 inline bool operator==(StringView a, ASCIILiteral b) { return equal(a, b); }
-inline bool operator==(ASCIILiteral a, StringView b) { return equal(b, a); }
 
 struct StringViewWithUnderlyingString;
 

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -322,8 +322,6 @@ static_assert(sizeof(String) == sizeof(void*), "String should effectively be a p
 
 inline bool operator==(const String& a, const String& b) { return equal(a.impl(), b.impl()); }
 inline bool operator==(const String& a, ASCIILiteral b) { return equal(a.impl(), b); }
-inline bool operator==(ASCIILiteral a, const String& b) { return equal(b.impl(), a); }
-template<size_t inlineCapacity> inline bool operator==(const Vector<char, inlineCapacity>& a, const String& b) { return equal(b.impl(), a.data(), a.size()); }
 template<size_t inlineCapacity> inline bool operator==(const String& a, const Vector<char, inlineCapacity>& b) { return b == a; }
 
 bool equalIgnoringASCIICase(const String&, const String&);

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -271,7 +271,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     } m_data;
 };
 
-inline bool operator==(const AtomString& a, const PossiblyQuotedIdentifier& b) { return a == b.identifier; }
 inline bool operator==(const PossiblyQuotedIdentifier& a, const AtomString& b) { return a.identifier == b; }
 
 inline const QualifiedName& CSSSelector::attribute() const

--- a/Source/WebCore/loader/cache/CachedResourceHandle.h
+++ b/Source/WebCore/loader/cache/CachedResourceHandle.h
@@ -81,9 +81,5 @@ template <class R, class RR> bool operator==(const CachedResourceHandle<R>& h, c
 { 
     return h.get() == res; 
 }
-template <class R, class RR> bool operator==(const RR* res, const CachedResourceHandle<R>& h) 
-{ 
-    return h.get() == res; 
-}
 
 } // namespace WebCore

--- a/Source/WebCore/platform/encryptedmedia/CDMProxy.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMProxy.h
@@ -96,7 +96,6 @@ public:
     // Two keys are equal if they have the same ID, ignoring key value and status.
     friend bool operator==(const KeyHandle &k1, const KeyHandle &k2) { return k1.m_id == k2.m_id; }
     friend bool operator==(const KeyHandle &k, const KeyIDType& keyID) { return k.m_id == keyID; }
-    friend bool operator==(const KeyIDType& keyID, const KeyHandle &k) { return k == keyID; }
 
 protected:
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -179,8 +179,6 @@ private:
         return a.isValid() && GST_IS_BUFFER(b) && a.size() == gst_buffer_get_size(nonConstB) && !gst_buffer_memcmp(nonConstB, 0, a.data(), a.size());
     }
 
-    friend bool operator==(const GstBuffer* a, const GstBufferMapper& b) { return operator==(b, a); }
-
     GstBuffer* m_buffer { nullptr };
     MapType m_info;
     bool m_isValid { false };

--- a/Source/WebCore/platform/win/COMPtr.h
+++ b/Source/WebCore/platform/win/COMPtr.h
@@ -208,26 +208,6 @@ template<typename T, typename U> inline bool operator==(const COMPtr<T>& a, U* b
     return a.get() == b;
 }
 
-template<typename T, typename U> inline bool operator==(T* a, const COMPtr<U>& b) 
-{
-    return a == b.get();
-}
-
-template<typename T, typename U> inline bool operator!=(const COMPtr<T>& a, const COMPtr<U>& b)
-{
-    return a.get() != b.get();
-}
-
-template<typename T, typename U> inline bool operator!=(const COMPtr<T>& a, U* b)
-{
-    return a.get() != b;
-}
-
-template<typename T, typename U> inline bool operator!=(T* a, const COMPtr<U>& b)
-{
-    return a != b.get();
-}
-
 #if ASSERT_ENABLED
 inline unsigned refCount(IUnknown* ptr)
 {

--- a/Source/WebKit/UIProcess/API/cpp/WKRetainPtr.h
+++ b/Source/WebKit/UIProcess/API/cpp/WKRetainPtr.h
@@ -219,11 +219,6 @@ template<typename T, typename U> inline bool operator==(const WKRetainPtr<T>& a,
     return a.get() == b; 
 }
 
-template<typename T, typename U> inline bool operator==(T* a, const WKRetainPtr<U>& b) 
-{
-    return a == b.get(); 
-}
-
 #if (defined(WIN32) || defined(_WIN32)) && !((_MSC_VER > 1900) && __clang__)
 template<typename T> inline WKRetainPtr<T> adoptWK(T) _Check_return_;
 #else


### PR DESCRIPTION
#### 74d33a84ca597da6e2be2416b3586468538cdc0c
<pre>
Drop operators that are no longer necessary with C++20
<a href="https://bugs.webkit.org/show_bug.cgi?id=291446">https://bugs.webkit.org/show_bug.cgi?id=291446</a>

Reviewed by Michael Catanzaro.

Drop operators that are no longer necessary with C++20:
- `operator==(b, a)` is no longer needed when `operator==(a, b)` exists
- `operator!=(a, a)` is no longer needed when operator==(a, a)` exists

* Source/JavaScriptCore/API/JSRetainPtr.h:
(operator==):
* Source/JavaScriptCore/dfg/DFGEdge.h:
(JSC::DFG::operator==):
* Source/JavaScriptCore/heap/Handle.h:
* Source/JavaScriptCore/heap/WeakInlines.h:
* Source/JavaScriptCore/runtime/JSCJSValue.h:
(JSC::operator==):
* Source/JavaScriptCore/runtime/PropertyName.h:
* Source/WTF/wtf/CompactPtr.h:
* Source/WTF/wtf/Expected.h:
(std::experimental::fundamentals_v3::operator==):
* Source/WTF/wtf/Float16.h:
(WTF::Float16::operator!= const): Deleted.
* Source/WTF/wtf/Markable.h:
(WTF::operator==):
* Source/WTF/wtf/Packed.h:
* Source/WTF/wtf/RefPtr.h:
* Source/WTF/wtf/RetainPtr.h:
* Source/WTF/wtf/SortedArrayMap.h:
* Source/WTF/wtf/URL.h:
* Source/WTF/wtf/WeakPtr.h:
* Source/WTF/wtf/cocoa/Entitlements.mm:
(WTF::hasEntitlementValueInArray):
* Source/WTF/wtf/glib/GRefPtr.h:
(WTF::operator!=): Deleted.
* Source/WTF/wtf/text/AtomString.h:
(WTF::operator==):
* Source/WTF/wtf/text/StringView.h:
(WTF::operator==):
* Source/WTF/wtf/text/WTFString.h:
(WTF::operator==):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/loader/cache/CachedResourceHandle.h:
(WebCore::operator==):
* Source/WebCore/platform/encryptedmedia/CDMProxy.h:
(WebCore::KeyHandle::operator==):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
(WebCore::unmapFunction):
* Source/WebCore/platform/win/COMPtr.h:
(operator!=): Deleted.
* Source/WebKit/UIProcess/API/cpp/WKRetainPtr.h:

Canonical link: <a href="https://commits.webkit.org/293614@main">https://commits.webkit.org/293614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/239c1153d6e179653314402111ba444bd0fc5a65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9287 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104517 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49987 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101427 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27469 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75647 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32744 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102393 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14698 "Found 1 new test failure: fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89732 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56006 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14492 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7715 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49347 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92069 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84418 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7802 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106874 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98005 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26500 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84609 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26862 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85936 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84122 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21342 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28787 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6476 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20243 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26440 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31641 "Found 1 new failure in runtime/BrandedStructure.h and found 1 fixed file: wtf/cocoa/Entitlements.mm") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121621 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26260 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33969 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29573 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27827 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->