### PR TITLE
[macOS] Add "public.rtf" to the list of valid pasteboard send types

### DIFF
--- a/Source/WebKit/Shared/mac/PasteboardTypes.mm
+++ b/Source/WebKit/Shared/mac/PasteboardTypes.mm
@@ -42,34 +42,77 @@ NSString * const PasteboardTypes::WebDummyPboardType = @"Apple WebKit dummy past
 NSArray* PasteboardTypes::forEditing()
 {
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN 
-    static NeverDestroyed<RetainPtr<NSArray>> types = @[WebArchivePboardType, (__bridge NSString *)kUTTypeWebArchive, WebCore::legacyHTMLPasteboardType(), WebCore::legacyFilenamesPasteboardType(), WebCore::legacyTIFFPasteboardType(), WebCore::legacyPDFPasteboardType(),
-        WebCore::legacyURLPasteboardType(), WebCore::legacyRTFDPasteboardType(), WebCore::legacyRTFPasteboardType(), WebCore::legacyStringPasteboardType(), WebCore::legacyColorPasteboardType(), (__bridge NSString *)kUTTypePNG];
+    static NeverDestroyed<RetainPtr<NSArray>> types = @[
+        WebArchivePboardType,
+        (__bridge NSString *)kUTTypeWebArchive,
+        WebCore::legacyHTMLPasteboardType(),
+        WebCore::legacyFilenamesPasteboardType(),
+        WebCore::legacyTIFFPasteboardType(),
+        WebCore::legacyPDFPasteboardType(),
+        WebCore::legacyURLPasteboardType(),
+        WebCore::legacyRTFDPasteboardType(),
+        WebCore::legacyRTFPasteboardType(),
+        WebCore::legacyStringPasteboardType(),
+        WebCore::legacyColorPasteboardType(),
+        (__bridge NSString *)kUTTypePNG
+    ];
 ALLOW_DEPRECATED_DECLARATIONS_END
     return types.get().get();
 }
 
 NSArray* PasteboardTypes::forURL()
 {
-    static NeverDestroyed<RetainPtr<NSArray>> types = @[WebURLsWithTitlesPboardType, WebCore::legacyURLPasteboardType(), WebURLPboardType,  WebURLNamePboardType, WebCore::legacyStringPasteboardType(), WebCore::legacyFilenamesPasteboardType(), WebCore::legacyFilesPromisePasteboardType()];
+    static NeverDestroyed<RetainPtr<NSArray>> types = @[
+        WebURLsWithTitlesPboardType,
+        WebCore::legacyURLPasteboardType(),
+        WebURLPboardType,
+        WebURLNamePboardType,
+        WebCore::legacyStringPasteboardType(),
+        WebCore::legacyFilenamesPasteboardType(),
+        WebCore::legacyFilesPromisePasteboardType()
+    ];
     return types.get().get();
 }
 
 NSArray* PasteboardTypes::forImages()
 {
-    static NeverDestroyed<RetainPtr<NSArray>> types = @[WebCore::legacyTIFFPasteboardType(), WebURLsWithTitlesPboardType, WebCore::legacyURLPasteboardType(), WebURLPboardType, WebURLNamePboardType, WebCore::legacyStringPasteboardType()];
+    static NeverDestroyed<RetainPtr<NSArray>> types = @[
+        WebCore::legacyTIFFPasteboardType(),
+        WebURLsWithTitlesPboardType,
+        WebCore::legacyURLPasteboardType(),
+        WebURLPboardType,
+        WebURLNamePboardType,
+        WebCore::legacyStringPasteboardType()
+    ];
     return types.get().get();
 }
 
 NSArray* PasteboardTypes::forImagesWithArchive()
 {
-    static NeverDestroyed<RetainPtr<NSArray>> types = @[WebCore::legacyTIFFPasteboardType(), WebURLsWithTitlesPboardType, WebCore::legacyURLPasteboardType(), WebURLPboardType, WebURLNamePboardType, WebCore::legacyStringPasteboardType(), WebCore::legacyRTFDPasteboardType(), WebArchivePboardType];
+    static NeverDestroyed<RetainPtr<NSArray>> types = @[
+        WebCore::legacyTIFFPasteboardType(),
+        WebURLsWithTitlesPboardType,
+        WebCore::legacyURLPasteboardType(),
+        WebURLPboardType,
+        WebURLNamePboardType,
+        WebCore::legacyStringPasteboardType(),
+        WebCore::legacyRTFDPasteboardType(),
+        WebArchivePboardType
+    ];
     return types.get().get();
 }
 
 NSArray* PasteboardTypes::forSelection()
 {
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN 
-    static NeverDestroyed<RetainPtr<NSArray>> types = @[WebArchivePboardType, (__bridge NSString *)kUTTypeWebArchive, WebCore::legacyRTFDPasteboardType(), WebCore::legacyRTFPasteboardType(), WebCore::legacyStringPasteboardType()];
+    static NeverDestroyed<RetainPtr<NSArray>> types = @[
+        WebArchivePboardType,
+        (__bridge NSString *)kUTTypeWebArchive,
+        NSPasteboardTypeRTF,
+        WebCore::legacyRTFDPasteboardType(),
+        WebCore::legacyRTFPasteboardType(),
+        WebCore::legacyStringPasteboardType()
+    ];
 ALLOW_DEPRECATED_DECLARATIONS_END
     return types.get().get();
 }

--- a/Tools/TestWebKitAPI/Tests/mac/NSResponderTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/NSResponderTests.mm
@@ -31,14 +31,15 @@
 
 namespace TestWebKitAPI {
 
-TEST(NSResponderTests, ValidRequestorForReturnTypes)
+TEST(NSResponderTests, ValidRequestorForSendAndReturnTypes)
 {
     auto webView = adoptNS([[TestWKWebView alloc] init]);
     [webView _setEditable:YES];
     [webView synchronouslyLoadTestPageNamed:@"simple"];
-    [webView stringByEvaluatingJavaScript:@"getSelection().setPosition(document.body)"];
+    [webView selectAll:nil];
     [webView waitForNextPresentationUpdate];
 
+    EXPECT_EQ(webView.get(), [webView validRequestorForSendType:NSPasteboardTypeRTF returnType:nil]);
     EXPECT_EQ(webView.get(), [webView validRequestorForSendType:nil returnType:(__bridge NSString *)kUTTypePNG]);
     EXPECT_NULL([webView validRequestorForSendType:nil returnType:(__bridge NSString *)kUTTypeAppleScript]);
 }


### PR DESCRIPTION
#### 884a14a935ed9a35a45d379a0bf9d9a9802db4b7
<pre>
[macOS] Add &quot;public.rtf&quot; to the list of valid pasteboard send types
<a href="https://bugs.webkit.org/show_bug.cgi?id=291479">https://bugs.webkit.org/show_bug.cgi?id=291479</a>
<a href="https://rdar.apple.com/149145551">rdar://149145551</a>

Reviewed by Richard Robinson.

Add `NSPasteboardTypeRTF` to the list of valid send types, supported by `WKWebView` on macOS. This
allows system clients (namely, Writing Tools) to paste rich text as RTF without having to write the
legacy `NSRTFPboardType` to the pasteboard.

* Source/WebKit/Shared/mac/PasteboardTypes.mm:
(WebKit::PasteboardTypes::forEditing):
(WebKit::PasteboardTypes::forURL):
(WebKit::PasteboardTypes::forImages):
(WebKit::PasteboardTypes::forImagesWithArchive):
(WebKit::PasteboardTypes::forSelection):

Add `NSPasteboardTypeRTF`; also clean up these methods by putting each type on its own line, to make
the list of types more readable (and to make it easier to blame changes in the future).

* Tools/TestWebKitAPI/Tests/mac/NSResponderTests.mm:
(TestWebKitAPI::TEST(NSResponderTests, ValidRequestorForReturnTypes)):

Augment an existing API test to cover this case.

Canonical link: <a href="https://commits.webkit.org/293640@main">https://commits.webkit.org/293640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b891b9b0e719edbb7e9096fe428784b3511d3123

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99470 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104601 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50072 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101511 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75709 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32810 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14775 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89817 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56068 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14572 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7801 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49431 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84498 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7888 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106959 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26584 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19398 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84669 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26946 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86021 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84187 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21363 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28862 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6557 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20356 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26524 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31725 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26344 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29657 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27911 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->