### PR TITLE
[iOS] Fix several flaky tests in fast/page-color-sampling

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-fixed-container-under-subscroller.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-fixed-container-under-subscroller.html
@@ -1,6 +1,5 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true AsyncOverflowScrollingEnabled=true ] -->
 <html>
-<meta name="viewport" content="width=device-width, initial-scale=1">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -47,6 +46,7 @@
         shouldBeNull("colors.left");
         shouldBeNull("colors.right");
         shouldBeNull("colors.bottom");
+        await UIHelper.setObscuredInsets(0, 0, 0, 0);
         finishJSTest();
     });
     </script>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2035,7 +2035,16 @@ FixedContainerEdges LocalFrameView::fixedContainerEdges(BoxSideSet sides) const
 
         document->hitTest({ HitTestSource::User, hitTestOptions }, result);
 
-        RefPtr hitNode = result.isRectBasedTest() ? result.listBasedTestResult().first().ptr() : result.innerNonSharedNode();
+        RefPtr hitNode = [&] -> RefPtr<Node> {
+            if (!result.isRectBasedTest())
+                return result.innerNonSharedNode();
+
+            if (auto& resultsList = result.listBasedTestResult(); !resultsList.isEmpty())
+                return resultsList.first().ptr();
+
+            return { };
+        }();
+
         if (!hitNode)
             return { };
 


### PR DESCRIPTION
#### 9aa5775e5d82a4f4eb5c59809e231a7ca2db3ebf
<pre>
[iOS] Fix several flaky tests in fast/page-color-sampling
<a href="https://bugs.webkit.org/show_bug.cgi?id=291461">https://bugs.webkit.org/show_bug.cgi?id=291461</a>

Reviewed by Megan Gardner and Aditya Keerthi.

Fix a couple of flaky test failures observed on debug iOS test runners; see below for more details.

* LayoutTests/fast/page-color-sampling/color-sampling-fixed-container-under-subscroller.html:

This layout test currently causes the next layout test that&apos;s run to fail, while resetting the test
harness to a consistent state by loading about:blank, due to a debug assert in `windowClipRect()`:

```
Thread 0 Crashed:
0   WebCore                                0x300002664 WTFCrashWithInfo(int, char const*, char const*, int) + 100
1   WebCore                                0x305976854 WebCore::LocalFrameView::windowClipRect() const + 184
2   WebCore                                0x305970f00 WebCore::LocalFrameView::applyRecursivelyWithVisibleRect(WTF::Function&lt;void (WebCore::LocalFrameView&amp;, WebCore::IntRect const&amp;)&gt; const&amp;) + 32
3   WebCore                                0x305965f74 WebCore::LocalFrameView::viewportContentsChanged() + 148

    …

15  WebCore                                0x305c8fff8 WebCore::ScrollView::setScrollbarModes(WebCore::ScrollbarMode, WebCore::ScrollbarMode, bool, bool) + 320
16  WebCore                                0x305965074 WebCore::LocalFrameView::resetScrollbars() + 100
17  WebCore                                0x305964b68 WebCore::LocalFrameView::~LocalFrameView() + 40
18  WebCore                                0x3059652c8 WebCore::LocalFrameView::~LocalFrameView() + 28

    …

25  WebKit                                 0x11c905388 WebKit::WebLocalFrameLoaderClient::transitionToCommittedForNewPage(WebCore::LocalFrameLoaderClient::InitializingIframe) + 2156 (WebLocalFrameLoaderClient.cpp:1610)
26  WebCore                                0x3056304c4 WebCore::FrameLoader::transitionToCommitted(WebCore::CachedPage*) + 2392
27  WebCore                                0x30562ee68 WebCore::FrameLoader::commitProvisionalLoad() + 2024
28  WebCore                                0x3055b30c4 WebCore::DocumentLoader::commitIfReady() + 100
```

Notably, this debug assertion is hit even after disabling all color sampling logic, so it&apos;s likely
an existing issue exposed by the new layout test. For now, work around it by manually resetting the
obscured insets before ending the test; I&apos;ve filed <a href="https://webkit.org/b/291464">https://webkit.org/b/291464</a> to track the
underlying issue.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):

Also check that `resultsList` is non-empty before accessing the first element in the `ListHashSet`.

Canonical link: <a href="https://commits.webkit.org/293631@main">https://commits.webkit.org/293631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa520c39c1eceafb46418b993bb0ceee7adf92a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9332 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104560 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50030 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101470 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75675 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32770 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102436 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14734 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89776 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56034 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14529 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7759 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49390 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84450 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7846 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106918 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26543 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19362 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84632 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26905 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85980 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84149 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21355 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28823 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6516 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20286 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26483 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31684 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26303 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29616 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27870 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->