### PR TITLE
Position Model UITargetedDragPreview for Drag and Drop

### DIFF
--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -758,8 +758,14 @@ bool ModelProcessModelPlayerProxy::stageModeInteractionInProgress() const
 
 void ModelProcessModelPlayerProxy::animateModelToFitPortal(CompletionHandler<void(bool)>&& completionHandler)
 {
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=291289
-    completionHandler(true);
+    if (!m_model || !m_layer)
+        completionHandler(false);
+
+    auto boundsOfLayerInMeters = makeMeterSizeFromPointSize(m_layer.get().bounds.size, effectivePointsPerMeter(m_layer.get()));
+    BOOL inStageMode = m_stageModeOperation != WebCore::StageModeOperation::None;
+    [m_modelRKEntity fitEntityWithinPortalBounds:boundsOfLayerInMeters ignoreClippingConstraints:NO isAnimated:YES withCompletion:makeBlockPtr([weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] () {
+        completionHandler(!!weakThis);
+    }).get()];
 }
 
 void ModelProcessModelPlayerProxy::applyEnvironmentMapDataAndRelease()

--- a/Source/WebKit/WebKitSwift/RealityKit/RKEntity.swift
+++ b/Source/WebKit/WebKitSwift/RealityKit/RKEntity.swift
@@ -392,6 +392,46 @@ public final class WKSRKEntity: NSObject {
         let offset = pivotPoint - interactionPivotPoint
         transform = WKEntityTransform(scale: newTransform.scale, rotation: newTransform.rotation, translation: newTransform.translation + offset)
     }
+    
+    private var preFitAnimationTransformMatrix: simd_float4x4? = nil
+    private var preFitAnimationController: AnimationPlaybackController? = nil
+    private var preFitAnimationCompletionSubscription: Cancellable? = nil
+    private var ignoreTransformUpdates: Bool = false
+    @objc(fitEntityWithinPortalBounds:isAnimated:withCompletion:) public func fitEntity(within bounds: simd_float2, animated: Bool, completion: (() -> Void)) {
+        let entityBounds = entity.visualBounds(relativeTo: nil)
+        let portalBounds = BoundingBox(min: .init(-bounds.x/2, -bounds.y/2, 0), max: .init(bounds.x/2, bounds.y/2, 2 * entityBounds.extents.z))
+        
+        let newScale = Float(min(portalBounds.extents.x/entityBounds.boundingRadius, portalBounds.extents.y/entityBounds.boundingRadius, 1)) * entity.scale(relativeTo: nil).x
+        let offset = (self.interactionPivotPoint - self.entity.position(relativeTo: nil)) * (newScale / entity.scale(relativeTo: nil).x)
+        let preLiftAnimationPosition = simd_float3(offset.x, offset.y, max(-entityBounds.boundingRadius, transform.translation.z))
+        let liftTargetTransform = Transform(scale: .init(repeating: newScale), rotation: transform.rotation, translation: -preLiftAnimationPosition)
+        let entityIsClipped = entityBounds.min.x < portalBounds.min.x || entityBounds.min.y < portalBounds.min.y || entityBounds.max.x > portalBounds.max.x || entityBounds.max.y > portalBounds.max.y
+        let entityInsetExceedsThreshold = transform.translation.z < -entityBounds.boundingRadius
+        
+        if (entityIsClipped || entityInsetExceedsThreshold) {
+            self.ignoreTransformUpdates = true
+            self.preFitAnimationTransformMatrix = self.entity.transformMatrix(relativeTo: nil)
+            self.preFitAnimationController = self.entity.move(to: liftTargetTransform, relativeTo: nil, duration: 0.3, timingFunction: .cubicBezier(controlPoint1: .init(0.08, 0.6), controlPoint2: .init(0.4, 1.0)))
+            self.preFitAnimationCompletionSubscription = self.entity.scene?.subscribe(to: AnimationEvents.PlaybackCompleted.self, on: self.entity) { _ in
+                self.ignoreTransformUpdates = false
+                completion()
+            }
+        }
+    }
+    
+    @objc(resetModelTransformAfterDrag) public func resetModelTransformAfterDrag() {
+        guard let preFitAnimationTransformMatrix else {
+            Logger.realityKitEntity.error("Unable to reset model transform after drag.")
+            return
+        }
+            
+        self.ignoreTransformUpdates = true
+        self.preFitAnimationController = self.entity.move(to: preFitAnimationTransformMatrix, relativeTo: nil, duration: 0.3, timingFunction: .cubicBezier(controlPoint1: .init(0.08, 0.6), controlPoint2: .init(0.4, 1.0)))
+        self.preFitAnimationCompletionSubscription = self.entity.scene?.subscribe(to: AnimationEvents.PlaybackCompleted.self, on: self.entity) { _ in
+            self.ignoreTransformUpdates = false
+        }
+        self.preFitAnimationTransformMatrix = nil
+    }
 }
 
 #endif // os(visionOS)

--- a/Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h
+++ b/Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h
@@ -69,6 +69,8 @@ typedef struct {
 - (void)interactionContainerDidRecenterFromTransform:(simd_float4x4)transform NS_SWIFT_NAME(interactionContainerDidRecenter(_:));
 - (void)recenterEntityAtTransform:(WKEntityTransform)transform NS_SWIFT_NAME(recenterEntity(at:));
 - (void)applyDefaultIBL NS_SWIFT_NAME(applyDefaultIBL());
+- (void)fitEntityWithinPortalBounds:(simd_float2)bounds isAnimated:(BOOL)animated withCompletion:(void(^)())completion NS_SWIFT_NAME(fitEntity(within:animated:completion:));
+- (void)resetModelTransformAfterDrag;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
#### a833b30abbd3f0d565bf734ba843d87364c7898a
<pre>
Position Model UITargetedDragPreview for Drag and Drop
<a href="https://bugs.webkit.org/show_bug.cgi?id=291468">https://bugs.webkit.org/show_bug.cgi?id=291468</a>
<a href="https://rdar.apple.com/146525262">rdar://146525262</a>

Reviewed by NOBODY (OOPS!).

This PR introduces a new API to animate the model to fit within the portal bounds in preparation
for drag and drop before we create a UITargetedDragPreview for it. It uses the orbit-fit position
such that if the model&apos;s bounds exceeds the portal&apos;s bounds, it will then animate to the orbit fit
location before the lift animation occurs.

* Source/WebKit/WebKitSwift/RealityKit/RKEntity.swift:
(WKSRKEntity.preFitAnimationTransformMatrix):
(WKSRKEntity.preFitAnimationController):
(WKSRKEntity.preFitAnimationCompletionSubscription):
(WKSRKEntity.ignoreTransformUpdates):
(WKSRKEntity.fitEntity(within:animated:completion:)):
(WKSRKEntity.resetModelTransformAfterDrag):
* Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a833b30abbd3f0d565bf734ba843d87364c7898a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22372 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107864 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53340 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30874 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78109 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35075 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105705 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17573 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92687 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58441 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17414 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52697 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87229 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10789 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110240 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29836 "Hash a833b30a for PR 43999 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21997 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87089 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30200 "Hash a833b30a for PR 43999 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88879 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86695 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9259 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24089 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29763 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35083 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29571 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32898 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31133 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->