### PR TITLE
REGRESSION(290385@main - 290390@main?): [ wk2 arm64 ] imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe.html is a flaky timeout.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-02-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-02-expected.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>DOM Test Reference</title>
+<p>You should see the word PASS below.</p>
+<div>PASS</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-02.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-02.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html class="reftest-wait">
+  <head>
+    <title>Adopting a shadow host child into an iframe</title>
+    <link rel="help" href="https://dom.spec.whatwg.org/#concept-node-adopt">
+    <link rel="match" href="remove-from-shadow-host-and-adopt-into-iframe-ref.html">
+    <style>
+      iframe { border: 0; }
+    </style>
+    <script src="/common/reftest-wait.js"></script>
+    <script>
+      onload = () => {
+        const root = host.attachShadow({mode:"open"});
+        root.innerHTML = "<slot>";
+        // force a layout
+        host.offsetTop;
+        iframe.contentWindow.document.body.style.margin = 0;
+        iframe.contentWindow.document.body.appendChild(adopted);
+        host.remove();
+        takeScreenshot();
+      }
+    </script>
+  </head>
+  <body>
+    <p>You should see the word PASS below.</p>
+    <iframe id="iframe"></iframe>
+    <div id="host"><span id="adopted">PASS</span></div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-03-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-03-expected.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>DOM Test Reference</title>
+<p>You should see the word PASS below.</p>
+<div>PASS</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-03.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-03.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html class="reftest-wait">
+  <head>
+    <title>Adopting a shadow host child into an iframe</title>
+    <link rel="help" href="https://dom.spec.whatwg.org/#concept-node-adopt">
+    <link rel="match" href="remove-from-shadow-host-and-adopt-into-iframe-ref.html">
+    <style>
+      iframe { border: 0; }
+    </style>
+    <script src="/common/reftest-wait.js"></script>
+    <script>
+      onload = () => {
+        const root = host.attachShadow({mode:"open"});
+        root.innerHTML = "<slot>";
+        // force a layout
+        host.offsetTop;
+        iframe.contentWindow.document.body.style.margin = 0;
+        iframe.contentWindow.document.body.appendChild(adopted);
+        host.remove();
+        takeScreenshot();
+      }
+    </script>
+  </head>
+  <body>
+    <p>You should see the word PASS below.</p>
+    <iframe id="iframe"></iframe>
+    <div id="host"><span id="adopted">PASS</span></div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-04-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-04-expected.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>DOM Test Reference</title>
+<p>You should see the word PASS below.</p>
+<div>PASS</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-04.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-04.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html class="reftest-wait">
+  <head>
+    <title>Adopting a shadow host child into an iframe</title>
+    <link rel="help" href="https://dom.spec.whatwg.org/#concept-node-adopt">
+    <link rel="match" href="remove-from-shadow-host-and-adopt-into-iframe-ref.html">
+    <style>
+      iframe { border: 0; }
+    </style>
+    <script src="/common/reftest-wait.js"></script>
+    <script>
+      onload = () => {
+        const root = host.attachShadow({mode:"open"});
+        root.innerHTML = "<slot>";
+        // force a layout
+        host.offsetTop;
+        iframe.contentWindow.document.body.style.margin = 0;
+        iframe.contentWindow.document.body.appendChild(adopted);
+        host.remove();
+        takeScreenshot();
+      }
+    </script>
+  </head>
+  <body>
+    <p>You should see the word PASS below.</p>
+    <iframe id="iframe"></iframe>
+    <div id="host"><span id="adopted">PASS</span></div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-05-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-05-expected.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>DOM Test Reference</title>
+<p>You should see the word PASS below.</p>
+<div>PASS</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-05.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-05.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html class="reftest-wait">
+  <head>
+    <title>Adopting a shadow host child into an iframe</title>
+    <link rel="help" href="https://dom.spec.whatwg.org/#concept-node-adopt">
+    <link rel="match" href="remove-from-shadow-host-and-adopt-into-iframe-ref.html">
+    <style>
+      iframe { border: 0; }
+    </style>
+    <script src="/common/reftest-wait.js"></script>
+    <script>
+      onload = () => {
+        const root = host.attachShadow({mode:"open"});
+        root.innerHTML = "<slot>";
+        // force a layout
+        host.offsetTop;
+        iframe.contentWindow.document.body.style.margin = 0;
+        iframe.contentWindow.document.body.appendChild(adopted);
+        host.remove();
+        takeScreenshot();
+      }
+    </script>
+  </head>
+  <body>
+    <p>You should see the word PASS below.</p>
+    <iframe id="iframe"></iframe>
+    <div id="host"><span id="adopted">PASS</span></div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-06-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-06-expected.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>DOM Test Reference</title>
+<p>You should see the word PASS below.</p>
+<div>PASS</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-06.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-06.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html class="reftest-wait">
+  <head>
+    <title>Adopting a shadow host child into an iframe</title>
+    <link rel="help" href="https://dom.spec.whatwg.org/#concept-node-adopt">
+    <link rel="match" href="remove-from-shadow-host-and-adopt-into-iframe-ref.html">
+    <style>
+      iframe { border: 0; }
+    </style>
+    <script src="/common/reftest-wait.js"></script>
+    <script>
+      onload = () => {
+        const root = host.attachShadow({mode:"open"});
+        root.innerHTML = "<slot>";
+        // force a layout
+        host.offsetTop;
+        iframe.contentWindow.document.body.style.margin = 0;
+        iframe.contentWindow.document.body.appendChild(adopted);
+        host.remove();
+        takeScreenshot();
+      }
+    </script>
+  </head>
+  <body>
+    <p>You should see the word PASS below.</p>
+    <iframe id="iframe"></iframe>
+    <div id="host"><span id="adopted">PASS</span></div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-07-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-07-expected.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>DOM Test Reference</title>
+<p>You should see the word PASS below.</p>
+<div>PASS</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-07.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-07.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html class="reftest-wait">
+  <head>
+    <title>Adopting a shadow host child into an iframe</title>
+    <link rel="help" href="https://dom.spec.whatwg.org/#concept-node-adopt">
+    <link rel="match" href="remove-from-shadow-host-and-adopt-into-iframe-ref.html">
+    <style>
+      iframe { border: 0; }
+    </style>
+    <script src="/common/reftest-wait.js"></script>
+    <script>
+      onload = () => {
+        const root = host.attachShadow({mode:"open"});
+        root.innerHTML = "<slot>";
+        // force a layout
+        host.offsetTop;
+        iframe.contentWindow.document.body.style.margin = 0;
+        iframe.contentWindow.document.body.appendChild(adopted);
+        host.remove();
+        takeScreenshot();
+      }
+    </script>
+  </head>
+  <body>
+    <p>You should see the word PASS below.</p>
+    <iframe id="iframe"></iframe>
+    <div id="host"><span id="adopted">PASS</span></div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-08-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-08-expected.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>DOM Test Reference</title>
+<p>You should see the word PASS below.</p>
+<div>PASS</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-08.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-08.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html class="reftest-wait">
+  <head>
+    <title>Adopting a shadow host child into an iframe</title>
+    <link rel="help" href="https://dom.spec.whatwg.org/#concept-node-adopt">
+    <link rel="match" href="remove-from-shadow-host-and-adopt-into-iframe-ref.html">
+    <style>
+      iframe { border: 0; }
+    </style>
+    <script src="/common/reftest-wait.js"></script>
+    <script>
+      onload = () => {
+        const root = host.attachShadow({mode:"open"});
+        root.innerHTML = "<slot>";
+        // force a layout
+        host.offsetTop;
+        iframe.contentWindow.document.body.style.margin = 0;
+        iframe.contentWindow.document.body.appendChild(adopted);
+        host.remove();
+        takeScreenshot();
+      }
+    </script>
+  </head>
+  <body>
+    <p>You should see the word PASS below.</p>
+    <iframe id="iframe"></iframe>
+    <div id="host"><span id="adopted">PASS</span></div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-09-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-09-expected.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>DOM Test Reference</title>
+<p>You should see the word PASS below.</p>
+<div>PASS</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-09.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-09.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html class="reftest-wait">
+  <head>
+    <title>Adopting a shadow host child into an iframe</title>
+    <link rel="help" href="https://dom.spec.whatwg.org/#concept-node-adopt">
+    <link rel="match" href="remove-from-shadow-host-and-adopt-into-iframe-ref.html">
+    <style>
+      iframe { border: 0; }
+    </style>
+    <script src="/common/reftest-wait.js"></script>
+    <script>
+      onload = () => {
+        const root = host.attachShadow({mode:"open"});
+        root.innerHTML = "<slot>";
+        // force a layout
+        host.offsetTop;
+        iframe.contentWindow.document.body.style.margin = 0;
+        iframe.contentWindow.document.body.appendChild(adopted);
+        host.remove();
+        takeScreenshot();
+      }
+    </script>
+  </head>
+  <body>
+    <p>You should see the word PASS below.</p>
+    <iframe id="iframe"></iframe>
+    <div id="host"><span id="adopted">PASS</span></div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-10-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-10-expected.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>DOM Test Reference</title>
+<p>You should see the word PASS below.</p>
+<div>PASS</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-10.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-10.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html class="reftest-wait">
+  <head>
+    <title>Adopting a shadow host child into an iframe</title>
+    <link rel="help" href="https://dom.spec.whatwg.org/#concept-node-adopt">
+    <link rel="match" href="remove-from-shadow-host-and-adopt-into-iframe-ref.html">
+    <style>
+      iframe { border: 0; }
+    </style>
+    <script src="/common/reftest-wait.js"></script>
+    <script>
+      onload = () => {
+        const root = host.attachShadow({mode:"open"});
+        root.innerHTML = "<slot>";
+        // force a layout
+        host.offsetTop;
+        iframe.contentWindow.document.body.style.margin = 0;
+        iframe.contentWindow.document.body.appendChild(adopted);
+        host.remove();
+        takeScreenshot();
+      }
+    </script>
+  </head>
+  <body>
+    <p>You should see the word PASS below.</p>
+    <iframe id="iframe"></iframe>
+    <div id="host"><span id="adopted">PASS</span></div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-11-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-11-expected.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>DOM Test Reference</title>
+<p>You should see the word PASS below.</p>
+<div>PASS</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-11.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-11.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html class="reftest-wait">
+  <head>
+    <title>Adopting a shadow host child into an iframe</title>
+    <link rel="help" href="https://dom.spec.whatwg.org/#concept-node-adopt">
+    <link rel="match" href="remove-from-shadow-host-and-adopt-into-iframe-ref.html">
+    <style>
+      iframe { border: 0; }
+    </style>
+    <script src="/common/reftest-wait.js"></script>
+    <script>
+      onload = () => {
+        const root = host.attachShadow({mode:"open"});
+        root.innerHTML = "<slot>";
+        // force a layout
+        host.offsetTop;
+        iframe.contentWindow.document.body.style.margin = 0;
+        iframe.contentWindow.document.body.appendChild(adopted);
+        host.remove();
+        takeScreenshot();
+      }
+    </script>
+  </head>
+  <body>
+    <p>You should see the word PASS below.</p>
+    <iframe id="iframe"></iframe>
+    <div id="host"><span id="adopted">PASS</span></div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-12-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-12-expected.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>DOM Test Reference</title>
+<p>You should see the word PASS below.</p>
+<div>PASS</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-12.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-12.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html class="reftest-wait">
+  <head>
+    <title>Adopting a shadow host child into an iframe</title>
+    <link rel="help" href="https://dom.spec.whatwg.org/#concept-node-adopt">
+    <link rel="match" href="remove-from-shadow-host-and-adopt-into-iframe-ref.html">
+    <style>
+      iframe { border: 0; }
+    </style>
+    <script src="/common/reftest-wait.js"></script>
+    <script>
+      onload = () => {
+        const root = host.attachShadow({mode:"open"});
+        root.innerHTML = "<slot>";
+        // force a layout
+        host.offsetTop;
+        iframe.contentWindow.document.body.style.margin = 0;
+        iframe.contentWindow.document.body.appendChild(adopted);
+        host.remove();
+        takeScreenshot();
+      }
+    </script>
+  </head>
+  <body>
+    <p>You should see the word PASS below.</p>
+    <iframe id="iframe"></iframe>
+    <div id="host"><span id="adopted">PASS</span></div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-13-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-13-expected.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>DOM Test Reference</title>
+<p>You should see the word PASS below.</p>
+<div>PASS</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-13.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-13.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html class="reftest-wait">
+  <head>
+    <title>Adopting a shadow host child into an iframe</title>
+    <link rel="help" href="https://dom.spec.whatwg.org/#concept-node-adopt">
+    <link rel="match" href="remove-from-shadow-host-and-adopt-into-iframe-ref.html">
+    <style>
+      iframe { border: 0; }
+    </style>
+    <script src="/common/reftest-wait.js"></script>
+    <script>
+      onload = () => {
+        const root = host.attachShadow({mode:"open"});
+        root.innerHTML = "<slot>";
+        // force a layout
+        host.offsetTop;
+        iframe.contentWindow.document.body.style.margin = 0;
+        iframe.contentWindow.document.body.appendChild(adopted);
+        host.remove();
+        takeScreenshot();
+      }
+    </script>
+  </head>
+  <body>
+    <p>You should see the word PASS below.</p>
+    <iframe id="iframe"></iframe>
+    <div id="host"><span id="adopted">PASS</span></div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-14-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-14-expected.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>DOM Test Reference</title>
+<p>You should see the word PASS below.</p>
+<div>PASS</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-14.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-14.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html class="reftest-wait">
+  <head>
+    <title>Adopting a shadow host child into an iframe</title>
+    <link rel="help" href="https://dom.spec.whatwg.org/#concept-node-adopt">
+    <link rel="match" href="remove-from-shadow-host-and-adopt-into-iframe-ref.html">
+    <style>
+      iframe { border: 0; }
+    </style>
+    <script src="/common/reftest-wait.js"></script>
+    <script>
+      onload = () => {
+        const root = host.attachShadow({mode:"open"});
+        root.innerHTML = "<slot>";
+        // force a layout
+        host.offsetTop;
+        iframe.contentWindow.document.body.style.margin = 0;
+        iframe.contentWindow.document.body.appendChild(adopted);
+        host.remove();
+        takeScreenshot();
+      }
+    </script>
+  </head>
+  <body>
+    <p>You should see the word PASS below.</p>
+    <iframe id="iframe"></iframe>
+    <div id="host"><span id="adopted">PASS</span></div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-15-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-15-expected.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>DOM Test Reference</title>
+<p>You should see the word PASS below.</p>
+<div>PASS</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-15.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-15.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html class="reftest-wait">
+  <head>
+    <title>Adopting a shadow host child into an iframe</title>
+    <link rel="help" href="https://dom.spec.whatwg.org/#concept-node-adopt">
+    <link rel="match" href="remove-from-shadow-host-and-adopt-into-iframe-ref.html">
+    <style>
+      iframe { border: 0; }
+    </style>
+    <script src="/common/reftest-wait.js"></script>
+    <script>
+      onload = () => {
+        const root = host.attachShadow({mode:"open"});
+        root.innerHTML = "<slot>";
+        // force a layout
+        host.offsetTop;
+        iframe.contentWindow.document.body.style.margin = 0;
+        iframe.contentWindow.document.body.appendChild(adopted);
+        host.remove();
+        takeScreenshot();
+      }
+    </script>
+  </head>
+  <body>
+    <p>You should see the word PASS below.</p>
+    <iframe id="iframe"></iframe>
+    <div id="host"><span id="adopted">PASS</span></div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-16-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-16-expected.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>DOM Test Reference</title>
+<p>You should see the word PASS below.</p>
+<div>PASS</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-16.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-16.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html class="reftest-wait">
+  <head>
+    <title>Adopting a shadow host child into an iframe</title>
+    <link rel="help" href="https://dom.spec.whatwg.org/#concept-node-adopt">
+    <link rel="match" href="remove-from-shadow-host-and-adopt-into-iframe-ref.html">
+    <style>
+      iframe { border: 0; }
+    </style>
+    <script src="/common/reftest-wait.js"></script>
+    <script>
+      onload = () => {
+        const root = host.attachShadow({mode:"open"});
+        root.innerHTML = "<slot>";
+        // force a layout
+        host.offsetTop;
+        iframe.contentWindow.document.body.style.margin = 0;
+        iframe.contentWindow.document.body.appendChild(adopted);
+        host.remove();
+        takeScreenshot();
+      }
+    </script>
+  </head>
+  <body>
+    <p>You should see the word PASS below.</p>
+    <iframe id="iframe"></iframe>
+    <div id="host"><span id="adopted">PASS</span></div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-17-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-17-expected.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>DOM Test Reference</title>
+<p>You should see the word PASS below.</p>
+<div>PASS</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-17.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-17.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html class="reftest-wait">
+  <head>
+    <title>Adopting a shadow host child into an iframe</title>
+    <link rel="help" href="https://dom.spec.whatwg.org/#concept-node-adopt">
+    <link rel="match" href="remove-from-shadow-host-and-adopt-into-iframe-ref.html">
+    <style>
+      iframe { border: 0; }
+    </style>
+    <script src="/common/reftest-wait.js"></script>
+    <script>
+      onload = () => {
+        const root = host.attachShadow({mode:"open"});
+        root.innerHTML = "<slot>";
+        // force a layout
+        host.offsetTop;
+        iframe.contentWindow.document.body.style.margin = 0;
+        iframe.contentWindow.document.body.appendChild(adopted);
+        host.remove();
+        takeScreenshot();
+      }
+    </script>
+  </head>
+  <body>
+    <p>You should see the word PASS below.</p>
+    <iframe id="iframe"></iframe>
+    <div id="host"><span id="adopted">PASS</span></div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-18-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-18-expected.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>DOM Test Reference</title>
+<p>You should see the word PASS below.</p>
+<div>PASS</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-18.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-18.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html class="reftest-wait">
+  <head>
+    <title>Adopting a shadow host child into an iframe</title>
+    <link rel="help" href="https://dom.spec.whatwg.org/#concept-node-adopt">
+    <link rel="match" href="remove-from-shadow-host-and-adopt-into-iframe-ref.html">
+    <style>
+      iframe { border: 0; }
+    </style>
+    <script src="/common/reftest-wait.js"></script>
+    <script>
+      onload = () => {
+        const root = host.attachShadow({mode:"open"});
+        root.innerHTML = "<slot>";
+        // force a layout
+        host.offsetTop;
+        iframe.contentWindow.document.body.style.margin = 0;
+        iframe.contentWindow.document.body.appendChild(adopted);
+        host.remove();
+        takeScreenshot();
+      }
+    </script>
+  </head>
+  <body>
+    <p>You should see the word PASS below.</p>
+    <iframe id="iframe"></iframe>
+    <div id="host"><span id="adopted">PASS</span></div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-19-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-19-expected.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>DOM Test Reference</title>
+<p>You should see the word PASS below.</p>
+<div>PASS</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-19.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-19.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html class="reftest-wait">
+  <head>
+    <title>Adopting a shadow host child into an iframe</title>
+    <link rel="help" href="https://dom.spec.whatwg.org/#concept-node-adopt">
+    <link rel="match" href="remove-from-shadow-host-and-adopt-into-iframe-ref.html">
+    <style>
+      iframe { border: 0; }
+    </style>
+    <script src="/common/reftest-wait.js"></script>
+    <script>
+      onload = () => {
+        const root = host.attachShadow({mode:"open"});
+        root.innerHTML = "<slot>";
+        // force a layout
+        host.offsetTop;
+        iframe.contentWindow.document.body.style.margin = 0;
+        iframe.contentWindow.document.body.appendChild(adopted);
+        host.remove();
+        takeScreenshot();
+      }
+    </script>
+  </head>
+  <body>
+    <p>You should see the word PASS below.</p>
+    <iframe id="iframe"></iframe>
+    <div id="host"><span id="adopted">PASS</span></div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-20-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-20-expected.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>DOM Test Reference</title>
+<p>You should see the word PASS below.</p>
+<div>PASS</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-20.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-20.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html class="reftest-wait">
+  <head>
+    <title>Adopting a shadow host child into an iframe</title>
+    <link rel="help" href="https://dom.spec.whatwg.org/#concept-node-adopt">
+    <link rel="match" href="remove-from-shadow-host-and-adopt-into-iframe-ref.html">
+    <style>
+      iframe { border: 0; }
+    </style>
+    <script src="/common/reftest-wait.js"></script>
+    <script>
+      onload = () => {
+        const root = host.attachShadow({mode:"open"});
+        root.innerHTML = "<slot>";
+        // force a layout
+        host.offsetTop;
+        iframe.contentWindow.document.body.style.margin = 0;
+        iframe.contentWindow.document.body.appendChild(adopted);
+        host.remove();
+        takeScreenshot();
+      }
+    </script>
+  </head>
+  <body>
+    <p>You should see the word PASS below.</p>
+    <iframe id="iframe"></iframe>
+    <div id="host"><span id="adopted">PASS</span></div>
+  </body>
+</html>


### PR DESCRIPTION
#### 4cd5d30cd68f86e4fa5ac9dd53fe3faec2e0cd56
<pre>
REGRESSION(290385@main - 290390@main?): [ wk2 arm64 ] imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe.html is a flaky timeout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=289090">https://bugs.webkit.org/show_bug.cgi?id=289090</a>
<a href="https://rdar.apple.com/146118642">rdar://146118642</a>

Reviewed by NOBODY (OOPS!).

Copy the test a bunch of times in the hope to reproduce the flakiness.

* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-02-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-02.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-03-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-03.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-04-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-04.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-05-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-05.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-06-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-06.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-07-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-07.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-08-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-08.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-09-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-09.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-10-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-10.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-11-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-11.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-12-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-12.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-13-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-13.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-14-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-14.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-15-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-15.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-16-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-16.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-17-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-17.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-18-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-18.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-19-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-19.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-20-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow-host-and-adopt-into-iframe-20.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cd5d30cd68f86e4fa5ac9dd53fe3faec2e0cd56

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19058 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104539 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50009 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19346 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27491 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75657 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32752 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14712 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89753 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56016 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14507 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7736 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49369 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84430 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7823 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106897 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26522 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19348 "Found 3 new test failures: imported/w3c/web-platform-tests/webvtt/api/VTTCue/constructor-exceptions.html inspector/injected-script/observable.html svg/animations/animate-and-remove-target-element.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84615 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26884 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85957 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84129 "Found 1 new API test failure: /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28804 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6495 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20265 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26462 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26282 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29595 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27849 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->