### PR TITLE
Minor cleanup in finishParsingHexColor()

### DIFF
--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -460,27 +460,22 @@ static inline bool mightBeHSL(std::span<const CharacterType> characters)
 static std::optional<SRGBA<uint8_t>> finishParsingHexColor(uint32_t value, unsigned length)
 {
     switch (length) {
-    case 3:
-        // #abc converts to #aabbcc
-        // FIXME: Replace conversion to PackedColor::ARGB with simpler bit math to construct
-        // the SRGBA<uint8_t> directly.
-        return asSRGBA(PackedColor::ARGB {
-               0xFF000000
-            | (value & 0xF00) << 12 | (value & 0xF00) << 8
-            | (value & 0xF0) << 8 | (value & 0xF0) << 4
-            | (value & 0xF) << 4 | (value & 0xF) });
-    case 4:
-        // #abcd converts to ddaabbcc since alpha bytes are the high bytes.
-        // FIXME: Replace conversion to PackedColor::ARGB with simpler bit math to construct
-        // the SRGBA<uint8_t> directly.
-        return asSRGBA(PackedColor::ARGB {
-              (value & 0xF) << 28 | (value & 0xF) << 24
-            | (value & 0xF000) << 8 | (value & 0xF000) << 4
-            | (value & 0xF00) << 4 | (value & 0xF00)
-            | (value & 0xF0) | (value & 0xF0) >> 4 });
+    case 3: {
+        // #234 converts to #223344.
+        uint8_t r = (value & 0x0F00) >> 8;
+        uint8_t g = (value & 0x00F0) >> 4;
+        uint8_t b = (value & 0x000F);
+        return SRGBA<uint8_t>(r << 4 | r, g << 4 | g, b << 4 | b);
+    }
+    case 4: {
+        // #234a converts to #223344aa.
+        uint8_t r = (value & 0xF000) >> 12;
+        uint8_t g = (value & 0x0F00) >> 8;
+        uint8_t b = (value & 0x00F0) >> 4;
+        uint8_t a = (value & 0x000F);
+        return SRGBA<uint8_t>(r << 4 | r, g << 4 | g, b << 4 | b, a << 4 | a);
+    }
     case 6:
-        // FIXME: Replace conversion to PackedColor::ARGB with simpler bit math to construct
-        // the SRGBA<uint8_t> directly.
         return asSRGBA(PackedColor::ARGB { 0xFF000000 | value });
     case 8:
         return asSRGBA(PackedColor::RGBA { value });


### PR DESCRIPTION
#### 90805fde47af113dc03fef9d58a8e364d6bc8b7c
<pre>
Minor cleanup in finishParsingHexColor()
<a href="https://bugs.webkit.org/show_bug.cgi?id=291453">https://bugs.webkit.org/show_bug.cgi?id=291453</a>
<a href="https://rdar.apple.com/149091397">rdar://149091397</a>

Reviewed by Sam Weinig.

Avoid going through the intermediate `PackedColor::ARGB` because constructing an `SRGBA&lt;uint8_t&gt;`
from a `PackedColor::ARGB` involves some additional bit shifting.

* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::finishParsingHexColor):

Canonical link: <a href="https://commits.webkit.org/293638@main">https://commits.webkit.org/293638@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7276e16fbff213baea7019bf171d7c60d02f8929

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99397 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104528 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49998 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75650 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32742 "Found 1 new test failure: fast/images/icon-decoding.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14702 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89742 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56009 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14496 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7725 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49358 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84421 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7812 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106886 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26511 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19339 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84606 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26873 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85946 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84119 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21360 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28792 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6484 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20254 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26451 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31652 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26271 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29584 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27838 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->