### PR TITLE
Reduce unsafe lambdas in WebCore/Modules/entriesapi and assorted

### DIFF
--- a/Source/WTF/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -1,3 +1,2 @@
-wtf/PrintStream.h
 wtf/RunLoop.h
 wtf/ThreadSafeWeakPtr.h

--- a/Source/WTF/wtf/PrintStream.h
+++ b/Source/WTF/wtf/PrintStream.h
@@ -67,7 +67,7 @@ public:
     WTF_EXPORT_PRIVATE virtual void flush();
     
     template<typename Func>
-    void atomically(const Func& func)
+    void atomically(NOESCAPE const Func& func)
     {
         func(begin());
         end();

--- a/Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp
+++ b/Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp
@@ -303,7 +303,7 @@ void DOMFileSystem::getEntry(ScriptExecutionContext& context, FileSystemDirector
     ASSERT(resolvedVirtualPath[0] == '/');
     auto fullPath = evaluatePath(resolvedVirtualPath);
     if (fullPath == m_rootPath) {
-        callOnMainThread([this, context = Ref { context }, completionCallback = WTFMove(completionCallback)]() mutable {
+        callOnMainThread([this, protectedThis = Ref { *this }, context = Ref { context }, completionCallback = WTFMove(completionCallback)]() mutable {
             completionCallback(Ref<FileSystemEntry> { root(context) });
         });
         return;

--- a/Source/WebCore/Modules/entriesapi/FileSystemDirectoryEntry.cpp
+++ b/Source/WebCore/Modules/entriesapi/FileSystemDirectoryEntry.cpp
@@ -60,8 +60,8 @@ void FileSystemDirectoryEntry::getEntry(ScriptExecutionContext& context, const S
     if (!successCallback && !errorCallback)
         return;
 
-    filesystem().getEntry(context, *this, path, flags, [this, pendingActivity = makePendingActivity(*this), matches = WTFMove(matches), successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback)](auto&& result) mutable {
-        RefPtr document = this->document();
+    filesystem().getEntry(context, *this, path, flags, [pendingActivity = makePendingActivity(*this), matches = WTFMove(matches), successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback)](auto&& result) mutable {
+        RefPtr document = pendingActivity->object().document();
         if (result.hasException()) {
             if (errorCallback && document) {
                 document->eventLoop().queueTask(TaskSource::Networking, [errorCallback = WTFMove(errorCallback), exception = result.releaseException(), pendingActivity = WTFMove(pendingActivity)]() mutable {

--- a/Source/WebCore/Modules/entriesapi/FileSystemEntry.cpp
+++ b/Source/WebCore/Modules/entriesapi/FileSystemEntry.cpp
@@ -66,8 +66,8 @@ void FileSystemEntry::getParent(ScriptExecutionContext& context, RefPtr<FileSyst
     if (!successCallback && !errorCallback)
         return;
 
-    filesystem().getParent(context, *this, [this, pendingActivity = makePendingActivity(*this), successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback)]<typename Result> (Result&& result) mutable {
-        RefPtr document = this->document();
+    filesystem().getParent(context, *this, [pendingActivity = makePendingActivity(*this), successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback)]<typename Result> (Result&& result) mutable {
+        RefPtr document = pendingActivity->object().document();
         if (!document)
             return;
 

--- a/Source/WebCore/Modules/entriesapi/FileSystemFileEntry.cpp
+++ b/Source/WebCore/Modules/entriesapi/FileSystemFileEntry.cpp
@@ -50,8 +50,8 @@ FileSystemFileEntry::FileSystemFileEntry(ScriptExecutionContext& context, DOMFil
 
 void FileSystemFileEntry::file(ScriptExecutionContext& context, Ref<FileCallback>&& successCallback, RefPtr<ErrorCallback>&& errorCallback)
 {
-    filesystem().getFile(context, *this, [this, pendingActivity = makePendingActivity(*this), successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback)](auto&& result) mutable {
-        RefPtr document = this->document();
+    filesystem().getFile(context, *this, [pendingActivity = makePendingActivity(*this), successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback)](auto&& result) mutable {
+        RefPtr document = pendingActivity->object().document();
         if (!document)
             return;
 

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -6,11 +6,6 @@ Modules/cache/DOMCache.cpp
 Modules/cache/DOMCacheStorage.cpp
 Modules/encryptedmedia/MediaKeySession.cpp
 Modules/encryptedmedia/NavigatorEME.cpp
-Modules/entriesapi/DOMFileSystem.cpp
-Modules/entriesapi/FileSystemDirectoryEntry.cpp
-Modules/entriesapi/FileSystemDirectoryReader.cpp
-Modules/entriesapi/FileSystemEntry.cpp
-Modules/entriesapi/FileSystemFileEntry.cpp
 Modules/gamepad/GamepadHapticActuator.cpp
 Modules/indexeddb/IDBObjectStore.cpp
 Modules/indexeddb/client/IDBConnectionProxy.cpp
@@ -62,7 +57,6 @@ dom/Document.cpp
 dom/Subscriber.cpp
 editing/Editor.cpp
 html/FormAssociatedCustomElement.cpp
-html/canvas/CanvasRenderingContext2DBase.cpp
 html/track/TrackBase.cpp
 inspector/InspectorOverlay.cpp
 inspector/agents/page/PageDOMDebuggerAgent.cpp
@@ -110,7 +104,6 @@ testing/MockMediaSessionCoordinator.cpp
 workers/Worker.cpp
 workers/WorkerMessagingProxy.cpp
 workers/WorkerOrWorkletThread.cpp
-workers/WorkerThread.cpp
 workers/service/ExtendableEvent.cpp
 workers/service/ServiceWorkerContainer.cpp
 workers/service/ServiceWorkerGlobalScope.cpp

--- a/Source/WebCore/css/CSSVariableReferenceValue.h
+++ b/Source/WebCore/css/CSSVariableReferenceValue.h
@@ -67,7 +67,7 @@ public:
     
     const CSSVariableData& data() const { return m_data.get(); }
 
-    template<typename CacheFunction> bool resolveAndCacheValue(Style::BuilderState&, CacheFunction&&) const;
+    template<typename CacheFunction> bool resolveAndCacheValue(Style::BuilderState&, NOESCAPE const CacheFunction&) const;
 
 private:
     explicit CSSVariableReferenceValue(Ref<CSSVariableData>&&);
@@ -98,7 +98,7 @@ private:
 };
 
 template<typename CacheFunction>
-bool CSSVariableReferenceValue::resolveAndCacheValue(Style::BuilderState& builderState, CacheFunction&& cacheFunction) const
+bool CSSVariableReferenceValue::resolveAndCacheValue(Style::BuilderState& builderState, NOESCAPE const CacheFunction& cacheFunction) const
 
 {
     if (auto data = tryResolveSimpleReference(builderState)) {

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1205,7 +1205,7 @@ void CanvasRenderingContext2DBase::fillInternal(const Path& path, CanvasFillRule
     } else
         c->fillPath(path);
 
-    didDraw(repaintEntireCanvas, [&]() {
+    didDraw(repaintEntireCanvas, [&] {
         return targetSwitcher ? targetSwitcher->expandedBounds() : path.fastBoundingRect();
     });
 
@@ -1245,7 +1245,7 @@ void CanvasRenderingContext2DBase::strokeInternal(const Path& path)
     } else
         c->strokePath(path);
 
-    didDraw(repaintEntireCanvas, [&]() {
+    didDraw(repaintEntireCanvas, [&] {
         return targetSwitcher ? targetSwitcher->expandedBounds() : inflatedStrokeRect(path.fastBoundingRect());
     });
 }
@@ -2386,7 +2386,7 @@ void CanvasRenderingContext2DBase::didDraw(bool entireCanvas, const FloatRect& r
 }
 
 template<typename RectProvider>
-void CanvasRenderingContext2DBase::didDraw(bool entireCanvas, RectProvider rectProvider, OptionSet<DidDrawOption> options)
+void CanvasRenderingContext2DBase::didDraw(bool entireCanvas, NOESCAPE const RectProvider& rectProvider, OptionSet<DidDrawOption> options)
 {
     if (isEntireBackingStoreDirty())
         didDraw(std::nullopt, options);

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -377,7 +377,7 @@ protected:
     void didDraw(std::optional<FloatRect>, OptionSet<DidDrawOption> = defaultDidDrawOptions());
     void didDrawEntireCanvas(OptionSet<DidDrawOption> options = defaultDidDrawOptions());
     void didDraw(bool entireCanvas, const FloatRect&, OptionSet<DidDrawOption> options = defaultDidDrawOptions());
-    template<typename RectProvider> void didDraw(bool entireCanvas, RectProvider, OptionSet<DidDrawOption> options = defaultDidDrawOptions());
+    template<typename RectProvider> void didDraw(bool entireCanvas, NOESCAPE const RectProvider&, OptionSet<DidDrawOption> options = defaultDidDrawOptions());
 
     virtual std::optional<FilterOperations> setFilterStringWithoutUpdatingStyle(const String&) { return std::nullopt; }
 

--- a/Source/WebCore/workers/WorkerThread.cpp
+++ b/Source/WebCore/workers/WorkerThread.cpp
@@ -151,7 +151,8 @@ Ref<Thread> WorkerThread::createThread()
         return Thread::currentSingleton();
     }
 
-    return Thread::create(threadName(), [this] {
+    // WorkerOrWorkletThread::workerOrWorkletThread destroys the worker and expects a single reference to this.
+    SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE return Thread::create(threadName(), [this] {
         workerOrWorkletThread();
     }, ThreadType::JavaScript);
 }


### PR DESCRIPTION
#### 4e3c3c6ebd612595bcadd3fa2129c89734eb8b51
<pre>
Reduce unsafe lambdas in WebCore/Modules/entriesapi and assorted
<a href="https://bugs.webkit.org/show_bug.cgi?id=291473">https://bugs.webkit.org/show_bug.cgi?id=291473</a>

Reviewed by Chris Dumez.

As per Safer CPP Guidelines:

- <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#capture-protectedthis-or-weakthis-in-asynchronous-lambdas-where-you-need-to-use-this">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#capture-protectedthis-or-weakthis-in-asynchronous-lambdas-where-you-need-to-use-this</a>
- <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#annotate-noescape-when-a-function-uses-a-lambda-synchronously">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#annotate-noescape-when-a-function-uses-a-lambda-synchronously</a>

* Source/WTF/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WTF/wtf/PrintStream.h:
(WTF::PrintStream::atomically):
* Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp:
(WebCore::DOMFileSystem::getEntry):
* Source/WebCore/Modules/entriesapi/FileSystemDirectoryEntry.cpp:
(WebCore::FileSystemDirectoryEntry::getEntry):
* Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.cpp:
(WebCore::FileSystemDirectoryReader::readEntries):
* Source/WebCore/Modules/entriesapi/FileSystemEntry.cpp:
(WebCore::FileSystemEntry::getParent):
* Source/WebCore/Modules/entriesapi/FileSystemFileEntry.cpp:
(WebCore::FileSystemFileEntry::file):
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/css/CSSVariableReferenceValue.h:
(WebCore::CSSVariableReferenceValue::resolveAndCacheValue const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::fillInternal):
(WebCore::CanvasRenderingContext2DBase::strokeInternal):
(WebCore::CanvasRenderingContext2DBase::didDraw):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/workers/WorkerThread.cpp:
(WebCore::WorkerThread::createThread):

Canonical link: <a href="https://commits.webkit.org/293671@main">https://commits.webkit.org/293671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82e7bf4345046777128cd1dc04b4bc53d7161dc9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99562 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104693 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50164 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101603 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27645 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75790 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32892 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14850 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89902 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56149 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14647 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7887 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49523 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92245 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84587 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7973 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107051 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98181 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26676 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19474 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84750 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27039 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86106 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84267 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28936 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6642 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20473 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16207 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26616 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31817 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121797 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26436 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34025 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29749 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28003 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->