### PR TITLE
CSS animations in SVG do not repaint when SVG is zoomed

### DIFF
--- a/LayoutTests/svg/repaint/image-animation-with-zoom-expected.txt
+++ b/LayoutTests/svg/repaint/image-animation-with-zoom-expected.txt
@@ -1,0 +1,5 @@
+
+(repaint rects
+  (rect 0 0 110 110)
+)
+

--- a/LayoutTests/svg/repaint/image-animation-with-zoom.html
+++ b/LayoutTests/svg/repaint/image-animation-with-zoom.html
@@ -1,0 +1,38 @@
+<!DOCTYPE HTML>
+<style>
+html {
+    zoom: 2.2;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+}
+</style>
+<body>
+    <img id="target" src="resources/animate-center.svg" width="50px" height="50px">
+    <pre id="resultContainer"></pre>
+</body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+(async () => {
+    if (window.internals)
+        internals.startTrackingRepaints();
+
+    // Wait for two frames.
+    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+    if (window.internals) {
+        const repaintRects = internals.repaintRectsAsText();
+        internals.stopTrackingRepaints();
+        document.getElementById("resultContainer").textContent = repaintRects;
+    }
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+})();
+</script>

--- a/LayoutTests/svg/repaint/resources/animate-center.svg
+++ b/LayoutTests/svg/repaint/resources/animate-center.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50">
+  <defs>
+    <style type="text/css"><![CDATA[
+      #square {
+        fill: red;
+        animation: keyframes 0.5s;
+        animation-fill-mode: forwards;
+        animation-timing-function: step-end;
+      }
+      @keyframes keyframes {
+        0% { fill: pink }
+        /* To prevent flakiness, rapidly switch to green */
+        1% { fill: green }
+        100% { fill: green }
+      }
+    ]]></style>
+  </defs>
+  <rect id="square" width="30" height="30" x="10" y="10"></rect>
+</svg>

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -5,7 +5,7 @@
  *           (C) 2006 Allan Sandfeld Jensen (kde@carewolf.com)
  *           (C) 2006 Samuel Weinig (sam.weinig@gmail.com)
  * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
- * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2010-2014 Google Inc. All rights reserved.
  * Copyright (C) Research In Motion Limited 2011-2012. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -407,9 +407,10 @@ void RenderImage::repaintOrMarkForLayout(ImageSizeChangeType imageSizeChange, co
     if (parent()) {
         auto repaintRect = contentBoxRect();
         if (rect) {
-            // The image changed rect is in source image coordinates (pre-zooming),
+            // The image changed rect is in source image coordinates (without zoom),
             // so map from the bounds of the image to the contentsBox.
-            repaintRect.intersect(enclosingIntRect(mapRect(*rect, FloatRect(FloatPoint(), imageResource().imageSize(1.0f)), repaintRect)));
+            auto imageSizeWithoutZoom = imageResource().imageSize(1.0f / style().usedZoom());
+            repaintRect.intersect(enclosingIntRect(mapRect(*rect, FloatRect(FloatPoint(), imageSizeWithoutZoom), repaintRect)));
         }
         repaintRectangle(repaintRect);
     }


### PR DESCRIPTION
#### 727de5369dbc893037b52c6e9305bd6f68ab4a9b
<pre>
CSS animations in SVG do not repaint when SVG is zoomed
<a href="https://bugs.webkit.org/show_bug.cgi?id=199364">https://bugs.webkit.org/show_bug.cgi?id=199364</a>
<a href="https://rdar.apple.com/problem/52459928">rdar://problem/52459928</a>

Reviewed by NOBODY (OOPS!).

Merge: <a href="https://github.com/chromium/chromium/commit/8f79cf8a43b2a5db9b2cc301733277d1f27b90b5">https://github.com/chromium/chromium/commit/8f79cf8a43b2a5db9b2cc301733277d1f27b90b5</a>

This patch changes the coordinate system used by RenderImage for
invalidation rects to account for zoom. When an SVG image issues
invalidations to its ImageResource clients, the invalidation rect does
not contain zoom. This is due to how SVG images work internally:
images are laid out without zoom so that relative sizes are resolved
correctly; as a result the invalidation rects do not include zoom.
This patch simply removes the zoom from the image size in
RenderImage::repaintOrMarkForLayout and clarifies the comment.

This change should not affect bitmap image invalidation because
bitmaps (even animated gifs) do not use invalidation rects.

* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::repaintOrMarkForLayout):
* LayoutTests/svg/repaint/resources/animate-center.svg:
* LayoutTests/svg/repaint/image-animation-with-zoom.html:
* LayoutTests/svg/repaint/image-animation-with-zoom-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/727de5369dbc893037b52c6e9305bd6f68ab4a9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106440 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51918 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103332 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29448 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77145 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34181 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104298 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16394 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91488 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57492 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16210 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9499 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51266 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86090 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9574 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108795 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28419 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20909 "11 flakes 2 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86120 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28781 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87695 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85676 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30403 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8110 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22518 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28349 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33623 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28161 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31481 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29719 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->