### PR TITLE
Fix ipc/serialized-type-info.html

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
@@ -53,7 +53,7 @@ messages -> RemoteDisplayListRecorder Stream {
     SetDropShadow(struct std::optional<WebCore::GraphicsDropShadow> dropShadow) StreamBatched
     SetStyle(std::optional<WebCore::GraphicsStyle> style) StreamBatched
     SetAlpha(float alpha) StreamBatched
-    SetTextDrawingMode(enum:uint8_t WebCore::TextDrawingModeFlags mode) StreamBatched
+    SetTextDrawingMode(WebCore::TextDrawingModeFlags mode) StreamBatched
     SetImageInterpolationQuality(enum:uint8_t WebCore::InterpolationQuality quality) StreamBatched
     SetShouldAntialias(bool shouldAntialias) StreamBatched
     SetShouldSmoothFonts(bool shouldSmooth) StreamBatched

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.serialization.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.serialization.in
@@ -29,4 +29,10 @@ struct WebKit::RemoteGraphicsContextGLInitializationState {
     GCGLenum externalImageBindingQuery;
 };
 
+enum class WebCore::TextDrawingMode : uint8_t {
+    Fill
+    Stroke,
+};
+using WebCore::TextDrawingModeFlags = OptionSet<WebCore::TextDrawingMode>;
+
 #endif


### PR DESCRIPTION
#### 59330374e718e2dcc4bef2e0648b44b2d039ef58
<pre>
Fix ipc/serialized-type-info.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=291469">https://bugs.webkit.org/show_bug.cgi?id=291469</a>
<a href="https://rdar.apple.com/149112511">rdar://149112511</a>

Unreviewed.

* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.serialization.in:

Canonical link: <a href="https://commits.webkit.org/293619@main">https://commits.webkit.org/293619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41188ad9f5a7b41063a3302c02cb1b180bf57cec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9341 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/104569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50039 "Failed to checkout and rebase branch from PR 44000") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27521 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/104569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/50039 "Failed to checkout and rebase branch from PR 44000") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102445 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/14743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/89786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/104569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/14539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49399 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/7856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106927 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26552 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26914 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/85990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/84157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/28831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/6526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20295 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16185 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26492 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/31693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26312 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29625 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27879 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->