### PR TITLE
[MacOS Debug] media/modern-media-controls/overflow-support/chapters.html is a flaky failure and timeout

### DIFF
--- a/LayoutTests/media/modern-media-controls/overflow-support/chapters-expected.txt
+++ b/LayoutTests/media/modern-media-controls/overflow-support/chapters-expected.txt
@@ -6,6 +6,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 PASS shadowRoot.querySelector('button.overflow') became different from null
 PASS shadowRoot.querySelector('button.overflow').getBoundingClientRect().width became different from 0
 PASS media.textTracks[0].mode became different from 'disabled'
+PASS media.textTracks[0].cues.length became 2
 Tapping overflow button...
 Selecting first chapter cue...
 PASS media.currentTime >= 5 became true

--- a/LayoutTests/media/modern-media-controls/overflow-support/chapters.html
+++ b/LayoutTests/media/modern-media-controls/overflow-support/chapters.html
@@ -27,13 +27,19 @@ media.addEventListener("play", async function() {
 
     await shouldBecomeDifferent("media.textTracks[0].mode", "'disabled'");
 
+    await shouldBecomeEqual("media.textTracks[0].cues.length", "2");
+
     debug("Tapping overflow button...");
-    await pressOnElement(shadowRoot.querySelector("button.overflow"));
-    await UIHelper.waitForContextMenuToShow();
+    await Promise.all([
+        pressOnElement(shadowRoot.querySelector("button.overflow")),
+        UIHelper.waitForContextMenuToShow()
+    ]);
 
     debug("Selecting first chapter cue...");
-    await UIHelper.chooseMenuAction("ipsum");
-    await UIHelper.waitForContextMenuToHide();
+    await Promise.all([
+        UIHelper.chooseMenuAction("ipsum"),
+        UIHelper.waitForContextMenuToHide()
+    ]);
 
     await shouldBecomeEqual("media.currentTime >= 5", "true");
 


### PR DESCRIPTION
#### e3c8c5a2a5936ec4710c5c57d1ebc556ae0aa4fa
<pre>
[MacOS Debug] media/modern-media-controls/overflow-support/chapters.html is a flaky failure and timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=227055">https://bugs.webkit.org/show_bug.cgi?id=227055</a>
<a href="https://rdar.apple.com/79370477">rdar://79370477</a>

Reviewed by Eric Carlson.

Update the test to wait until all chapter cues are loaded before continuing, and also make the test
more robust to ordering issues by using Promise.all() to await UIHelper promises.

* LayoutTests/media/modern-media-controls/overflow-support/chapters-expected.txt:
* LayoutTests/media/modern-media-controls/overflow-support/chapters.html:

Canonical link: <a href="https://commits.webkit.org/293684@main">https://commits.webkit.org/293684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8912c7722c077b5a3343e1b7f9b1e7d09263b61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99392 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9293 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104523 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49993 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27475 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75644 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32739 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102399 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14699 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89740 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56003 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14493 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7723 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49353 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84419 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7810 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106880 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26506 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19335 "Found 1 new test failure: ipc/serialized-type-info.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84603 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26868 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85944 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84116 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21398 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28785 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6482 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20249 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26446 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26266 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29579 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27833 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->