### PR TITLE
Reduce repainting when the entire RenderView is dirtied

### DIFF
--- a/LayoutTests/fast/repaint/iframe-avoid-redundant-repaint-expected.txt
+++ b/LayoutTests/fast/repaint/iframe-avoid-redundant-repaint-expected.txt
@@ -1,0 +1,6 @@
+
+(repaint rects
+  (rect 10 10 300 300)
+  (rect 10 10 300 300)
+)
+

--- a/LayoutTests/fast/repaint/iframe-avoid-redundant-repaint.html
+++ b/LayoutTests/fast/repaint/iframe-avoid-redundant-repaint.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        iframe {
+            width: 300px;
+            height: 300px;
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        async function repaintTest()
+        {
+            await UIHelper.renderingUpdate();
+
+            if (window.internals)
+                internals.startTrackingRepaints();
+            
+            const iframe = document.getElementsByTagName('iframe')[0];
+            const iframeDocument = iframe.contentDocument;
+            iframeDocument.body.classList.add('changed');
+
+            await UIHelper.renderingUpdate();
+
+            if (window.internals) {
+                const repaintRects = internals.repaintRectsAsText();
+                internals.stopTrackingRepaints();
+                const pre = document.createElement('pre');
+                pre.innerText = repaintRects;
+                document.body.appendChild(pre);
+            }
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+
+        window.addEventListener('load', () => {
+            setTimeout(repaintTest, 0);
+        }, false);
+    </script>
+</head>
+<body>
+    <iframe scrolling="no" srcdoc="
+    <style>
+        body {
+            height: 100%;
+            margin: 0;
+            overflow: clip;
+        }
+
+        rect {
+            fill: blue;
+        }
+        
+        body.changed rect {
+            width: 310px;
+        }
+    </style>
+    <body>
+        <svg width=300 height=300>
+            <rect x=0 y=0 width=300 height=300 />
+            <rect x=0 y=0 width=300 height=300 />
+            <rect x=0 y=0 width=300 height=300 />
+        </svg>
+    </body>
+    "></iframe>
+</body>
+</html>


### PR DESCRIPTION
#### 0f23344c411ae58815ada68fecacc834e7eab319
<pre>
Reduce repainting when the entire RenderView is dirtied
<a href="https://bugs.webkit.org/show_bug.cgi?id=291458">https://bugs.webkit.org/show_bug.cgi?id=291458</a>
<a href="https://rdar.apple.com/149103053">rdar://149103053</a>

Reviewed by Alan Baradlay.

We can avoid some excess repaints in an iframe&apos;s contents by detecting that
some earlier repaint dirtied the entire RenderView. Calling `layoutContext().setNeedsFullRepaint()`
sets state on the layout context that avoid later repaints even computing repaint rects,
via `RenderElement::checkForRepaintDuringLayout()`.

This applies under a limited set of conditions: a non-composited iframe (i.e. non-scrollable,
with no composited descendants), and when repaints are triggered by renderers without
self-painting layers.

* LayoutTests/fast/repaint/iframe-avoid-redundant-repaint-expected.txt: Added.
* LayoutTests/fast/repaint/iframe-avoid-redundant-repaint.html: Added.
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::repaintViewRectangle const):

Canonical link: <a href="https://commits.webkit.org/293674@main">https://commits.webkit.org/293674@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9eca5ef42094808bfb40d384a174d22c41909432

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19075 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104556 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50026 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101466 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27508 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75669 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32766 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102432 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89769 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56028 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14523 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7752 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49386 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106914 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26539 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19361 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84628 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26901 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85973 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84143 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21389 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28822 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20282 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26479 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31680 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26299 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29612 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27866 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->