### PR TITLE
Reduce unsafe lambdas in WebCore/page/scrolling

### DIFF
--- a/Source/WTF/wtf/SmallMap.h
+++ b/Source/WTF/wtf/SmallMap.h
@@ -42,7 +42,7 @@ public:
 
     static_assert(sizeof(Pair) <= 4 * sizeof(uint64_t), "Don't use SmallMap with large types. It probably wastes memory.");
 
-    Value& ensure(const Key& key, const auto& functor)
+    Value& ensure(const Key& key, NOESCAPE const auto& functor)
     {
         ASSERT(Map::isValidKey(key));
         if (std::holds_alternative<std::monostate>(m_storage)) {
@@ -83,7 +83,7 @@ public:
         return nullptr;
     }
 
-    void forEach(const auto& callback) const
+    void forEach(NOESCAPE const auto& callback) const
     {
         switchOn(m_storage, [&] (const std::monostate&) {
         }, [&] (const Pair& pair) {

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -76,9 +76,6 @@ page/ShareDataReader.cpp
 page/UserMessageHandlersNamespace.cpp
 page/cocoa/ResourceUsageOverlayCocoa.mm
 page/csp/ContentSecurityPolicy.cpp
-page/scrolling/AsyncScrollingCoordinator.cpp
-page/scrolling/ThreadedScrollingCoordinator.cpp
-page/scrolling/mac/ScrollerPairMac.mm
 platform/RemoteCommandListener.cpp
 platform/ScrollableArea.cpp
 platform/Timer.h

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -1215,7 +1215,7 @@ std::optional<ScrollingNodeID> AsyncScrollingCoordinator::scrollableContainerNod
 String AsyncScrollingCoordinator::scrollingStateTreeAsText(OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const
 {
     StringBuilder stateTree;
-    m_scrollingStateTrees.forEach([&] (auto& key, auto& tree) {
+    m_scrollingStateTrees.forEach([&](auto& key, auto& tree) {
         if (tree->rootStateNode()) {
             if (m_eventTrackingRegionsDirty)
                 tree->rootStateNode()->setEventTrackingRegions(absoluteEventTrackingRegions());

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -271,18 +271,16 @@ OptionSet<EventListenerRegionType> ScrollingTree::eventListenerRegionTypesForPoi
 }
 #endif
 
-void ScrollingTree::traverseScrollingTree(VisitorFunction&& visitorFunction)
+void ScrollingTree::traverseScrollingTree(NOESCAPE const VisitorFunction& visitorFunction)
 {
     Locker locker { m_treeLock };
     RefPtr rootNode = m_rootNode;
     if (!rootNode)
         return;
-
-    auto function = WTFMove(visitorFunction);
-    traverseScrollingTreeRecursive(*rootNode, function);
+    traverseScrollingTreeRecursive(*rootNode, visitorFunction);
 }
 
-void ScrollingTree::traverseScrollingTreeRecursive(ScrollingTreeNode& node, const VisitorFunction& visitorFunction)
+void ScrollingTree::traverseScrollingTreeRecursive(ScrollingTreeNode& node, NOESCAPE const VisitorFunction& visitorFunction)
 {
     bool scrolledSinceLastCommit = false;
     std::optional<FloatPoint> scrollPosition;

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -119,7 +119,7 @@ public:
     WEBCORE_EXPORT ScrollingTreeNode* nodeForID(std::optional<ScrollingNodeID>) const;
 
     using VisitorFunction = Function<void(ScrollingNodeID, ScrollingNodeType, std::optional<FloatPoint> scrollPosition, std::optional<FloatPoint> layoutViewportOrigin, bool scrolledSinceLastCommit)>;
-    void traverseScrollingTree(VisitorFunction&&);
+    void traverseScrollingTree(NOESCAPE const VisitorFunction&);
 
     // Called after a scrolling tree node has handled a scroll and updated its layers.
     // Updates FrameView/RenderLayer scrolling state and GraphicsLayers.
@@ -288,7 +288,7 @@ private:
 
     void applyLayerPositionsRecursive(ScrollingTreeNode&) WTF_REQUIRES_LOCK(m_treeLock);
     void notifyRelatedNodesRecursive(ScrollingTreeNode&);
-    void traverseScrollingTreeRecursive(ScrollingTreeNode&, const VisitorFunction&) WTF_REQUIRES_LOCK(m_treeLock);
+    void traverseScrollingTreeRecursive(ScrollingTreeNode&, NOESCAPE const VisitorFunction&) WTF_REQUIRES_LOCK(m_treeLock);
     
     void setOverlayScrollbarsEnabled(bool);
     

--- a/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
@@ -58,7 +58,7 @@ void ThreadedScrollingCoordinator::pageDestroyed()
 
 void ThreadedScrollingCoordinator::commitTreeStateIfNeeded()
 {
-    scrollingStateTrees().forEach([&] (auto& key, auto& value) {
+    scrollingStateTrees().forEach([&](auto& key, auto& value) {
         willCommitTree(key);
 
         LOG_WITH_STREAM(Scrolling, stream << "ThreadedScrollingCoordinator::commitTreeState, has changes " << value->hasChangedProperties());

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -401,7 +401,7 @@ void ScrollerMac::updatePairScrollerImps()
 
 void ScrollerMac::mouseEnteredScrollbar()
 {
-    m_pair.ensureOnMainThreadWithProtectedThis([this] {
+    m_pair.ensureOnMainThreadWithProtectedThis([this](auto&) {
         // At this time, only legacy scrollbars needs to send notifications here.
         if (m_pair.scrollbarStyle() != WebCore::ScrollbarStyle::AlwaysVisible)
             return;
@@ -415,7 +415,7 @@ void ScrollerMac::mouseEnteredScrollbar()
 
 void ScrollerMac::mouseExitedScrollbar()
 {
-    m_pair.ensureOnMainThreadWithProtectedThis([this] {
+    m_pair.ensureOnMainThreadWithProtectedThis([this](auto&) {
         // At this time, only legacy scrollbars needs to send notifications here.
         if (m_pair.scrollbarStyle() != WebCore::ScrollbarStyle::AlwaysVisible)
             return;

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -108,7 +108,7 @@ public:
     void mouseIsInScrollbar(ScrollbarHoverState);
 
     NSScrollerImpPair *scrollerImpPair() const { return m_scrollerImpPair.get(); }
-    void ensureOnMainThreadWithProtectedThis(Function<void()>&&);
+    void ensureOnMainThreadWithProtectedThis(Function<void(ScrollerPairMac&)>&&);
     RefPtr<ScrollingTreeScrollingNode> protectedNode() const { return m_scrollingNode.get(); }
 
     bool mouseInContentArea() const { return m_mouseInContentArea; }


### PR DESCRIPTION
#### 29a5f5edadb7f15d355bf2c980d6dcdb70868f38
<pre>
Reduce unsafe lambdas in WebCore/page/scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=291470">https://bugs.webkit.org/show_bug.cgi?id=291470</a>

Reviewed by Chris Dumez.

As per Safer CPP Guidelines:

- <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#capture-protectedthis-or-weakthis-in-asynchronous-lambdas-where-you-need-to-use-this">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#capture-protectedthis-or-weakthis-in-asynchronous-lambdas-where-you-need-to-use-this</a>
- <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#annotate-noescape-when-a-function-uses-a-lambda-synchronously">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#annotate-noescape-when-a-function-uses-a-lambda-synchronously</a>

* Source/WTF/wtf/SmallMap.h:
(WTF::SmallMap::ensure):
(WTF::SmallMap::forEach const):
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::scrollingStateTreeAsText const):
* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::traverseScrollingTree):
(WebCore::ScrollingTree::traverseScrollingTreeRecursive):
* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp:
(WebCore::ThreadedScrollingCoordinator::commitTreeStateIfNeeded):
* Source/WebCore/page/scrolling/mac/ScrollerMac.mm:
(WebCore::ScrollerMac::mouseEnteredScrollbar):
(WebCore::ScrollerMac::mouseExitedScrollbar):
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
(WebCore::ScrollerPairMac::handleWheelEventPhase):
(WebCore::ScrollerPairMac::viewWillStartLiveResize):
(WebCore::ScrollerPairMac::viewWillEndLiveResize):
(WebCore::ScrollerPairMac::contentsSizeChanged):
(WebCore::ScrollerPairMac::updateValues):
(WebCore::ScrollerPairMac::setVerticalScrollerImp):
(WebCore::ScrollerPairMac::setHorizontalScrollerImp):
(WebCore::ScrollerPairMac::setScrollbarStyle):
(WebCore::ScrollerPairMac::ensureOnMainThreadWithProtectedThis):
(WebCore::ScrollerPairMac::mouseEnteredContentArea):
(WebCore::ScrollerPairMac::mouseExitedContentArea):
(WebCore::ScrollerPairMac::mouseMovedInContentArea):

Canonical link: <a href="https://commits.webkit.org/293643@main">https://commits.webkit.org/293643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09c53e143bb7aebca489943854dc3e8dd5e4c7cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99448 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104579 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50049 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101489 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75692 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32789 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14753 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89795 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56051 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14549 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7778 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49409 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92131 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84469 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7866 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106937 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98067 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26562 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19379 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84651 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26924 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85999 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84169 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28841 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6535 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20315 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16192 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26502 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31703 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121683 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26322 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33985 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29635 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27889 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->