### PR TITLE
Invalid IPC crash when a client provides an NSError with differing failing URL keys

### DIFF
--- a/Source/WebCore/platform/network/cf/ResourceError.h
+++ b/Source/WebCore/platform/network/cf/ResourceError.h
@@ -71,6 +71,8 @@ public:
 
     WEBCORE_EXPORT ErrorRecoveryMethod errorRecoveryMethod() const;
 
+    WEBCORE_EXPORT bool hasMatchingFailingURLKeys() const;
+
     static bool platformCompare(const ResourceError& a, const ResourceError& b);
 
 

--- a/Source/WebCore/platform/network/mac/ResourceErrorMac.mm
+++ b/Source/WebCore/platform/network/mac/ResourceErrorMac.mm
@@ -314,4 +314,21 @@ String ResourceError::blockedTrackerHostName() const
 
 #endif // ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
 
+bool ResourceError::hasMatchingFailingURLKeys() const
+{
+    if (id nsErrorFailingURL = [nsError().userInfo objectForKey:@"NSErrorFailingURLKey"]) {
+        auto *failingURL = dynamic_objc_cast<NSURL>(nsErrorFailingURL);
+        if (!failingURL)
+            return false;
+        if (id nsErrorFailingURLString = [nsError().userInfo objectForKey:@"NSErrorFailingURLStringKey"]) {
+            auto *failingURLString = dynamic_objc_cast<NSString>(nsErrorFailingURLString);
+            if (!failingURLString)
+                return false;
+            if (![failingURL isEqual:URL(failingURLString)])
+                return false;
+        }
+    }
+    return true;
+}
+
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6875,6 +6875,9 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
 
     MESSAGE_CHECK_URL(process, provisionalURL);
     MESSAGE_CHECK_URL(process, error.failingURL());
+#if PLATFORM(COCOA)
+    MESSAGE_CHECK(process, error.hasMatchingFailingURLKeys());
+#endif
 
     RefPtr protectedPageClient { pageClient() };
 


### PR DESCRIPTION
#### 4ad879fbc566a13a4d7be356ce60a110395c9124
<pre>
Invalid IPC crash when a client provides an NSError with differing failing URL keys
<a href="https://bugs.webkit.org/show_bug.cgi?id=288737">https://bugs.webkit.org/show_bug.cgi?id=288737</a>
<a href="https://rdar.apple.com/145681217">rdar://145681217</a>

Reviewed by Ryosuke Niwa.

Clients can provide an NSError in API, which may be sent to the WCP/NP and may fail the IPC validation
added in <a href="https://rdar.apple.com/140567340">rdar://140567340</a>. For now, we should just implement a more targeted fix, protecting only the IPC
endpoint that we know is at risk when the keys do not match.

* Source/WebCore/platform/network/cf/ResourceError.h:
* Source/WebCore/platform/network/mac/ResourceErrorMac.mm:
(WebCore::ResourceError::hasMatchingFailingURLKeys const):
* Source/WebKit/Shared/Cocoa/CoreIPCError.mm:
(WebKit::CoreIPCError::hasValidUserInfo):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didFailProvisionalLoadForFrameShared):

Originally-landed-as: 289651.196@safari-7621-branch (113710100ae4). rdar://148056574
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ad879fbc566a13a4d7be356ce60a110395c9124

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99748 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19394 "Hash 4ad879fb for PR 43983 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9667 "Hash 4ad879fb for PR 43983 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104873 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50337 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101789 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19699 "Hash 4ad879fb for PR 43983 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27830 "Hash 4ad879fb for PR 43983 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75932 "Found 65 new test failures: compositing/layer-creation/will-change-layer-creation.html compositing/patterns/direct-pattern-compositing-position.html fast/canvas/image-buffer-backend-variants.html fast/inline/list-marker-float-crash.html fast/inline/list-marker-inside-container-with-margin.html fast/inline/min-content-width-with-hypens.html fast/inline/overflowing-content-with-hypens.html fast/mediastream/stream-switch.html fast/multicol/columns-on-body.html fast/multicol/layers-split-across-columns.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33024 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102755 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/19699 "Hash 4ad879fb for PR 43983 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/9667 "Hash 4ad879fb for PR 43983 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56293 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/19699 "Hash 4ad879fb for PR 43983 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/9667 "Hash 4ad879fb for PR 43983 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49698 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/19699 "Hash 4ad879fb for PR 43983 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/9667 "Hash 4ad879fb for PR 43983 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107234 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26860 "Hash 4ad879fb for PR 43983 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/27830 "Hash 4ad879fb for PR 43983 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84890 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27223 "Hash 4ad879fb for PR 43983 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/9667 "Hash 4ad879fb for PR 43983 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84411 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/9667 "Hash 4ad879fb for PR 43983 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20676 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26799 "Hash 4ad879fb for PR 43983 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32008 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26612 "Hash 4ad879fb for PR 43983 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29928 "Hash 4ad879fb for PR 43983 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28180 "Hash 4ad879fb for PR 43983 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->