### PR TITLE
[GTK4] Blank WebView depending on the monitor it appears in

### DIFF
--- a/Source/WebCore/platform/graphics/Damage.h
+++ b/Source/WebCore/platform/graphics/Damage.h
@@ -361,8 +361,10 @@ public:
     void addDamage(const Damage& damage)
     {
         Region region;
-        for (const auto& rect : damage.rects())
-            region.unite(rect);
+        for (const auto& rect : damage.rects()) {
+            Region subRegion(rect);
+            region.unite(subRegion);
+        }
         m_damageInfo.append(WTFMove(region));
     }
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -349,9 +349,12 @@ void LayerTreeHost::ensureDrawing()
 void LayerTreeHost::sizeDidChange()
 {
     m_pendingResize = true;
-    if (m_isWaitingForRenderer)
+    if (m_isWaitingForRenderer) {
+        // Set m_isWaitingForRenderer to false, otherwise scheduleLayerFlush() will return without
+        // having scheduled anything.
+        m_isWaitingForRenderer = false;
         scheduleLayerFlush();
-    else {
+    } else {
         cancelPendingLayerFlush();
         flushLayers();
     }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -341,8 +341,13 @@ void ThreadedCompositor::renderLayerTree()
 #endif
     }
 
-    if (viewportSize.isEmpty())
+    if (viewportSize.isEmpty()) {
+        // Make sure the compositing runloop goes back to idle state. Otherwise sub-sequent
+        // compositing requests will not be scheduled (because the runloop would be stuck in
+        // InProgress state).
+        frameComplete();
         return;
+    }
 
     TransformationMatrix viewportTransform;
     viewportTransform.scale(deviceScaleFactor);


### PR DESCRIPTION
#### 5384426efb8b85117cfd1700fb98ce3f9c7d4a21
<pre>
[GTK4] Blank WebView depending on the monitor it appears in
<a href="https://bugs.webkit.org/show_bug.cgi?id=288602">https://bugs.webkit.org/show_bug.cgi?id=288602</a>

Reviewed by NOBODY (OOPS!).

Make sure page size notifications trigger a layer flush in the layer tree host. Also when the
threaded compositor is triggered before the page size is known, the early return should reset the
compositing runloop state back to Idle, otherwise the following update requests will be ignored.

Driving-by, fix a crash in Damage, there is no Region::unite() method accepting a Rect, so make a
Region and then unite it with the main region.

* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::sizeDidChange):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::renderLayerTree):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5384426efb8b85117cfd1700fb98ce3f9c7d4a21

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104616 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50087 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101526 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19423 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27568 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75723 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32824 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102492 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89831 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56082 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14586 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7815 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49446 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84515 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106974 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26599 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19413 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84685 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26961 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86035 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84202 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28876 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6571 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20379 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26539 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31740 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26359 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29672 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27926 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->