### PR TITLE
Reduce the number of implicit conversion from String to NSString in the project

### DIFF
--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -242,7 +242,7 @@ std::optional<bool> allowsMaterializingDatalessFiles(PolicyScope scope)
 bool isSafeToUseMemoryMapForPath(const String& path)
 {
     NSError *error = nil;
-    NSDictionary<NSFileAttributeKey, id> *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:path error:&error];
+    NSDictionary<NSFileAttributeKey, id> *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:path.createNSString().get() error:&error];
     if (error) {
         LOG_ERROR("Unable to get path protection class");
         return false;
@@ -260,7 +260,7 @@ bool makeSafeToUseMemoryMapForPath(const String& path)
         return true;
     
     NSError *error = nil;
-    BOOL success = [[NSFileManager defaultManager] setAttributes:@{ NSFileProtectionKey: NSFileProtectionCompleteUnlessOpen } ofItemAtPath:path error:&error];
+    BOOL success = [[NSFileManager defaultManager] setAttributes:@{ NSFileProtectionKey: NSFileProtectionCompleteUnlessOpen } ofItemAtPath:path.createNSString().get() error:&error];
     if (error || !success) {
         WTFLogAlways("makeSafeToUseMemoryMapForPath(%s) failed with error %@", path.utf8().data(), error);
         return false;

--- a/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
+++ b/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
@@ -231,9 +231,9 @@ static void attributeStringSetLanguage(NSMutableAttributedString *attrString, Re
         return;
 
     RefPtr object = renderer->document().axObjectCache()->getOrCreate(*renderer);
-    NSString *language = object->languageIncludingAncestors();
-    if (language.length)
-        [attrString addAttribute:AccessibilityTokenLanguage value:language range:range];
+    RetainPtr language = object->languageIncludingAncestors().createNSString();
+    if (language.get().length)
+        [attrString addAttribute:AccessibilityTokenLanguage value:language.get() range:range];
     else
         [attrString removeAttribute:AccessibilityTokenLanguage range:range];
 }
@@ -303,8 +303,9 @@ static void attributedStringSetCompositionAttributes(NSMutableAttributedString *
 
     if (!lastPresentedCompleteWord.text.isEmpty() && lastPresentedCompleteWordPosition + lastPresentedCompleteWordLength <= [attributedString length]) {
         NSRange completeWordRange = NSMakeRange(lastPresentedCompleteWordPosition, lastPresentedCompleteWordLength);
-        if ([[attributedString.string substringWithRange:completeWordRange] isEqualToString:lastPresentedCompleteWord.text])
-            [attributedString addAttribute:AccessibilityAcceptedInlineTextCompletion value:lastPresentedCompleteWord.text range:completeWordRange];
+        RetainPtr lastPresentedCompleteWordText = lastPresentedCompleteWord.text.createNSString();
+        if ([[attributedString.string substringWithRange:completeWordRange] isEqualToString:lastPresentedCompleteWordText.get()])
+            [attributedString addAttribute:AccessibilityAcceptedInlineTextCompletion value:lastPresentedCompleteWordText.get() range:completeWordRange];
     }
 
     auto& lastPresentedTextPrediction = object->lastPresentedTextPrediction();
@@ -313,7 +314,7 @@ static void attributedStringSetCompositionAttributes(NSMutableAttributedString *
 
     if (!lastPresentedTextPrediction.text.isEmpty() && lastPresentedPosition + lastPresentedLength <= [attributedString length]) {
         NSRange presentedRange = NSMakeRange(lastPresentedPosition, lastPresentedLength);
-        if (![[attributedString.string substringWithRange:presentedRange] isEqualToString:lastPresentedTextPrediction.text])
+        if (![[attributedString.string substringWithRange:presentedRange] isEqualToString:lastPresentedTextPrediction.text.createNSString().get()])
             return;
 
         [attributedString addAttribute:AccessibilityInlineTextCompletion value:[attributedString.string substringWithRange:presentedRange] range:presentedRange];

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -294,7 +294,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
     if (![self _prepareAccessibilityCall])
         return nil;
 
-    return self.axBackingObject->identifierAttribute();
+    return self.axBackingObject->identifierAttribute().createNSString().autorelease();
 }
 
 - (BOOL)accessibilityCanFuzzyHitTest
@@ -497,7 +497,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
     if (![self _prepareAccessibilityCall])
         return nil;
 
-    return accessibilityRoleToString(self.axBackingObject->roleValue());
+    return accessibilityRoleToString(self.axBackingObject->roleValue()).createNSString().autorelease();
 }
 
 - (BOOL)accessibilityHasPopup
@@ -513,7 +513,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
     if (![self _prepareAccessibilityCall])
         return nil;
 
-    return self.axBackingObject->popupValue();
+    return self.axBackingObject->popupValue().createNSString().autorelease();
 }
 
 - (BOOL)accessibilityIsInDescriptionListDefinition
@@ -564,7 +564,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
     if (![self _prepareAccessibilityCall])
         return nil;
     
-    return self.axBackingObject->languageIncludingAncestors();
+    return self.axBackingObject->languageIncludingAncestors().createNSString().autorelease();
 }
 
 - (BOOL)accessibilityIsDialog
@@ -710,7 +710,7 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
 - (NSString *)interactiveVideoDescription
 {
     auto* mediaObject = dynamicDowncast<AccessibilityMediaObject>(self.axBackingObject);
-    return mediaObject ? mediaObject->interactiveVideoDuration() : nullString();
+    return mediaObject ? mediaObject->interactiveVideoDuration().createNSString().autorelease() : @"";
 }
 
 - (BOOL)accessibilityIsMediaPlaying
@@ -1130,23 +1130,23 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
         return nil;
 
     if (self.axBackingObject->isColorWell())
-        return AXColorWellText();
+        return AXColorWellText().createNSString().autorelease();
 
-    return self.axBackingObject->roleDescription();
+    return self.axBackingObject->roleDescription().createNSString().autorelease();
 }
 
 - (NSString *)accessibilityBrailleLabel
 {
     if (![self _prepareAccessibilityCall])
         return nil;
-    return self.axBackingObject->brailleLabel();
+    return self.axBackingObject->brailleLabel().createNSString().autorelease();
 }
 
 - (NSString *)accessibilityBrailleRoleDescription
 {
     if (![self _prepareAccessibilityCall])
         return nil;
-    return self.axBackingObject->brailleRoleDescription();
+    return self.axBackingObject->brailleRoleDescription().createNSString().autorelease();
 }
 
 - (NSString *)accessibilityLabel
@@ -1175,8 +1175,8 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
         if (heading) {
             auto headingLabel = heading->descriptionAttributeValue();
             if (!headingLabel.isEmpty())
-                return headingLabel;
-            return backingObject->stringValue();
+                return headingLabel.createNSString().autorelease();
+            return backingObject->stringValue().createNSString().autorelease();
         }
     }
 
@@ -1184,8 +1184,8 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     // so concatenate them when different.
     String title = backingObject->titleAttributeValue();
     String description = backingObject->descriptionAttributeValue();
-    NSString *landmarkDescription = [self ariaLandmarkRoleDescription];
-    NSString *interactiveVideoDescription = [self interactiveVideoDescription];
+    RetainPtr landmarkDescription = [self ariaLandmarkRoleDescription];
+    RetainPtr interactiveVideoDescription = [self interactiveVideoDescription];
 
     // We should expose the value of the input type date or time through AXValue instead of AXTitle.
     if (backingObject->isDateTime() && title == String([self accessibilityValue]))
@@ -1193,22 +1193,22 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
 
     // Footer is not considered a landmark, but we want the role description.
     if (backingObject->roleValue() == AccessibilityRole::Footer)
-        landmarkDescription = AXFooterRoleDescriptionText();
+        landmarkDescription = AXFooterRoleDescriptionText().createNSString();
 
     NSMutableString *result = [NSMutableString string];
     if (backingObject->roleValue() == AccessibilityRole::HorizontalRule)
-        appendStringToResult(result, AXHorizontalRuleDescriptionText());
+        appendStringToResult(result, AXHorizontalRuleDescriptionText().createNSString().get());
 
-    appendStringToResult(result, title);
+    appendStringToResult(result, title.createNSString().get());
     if (description != title)
-        appendStringToResult(result, description);
+        appendStringToResult(result, description.createNSString().get());
     if ([self stringValueShouldBeUsedInLabel]) {
-        NSString *valueLabel = backingObject->stringValue();
+        RetainPtr valueLabel = backingObject->stringValue().createNSString();
         valueLabel = [valueLabel stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-        appendStringToResult(result, valueLabel);
+        appendStringToResult(result, valueLabel.get());
     }
-    appendStringToResult(result, landmarkDescription);
-    appendStringToResult(result, interactiveVideoDescription);
+    appendStringToResult(result, landmarkDescription.get());
+    appendStringToResult(result, interactiveVideoDescription.get());
 
     return [result length] ? result : nil;
 }
@@ -1468,7 +1468,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     if (auto* parent = Accessibility::findAncestor<AXCoreObject>(*self.axBackingObject, true, [] (const AXCoreObject& object) {
         return object.supportsDatetimeAttribute();
     }))
-        return parent->datetimeAttributeValue();
+        return parent->datetimeAttributeValue().createNSString().autorelease();
 
     return nil;
 }
@@ -1478,7 +1478,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     if (![self _prepareAccessibilityCall])
         return nil;
 
-    return self.axBackingObject->placeholderValue();
+    return self.axBackingObject->placeholderValue().createNSString().autorelease();
 }
 
 - (NSString *)accessibilityColorStringValue
@@ -1543,13 +1543,13 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
 
     // A text control should return its text data as the axValue (per iPhone AX API).
     if (![self stringValueShouldBeUsedInLabel])
-        return backingObject->stringValue();
+        return backingObject->stringValue().createNSString().autorelease();
 
     if (backingObject->isRangeControl()) {
         // Prefer a valueDescription if provided by the author (through aria-valuetext).
         String valueDescription = backingObject->valueDescription();
         if (!valueDescription.isEmpty())
-            return valueDescription;
+            return valueDescription.createNSString().autorelease();
 
         return [NSString stringWithFormat:@"%.2f", backingObject->valueForRange()];
     }
@@ -1623,7 +1623,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     appendStringToResult(result, [self baseAccessibilityHelpText]);
     
     if ([self accessibilityIsShowingValidationMessage])
-        appendStringToResult(result, self.axBackingObject->validationMessage());
+        appendStringToResult(result, self.axBackingObject->validationMessage().createNSString().get());
     
     return result;
 }
@@ -1888,7 +1888,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     if (![self _prepareAccessibilityCall])
         return nil;
     
-    return self.axBackingObject->embeddedImageDescription();
+    return self.axBackingObject->embeddedImageDescription().createNSString().autorelease();
 }
 
 - (NSArray *)accessibilityImageOverlayElements
@@ -1906,7 +1906,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     if (![self _prepareAccessibilityCall])
         return nil;
     
-    return self.axBackingObject->linkRelValue();
+    return self.axBackingObject->linkRelValue().createNSString().autorelease();
 }
 
 - (BOOL)accessibilityRequired
@@ -2228,7 +2228,7 @@ static RenderObject* rendererForView(WAKView* view)
     AXTextMarkerRange axRange { markers };
     if (!axRange)
         return nil;
-    return axRange.toString();
+    return axRange.toString().createNSString().autorelease();
 }
 
 // This method is intended to return an array of strings and accessibility elements that
@@ -2367,7 +2367,7 @@ static RenderObject* rendererForView(WAKView* view)
     auto webRange = makeDOMRange(self.axBackingObject->document(), range);
     if (!webRange)
         return nil;
-    return AXTextMarkerRange { webRange }.toString();
+    return AXTextMarkerRange { webRange }.toString().createNSString().autorelease();
 }
 
 - (NSAttributedString *)attributedStringForRange:(NSRange)range
@@ -2797,14 +2797,14 @@ static RenderObject* rendererForView(WAKView* view)
 {
     if (![self _prepareAccessibilityCall])
         return nil;
-    return self.axBackingObject->expandedTextValue();
+    return self.axBackingObject->expandedTextValue().createNSString().autorelease();
 }
 
 - (NSString *)accessibilityIdentifier
 {
     if (![self _prepareAccessibilityCall])
         return nil;
-    return self.axBackingObject->identifierAttribute();
+    return self.axBackingObject->identifierAttribute().createNSString().autorelease();
 }
 
 - (BOOL)accessibilityIsInsertion
@@ -2904,7 +2904,7 @@ static RenderObject* rendererForView(WAKView* view)
     if (![self _prepareAccessibilityCall])
         return nil;
 
-    return self.axBackingObject->liveRegionStatus();
+    return self.axBackingObject->liveRegionStatus().createNSString().autorelease();
 }
 
 - (NSString *)accessibilityARIARelevantStatus
@@ -2912,7 +2912,7 @@ static RenderObject* rendererForView(WAKView* view)
     if (![self _prepareAccessibilityCall])
         return nil;
     
-    return self.axBackingObject->liveRegionRelevant();
+    return self.axBackingObject->liveRegionRelevant().createNSString().autorelease();
 }
 
 - (BOOL)accessibilityARIALiveRegionIsAtomic
@@ -2984,7 +2984,7 @@ static RenderObject* rendererForView(WAKView* view)
     if (![self _prepareAccessibilityCall])
         return nil;
     
-    return self.axBackingObject->invalidStatus();
+    return self.axBackingObject->invalidStatus().createNSString().autorelease();
 }
 
 - (NSString *)accessibilityCurrentState
@@ -2992,7 +2992,7 @@ static RenderObject* rendererForView(WAKView* view)
     if (![self _prepareAccessibilityCall])
         return nil;
 
-    return self.axBackingObject->currentValue();
+    return self.axBackingObject->currentValue().createNSString().autorelease();
 }
 
 - (NSString *)accessibilitySortDirection
@@ -3114,7 +3114,7 @@ static RenderObject* rendererForView(WAKView* view)
     if (![self _prepareAccessibilityCall])
         return nil;
 
-    return self.axBackingObject->mathFencedOpenString();
+    return self.axBackingObject->mathFencedOpenString().createNSString().autorelease();
 }
 
 - (NSString *)accessibilityMathFencedCloseString
@@ -3122,7 +3122,7 @@ static RenderObject* rendererForView(WAKView* view)
     if (![self _prepareAccessibilityCall])
         return nil;
 
-    return self.axBackingObject->mathFencedCloseString();
+    return self.axBackingObject->mathFencedCloseString().createNSString().autorelease();
 }
 
 - (BOOL)accessibilityIsMathTopObject

--- a/Source/WebCore/editing/cocoa/DataDetection.mm
+++ b/Source/WebCore/editing/cocoa/DataDetection.mm
@@ -619,8 +619,8 @@ static NSArray * processDataDetectorScannerResults(DDScannerRef scanner, OptionS
         if (resultRanges.isEmpty())
             continue;
 
-        NSString *identifier = dataDetectorStringForPath(indexPaths[resultIndex].get());
-        NSString *correspondingURL = constructURLStringForResult(coreResult, identifier, referenceDate, (NSTimeZone *)tz.get(), types);
+        RetainPtr identifier = dataDetectorStringForPath(indexPaths[resultIndex].get()).createNSString();
+        RetainPtr correspondingURL = constructURLStringForResult(coreResult, identifier.get(), referenceDate, (NSTimeZone *)tz.get(), types);
 
         if (!correspondingURL || searchForLinkRemovingExistingDDLinks(resultRanges.first().start.container, resultRanges.last().end.container))
             continue;
@@ -657,7 +657,7 @@ static NSArray * processDataDetectorScannerResults(DDScannerRef scanner, OptionS
             parentNode->insertBefore(newTextNode.copyRef(), currentTextNode.get());
 
             Ref<HTMLAnchorElement> anchorElement = HTMLAnchorElement::create(document);
-            anchorElement->setHref(correspondingURL);
+            anchorElement->setHref(correspondingURL.get());
             anchorElement->setDir("ltr"_s);
 
             if (shouldUseLightLinks) {
@@ -689,7 +689,7 @@ static NSArray * processDataDetectorScannerResults(DDScannerRef scanner, OptionS
             // Add a special attribute to mark this URLification as the result of data detectors.
             anchorElement->setAttributeWithoutSynchronization(x_apple_data_detectorsAttr, trueAtom());
             anchorElement->setAttributeWithoutSynchronization(x_apple_data_detectors_typeAttr, dataDetectorTypeForCategory(PAL::softLink_DataDetectorsCore_DDResultGetCategory(coreResult)));
-            anchorElement->setAttributeWithoutSynchronization(x_apple_data_detectors_resultAttr, identifier);
+            anchorElement->setAttributeWithoutSynchronization(x_apple_data_detectors_resultAttr, identifier.get());
 
             parentNode->insertBefore(WTFMove(anchorElement), currentTextNode.get());
 

--- a/Source/WebCore/editing/ios/EditorIOS.mm
+++ b/Source/WebCore/editing/ios/EditorIOS.mm
@@ -116,7 +116,7 @@ void Editor::writeImageToPasteboard(Pasteboard& pasteboard, Element& imageElemen
     }
     pasteboardImage.suggestedName = imageSourceURL.lastPathComponent().toString();
     pasteboardImage.imageSize = image->size();
-    pasteboardImage.resourceMIMEType = pasteboard.resourceMIMEType(cachedImage->response().mimeType());
+    pasteboardImage.resourceMIMEType = pasteboard.resourceMIMEType(cachedImage->response().mimeType().createNSString().get());
     if (auto* buffer = cachedImage->resourceBuffer())
         pasteboardImage.resourceData = buffer->makeContiguous();
 

--- a/Source/WebCore/platform/ios/ValidationBubbleIOS.mm
+++ b/Source/WebCore/platform/ios/ValidationBubbleIOS.mm
@@ -175,7 +175,7 @@ ValidationBubble::ValidationBubble(UIView *view, const String& message, const Se
     m_tapRecognizer = adoptNS([[WebValidationBubbleTapRecognizer alloc] initWithPopoverController:m_popoverController.get()]);
 
     UILabel *validationLabel = label(m_popoverController.get());
-    validationLabel.text = message;
+    validationLabel.text = message.createNSString().get();
     m_fontSize = validationLabel.font.pointSize;
     CGSize labelSize = [validationLabel sizeThatFits:CGSizeMake(validationBubbleMaxLabelWidth, CGFLOAT_MAX)];
     [m_popoverController setPreferredContentSize:CGSizeMake(labelSize.width + validationBubbleHorizontalPadding * 2, labelSize.height + validationBubbleVerticalPadding * 2)];
@@ -201,7 +201,7 @@ void ValidationBubble::show()
         protectedThis->m_startingToPresentViewController = false;
     }];
 
-    PAL::softLinkUIKitUIAccessibilityPostNotification(PAL::get_UIKit_UIAccessibilityAnnouncementNotification(), m_message);
+    PAL::softLinkUIKitUIAccessibilityPostNotification(PAL::get_UIKit_UIAccessibilityAnnouncementNotification(), m_message.createNSString().get());
 }
 
 static UIViewController *fallbackViewController(UIView *view)

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
@@ -821,7 +821,7 @@ WebAVPlayerLayer *VideoPresentationInterfaceAVKitLegacy::fullscreenPlayerLayer()
 void VideoPresentationInterfaceAVKitLegacy::updateRouteSharingPolicy()
 {
     if (m_playerViewController && !m_routingContextUID.isEmpty())
-        [m_playerViewController setWebKitOverrideRouteSharingPolicy:(NSUInteger)m_routeSharingPolicy routingContextUID:m_routingContextUID];
+        [m_playerViewController setWebKitOverrideRouteSharingPolicy:(NSUInteger)m_routeSharingPolicy routingContextUID:m_routingContextUID.createNSString().get()];
 }
 
 void VideoPresentationInterfaceAVKitLegacy::hasVideoChanged(bool hasVideo)
@@ -860,7 +860,7 @@ void VideoPresentationInterfaceAVKitLegacy::setupPlayerViewController()
     [m_playerViewController setAllowsPictureInPicturePlayback:m_allowsPictureInPicturePlayback];
     [playerController() setAllowsPictureInPicture:m_allowsPictureInPicturePlayback];
     if (!m_routingContextUID.isEmpty())
-        [m_playerViewController setWebKitOverrideRouteSharingPolicy:(NSUInteger)m_routeSharingPolicy routingContextUID:m_routingContextUID];
+        [m_playerViewController setWebKitOverrideRouteSharingPolicy:(NSUInteger)m_routeSharingPolicy routingContextUID:m_routingContextUID.createNSString().get()];
 
     if (!m_currentMode.hasPictureInPicture() && !m_changingStandbyOnly) {
         ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, "Moving videoView to fullscreen WebAVPlayerLayerView");

--- a/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.mm
+++ b/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.mm
@@ -193,9 +193,9 @@ bool AVAudioSessionCaptureDeviceManager::setPreferredAudioSessionDeviceIDs()
 {
     AVAudioSessionPortDescription *preferredInputPort = nil;
     if (!m_preferredMicrophoneID.isEmpty()) {
-        NSString *nsDeviceUID = m_preferredMicrophoneID;
+        RetainPtr nsDeviceUID = m_preferredMicrophoneID.createNSString();
         for (AVAudioSessionPortDescription *portDescription in [m_audioSession availableInputs]) {
-            if ([portDescription.UID isEqualToString:nsDeviceUID]) {
+            if ([portDescription.UID isEqualToString:nsDeviceUID.get()]) {
                 preferredInputPort = portDescription;
                 break;
             }

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -1068,7 +1068,7 @@ bool AVVideoCaptureSource::setupSession()
     WARNING_LOG_IF(loggerPtr() && mediaEnvironment.isEmpty(), "Media environment is empty");
     // FIXME (119325252): Remove staging code for -[AVCaptureSession initWithMediaEnvironment:]
     if (!mediaEnvironment.isEmpty() && [PAL::getAVCaptureSessionClass() instancesRespondToSelector:@selector(initWithMediaEnvironment:)])
-        m_session = adoptNS([PAL::allocAVCaptureSessionInstance() initWithMediaEnvironment:mediaEnvironment]);
+        m_session = adoptNS([PAL::allocAVCaptureSessionInstance() initWithMediaEnvironment:mediaEnvironment.createNSString().get()]);
 #endif
 
 #if ENABLE(APP_PRIVACY_REPORT)

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -1238,7 +1238,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     auto documentInteractionController = adoptNS([PAL::allocUIDocumentInteractionControllerInstance() init]);
 ALLOW_DEPRECATED_DECLARATIONS_END
 
-    [documentInteractionController setName:fileName.isEmpty() ? title : fileName];
+    [documentInteractionController setName:fileName.isEmpty() ? title.createNSString().get() : fileName.createNSString().get()];
 
     if (!attachmentType.isEmpty()) {
         String UTI;

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -116,7 +116,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (error && *error) {
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250442
         WTFLogAlways("MSL compilation error: %@", [*error localizedDescription]);
-        *error = [NSError errorWithDomain:@"WebGPU" code:1 userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to compile the shader source, generated metal:\n%@ - error %@", (NSString*)msl, [*error localizedDescription]] }];
+        *error = [NSError errorWithDomain:@"WebGPU" code:1 userInfo:@{ NSLocalizedDescriptionKey: adoptNS([[NSString alloc] initWithFormat:@"Failed to compile the shader source, generated metal:\n%@ - error %@", msl.createNSString().get(), [*error localizedDescription]]).get() }];
         return nil;
     }
     library.label = label.createNSString().get();

--- a/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
@@ -69,7 +69,7 @@ RetainPtr<NSDictionary> GPUProcess::additionalStateForDiagnosticReport() const
 
             auto stateInfo = adoptNS([[NSMutableDictionary alloc] initWithCapacity:backendMap.size()]);
             // FIXME: Log some additional diagnostic state on RemoteRenderingBackend.
-            [webProcessConnectionInfo setObject:stateInfo.get() forKey:webProcessIdentifier.loggingString()];
+            [webProcessConnectionInfo setObject:stateInfo.get() forKey:webProcessIdentifier.loggingString().createNSString().get()];
         }
 
         if ([webProcessConnectionInfo count])

--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
@@ -71,7 +71,7 @@ void Download::resume(std::span<const uint8_t> resumeData, const String& path, S
     }
     ASSERT(!cocoaSession.sessionWrapperForDownloadResume().downloadMap.contains(taskIdentifier));
     cocoaSession.sessionWrapperForDownloadResume().downloadMap.add(taskIdentifier, m_downloadID);
-    m_downloadTask.get()._pathToDownloadTaskFile = path;
+    m_downloadTask.get()._pathToDownloadTaskFile = path.createNSString().get();
 
     [m_downloadTask resume];
 

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm
@@ -115,11 +115,11 @@ void NetworkLoader::start(URL&& url, RefPtr<JSON::Object>&& jsonPayload, WebCore
         return callback({ }, { });
 
     auto request = adoptNS([[NSMutableURLRequest alloc] initWithURL:url.createNSURL().get()]);
-    [request setValue:WebCore::HTTPHeaderValues::maxAge0() forHTTPHeaderField:@"Cache-Control"];
-    [request setValue:WebCore::standardUserAgentWithApplicationName({ }) forHTTPHeaderField:@"User-Agent"];
+    [request setValue:WebCore::HTTPHeaderValues::maxAge0().createNSString().get() forHTTPHeaderField:@"Cache-Control"];
+    [request setValue:WebCore::standardUserAgentWithApplicationName({ }).createNSString().get() forHTTPHeaderField:@"User-Agent"];
     if (jsonPayload) {
         request.get().HTTPMethod = @"POST";
-        [request setValue:WebCore::HTTPHeaderValues::applicationJSONContentType() forHTTPHeaderField:@"Content-Type"];
+        [request setValue:WebCore::HTTPHeaderValues::applicationJSONContentType().createNSString().get() forHTTPHeaderField:@"Content-Type"];
         auto body = jsonPayload->toJSONString().utf8();
         request.get().HTTPBody = toNSData(byteCast<uint8_t>(body.span())).get();
     }

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -159,7 +159,7 @@ void NetworkDataTaskCocoa::applySniffingPoliciesAndBindRequestToInferfaceIfNeede
         [mutableRequest _setProperty:@NO forKey:bridge_cast(_kCFURLConnectionPropertyShouldSniff)];
 
     if (!boundInterfaceIdentifier.isNull())
-        [mutableRequest setBoundInterfaceIdentifier:boundInterfaceIdentifier];
+        [mutableRequest setBoundInterfaceIdentifier:boundInterfaceIdentifier.createNSString().get()];
 
     nsRequest = WTFMove(mutableRequest);
 }
@@ -518,7 +518,7 @@ void NetworkDataTaskCocoa::setPendingDownloadLocation(const WTF::String& filenam
     if (RefPtr extention = m_sandboxExtension)
         extention->consume();
 
-    m_task.get()._pathToDownloadTaskFile = m_pendingDownloadLocation;
+    m_task.get()._pathToDownloadTaskFile = m_pendingDownloadLocation.createNSString().get();
 
     if (allowOverwrite && FileSystem::fileExists(m_pendingDownloadLocation))
         FileSystem::deleteFile(filename);

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -154,7 +154,7 @@ void NetworkProcess::deleteHSTSCacheForHostNames(PAL::SessionID sessionID, const
 {
     if (auto* networkSession = downcast<NetworkSessionCocoa>(this->networkSession(sessionID))) {
         for (auto& hostName : hostNames)
-            [networkSession->hstsStorage() resetHSTSForHost:hostName];
+            [networkSession->hstsStorage() resetHSTSForHost:hostName.createNSString().get()];
     }
 }
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1434,12 +1434,12 @@ NetworkSessionCocoa::NetworkSessionCocoa(NetworkProcess& networkProcess, const N
 
     if (!!parameters.hstsStorageDirectory && !m_sessionID.isEphemeral()) {
         SandboxExtension::consumePermanently(parameters.hstsStorageDirectoryExtensionHandle);
-        configuration.get()._hstsStorage = adoptNS([[_NSHSTSStorage alloc] initPersistentStoreWithURL:[NSURL fileURLWithPath:parameters.hstsStorageDirectory isDirectory:YES]]).get();
+        configuration.get()._hstsStorage = adoptNS([[_NSHSTSStorage alloc] initPersistentStoreWithURL:adoptNS([[NSURL alloc] initFileURLWithPath:parameters.hstsStorageDirectory.createNSString().get() isDirectory:YES]).get()]).get();
     }
 
 #if HAVE(CFNETWORK_SEPARATE_CREDENTIAL_STORAGE)
     if (parameters.dataStoreIdentifier && !m_sessionID.isEphemeral())
-        configuration.get().URLCredentialStorage = adoptNS([[NSURLCredentialStorage alloc] _initWithIdentifier:parameters.dataStoreIdentifier->toString() private:NO]).get();
+        configuration.get().URLCredentialStorage = adoptNS([[NSURLCredentialStorage alloc] _initWithIdentifier:parameters.dataStoreIdentifier->toString().createNSString().get() private:NO]).get();
 #endif
 
 #if HAVE(NETWORK_LOADER)
@@ -1469,17 +1469,17 @@ NetworkSessionCocoa::NetworkSessionCocoa(NetworkProcess& networkProcess, const N
         configuration.get()._sourceApplicationAuditTokenData = (__bridge NSData *)data.get();
 
     if (!m_sourceApplicationBundleIdentifier.isEmpty()) {
-        configuration.get()._sourceApplicationBundleIdentifier = m_sourceApplicationBundleIdentifier;
+        configuration.get()._sourceApplicationBundleIdentifier = m_sourceApplicationBundleIdentifier.createNSString().get();
         configuration.get()._sourceApplicationAuditTokenData = nil;
     }
 
     if (!m_sourceApplicationSecondaryIdentifier.isEmpty())
-        configuration.get()._sourceApplicationSecondaryIdentifier = m_sourceApplicationSecondaryIdentifier;
+        configuration.get()._sourceApplicationSecondaryIdentifier = m_sourceApplicationSecondaryIdentifier.createNSString().get();
 
 #if HAVE(ALTERNATIVE_SERVICE)
     if (!parameters.alternativeServiceDirectory.isEmpty()) {
         SandboxExtension::consumePermanently(parameters.alternativeServiceDirectoryExtensionHandle);
-        configuration.get()._alternativeServicesStorage = adoptNS([[_NSHTTPAlternativeServicesStorage alloc] initPersistentStoreWithURL:[[NSURL fileURLWithPath:parameters.alternativeServiceDirectory isDirectory:YES] URLByAppendingPathComponent:@"AlternativeService.sqlite" isDirectory:NO]]).get();
+        configuration.get()._alternativeServicesStorage = adoptNS([[_NSHTTPAlternativeServicesStorage alloc] initPersistentStoreWithURL:[adoptNS([[NSURL alloc] initFileURLWithPath:parameters.alternativeServiceDirectory.createNSString().get() isDirectory:YES]) URLByAppendingPathComponent:@"AlternativeService.sqlite" isDirectory:NO]]).get();
         if ([configuration.get()._alternativeServicesStorage respondsToSelector:@selector(setCanSuspendLocked:)])
             [configuration.get()._alternativeServicesStorage setCanSuspendLocked:YES];
     }
@@ -2008,7 +2008,7 @@ void NetworkSessionCocoa::addWebPageNetworkParameters(WebPageProxyIdentifier pag
     ASSERT(addResult2.isNewEntry);
     RetainPtr<NSURLSessionConfiguration> configuration = adoptNS([m_defaultSessionSet->sessionWithCredentialStorage.session.get().configuration copy]);
 #if USE(APPLE_INTERNAL_SDK)
-    configuration.get()._attributedBundleIdentifier = parameters.attributedBundleIdentifier();
+    configuration.get()._attributedBundleIdentifier = parameters.attributedBundleIdentifier().createNSString().get();
 #endif
     initializeNSURLSessionsInSet(addResult2.iterator->value.get(), configuration.get());
     addResult1.iterator->value = addResult2.iterator->value.get();
@@ -2285,7 +2285,7 @@ void NetworkSessionCocoa::deleteAlternativeServicesForHostNames(const Vector<Str
 #if HAVE(ALTERNATIVE_SERVICE)
     RetainPtr<_NSHTTPAlternativeServicesStorage> storage = m_defaultSessionSet->sessionWithCredentialStorage.session.get().configuration._alternativeServicesStorage;
     for (auto& host : hosts)
-        [storage removeHTTPAlternativeServiceEntriesWithRegistrableDomain:host];
+        [storage removeHTTPAlternativeServiceEntriesWithRegistrableDomain:host.createNSString().get()];
 #else
     UNUSED_PARAM(hosts);
 #endif

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
@@ -174,7 +174,7 @@ void NetworkTaskCocoa::setCookieTransformForThirdPartyRequest(const WebCore::Res
 
         // FIXME: Consider making these session cookies, as well.
         if (!cookiePartition.isEmpty())
-            cookiesSetInResponse = cookiesBySettingPartition(cookiesSetInResponse, cookiePartition);
+            cookiesSetInResponse = cookiesBySettingPartition(cookiesSetInResponse, cookiePartition.createNSString().get());
 
         return cookiesSetInResponse;
     }).get();
@@ -361,7 +361,7 @@ void NetworkTaskCocoa::updateTaskWithStoragePartitionIdentifier(const WebCore::R
 
     // FIXME: Remove respondsToSelector when available with NWLoader. rdar://134913391
     if ([task() respondsToSelector:@selector(set_storagePartitionIdentifier:)])
-        task()._storagePartitionIdentifier = networkStorageSession->cookiePartitionIdentifier(request);
+        task()._storagePartitionIdentifier = networkStorageSession->cookiePartitionIdentifier(request).createNSString().get();
 }
 #endif
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.mm
@@ -30,6 +30,7 @@
 
 #import <WebCore/RegistrableDomain.h>
 #import <wtf/SoftLinking.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/text/WTFString.h>
 
 SOFT_LINK_LIBRARY(libnetworkextension)
@@ -64,10 +65,10 @@ void setNWParametersTrackerOptions(nw_parameters_t parameters, bool shouldBypass
 
 bool isKnownTracker(const WebCore::RegistrableDomain& domain)
 {
-    NSArray<NSString *> *domains = @[domain.string()];
+    RetainPtr domains = @[domain.string().createNSString().get()];
     NEHelperTrackerDomainContextRef *context = nil;
     CFIndex index = 0;
-    return !!NEHelperTrackerGetDisposition(nullptr, (CFArrayRef)domains, context, &index);
+    return !!NEHelperTrackerGetDisposition(nullptr, bridge_cast(domains.get()), context, &index);
 }
 
 std::optional<uint32_t> trafficClassFromDSCP(rtc::DiffServCodePoint dscpValue)

--- a/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
+++ b/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
@@ -282,9 +282,9 @@ void requestVisualTranslation(CocoaImageAnalyzer *analyzer, NSURL *imageURL, con
             });
 
             if ([analysis respondsToSelector:@selector(translateFrom:to:withCompletion:)])
-                [analysis translateFrom:sourceLocale to:targetLocale withCompletion:completionBlock.get()];
+                [analysis translateFrom:sourceLocale.createNSString().get() to:targetLocale.createNSString().get() withCompletion:completionBlock.get()];
             else
-                [analysis translateTo:targetLocale withCompletion:completionBlock.get()];
+                [analysis translateTo:targetLocale.createNSString().get() withCompletion:completionBlock.get()];
         });
     }).get()];
 }

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -453,7 +453,7 @@ void ResourceMonitorURLsController::getSource(CompletionHandler<void(String&&)>&
             RELEASE_LOG_ERROR(ResourceMonitoring, "Failed to request resource monitor urls source from WebPrivacy");
 
         for (auto& completionHandler : std::exchange(lookupCompletionHandlers.get(), { }))
-            completionHandler(String { source });
+            completionHandler(source);
     }];
 }
 

--- a/Source/WebKit/Platform/mac/MenuUtilities.mm
+++ b/Source/WebKit/Platform/mac/MenuUtilities.mm
@@ -127,7 +127,7 @@ NSMenuItem *menuItemForTelephoneNumber(const String& telephoneNumber)
     for (NSMenuItem *item in proposedMenuItems) {
         auto action = actionForMenuItem(item);
         if ([action.actionUTI hasPrefix:@"com.apple.dial"]) {
-            item.title = formattedPhoneNumberString(telephoneNumber);
+            item.title = formattedPhoneNumberString(telephoneNumber.createNSString().get());
             return item;
         }
     }
@@ -143,7 +143,7 @@ RetainPtr<NSMenu> menuForTelephoneNumber(const String& telephoneNumber, NSView *
     RetainPtr<NSMenu> menu = adoptNS([[NSMenu alloc] init]);
     auto urlComponents = adoptNS([[NSURLComponents alloc] init]);
     [urlComponents setScheme:@"tel"];
-    [urlComponents setPath:telephoneNumber];
+    [urlComponents setPath:telephoneNumber.createNSString().get()];
     auto item = adoptNS([PAL::allocRVItemInstance() initWithURL:[urlComponents URL] rangeInContext:NSMakeRange(0, telephoneNumber.length())]);
     auto presenter = adoptNS([PAL::allocRVPresenterInstance() init]);
     auto delegate = adoptNS([[WKEmptyPresenterHighlightDelegate alloc] initWithRect:rect]);

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -8,7 +8,6 @@ GeneratedSerializers.h
 GeneratedWebKitSecureCoding.mm
 NetworkProcess/Authentication/cocoa/AuthenticationManagerCocoa.mm
 NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm
-NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
 NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm
 NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
 NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm
@@ -41,7 +40,6 @@ Shared/API/Cocoa/RemoteObjectRegistry.mm
 Shared/API/Cocoa/WKBrowsingContextHandle.mm
 Shared/API/Cocoa/WKRemoteObjectCoder.mm
 Shared/API/Cocoa/_WKFrameHandle.mm
-Shared/API/Cocoa/_WKHitTestResult.mm
 Shared/API/Cocoa/_WKRemoteObjectInterface.mm
 Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
 Shared/API/c/mac/WKURLRequestNS.mm
@@ -61,8 +59,6 @@ Shared/Cocoa/AuxiliaryProcessCocoa.mm
 Shared/Cocoa/CompletionHandlerCallChecker.mm
 Shared/Cocoa/CoreIPCContacts.mm
 Shared/Cocoa/CoreIPCError.mm
-Shared/Cocoa/CoreIPCLocale.mm
-Shared/Cocoa/CoreIPCNSURLRequest.mm
 Shared/Cocoa/CoreIPCPKPaymentSetupFeature.mm
 Shared/Cocoa/CoreIPCPKSecureElementPass.mm
 Shared/Cocoa/CoreIPCPassKit.mm
@@ -117,8 +113,6 @@ UIProcess/API/Cocoa/WKUserContentController.mm
 UIProcess/API/Cocoa/WKUserScript.mm
 UIProcess/API/Cocoa/WKWebView.mm
 UIProcess/API/Cocoa/WKWebViewConfiguration.mm
-UIProcess/API/Cocoa/WKWebViewTesting.mm
-UIProcess/API/Cocoa/WKWebpagePreferences.mm
 UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
 UIProcess/API/Cocoa/WKWebsiteDataRecordInternal.h
 UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -130,14 +124,12 @@ UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.mm
 UIProcess/API/Cocoa/_WKAuthenticatorAssertionResponse.mm
 UIProcess/API/Cocoa/_WKAuthenticatorAttestationResponse.mm
 UIProcess/API/Cocoa/_WKAuthenticatorResponse.mm
-UIProcess/API/Cocoa/_WKCustomHeaderFields.mm
 UIProcess/API/Cocoa/_WKDataTask.mm
 UIProcess/API/Cocoa/_WKDownload.mm
 UIProcess/API/Cocoa/_WKFeature.mm
 UIProcess/API/Cocoa/_WKInspector.mm
 UIProcess/API/Cocoa/_WKInspectorConfiguration.mm
 UIProcess/API/Cocoa/_WKInspectorExtension.mm
-UIProcess/API/Cocoa/_WKLinkIconParameters.mm
 UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
 UIProcess/API/Cocoa/_WKPublicKeyCredentialCreationOptions.mm
 UIProcess/API/Cocoa/_WKPublicKeyCredentialDescriptor.mm
@@ -149,7 +141,6 @@ UIProcess/API/Cocoa/_WKPublicKeyCredentialUserEntity.mm
 UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
 UIProcess/API/Cocoa/_WKResourceLoadInfo.mm
 UIProcess/API/Cocoa/_WKSystemPreferences.mm
-UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
 UIProcess/API/Cocoa/_WKTextManipulationConfiguration.mm
 UIProcess/API/Cocoa/_WKTextManipulationToken.mm
 UIProcess/API/Cocoa/_WKThumbnailView.mm
@@ -162,7 +153,6 @@ UIProcess/API/mac/WKWebViewMac.mm
 UIProcess/API/mac/WKWebViewTestingMac.mm
 UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm
 UIProcess/Authentication/cocoa/SecKeyProxyStore.mm
-UIProcess/Automation/cocoa/WebAutomationSessionCocoa.mm
 UIProcess/Automation/mac/WebAutomationSessionMac.mm
 UIProcess/Cocoa/AutomationClient.mm
 UIProcess/Cocoa/AutomationSessionClient.mm
@@ -194,7 +184,6 @@ UIProcess/Cocoa/WKStorageAccessAlert.mm
 UIProcess/Cocoa/WKTextExtractionUtilities.mm
 UIProcess/Cocoa/WebKitSwiftSoftLink.h
 UIProcess/Cocoa/WebPageProxyCocoa.mm
-UIProcess/Cocoa/WebPreferencesCocoa.mm
 UIProcess/Cocoa/WebProcessPoolCocoa.mm
 UIProcess/Cocoa/WebProcessProxyCocoa.mm
 UIProcess/Cocoa/_WKWarningView.mm
@@ -230,14 +219,11 @@ UIProcess/WebAuthentication/Cocoa/LocalService.mm
 UIProcess/WebAuthentication/Cocoa/NearFieldSoftLink.h
 UIProcess/WebAuthentication/Cocoa/NfcService.mm
 UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
-UIProcess/WebAuthentication/Mock/MockCcidService.mm
 UIProcess/WebAuthentication/Mock/MockLocalConnection.mm
 UIProcess/WebAuthentication/Mock/MockNfcService.mm
-UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm
 UIProcess/WebAuthentication/Virtual/VirtualLocalConnection.mm
 UIProcess/WebProcessPool.h
 UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
-UIProcess/mac/CorrectionPanel.mm
 UIProcess/mac/DisplayCaptureSessionManager.mm
 UIProcess/mac/PageClientImplMac.mm
 UIProcess/mac/SecItemShimProxy.cpp

--- a/Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -2,7 +2,6 @@ Platform/classifier/cocoa/ResourceLoadStatisticsClassifierCocoa.cpp
 Platform/cocoa/PaymentAuthorizationPresenter.mm
 Platform/cocoa/_WKWebViewTextInputNotifications.mm
 Platform/mac/MenuUtilities.mm
-UIProcess/API/Cocoa/APIAttachmentCocoa.mm
 UIProcess/API/Cocoa/NSAttributedString.mm
 UIProcess/API/Cocoa/WKContentRuleList.mm
 UIProcess/API/Cocoa/WKContentRuleListStore.mm
@@ -34,7 +33,6 @@ WebProcess/Plugins/PDF/PDFPluginBase.mm
 WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
 WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
 WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
-WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
 WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm
 WebProcess/WebPage/Cocoa/WebCookieJarCocoa.mm
 WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm

--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
@@ -47,7 +47,7 @@
 
 static NSURL *URLFromString(const WTF::String& urlString)
 {
-    return urlString.isEmpty() ? nil : [NSURL URLWithString:urlString];
+    return urlString.isEmpty() ? nil : [NSURL URLWithString:urlString.createNSString().get()];
 }
 
 - (NSURL *)absoluteImageURL
@@ -72,7 +72,7 @@ static NSURL *URLFromString(const WTF::String& urlString)
 
 - (NSString *)linkLocalDataMIMEType
 {
-    return _hitTestResult->linkLocalDataMIMEType();
+    return _hitTestResult->linkLocalDataMIMEType().createNSString().autorelease();
 }
 
 - (NSURL *)absoluteMediaURL
@@ -82,32 +82,32 @@ static NSURL *URLFromString(const WTF::String& urlString)
 
 - (NSString *)linkLabel
 {
-    return _hitTestResult->linkLabel();
+    return _hitTestResult->linkLabel().createNSString().autorelease();
 }
 
 - (NSString *)linkTitle
 {
-    return _hitTestResult->linkTitle();
+    return _hitTestResult->linkTitle().createNSString().autorelease();
 }
 
 - (NSString *)lookupText
 {
-    return _hitTestResult->lookupText();
+    return _hitTestResult->lookupText().createNSString().autorelease();
 }
 
 - (NSString *)linkSuggestedFilename
 {
-    return _hitTestResult->linkSuggestedFilename();
+    return _hitTestResult->linkSuggestedFilename().createNSString().autorelease();
 }
 
 - (NSString *)imageSuggestedFilename
 {
-    return _hitTestResult->imageSuggestedFilename();
+    return _hitTestResult->imageSuggestedFilename().createNSString().autorelease();
 }
 
 - (NSString *)imageMIMEType
 {
-    return _hitTestResult->sourceImageMIMEType();
+    return _hitTestResult->sourceImageMIMEType().createNSString().autorelease();
 }
 
 - (BOOL)isContentEditable

--- a/Source/WebKit/Shared/ApplePay/cocoa/AutomaticReloadPaymentRequestCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/AutomaticReloadPaymentRequestCocoa.mm
@@ -39,11 +39,11 @@ using namespace WebCore;
 
 RetainPtr<PKAutomaticReloadPaymentRequest> platformAutomaticReloadPaymentRequest(const ApplePayAutomaticReloadPaymentRequest& webAutomaticReloadPaymentRequest)
 {
-    auto pkAutomaticReloadPaymentRequest = adoptNS([PAL::allocPKAutomaticReloadPaymentRequestInstance() initWithPaymentDescription:webAutomaticReloadPaymentRequest.paymentDescription automaticReloadBilling:platformAutomaticReloadSummaryItem(webAutomaticReloadPaymentRequest.automaticReloadBilling) managementURL:[NSURL URLWithString:webAutomaticReloadPaymentRequest.managementURL]]);
+    auto pkAutomaticReloadPaymentRequest = adoptNS([PAL::allocPKAutomaticReloadPaymentRequestInstance() initWithPaymentDescription:webAutomaticReloadPaymentRequest.paymentDescription.createNSString().get() automaticReloadBilling:platformAutomaticReloadSummaryItem(webAutomaticReloadPaymentRequest.automaticReloadBilling) managementURL:adoptNS([[NSURL alloc] initWithString:webAutomaticReloadPaymentRequest.managementURL.createNSString().get()]).get()]);
     if (auto& billingAgreement = webAutomaticReloadPaymentRequest.billingAgreement; !billingAgreement.isNull())
-        [pkAutomaticReloadPaymentRequest setBillingAgreement:billingAgreement];
+        [pkAutomaticReloadPaymentRequest setBillingAgreement:billingAgreement.createNSString().get()];
     if (auto& tokenNotificationURL = webAutomaticReloadPaymentRequest.tokenNotificationURL; !tokenNotificationURL.isNull())
-        [pkAutomaticReloadPaymentRequest setTokenNotificationURL:[NSURL URLWithString:tokenNotificationURL]];
+        [pkAutomaticReloadPaymentRequest setTokenNotificationURL:adoptNS([[NSURL alloc] initWithString:tokenNotificationURL.createNSString().get()]).get()];
     return pkAutomaticReloadPaymentRequest;
 }
 

--- a/Source/WebKit/Shared/ApplePay/cocoa/DeferredPaymentRequestCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/DeferredPaymentRequestCocoa.mm
@@ -40,21 +40,21 @@ using namespace WebCore;
 RetainPtr<PKDeferredPaymentRequest> platformDeferredPaymentRequest(const ApplePayDeferredPaymentRequest& webDeferredPaymentRequest)
 {
     auto pkDeferredPaymentRequest = adoptNS([PAL::allocPKDeferredPaymentRequestInstance()
-        initWithPaymentDescription:webDeferredPaymentRequest.paymentDescription
+        initWithPaymentDescription:webDeferredPaymentRequest.paymentDescription.createNSString().get()
         deferredBilling:platformDeferredSummaryItem(webDeferredPaymentRequest.deferredBilling)
-        managementURL:[NSURL URLWithString:webDeferredPaymentRequest.managementURL]]);
+        managementURL:adoptNS([[NSURL alloc] initWithString:webDeferredPaymentRequest.managementURL.createNSString().get()]).get()]);
     if (auto& billingAgreement = webDeferredPaymentRequest.billingAgreement; !billingAgreement.isNull())
-        [pkDeferredPaymentRequest setBillingAgreement:billingAgreement];
+        [pkDeferredPaymentRequest setBillingAgreement:billingAgreement.createNSString().get()];
     if (auto& freeCancellationDate = webDeferredPaymentRequest.freeCancellationDate; !freeCancellationDate.isNaN()) {
         if (auto& freeCancellationDateTimeZone = webDeferredPaymentRequest.freeCancellationDateTimeZone; !freeCancellationDateTimeZone.isNull()) {
-            if (RetainPtr timeZone = [NSTimeZone timeZoneWithName:freeCancellationDateTimeZone]) {
+            if (RetainPtr timeZone = [NSTimeZone timeZoneWithName:freeCancellationDateTimeZone.createNSString().get()]) {
                 [pkDeferredPaymentRequest setFreeCancellationDate:[NSDate dateWithTimeIntervalSince1970:freeCancellationDate.secondsSinceEpoch().value()]];
                 [pkDeferredPaymentRequest setFreeCancellationDateTimeZone:timeZone.get()];
             }
         }
     }
     if (auto& tokenNotificationURL = webDeferredPaymentRequest.tokenNotificationURL; !tokenNotificationURL.isNull())
-        [pkDeferredPaymentRequest setTokenNotificationURL:[NSURL URLWithString:tokenNotificationURL]];
+        [pkDeferredPaymentRequest setTokenNotificationURL:adoptNS([[NSURL alloc] initWithString:tokenNotificationURL.createNSString().get()]).get()];
     return pkDeferredPaymentRequest;
 }
 

--- a/Source/WebKit/Shared/ApplePay/cocoa/DisbursementRequestCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/DisbursementRequestCocoa.mm
@@ -66,7 +66,7 @@ static PKContactField platformContactField(ApplePayContactField contactField)
 RetainPtr<PKDisbursementPaymentRequest> platformDisbursementRequest(const ApplePaySessionPaymentRequest& request, const URL& originatingURL, const std::optional<Vector<ApplePayContactField>>& requiredRecipientContactFields)
 {
     // This merchantID is not actually used for web payments, passing an empty string here is fine
-    auto disbursementRequest = adoptNS([PAL::allocPKDisbursementRequestInstance() initWithMerchantIdentifier:@"" currencyCode:request.currencyCode() regionCode:request.countryCode() supportedNetworks:createNSArray(request.supportedNetworks()).get() merchantCapabilities:toPKMerchantCapabilities(request.merchantCapabilities()) summaryItems:WebCore::platformDisbursementSummaryItems(request.lineItems())]);
+    auto disbursementRequest = adoptNS([PAL::allocPKDisbursementRequestInstance() initWithMerchantIdentifier:@"" currencyCode:request.currencyCode().createNSString().get() regionCode:request.countryCode().createNSString().get() supportedNetworks:createNSArray(request.supportedNetworks()).get() merchantCapabilities:toPKMerchantCapabilities(request.merchantCapabilities()) summaryItems:WebCore::platformDisbursementSummaryItems(request.lineItems())]);
 
     // FIXME: we should consolidate the types for various contact fields in the system(WebCore::ApplePayContactField, WebCore::ApplePaySessionPaymentRequest::ContactFields etc.)
     if (requiredRecipientContactFields)

--- a/Source/WebKit/Shared/ApplePay/cocoa/PaymentSetupConfigurationCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/PaymentSetupConfigurationCocoa.mm
@@ -50,17 +50,17 @@ static RetainPtr<PKPaymentSetupConfiguration> toPlatformConfiguration(const WebC
 #endif
 
     auto configuration = adoptNS([PAL::allocPKPaymentSetupConfigurationInstance() init]);
-    [configuration setMerchantIdentifier:coreConfiguration.merchantIdentifier];
+    [configuration setMerchantIdentifier:coreConfiguration.merchantIdentifier.createNSString().get()];
     [configuration setOriginatingURL:url.createNSURL().get()];
-    [configuration setReferrerIdentifier:coreConfiguration.referrerIdentifier];
+    [configuration setReferrerIdentifier:coreConfiguration.referrerIdentifier.createNSString().get()];
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
-    [configuration setSignature:coreConfiguration.signature];
+    [configuration setSignature:coreConfiguration.signature.createNSString().get()];
 ALLOW_NEW_API_WITHOUT_GUARDS_END
 
     if ([configuration respondsToSelector:@selector(setSignedFields:)]) {
         RetainPtr signedFields = adoptNS([[NSMutableArray alloc] initWithCapacity:coreConfiguration.signedFields.size()]);
         for (auto& signedField : coreConfiguration.signedFields)
-            [signedFields addObject:signedField];
+            [signedFields addObject:signedField.createNSString().get()];
         [configuration setSignedFields:signedFields.get()];
     }
 

--- a/Source/WebKit/Shared/ApplePay/cocoa/PaymentTokenContextCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/PaymentTokenContextCocoa.mm
@@ -44,8 +44,8 @@ RetainPtr<PKPaymentTokenContext> platformPaymentTokenContext(const ApplePayPayme
 {
     RetainPtr<NSString> merchantDomain;
     if (!webTokenContext.merchantDomain.isNull())
-        merchantDomain = webTokenContext.merchantDomain;
-    return adoptNS([PAL::allocPKPaymentTokenContextInstance() initWithMerchantIdentifier:webTokenContext.merchantIdentifier externalIdentifier:webTokenContext.externalIdentifier merchantName:webTokenContext.merchantName merchantDomain:merchantDomain.get() amount:WebCore::toDecimalNumber(webTokenContext.amount)]);
+        merchantDomain = webTokenContext.merchantDomain.createNSString();
+    return adoptNS([PAL::allocPKPaymentTokenContextInstance() initWithMerchantIdentifier:webTokenContext.merchantIdentifier.createNSString().get() externalIdentifier:webTokenContext.externalIdentifier.createNSString().get() merchantName:webTokenContext.merchantName.createNSString().get() merchantDomain:merchantDomain.get() amount:WebCore::toDecimalNumber(webTokenContext.amount)]);
 }
 
 RetainPtr<NSArray<PKPaymentTokenContext *>> platformPaymentTokenContexts(const Vector<ApplePayPaymentTokenContext>& webTokenContexts)

--- a/Source/WebKit/Shared/ApplePay/cocoa/RecurringPaymentRequestCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/RecurringPaymentRequestCocoa.mm
@@ -39,13 +39,13 @@ using namespace WebCore;
 
 RetainPtr<PKRecurringPaymentRequest> platformRecurringPaymentRequest(const ApplePayRecurringPaymentRequest& webRecurringPaymentRequest)
 {
-    auto pkRecurringPaymentRequest = adoptNS([PAL::allocPKRecurringPaymentRequestInstance() initWithPaymentDescription:webRecurringPaymentRequest.paymentDescription regularBilling:platformRecurringSummaryItem(webRecurringPaymentRequest.regularBilling) managementURL:[NSURL URLWithString:webRecurringPaymentRequest.managementURL]]);
+    auto pkRecurringPaymentRequest = adoptNS([PAL::allocPKRecurringPaymentRequestInstance() initWithPaymentDescription:webRecurringPaymentRequest.paymentDescription.createNSString().get() regularBilling:platformRecurringSummaryItem(webRecurringPaymentRequest.regularBilling) managementURL:adoptNS([[NSURL alloc] initWithString:webRecurringPaymentRequest.managementURL.createNSString().get()]).get()]);
     if (auto& trialBilling = webRecurringPaymentRequest.trialBilling)
         [pkRecurringPaymentRequest setTrialBilling:platformRecurringSummaryItem(*trialBilling)];
     if (auto& billingAgreement = webRecurringPaymentRequest.billingAgreement; !billingAgreement.isNull())
-        [pkRecurringPaymentRequest setBillingAgreement:billingAgreement];
+        [pkRecurringPaymentRequest setBillingAgreement:billingAgreement.createNSString().get()];
     if (auto& tokenNotificationURL = webRecurringPaymentRequest.tokenNotificationURL; !tokenNotificationURL.isNull())
-        [pkRecurringPaymentRequest setTokenNotificationURL:[NSURL URLWithString:tokenNotificationURL]];
+        [pkRecurringPaymentRequest setTokenNotificationURL:adoptNS([[NSURL alloc] initWithString:tokenNotificationURL.createNSString().get()]).get()];
     return pkRecurringPaymentRequest;
 }
 

--- a/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
@@ -185,7 +185,7 @@ RetainPtr<id> AuxiliaryProcess::decodePreferenceValue(const std::optional<String
     if (!encodedValue)
         return nil;
     
-    RetainPtr encodedData = adoptNS([[NSData alloc] initWithBase64EncodedString:*encodedValue options:0]);
+    RetainPtr encodedData = adoptNS([[NSData alloc] initWithBase64EncodedString:encodedValue->createNSString().get() options:0]);
     RetainPtr classes = [NSSet setWithObjects:
         NSString.class,
         NSMutableString.class,
@@ -209,8 +209,8 @@ void AuxiliaryProcess::setPreferenceValue(const String& domain, const String& ke
     if (domain.isEmpty()) {
         CFPreferencesSetValue(key.createCFString().get(), (__bridge CFPropertyListRef)value, kCFPreferencesAnyApplication, kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
 #if ASSERT_ENABLED
-        id valueAfterSetting = [[NSUserDefaults standardUserDefaults] objectForKey:key];
-        ASSERT(valueAfterSetting == value || [valueAfterSetting isEqual:value] || key == "AppleLanguages"_s || key == "PayloadUUID"_s);
+        RetainPtr valueAfterSetting = [[NSUserDefaults standardUserDefaults] objectForKey:key.createNSString().get()];
+        ASSERT(valueAfterSetting.get() == value || [valueAfterSetting.get() isEqual:value] || key == "AppleLanguages"_s || key == "PayloadUUID"_s);
 #endif
     } else
         CFPreferencesSetValue(key.createCFString().get(), (__bridge CFPropertyListRef)value, domain.createCFString().get(), kCFPreferencesCurrentUser, kCFPreferencesAnyHost);

--- a/Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.mm
@@ -55,8 +55,8 @@ CoreIPCAVOutputContext::CoreIPCAVOutputContext(AVOutputContext *context)
 RetainPtr<id> CoreIPCAVOutputContext::toID() const
 {
     RetainPtr dict = adoptNS([[NSMutableDictionary alloc] initWithCapacity:2]);
-    [dict setObject:(NSString *)m_data.contextID forKey:@"contextID"];
-    [dict setObject:(NSString *)m_data.contextType forKey:@"contextType"];
+    [dict setObject:m_data.contextID.createNSString().get() forKey:@"contextID"];
+    [dict setObject:m_data.contextType.createNSString().get() forKey:@"contextType"];
     return adoptNS([[PAL::getAVOutputContextClass() alloc] _initWithWebKitPropertyListData:dict.get()]);
 }
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCContacts.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCContacts.mm
@@ -157,45 +157,45 @@ static RetainPtr<NSArray> nsArrayFromVectorOfLabeledValues(const Vector<CoreIPCC
             return actualValue.toID();
         }, labeledValue.value);
 
-        return adoptNS([[PAL::getCNLabeledValueClass() alloc] initWithIdentifier:labeledValue.identifier label:labeledValue.label value:theValue.get()]);
+        return adoptNS([[PAL::getCNLabeledValueClass() alloc] initWithIdentifier:labeledValue.identifier.createNSString().get() label:labeledValue.label.createNSString().get() value:theValue.get()]);
     });
 }
 
 RetainPtr<id> CoreIPCCNContact::toID() const
 {
-    RetainPtr<CNMutableContact> result = adoptNS([[PAL::getCNMutableContactClass() alloc] initWithIdentifier:m_identifier]);
+    RetainPtr<CNMutableContact> result = adoptNS([[PAL::getCNMutableContactClass() alloc] initWithIdentifier:m_identifier.createNSString().get()]);
     result.get().contactType = (CNContactType)m_contactType;
 
     if (!m_namePrefix.isNull())
-        result.get().namePrefix = m_namePrefix;
+        result.get().namePrefix = m_namePrefix.createNSString().get();
     if (!m_givenName.isNull())
-        result.get().givenName = m_givenName;
+        result.get().givenName = m_givenName.createNSString().get();
     if (!m_middleName.isNull())
-        result.get().middleName = m_middleName;
+        result.get().middleName = m_middleName.createNSString().get();
     if (!m_familyName.isNull())
-        result.get().familyName = m_familyName;
+        result.get().familyName = m_familyName.createNSString().get();
     if (!m_previousFamilyName.isNull())
-        result.get().previousFamilyName = m_previousFamilyName;
+        result.get().previousFamilyName = m_previousFamilyName.createNSString().get();
     if (!m_nameSuffix.isNull())
-        result.get().nameSuffix = m_nameSuffix;
+        result.get().nameSuffix = m_nameSuffix.createNSString().get();
     if (!m_nickname.isNull())
-        result.get().nickname = m_nickname;
+        result.get().nickname = m_nickname.createNSString().get();
     if (!m_organizationName.isNull())
-        result.get().organizationName = m_organizationName;
+        result.get().organizationName = m_organizationName.createNSString().get();
     if (!m_departmentName.isNull())
-        result.get().departmentName = m_departmentName;
+        result.get().departmentName = m_departmentName.createNSString().get();
     if (!m_jobTitle.isNull())
-        result.get().jobTitle = m_jobTitle;
+        result.get().jobTitle = m_jobTitle.createNSString().get();
     if (!m_phoneticGivenName.isNull())
-        result.get().phoneticGivenName = m_phoneticGivenName;
+        result.get().phoneticGivenName = m_phoneticGivenName.createNSString().get();
     if (!m_phoneticMiddleName.isNull())
-        result.get().phoneticMiddleName = m_phoneticMiddleName;
+        result.get().phoneticMiddleName = m_phoneticMiddleName.createNSString().get();
     if (!m_phoneticFamilyName.isNull())
-        result.get().phoneticFamilyName = m_phoneticFamilyName;
+        result.get().phoneticFamilyName = m_phoneticFamilyName.createNSString().get();
     if (!m_phoneticOrganizationName.isNull())
-        result.get().phoneticOrganizationName = m_phoneticOrganizationName;
+        result.get().phoneticOrganizationName = m_phoneticOrganizationName.createNSString().get();
     if (!m_note.isNull())
-        result.get().note = m_note;
+        result.get().note = m_note.createNSString().get();
 
     if (m_birthday)
         result.get().birthday = m_birthday->toID().get();

--- a/Source/WebKit/Shared/Cocoa/CoreIPCError.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCError.mm
@@ -89,9 +89,9 @@ RetainPtr<id> CoreIPCError::toID() const
 
         auto mutableUserInfo = adoptCF(CFDictionaryCreateMutableCopy(kCFAllocatorDefault, CFDictionaryGetCount(m_userInfo.get()) + 1, m_userInfo.get()));
         CFDictionarySetValue(mutableUserInfo.get(), (__bridge CFStringRef)NSUnderlyingErrorKey, (__bridge CFTypeRef)underlyingNSError.get());
-        return adoptNS([[NSError alloc] initWithDomain:m_domain code:m_code userInfo:(__bridge NSDictionary *)mutableUserInfo.get()]);
+        return adoptNS([[NSError alloc] initWithDomain:m_domain.createNSString().get() code:m_code userInfo:(__bridge NSDictionary *)mutableUserInfo.get()]);
     }
-    return adoptNS([[NSError alloc] initWithDomain:m_domain code:m_code userInfo:(__bridge NSDictionary *)m_userInfo.get()]);
+    return adoptNS([[NSError alloc] initWithDomain:m_domain.createNSString().get() code:m_code userInfo:(__bridge NSDictionary *)m_userInfo.get()]);
 }
 
 bool CoreIPCError::isSafeToEncodeUserInfo(id value)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCLocale.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCLocale.mm
@@ -28,13 +28,14 @@
 
 #import <wtf/HashMap.h>
 #import <wtf/NeverDestroyed.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/text/StringHash.h>
 
 namespace WebKit {
 
 bool CoreIPCLocale::isValidIdentifier(const String& identifier)
 {
-    if ([[NSLocale availableLocaleIdentifiers] containsObject:identifier])
+    if ([[NSLocale availableLocaleIdentifiers] containsObject:identifier.createNSString().get()])
         return true;
     if (canonicalLocaleStringReplacement(identifier))
         return true;
@@ -49,7 +50,7 @@ CoreIPCLocale::CoreIPCLocale(NSLocale *locale)
 CoreIPCLocale::CoreIPCLocale(String&& identifier)
     : m_identifier([[NSLocale currentLocale] localeIdentifier])
 {
-    if ([[NSLocale availableLocaleIdentifiers] containsObject:identifier])
+    if ([[NSLocale availableLocaleIdentifiers] containsObject:identifier.createNSString().get()])
         m_identifier = identifier;
     else if (auto fixedLocale = canonicalLocaleStringReplacement(identifier))
         m_identifier = *fixedLocale;
@@ -71,7 +72,7 @@ std::optional<String> CoreIPCLocale::canonicalLocaleStringReplacement(const Stri
         }
         return dictionary;
     }();
-    if (RetainPtr<NSString> entry = [dictionary.get() objectForKey:identifier])
+    if (RetainPtr entry = checked_objc_cast<NSString>([dictionary.get() objectForKey:identifier.createNSString().get()]))
         return String(entry.get());
     return std::nullopt;
 }

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
@@ -259,17 +259,17 @@ RetainPtr<id> CoreIPCNSURLRequest::toID() const
         auto headerFields = adoptNS([[NSMutableDictionary alloc] initWithCapacity:(*m_data.headerFields).size()]);
         for (auto& headerPair : *m_data.headerFields) {
             WTF::switchOn(headerPair.second,
-                [&] (const String& s) {
+                [&] (const String& string) {
                     auto array = adoptNS([[NSMutableArray alloc] initWithCapacity:1]);
-                    if (!s.isNull() && !headerPair.first.isNull()) {
-                        [array addObject: s];
+                    if (!string.isNull() && !headerPair.first.isNull()) {
+                        [array addObject:string.createNSString().get()];
                         [headerFields setObject:array.get() forKey:headerPair.first.createNSString().get()];
                     }
                 },
                 [&] (const Vector<String>& vector) {
                     auto array = adoptNS([[NSMutableArray alloc] initWithCapacity:vector.size()]);
                     for (auto& item : vector)
-                        [array addObject: item];
+                        [array addObject:item.createNSString().get()];
                     if (!headerPair.first.isNull())
                         [headerFields setObject:array.get() forKey:headerPair.first.createNSString().get()];
                 }

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPresentationIntent.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPresentationIntent.mm
@@ -89,7 +89,7 @@ RetainPtr<id> CoreIPCPresentationIntent::toID() const
     case NSPresentationIntentKindListItem:
         return [NSPresentationIntent listItemIntentWithIdentity:m_identity ordinal:m_ordinal nestedInsideIntent:parent.get()];
     case NSPresentationIntentKindCodeBlock:
-        return [NSPresentationIntent codeBlockIntentWithIdentity:m_identity languageHint:m_languageHint nestedInsideIntent:parent.get()];
+        return [NSPresentationIntent codeBlockIntentWithIdentity:m_identity languageHint:m_languageHint.createNSString().get() nestedInsideIntent:parent.get()];
     case NSPresentationIntentKindBlockQuote:
         return [NSPresentationIntent blockQuoteIntentWithIdentity:m_identity nestedInsideIntent:parent.get()];
     case NSPresentationIntentKindThematicBreak:

--- a/Source/WebKit/Shared/Cocoa/CoreIPCString.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCString.h
@@ -46,7 +46,7 @@ public:
 
     CoreIPCString() = default;
 
-    RetainPtr<id> toID() const { return (NSString *)m_string; }
+    RetainPtr<id> toID() const { return m_string.createNSString(); }
 
 private:
     friend struct IPC::ArgumentCoder<CoreIPCString, void>;

--- a/Source/WebKit/Shared/Cocoa/RevealItem.mm
+++ b/Source/WebKit/Shared/Cocoa/RevealItem.mm
@@ -53,7 +53,7 @@ NSRange RevealItem::highlightRange() const
 RVItem *RevealItem::item() const
 {
     if (!m_item)
-        m_item = adoptNS([PAL::allocRVItemInstance() initWithText:m_text selectedRange:NSMakeRange(m_selectedRange.location, m_selectedRange.length)]);
+        m_item = adoptNS([PAL::allocRVItemInstance() initWithText:m_text.createNSString().get() selectedRange:NSMakeRange(m_selectedRange.location, m_selectedRange.length)]);
     return m_item.get();
 }
 

--- a/Source/WebKit/Shared/Cocoa/WebIconUtilities.mm
+++ b/Source/WebKit/Shared/Cocoa/WebIconUtilities.mm
@@ -172,7 +172,7 @@ RetainPtr<CocoaImage> iconForFiles(const Vector<String>& filenames)
 
     // FIXME: We should generate an icon showing multiple files here, if applicable. Currently, if there are multiple
     // files, we only use the first URL to generate an icon.
-    RetainPtr file = [NSURL fileURLWithPath:filenames[0] isDirectory:NO];
+    RetainPtr file = adoptNS([[NSURL alloc] initFileURLWithPath:filenames[0].createNSString().get() isDirectory:NO]);
     if (!file)
         return nil;
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
@@ -297,7 +297,7 @@ bool validateDictionary(NSDictionary<NSString *, id> *dictionary, NSString *sour
         errorString = [[NSString alloc] initWithFormat:@"it is missing required keys: %@", formatList(remainingRequiredKeys.allObjects)];
 
     if (errorString && outExceptionString)
-        *outExceptionString = toErrorString(nullString(), sourceKey, errorString);
+        *outExceptionString = toErrorString(nullString(), sourceKey, errorString).createNSString().autorelease();
 
     return !errorString;
 }
@@ -310,14 +310,14 @@ bool validateObject(NSObject *object, NSString *sourceKey, id expectedValueType,
     validate(nil, object, expectedValueType, &errorString);
 
     if (errorString && outExceptionString)
-        *outExceptionString = toErrorString(nullString(), sourceKey, errorString);
+        *outExceptionString = toErrorString(nullString(), sourceKey, errorString).createNSString().autorelease();
 
     return !errorString;
 }
 
 JSObjectRef toJSError(JSContextRef context, NSString *callingAPIName, NSString *sourceKey, NSString *underlyingErrorString)
 {
-    return toJSError(context, toErrorString(callingAPIName, sourceKey, underlyingErrorString));
+    return toJSError(context, toErrorString(callingAPIName, sourceKey, underlyingErrorString).createNSString().get());
 }
 
 JSObjectRef toJSRejectedPromise(JSContextRef context, NSString *callingAPIName, NSString *sourceKey, NSString *underlyingErrorString)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -417,7 +417,7 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
         layer.masksToBounds = properties.masksToBounds;
 
     if (properties.changedProperties & LayerChange::NameChanged)
-        layer.name = properties.name;
+        layer.name = properties.name.createNSString().get();
 
     if (properties.changedProperties & LayerChange::BackgroundColorChanged)
         layer.backgroundColor = cgColorFromColor(properties.backgroundColor).get();

--- a/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
+++ b/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
@@ -79,7 +79,7 @@
 
 - (NSString *)title
 {
-    return _page->pageLoadState().title();
+    return _page->pageLoadState().title().createNSString().autorelease();
 }
 
 - (NSURL *)URL

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm
@@ -62,7 +62,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     if (!item->title())
         return nil;
 
-    return item->title();
+    return item->title().createNSString().autorelease();
 }
 
 - (NSURL *)initialURL

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleList.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleList.mm
@@ -52,7 +52,7 @@
 - (NSString *)identifier
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    return Ref { *_contentRuleList }->name();
+    return Ref { *_contentRuleList }->name().createNSString().autorelease();
 #else
     return nil;
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
@@ -209,7 +209,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
             rawHandler(nil);
 #pragma clang diagnostic pop
         } else
-            rawHandler(source);
+            rawHandler(source.createNSString().get());
     });
 #endif
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm
@@ -77,7 +77,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     if (_contentWorld->name().isNull())
         return nil;
 
-    return _contentWorld->name();
+    return _contentWorld->name().createNSString().autorelease();
 }
 
 #pragma mark WKObject protocol implementation

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm
@@ -34,7 +34,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (NSString *)name
 {
-    return _name;
+    return _name.createNSString().autorelease();
 }
 
 - (void)setName:(NSString *)name

--- a/Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm
@@ -116,7 +116,7 @@ private:
         if (!m_delegate)
             return completionHandler(WebKit::AllowOverwrite::No, { });
 
-        [m_delegate download:wrapper(download) decideDestinationUsingResponse:response.nsURLResponse() suggestedFilename:suggestedFilename completionHandler:makeBlockPtr([download = Ref { download }, completionHandler = WTFMove(completionHandler), checker = WebKit::CompletionHandlerCallChecker::create(m_delegate.get().get(), @selector(download:decideDestinationUsingResponse:suggestedFilename:completionHandler:))] (NSURL *destination) mutable {
+        [m_delegate download:wrapper(download) decideDestinationUsingResponse:response.nsURLResponse() suggestedFilename:suggestedFilename.createNSString().get() completionHandler:makeBlockPtr([download = Ref { download }, completionHandler = WTFMove(completionHandler), checker = WebKit::CompletionHandlerCallChecker::create(m_delegate.get().get(), @selector(download:decideDestinationUsingResponse:suggestedFilename:completionHandler:))] (NSURL *destination) mutable {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKError.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKError.mm
@@ -38,59 +38,58 @@ NSString * const _WKJavaScriptExceptionLineNumberErrorKey = @"WKJavaScriptExcept
 NSString * const _WKJavaScriptExceptionColumnNumberErrorKey = @"WKJavaScriptExceptionColumnNumber";
 NSString * const _WKJavaScriptExceptionSourceURLErrorKey = @"WKJavaScriptExceptionSourceURL";
 
-NSString *localizedDescriptionForErrorCode(WKErrorCode errorCode)
+RetainPtr<NSString> localizedDescriptionForErrorCode(WKErrorCode errorCode)
 {
     switch (errorCode) {
     case WKErrorUnknown:
-        return WEB_UI_STRING("An unknown error occurred", "WKErrorUnknown description");
+        return WEB_UI_STRING("An unknown error occurred", "WKErrorUnknown description").createNSString();
 
     case WKErrorWebContentProcessTerminated:
-        return WEB_UI_STRING("The Web Content process was terminated", "WKErrorWebContentProcessTerminated description");
+        return WEB_UI_STRING("The Web Content process was terminated", "WKErrorWebContentProcessTerminated description").createNSString();
 
     case WKErrorWebViewInvalidated:
-        return WEB_UI_STRING("The WKWebView was invalidated", "WKErrorWebViewInvalidated description");
+        return WEB_UI_STRING("The WKWebView was invalidated", "WKErrorWebViewInvalidated description").createNSString();
 
     case WKErrorJavaScriptExceptionOccurred:
-        return WEB_UI_STRING("A JavaScript exception occurred", "WKErrorJavaScriptExceptionOccurred description");
-
+        return WEB_UI_STRING("A JavaScript exception occurred", "WKErrorJavaScriptExceptionOccurred description").createNSString();
     case WKErrorJavaScriptResultTypeIsUnsupported:
-        return WEB_UI_STRING("JavaScript execution returned a result of an unsupported type", "WKErrorJavaScriptResultTypeIsUnsupported description");
+        return WEB_UI_STRING("JavaScript execution returned a result of an unsupported type", "WKErrorJavaScriptResultTypeIsUnsupported description").createNSString();
 
     case WKErrorContentRuleListStoreLookUpFailed:
-        return WEB_UI_STRING("Looking up a WKContentRuleList failed", "WKErrorContentRuleListStoreLookupFailed description");
+        return WEB_UI_STRING("Looking up a WKContentRuleList failed", "WKErrorContentRuleListStoreLookupFailed description").createNSString();
 
     case WKErrorContentRuleListStoreVersionMismatch:
-        return WEB_UI_STRING("Looking up a WKContentRuleList found a binary that is incompatible", "WKErrorContentRuleListStoreVersionMismatch description");
+        return WEB_UI_STRING("Looking up a WKContentRuleList found a binary that is incompatible", "WKErrorContentRuleListStoreVersionMismatch description").createNSString();
 
     case WKErrorContentRuleListStoreCompileFailed:
-        return WEB_UI_STRING("Compiling a WKContentRuleList failed", "WKErrorContentRuleListStoreCompileFailed description");
+        return WEB_UI_STRING("Compiling a WKContentRuleList failed", "WKErrorContentRuleListStoreCompileFailed description").createNSString();
 
     case WKErrorContentRuleListStoreRemoveFailed:
-        return WEB_UI_STRING("Removing a WKContentRuleList failed", "WKErrorContentRuleListStoreRemoveFailed description");
+        return WEB_UI_STRING("Removing a WKContentRuleList failed", "WKErrorContentRuleListStoreRemoveFailed description").createNSString();
 
     case WKErrorAttributedStringContentFailedToLoad:
-        return WEB_UI_STRING("Attributed string content failed to load", "WKErrorAttributedStringContentFailedToLoad description");
+        return WEB_UI_STRING("Attributed string content failed to load", "WKErrorAttributedStringContentFailedToLoad description").createNSString();
 
     case WKErrorAttributedStringContentLoadTimedOut:
-        return WEB_UI_STRING("Timed out while loading attributed string content", "WKErrorAttributedStringContentLoadTimedOut description");
+        return WEB_UI_STRING("Timed out while loading attributed string content", "WKErrorAttributedStringContentLoadTimedOut description").createNSString();
 
     case WKErrorJavaScriptInvalidFrameTarget:
-        return WEB_UI_STRING("JavaScript execution targeted an invalid frame", "WKErrorJavaScriptInvalidFrameTarget description");
+        return WEB_UI_STRING("JavaScript execution targeted an invalid frame", "WKErrorJavaScriptInvalidFrameTarget description").createNSString();
 
     case WKErrorNavigationAppBoundDomain:
-        return WEB_UI_STRING("Attempted to navigate away from an app-bound domain or navigate after using restricted APIs", "WKErrorNavigationAppBoundDomain description");
+        return WEB_UI_STRING("Attempted to navigate away from an app-bound domain or navigate after using restricted APIs", "WKErrorNavigationAppBoundDomain description").createNSString();
 
     case WKErrorJavaScriptAppBoundDomain:
-        return WEB_UI_STRING("JavaScript execution targeted a frame that is not in an app-bound domain", "WKErrorJavaScriptAppBoundDomain description");
+        return WEB_UI_STRING("JavaScript execution targeted a frame that is not in an app-bound domain", "WKErrorJavaScriptAppBoundDomain description").createNSString();
 
     case WKErrorDuplicateCredential:
-        return WEB_UI_STRING("This credential is already present", "WKErrorDuplicateCredential description");
+        return WEB_UI_STRING("This credential is already present", "WKErrorDuplicateCredential description").createNSString();
 
     case WKErrorMalformedCredential:
-        return WEB_UI_STRING("This credential is malformed", "WKErrorMalformedCredential description");
+        return WEB_UI_STRING("This credential is malformed", "WKErrorMalformedCredential description").createNSString();
             
     case WKErrorCredentialNotFound:
-        return WEB_UI_STRING("Credential could not be found", "WKErrorCredentialNotFound description");
+        return WEB_UI_STRING("Credential could not be found", "WKErrorCredentialNotFound description").createNSString();
     }
 }
 
@@ -98,9 +97,9 @@ RetainPtr<NSError> createNSError(WKErrorCode errorCode, NSError* underlyingError
 {
     NSDictionary *userInfo = nil;
     if (underlyingError)
-        userInfo = @{ NSLocalizedDescriptionKey: localizedDescriptionForErrorCode(errorCode), NSUnderlyingErrorKey: underlyingError };
+        userInfo = @{ NSLocalizedDescriptionKey:localizedDescriptionForErrorCode(errorCode).get(), NSUnderlyingErrorKey:underlyingError };
     else
-        userInfo = @{ NSLocalizedDescriptionKey: localizedDescriptionForErrorCode(errorCode) };
+        userInfo = @{ NSLocalizedDescriptionKey:localizedDescriptionForErrorCode(errorCode).get() };
 
     return adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:errorCode userInfo:userInfo]);
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKErrorInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKErrorInternal.h
@@ -28,4 +28,4 @@
 #import <wtf/RetainPtr.h>
 
 RetainPtr<NSError> createNSError(WKErrorCode, NSError* underlyingError = nil);
-NSString *localizedDescriptionForErrorCode(WKErrorCode);
+RetainPtr<NSString> localizedDescriptionForErrorCode(WKErrorCode);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
@@ -129,7 +129,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (NSString *)_title
 {
-    return _frameInfo->title();
+    return _frameInfo->title().createNSString().autorelease();
 }
 
 - (BOOL)_isScrollable

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
@@ -270,7 +270,7 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
     auto& name = _navigationAction->targetFrameName();
     if (name.isNull())
         return nil;
-    return name;
+    return name.createNSString().autorelease();
 }
 
 - (BOOL)_hasOpener

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationData.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationData.mm
@@ -48,7 +48,7 @@
 
 - (NSString *)title
 {
-    return _data->title();
+    return _data->title().createNSString().autorelease();
 }
 
 - (NSURLRequest *)originalRequest

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
@@ -98,7 +98,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (NSString *)_proxyName
 {
-    return _navigationResponse->response().proxyName();
+    return _navigationResponse->response().proxyName().createNSString().autorelease();
 }
 
 - (BOOL)_isFromNetwork

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -540,7 +540,7 @@ static _WKStorageBlockingPolicy toAPI(WebCore::StorageBlockingPolicy policy)
 
 - (NSString *)_fixedPitchFontFamily
 {
-    return _preferences->fixedFontFamily();
+    return _preferences->fixedFontFamily().createNSString().autorelease();
 }
 
 - (void)_setFixedPitchFontFamily:(NSString *)fixedPitchFontFamily
@@ -1003,7 +1003,7 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
 
 - (NSString *)_defaultTextEncodingName
 {
-    return _preferences->defaultTextEncodingName();
+    return _preferences->defaultTextEncodingName().createNSString().autorelease();
 }
 
 - (void)_setAuthorAndUserStylesEnabled:(BOOL)enabled
@@ -1133,7 +1133,7 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
 
 - (NSString *)_standardFontFamily
 {
-    return _preferences->standardFontFamily();
+    return _preferences->standardFontFamily().createNSString().autorelease();
 }
 
 - (void)_setBackspaceKeyNavigationEnabled:(BOOL)enabled

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -334,7 +334,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (NSURL *)_javaScriptConfigurationDirectory
 {
-    return [NSURL fileURLWithPath:_processPool->javaScriptConfigurationDirectory() isDirectory:YES];
+    return [NSURL fileURLWithPath:_processPool->javaScriptConfigurationDirectory().createNSString().get() isDirectory:YES];
 }
 
 - (void)_setJavaScriptConfigurationDirectory:(NSURL *)directory

--- a/Source/WebKit/UIProcess/API/Cocoa/WKSecurityOrigin.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKSecurityOrigin.mm
@@ -52,12 +52,12 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (NSString *)protocol
 {
-    return _securityOrigin->securityOrigin().protocol();
+    return _securityOrigin->securityOrigin().protocol().createNSString().autorelease();
 }
 
 - (NSString *)host
 {
-    return _securityOrigin->securityOrigin().host();
+    return _securityOrigin->securityOrigin().host().createNSString().autorelease();
 }
 
 - (NSInteger)port

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserScript.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserScript.mm
@@ -62,7 +62,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (NSString *)source
 {
-    return _userScript->userScript().source();
+    return _userScript->userScript().source().createNSString().autorelease();
 }
 
 - (WKUserScriptInjectionTime)injectionTime

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.mm
@@ -83,12 +83,12 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionAction, WebExtensionAction, 
 
 - (NSString *)label
 {
-    return self._protectedWebExtensionAction->label();
+    return self._protectedWebExtensionAction->label().createNSString().autorelease();
 }
 
 - (NSString *)badgeText
 {
-    return self._protectedWebExtensionAction->badgeText();
+    return self._protectedWebExtensionAction->badgeText().createNSString().autorelease();
 }
 
 - (BOOL)hasUnreadBadgeText

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm
@@ -84,18 +84,18 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionCommand, WebExtensionCommand
 
 - (NSString *)identifier
 {
-    return _webExtensionCommand->identifier();
+    return _webExtensionCommand->identifier().createNSString().autorelease();
 }
 
 - (NSString *)title
 {
-    return _webExtensionCommand->description();
+    return _webExtensionCommand->description().createNSString().autorelease();
 }
 
 - (NSString *)activationKey
 {
     if (auto& activationKey = self._protectedWebExtensionCommand->activationKey(); !activationKey.isEmpty())
-        return activationKey;
+        return activationKey.createNSString().autorelease();
     return nil;
 }
 
@@ -132,12 +132,12 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionCommand, WebExtensionCommand
 
 - (NSString *)_shortcut
 {
-    return self._protectedWebExtensionCommand->shortcutString();
+    return self._protectedWebExtensionCommand->shortcutString().createNSString().autorelease();
 }
 
 - (NSString *)_userVisibleShortcut
 {
-    return self._protectedWebExtensionCommand->userVisibleShortcut();
+    return self._protectedWebExtensionCommand->userVisibleShortcut().createNSString().autorelease();
 }
 
 - (BOOL)_isActionCommand

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
@@ -131,7 +131,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionContext, WebExtensionContext
 
 - (NSString *)uniqueIdentifier
 {
-    return Ref { *_webExtensionContext }->uniqueIdentifier();
+    return Ref { *_webExtensionContext }->uniqueIdentifier().createNSString().autorelease();
 }
 
 - (void)setUniqueIdentifier:(NSString *)uniqueIdentifier
@@ -199,7 +199,7 @@ static inline NSDictionary<WKWebExtensionPermission, NSDate *> *toAPI(const WebK
     NSMutableDictionary<WKWebExtensionPermission, NSDate *> *result = [NSMutableDictionary dictionaryWithCapacity:permissions.size()];
 
     for (auto& entry : permissions)
-        [result setObject:WebKit::toAPI(entry.value) forKey:entry.key];
+        [result setObject:WebKit::toAPI(entry.value) forKey:entry.key.createNSString().get()];
 
     return [result copy];
 }
@@ -318,7 +318,7 @@ static inline NSSet<WKWebExtensionPermission> *toAPI(const WebKit::WebExtensionC
     NSMutableSet<WKWebExtensionPermission> *result = [NSMutableSet setWithCapacity:permissions.size()];
 
     for (auto& permission : permissions)
-        [result addObject:permission];
+        [result addObject:permission.createNSString().get()];
 
     return [result copy];
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfiguration.mm
@@ -198,7 +198,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionControllerConfiguration, Web
 - (NSString *)_storageDirectoryPath
 {
     if (auto& directory = _webExtensionControllerConfiguration->storageDirectory(); !directory.isEmpty())
-        return directory;
+        return directory.createNSString().autorelease();
     return nil;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataRecord.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataRecord.mm
@@ -54,12 +54,12 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionDataRecord, WebExtensionData
 
 - (NSString *)displayName
 {
-    return _webExtensionDataRecord->displayName();
+    return _webExtensionDataRecord->displayName().createNSString().autorelease();
 }
 
 - (NSString *)uniqueIdentifier
 {
-    return _webExtensionDataRecord->uniqueIdentifier();
+    return _webExtensionDataRecord->uniqueIdentifier().createNSString().autorelease();
 }
 
 - (NSSet<WKWebExtensionDataType> *)containedDataTypes

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.mm
@@ -183,7 +183,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionMatchPattern, WebExtensionMa
     Ref pattern = *_webExtensionMatchPattern;
     if (pattern->scheme().isNull())
         return nil;
-    return pattern->scheme();
+    return pattern->scheme().createNSString().autorelease();
 }
 
 - (NSString *)host
@@ -191,7 +191,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionMatchPattern, WebExtensionMa
     Ref pattern = *_webExtensionMatchPattern;
     if (pattern->host().isNull())
         return nil;
-    return pattern->host();
+    return pattern->host().createNSString().autorelease();
 }
 
 - (NSString *)path
@@ -199,12 +199,12 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionMatchPattern, WebExtensionMa
     Ref pattern = *_webExtensionMatchPattern;
     if (pattern->path().isNull())
         return nil;
-    return pattern->path();
+    return pattern->path().createNSString().autorelease();
 }
 
 - (NSString *)string
 {
-    return self._protectedWebExtensionMatchPattern->string();
+    return self._protectedWebExtensionMatchPattern->string().createNSString().autorelease();
 }
 
 - (BOOL)matchesAllURLs

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePort.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePort.mm
@@ -57,7 +57,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionMessagePort, WebExtensionMes
 - (NSString *)applicationIdentifier
 {
     if (auto& applicationIdentifier = _webExtensionMessagePort->applicationIdentifier(); !applicationIdentifier.isNull())
-        return applicationIdentifier;
+        return applicationIdentifier.createNSString().autorelease();
     return nil;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -231,7 +231,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     [coder encodeBool:self.suppressesIncrementalRendering forKey:@"suppressesIncrementalRendering"];
 
     if (auto& applicationNameForUserAgent = _pageConfiguration->applicationNameForUserAgent())
-        [coder encodeObject:*applicationNameForUserAgent forKey:@"applicationNameForUserAgent"];
+        [coder encodeObject:applicationNameForUserAgent->createNSString().get() forKey:@"applicationNameForUserAgent"];
 
     [coder encodeBool:self.allowsAirPlayForMediaPlayback forKey:@"allowsAirPlayForMediaPlayback"];
 
@@ -1050,7 +1050,7 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
     const auto& schemes = self._protectedPageConfiguration->maskedURLSchemes();
     NSMutableSet<NSString *> *set = [NSMutableSet setWithCapacity:schemes.size()];
     for (const auto& scheme : schemes)
-        [set addObject:scheme];
+        [set addObject:scheme.createNSString().get()];
     return set;
 }
 
@@ -1089,7 +1089,7 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
         return nil;
     NSMutableSet<NSString *> *set = [NSMutableSet setWithCapacity:hosts->size()];
     for (const auto& host : *hosts)
-        [set addObject:host];
+        [set addObject:host.createNSString().get()];
     return set;
 }
 
@@ -1319,7 +1319,7 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 
 - (NSString *)_overrideContentSecurityPolicy
 {
-    return _pageConfiguration->overrideContentSecurityPolicy();
+    return _pageConfiguration->overrideContentSecurityPolicy().createNSString().autorelease();
 }
 
 - (void)_setOverrideContentSecurityPolicy:(NSString *)overrideContentSecurityPolicy
@@ -1329,7 +1329,7 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 
 - (NSString *)_mediaContentTypesRequiringHardwareSupport
 {
-    return _pageConfiguration->mediaContentTypesRequiringHardwareSupport();
+    return _pageConfiguration->mediaContentTypesRequiringHardwareSupport().createNSString().autorelease();
 }
 
 - (void)_setMediaContentTypesRequiringHardwareSupport:(NSString *)mediaContentTypesRequiringHardwareSupport
@@ -1454,7 +1454,7 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 
 - (NSString *)_processDisplayName
 {
-    return _pageConfiguration->processDisplayName();
+    return _pageConfiguration->processDisplayName().createNSString().autorelease();
 }
 
 - (void)_setProcessDisplayName:(NSString *)lsDisplayName
@@ -1492,7 +1492,7 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
     auto& identifier = _pageConfiguration->attributedBundleIdentifier();
     if (!identifier)
         return nil;
-    return identifier;
+    return identifier.createNSString().autorelease();
 }
 
 - (void)_setContentSecurityPolicyModeForExtension:(_WKContentSecurityPolicyModeForExtension)mode

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -95,7 +95,7 @@
 #endif
     }
 
-    return ts.release();
+    return ts.release().createNSString().autorelease();
 }
 
 static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
@@ -233,7 +233,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     }
 
     _page->requestActiveNowPlayingSessionInfo([handler = makeBlockPtr(callback)] (bool registeredAsNowPlayingApplication, WebCore::NowPlayingInfo&& nowPlayingInfo) {
-        handler(nowPlayingInfo.allowsNowPlayingControlsVisibility, registeredAsNowPlayingApplication, nowPlayingInfo.metadata.title, nowPlayingInfo.duration, nowPlayingInfo.currentTime, nowPlayingInfo.uniqueIdentifier ? nowPlayingInfo.uniqueIdentifier->toUInt64() : 0);
+        handler(nowPlayingInfo.allowsNowPlayingControlsVisibility, registeredAsNowPlayingApplication, nowPlayingInfo.metadata.title.createNSString().get(), nowPlayingInfo.duration, nowPlayingInfo.currentTime, nowPlayingInfo.uniqueIdentifier ? nowPlayingInfo.uniqueIdentifier->toUInt64() : 0);
     });
 }
 
@@ -250,10 +250,10 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
     auto nowPlayingMetadataObserver = makeUnique<WebCore::NowPlayingMetadataObserver>([observer = makeBlockPtr(observer)](auto& metadata) {
         RetainPtr nowPlayingMetadata = adoptNS([[_WKNowPlayingMetadata alloc] init]);
-        [nowPlayingMetadata setTitle:metadata.title];
-        [nowPlayingMetadata setArtist:metadata.artist];
-        [nowPlayingMetadata setAlbum:metadata.album];
-        [nowPlayingMetadata setSourceApplicationIdentifier:metadata.sourceApplicationIdentifier];
+        [nowPlayingMetadata setTitle:metadata.title.createNSString().get()];
+        [nowPlayingMetadata setArtist:metadata.artist.createNSString().get()];
+        [nowPlayingMetadata setAlbum:metadata.album.createNSString().get()];
+        [nowPlayingMetadata setSourceApplicationIdentifier:metadata.sourceApplicationIdentifier.createNSString().get()];
         observer(nowPlayingMetadata.get());
     });
 
@@ -272,7 +272,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     if (!coordinator)
         return @"";
 
-    return coordinator->scrollingTreeAsText();
+    return coordinator->scrollingTreeAsText().createNSString().autorelease();
 }
 
 - (pid_t)_networkProcessIdentifier
@@ -461,7 +461,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 {
     if (!_page || !ObjectIdentifier<WebCore::ProcessIdentifierType>::isValidIdentifier(processID) || !ObjectIdentifier<WebCore::ScrollingNodeIDType>::isValidIdentifier(scrollingNodeID))
         return @"";
-    return _page->scrollbarStateForScrollingNodeID(WebCore::ScrollingNodeID(ObjectIdentifier<WebCore::ScrollingNodeIDType>(scrollingNodeID), ObjectIdentifier<WebCore::ProcessIdentifierType>(processID)), isVertical);
+    return _page->scrollbarStateForScrollingNodeID(WebCore::ScrollingNodeID(ObjectIdentifier<WebCore::ScrollingNodeIDType>(scrollingNodeID), ObjectIdentifier<WebCore::ProcessIdentifierType>(processID)), isVertical).createNSString().autorelease();
 }
 
 - (WKWebViewAudioRoutingArbitrationStatus)_audioRoutingArbitrationStatus
@@ -567,7 +567,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
         return completionHandler({ });
 
     pageForTesting->dumpPrivateClickMeasurement([completionHandler = makeBlockPtr(completionHandler)](const String& privateClickMeasurement) {
-        completionHandler(privateClickMeasurement);
+        completionHandler(privateClickMeasurement.createNSString().get());
     });
 }
 
@@ -810,7 +810,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
         void setTrack(const String& track, WebKit::MediaSessionCommandCompletionHandler&& callback) final
         {
-            [m_clientCoordinator setTrack:track withCompletion:makeBlockPtr([weakThis = WeakPtr { *this }, callback = WTFMove(callback)] (BOOL success) mutable {
+            [m_clientCoordinator setTrack:track.createNSString().get() withCompletion:makeBlockPtr([weakThis = WeakPtr { *this }, callback = WTFMove(callback)] (BOOL success) mutable {
                 if (!weakThis) {
                     callback(WebCore::ExceptionData { WebCore::ExceptionCode::InvalidStateError, String() });
                     return;
@@ -857,7 +857,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
         void trackIdentifierChanged(const String& identifier) final
         {
-            [m_clientCoordinator trackIdentifierChanged:identifier];
+            [m_clientCoordinator trackIdentifierChanged:identifier.createNSString().get()];
         }
 
     private:

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -236,8 +236,8 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     for (const auto& pair : _websitePolicies->activeContentRuleListActionPatterns()) {
         NSMutableSet<NSString *> *set = [NSMutableSet set];
         for (const auto& pattern : pair.value)
-            [set addObject:pattern];
-        [dictionary setObject:set forKey:pair.key];
+            [set addObject:pattern.createNSString().get()];
+        [dictionary setObject:set forKey:pair.key.createNSString().get()];
     }
     return dictionary;
 }
@@ -431,7 +431,7 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
 
 - (NSString *)_customUserAgent
 {
-    return _websitePolicies->customUserAgent();
+    return _websitePolicies->customUserAgent().createNSString().autorelease();
 }
 
 - (void)_setCustomUserAgentAsSiteSpecificQuirks:(NSString *)customUserAgent
@@ -441,7 +441,7 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
 
 - (NSString *)_customUserAgentAsSiteSpecificQuirks
 {
-    return _websitePolicies->customUserAgentAsSiteSpecificQuirks();
+    return _websitePolicies->customUserAgentAsSiteSpecificQuirks().createNSString().autorelease();
 }
 
 - (void)_setCustomNavigatorPlatform:(NSString *)customNavigatorPlatform
@@ -451,7 +451,7 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
 
 - (NSString *)_customNavigatorPlatform
 {
-    return _websitePolicies->customNavigatorPlatform();
+    return _websitePolicies->customNavigatorPlatform().createNSString().autorelease();
 }
 
 - (BOOL)_allowSiteSpecificQuirksToOverrideCompatibilityMode
@@ -466,7 +466,7 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
 
 - (NSString *)_applicationNameForUserAgentWithModernCompatibility
 {
-    return _websitePolicies->applicationNameForDesktopUserAgent();
+    return _websitePolicies->applicationNameForDesktopUserAgent().createNSString().autorelease();
 }
 
 - (void)_setApplicationNameForUserAgentWithModernCompatibility:(NSString *)applicationName
@@ -729,7 +729,7 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
         for (auto& selectors : selectorsForElement) {
             RetainPtr nsSelectors = adoptNS([[NSMutableSet alloc] initWithCapacity:selectors.size()]);
             for (auto& selector : selectors)
-                [nsSelectors addObject:selector];
+                [nsSelectors addObject:selector.createNSString().get()];
             [nsSelectorsForElement addObject:nsSelectors.get()];
         }
         [result addObject:nsSelectorsForElement.get()];
@@ -755,7 +755,7 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
         }
 
         for (auto& selector : elementSelectors.first())
-            [selectors addObject:selector];
+            [selectors addObject:selector.createNSString().get()];
     }
     return selectors.autorelease();
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
@@ -135,7 +135,7 @@ static NSString *dataTypesToString(NSSet *dataTypes)
 
 - (NSString *)displayName
 {
-    return _websiteDataRecord->websiteDataRecord().displayName;
+    return _websiteDataRecord->websiteDataRecord().displayName.createNSString().autorelease();
 }
 
 - (NSSet *)dataTypes
@@ -166,8 +166,8 @@ static NSString *dataTypesToString(NSSet *dataTypes)
 
 - (NSArray<NSString *> *)_originsStrings
 {
-    return createNSArray(_websiteDataRecord->websiteDataRecord().origins, [] (auto& origin) -> NSString * {
-        return origin.toString();
+    return createNSArray(_websiteDataRecord->websiteDataRecord().origins, [] (auto& origin) {
+        return origin.toString().createNSString();
     }).autorelease();
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
@@ -120,10 +120,10 @@ static std::optional<WebCore::ApplicationManifest::Shortcut> makeVectorElement(c
 
     if (icon) {
         _src = icon->src.createNSURL();
-        _sizes = createNSArray(icon->sizes, [] (auto& size) -> NSString * {
-            return size;
+        _sizes = createNSArray(icon->sizes, [] (auto& size) {
+            return size.createNSString();
         });
-        _type = adoptNS([icon->type copy]);
+        _type = icon->type.createNSString();
         _purposes = fromPurposes(icon->purposes);
     }
 
@@ -212,7 +212,7 @@ static std::optional<WebCore::ApplicationManifest::Shortcut> makeVectorElement(c
         return nil;
 
     if (shortcut) {
-        _name = adoptNS([shortcut->name copy]);
+        _name = shortcut->name.createNSString();
         _url = shortcut->url.createNSURL();
         _icons = createNSArray(shortcut->icons, [] (auto& icon) {
             return adoptNS([[_WKApplicationManifestIcon alloc] initWithCoreIcon:&icon]);
@@ -476,8 +476,8 @@ static RetainPtr<NSString> nullableNSString(const WTF::String& string)
 
 - (NSArray<NSString *> *)categories
 {
-    return createNSArray(_applicationManifest->applicationManifest().categories, [] (auto& category) -> NSString * {
-        return category;
+    return createNSArray(_applicationManifest->applicationManifest().categories, [] (auto& category) {
+        return category.createNSString();
     }).autorelease();
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAttachment.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAttachment.mm
@@ -58,9 +58,9 @@ static const NSInteger InvalidAttachmentErrorCode = 2;
         return nil;
 
     _attachment = &attachment;
-    _filePath = attachment.filePath();
-    _mimeType = attachment.mimeType();
-    _utiType = attachment.utiType();
+    _filePath = attachment.filePath().createNSString();
+    _mimeType = attachment.mimeType().createNSString();
+    _utiType = attachment.utiType().createNSString();
     return self;
 }
 
@@ -180,7 +180,7 @@ static const NSInteger InvalidAttachmentErrorCode = 2;
 
 - (NSString *)uniqueIdentifier
 {
-    return _attachment->identifier();
+    return _attachment->identifier().createNSString().autorelease();
 }
 
 - (NSString *)description

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSession.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSession.mm
@@ -81,7 +81,7 @@
 
 - (NSString *)sessionIdentifier
 {
-    return _session->sessionIdentifier();
+    return _session->sessionIdentifier().createNSString().autorelease();
 }
 
 - (void)setSessionIdentifier:(NSString *)sessionIdentifier

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKCustomHeaderFields.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKCustomHeaderFields.mm
@@ -55,7 +55,7 @@
     auto& vector = _fields->fields();
     NSMutableDictionary<NSString *, NSString *> *dictionary = [NSMutableDictionary dictionaryWithCapacity:vector.size()];
     for (auto& field : vector)
-        [dictionary setObject:field.value() forKey:field.name()];
+        [dictionary setObject:field.value().createNSString().get() forKey:field.name().createNSString().get()];
     return dictionary;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKFeature.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKFeature.mm
@@ -49,7 +49,7 @@
 
 - (NSString *)name
 {
-    return _wrappedFeature->name();
+    return _wrappedFeature->name().createNSString().autorelease();
 }
 
 - (WebFeatureStatus)status
@@ -108,12 +108,12 @@
 
 - (NSString *)key
 {
-    return _wrappedFeature->key();
+    return _wrappedFeature->key().createNSString().autorelease();
 }
 
 - (NSString *)details
 {
-    return _wrappedFeature->details();
+    return _wrappedFeature->details().createNSString().autorelease();
 }
 
 - (BOOL)defaultValue

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm
@@ -69,7 +69,7 @@ private:
         if (!m_delegate || !m_respondsToInspectorOpenURLExternally)
             return;
 
-        [m_delegate inspector:wrapper(inspector) openURLExternally:[NSURL URLWithString:url]];
+        [m_delegate inspector:wrapper(inspector) openURLExternally:adoptNS([[NSURL alloc] initWithString:url.createNSString().get()]).get()];
     }
 
     void frontendLoaded(WebKit::WebInspectorUIProxy& inspector) final
@@ -239,20 +239,20 @@ private:
 #if ENABLE(INSPECTOR_EXTENSIONS)
     // It is an error to call this method prior to creating a frontend (i.e., with -connect or -show).
     if (!_inspector->extensionController()) {
-        completionHandler([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(Inspector::ExtensionError::InvalidRequest)}], nil);
+        completionHandler(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(Inspector::ExtensionError::InvalidRequest).createNSString().get() }]).get(), nil);
         return;
     }
 
     _inspector->extensionController()->registerExtension(extensionID, extensionBundleIdentifier, displayName, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (Expected<RefPtr<API::InspectorExtension>, Inspector::ExtensionError> result) mutable {
         if (!result) {
-            capturedBlock([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error())}], nil);
+            capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()).createNSString().get() }]).get(), nil);
             return;
         }
 
         capturedBlock(nil, wrapper(result.value()));
     });
 #else
-    completionHandler([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:nil], nil);
+    completionHandler(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:nil]).get(), nil);
 #endif
 }
 
@@ -261,20 +261,20 @@ private:
 #if ENABLE(INSPECTOR_EXTENSIONS)
     // It is an error to call this method prior to creating a frontend (i.e., with -connect or -show).
     if (!_inspector->extensionController()) {
-        completionHandler([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(Inspector::ExtensionError::InvalidRequest)}]);
+        completionHandler(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(Inspector::ExtensionError::InvalidRequest).createNSString().get() }]).get());
         return;
     }
 
     _inspector->extensionController()->unregisterExtension(extension.extensionID, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (Expected<void, Inspector::ExtensionError> result) mutable {
         if (!result) {
-            capturedBlock([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error())}]);
+            capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()).createNSString().get() }]).get());
             return;
         }
 
         capturedBlock(nil);
     });
 #else
-    completionHandler([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:nil]);
+    completionHandler(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:nil]).get());
 #endif
 }
 
@@ -283,13 +283,13 @@ private:
 #if ENABLE(INSPECTOR_EXTENSIONS)
     // It is an error to call this method prior to creating a frontend (i.e., with -connect or -show).
     if (!_inspector->extensionController()) {
-        completionHandler([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(Inspector::ExtensionError::InvalidRequest)}]);
+        completionHandler(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(Inspector::ExtensionError::InvalidRequest).createNSString().get() }]).get());
         return;
     }
 
     _inspector->extensionController()->showExtensionTab(extensionTabIdentifier, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (Expected<void, Inspector::ExtensionError>&& result) mutable {
         if (!result) {
-            capturedBlock([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error())}]);
+            capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()).createNSString().get() }]).get());
             return;
         }
 
@@ -303,13 +303,13 @@ private:
 #if ENABLE(INSPECTOR_EXTENSIONS)
     // It is an error to call this method prior to creating a frontend (i.e., with -connect or -show).
     if (!_inspector->extensionController()) {
-        completionHandler([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(Inspector::ExtensionError::InvalidRequest) }]);
+        completionHandler(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(Inspector::ExtensionError::InvalidRequest).createNSString().get() }]).get());
         return;
     }
 
     _inspector->extensionController()->navigateTabForExtension(extensionTabIdentifier, url, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (const std::optional<Inspector::ExtensionError>&& result) mutable {
         if (result) {
-            capturedBlock([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.value()) }]);
+            capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.value()).createNSString().get() }]).get());
             return;
         }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.mm
@@ -75,7 +75,7 @@
 {
     for (auto pair : _configuration->urlSchemeHandlers()) {
         auto& handler = downcast<WebKit::WebURLSchemeHandlerCocoa>(pair.first.get());
-        [configuration setURLSchemeHandler:handler.apiHandler() forURLScheme:pair.second];
+        [configuration setURLSchemeHandler:handler.apiHandler() forURLScheme:pair.second.createNSString().get()];
     }
 
     if (auto* processPool = self.processPool)
@@ -91,7 +91,7 @@
 
     for (auto pair : _configuration->urlSchemeHandlers()) {
         auto& handler = downcast<WebKit::WebURLSchemeHandlerCocoa>(pair.first.get());
-        [configuration setURLSchemeHandler:handler.apiHandler() forURLScheme:pair.second];
+        [configuration setURLSchemeHandler:handler.apiHandler() forURLScheme:pair.second.createNSString().get()];
     }
 
     if (auto* processPool = self.processPool)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorDebuggableInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorDebuggableInfo.mm
@@ -52,7 +52,7 @@
 
 - (NSString *)targetPlatformName
 {
-    return _debuggableInfo->targetPlatformName();
+    return _debuggableInfo->targetPlatformName().createNSString().autorelease();
 }
 
 - (void)setTargetPlatformName:(NSString *)targetPlatformName
@@ -62,7 +62,7 @@
 
 - (NSString *)targetBuildVersion
 {
-    return _debuggableInfo->targetBuildVersion();
+    return _debuggableInfo->targetBuildVersion().createNSString().autorelease();
 }
 
 - (void)setTargetBuildVersion:(NSString *)targetBuildVersion
@@ -72,7 +72,7 @@
 
 - (NSString *)targetProductVersion
 {
-    return _debuggableInfo->targetProductVersion();
+    return _debuggableInfo->targetProductVersion().createNSString().autorelease();
 }
 
 - (void)setTargetProductVersion:(NSString *)targetProductVersion

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm
@@ -75,11 +75,11 @@
 {
     _extension->createTab(tabName, { tabIconURL.baseURL, tabIconURL.relativeString }, { tabIconURL.baseURL, sourceURL.relativeString }, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (Expected<Inspector::ExtensionTabID, Inspector::ExtensionError> result) mutable {
         if (!result) {
-            capturedBlock([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error())}], nil);
+            capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()).createNSString().get() }]).get(), nil);
             return;
         }
 
-        capturedBlock(nil, result.value());
+        capturedBlock(nil, result.value().createNSString().get());
     });
 }
 
@@ -89,7 +89,7 @@
     std::optional<URL> optionalContextSecurityOrigin = contextSecurityOrigin ? std::make_optional(URL(contextSecurityOrigin)) : std::nullopt;
     _extension->evaluateScript(scriptSource, optionalFrameURL, optionalContextSecurityOrigin, useContentScriptContext, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(WTFMove(completionHandler))] (Inspector::ExtensionEvaluationResult&& result) mutable {
         if (!result) {
-            capturedBlock([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error())}], nil);
+            capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()).createNSString().get() }]).get(), nil);
             return;
         }
         
@@ -107,7 +107,7 @@
 {
     _extension->evaluateScriptInExtensionTab(extensionTabIdentifier, scriptSource, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(WTFMove(completionHandler))] (Inspector::ExtensionEvaluationResult&& result) mutable {
         if (!result) {
-            capturedBlock([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()) }], nil);
+            capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()).createNSString().get() }]).get(), nil);
             return;
         }
         
@@ -125,7 +125,7 @@
 {
     _extension->navigateTab(extensionTabIdentifier, url, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(WTFMove(completionHandler))] (const std::optional<Inspector::ExtensionError> result) mutable {
         if (result) {
-            capturedBlock([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.value()) }]);
+            capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.value()).createNSString().get() }]).get());
             return;
         }
 
@@ -139,7 +139,7 @@
     std::optional<String> optionalInjectedScript = injectedScript ? std::make_optional(String(injectedScript)) : std::nullopt;
     _extension->reloadIgnoringCache(ignoreCache, optionalUserAgent, optionalInjectedScript, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(WTFMove(completionHandler))] (Inspector::ExtensionVoidResult&& result) mutable {
         if (!result) {
-            capturedBlock([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()) }]);
+            capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()).createNSString().get() }]).get());
             return;
         }
 
@@ -151,7 +151,7 @@
 
 - (NSString *)extensionID
 {
-    return _extension->identifier();
+    return _extension->identifier().createNSString().autorelease();
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKLinkIconParameters.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKLinkIconParameters.mm
@@ -61,7 +61,7 @@
 
     _attributes = adoptNS([[NSMutableDictionary alloc] initWithCapacity:linkIcon.attributes.size()]);
     for (auto& attributePair : linkIcon.attributes)
-        _attributes.get()[attributePair.first.createNSString().get()] = attributePair.second;
+        _attributes.get()[attributePair.first.createNSString().get()] = attributePair.second.createNSString().get();
 
     return self;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
@@ -56,7 +56,7 @@
 
 - (NSURL *)injectedBundleURL
 {
-    return [NSURL fileURLWithPath:_processPoolConfiguration->injectedBundlePath()];
+    return [NSURL fileURLWithPath:_processPoolConfiguration->injectedBundlePath().createNSString().get()];
 }
 
 - (void)setInjectedBundleURL:(NSURL *)injectedBundleURL
@@ -369,7 +369,7 @@
 
 - (NSString *)timeZoneOverride
 {
-    return _processPoolConfiguration->timeZoneOverride();
+    return _processPoolConfiguration->timeZoneOverride().createNSString().autorelease();
 }
 
 - (void)setTimeZoneOverride:(NSString *)timeZone

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
@@ -69,7 +69,7 @@ public:
 
     void sendMessageToBackend(const String& message) override
     {
-        [m_controller sendMessageToBackend:message];
+        [m_controller sendMessageToBackend:message.createNSString().get()];
     }
 
     void closeFromFrontend() override
@@ -178,20 +178,20 @@ private:
 #if ENABLE(INSPECTOR_EXTENSIONS)
     // If this method is called prior to creating a frontend with -loadForDebuggable:backendCommandsURL:, it will not succeed.
     if (!m_remoteInspectorProxy->extensionController()) {
-        completionHandler([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(Inspector::ExtensionError::InvalidRequest) }], nil);
+        completionHandler(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(Inspector::ExtensionError::InvalidRequest).createNSString().get() }]).get(), nil);
         return;
     }
 
     m_remoteInspectorProxy->extensionController()->registerExtension(extensionID, extensionBundleIdentifier, displayName, [protectedExtensionID = retainPtr(extensionID), protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (Expected<RefPtr<API::InspectorExtension>, Inspector::ExtensionError> result) mutable {
         if (!result) {
-            capturedBlock([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()) }], nil);
+            capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()).createNSString().get() }]).get(), nil);
             return;
         }
 
         capturedBlock(nil, wrapper(result.value()));
     });
 #else
-    completionHandler([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:nil], nil);
+    completionHandler(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:nil]).get(), nil);
 #endif
 }
 
@@ -200,19 +200,19 @@ private:
 #if ENABLE(INSPECTOR_EXTENSIONS)
     // If this method is called prior to creating a frontend with -loadForDebuggable:backendCommandsURL:, it will not succeed.
     if (!m_remoteInspectorProxy->extensionController()) {
-        completionHandler([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(Inspector::ExtensionError::InvalidRequest) }]);
+        completionHandler(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(Inspector::ExtensionError::InvalidRequest).createNSString().get() }]).get());
         return;
     }
     m_remoteInspectorProxy->extensionController()->unregisterExtension(extension.extensionID, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (Expected<void, Inspector::ExtensionError> result) mutable {
         if (!result) {
-            capturedBlock([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()) }]);
+            capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()).createNSString().get() }]).get());
             return;
         }
 
         capturedBlock(nil);
     });
 #else
-    completionHandler([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:nil]);
+    completionHandler(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:nil]).get());
 #endif
 }
 
@@ -231,13 +231,13 @@ private:
 #if ENABLE(INSPECTOR_EXTENSIONS)
     // It is an error to call this method prior to creating a frontend (i.e., with -connect or -show).
     if (!m_remoteInspectorProxy->extensionController()) {
-        completionHandler([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(Inspector::ExtensionError::InvalidRequest)}]);
+        completionHandler(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(Inspector::ExtensionError::InvalidRequest).createNSString().get() }]).get());
         return;
     }
 
     m_remoteInspectorProxy->extensionController()->showExtensionTab(extensionTabIdentifier, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (Expected<void, Inspector::ExtensionError>&& result) mutable {
         if (!result) {
-            capturedBlock([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error())}]);
+            capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()).createNSString().get() }]).get());
             return;
         }
 
@@ -251,13 +251,13 @@ private:
 #if ENABLE(INSPECTOR_EXTENSIONS)
     // It is an error to call this method prior to creating a frontend (i.e., with -connect or -show).
     if (!m_remoteInspectorProxy->extensionController()) {
-        completionHandler([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(Inspector::ExtensionError::InvalidRequest) }]);
+        completionHandler(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(Inspector::ExtensionError::InvalidRequest).createNSString().get() }]).get());
         return;
     }
 
     m_remoteInspectorProxy->extensionController()->navigateTabForExtension(extensionTabIdentifier, url, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (const std::optional<Inspector::ExtensionError> result) mutable {
         if (result) {
-            capturedBlock([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.value()) }]);
+            capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.value()).createNSString().get() }]).get());
             return;
         }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.mm
@@ -117,7 +117,7 @@ static _WKResourceLoadInfoResourceType toWKResourceLoadInfoResourceType(WebKit::
 
 - (NSString *)originalHTTPMethod
 {
-    return _info->originalHTTPMethod();
+    return _info->originalHTTPMethod().createNSString().autorelease();
 }
 
 - (NSDate *)eventTimestamp

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadStatisticsFirstParty.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadStatisticsFirstParty.mm
@@ -40,7 +40,7 @@
 
 - (NSString *)firstPartyDomain
 {
-    return _firstParty->firstPartyDomain();
+    return _firstParty->firstPartyDomain().createNSString().autorelease();
 }
 
 - (BOOL)storageAccess

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadStatisticsThirdParty.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadStatisticsThirdParty.mm
@@ -42,7 +42,7 @@
 
 - (NSString *)thirdPartyDomain
 {
-    return _thirdParty->thirdPartyDomain();
+    return _thirdParty->thirdPartyDomain().createNSString().autorelease();
 }
 
 - (NSArray<_WKResourceLoadStatisticsFirstParty *> *)underFirstParties

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
@@ -99,7 +99,7 @@
     for (auto& selectors : _info->selectors()) {
         RetainPtr nsSelectors = adoptNS([[NSMutableArray alloc] initWithCapacity:selectors.size()]);
         for (auto& selector : selectors)
-            [nsSelectors addObject:selector];
+            [nsSelectors addObject:selector.createNSString().get()];
         [result addObject:nsSelectors.get()];
     }
     return result.autorelease();
@@ -107,17 +107,17 @@
 
 - (NSString *)renderedText
 {
-    return _info->renderedText();
+    return _info->renderedText().createNSString().autorelease();
 }
 
 - (NSString *)searchableText
 {
-    return _info->searchableText();
+    return _info->searchableText().createNSString().autorelease();
 }
 
 - (NSString *)screenReaderText
 {
-    return _info->screenReaderText();
+    return _info->screenReaderText().createNSString().autorelease();
 }
 
 - (_WKRectEdge)offsetEdges

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextRun.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextRun.mm
@@ -46,7 +46,7 @@
 
 - (NSString *)text
 {
-    return _textRun->string();
+    return _textRun->string().createNSString().autorelease();
 }
 
 - (CGRect)rectInWebView

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm
@@ -73,7 +73,7 @@
 
 - (NSString *)source
 {
-    return _userStyleSheet->userStyleSheet().source();
+    return _userStyleSheet->userStyleSheet().source().createNSString().autorelease();
 }
 
 - (NSURL *)baseURL

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm
@@ -45,12 +45,12 @@
 
 - (NSString *)name
 {
-    return _response->name();
+    return _response->name().createNSString().autorelease();
 }
 
 - (NSString *)displayName
 {
-    return _response->displayName();
+    return _response->displayName().createNSString().autorelease();
 }
 
 - (NSData *)userHandle
@@ -65,7 +65,7 @@
 
 - (NSString *)group
 {
-    return _response->group();
+    return _response->group().createNSString().autorelease();
 }
 
 - (NSData *)credentialID
@@ -75,7 +75,7 @@
 
 - (NSString *)accessGroup
 {
-    return _response->accessGroup();
+    return _response->accessGroup().createNSString().autorelease();
 }
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -170,7 +170,7 @@ NSString * const _WKLocalAuthenticatorCredentialLastUsedDateKey = @"_WKLocalAuth
 
 - (NSString *)relyingPartyID
 {
-    return _panel->rpId();
+    return _panel->rpId().createNSString().autorelease();
 }
 
 static _WKWebAuthenticationTransport wkWebAuthenticationTransport(WebCore::AuthenticatorTransport transport)
@@ -240,7 +240,7 @@ static fido::AuthenticatorSupportedOptions::UserVerificationAvailability coreUse
 
 - (NSString *)userName
 {
-    return _panel->userName();
+    return _panel->userName().createNSString().autorelease();
 }
 
 #else // ENABLE(WEB_AUTHN)
@@ -306,7 +306,7 @@ static RetainPtr<NSArray> getAllLocalAuthenticatorCredentialsImpl(NSString *acce
         if (!credentialID)
             credentialID = attributes[bridge_cast(kSecAttrApplicationLabel)];
         auto credential = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:
-            username, _WKLocalAuthenticatorCredentialNameKey,
+            username.createNSString().get(), _WKLocalAuthenticatorCredentialNameKey,
             credentialID, _WKLocalAuthenticatorCredentialIDKey,
             attributes[bridge_cast(kSecAttrLabel)], _WKLocalAuthenticatorCredentialRelyingPartyIDKey,
             attributes[bridge_cast(kSecAttrModificationDate)], _WKLocalAuthenticatorCredentialLastModificationDateKey,
@@ -324,7 +324,7 @@ static RetainPtr<NSArray> getAllLocalAuthenticatorCredentialsImpl(NSString *acce
 
         it = responseMap.find(cbor::CBORValue(fido::kDisplayNameMapKey));
         if (it != responseMap.end() && it->second.isString())
-            [credential setObject:it->second.getString() forKey:_WKLocalAuthenticatorCredentialDisplayNameKey];
+            [credential setObject:it->second.getString().createNSString().get() forKey:_WKLocalAuthenticatorCredentialDisplayNameKey];
 
         [result addObject:credential.get()];
     }
@@ -661,7 +661,7 @@ static void createNSErrorFromWKErrorIfNecessary(NSError **error, WKErrorCode err
     BOOL useAlternateKeychainAttribute = WebKit::shouldUseAlternateKeychainAttribute();
     auto query = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:
         (id)kSecClassKey, (id)kSecClass,
-        (id)rp, (id)kSecAttrLabel,
+        (id)rp.createNSString().get(), (id)kSecAttrLabel,
         @YES, (id)kSecUseDataProtectionKeychain,
         nil
     ]);
@@ -691,7 +691,7 @@ static void createNSErrorFromWKErrorIfNecessary(NSError **error, WKErrorCode err
     auto addQuery = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:
         (id)key.get(), (id)kSecValueRef,
         (id)kSecAttrKeyClassPrivate, (id)kSecAttrKeyClass,
-        (id)rp, (id)kSecAttrLabel,
+        (id)rp.createNSString().get(), (id)kSecAttrLabel,
         secAttrApplicationTag.get(), (id)kSecAttrApplicationTag,
         @YES, (id)kSecUseDataProtectionKeychain,
         (id)kSecAttrAccessibleAfterFirstUnlock, (id)kSecAttrAccessible,
@@ -1033,7 +1033,7 @@ static RetainPtr<_WKAuthenticatorAttestationResponse> wkAuthenticatorAttestation
         WTF::switchOn(result, [&](const Ref<WebCore::AuthenticatorResponse>& response) {
             handler(wkAuthenticatorAttestationResponse(response->data(), clientDataJSON.get(), response->attachment()).get(), nil);
         }, [&](const WebCore::ExceptionData& exception) {
-            handler(nil, [NSError errorWithDomain:WKErrorDomain code:static_cast<NSInteger>(exception.code) userInfo:@{ NSLocalizedDescriptionKey: exception.message }]);
+            handler(nil, adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:static_cast<NSInteger>(exception.code) userInfo:@{ NSLocalizedDescriptionKey: exception.message.createNSString().get() }]).get());
         });
     };
     _panel->handleRequest({ WTFMove(hash), [_WKWebAuthenticationPanel convertToCoreCreationOptionsWithOptions:options], nullptr, WebKit::WebAuthenticationPanelResult::Unavailable, nullptr, std::nullopt, { }, String(), nullptr, std::nullopt, std::nullopt }, WTFMove(callback));
@@ -1047,7 +1047,7 @@ static RetainPtr<_WKAuthenticatorAttestationResponse> wkAuthenticatorAttestation
         WTF::switchOn(result, [&](const Ref<WebCore::AuthenticatorResponse>& response) {
             handler(wkAuthenticatorAttestationResponse(response->data(), nullptr, response->attachment()).get(), nil);
         }, [&](const WebCore::ExceptionData& exception) {
-            handler(nil, [NSError errorWithDomain:WKErrorDomain code:static_cast<NSInteger>(exception.code) userInfo:@{ NSLocalizedDescriptionKey: exception.message }]);
+            handler(nil, adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:static_cast<NSInteger>(exception.code) userInfo:@{ NSLocalizedDescriptionKey: exception.message.createNSString().get() }]).get());
         });
     };
     _panel->handleRequest({ makeVector(clientDataHash), [_WKWebAuthenticationPanel convertToCoreCreationOptionsWithOptions:options], nullptr, WebKit::WebAuthenticationPanelResult::Unavailable, nullptr, std::nullopt, { }, String(), nullptr, toWebCore(mediation), std::nullopt }, WTFMove(callback));
@@ -1101,7 +1101,7 @@ static RetainPtr<_WKAuthenticatorAssertionResponse> wkAuthenticatorAssertionResp
         WTF::switchOn(result, [&](const Ref<WebCore::AuthenticatorResponse>& response) {
             handler(wkAuthenticatorAssertionResponse(response->data(), clientDataJSON.get(), response->attachment()).get(), nil);
         }, [&](const WebCore::ExceptionData& exception) {
-            handler(nil, [NSError errorWithDomain:WKErrorDomain code:static_cast<NSInteger>(exception.code) userInfo:@{ NSLocalizedDescriptionKey: exception.message }]);
+            handler(nil, adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:static_cast<NSInteger>(exception.code) userInfo:@{ NSLocalizedDescriptionKey: exception.message.createNSString().get() }]).get());
         });
     };
     _panel->handleRequest({ WTFMove(hash), [_WKWebAuthenticationPanel convertToCoreRequestOptionsWithOptions:options], nullptr, WebKit::WebAuthenticationPanelResult::Unavailable, nullptr, std::nullopt, { }, String(), nullptr, std::nullopt, std::nullopt }, WTFMove(callback));
@@ -1115,7 +1115,7 @@ static RetainPtr<_WKAuthenticatorAssertionResponse> wkAuthenticatorAssertionResp
         WTF::switchOn(result, [&](const Ref<WebCore::AuthenticatorResponse>& response) {
             handler(wkAuthenticatorAssertionResponse(response->data(), nullptr, response->attachment()).get(), nil);
         }, [&](const WebCore::ExceptionData& exception) {
-            handler(nil, [NSError errorWithDomain:WKErrorDomain code:static_cast<NSInteger>(exception.code) userInfo:@{ NSLocalizedDescriptionKey: exception.message }]);
+            handler(nil, adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:static_cast<NSInteger>(exception.code) userInfo:@{ NSLocalizedDescriptionKey: exception.message.createNSString().get() }]).get());
         });
     };
     _panel->handleRequest({ makeVector(clientDataHash), [_WKWebAuthenticationPanel convertToCoreRequestOptionsWithOptions:options], nullptr, WebKit::WebAuthenticationPanelResult::Unavailable, nullptr, std::nullopt, { }, String(), nullptr, toWebCore(mediation), std::nullopt }, WTFMove(callback));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.mm
@@ -128,8 +128,8 @@ static _WKWebPushPermissionState toWKPermissionsState(WebCore::PushPermissionSta
             return completionHandlerCopy(wrapper(API::WebPushSubscriptionData::create(WTFMove(result.value()))).get(), nil);
 
         // FIXME: This error can be used to create DOMException; we may consider adding a new value to WKErrorCode for it.
-        auto error = [NSError errorWithDomain:@"WKErrorDomain" code:WKErrorUnknown userInfo:@{ NSLocalizedDescriptionKey:result.error().message }];
-        completionHandlerCopy(nil, error);
+        RetainPtr error = adoptNS([[NSError alloc] initWithDomain:@"WKErrorDomain" code:WKErrorUnknown userInfo:@{ NSLocalizedDescriptionKey:result.error().message.createNSString().get() }]);
+        completionHandlerCopy(nil, error.get());
     });
 }
 
@@ -139,8 +139,8 @@ static _WKWebPushPermissionState toWKPermissionsState(WebCore::PushPermissionSta
         if (result)
             return completionHandlerCopy(result.value(), nil);
 
-        auto error = [NSError errorWithDomain:@"WKErrorDomain" code:WKErrorUnknown userInfo:@{ NSLocalizedDescriptionKey:result.error().message }];
-        completionHandlerCopy(false, error);
+        RetainPtr error = adoptNS([[NSError alloc] initWithDomain:@"WKErrorDomain" code:WKErrorUnknown userInfo:@{ NSLocalizedDescriptionKey:result.error().message.createNSString().get() }]);
+        completionHandlerCopy(false, error.get());
     });
 }
 
@@ -154,8 +154,8 @@ static _WKWebPushPermissionState toWKPermissionsState(WebCore::PushPermissionSta
             return completionHandlerCopy(nil, nil);
         }
 
-        auto error = [NSError errorWithDomain:@"WKErrorDomain" code:WKErrorUnknown userInfo:@{ NSLocalizedDescriptionKey:result.error().message }];
-        completionHandlerCopy(nil, error);
+        RetainPtr error = adoptNS([[NSError alloc] initWithDomain:@"WKErrorDomain" code:WKErrorUnknown userInfo:@{ NSLocalizedDescriptionKey:result.error().message.createNSString().get() }]);
+        completionHandlerCopy(nil, error.get());
     });
 }
 
@@ -188,8 +188,8 @@ static _WKWebPushPermissionState toWKPermissionsState(WebCore::PushPermissionSta
             return completionHandlerCopy(nsResult, nil);
         }
 
-        auto error = [NSError errorWithDomain:@"WKErrorDomain" code:WKErrorUnknown userInfo:@{ NSLocalizedDescriptionKey:result.error().message }];
-        completionHandlerCopy(nil, error);
+        RetainPtr error = adoptNS([[NSError alloc] initWithDomain:@"WKErrorDomain" code:WKErrorUnknown userInfo:@{ NSLocalizedDescriptionKey:result.error().message.createNSString().get() }]);
+        completionHandlerCopy(nil, error.get());
     });
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushMessage.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushMessage.mm
@@ -55,7 +55,7 @@
 
 - (NSString *)partition
 {
-    return _message->partition();
+    return _message->partition().createNSString().autorelease();
 }
 
 - (API::Object&)_apiObject

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
@@ -108,7 +108,7 @@ static void checkURLArgument(NSURL *url)
 
 - (NSURL *)_webStorageDirectory
 {
-    return [NSURL fileURLWithPath:_configuration->localStorageDirectory() isDirectory:YES];
+    return [NSURL fileURLWithPath:_configuration->localStorageDirectory().createNSString().get() isDirectory:YES];
 }
 
 - (void)_setWebStorageDirectory:(NSURL *)url
@@ -125,7 +125,7 @@ static void checkURLArgument(NSURL *url)
 
 - (NSURL *)_indexedDBDatabaseDirectory
 {
-    return [NSURL fileURLWithPath:_configuration->indexedDBDatabaseDirectory() isDirectory:YES];
+    return [NSURL fileURLWithPath:_configuration->indexedDBDatabaseDirectory().createNSString().get() isDirectory:YES];
 }
 
 - (void)_setIndexedDBDatabaseDirectory:(NSURL *)url
@@ -142,7 +142,7 @@ static void checkURLArgument(NSURL *url)
 
 - (NSURL *)networkCacheDirectory
 {
-    return [NSURL fileURLWithPath:_configuration->networkCacheDirectory() isDirectory:YES];
+    return [NSURL fileURLWithPath:_configuration->networkCacheDirectory().createNSString().get() isDirectory:YES];
 }
 
 - (void)setNetworkCacheDirectory:(NSURL *)url
@@ -159,7 +159,7 @@ static void checkURLArgument(NSURL *url)
 
 - (NSURL *)deviceIdHashSaltsStorageDirectory
 {
-    return [NSURL fileURLWithPath:_configuration->deviceIdHashSaltsStorageDirectory() isDirectory:YES];
+    return [NSURL fileURLWithPath:_configuration->deviceIdHashSaltsStorageDirectory().createNSString().get() isDirectory:YES];
 }
 
 - (void)setDeviceIdHashSaltsStorageDirectory:(NSURL *)url
@@ -176,7 +176,7 @@ static void checkURLArgument(NSURL *url)
 
 - (NSURL *)_webSQLDatabaseDirectory
 {
-    return [NSURL fileURLWithPath:_configuration->webSQLDatabaseDirectory() isDirectory:YES];
+    return [NSURL fileURLWithPath:_configuration->webSQLDatabaseDirectory().createNSString().get() isDirectory:YES];
 }
 
 - (void)_setWebSQLDatabaseDirectory:(NSURL *)url
@@ -213,7 +213,7 @@ static void checkURLArgument(NSURL *url)
 
 - (NSURL *)_cookieStorageFile
 {
-    return [NSURL fileURLWithPath:_configuration->cookieStorageFile() isDirectory:NO];
+    return [NSURL fileURLWithPath:_configuration->cookieStorageFile().createNSString().get() isDirectory:NO];
 }
 
 - (void)_setCookieStorageFile:(NSURL *)url
@@ -233,7 +233,7 @@ static void checkURLArgument(NSURL *url)
 
 - (NSURL *)_resourceLoadStatisticsDirectory
 {
-    return [NSURL fileURLWithPath:_configuration->resourceLoadStatisticsDirectory() isDirectory:YES];
+    return [NSURL fileURLWithPath:_configuration->resourceLoadStatisticsDirectory().createNSString().get() isDirectory:YES];
 }
 
 - (void)_setResourceLoadStatisticsDirectory:(NSURL *)url
@@ -250,7 +250,7 @@ static void checkURLArgument(NSURL *url)
 
 - (NSURL *)_cacheStorageDirectory
 {
-    return [NSURL fileURLWithPath:_configuration->cacheStorageDirectory() isDirectory:YES];
+    return [NSURL fileURLWithPath:_configuration->cacheStorageDirectory().createNSString().get() isDirectory:YES];
 }
 
 - (void)_setCacheStorageDirectory:(NSURL *)url
@@ -267,7 +267,7 @@ static void checkURLArgument(NSURL *url)
 
 - (NSURL *)_serviceWorkerRegistrationDirectory
 {
-    return [NSURL fileURLWithPath:_configuration->serviceWorkerRegistrationDirectory() isDirectory:YES];
+    return [NSURL fileURLWithPath:_configuration->serviceWorkerRegistrationDirectory().createNSString().get() isDirectory:YES];
 }
 
 - (void)_setServiceWorkerRegistrationDirectory:(NSURL *)url
@@ -299,12 +299,12 @@ static void checkURLArgument(NSURL *url)
 
 - (NSString *)sourceApplicationBundleIdentifier
 {
-    return _configuration->sourceApplicationBundleIdentifier();
+    return _configuration->sourceApplicationBundleIdentifier().createNSString().autorelease();
 }
 
 - (NSString *)sourceApplicationSecondaryIdentifier
 {
-    return _configuration->sourceApplicationSecondaryIdentifier();
+    return _configuration->sourceApplicationSecondaryIdentifier().createNSString().autorelease();
 }
 
 - (void)setSourceApplicationSecondaryIdentifier:(NSString *)identifier
@@ -314,7 +314,7 @@ static void checkURLArgument(NSURL *url)
 
 - (NSURL *)applicationCacheDirectory
 {
-    return [NSURL fileURLWithPath:_configuration->applicationCacheDirectory() isDirectory:YES];
+    return [NSURL fileURLWithPath:_configuration->applicationCacheDirectory().createNSString().get() isDirectory:YES];
 }
 
 - (void)setApplicationCacheDirectory:(NSURL *)url
@@ -331,7 +331,7 @@ static void checkURLArgument(NSURL *url)
 
 - (NSString *)applicationCacheFlatFileSubdirectoryName
 {
-    return _configuration->applicationCacheFlatFileSubdirectoryName();
+    return _configuration->applicationCacheFlatFileSubdirectoryName().createNSString().autorelease();
 }
 
 - (void)setApplicationCacheFlatFileSubdirectoryName:(NSString *)name
@@ -347,7 +347,7 @@ static void checkURLArgument(NSURL *url)
 
 - (NSURL *)mediaCacheDirectory
 {
-    return [NSURL fileURLWithPath:_configuration->mediaCacheDirectory() isDirectory:YES];
+    return [NSURL fileURLWithPath:_configuration->mediaCacheDirectory().createNSString().get() isDirectory:YES];
 }
 
 - (void)setMediaCacheDirectory:(NSURL *)url
@@ -364,7 +364,7 @@ static void checkURLArgument(NSURL *url)
 
 - (NSURL *)mediaKeysStorageDirectory
 {
-    return [NSURL fileURLWithPath:_configuration->mediaKeysStorageDirectory() isDirectory:YES];
+    return [NSURL fileURLWithPath:_configuration->mediaKeysStorageDirectory().createNSString().get() isDirectory:YES];
 }
 
 - (void)setMediaKeysStorageDirectory:(NSURL *)url
@@ -381,7 +381,7 @@ static void checkURLArgument(NSURL *url)
 
 - (NSURL *)hstsStorageDirectory
 {
-    return [NSURL fileURLWithPath:_configuration->hstsStorageDirectory() isDirectory:YES];
+    return [NSURL fileURLWithPath:_configuration->hstsStorageDirectory().createNSString().get() isDirectory:YES];
 }
 
 - (void)setHSTSStorageDirectory:(NSURL *)url
@@ -398,7 +398,7 @@ static void checkURLArgument(NSURL *url)
 
 - (NSURL *)alternativeServicesStorageDirectory
 {
-    return [NSURL fileURLWithPath:_configuration->alternativeServicesDirectory() isDirectory:YES];
+    return [NSURL fileURLWithPath:_configuration->alternativeServicesDirectory().createNSString().get() isDirectory:YES];
 }
 
 - (void)setAlternativeServicesStorageDirectory:(NSURL *)url
@@ -418,7 +418,7 @@ static void checkURLArgument(NSURL *url)
     auto& directory = _configuration->generalStorageDirectory();
     if (directory.isNull())
         return nil;
-    return [NSURL fileURLWithPath:directory isDirectory:YES];
+    return [NSURL fileURLWithPath:directory.createNSString().get() isDirectory:YES];
 }
 
 - (void)setGeneralStorageDirectory:(NSURL *)url
@@ -469,7 +469,7 @@ static WebKit::UnifiedOriginStorageLevel toUnifiedOriginStorageLevel(_WKUnifiedO
 
 - (NSString *)webPushPartitionString
 {
-    return _configuration->webPushPartitionString();
+    return _configuration->webPushPartitionString().createNSString().autorelease();
 }
 
 - (void)setWebPushPartitionString:(NSString *)string
@@ -597,7 +597,7 @@ static WebKit::UnifiedOriginStorageLevel toUnifiedOriginStorageLevel(_WKUnifiedO
 
 - (NSURL *)_resourceMonitorThrottlerDirectory
 {
-    return [NSURL fileURLWithPath:_configuration->resourceMonitorThrottlerDirectory() isDirectory:YES];
+    return [NSURL fileURLWithPath:_configuration->resourceMonitorThrottlerDirectory().createNSString().get() isDirectory:YES];
 }
 
 - (void)_setResourceMonitorThrottlerDirectory:(NSURL *)url
@@ -661,7 +661,7 @@ static WebKit::UnifiedOriginStorageLevel toUnifiedOriginStorageLevel(_WKUnifiedO
 
 - (NSString *)boundInterfaceIdentifier
 {
-    return _configuration->boundInterfaceIdentifier();
+    return _configuration->boundInterfaceIdentifier().createNSString().autorelease();
 }
 
 - (void)setBoundInterfaceIdentifier:(NSString *)identifier
@@ -696,7 +696,7 @@ static WebKit::UnifiedOriginStorageLevel toUnifiedOriginStorageLevel(_WKUnifiedO
 
 - (NSString *)dataConnectionServiceType
 {
-    return _configuration->dataConnectionServiceType();
+    return _configuration->dataConnectionServiceType().createNSString().autorelease();
 }
 
 - (void)setDataConnectionServiceType:(NSString *)type
@@ -791,7 +791,7 @@ static WebKit::UnifiedOriginStorageLevel toUnifiedOriginStorageLevel(_WKUnifiedO
 
 - (NSString *)pcmMachServiceName
 {
-    return _configuration->pcmMachServiceName();
+    return _configuration->pcmMachServiceName().createNSString().autorelease();
 }
 
 - (void)setPCMMachServiceName:(NSString *)name
@@ -801,7 +801,7 @@ static WebKit::UnifiedOriginStorageLevel toUnifiedOriginStorageLevel(_WKUnifiedO
 
 - (NSString *)webPushMachServiceName
 {
-    return _configuration->webPushMachServiceName();
+    return _configuration->webPushMachServiceName().createNSString().autorelease();
 }
 
 - (void)setWebPushMachServiceName:(NSString *)name

--- a/Source/WebKit/UIProcess/Automation/cocoa/WebAutomationSessionCocoa.mm
+++ b/Source/WebKit/UIProcess/Automation/cocoa/WebAutomationSessionCocoa.mm
@@ -76,24 +76,24 @@ std::optional<String> WebAutomationSession::platformGetBase64EncodedPNGData(cons
 
 std::optional<String> WebAutomationSession::platformGenerateLocalFilePathForRemoteFile(const String& remoteFilePath, const String& base64EncodedFileContents)
 {
-    RetainPtr<NSData> fileContents = adoptNS([[NSData alloc] initWithBase64EncodedString:base64EncodedFileContents options:0]);
+    RetainPtr<NSData> fileContents = adoptNS([[NSData alloc] initWithBase64EncodedString:base64EncodedFileContents.createNSString().get() options:0]);
     if (!fileContents) {
         LOG_ERROR("WebAutomationSession: unable to decode base64-encoded file contents.");
         return std::nullopt;
     }
 
     NSString *temporaryDirectory = FileSystem::createTemporaryDirectory(@"WebDriver");
-    NSURL *remoteFile = [NSURL fileURLWithPath:remoteFilePath isDirectory:NO];
-    NSString *localFilePath = [temporaryDirectory stringByAppendingPathComponent:remoteFile.lastPathComponent];
+    RetainPtr remoteFile = adoptNS([[NSURL alloc] initFileURLWithPath:remoteFilePath.createNSString().get() isDirectory:NO]);
+    RetainPtr localFilePath = [temporaryDirectory stringByAppendingPathComponent:remoteFile.get().lastPathComponent];
 
     NSError *fileWriteError;
-    [fileContents.get() writeToFile:localFilePath options:NSDataWritingAtomic error:&fileWriteError];
+    [fileContents.get() writeToFile:localFilePath.get() options:NSDataWritingAtomic error:&fileWriteError];
     if (fileWriteError) {
         LOG_ERROR("WebAutomationSession: Error writing image data to temporary file: %@", fileWriteError);
         return std::nullopt;
     }
 
-    return String(localFilePath);
+    return String(localFilePath.get());
 }
 
 std::optional<unichar> WebAutomationSession::charCodeForVirtualKey(Inspector::Protocol::Automation::VirtualKey key) const

--- a/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
+++ b/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
@@ -125,13 +125,13 @@ void WebAutomationSession::sendSynthesizedEventsToPage(WebPageProxy& page, NSArr
 
 void WebAutomationSession::markEventAsSynthesizedForAutomation(NSEvent *event)
 {
-    objc_setAssociatedObject(event, &synthesizedAutomationEventAssociatedObjectKey, m_sessionIdentifier, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(event, &synthesizedAutomationEventAssociatedObjectKey, m_sessionIdentifier.createNSString().get(), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 bool WebAutomationSession::wasEventSynthesizedForAutomation(NSEvent *event)
 {
     NSString *senderSessionIdentifier = objc_getAssociatedObject(event, &synthesizedAutomationEventAssociatedObjectKey);
-    if ([senderSessionIdentifier isEqualToString:m_sessionIdentifier])
+    if ([senderSessionIdentifier isEqualToString:m_sessionIdentifier.createNSString().get()])
         return true;
 
     switch (event.type) {
@@ -700,8 +700,8 @@ void WebAutomationSession::platformSimulateKeyboardInteraction(WebPageProxy& pag
         },
         [&] (CharKey charKey) {
             keyCode = keyCodeForCharKey(charKey);
-            characters = charKey;
-            unmodifiedCharacters = charKey;
+            characters = charKey.createNSString();
+            unmodifiedCharacters = characters;
         }
     );
 
@@ -813,14 +813,14 @@ void WebAutomationSession::platformSimulateKeySequence(WebPageProxy& page, const
     // This command is more similar to the 'insertText:' editing command, except
     // that this emits keyup/keydown/keypress events for roughly each character.
     // This API should move more towards that direction in the future.
-    NSString *text = keySequence;
+    RetainPtr text = keySequence.createNSString();
 
     NSTimeInterval timestamp = [NSDate timeIntervalSinceReferenceDate];
     NSWindow *window = page.platformWindow();
     NSInteger windowNumber = window.windowNumber;
     NSPoint eventPosition = NSMakePoint(0, window.frame.size.height);
 
-    [text enumerateSubstringsInRange:NSMakeRange(0, text.length) options:NSStringEnumerationByComposedCharacterSequences usingBlock:^(NSString *substring, NSRange substringRange, NSRange enclosingRange, BOOL *stop) {
+    [text enumerateSubstringsInRange:NSMakeRange(0, text.get().length) options:NSStringEnumerationByComposedCharacterSequences usingBlock:^(NSString *substring, NSRange substringRange, NSRange enclosingRange, BOOL *stop) {
     
         // For ASCII characters that are produced using Shift on a US-108 key keyboard layout,
         // WebDriver expects these to be delivered as [shift-down, key-down, key-up, shift-up]

--- a/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm
@@ -156,7 +156,7 @@ void AutomationSessionClient::unloadWebExtension(WebKit::WebAutomationSession& s
         return;
     }
 
-    [m_delegate.get() _automationSession:wrapper(session) unloadWebExtensionWithIdentifier:identifier completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](BOOL success) mutable {
+    [m_delegate.get() _automationSession:wrapper(session) unloadWebExtensionWithIdentifier:identifier.createNSString().get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](BOOL success) mutable {
         completionHandler(success);
     }).get()];
 }
@@ -193,7 +193,7 @@ String AutomationSessionClient::messageOfCurrentJavaScriptDialogOnPage(WebAutoma
 void AutomationSessionClient::setUserInputForCurrentJavaScriptPromptOnPage(WebAutomationSession& session, WebPageProxy& page, const String& value)
 {
     if (auto webView = page.cocoaView(); webView && m_delegateMethods.setUserInputForCurrentJavaScriptPromptForWebView)
-        [m_delegate.get() _automationSession:wrapper(session) setUserInput:value forCurrentJavaScriptDialogForWebView:webView.get()];
+        [m_delegate.get() _automationSession:wrapper(session) setUserInput:value.createNSString().get() forCurrentJavaScriptDialogForWebView:webView.get()];
 }
 
 static std::optional<API::AutomationSessionClient::JavaScriptDialogType> toImpl(_WKAutomationSessionJavaScriptDialogType type)

--- a/Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm
@@ -151,8 +151,8 @@ static NSMutableAttributedString *browsingDetailsText(const URL& url, SSBService
 
         RetainPtr attributedString = adoptNS([[NSMutableAttributedString alloc] initWithString:adoptNS([[NSString alloc] initWithFormat:@"%@ %@\n\n%@", phishingDescription.get(), learnMore.get(), phishingActions.get()]).get()]);
         addLinkAndReplace(attributedString.get(), learnMore.get(), learnMore.get(), learnMoreURL(result));
-        replace(attributedString.get(), @"%provider-display-name%", localizedProviderDisplayName(result));
-        replace(attributedString.get(), @"%provider%", localizedProviderShortName(result));
+        replace(attributedString.get(), @"%provider-display-name%", localizedProviderDisplayName(result).createNSString().get());
+        replace(attributedString.get(), @"%provider%", localizedProviderShortName(result).createNSString().get());
         addLinkAndReplace(attributedString.get(), @"%report-an-error%", reportAnError.get(), reportAnErrorURL(url, result).get());
         addLinkAndReplace(attributedString.get(), @"%bypass-link%", visitUnsafeWebsite.get(), BrowsingWarning::visitUnsafeWebsiteSentinel());
         return attributedString.autorelease();
@@ -160,9 +160,9 @@ static NSMutableAttributedString *browsingDetailsText(const URL& url, SSBService
 
     auto malwareOrUnwantedSoftwareDetails = [&] (NSString *description, NSString *statusStringToReplace, bool confirmMalware) {
         auto malwareDescription = adoptNS([[NSMutableAttributedString alloc] initWithString:description]);
-        replace(malwareDescription.get(), @"%safeBrowsingProvider%", localizedProviderDisplayName(result));
+        replace(malwareDescription.get(), @"%safeBrowsingProvider%", localizedProviderDisplayName(result).createNSString().get());
         auto statusLink = adoptNS([[NSMutableAttributedString alloc] initWithString:WEB_UI_NSSTRING(@"the status of “%site%”", "Part of malware description")]);
-        replace(statusLink.get(), @"%site%", url.host().toString());
+        replace(statusLink.get(), @"%site%", url.host().toString().createNSString().get());
         addLinkAndReplace(malwareDescription.get(), statusStringToReplace, [statusLink string], malwareDetailsURL(url, result).get());
 
         auto ifYouUnderstand = adoptNS([[NSMutableAttributedString alloc] initWithString:WEB_UI_NSSTRING(@"If you understand the risks involved, you can %visit-this-unsafe-site-link%.", "Action from safe browsing warning")]);

--- a/Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.mm
@@ -61,7 +61,7 @@ void DiagnosticLoggingClient::setDelegate(id <_WKDiagnosticLoggingDelegate> dele
 void DiagnosticLoggingClient::logDiagnosticMessage(WebKit::WebPageProxy*, const WTF::String& message, const WTF::String& description)
 {
     if (m_delegateMethods.webviewLogDiagnosticMessage)
-        [m_delegate.get() _webView:m_webView.get().get() logDiagnosticMessage:message description:description];
+        [m_delegate.get() _webView:m_webView.get().get() logDiagnosticMessage:message.createNSString().get() description:description.createNSString().get()];
 }
 
 static _WKDiagnosticLoggingResultType toWKDiagnosticLoggingResultType(WebCore::DiagnosticLoggingResultType result)
@@ -87,31 +87,31 @@ static _WKDiagnosticLoggingDomain toWKDiagnosticLoggingDomain(WebCore::Diagnosti
 void DiagnosticLoggingClient::logDiagnosticMessageWithResult(WebKit::WebPageProxy*, const WTF::String& message, const WTF::String& description, WebCore::DiagnosticLoggingResultType result)
 {
     if (m_delegateMethods.webviewLogDiagnosticMessageWithResult)
-        [m_delegate.get() _webView:m_webView.get().get() logDiagnosticMessageWithResult:message description:description result:toWKDiagnosticLoggingResultType(result)];
+        [m_delegate.get() _webView:m_webView.get().get() logDiagnosticMessageWithResult:message.createNSString().get() description:description.createNSString().get() result:toWKDiagnosticLoggingResultType(result)];
 }
 
 void DiagnosticLoggingClient::logDiagnosticMessageWithValue(WebKit::WebPageProxy*, const WTF::String& message, const WTF::String& description, const WTF::String& value)
 {
     if (m_delegateMethods.webviewLogDiagnosticMessageWithValue)
-        [m_delegate.get() _webView:m_webView.get().get() logDiagnosticMessageWithValue:message description:description value:value];
+        [m_delegate.get() _webView:m_webView.get().get() logDiagnosticMessageWithValue:message.createNSString().get() description:description.createNSString().get() value:value.createNSString().get()];
 }
 
 void DiagnosticLoggingClient::logDiagnosticMessageWithEnhancedPrivacy(WebKit::WebPageProxy*, const WTF::String& message, const WTF::String& description)
 {
     if (m_delegateMethods.webviewLogDiagnosticMessageWithEnhancedPrivacy)
-        [m_delegate.get() _webView:m_webView.get().get() logDiagnosticMessageWithEnhancedPrivacy:message description:description];
+        [m_delegate.get() _webView:m_webView.get().get() logDiagnosticMessageWithEnhancedPrivacy:message.createNSString().get() description:description.createNSString().get()];
 }
 
 void DiagnosticLoggingClient::logDiagnosticMessageWithValueDictionary(WebPageProxy*, const String& message, const String& description, Ref<API::Dictionary>&& valueDictionary)
 {
     if (m_delegateMethods.webviewLogDiagnosticMessageWithValueDictionary)
-        [m_delegate.get() _webView:m_webView.get().get() logDiagnosticMessage:message description:description valueDictionary:static_cast<NSDictionary*>(valueDictionary->wrapper())];
+        [m_delegate.get() _webView:m_webView.get().get() logDiagnosticMessage:message.createNSString().get() description:description.createNSString().get() valueDictionary:static_cast<NSDictionary*>(valueDictionary->wrapper())];
 }
 
 void DiagnosticLoggingClient::logDiagnosticMessageWithDomain(WebPageProxy*, const String& message, WebCore::DiagnosticLoggingDomain domain)
 {
     if (m_delegateMethods.webviewLogDiagnosticMessageWithDomain)
-        [m_delegate.get() _webView:m_webView.get().get() logDiagnosticMessageWithDomain:message domain:toWKDiagnosticLoggingDomain(domain)];
+        [m_delegate.get() _webView:m_webView.get().get() logDiagnosticMessageWithDomain:message.createNSString().get() domain:toWKDiagnosticLoggingDomain(domain)];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/FindClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/FindClient.mm
@@ -57,19 +57,19 @@ void FindClient::setDelegate(id <_WKFindDelegate> delegate)
 void FindClient::didCountStringMatches(WebPageProxy*, const String& string, uint32_t matchCount)
 {
     if (m_delegateMethods.webviewDidCountStringMatches)
-        [m_delegate.get() _webView:m_webView.get().get() didCountMatches:matchCount forString:string];
+        [m_delegate.get() _webView:m_webView.get().get() didCountMatches:matchCount forString:string.createNSString().get()];
 }
 
 void FindClient::didFindString(WebPageProxy*, const String& string, const Vector<WebCore::IntRect>&, uint32_t matchCount, int32_t matchIndex, bool)
 {
     if (m_delegateMethods.webviewDidFindString)
-        [m_delegate.get() _webView:m_webView.get().get() didFindMatches:matchCount forString:string withMatchIndex:matchIndex];
+        [m_delegate.get() _webView:m_webView.get().get() didFindMatches:matchCount forString:string.createNSString().get() withMatchIndex:matchIndex];
 }
 
 void FindClient::didFailToFindString(WebPageProxy*, const String& string)
 {
     if (m_delegateMethods.webviewDidFailToFindString)
-        [m_delegate.get() _webView:m_webView.get().get() didFailToFindString:string];
+        [m_delegate.get() _webView:m_webView.get().get() didFailToFindString:string.createNSString().get()];
 }
 
 void FindClient::didAddLayerForFindOverlay(WebKit::WebPageProxy*, PlatformLayer* layer)

--- a/Source/WebKit/UIProcess/Cocoa/GlobalFindInPageState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GlobalFindInPageState.mm
@@ -55,7 +55,7 @@ static String& globalStringForFind()
 void updateStringForFind(const String& string)
 {
 #if PLATFORM(MAC)
-    [findPasteboard() setString:string forType:WebCore::legacyStringPasteboardType()];
+    [findPasteboard() setString:string.createNSString().get() forType:WebCore::legacyStringPasteboardType()];
 #else
     globalStringForFind() = string;
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
@@ -220,7 +220,7 @@ void GroupActivitiesCoordinator::playbackStateChanged(MediaSessionPlaybackState 
 void GroupActivitiesCoordinator::trackIdentifierChanged(const String& identifier)
 {
     if (identifier != String([m_playbackCoordinator currentItemIdentifier]))
-        [m_playbackCoordinator transitionToItemWithIdentifier:identifier proposingInitialTimingBasedOnTimebase:nil];
+        [m_playbackCoordinator transitionToItemWithIdentifier:identifier.createNSString().get() proposingInitialTimingBasedOnTimebase:nil];
 }
 
 void GroupActivitiesCoordinator::issuePlayCommand(AVDelegatingPlaybackCoordinatorPlayCommand *playCommand, CommandCompletionHandler&& callback)

--- a/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm
@@ -128,7 +128,7 @@ void LegacyDownloadClient::didReceiveAuthenticationChallenge(DownloadProxy& down
 void LegacyDownloadClient::didCreateDestination(DownloadProxy& downloadProxy, const String& destination)
 {
     if (m_delegateMethods.downloadDidCreateDestination)
-        [m_delegate _download:[_WKDownload downloadWithDownload:wrapper(downloadProxy)] didCreateDestination:destination];
+        [m_delegate _download:[_WKDownload downloadWithDownload:wrapper(downloadProxy)] didCreateDestination:destination.createNSString().get()];
 }
 
 void LegacyDownloadClient::processDidCrash(DownloadProxy& downloadProxy)
@@ -147,11 +147,11 @@ void LegacyDownloadClient::decideDestinationWithSuggestedFilename(DownloadProxy&
     if (m_delegateMethods.downloadDecideDestinationWithSuggestedFilenameAllowOverwrite) {
         BOOL allowOverwrite = NO;
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        RetainPtr destination = [m_delegate _download:[_WKDownload downloadWithDownload:wrapper(downloadProxy)] decideDestinationWithSuggestedFilename:filename allowOverwrite:&allowOverwrite];
+        RetainPtr destination = [m_delegate _download:[_WKDownload downloadWithDownload:wrapper(downloadProxy)] decideDestinationWithSuggestedFilename:filename.createNSString().get() allowOverwrite:&allowOverwrite];
 ALLOW_DEPRECATED_DECLARATIONS_END
         completionHandler(allowOverwrite ? AllowOverwrite::Yes : AllowOverwrite::No, destination.get());
     } else {
-        [m_delegate _download:[_WKDownload downloadWithDownload:wrapper(downloadProxy)] decideDestinationWithSuggestedFilename:filename completionHandler:makeBlockPtr([checker = CompletionHandlerCallChecker::create(m_delegate.get().get(), @selector(_download:decideDestinationWithSuggestedFilename:completionHandler:)), completionHandler = WTFMove(completionHandler)] (BOOL allowOverwrite, NSString *destination) mutable {
+        [m_delegate _download:[_WKDownload downloadWithDownload:wrapper(downloadProxy)] decideDestinationWithSuggestedFilename:filename.createNSString().get() completionHandler:makeBlockPtr([checker = CompletionHandlerCallChecker::create(m_delegate.get().get(), @selector(_download:decideDestinationWithSuggestedFilename:completionHandler:)), completionHandler = WTFMove(completionHandler)] (BOOL allowOverwrite, NSString *destination) mutable {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();

--- a/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
@@ -156,39 +156,39 @@ static RetainPtr<NSString> alertMessageText(MediaPermissionReason reason, const 
     }
 }
 
-static NSString *allowButtonText(MediaPermissionReason reason)
+static RetainPtr<NSString> allowButtonText(MediaPermissionReason reason)
 {
     switch (reason) {
     case MediaPermissionReason::Camera:
     case MediaPermissionReason::CameraAndMicrophone:
     case MediaPermissionReason::Microphone:
-        return WEB_UI_STRING_KEY(@"Allow", "Allow (usermedia)", @"Allow button title in user media prompt");
+        return WEB_UI_STRING_KEY(@"Allow", "Allow (usermedia)", @"Allow button title in user media prompt").createNSString();
     case MediaPermissionReason::ScreenCapture:
-        return WEB_UI_STRING_KEY(@"Allow", "Allow (screensharing)", @"Allow button title in screen sharing prompt");
+        return WEB_UI_STRING_KEY(@"Allow", "Allow (screensharing)", @"Allow button title in screen sharing prompt").createNSString();
     case MediaPermissionReason::DeviceOrientation:
-        return WEB_UI_STRING_KEY(@"Allow", "Allow (device motion and orientation access)", @"Button title in Device Orientation Permission API prompt");
+        return WEB_UI_STRING_KEY(@"Allow", "Allow (device motion and orientation access)", @"Button title in Device Orientation Permission API prompt").createNSString();
     case MediaPermissionReason::Geolocation:
-        return WEB_UI_STRING_KEY(@"Allow", "Allow (geolocation)", @"Allow button title in geolocation prompt");
+        return WEB_UI_STRING_KEY(@"Allow", "Allow (geolocation)", @"Allow button title in geolocation prompt").createNSString();
     case MediaPermissionReason::SpeechRecognition:
-        return WEB_UI_STRING_KEY(@"Allow", "Allow (speechrecognition)", @"Allow button title in speech recognition prompt");
+        return WEB_UI_STRING_KEY(@"Allow", "Allow (speechrecognition)", @"Allow button title in speech recognition prompt").createNSString();
     }
 }
 
-static NSString *doNotAllowButtonText(MediaPermissionReason reason)
+static RetainPtr<NSString> doNotAllowButtonText(MediaPermissionReason reason)
 {
     switch (reason) {
     case MediaPermissionReason::Camera:
     case MediaPermissionReason::CameraAndMicrophone:
     case MediaPermissionReason::Microphone:
-        return WEB_UI_STRING_KEY(@"Don’t Allow", "Don’t Allow (usermedia)", @"Disallow button title in user media prompt");
+        return WEB_UI_STRING_KEY(@"Don’t Allow", "Don’t Allow (usermedia)", @"Disallow button title in user media prompt").createNSString();
     case MediaPermissionReason::ScreenCapture:
-        return WEB_UI_STRING_KEY(@"Don’t Allow", "Don’t Allow (screensharing)", @"Disallow button title in screen sharing prompt");
+        return WEB_UI_STRING_KEY(@"Don’t Allow", "Don’t Allow (screensharing)", @"Disallow button title in screen sharing prompt").createNSString();
     case MediaPermissionReason::DeviceOrientation:
-        return WEB_UI_STRING_KEY(@"Cancel", "Cancel (device motion and orientation access)", @"Button title in Device Orientation Permission API prompt");
+        return WEB_UI_STRING_KEY(@"Cancel", "Cancel (device motion and orientation access)", @"Button title in Device Orientation Permission API prompt").createNSString();
     case MediaPermissionReason::Geolocation:
-        return WEB_UI_STRING_KEY(@"Don’t Allow", "Don’t Allow (geolocation)", @"Disallow button title in geolocation prompt");
+        return WEB_UI_STRING_KEY(@"Don’t Allow", "Don’t Allow (geolocation)", @"Disallow button title in geolocation prompt").createNSString();
     case MediaPermissionReason::SpeechRecognition:
-        return WEB_UI_STRING_KEY(@"Don’t Allow", "Don’t Allow (speechrecognition)", @"Disallow button title in speech recognition prompt");
+        return WEB_UI_STRING_KEY(@"Don’t Allow", "Don’t Allow (speechrecognition)", @"Disallow button title in speech recognition prompt").createNSString();
     }
 }
 
@@ -312,7 +312,7 @@ IGNORE_WARNINGS_END
 
 bool checkSpeechRecognitionServiceAvailability(const String& localeIdentifier)
 {
-    auto recognizer = localeIdentifier.isEmpty() ? adoptNS([PAL::allocSFSpeechRecognizerInstance() init]) : adoptNS([PAL::allocSFSpeechRecognizerInstance() initWithLocale:[NSLocale localeWithLocaleIdentifier:localeIdentifier]]);
+    auto recognizer = localeIdentifier.isEmpty() ? adoptNS([PAL::allocSFSpeechRecognizerInstance() init]) : adoptNS([PAL::allocSFSpeechRecognizerInstance() initWithLocale:[NSLocale localeWithLocaleIdentifier:localeIdentifier.createNSString().get()]]);
     return recognizer && [recognizer isAvailable];
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
@@ -169,7 +169,7 @@ void ModelElementController::modelElementCreateRemotePreview(String uuid, WebCor
         return;
     }
 
-    auto nsUUID = adoptNS([[NSUUID alloc] initWithUUIDString:uuid]);
+    auto nsUUID = adoptNS([[NSUUID alloc] initWithUUIDString:uuid.createNSString().get()]);
     auto preview = adoptNS([allocASVInlinePreviewInstance() initWithFrame:CGRectMake(0, 0, size.width(), size.height()) UUID:nsUUID.get()]);
 
     LOG(ModelElement, "Created remote preview with UUID %s.", uuid.utf8().data());
@@ -229,7 +229,7 @@ void ModelElementController::modelElementLoadRemotePreview(String uuid, URL file
     });
 
     RELEASE_ASSERT(isMainRunLoop());
-    [preview preparePreviewOfFileAtURL:adoptNS([[NSURL alloc] initFileURLWithPath:fileURL.fileSystemPath()]).get() completionHandler:makeBlockPtr([
+    [preview preparePreviewOfFileAtURL:adoptNS([[NSURL alloc] initFileURLWithPath:fileURL.fileSystemPath().createNSString().get()]).get() completionHandler:makeBlockPtr([
         weakThis = WeakPtr { *this },
 #if PLATFORM(MAC)
         preview, // FIXME: Remove when rdar://143993062 is fixed.

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -755,8 +755,8 @@ void NavigationState::NavigationClient::contentRuleListNotification(WebPageProxy
                 identifiers = adoptNS([NSMutableArray new]);
             if (!notifications)
                 notifications = adoptNS([NSMutableArray new]);
-            [identifiers addObject:listIdentifier];
-            [notifications addObject:notification];
+            [identifiers addObject:listIdentifier.createNSString().get()];
+            [notifications addObject:notification.createNSString().get()];
         }
     }
 
@@ -765,7 +765,7 @@ void NavigationState::NavigationClient::contentRuleListNotification(WebPageProxy
 
     if (m_navigationState->m_navigationDelegateMethods.webViewContentRuleListWithIdentifierPerformedActionForURL) {
         for (auto&& pair : WTFMove(results.results))
-            [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:protectedNavigationState()->webView().get() contentRuleListWithIdentifier:pair.first performedAction:wrapper(API::ContentRuleListAction::create(WTFMove(pair.second)).get()) forURL:url.createNSURL().get()];
+            [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:protectedNavigationState()->webView().get() contentRuleListWithIdentifier:pair.first.createNSString().get() performedAction:wrapper(API::ContentRuleListAction::create(WTFMove(pair.second)).get()) forURL:url.createNSURL().get()];
     }
 }
 #endif
@@ -1086,7 +1086,7 @@ void NavigationState::NavigationClient::didPromptForStorageAccess(WebPageProxy&,
         return;
 
     if (navigationState->m_navigationDelegateMethods.webViewDidPromptForStorageAccessForSubFrameDomainForQuirk)
-        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() didPromptForStorageAccess:topFrameDomain forSubFrameDomain:subFrameDomain forQuirk:hasQuirk];
+        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() didPromptForStorageAccess:topFrameDomain.createNSString().get() forSubFrameDomain:subFrameDomain.createNSString().get() forQuirk:hasQuirk];
 }
 
 void NavigationState::NavigationClient::didFailNavigationWithError(WebPageProxy& page, const FrameInfoData& frameInfo, API::Navigation* navigation, const URL& url, const WebCore::ResourceError& error, API::Object* userInfo)
@@ -1485,7 +1485,7 @@ void NavigationState::NavigationClient::decidePolicyForSOAuthorizationLoad(WebPa
     }
 
     auto checker = CompletionHandlerCallChecker::create(navigationDelegate.get(), @selector(_webView:decidePolicyForSOAuthorizationLoadWithCurrentPolicy:forExtension:completionHandler:));
-    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() decidePolicyForSOAuthorizationLoadWithCurrentPolicy:wkSOAuthorizationLoadPolicy(currentSOAuthorizationLoadPolicy) forExtension:extension completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)](_WKSOAuthorizationLoadPolicy policy) mutable {
+    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() decidePolicyForSOAuthorizationLoadWithCurrentPolicy:wkSOAuthorizationLoadPolicy(currentSOAuthorizationLoadPolicy) forExtension:extension.createNSString().get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)](_WKSOAuthorizationLoadPolicy policy) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -1566,7 +1566,7 @@ void NavigationState::HistoryClient::didUpdateHistoryTitle(WebPageProxy&, const 
     if (!historyDelegate)
         return;
 
-    [historyDelegate _webView:navigationState->webView().get() didUpdateHistoryTitle:title forURL:[NSURL _web_URLWithWTFString:url]];
+    [historyDelegate _webView:navigationState->webView().get() didUpdateHistoryTitle:title.createNSString().get() forURL:[NSURL _web_URLWithWTFString:url.createNSString().get()]];
 }
 
 void NavigationState::willChangeIsLoading()

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -124,7 +124,7 @@ bool PageClientImplCocoa::scrollingUpdatesDisabledForTesting()
 
 void PageClientImplCocoa::didInsertAttachment(API::Attachment& attachment, const String& source)
 {
-    [m_webView _didInsertAttachment:attachment withSource:source];
+    [m_webView _didInsertAttachment:attachment withSource:source.createNSString().get()];
 }
 
 void PageClientImplCocoa::didRemoveAttachment(API::Attachment& attachment)

--- a/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
@@ -430,10 +430,10 @@ void ProcessAssertion::init(const String& environmentIdentifier)
     if (environmentIdentifier.isEmpty())
         target = [RBSTarget targetWithPid:m_pid];
     else
-        target = [RBSTarget targetWithPid:m_pid environmentIdentifier:environmentIdentifier];
+        target = [RBSTarget targetWithPid:m_pid environmentIdentifier:environmentIdentifier.createNSString().get()];
 
-    RBSDomainAttribute *domainAttribute = [RBSDomainAttribute attributeWithDomain:String(runningBoardDomainForAssertionType(m_assertionType)) name:String(runningBoardAssertionName)];
-    m_rbsAssertion = adoptNS([[RBSAssertion alloc] initWithExplanation:m_reason target:target attributes:@[domainAttribute]]);
+    RBSDomainAttribute *domainAttribute = [RBSDomainAttribute attributeWithDomain:runningBoardDomainForAssertionType(m_assertionType).createNSString().get() name:runningBoardAssertionName.createNSString().get()];
+    m_rbsAssertion = adoptNS([[RBSAssertion alloc] initWithExplanation:m_reason.createNSString().get() target:target attributes:@[domainAttribute]]);
 
     m_delegate = adoptNS([[WKRBSAssertionDelegate alloc] init]);
     [m_rbsAssertion addObserver:m_delegate.get()];

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -430,7 +430,7 @@ void UIDelegate::UIClient::runJavaScriptAlert(WebPageProxy& page, const WTF::Str
     page.makeViewBlankIfUnpaintedSinceLastLoadCommit();
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(webView:runJavaScriptAlertPanelWithMessage:initiatedByFrame:completionHandler:));
-    [delegate webView:uiDelegate->m_webView.get().get() runJavaScriptAlertPanelWithMessage:message initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] {
+    [delegate webView:uiDelegate->m_webView.get().get() runJavaScriptAlertPanelWithMessage:message.createNSString().get() initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] {
         if (checker->completionHandlerHasBeenCalled())
             return;
         completionHandler();
@@ -458,7 +458,7 @@ void UIDelegate::UIClient::runJavaScriptConfirm(WebPageProxy& page, const WTF::S
     page.makeViewBlankIfUnpaintedSinceLastLoadCommit();
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(webView:runJavaScriptConfirmPanelWithMessage:initiatedByFrame:completionHandler:));
-    [delegate webView:uiDelegate->m_webView.get().get() runJavaScriptConfirmPanelWithMessage:message initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
+    [delegate webView:uiDelegate->m_webView.get().get() runJavaScriptConfirmPanelWithMessage:message.createNSString().get() initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         completionHandler(result);
@@ -486,7 +486,7 @@ void UIDelegate::UIClient::runJavaScriptPrompt(WebPageProxy& page, const WTF::St
     page.makeViewBlankIfUnpaintedSinceLastLoadCommit();
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(webView:runJavaScriptTextInputPanelWithPrompt:defaultText:initiatedByFrame:completionHandler:));
-    [delegate webView:uiDelegate->m_webView.get().get() runJavaScriptTextInputPanelWithPrompt:message defaultText:defaultValue initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (NSString *result) mutable {
+    [delegate webView:uiDelegate->m_webView.get().get() runJavaScriptTextInputPanelWithPrompt:message.createNSString().get() defaultText:defaultValue.createNSString().get() initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (NSString *result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         completionHandler(result);
@@ -517,14 +517,14 @@ void UIDelegate::UIClient::requestStorageAccessConfirm(WebPageProxy& webPageProx
                 for (auto& [topFrameDomain, subFrameDomains] : organizationStorageAccessPromptQuirk->quirkDomains) {
                     RetainPtr<NSMutableArray<NSString *>> mutableSubFrameDomains = adoptNS([[NSMutableArray alloc] initWithCapacity:subFrameDomains.size()]);
                     for (auto& subFrameDomain : subFrameDomains)
-                        [mutableSubFrameDomains addObject:subFrameDomain.string()];
-                    [quirkDomains setObject:mutableSubFrameDomains.get() forKey:topFrameDomain.string()];
+                        [mutableSubFrameDomains addObject:subFrameDomain.string().createNSString().get()];
+                    [quirkDomains setObject:mutableSubFrameDomains.get() forKey:topFrameDomain.string().createNSString().get()];
                 }
             } else
-                [quirkDomains setObject:@[additionalLoginDomain->string()] forKey:currentDomain.string()];
+                [quirkDomains setObject:@[additionalLoginDomain->string().createNSString().get()] forKey:currentDomain.string().createNSString().get()];
 
             auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:requestStorageAccessPanelForDomain:underCurrentDomain:forQuirkDomains:completionHandler:));
-            [delegate _webView:uiDelegate->m_webView.get().get() requestStorageAccessPanelForDomain:requestingDomain.string() underCurrentDomain:currentDomain.string() forQuirkDomains:quirkDomains.get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
+            [delegate _webView:uiDelegate->m_webView.get().get() requestStorageAccessPanelForDomain:requestingDomain.string().createNSString().get() underCurrentDomain:currentDomain.string().createNSString().get() forQuirkDomains:quirkDomains.get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
                 if (checker->completionHandlerHasBeenCalled())
                     return;
                 completionHandler(result);
@@ -557,7 +557,7 @@ void UIDelegate::UIClient::requestStorageAccessConfirm(WebPageProxy& webPageProx
     }
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:requestStorageAccessPanelForDomain:underCurrentDomain:completionHandler:));
-    [delegate _webView:uiDelegate->m_webView.get().get() requestStorageAccessPanelForDomain:requestingDomain.string() underCurrentDomain:currentDomain.string() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
+    [delegate _webView:uiDelegate->m_webView.get().get() requestStorageAccessPanelForDomain:requestingDomain.string().createNSString().get() underCurrentDomain:currentDomain.string().createNSString().get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         completionHandler(result);
@@ -650,7 +650,7 @@ void UIDelegate::UIClient::runBeforeUnloadConfirmPanel(WebPageProxy& page, const
     }
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:runBeforeUnloadConfirmPanelWithMessage:initiatedByFrame:completionHandler:));
-    [delegate _webView:uiDelegate->m_webView.get().get() runBeforeUnloadConfirmPanelWithMessage:message initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
+    [delegate _webView:uiDelegate->m_webView.get().get() runBeforeUnloadConfirmPanelWithMessage:message.createNSString().get() initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         completionHandler(result);
@@ -682,7 +682,7 @@ void UIDelegate::UIClient::exceededDatabaseQuota(WebPageProxy*, WebFrameProxy*, 
 
     if (uiDelegate->m_delegateMethods.webViewDecideDatabaseQuotaForSecurityOriginDatabaseNameDisplayNameCurrentQuotaCurrentOriginUsageCurrentDatabaseUsageExpectedUsageDecisionHandler) {
         auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:decideDatabaseQuotaForSecurityOrigin:databaseName:displayName:currentQuota:currentOriginUsage:currentDatabaseUsage:expectedUsage:decisionHandler:));
-        [delegate _webView:uiDelegate->m_webView.get().get() decideDatabaseQuotaForSecurityOrigin:wrapper(*securityOrigin) databaseName:databaseName displayName:displayName currentQuota:currentQuota currentOriginUsage:currentOriginUsage currentDatabaseUsage:currentUsage expectedUsage:expectedUsage decisionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)](unsigned long long newQuota) {
+        [delegate _webView:uiDelegate->m_webView.get().get() decideDatabaseQuotaForSecurityOrigin:wrapper(*securityOrigin) databaseName:databaseName.createNSString().get() displayName:displayName.createNSString().get() currentQuota:currentQuota currentOriginUsage:currentOriginUsage currentDatabaseUsage:currentUsage expectedUsage:expectedUsage decisionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)](unsigned long long newQuota) {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();
@@ -1004,7 +1004,7 @@ void UIDelegate::UIClient::drawHeader(WebPageProxy&, WebFrameProxy& frame, WebCo
     if (!delegate)
         return;
     
-    [delegate _webView:uiDelegate->m_webView.get().get() drawHeaderInRect:rect forPageWithTitle:frame.title() URL:frame.url().createNSURL().get()];
+    [delegate _webView:uiDelegate->m_webView.get().get() drawHeaderInRect:rect forPageWithTitle:frame.title().createNSString().get() URL:frame.url().createNSURL().get()];
 }
 
 void UIDelegate::UIClient::drawFooter(WebPageProxy&, WebFrameProxy& frame, WebCore::FloatRect&& rect)
@@ -1020,7 +1020,7 @@ void UIDelegate::UIClient::drawFooter(WebPageProxy&, WebFrameProxy& frame, WebCo
     if (!delegate)
         return;
     
-    [delegate _webView:uiDelegate->m_webView.get().get() drawFooterInRect:rect forPageWithTitle:frame.title() URL:frame.url().createNSURL().get()];
+    [delegate _webView:uiDelegate->m_webView.get().get() drawFooterInRect:rect forPageWithTitle:frame.title().createNSString().get() URL:frame.url().createNSURL().get()];
 }
 
 void UIDelegate::UIClient::pageDidScroll(WebPageProxy*)
@@ -1206,7 +1206,7 @@ void UIDelegate::UIClient::saveDataToFileInDownloadsFolder(WebPageProxy*, const 
     if (!delegate)
         return;
 
-    [delegate _webView:uiDelegate->m_webView.get().get() saveDataToFile:wrapper(data) suggestedFilename:suggestedFilename mimeType:mimeType originatingURL:originatingURL.createNSURL().get()];
+    [delegate _webView:uiDelegate->m_webView.get().get() saveDataToFile:wrapper(data) suggestedFilename:suggestedFilename.createNSString().get() mimeType:mimeType.createNSString().get() originatingURL:originatingURL.createNSURL().get()];
 }
 
 Ref<API::InspectorConfiguration> UIDelegate::UIClient::configurationForLocalInspector(WebPageProxy&, WebInspectorUIProxy& inspector)
@@ -1874,7 +1874,7 @@ void UIDelegate::UIClient::requestWebAuthenticationConditonalMediationRegistrati
         return completionHandler(std::nullopt);
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:requestWebAuthenticationConditionalMediationRegistrationForUser:completionHandler:));
-    [delegate _webView:uiDelegate->m_webView.get().get() requestWebAuthenticationConditionalMediationRegistrationForUser:username completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
+    [delegate _webView:uiDelegate->m_webView.get().get() requestWebAuthenticationConditionalMediationRegistrationForUser:username.createNSString().get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -1935,7 +1935,7 @@ void UIDelegate::UIClient::queryPermission(const String& permissionName, API::Se
     }
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:queryPermission:forOrigin:completionHandler:));
-    [delegate _webView:uiDelegate->m_webView.get().get() queryPermission:permissionName forOrigin:wrapper(origin) completionHandler:makeBlockPtr([callback = WTFMove(callback), checker = WTFMove(checker)](WKPermissionDecision permissionState) mutable {
+    [delegate _webView:uiDelegate->m_webView.get().get() queryPermission:permissionName.createNSString().get() forOrigin:wrapper(origin) completionHandler:makeBlockPtr([callback = WTFMove(callback), checker = WTFMove(checker)](WKPermissionDecision permissionState) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm
@@ -113,7 +113,7 @@ static WebCore::VideoFrameRotation computeVideoFrameRotation(int rotation)
         if (!PAL::getAVCaptureDeviceRotationCoordinatorClass())
             return { };
 
-        RetainPtr avDevice = [PAL::getAVCaptureDeviceClass() deviceWithUniqueID:persistentId];
+        RetainPtr avDevice = [PAL::getAVCaptureDeviceClass() deviceWithUniqueID:persistentId.createNSString().get()];
         if (!avDevice)
             return { };
 

--- a/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
@@ -268,7 +268,7 @@ static void appendFilesAsShareableURLs(RetainPtr<NSMutableArray>&& shareDataArra
     auto queue = WorkQueue::create("com.apple.WebKit.WKShareSheet.ShareableFileWriter"_s);
     queue->dispatch([shareDataArray = WTFMove(shareDataArray), fileWriteTasks = WTFMove(fileWriteTasks), temporaryDirectory = retainPtr(temporaryDirectory), usePlaceholderFiles, completionHandler = WTFMove(completionHandler)]() mutable {
         for (auto& fileWriteTask : fileWriteTasks) {
-            RetainPtr fileURL = [WKShareSheet writeFileToShareableURL:WebCore::ResourceResponseBase::sanitizeSuggestedFilename(fileWriteTask.fileName) data:fileWriteTask.fileData.get() temporaryDirectory:temporaryDirectory.get()];
+            RetainPtr fileURL = [WKShareSheet writeFileToShareableURL:WebCore::ResourceResponseBase::sanitizeSuggestedFilename(fileWriteTask.fileName).createNSString().get() data:fileWriteTask.fileData.get() temporaryDirectory:temporaryDirectory.get()];
             if (!fileURL) {
                 shareDataArray = nil;
                 break;
@@ -305,7 +305,7 @@ static void appendFilesAsShareableURLs(RetainPtr<NSMutableArray>&& shareDataArra
         RetainPtr url = data.url.value().createNSURL();
         RetainPtr<NSString> title;
         if (!data.shareData.title.isEmpty())
-            title = data.shareData.title;
+            title = data.shareData.title.createNSString();
 
         if (data.originator == WebCore::ShareDataOriginator::Web) {
 #if PLATFORM(IOS_FAMILY)
@@ -503,8 +503,8 @@ static void appendFilesAsShareableURLs(RetainPtr<NSMutableArray>&& shareDataArra
 + (BOOL)setQuarantineInformationForFilePath:(NSURL *)fileURL
 {
     RetainPtr quarantineProperties = @{
-        (__bridge NSString *)kLSQuarantineTypeKey: (__bridge NSString *)kLSQuarantineTypeWebDownload,
-        (__bridge NSString *)kLSQuarantineAgentBundleIdentifierKey: applicationBundleIdentifier()
+        bridge_cast(kLSQuarantineTypeKey): bridge_cast(kLSQuarantineTypeWebDownload),
+        bridge_cast(kLSQuarantineAgentBundleIdentifierKey): applicationBundleIdentifier().createNSString().get()
     };
 
     if (![fileURL setResourceValue:quarantineProperties.get() forKey:NSURLQuarantinePropertiesKey error:nil])

--- a/Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm
@@ -175,7 +175,7 @@ void presentStorageAccessAlertSSOQuirk(WKWebView *webView, const String& organiz
         relatedWebsitesString = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Related %@ websites", @"Label describing the list of related websites controlled by the same organization"), organizationName.createCFString().get()]);
         accessoryTextList = adoptNS([[NSMutableArray alloc] initWithCapacity:uniqueDomainList.size()]);
         for (const auto& domains : uniqueDomainList)
-            [accessoryTextList addObject:domains];
+            [accessoryTextList addObject:domains.createNSString().get()];
     }
 
     displayStorageAccessAlert(webView, alertTitle.get(), informativeText.get(), relatedWebsitesString.get(), accessoryTextList.get(), WTFMove(completionHandler));

--- a/Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.mm
@@ -71,8 +71,8 @@ inline static RetainPtr<WKTextExtractionTextItem> createWKTextItem(const TextExt
     RetainPtr<WKTextExtractionEditable> editable;
     if (data.editable) {
         editable = adoptNS([allocWKTextExtractionEditableInstance()
-            initWithLabel:data.editable->label
-            placeholder:data.editable->placeholder
+            initWithLabel:data.editable->label.createNSString().get()
+            placeholder:data.editable->placeholder.createNSString().get()
             isSecure:static_cast<BOOL>(data.editable->isSecure)
             isFocused:static_cast<BOOL>(data.editable->isFocused)]);
     }
@@ -96,7 +96,7 @@ inline static RetainPtr<WKTextExtractionTextItem> createWKTextItem(const TextExt
     });
 
     return adoptNS([allocWKTextExtractionTextItemInstance()
-        initWithContent:data.content
+        initWithContent:data.content.createNSString().get()
         selectedRange:selectedRange
         links:links.get()
         editable:editable.get()
@@ -113,7 +113,7 @@ inline static RetainPtr<WKTextExtractionItem> createItemWithChildren(const TextE
         }, [&](const TextExtraction::ScrollableItemData& data) -> RetainPtr<WKTextExtractionItem> {
             return adoptNS([allocWKTextExtractionScrollableItemInstance() initWithContentSize:data.contentSize rectInWebView:rectInWebView children:children]);
         }, [&](const TextExtraction::ImageItemData& data) -> RetainPtr<WKTextExtractionItem> {
-            return adoptNS([allocWKTextExtractionImageItemInstance() initWithName:data.name altText:data.altText rectInWebView:rectInWebView children:children]);
+            return adoptNS([allocWKTextExtractionImageItemInstance() initWithName:data.name.createNSString().get() altText:data.altText.createNSString().get() rectInWebView:rectInWebView children:children]);
         }, [&](TextExtraction::ContainerType type) -> RetainPtr<WKTextExtractionItem> {
             return adoptNS([allocWKTextExtractionContainerItemInstance() initWithContainer:containerType(type) rectInWebView:rectInWebView children:children]);
         }

--- a/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
@@ -203,7 +203,7 @@ void WebPasteboardProxy::getPasteboardPathnamesForType(IPC::Connection& connecti
 #if PLATFORM(MAC)
             bool needsExtensions = pasteboardType == String(WebCore::legacyFilenamesPasteboardType());
             sandboxExtensions = pathnames.map([needsExtensions](auto& filename) {
-                if (!needsExtensions || ![[NSFileManager defaultManager] fileExistsAtPath:filename])
+                if (!needsExtensions || ![[NSFileManager defaultManager] fileExistsAtPath:filename.createNSString().get()])
                     return SandboxExtension::Handle { };
 
                 return valueOrDefault(SandboxExtension::createHandle(filename, SandboxExtension::Type::ReadOnly));

--- a/Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm
@@ -36,10 +36,10 @@
 
 namespace WebKit {
 
-static inline NSString *makeKey(const String& identifier, const String& keyPrefix, const String& key)
+static inline RetainPtr<NSString> makeKey(const String& identifier, const String& keyPrefix, const String& key)
 {
     ASSERT(!identifier.isEmpty());
-    return makeString(identifier, keyPrefix, key);
+    return makeString(identifier, keyPrefix, key).createNSString();
 }
 
 bool WebPreferences::platformGetStringUserValueForKey(const String& key, String& userValue)
@@ -47,7 +47,7 @@ bool WebPreferences::platformGetStringUserValueForKey(const String& key, String&
     if (!m_identifier)
         return false;
 
-    RetainPtr object = [[NSUserDefaults standardUserDefaults] objectForKey:makeKey(m_identifier, m_keyPrefix, key)];
+    RetainPtr object = [[NSUserDefaults standardUserDefaults] objectForKey:makeKey(m_identifier, m_keyPrefix, key).get()];
     if (!object)
         return false;
     RetainPtr string = dynamic_objc_cast<NSString>(object.get());
@@ -63,7 +63,7 @@ bool WebPreferences::platformGetBoolUserValueForKey(const String& key, bool& use
     if (!m_identifier)
         return false;
 
-    RetainPtr object = [[NSUserDefaults standardUserDefaults] objectForKey:makeKey(m_identifier, m_keyPrefix, key)];
+    RetainPtr object = [[NSUserDefaults standardUserDefaults] objectForKey:makeKey(m_identifier, m_keyPrefix, key).get()];
     if (!object)
         return false;
     if (![object respondsToSelector:@selector(boolValue)])
@@ -78,7 +78,7 @@ bool WebPreferences::platformGetUInt32UserValueForKey(const String& key, uint32_
     if (!m_identifier)
         return false;
 
-    RetainPtr object = [[NSUserDefaults standardUserDefaults] objectForKey:makeKey(m_identifier, m_keyPrefix, key)];
+    RetainPtr object = [[NSUserDefaults standardUserDefaults] objectForKey:makeKey(m_identifier, m_keyPrefix, key).get()];
     if (!object)
         return false;
     if (![object respondsToSelector:@selector(intValue)])
@@ -93,7 +93,7 @@ bool WebPreferences::platformGetDoubleUserValueForKey(const String& key, double&
     if (!m_identifier)
         return false;
 
-    RetainPtr object = [[NSUserDefaults standardUserDefaults] objectForKey:makeKey(m_identifier, m_keyPrefix, key)];
+    RetainPtr object = [[NSUserDefaults standardUserDefaults] objectForKey:makeKey(m_identifier, m_keyPrefix, key).get()];
     if (!object)
         return false;
     if (![object respondsToSelector:@selector(doubleValue)])
@@ -109,11 +109,11 @@ static RetainPtr<id> debugUserDefaultsValue(const String& identifier, const Stri
     RetainPtr<id> object;
 
     if (!identifier.isEmpty())
-        object = [standardUserDefaults objectForKey:makeKey(identifier, keyPrefix, key)];
+        object = [standardUserDefaults objectForKey:makeKey(identifier, keyPrefix, key).get()];
 
     if (!object) {
         // Allow debug preferences to be set globally, using the debug key prefix.
-        object = [standardUserDefaults objectForKey:[globalDebugKeyPrefix stringByAppendingString:key]];
+        object = [standardUserDefaults objectForKey:[globalDebugKeyPrefix.createNSString() stringByAppendingString:key.createNSString().get()]];
     }
 
     return object;
@@ -184,7 +184,7 @@ void WebPreferences::platformUpdateStringValueForKey(const String& key, const St
     if (!m_identifier)
         return;
 
-    [[NSUserDefaults standardUserDefaults] setObject:value forKey:makeKey(m_identifier, m_keyPrefix, key)];
+    [[NSUserDefaults standardUserDefaults] setObject:value.createNSString().get() forKey:makeKey(m_identifier, m_keyPrefix, key).get()];
 }
 
 void WebPreferences::platformUpdateBoolValueForKey(const String& key, bool value)
@@ -192,7 +192,7 @@ void WebPreferences::platformUpdateBoolValueForKey(const String& key, bool value
     if (!m_identifier)
         return;
 
-    [[NSUserDefaults standardUserDefaults] setBool:value forKey:makeKey(m_identifier, m_keyPrefix, key)];
+    [[NSUserDefaults standardUserDefaults] setBool:value forKey:makeKey(m_identifier, m_keyPrefix, key).get()];
 }
 
 void WebPreferences::platformUpdateUInt32ValueForKey(const String& key, uint32_t value)
@@ -200,7 +200,7 @@ void WebPreferences::platformUpdateUInt32ValueForKey(const String& key, uint32_t
     if (!m_identifier)
         return;
 
-    [[NSUserDefaults standardUserDefaults] setInteger:value forKey:makeKey(m_identifier, m_keyPrefix, key)];
+    [[NSUserDefaults standardUserDefaults] setInteger:value forKey:makeKey(m_identifier, m_keyPrefix, key).get()];
 }
 
 void WebPreferences::platformUpdateDoubleValueForKey(const String& key, double value)
@@ -208,7 +208,7 @@ void WebPreferences::platformUpdateDoubleValueForKey(const String& key, double v
     if (!m_identifier)
         return;
 
-    [[NSUserDefaults standardUserDefaults] setDouble:value forKey:makeKey(m_identifier, m_keyPrefix, key)];
+    [[NSUserDefaults standardUserDefaults] setDouble:value forKey:makeKey(m_identifier, m_keyPrefix, key).get()];
 }
 
 void WebPreferences::platformUpdateFloatValueForKey(const String& key, float value)
@@ -216,7 +216,7 @@ void WebPreferences::platformUpdateFloatValueForKey(const String& key, float val
     if (!m_identifier)
         return;
 
-    [[NSUserDefaults standardUserDefaults] setFloat:value forKey:makeKey(m_identifier, m_keyPrefix, key)];
+    [[NSUserDefaults standardUserDefaults] setFloat:value forKey:makeKey(m_identifier, m_keyPrefix, key).get()];
 }
 
 void WebPreferences::platformDeleteKey(const String& key)
@@ -224,7 +224,7 @@ void WebPreferences::platformDeleteKey(const String& key)
     if (!m_identifier)
         return;
 
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:makeKey(m_identifier, m_keyPrefix, key)];
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:makeKey(m_identifier, m_keyPrefix, key).get()];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -548,8 +548,8 @@ void WebProcessPool::platformInitializeNetworkProcess(NetworkProcessCreationPara
     parameters.uiProcessCookieStorageIdentifier = identifyingDataFromCookieStorage([[NSHTTPCookieStorage sharedHTTPCookieStorage] _cookieStorage]);
 #endif
 
-    parameters.enablePrivateClickMeasurement = ![defaults objectForKey:WebPreferencesKey::privateClickMeasurementEnabledKey()] || [defaults boolForKey:WebPreferencesKey::privateClickMeasurementEnabledKey()];
-    parameters.ftpEnabled = [defaults objectForKey:WebPreferencesKey::ftpEnabledKey()] && [defaults boolForKey:WebPreferencesKey::ftpEnabledKey()];
+    parameters.enablePrivateClickMeasurement = ![defaults objectForKey:WebPreferencesKey::privateClickMeasurementEnabledKey().createNSString().get()] || [defaults boolForKey:WebPreferencesKey::privateClickMeasurementEnabledKey().createNSString().get()];
+    parameters.ftpEnabled = [defaults objectForKey:WebPreferencesKey::ftpEnabledKey().createNSString().get()] && [defaults boolForKey:WebPreferencesKey::ftpEnabledKey().createNSString().get()];
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
     parameters.storageAccessPromptQuirksData = StorageAccessPromptQuirkController::sharedSingleton().cachedListData();

--- a/Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm
+++ b/Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm
@@ -341,14 +341,14 @@ static RetainPtr<ViewType> makeLabel(NSAttributedString *attributedString)
 - (void)addContent
 {
     RetainPtr warningViewIcon = viewForIconImage(self);
-    auto title = makeLabel(adoptNS([[NSAttributedString alloc] initWithString:_warning->title() attributes:@{
+    auto title = makeLabel(adoptNS([[NSAttributedString alloc] initWithString:_warning->title().createNSString().get() attributes:@{
         NSFontAttributeName:fontOfSize(WarningTextSize::Title),
         NSForegroundColorAttributeName:colorForItem(WarningItem::TitleText, self)
 #if PLATFORM(WATCHOS)
         , NSHyphenationFactorDocumentAttribute:@1
 #endif
     }]).get());
-    auto warning = makeLabel(adoptNS([[NSAttributedString alloc] initWithString:_warning->warning() attributes:@{
+    auto warning = makeLabel(adoptNS([[NSAttributedString alloc] initWithString:_warning->warning().createNSString().get() attributes:@{
         NSFontAttributeName:fontOfSize(WarningTextSize::Body),
         NSForegroundColorAttributeName:colorForItem(WarningItem::MessageText, self)
 #if PLATFORM(WATCHOS)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
@@ -134,7 +134,7 @@ void WebExtensionContext::declarativeNetRequestToggleRulesets(const Vector<Strin
         else
             m_enabledStaticRulesetIDs.remove(identifier);
 
-        [rulesetIdentifiersToEnabledState setObject:@(newValue) forKey:identifier];
+        [rulesetIdentifiersToEnabledState setObject:@(newValue) forKey:identifier.createNSString().get()];
     }
 }
 
@@ -276,7 +276,7 @@ void WebExtensionContext::declarativeNetRequestGetMatchedRules(std::optional<Web
 _WKWebExtensionDeclarativeNetRequestSQLiteStore *WebExtensionContext::declarativeNetRequestDynamicRulesStore()
 {
     if (!m_declarativeNetRequestDynamicRulesStore)
-        m_declarativeNetRequestDynamicRulesStore = [[_WKWebExtensionDeclarativeNetRequestSQLiteStore alloc] initWithUniqueIdentifier:uniqueIdentifier() storageType:_WKWebExtensionDeclarativeNetRequestStorageType::Dynamic directory:storageDirectory() usesInMemoryDatabase:!storageIsPersistent()];
+        m_declarativeNetRequestDynamicRulesStore = [[_WKWebExtensionDeclarativeNetRequestSQLiteStore alloc] initWithUniqueIdentifier:uniqueIdentifier().createNSString().get() storageType:_WKWebExtensionDeclarativeNetRequestStorageType::Dynamic directory:storageDirectory().createNSString().get() usesInMemoryDatabase:!storageIsPersistent()];
 
     return m_declarativeNetRequestDynamicRulesStore.get();
 }
@@ -284,7 +284,7 @@ _WKWebExtensionDeclarativeNetRequestSQLiteStore *WebExtensionContext::declarativ
 _WKWebExtensionDeclarativeNetRequestSQLiteStore *WebExtensionContext::declarativeNetRequestSessionRulesStore()
 {
     if (!m_declarativeNetRequestSessionRulesStore)
-        m_declarativeNetRequestSessionRulesStore = [[_WKWebExtensionDeclarativeNetRequestSQLiteStore alloc] initWithUniqueIdentifier:uniqueIdentifier() storageType:_WKWebExtensionDeclarativeNetRequestStorageType::Session directory:storageDirectory() usesInMemoryDatabase:YES];
+        m_declarativeNetRequestSessionRulesStore = [[_WKWebExtensionDeclarativeNetRequestSQLiteStore alloc] initWithUniqueIdentifier:uniqueIdentifier().createNSString().get() storageType:_WKWebExtensionDeclarativeNetRequestStorageType::Session directory:storageDirectory().createNSString().get() usesInMemoryDatabase:YES];
 
     return m_declarativeNetRequestSessionRulesStore.get();
 }
@@ -376,7 +376,7 @@ void WebExtensionContext::declarativeNetRequestUpdateDynamicRules(String&& rules
         return @(ruleID);
     }).get();
 
-    auto *rulesToAdd = dynamic_objc_cast<NSArray>(parseJSON(rulesToAddJSON, JSONOptions::FragmentsAllowed)) ?: @[ ];
+    auto *rulesToAdd = dynamic_objc_cast<NSArray>(parseJSON(rulesToAddJSON.createNSString().get(), JSONOptions::FragmentsAllowed)) ?: @[ ];
 
     if (!ruleIDsToDelete.count && !rulesToAdd.count) {
         completionHandler({ });
@@ -418,7 +418,7 @@ void WebExtensionContext::declarativeNetRequestUpdateSessionRules(String&& rules
         return @(ruleID);
     }).get();
 
-    auto *rulesToAdd = dynamic_objc_cast<NSArray>(parseJSON(rulesToAddJSON, JSONOptions::FragmentsAllowed)) ?: @[ ];
+    auto *rulesToAdd = dynamic_objc_cast<NSArray>(parseJSON(rulesToAddJSON.createNSString().get(), JSONOptions::FragmentsAllowed)) ?: @[ ];
 
     if (!ruleIDsToDelete.count && !rulesToAdd.count) {
         completionHandler({ });

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm
@@ -221,7 +221,7 @@ void WebExtensionContext::firePortMessageEventsIfNeeded(WebExtensionContentWorld
 
     case WebExtensionContentWorldType::Native:
         if (RefPtr nativePort = m_nativePortMap.get(channelIdentifier))
-            nativePort->receiveMessage(parseJSON(messageJSON, JSONOptions::FragmentsAllowed), std::nullopt);
+            nativePort->receiveMessage(parseJSON(messageJSON.createNSString().get(), JSONOptions::FragmentsAllowed), std::nullopt);
         return;
 
     case WebExtensionContentWorldType::WebPage:
@@ -260,7 +260,7 @@ void WebExtensionContext::sendQueuedNativePortMessagesIfNeeded(WebExtensionPortC
     RELEASE_LOG_DEBUG(Extensions, "Sending %{public}zu queued message(s) to port channel %{public}llu in native world", messages.size(), channelIdentifier.toUInt64());
 
     for (auto& entry : messages) {
-        id message = parseJSON(std::get<String>(entry), JSONOptions::FragmentsAllowed);
+        id message = parseJSON(std::get<String>(entry).createNSString().get(), JSONOptions::FragmentsAllowed);
 
         nativePort->sendMessage(message, [=](WebExtensionMessagePort::Error error) {
             if (error)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
@@ -344,7 +344,7 @@ void WebExtensionContext::sendNativeMessage(const String& applicationID, id mess
 
 void WebExtensionContext::runtimeSendNativeMessage(const String& applicationID, const String& messageJSON, CompletionHandler<void(Expected<String, WebExtensionError>&&)>&& completionHandler)
 {
-    sendNativeMessage(applicationID, parseJSON(messageJSON, JSONOptions::FragmentsAllowed), [completionHandler = WTFMove(completionHandler)](auto&& result) mutable {
+    sendNativeMessage(applicationID, parseJSON(messageJSON.createNSString().get(), JSONOptions::FragmentsAllowed), [completionHandler = WTFMove(completionHandler)](auto&& result) mutable {
         if (!result) {
             completionHandler(makeUnexpected(result.error()));
             return;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
@@ -349,7 +349,7 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
         auto scriptID = parameters.identifier;
 
         if (firstTimeRegistration == FirstTimeRegistration::Yes && (m_registeredScriptsMap.contains(scriptID) || idsToAdd.contains(scriptID))) {
-            *errorMessage = toErrorString(callingAPIName, nullString(), @"duplicate ID '%@'", scriptID.createNSString().get());
+            *errorMessage = toErrorString(callingAPIName, nullString(), @"duplicate ID '%@'", scriptID.createNSString().get()).createNSString().autorelease();
             return false;
         }
 
@@ -369,7 +369,7 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
             RefPtr<API::Error> error;
             if (!extension->resourceStringForPath(scriptPath, error)) {
                 recordError(::WebKit::wrapper(*error));
-                *errorMessage = toErrorString(callingAPIName, nullString(), @"invalid resource '%@'", scriptPath);
+                *errorMessage = toErrorString(callingAPIName, nullString(), @"invalid resource '%@'", scriptPath).createNSString().autorelease();
                 return false;
             }
         }
@@ -384,7 +384,7 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
             RefPtr<API::Error> error;
             if (!extension->resourceStringForPath(styleSheetPath, error)) {
                 recordError(::WebKit::wrapper(*error));
-                *errorMessage = toErrorString(callingAPIName, nullString(), @"invalid resource '%@'", styleSheetPath);
+                *errorMessage = toErrorString(callingAPIName, nullString(), @"invalid resource '%@'", styleSheetPath).createNSString().autorelease();
                 return false;
             }
         }
@@ -393,13 +393,13 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
         auto *matchesArray = parameters.matchPatterns ? createNSArray(parameters.matchPatterns.value()).get() : @[ ];
         for (NSString *matchPatternString in matchesArray) {
             if (!matchPatternString.length) {
-                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' contains an empty match pattern", scriptID.createNSString().get());
+                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' contains an empty match pattern", scriptID.createNSString().get()).createNSString().autorelease();
                 return false;
             }
 
             RefPtr matchPattern = WebExtensionMatchPattern::getOrCreate(matchPatternString);
             if (!matchPattern || !matchPattern->isSupported()) {
-                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' has an invalid match pattern '%@'", scriptID.createNSString().get(), matchPatternString);
+                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' has an invalid match pattern '%@'", scriptID.createNSString().get(), matchPatternString).createNSString().autorelease();
                 return false;
             }
 
@@ -410,13 +410,13 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
         auto *excludeMatchesArray = parameters.excludeMatchPatterns ? createNSArray(parameters.excludeMatchPatterns.value()).get() : @[ ];
         for (NSString *matchPatternString in excludeMatchesArray) {
             if (!matchPatternString.length) {
-                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' contains an empty exclude match pattern", scriptID.createNSString().get());
+                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' contains an empty exclude match pattern", scriptID.createNSString().get()).createNSString().autorelease();
                 return false;
             }
 
             RefPtr matchPattern = WebExtensionMatchPattern::getOrCreate(matchPatternString);
             if (!matchPattern || !matchPattern->isSupported()) {
-                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' has an invalid exclude match pattern '%@'", scriptID.createNSString().get(), matchPatternString);
+                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' has an invalid exclude match pattern '%@'", scriptID.createNSString().get(), matchPatternString).createNSString().autorelease();
                 return false;
             }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -600,10 +600,10 @@ void WebExtensionContext::tabsExecuteScript(WebPageProxyIdentifier webPageProxyI
         if (parameters.code)
             scriptData = SourcePair { parameters.code.value(), URL { } };
         else {
-            NSString *filePath = parameters.files.value().first();
-            scriptData = sourcePairForResource(filePath, *this);
+            RetainPtr filePath = parameters.files.value().first().createNSString();
+            scriptData = sourcePairForResource(filePath.get(), *this);
             if (!scriptData) {
-                completionHandler(toWebExtensionError(apiName, nullString(), @"Invalid resource: %@", filePath));
+                completionHandler(toWebExtensionError(apiName, nullString(), @"Invalid resource: %@", filePath.get()));
                 return;
             }
         }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionControllerAPITestCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionControllerAPITestCocoa.mm
@@ -43,7 +43,7 @@ void WebExtensionController::testResult(bool result, String message, String sour
 {
     auto delegate = this->delegate();
     if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestAssertionResult:withMessage:andSourceURL:lineNumber:)]) {
-        [delegate _webExtensionController:wrapper() recordTestAssertionResult:result withMessage:message andSourceURL:sourceURL lineNumber:lineNumber];
+        [delegate _webExtensionController:wrapper() recordTestAssertionResult:result withMessage:message.createNSString().get() andSourceURL:sourceURL.createNSString().get() lineNumber:lineNumber];
         return;
     }
 
@@ -62,7 +62,7 @@ void WebExtensionController::testEqual(bool result, String expectedValue, String
 {
     auto delegate = this->delegate();
     if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestEqualityResult:expectedValue:actualValue:withMessage:andSourceURL:lineNumber:)]) {
-        [delegate _webExtensionController:wrapper() recordTestEqualityResult:result expectedValue:expectedValue actualValue:actualValue withMessage:message andSourceURL:sourceURL lineNumber:lineNumber];
+        [delegate _webExtensionController:wrapper() recordTestEqualityResult:result expectedValue:expectedValue.createNSString().get() actualValue:actualValue.createNSString().get() withMessage:message.createNSString().get() andSourceURL:sourceURL.createNSString().get() lineNumber:lineNumber];
         return;
     }
 
@@ -81,7 +81,7 @@ void WebExtensionController::testLogMessage(String message, String sourceURL, un
 {
     auto delegate = this->delegate();
     if ([delegate respondsToSelector:@selector(_webExtensionController:logTestMessage:andSourceURL:lineNumber:)]) {
-        [delegate _webExtensionController:wrapper() logTestMessage:message andSourceURL:sourceURL lineNumber:lineNumber];
+        [delegate _webExtensionController:wrapper() logTestMessage:message.createNSString().get() andSourceURL:sourceURL.createNSString().get() lineNumber:lineNumber];
         return;
     }
 
@@ -95,18 +95,18 @@ void WebExtensionController::testSentMessage(String message, String argument, St
 {
     auto delegate = this->delegate();
     if ([delegate respondsToSelector:@selector(_webExtensionController:receivedTestMessage:withArgument:andSourceURL:lineNumber:)]) {
-        [delegate _webExtensionController:wrapper() receivedTestMessage:message withArgument:parseJSON(argument, JSONOptions::FragmentsAllowed) andSourceURL:sourceURL lineNumber:lineNumber];
+        [delegate _webExtensionController:wrapper() receivedTestMessage:message.createNSString().get() withArgument:parseJSON(argument.createNSString().get(), JSONOptions::FragmentsAllowed) andSourceURL:sourceURL.createNSString().get() lineNumber:lineNumber];
         return;
     }
 
-    RELEASE_LOG_INFO(Extensions, "Test sent message: %{public}@ %{public}@ (%{public}@:%{public}u)", message.createNSString().get(), (NSString *)argument, sourceURL.createNSString().get(), lineNumber);
+    RELEASE_LOG_INFO(Extensions, "Test sent message: %{public}@ %{public}@ (%{public}@:%{public}u)", message.createNSString().get(), argument.createNSString().get(), sourceURL.createNSString().get(), lineNumber);
 }
 
 void WebExtensionController::testAdded(String testName, String sourceURL, unsigned lineNumber)
 {
     auto delegate = this->delegate();
     if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestAddedWithName:andSourceURL:lineNumber:)]) {
-        [delegate _webExtensionController:wrapper() recordTestAddedWithName:testName andSourceURL:sourceURL lineNumber:lineNumber];
+        [delegate _webExtensionController:wrapper() recordTestAddedWithName:testName.createNSString().get() andSourceURL:sourceURL.createNSString().get() lineNumber:lineNumber];
         return;
     }
 
@@ -117,7 +117,7 @@ void WebExtensionController::testStarted(String testName, String sourceURL, unsi
 {
     auto delegate = this->delegate();
     if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestStartedWithName:andSourceURL:lineNumber:)]) {
-        [delegate _webExtensionController:wrapper() recordTestStartedWithName:testName andSourceURL:sourceURL lineNumber:lineNumber];
+        [delegate _webExtensionController:wrapper() recordTestStartedWithName:testName.createNSString().get() andSourceURL:sourceURL.createNSString().get() lineNumber:lineNumber];
         return;
     }
 
@@ -128,7 +128,7 @@ void WebExtensionController::testFinished(String testName, bool result, String m
 {
     auto delegate = this->delegate();
     if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestFinishedWithName:result:message:andSourceURL:lineNumber:)]) {
-        [delegate _webExtensionController:wrapper() recordTestFinishedWithName:testName result:result message:message andSourceURL:sourceURL lineNumber:lineNumber];
+        [delegate _webExtensionController:wrapper() recordTestFinishedWithName:testName.createNSString().get() result:result message:message.createNSString().get() andSourceURL:sourceURL.createNSString().get() lineNumber:lineNumber];
         return;
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -849,13 +849,13 @@ NSString *WebExtensionAction::popupWebViewInspectionName()
         if (RefPtr extensionContext = this->extensionContext())
             m_popupWebViewInspectionName = WEB_UI_FORMAT_CFSTRING("%@ — Extension Popup Page", "Label for an inspectable Web Extension popup page", extensionContext->protectedExtension()->displayShortName().createCFString().get());
     }
-    return m_popupWebViewInspectionName;
+    return m_popupWebViewInspectionName.createNSString().autorelease();
 }
 
 void WebExtensionAction::setPopupWebViewInspectionName(const String& name)
 {
     m_popupWebViewInspectionName = name;
-    m_popupWebView.get()._remoteInspectionNameOverride = name;
+    m_popupWebView.get()._remoteInspectionNameOverride = name.createNSString().get();
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -988,7 +988,7 @@ WKWebView *WebExtensionAction::popupWebView()
     m_popupWebView.get().navigationDelegate = m_popupWebViewDelegate.get();
     m_popupWebView.get().UIDelegate = m_popupWebViewDelegate.get();
     m_popupWebView.get().inspectable = extensionContext->isInspectable();
-    m_popupWebView.get().accessibilityLabel = extensionContext->protectedExtension()->displayName();
+    m_popupWebView.get().accessibilityLabel = extensionContext->protectedExtension()->displayName().createNSString().get();
     m_popupWebView.get()._remoteInspectionNameOverride = popupWebViewInspectionName();
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -74,7 +74,7 @@ WebExtension::WebExtension(NSBundle *appExtensionBundle, NSURL *resourceURL, Ref
 
     if (m_resourceBaseURL.isValid()) {
         BOOL isDirectory;
-        if (![NSFileManager.defaultManager fileExistsAtPath:m_resourceBaseURL.fileSystemPath() isDirectory:&isDirectory]) {
+        if (![NSFileManager.defaultManager fileExistsAtPath:m_resourceBaseURL.fileSystemPath().createNSString().get() isDirectory:&isDirectory]) {
             outError = createError(Error::Unknown);
             return;
         }
@@ -135,7 +135,7 @@ NSDictionary *WebExtension::manifestDictionary()
     if (!manifestObject)
         return nil;
 
-    return parseJSON(manifestObject->toJSONString());
+    return parseJSON(manifestObject->toJSONString().createNSString().get());
 }
 
 SecStaticCodeRef WebExtension::bundleStaticCode() const
@@ -392,10 +392,11 @@ RefPtr<WebCore::Icon> WebExtension::bestIcon(RefPtr<JSON::Object> icons, WebCore
         if (iconPath.isEmpty())
             continue;
 
-        [uniquePaths addObject:iconPath];
+        RetainPtr nsIconPath = iconPath.createNSString();
+        [uniquePaths addObject:nsIconPath.get()];
 
 #if PLATFORM(IOS_FAMILY)
-        scalePaths[@(scale)] = iconPath;
+        scalePaths[@(scale)] = nsIconPath.get();
 #endif
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
@@ -218,7 +218,7 @@ String WebExtensionCommand::userVisibleShortcut() const
         return emptyString();
 
 #if PLATFORM(MAC)
-    NSKeyboardShortcut *shortcut = [NSKeyboardShortcut shortcutWithKeyEquivalent:key modifierMask:flags.toRaw()];
+    NSKeyboardShortcut *shortcut = [NSKeyboardShortcut shortcutWithKeyEquivalent:key.createNSString().get() modifierMask:flags.toRaw()];
     return shortcut.localizedDisplayName ?: @"";
 #else
     static NeverDestroyed<HashMap<String, String>> specialKeyMap = HashMap<String, String> {
@@ -275,12 +275,12 @@ String WebExtensionCommand::userVisibleShortcut() const
 CocoaMenuItem *WebExtensionCommand::platformMenuItem() const
 {
 #if USE(APPKIT)
-    auto *result = [[_WKWebExtensionMenuItem alloc] initWithTitle:description() handler:makeBlockPtr([this, protectedThis = Ref { *this }](id sender) mutable {
+    auto *result = [[_WKWebExtensionMenuItem alloc] initWithTitle:description().createNSString().get() handler:makeBlockPtr([this, protectedThis = Ref { *this }](id sender) mutable {
         if (RefPtr context = extensionContext())
             context->performCommand(const_cast<WebExtensionCommand&>(*this), WebExtensionContext::UserTriggered::Yes);
     }).get()];
 
-    result.keyEquivalent = activationKey();
+    result.keyEquivalent = activationKey().createNSString().get();
     result.keyEquivalentModifierMask = modifierFlags().toRaw();
     if (RefPtr context = extensionContext())
         result.image = toCocoaImage(context->protectedExtension()->icon(WebCore::FloatSize(16, 16)));

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -165,7 +165,7 @@ void WebExtensionController::getDataRecords(OptionSet<WebExtensionDataType> data
 
             calculateStorageSize(storage, dataType, makeBlockPtr([recordHolder, aggregator, uniqueIdentifier, displayName, dataType, record = Ref { record }](Expected<size_t, WebExtensionError>&& result) mutable {
                 if (!result)
-                    record->addError(result.error(), dataType);
+                    record->addError(result.error().createNSString().get(), dataType);
                 else
                     record->setSizeOfType(dataType, result.value());
             }));
@@ -215,7 +215,7 @@ void WebExtensionController::getDataRecord(OptionSet<WebExtensionDataType> dataT
 
         calculateStorageSize(storage, dataType, makeBlockPtr([recordHolder, aggregator, matchingUniqueIdentifier, displayName, dataType, record = Ref { record }](Expected<size_t, WebExtensionError>&& result) mutable {
             if (!result)
-                record->addError(result.error(), dataType);
+                record->addError(result.error().createNSString().get(), dataType);
             else
                 record->setSizeOfType(dataType, result.value());
         }));
@@ -246,9 +246,9 @@ void WebExtensionController::removeData(OptionSet<WebExtensionDataType> dataType
 
             removeStorage(storage, dataType, makeBlockPtr([aggregator, uniqueIdentifier, dataType, record = Ref { record }](Expected<void, WebExtensionError>&& result) mutable {
                 if (!result)
-                    record->addError(result.error(), dataType);
+                    record->addError(result.error().createNSString().get(), dataType);
                 else
-                    [NSDistributedNotificationCenter.defaultCenter postNotificationName:WebExtensionLocalStorageWasDeletedNotification object:nil userInfo:@{ WebExtensionUniqueIdentifierKey: uniqueIdentifier }];
+                    [NSDistributedNotificationCenter.defaultCenter postNotificationName:WebExtensionLocalStorageWasDeletedNotification object:nil userInfo:@{ WebExtensionUniqueIdentifierKey: uniqueIdentifier.createNSString().get() }];
             }));
         }
     }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -166,7 +166,7 @@ void executeScript(const SourcePairs& scriptPairs, WKWebView *webView, API::Cont
             }
 
             for (auto& script : scriptPairs) {
-                [webView _evaluateJavaScript:script.first withSourceURL:script.second.createNSURL().get() inFrame:frameInfo inContentWorld:executionWorld->wrapper() completionHandler:makeBlockPtr([injectionResults, aggregator, frameInfo](id resultOfExecution, NSError *error) mutable {
+                [webView _evaluateJavaScript:script.first.createNSString().get() withSourceURL:script.second.createNSURL().get() inFrame:frameInfo inContentWorld:executionWorld->wrapper() completionHandler:makeBlockPtr([injectionResults, aggregator, frameInfo](id resultOfExecution, NSError *error) mutable {
                     injectionResults->results.append(toInjectionResultParameters(resultOfExecution, frameInfo, error.localizedDescription));
                 }).get()];
             }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm
@@ -289,13 +289,13 @@ CocoaMenuItem *WebExtensionMenuItem::platformMenuItem(const WebExtensionMenuItem
     if (type() == WebExtensionMenuItemType::Separator)
         return [NSMenuItem separatorItem];
 
-    auto *result = [[_WKWebExtensionMenuItem alloc] initWithTitle:processedTitle handler:makeBlockPtr([this, protectedThis = Ref { *this }, contextParameters](id sender) mutable {
+    auto *result = [[_WKWebExtensionMenuItem alloc] initWithTitle:processedTitle.createNSString().get() handler:makeBlockPtr([this, protectedThis = Ref { *this }, contextParameters](id sender) mutable {
         if (RefPtr context = extensionContext())
             context->performMenuItem(const_cast<WebExtensionMenuItem&>(*this), contextParameters, WebExtensionContext::UserTriggered::Yes);
     }).get()];
 
     if (RefPtr command = this->command()) {
-        result.keyEquivalent = command->activationKey();
+        result.keyEquivalent = command->activationKey().createNSString().get();
         result.keyEquivalentModifierMask = command->modifierFlags().toRaw();
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
@@ -127,9 +127,9 @@ void WebExtensionURLSchemeHandler::platformStartTask(WebPageProxy& page, WebURLS
 
         auto *urlResponse = [[NSHTTPURLResponse alloc] initWithURL:requestURL.createNSURL().get() statusCode:200 HTTPVersion:nil headerFields:@{
             @"Access-Control-Allow-Origin": @"*",
-            @"Content-Security-Policy": extension->contentSecurityPolicy(),
+            @"Content-Security-Policy": extension->contentSecurityPolicy().createNSString().get(),
             @"Content-Length": @(resourceData->size()).stringValue,
-            @"Content-Type": mimeType
+            @"Content-Type": mimeType.createNSString().get()
         }];
 
         task->didReceiveResponse(urlResponse);

--- a/Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm
+++ b/Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm
@@ -79,7 +79,7 @@ void InspectorExtensionDelegate::InspectorExtensionClient::didShowExtensionTab(c
     if (!delegate)
         return;
 
-    [delegate inspectorExtension:m_inspectorExtensionDelegate->m_inspectorExtension.get().get() didShowTabWithIdentifier:extensionTabID withFrameHandle:wrapper(API::FrameHandle::create(frameID)).get()];
+    [delegate inspectorExtension:m_inspectorExtensionDelegate->m_inspectorExtension.get().get() didShowTabWithIdentifier:extensionTabID.createNSString().get() withFrameHandle:wrapper(API::FrameHandle::create(frameID)).get()];
 }
 
 void InspectorExtensionDelegate::InspectorExtensionClient::didHideExtensionTab(const Inspector::ExtensionTabID& extensionTabID)
@@ -91,7 +91,7 @@ void InspectorExtensionDelegate::InspectorExtensionClient::didHideExtensionTab(c
     if (!delegate)
         return;
 
-    [delegate inspectorExtension:m_inspectorExtensionDelegate->m_inspectorExtension.get().get() didHideTabWithIdentifier:extensionTabID];
+    [delegate inspectorExtension:m_inspectorExtensionDelegate->m_inspectorExtension.get().get() didHideTabWithIdentifier:extensionTabID.createNSString().get()];
 }
 
 void InspectorExtensionDelegate::InspectorExtensionClient::didNavigateExtensionTab(const Inspector::ExtensionTabID& extensionTabID, const WTF::URL& newURL)
@@ -103,7 +103,7 @@ void InspectorExtensionDelegate::InspectorExtensionClient::didNavigateExtensionT
     if (!delegate)
         return;
 
-    [delegate inspectorExtension:m_inspectorExtensionDelegate->m_inspectorExtension.get().get() didNavigateTabWithIdentifier:extensionTabID newURL:newURL.createNSURL().get()];
+    [delegate inspectorExtension:m_inspectorExtensionDelegate->m_inspectorExtension.get().get() didNavigateTabWithIdentifier:extensionTabID.createNSString().get() newURL:newURL.createNSURL().get()];
 }
 
 void InspectorExtensionDelegate::InspectorExtensionClient::inspectedPageDidNavigate(const WTF::URL& newURL)

--- a/Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
@@ -160,16 +160,16 @@ void RemoteWebInspectorUIProxy::platformSave(Vector<InspectorFrontendClient::Sav
     RetainPtr<NSString> urlCommonPrefix;
     for (auto& item : saveDatas) {
         if (!urlCommonPrefix)
-            urlCommonPrefix = item.url;
+            urlCommonPrefix = item.url.createNSString();
         else
-            urlCommonPrefix = [urlCommonPrefix commonPrefixWithString:item.url options:0];
+            urlCommonPrefix = [urlCommonPrefix commonPrefixWithString:item.url.createNSString().get() options:0];
     }
     if ([urlCommonPrefix hasSuffix:@"."])
         urlCommonPrefix = [urlCommonPrefix substringToIndex:[urlCommonPrefix length] - 1];
 
     RetainPtr platformURL = m_suggestedToActualURLMap.get(urlCommonPrefix.get());
     if (!platformURL) {
-        platformURL = [NSURL URLWithString:urlCommonPrefix.get()];
+        platformURL = adoptNS([[NSURL alloc] initWithString:urlCommonPrefix.get()]);
         // The user must confirm new filenames before we can save to them.
         forceSaveAs = true;
     }
@@ -236,12 +236,12 @@ void RemoteWebInspectorUIProxy::platformStartWindowDrag()
 
 void RemoteWebInspectorUIProxy::platformOpenURLExternally(const String& url)
 {
-    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
+    [[NSWorkspace sharedWorkspace] openURL:adoptNS([[NSURL alloc] initWithString:url.createNSString().get()]).get()];
 }
 
 void RemoteWebInspectorUIProxy::platformRevealFileExternally(const String& path)
 {
-    [[NSWorkspace sharedWorkspace] activateFileViewerSelectingURLs:@[ [NSURL URLWithString:path] ]];
+    [[NSWorkspace sharedWorkspace] activateFileViewerSelectingURLs:@[ adoptNS([[NSURL alloc] initWithString:path.createNSString().get()]).get() ]];
 }
 
 void RemoteWebInspectorUIProxy::platformShowCertificate(const CertificateInfo& certificateInfo)

--- a/Source/WebKit/UIProcess/Inspector/mac/WKInspectorResourceURLSchemeHandler.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WKInspectorResourceURLSchemeHandler.mm
@@ -56,7 +56,7 @@
 - (NSSet<NSURL *> *)mainResourceURLsForCSP
 {
     if (!_mainResourceURLsForCSP)
-        _mainResourceURLsForCSP = adoptNS([[NSSet alloc] initWithObjects:[NSURL URLWithString:WebKit::WebInspectorUIProxy::inspectorPageURL()], [NSURL URLWithString:WebKit::WebInspectorUIProxy::inspectorTestPageURL()], nil]);
+        _mainResourceURLsForCSP = adoptNS([[NSSet alloc] initWithObjects:adoptNS([[NSURL alloc] initWithString:WebKit::WebInspectorUIProxy::inspectorPageURL().createNSString().get()]).get(), adoptNS([[NSURL alloc] initWithString:WebKit::WebInspectorUIProxy::inspectorTestPageURL().createNSString().get()]).get(), nil]);
 
     return _mainResourceURLsForCSP.get();
 }
@@ -98,14 +98,14 @@
             return;
         }
 
-        NSString *mimeType = WebCore::MIMETypeRegistry::mimeTypeForExtension(String(fileURLForRequest.pathExtension));
+        RetainPtr mimeType = WebCore::MIMETypeRegistry::mimeTypeForExtension(String(fileURLForRequest.pathExtension)).createNSString();
         if (!mimeType)
             mimeType = @"application/octet-stream";
 
         RetainPtr<NSMutableDictionary> headerFields = adoptNS(@{
             @"Access-Control-Allow-Origin": @"*",
             @"Content-Length": adoptNS([[NSString alloc] initWithFormat:@"%zu", (size_t)fileData.length]).get(),
-            @"Content-Type": mimeType,
+            @"Content-Type": mimeType.get(),
         }.mutableCopy);
 
         // Allow fetches for resources that use a registered custom URL scheme.

--- a/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
@@ -126,7 +126,7 @@ static NSString * const WKInspectorResourceScheme = @"inspector-resource";
     RetainPtr<WKInspectorResourceURLSchemeHandler> inspectorSchemeHandler = adoptNS([WKInspectorResourceURLSchemeHandler new]);
     RetainPtr<NSMutableSet<NSString *>> allowedURLSchemes = adoptNS([[NSMutableSet alloc] initWithObjects:WKInspectorResourceScheme, nil]);
     for (auto& pair : _configuration->_configuration->urlSchemeHandlers())
-        [allowedURLSchemes addObject:pair.second];
+        [allowedURLSchemes addObject:pair.second.createNSString().get()];
 
     [inspectorSchemeHandler setAllowedURLSchemesForCSP:allowedURLSchemes.get()];
     [configuration setURLSchemeHandler:inspectorSchemeHandler.get() forURLScheme:WKInspectorResourceScheme];
@@ -178,7 +178,7 @@ static NSString * const WKInspectorResourceScheme = @"inspector-resource";
 
     // Ensure that a page group identifier is set. This is for computing inspection levels.
     if (!configuration.get()._groupIdentifier)
-        [configuration _setGroupIdentifier:WebKit::defaultInspectorPageGroupIdentifierForPage(inspectedPage.get())];
+        [configuration _setGroupIdentifier:WebKit::defaultInspectorPageGroupIdentifierForPage(inspectedPage.get()).createNSString().get()];
 
     // Prefer using a custom persistent data store if one exists.
     RetainPtr<WKWebsiteDataStore> targetDataStore;

--- a/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm
+++ b/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm
@@ -184,7 +184,7 @@ void MediaUsageManagerCocoa::updateMediaUsage(WebCore::MediaSessionIdentifier id
             if (!mediaUsageInfo.isPlaying)
                 return;
 
-            session->usageTracker = adoptNS([PAL::allocUSVideoUsageInstance() initWithBundleIdentifier:session->bundleIdentifier URL:session->pageURL.createNSURL().get()
+            session->usageTracker = adoptNS([PAL::allocUSVideoUsageInstance() initWithBundleIdentifier:session->bundleIdentifier.createNSString().get() URL:session->pageURL.createNSURL().get()
                 mediaURL:mediaUsageInfo.mediaURL.createNSURL().get() videoMetadata:metadata]);
             ASSERT(session->usageTracker);
             if (!session->usageTracker)

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -525,7 +525,7 @@ void LocalAuthenticator::continueMakeCredentialAfterUserVerification(SecAccessCo
         auto query = adoptNS([[NSMutableDictionary alloc] init]);
         [query setDictionary:@{
             (id)kSecClass: (id)kSecClassKey,
-            (id)kSecAttrLabel: secAttrLabel,
+            (id)kSecAttrLabel: secAttrLabel.createNSString().get(),
             (id)kSecAttrApplicationLabel: m_provisionalCredentialId.get(),
             (id)kSecUseDataProtectionKeychain: @YES
         }];

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -315,10 +315,10 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForRegistration(con
         }
     }
 
-    RetainPtr<ASPublicKeyCredentialClientData> clientData = adoptNS([allocASPublicKeyCredentialClientDataInstance() initWithChallenge:toNSData(options.challenge).get() origin:callerOrigin.toString()]);
+    RetainPtr<ASPublicKeyCredentialClientData> clientData = adoptNS([allocASPublicKeyCredentialClientDataInstance() initWithChallenge:toNSData(options.challenge).get() origin:callerOrigin.toString().createNSString().get()]);
     if (includePlatformRequest) {
-        RetainPtr provider = adoptNS([allocASAuthorizationPlatformPublicKeyCredentialProviderInstance() initWithRelyingPartyIdentifier:options.rp.id]);
-        RetainPtr request = adoptNS([provider createCredentialRegistrationRequestWithClientData:clientData.get() name:options.user.name userID:toNSData(options.user.id).get()]);
+        RetainPtr provider = adoptNS([allocASAuthorizationPlatformPublicKeyCredentialProviderInstance() initWithRelyingPartyIdentifier:options.rp.id.createNSString().get()]);
+        RetainPtr request = adoptNS([provider createCredentialRegistrationRequestWithClientData:clientData.get() name:options.user.name.createNSString().get() userID:toNSData(options.user.id).get()]);
 
         if (m_isConditionalMediation && [request respondsToSelector:@selector(setRequestStyle:)])
             request.get().requestStyle = ASAuthorizationPlatformPublicKeyCredentialRegistrationRequestStyleConditional;
@@ -347,12 +347,12 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForRegistration(con
     }
 #if HAVE(SECURITY_KEY_API)
     if (includeSecurityKeyRequest) {
-        RetainPtr provider = adoptNS([allocASAuthorizationSecurityKeyPublicKeyCredentialProviderInstance() initWithRelyingPartyIdentifier:options.rp.id]);
+        RetainPtr provider = adoptNS([allocASAuthorizationSecurityKeyPublicKeyCredentialProviderInstance() initWithRelyingPartyIdentifier:options.rp.id.createNSString().get()]);
         RetainPtr<ASAuthorizationSecurityKeyPublicKeyCredentialRegistrationRequest> request;
         if ([provider respondsToSelector:@selector(createCredentialRegistrationRequestWithClientData:displayName:name:userID:)])
-            request = adoptNS([provider createCredentialRegistrationRequestWithClientData:clientData.get() displayName:options.user.displayName name:options.user.name userID:toNSData(options.user.id).get()]);
+            request = adoptNS([provider createCredentialRegistrationRequestWithClientData:clientData.get() displayName:options.user.displayName.createNSString().get() name:options.user.name.createNSString().get() userID:toNSData(options.user.id).get()]);
         else
-            request = adoptNS([provider createCredentialRegistrationRequestWithChallenge:toNSData(options.challenge).get() displayName:options.user.displayName name:options.user.name userID:toNSData(options.user.id).get()]);
+            request = adoptNS([provider createCredentialRegistrationRequestWithChallenge:toNSData(options.challenge).get() displayName:options.user.displayName.createNSString().get() name:options.user.name.createNSString().get() userID:toNSData(options.user.id).get()]);
         request.get().attestationPreference = toAttestationConveyancePreference(options.attestation).get();
         RetainPtr<NSMutableArray<ASAuthorizationPublicKeyCredentialParameters *>> parameters = adoptNS([[NSMutableArray alloc] init]);
         for (auto alg : options.pubKeyCredParams)
@@ -412,13 +412,13 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForAssertion(const 
         if (!allowHybrid && allowsHybrid(credential.transports))
             allowHybrid = true;
     }
-    RetainPtr clientData = adoptNS([allocASPublicKeyCredentialClientDataInstance() initWithChallenge:toNSData(options.challenge).get() origin:callerOrigin.toString()]);
+    RetainPtr clientData = adoptNS([allocASPublicKeyCredentialClientDataInstance() initWithChallenge:toNSData(options.challenge).get() origin:callerOrigin.toString().createNSString().get()]);
     if (parentOrigin) {
         clientData.get().crossOrigin = ASPublicKeyCredentialClientDataCrossOriginValueCrossOrigin;
-        clientData.get().topOrigin = parentOrigin->toString();
+        clientData.get().topOrigin = parentOrigin->toString().createNSString().get();
     }
     if ([platformAllowedCredentials count] || ![crossPlatformAllowedCredentials count]) {
-        RetainPtr provider = adoptNS([allocASAuthorizationPlatformPublicKeyCredentialProviderInstance() initWithRelyingPartyIdentifier:options.rpId]);
+        RetainPtr provider = adoptNS([allocASAuthorizationPlatformPublicKeyCredentialProviderInstance() initWithRelyingPartyIdentifier:options.rpId.createNSString().get()]);
         RetainPtr request = adoptNS([provider createCredentialAssertionRequestWithClientData:clientData.get()]);
         if (platformAllowedCredentials)
             request.get().allowedCredentials = platformAllowedCredentials.get();
@@ -461,7 +461,7 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForAssertion(const 
 
 #if HAVE(SECURITY_KEY_API)
     if (!m_isConditionalMediation && ([crossPlatformAllowedCredentials count] || ![platformAllowedCredentials count])) {
-        RetainPtr provider = adoptNS([allocASAuthorizationSecurityKeyPublicKeyCredentialProviderInstance() initWithRelyingPartyIdentifier:options.rpId]);
+        RetainPtr provider = adoptNS([allocASAuthorizationSecurityKeyPublicKeyCredentialProviderInstance() initWithRelyingPartyIdentifier:options.rpId.createNSString().get()]);
         RetainPtr<ASAuthorizationSecurityKeyPublicKeyCredentialAssertionRequest> request;
         if ([provider respondsToSelector:@selector(createCredentialAssertionRequestWithClientData:)])
             request = adoptNS([provider createCredentialAssertionRequestWithClientData:clientData.get()]);
@@ -471,7 +471,7 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForAssertion(const 
         if (crossPlatformAllowedCredentials)
             request.get().allowedCredentials = crossPlatformAllowedCredentials.get();
         if (options.extensions && !options.extensions->appid.isNull())
-            request.get().appID = options.extensions->appid;
+            request.get().appID = options.extensions->appid.createNSString().get();
         [requests addObject:request.leakRef()];
     }
 #endif // HAVE(SECURITY_KEY_API)
@@ -785,7 +785,7 @@ static inline RetainPtr<ASCPublicKeyCredentialDescriptor> toASCDescriptor(Public
 static inline RetainPtr<ASCWebAuthenticationExtensionsClientInputs> toASCExtensions(const AuthenticationExtensionsClientInputs& extensions)
 {
     if ([getASCWebAuthenticationExtensionsClientInputsClass() instancesRespondToSelector:@selector(initWithAppID:)])
-        return adoptNS([allocASCWebAuthenticationExtensionsClientInputsInstance() initWithAppID:extensions.appid]);
+        return adoptNS([allocASCWebAuthenticationExtensionsClientInputsInstance() initWithAppID:extensions.appid.createNSString().get()]);
 
     return nil;
 }
@@ -839,7 +839,7 @@ static RetainPtr<ASCCredentialRequestContext> configureRegistrationRequestContex
 
     auto requestContext = adoptNS([allocASCCredentialRequestContextInstance() initWithRequestTypes:requestTypes]);
     ASSERT(options.rp.id);
-    [requestContext setRelyingPartyIdentifier:options.rp.id];
+    [requestContext setRelyingPartyIdentifier:options.rp.id.createNSString().get()];
     setGlobalFrameIDForContext(requestContext, globalFrameID);
 
     auto credentialCreationOptions = adoptNS([allocASCPublicKeyCredentialCreationOptionsInstance() init]);
@@ -848,10 +848,10 @@ static RetainPtr<ASCCredentialRequestContext> configureRegistrationRequestContex
     RetainPtr nsClientDataJSON = toNSData(clientDataJson->span());
     [credentialCreationOptions setClientDataJSON:nsClientDataJSON.get()];
 
-    [credentialCreationOptions setRelyingPartyIdentifier:options.rp.id];
-    [credentialCreationOptions setUserName:options.user.name];
+    [credentialCreationOptions setRelyingPartyIdentifier:options.rp.id.createNSString().get()];
+    [credentialCreationOptions setUserName:options.user.name.createNSString().get()];
     [credentialCreationOptions setUserIdentifier:WebCore::toNSData(options.user.id).get()];
-    [credentialCreationOptions setUserDisplayName:options.user.displayName];
+    [credentialCreationOptions setUserDisplayName:options.user.displayName.createNSString().get()];
     [credentialCreationOptions setUserVerificationPreference:userVerification.get()];
     if ([credentialCreationOptions respondsToSelector:@selector(setResidentKeyPreference:)])
         [credentialCreationOptions setResidentKeyPreference:toASCResidentKeyPreference(residentKeyRequirement, shouldRequireResidentKey)];
@@ -906,9 +906,9 @@ static inline RetainPtr<ASCPublicKeyCredentialAssertionOptions> configureAsserti
     RetainPtr nsClientDataJSON = toNSData(clientDataJson->span());
     RetainPtr<ASCPublicKeyCredentialAssertionOptions> assertionOptions;
     if ([getASCPublicKeyCredentialAssertionOptionsClass() instancesRespondToSelector:@selector(initWithKind:relyingPartyIdentifier:clientDataJSON:userVerificationPreference:allowedCredentials:origin:)])
-        assertionOptions = adoptNS([allocASCPublicKeyCredentialAssertionOptionsInstance() initWithKind:kind relyingPartyIdentifier:options.rpId clientDataJSON:nsClientDataJSON.get() userVerificationPreference:userVerification.get() allowedCredentials:allowedCredentials.get() origin:callerOrigin.toString()]);
+        assertionOptions = adoptNS([allocASCPublicKeyCredentialAssertionOptionsInstance() initWithKind:kind relyingPartyIdentifier:options.rpId.createNSString().get() clientDataJSON:nsClientDataJSON.get() userVerificationPreference:userVerification.get() allowedCredentials:allowedCredentials.get() origin:callerOrigin.toString().createNSString().get()]);
     else
-        assertionOptions = adoptNS([allocASCPublicKeyCredentialAssertionOptionsInstance() initWithKind:kind relyingPartyIdentifier:options.rpId clientDataJSON:nsClientDataJSON.get() userVerificationPreference:userVerification.get() allowedCredentials:allowedCredentials.get()]);
+        assertionOptions = adoptNS([allocASCPublicKeyCredentialAssertionOptionsInstance() initWithKind:kind relyingPartyIdentifier:options.rpId.createNSString().get() clientDataJSON:nsClientDataJSON.get() userVerificationPreference:userVerification.get() allowedCredentials:allowedCredentials.get()]);
     if (options.extensions) {
         if ([assertionOptions respondsToSelector:@selector(setExtensionsCBOR:)])
             [assertionOptions setExtensionsCBOR:toNSData(options.extensions->toCBOR()).get()];
@@ -916,7 +916,7 @@ static inline RetainPtr<ASCPublicKeyCredentialAssertionOptions> configureAsserti
             [assertionOptions setExtensions:toASCExtensions(*options.extensions).get()];
     }
     if (parentOrigin && [assertionOptions respondsToSelector:@selector(setDestinationSiteForCrossSiteAssertion:)])
-        assertionOptions.get().destinationSiteForCrossSiteAssertion = RegistrableDomain { *parentOrigin }.string();
+        assertionOptions.get().destinationSiteForCrossSiteAssertion = RegistrableDomain { *parentOrigin }.string().createNSString().get();
     else if (parentOrigin && ![assertionOptions respondsToSelector:@selector(setDestinationSiteForCrossSiteAssertion:)])
         return nil;
     if (options.timeout && [assertionOptions respondsToSelector:@selector(setTimeout:)])
@@ -947,7 +947,7 @@ static RetainPtr<ASCCredentialRequestContext> configurationAssertionRequestConte
     }
 
     auto requestContext = adoptNS([allocASCCredentialRequestContextInstance() initWithRequestTypes:requestTypes]);
-    [requestContext setRelyingPartyIdentifier:options.rpId];
+    [requestContext setRelyingPartyIdentifier:options.rpId.createNSString().get()];
     if (mediation == MediationRequirement::Conditional) {
         if (![requestContext respondsToSelector:@selector(setRequestStyle:)])
             return nil;
@@ -1191,7 +1191,7 @@ void WebAuthenticatorCoordinatorProxy::performRequestLegacy(RetainPtr<ASCCredent
 static inline void getCanCurrentProcessAccessPasskeyForRelyingParty(const WebCore::SecurityOriginData& data, CompletionHandler<void(bool)>&& handler)
 {
     if ([getASCWebKitSPISupportClass() respondsToSelector:@selector(getCanCurrentProcessAccessPasskeysForRelyingParty:withCompletionHandler:)]) {
-        [getASCWebKitSPISupportClass() getCanCurrentProcessAccessPasskeysForRelyingParty:data.securityOrigin()->domain() withCompletionHandler:makeBlockPtr([handler = WTFMove(handler)](BOOL result) mutable {
+        [getASCWebKitSPISupportClass() getCanCurrentProcessAccessPasskeysForRelyingParty:data.securityOrigin()->domain().createNSString().get() withCompletionHandler:makeBlockPtr([handler = WTFMove(handler)](BOOL result) mutable {
             ensureOnMainRunLoop([handler = WTFMove(handler), result]() mutable {
                 handler(result);
             });
@@ -1204,7 +1204,7 @@ static inline void getCanCurrentProcessAccessPasskeyForRelyingParty(const WebCor
 static inline void getArePasskeysDisallowedForRelyingParty(const WebCore::SecurityOriginData& data, CompletionHandler<void(bool)>&& handler)
 {
     if ([getASCWebKitSPISupportClass() respondsToSelector:@selector(getArePasskeysDisallowedForRelyingParty:withCompletionHandler:)]) {
-        [getASCWebKitSPISupportClass() getArePasskeysDisallowedForRelyingParty:data.securityOrigin()->domain() withCompletionHandler:makeBlockPtr([handler = WTFMove(handler)](BOOL result) mutable {
+        [getASCWebKitSPISupportClass() getArePasskeysDisallowedForRelyingParty:data.securityOrigin()->domain().createNSString().get() withCompletionHandler:makeBlockPtr([handler = WTFMove(handler)](BOOL result) mutable {
             ensureOnMainRunLoop([handler = WTFMove(handler), result]() mutable {
                 handler(result);
             });
@@ -1229,7 +1229,7 @@ void WebAuthenticatorCoordinatorProxy::getClientCapabilities(const WebCore::Secu
         return;
     }
 
-    [getASCWebKitSPISupportClass() getClientCapabilitiesForRelyingParty:originData.securityOrigin()->domain() withCompletionHandler:makeBlockPtr([handler = WTFMove(handler)](NSDictionary<NSString *, NSNumber *> *result) mutable {
+    [getASCWebKitSPISupportClass() getClientCapabilitiesForRelyingParty:originData.securityOrigin()->domain().createNSString().get() withCompletionHandler:makeBlockPtr([handler = WTFMove(handler)](NSDictionary<NSString *, NSNumber *> *result) mutable {
         Vector<KeyValuePair<String, bool>> capabilities;
         for (NSString *key in result)
             capabilities.append({ key, result[key].boolValue });
@@ -1302,7 +1302,7 @@ void WebAuthenticatorCoordinatorProxy::signalUnknownCredential(const WebCore::Se
         return;
     }
 
-    [getCredentialUpdaterShimClass() signalUnknownCredentialWithRelyingPartyIdentifier:options.rpId credentialID:WTF::toNSData(*decodedCredentialId).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
+    [getCredentialUpdaterShimClass() signalUnknownCredentialWithRelyingPartyIdentifier:options.rpId.createNSString().get() credentialID:WTF::toNSData(*decodedCredentialId).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(WebAuthn, "Error signaling unknown credential: %@.", error.localizedDescription);
             completionHandler(ExceptionData { ExceptionCode::UnknownError, "Error signaling unknown credential."_s });
@@ -1331,7 +1331,7 @@ void WebAuthenticatorCoordinatorProxy::signalAllAcceptedCredentials(const WebCor
         [credentialIds addObject:toNSData(*decodedCredentialId).leakRef()];
     }
 
-    [getCredentialUpdaterShimClass() signalAllAcceptedCredentialsWithRelyingPartyIdentifier:options.rpId userHandle:WTF::toNSData(*userHandle).get() acceptedCredentialIDs:credentialIds.get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
+    [getCredentialUpdaterShimClass() signalAllAcceptedCredentialsWithRelyingPartyIdentifier:options.rpId.createNSString().get() userHandle:WTF::toNSData(*userHandle).get() acceptedCredentialIDs:credentialIds.get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(WebAuthn, "Error signaling all accepted credentials: %@.", error.localizedDescription);
             completionHandler(ExceptionData { ExceptionCode::UnknownError, "Error signaling all accepted credentials"_s });
@@ -1350,7 +1350,7 @@ void WebAuthenticatorCoordinatorProxy::signalCurrentUserDetails(const WebCore::S
         return;
     }
 
-    [getCredentialUpdaterShimClass() signalCurrentUserDetailsWithRelyingPartyIdentifier:options.rpId userHandle:WTF::toNSData(*userHandle).get() newName:options.name completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
+    [getCredentialUpdaterShimClass() signalCurrentUserDetailsWithRelyingPartyIdentifier:options.rpId.createNSString().get() userHandle:WTF::toNSData(*userHandle).get() newName:options.name.createNSString().get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(WebAuthn, "Error signaling current user details: %@.", error.localizedDescription);
             completionHandler(ExceptionData { ExceptionCode::UnknownError, "Error signaling current user details."_s });

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.mm
@@ -93,7 +93,7 @@ RetainPtr<NSData> MockCcidService::nextReply()
     if (m_configuration.ccid->payloadBase64.isEmpty())
         return nil;
 
-    auto result = adoptNS([[NSData alloc] initWithBase64EncodedString:m_configuration.ccid->payloadBase64[0] options:NSDataBase64DecodingIgnoreUnknownCharacters]);
+    auto result = adoptNS([[NSData alloc] initWithBase64EncodedString:m_configuration.ccid->payloadBase64[0].createNSString().get() options:NSDataBase64DecodingIgnoreUnknownCharacters]);
     m_configuration.ccid->payloadBase64.remove(0);
     return result;
 }

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm
@@ -200,7 +200,7 @@ NSData* MockNfcService::transceive()
     if (m_configuration.nfc->payloadBase64.isEmpty())
         return nil;
 
-    auto result = adoptNS([[NSData alloc] initWithBase64EncodedString:m_configuration.nfc->payloadBase64[0] options:NSDataBase64DecodingIgnoreUnknownCharacters]);
+    auto result = adoptNS([[NSData alloc] initWithBase64EncodedString:m_configuration.nfc->payloadBase64[0].createNSString().get() options:NSDataBase64DecodingIgnoreUnknownCharacters]);
     m_configuration.nfc->payloadBase64.remove(0);
     return result.autorelease();
 }

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm
@@ -115,7 +115,7 @@ RetainPtr<SecKeyRef> privateKeyFromBase64(const String& base64PrivateKey)
         (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPrivate,
         (id)kSecAttrKeySizeInBits: @256,
     };
-    RetainPtr<NSData> privateKey = adoptNS([[NSData alloc] initWithBase64EncodedString:base64PrivateKey options:0]);
+    RetainPtr<NSData> privateKey = adoptNS([[NSData alloc] initWithBase64EncodedString:base64PrivateKey.createNSString().get() options:0]);
     CFErrorRef errorRef = nullptr;
     auto key = adoptCF(SecKeyCreateWithData(
         bridge_cast(privateKey.get()),

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/ScreenTimeWebsiteDataSupport.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/ScreenTimeWebsiteDataSupport.mm
@@ -49,11 +49,11 @@ void getScreenTimeURLs(std::optional<WTF::UUID> identifier, CompletionHandler<vo
     if (![PAL::getSTWebHistoryClass() instancesRespondToSelector:@selector(fetchAllHistoryWithCompletionHandler:)])
         return completionHandler({ });
 
-    STWebHistoryProfileIdentifier profileIdentifier = nil;
+    RetainPtr<NSString> profileIdentifier;
     if (identifier)
-        profileIdentifier = identifier->toString();
+        profileIdentifier = identifier->toString().createNSString();
 
-    RetainPtr webHistory = adoptNS([PAL::allocSTWebHistoryInstance() initWithProfileIdentifier:profileIdentifier]);
+    RetainPtr webHistory = adoptNS([PAL::allocSTWebHistoryInstance() initWithProfileIdentifier:profileIdentifier.get()]);
 
     // STWebHistory.fetchAllHistoryWithCompletionHandler sometimes deallocates its block instead of calling it.
     // FIXME: Remove this once rdar://145889845 is widely available.
@@ -82,11 +82,11 @@ void getScreenTimeURLs(std::optional<WTF::UUID> identifier, CompletionHandler<vo
 
 void removeScreenTimeData(const HashSet<URL>& websitesToRemove, const WebsiteDataStoreConfiguration& configuration)
 {
-    STWebHistoryProfileIdentifier profileIdentifier = nil;
+    RetainPtr<NSString> profileIdentifier;
     if (configuration.identifier())
-        profileIdentifier = configuration.identifier()->toString();
+        profileIdentifier = configuration.identifier()->toString().createNSString();
 
-    RetainPtr webHistory = adoptNS([PAL::allocSTWebHistoryInstance() initWithProfileIdentifier:profileIdentifier]);
+    RetainPtr webHistory = adoptNS([PAL::allocSTWebHistoryInstance() initWithProfileIdentifier:profileIdentifier.get()]);
 
     for (auto& url : websitesToRemove)
         [webHistory deleteHistoryForURL:url.createNSURL().get()];
@@ -94,11 +94,11 @@ void removeScreenTimeData(const HashSet<URL>& websitesToRemove, const WebsiteDat
 
 void removeScreenTimeDataWithInterval(WallTime modifiedSince, const WebsiteDataStoreConfiguration& configuration)
 {
-    STWebHistoryProfileIdentifier profileIdentifier = nil;
+    RetainPtr<NSString> profileIdentifier;
     if (configuration.identifier())
-        profileIdentifier = configuration.identifier()->toString();
+        profileIdentifier = configuration.identifier()->toString().createNSString();
 
-    RetainPtr webHistory = adoptNS([PAL::allocSTWebHistoryInstance() initWithProfileIdentifier:profileIdentifier]);
+    RetainPtr webHistory = adoptNS([PAL::allocSTWebHistoryInstance() initWithProfileIdentifier:profileIdentifier.get()]);
 
     if (!modifiedSince.isNaN()) {
         NSTimeInterval timeInterval = modifiedSince.secondsSinceEpoch().seconds();

--- a/Source/WebKit/UIProcess/mac/CorrectionPanel.mm
+++ b/Source/WebKit/UIProcess/mac/CorrectionPanel.mm
@@ -96,7 +96,7 @@ void CorrectionPanel::recordAutocorrectionResponse(WebViewImpl& webViewImpl, NSI
     if (webViewImpl.page().sessionID().isEphemeral())
         return;
 
-    [[NSSpellChecker sharedSpellChecker] recordResponse:response toCorrection:replacementString forWord:replacedString language:nil inSpellDocumentWithTag:spellCheckerDocumentTag];
+    [[NSSpellChecker sharedSpellChecker] recordResponse:response toCorrection:replacementString.createNSString().get() forWord:replacedString.createNSString().get() language:nil inSpellDocumentWithTag:spellCheckerDocumentTag];
 }
 
 void CorrectionPanel::handleAcceptedReplacement(WebViewImpl& webViewImpl, NSString* acceptedReplacement, NSString* replaced, NSString* proposedReplacement,  NSCorrectionIndicatorType correctionIndicatorType)

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -394,7 +394,7 @@ void PageClientImpl::setPromisedDataForImage(const String& pasteboardName, Ref<F
 {
     auto image = BitmapImage::create();
     image->setData(WTFMove(imageBuffer), true);
-    m_impl->setPromisedDataForImage(image.get(), filename, extension, title, url, visibleURL, archiveBuffer.get(), pasteboardName, originIdentifier);
+    m_impl->setPromisedDataForImage(image.get(), filename.createNSString().get(), extension.createNSString().get(), title.createNSString().get(), url.createNSString().get(), visibleURL.createNSString().get(), archiveBuffer.get(), pasteboardName.createNSString().get(), originIdentifier.createNSString().get());
 }
 
 void PageClientImpl::updateSecureInputState()
@@ -755,7 +755,7 @@ void PageClientImpl::intrinsicContentSizeDidChange(const IntSize& intrinsicConte
 
 bool PageClientImpl::executeSavedCommandBySelector(const String& selectorString)
 {
-    return m_impl->executeSavedCommandBySelector(NSSelectorFromString(selectorString));
+    return m_impl->executeSavedCommandBySelector(NSSelectorFromString(selectorString.createNSString().get()));
 }
 
 void PageClientImpl::showDictationAlternativeUI(const WebCore::FloatRect& boundingBoxOfDictatedText, WebCore::DictationContext dictationContext)
@@ -932,7 +932,7 @@ void PageClientImpl::didSameDocumentNavigationForMainFrame(SameDocumentNavigatio
 
 void PageClientImpl::handleControlledElementIDResponse(const String& identifier)
 {
-    [webView() _handleControlledElementIDResponse:identifier];
+    [webView() _handleControlledElementIDResponse:identifier.createNSString().get()];
 }
 
 void PageClientImpl::didChangeBackgroundColor()

--- a/Source/WebKit/UIProcess/mac/TextCheckerMac.mm
+++ b/Source/WebKit/UIProcess/mac/TextCheckerMac.mm
@@ -472,7 +472,7 @@ void TextChecker::toggleSpellingUIIsShowing()
 
 void TextChecker::updateSpellingUIWithMisspelledWord(SpellDocumentTag, const String& misspelledWord)
 {
-    [[NSSpellChecker sharedSpellChecker] updateSpellingPanelWithMisspelledWord:misspelledWord];
+    [[NSSpellChecker sharedSpellChecker] updateSpellingPanelWithMisspelledWord:misspelledWord.createNSString().get()];
 }
 
 void TextChecker::updateSpellingUIWithGrammarString(SpellDocumentTag, const String& badGrammarPhrase, const GrammarDetail& grammarDetail)
@@ -485,10 +485,10 @@ void TextChecker::updateSpellingUIWithGrammarString(SpellDocumentTag, const Stri
 
     RetainPtr detail = @{
         NSGrammarRange : [NSValue valueWithRange:grammarDetail.range],
-        NSGrammarUserDescription : grammarDetail.userDescription,
+        NSGrammarUserDescription : grammarDetail.userDescription.createNSString().get(),
         NSGrammarCorrections : createNSArray(grammarDetail.guesses).get(),
     };
-    [[NSSpellChecker sharedSpellChecker] updateSpellingPanelWithGrammarString:badGrammarPhrase detail:detail.get()];
+    [[NSSpellChecker sharedSpellChecker] updateSpellingPanelWithGrammarString:badGrammarPhrase.createNSString().get() detail:detail.get()];
 }
 
 void TextChecker::getGuessesForWord(SpellDocumentTag spellDocumentTag, const String& word, const String& context, int32_t insertionPoint, Vector<String>& guesses, bool initialCapitalizationEnabled)
@@ -501,20 +501,20 @@ void TextChecker::getGuessesForWord(SpellDocumentTag spellDocumentTag, const Str
         NSTextCheckingSuppressInitialCapitalizationKey : @(!initialCapitalizationEnabled)
     };
     if (context.length()) {
-        [checker checkString:context range:NSMakeRange(0, context.length()) types:NSTextCheckingTypeOrthography options:options inSpellDocumentWithTag:spellDocumentTag orthography:&orthography wordCount:0];
-        language = [checker languageForWordRange:NSMakeRange(0, context.length()) inString:context orthography:orthography];
+        [checker checkString:context.createNSString().get() range:NSMakeRange(0, context.length()) types:NSTextCheckingTypeOrthography options:options inSpellDocumentWithTag:spellDocumentTag orthography:&orthography wordCount:0];
+        language = [checker languageForWordRange:NSMakeRange(0, context.length()) inString:context.createNSString().get() orthography:orthography];
     }
-    guesses = makeVector<String>([checker guessesForWordRange:NSMakeRange(0, word.length()) inString:word language:language.get() inSpellDocumentWithTag:spellDocumentTag]);
+    guesses = makeVector<String>([checker guessesForWordRange:NSMakeRange(0, word.length()) inString:word.createNSString().get() language:language.get() inSpellDocumentWithTag:spellDocumentTag]);
 }
 
 void TextChecker::learnWord(SpellDocumentTag, const String& word)
 {
-    [[NSSpellChecker sharedSpellChecker] learnWord:word];
+    [[NSSpellChecker sharedSpellChecker] learnWord:word.createNSString().get()];
 }
 
 void TextChecker::ignoreWord(SpellDocumentTag spellDocumentTag, const String& word)
 {
-    [[NSSpellChecker sharedSpellChecker] ignoreWord:word inSpellDocumentWithTag:spellDocumentTag];
+    [[NSSpellChecker sharedSpellChecker] ignoreWord:word.createNSString().get() inSpellDocumentWithTag:spellDocumentTag];
 }
 
 void TextChecker::requestCheckingOfString(Ref<TextCheckerCompletion>&&, int32_t)

--- a/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
+++ b/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
@@ -477,7 +477,7 @@
     if (!hitTestResult)
         return nil;
 
-    RetainPtr menuItems = [[PAL::getDDActionsManagerClass() sharedManager] menuItemsForTargetURL:hitTestResult->absoluteLinkURL() actionContext:_currentActionContext.get()];
+    RetainPtr menuItems = [[PAL::getDDActionsManagerClass() sharedManager] menuItemsForTargetURL:hitTestResult->absoluteLinkURL().createNSString().get() actionContext:_currentActionContext.get()];
 
     if (menuItems.get().count != 1)
         return nil;

--- a/Source/WebKit/UIProcess/mac/WKRevealItemPresenter.mm
+++ b/Source/WebKit/UIProcess/mac/WKRevealItemPresenter.mm
@@ -72,11 +72,11 @@
     if (!view)
         return;
 
-    auto menuItems = retainPtr([_presenter menuItemsForItem:_item.get() documentContext:nil presentingContext:_presentingContext.get() options:nil]);
+    RetainPtr menuItems = [_presenter menuItemsForItem:_item.get() documentContext:nil presentingContext:_presentingContext.get() options:nil];
     if (![menuItems count])
         return;
 
-    auto menu = adoptNS([[NSMenu alloc] initWithTitle:emptyString()]);
+    RetainPtr menu = adoptNS([[NSMenu alloc] initWithTitle:@""]);
     [menu setAutoenablesItems:NO];
     [menu setItemArray:menuItems.get()];
 

--- a/Source/WebKit/UIProcess/mac/WKTextFinderClient.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextFinderClient.mm
@@ -260,7 +260,7 @@ private:
     void (^copiedCompletionHandler)(NSString *) = Block_copy(completionHandler);
 
     self._protectedPage->getSelectionOrContentsAsString([copiedCompletionHandler] (const String& string) {
-        copiedCompletionHandler(string);
+        copiedCompletionHandler(string.createNSString().get());
         Block_release(copiedCompletionHandler);
     });
 }

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -279,7 +279,7 @@ void WebContextMenuProxyMac::setupServicesMenu()
     RetainPtr<NSItemProvider> itemProvider;
     if (hasControlledImage) {
         if (attachment)
-            itemProvider = adoptNS([[NSItemProvider alloc] initWithItem:attachment->associatedElementNSData() typeIdentifier:attachment->utiType()]);
+            itemProvider = adoptNS([[NSItemProvider alloc] initWithItem:attachment->associatedElementNSData() typeIdentifier:attachment->utiType().createNSString().get()]);
         else {
             RefPtr<ShareableBitmap> image = m_context.controlledImage();
             if (!image)
@@ -296,7 +296,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     } else if (RetainPtr selection = m_context.controlledSelection().nsAttributedString())
         items = @[ selection.get() ];
     else if (isPDFAttachment) {
-        itemProvider = adoptNS([[NSItemProvider alloc] initWithItem:attachment->associatedElementNSData() typeIdentifier:attachment->utiType()]);
+        itemProvider = adoptNS([[NSItemProvider alloc] initWithItem:attachment->associatedElementNSData() typeIdentifier:attachment->utiType().createNSString().get()]);
         items = @[ itemProvider.get() ];
     } else {
         LOG_ERROR("No service controlled item represented in the context");
@@ -383,8 +383,8 @@ void WebContextMenuProxyMac::appendRemoveBackgroundItemToControlledImageMenuIfNe
             if (!strongMenu)
                 return;
 
-            auto removeBackgroundItem = adoptNS([[NSMenuItem alloc] initWithTitle:contextMenuItemTitleRemoveBackground() action:@selector(removeBackground) keyEquivalent:@""]);
-            [removeBackgroundItem setImage:[NSImage imageWithSystemSymbolName:@"person.fill.viewfinder" accessibilityDescription:contextMenuItemTitleRemoveBackground()]];
+            auto removeBackgroundItem = adoptNS([[NSMenuItem alloc] initWithTitle:contextMenuItemTitleRemoveBackground().createNSString().get() action:@selector(removeBackground) keyEquivalent:@""]);
+            [removeBackgroundItem setImage:[NSImage imageWithSystemSymbolName:@"person.fill.viewfinder" accessibilityDescription:contextMenuItemTitleRemoveBackground().createNSString().get()]];
             [removeBackgroundItem setTarget:WKSharingServicePickerDelegate.sharedSharingServicePickerDelegate];
             [removeBackgroundItem setAction:@selector(removeBackground)];
             [removeBackgroundItem setIndentationLevel:[strongMenu itemArray].lastObject.indentationLevel];
@@ -740,7 +740,7 @@ static RetainPtr<NSMenuItem> createMenuActionItem(const WebContextMenuItemData& 
     auto type = item.type();
     ASSERT_UNUSED(type, type == WebCore::ContextMenuItemType::Action || type == WebCore::ContextMenuItemType::CheckableAction);
 
-    auto menuItem = adoptNS([[NSMenuItem alloc] initWithTitle:item.title() action:@selector(forwardContextMenuAction:) keyEquivalent:@""]);
+    RetainPtr menuItem = adoptNS([[NSMenuItem alloc] initWithTitle:item.title().createNSString().get() action:@selector(forwardContextMenuAction:) keyEquivalent:@""]);
 
     [menuItem setTag:item.action()];
     [menuItem setEnabled:item.enabled()];
@@ -942,7 +942,7 @@ void WebContextMenuProxyMac::getContextMenuItem(const WebContextMenuItemData& it
 
     case WebCore::ContextMenuItemType::Submenu: {
         getContextMenuFromItems(item.submenu(), [action = item.action(), completionHandler = WTFMove(completionHandler), enabled = item.enabled(), title = item.title(), indentationLevel = item.indentationLevel()](NSMenu *menu) mutable {
-            auto menuItem = adoptNS([[NSMenuItem alloc] initWithTitle:title action:nullptr keyEquivalent:@""]);
+            RetainPtr menuItem = adoptNS([[NSMenuItem alloc] initWithTitle:title.createNSString().get() action:nullptr keyEquivalent:@""]);
             [menuItem setEnabled:enabled];
             [menuItem setIndentationLevel:indentationLevel];
             [menuItem setSubmenu:menu];

--- a/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
@@ -531,7 +531,7 @@ static BOOL shouldShowDividersBetweenCells(const Vector<WebCore::DataListSuggest
 
     auto& suggestion = _suggestions.at(row);
     [result setShouldShowBottomDivider:_showDividersBetweenCells && row < static_cast<NSInteger>(_suggestions.size() - 1)];
-    [result setValue:suggestion.value label:suggestion.label];
+    [result setValue:suggestion.value.createNSString().get() label:suggestion.label.createNSString().get()];
 
     return result.autorelease();
 }

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -160,7 +160,7 @@ void WebPageProxy::getIsSpeaking(CompletionHandler<void(bool)>&& completionHandl
 void WebPageProxy::speak(const String& string)
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
-    [NSApp speakString:string];
+    [NSApp speakString:string.createNSString().get()];
 }
 
 void WebPageProxy::stopSpeaking()
@@ -173,7 +173,7 @@ void WebPageProxy::searchTheWeb(const String& string)
 {
     RetainPtr pasteboard = [NSPasteboard pasteboardWithUniqueName];
     [pasteboard declareTypes:@[legacyStringPasteboardType()] owner:nil];
-    [pasteboard setString:string forType:legacyStringPasteboardType()];
+    [pasteboard setString:string.createNSString().get() forType:legacyStringPasteboardType()];
     
     NSPerformService(@"Search With %WebSearchProvider@", pasteboard.get());
 }
@@ -596,7 +596,7 @@ void WebPageProxy::showPDFContextMenu(const WebKit::PDFContextMenu& contextMenu,
         }
         
         RetainPtr nsItem = adoptNS([[NSMenuItem alloc] init]);
-        [nsItem setTitle:item.title];
+        [nsItem setTitle:item.title.createNSString().get()];
         [nsItem setEnabled:item.enabled == ContextMenuItemEnablement::Enabled];
         [nsItem setState:item.state];
 #if ENABLE(CONTEXT_MENU_IMAGES_FOR_INTERNAL_CLIENTS)
@@ -879,7 +879,7 @@ void WebPageProxy::showImageInQuickLookPreviewPanel(ShareableBitmap& imageBitmap
     if (!CGImageDestinationFinalize(destination.get()))
         return;
 
-    m_quickLookPreviewController = adoptNS([[WKQuickLookPreviewController alloc] initWithPage:*this imageData:(__bridge NSData *)imageData.get() title:tooltip imageURL:imageURL.createNSURL().get() activity:activity]);
+    m_quickLookPreviewController = adoptNS([[WKQuickLookPreviewController alloc] initWithPage:*this imageData:(__bridge NSData *)imageData.get() title:tooltip.createNSString().get() imageURL:imageURL.createNSURL().get() activity:activity]);
 
     // When presenting the shared QLPreviewPanel, QuickLook will search the responder chain for a suitable panel controller.
     // Make sure that we (by default) start the search at the web view, which knows how to vend the Visual Search preview

--- a/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
@@ -87,14 +87,14 @@ void WebPopupMenuProxyMac::populate(const Vector<WebPopupItem>& items, NSFont *f
                 RetainPtr<NSArray> writingDirectionArray = adoptNS([[NSArray alloc] initWithObjects:writingDirectionNumber.get(), nil]);
                 [attributes setObject:writingDirectionArray.get() forKey:NSWritingDirectionAttributeName];
             }
-            RetainPtr<NSAttributedString> string = adoptNS([[NSAttributedString alloc] initWithString:items[i].m_text attributes:attributes.get()]);
+            RetainPtr<NSAttributedString> string = adoptNS([[NSAttributedString alloc] initWithString:items[i].m_text.createNSString().get() attributes:attributes.get()]);
 
             [menuItem setAttributedTitle:string.get()];
             // We set the title as well as the attributed title here. The attributed title will be displayed in the menu,
             // but typeahead will use the non-attributed string that doesn't contain any leading or trailing whitespace.
             [menuItem setTitle:[[string string] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]]];
             [menuItem setEnabled:items[i].m_isEnabled];
-            [menuItem setToolTip:items[i].m_toolTip];
+            [menuItem setToolTip:items[i].m_toolTip.createNSString().get()];
         }
     }
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
@@ -79,7 +79,7 @@ bool WebExtensionAPIAction::parseActionDetails(NSDictionary *details, std::optio
         return false;
 
     if (details[tabIdKey] && details[windowIdKey]) {
-        *outExceptionString = toErrorString(nullString(), @"details", @"it cannot specify both 'tabId' and 'windowID'");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it cannot specify both 'tabId' and 'windowID'").createNSString().autorelease();
         return false;
     }
 
@@ -109,11 +109,11 @@ void WebExtensionAPIAction::getTitle(NSDictionary *details, Ref<WebExtensionCall
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionGetTitle(windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
-        callback->call(result.value());
+        callback->call(result.value().createNSString().get());
     }, extensionContext().identifier());
 }
 
@@ -141,7 +141,7 @@ void WebExtensionAPIAction::setTitle(NSDictionary *details, Ref<WebExtensionCall
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetTitle(windowIdentifier, tabIdentifier, title), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -160,11 +160,11 @@ void WebExtensionAPIAction::getBadgeText(NSDictionary *details, Ref<WebExtension
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionGetBadgeText(windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
-        callback->call(result.value());
+        callback->call(result.value().createNSString().get());
     }, extensionContext().identifier());
 }
 
@@ -192,7 +192,7 @@ void WebExtensionAPIAction::setBadgeText(NSDictionary *details, Ref<WebExtension
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetBadgeText(windowIdentifier, tabIdentifier, text), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -238,7 +238,7 @@ void WebExtensionAPIAction::enable(double tabID, Ref<WebExtensionCallbackHandler
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetEnabled(tabIdentifer, true), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -256,7 +256,7 @@ void WebExtensionAPIAction::disable(double tabID, Ref<WebExtensionCallbackHandle
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetEnabled(tabIdentifer, false), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -275,7 +275,7 @@ void WebExtensionAPIAction::isEnabled(NSDictionary *details, Ref<WebExtensionCal
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionGetEnabled(windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<bool, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -292,13 +292,13 @@ static NSString *dataURLFromImageData(JSValue *imageData, size_t *outWidth, NSSt
 
     auto *imageDataConstructor = imageData.context[@"ImageData"];
     if (![imageData isInstanceOf:imageDataConstructor]) {
-        *outExceptionString = toErrorString(nullString(), sourceKey, notImageDataError);
+        *outExceptionString = toErrorString(nullString(), sourceKey, notImageDataError).createNSString().autorelease();
         return nil;
     }
 
     auto *dataObject = imageData[@"data"];
     if (!dataObject.isObject) {
-        *outExceptionString = toErrorString(nullString(), sourceKey, notImageDataError);
+        *outExceptionString = toErrorString(nullString(), sourceKey, notImageDataError).createNSString().autorelease();
         return nil;
     }
 
@@ -307,7 +307,7 @@ static NSString *dataURLFromImageData(JSValue *imageData, size_t *outWidth, NSSt
 
     auto dataArrayType = JSValueGetTypedArrayType(context, dataObjectRef, nullptr);
     if (dataArrayType != kJSTypedArrayTypeUint8ClampedArray) {
-        *outExceptionString = toErrorString(nullString(), sourceKey, notImageDataError);
+        *outExceptionString = toErrorString(nullString(), sourceKey, notImageDataError).createNSString().autorelease();
         return nil;
     }
 
@@ -336,7 +336,7 @@ static NSString *dataURLFromImageData(JSValue *imageData, size_t *outWidth, NSSt
     RetainPtr cgImage = adoptCF(CGImageCreate(width, height, bitsPerComponent, bitsPerPixel, bytesPerRow, colorSpace.get(), bitmapInfo, dataProvider.get(), decode, shouldInterpolate, renderingIntent));
 
     if (!cgImage) {
-        *outExceptionString = toErrorString(nullString(), sourceKey, notImageDataError);
+        *outExceptionString = toErrorString(nullString(), sourceKey, notImageDataError).createNSString().autorelease();
         return nil;
     }
 
@@ -349,13 +349,13 @@ static NSString *dataURLFromImageData(JSValue *imageData, size_t *outWidth, NSSt
 #endif
 
     if (!pngData.length) {
-        *outExceptionString = toErrorString(nullString(), sourceKey, notImageDataError);
+        *outExceptionString = toErrorString(nullString(), sourceKey, notImageDataError).createNSString().autorelease();
         return nil;
     }
 
     auto *base64String = [pngData base64EncodedStringWithOptions:0];
     if (!base64String.length) {
-        *outExceptionString = toErrorString(nullString(), sourceKey, notImageDataError);
+        *outExceptionString = toErrorString(nullString(), sourceKey, notImageDataError).createNSString().autorelease();
         return nil;
     }
 
@@ -393,7 +393,7 @@ NSString *WebExtensionAPIAction::parseIconPath(NSString *path, const URL& baseUR
     // Resolve paths as relative against the base URL, unless it is a data URL.
     if ([path hasPrefix:@"data:"])
         return path;
-    return URL { baseURL, path }.path().toString();
+    return URL { baseURL, path }.path().toString().createNSString().autorelease();
 }
 
 NSMutableDictionary *WebExtensionAPIAction::parseIconPathsDictionary(NSDictionary *input, const URL& baseURL, bool forVariants, NSString *inputKey, NSString **outExceptionString)
@@ -408,7 +408,7 @@ NSMutableDictionary *WebExtensionAPIAction::parseIconPathsDictionary(NSDictionar
 
         if (!isValidDimensionKey(key)) {
             if (outExceptionString)
-                *outExceptionString = toErrorString(nullString(), inputKey, @"'%@' is not a valid dimension", key);
+                *outExceptionString = toErrorString(nullString(), inputKey, @"'%@' is not a valid dimension", key).createNSString().autorelease();
             return nil;
         }
 
@@ -434,7 +434,7 @@ NSMutableDictionary *WebExtensionAPIAction::parseIconImageDataDictionary(NSDicti
 
         if (!isValidDimensionKey(key)) {
             if (outExceptionString)
-                *outExceptionString = toErrorString(nullString(), inputKey, @"'%@' is not a valid dimension", key);
+                *outExceptionString = toErrorString(nullString(), inputKey, @"'%@' is not a valid dimension", key).createNSString().autorelease();
             return nil;
         }
 
@@ -482,7 +482,7 @@ NSArray *WebExtensionAPIAction::parseIconVariants(NSArray *input, const URL& bas
 
             if (![colorSchemes containsObject:lightKey] && ![colorSchemes containsObject:darkKey]) {
                 if (!firstExceptionString)
-                    firstExceptionString = toErrorString(nullString(), colorSchemesCompositeKey, @"it must specify either 'light' or 'dark'");
+                    firstExceptionString = toErrorString(nullString(), colorSchemesCompositeKey, @"it must specify either 'light' or 'dark'").createNSString().autorelease();
                 continue;
             }
 
@@ -497,7 +497,7 @@ NSArray *WebExtensionAPIAction::parseIconVariants(NSArray *input, const URL& bas
         // An exception is only set if no valid icon variants were found,
         // maintaining flexibility for future support of different inputs.
         if (!firstExceptionString)
-            firstExceptionString = toErrorString(nullString(), inputKey, @"it didn't contain any valid icon variants");
+            firstExceptionString = toErrorString(nullString(), inputKey, @"it didn't contain any valid icon variants").createNSString().autorelease();
         if (outExceptionString)
             *outExceptionString = firstExceptionString;
         return nil;
@@ -529,7 +529,7 @@ void WebExtensionAPIAction::setIcon(WebFrame& frame, NSDictionary *details, Ref<
         return;
 
     if (details[pathKey] && details[imageDataKey]) {
-        *outExceptionString = toErrorString(nullString(), @"details", @"it cannot specify both 'path' and 'imageData'");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it cannot specify both 'path' and 'imageData'").createNSString().autorelease();
         return;
     }
 
@@ -577,7 +577,7 @@ void WebExtensionAPIAction::setIcon(WebFrame& frame, NSDictionary *details, Ref<
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetIcon(windowIdentifier, tabIdentifier, iconsJSON), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -596,11 +596,11 @@ void WebExtensionAPIAction::getPopup(NSDictionary *details, Ref<WebExtensionCall
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionGetPopup(windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
-        callback->call(result.value());
+        callback->call(result.value().createNSString().get());
     }, extensionContext().identifier());
 }
 
@@ -628,7 +628,7 @@ void WebExtensionAPIAction::setPopup(NSDictionary *details, Ref<WebExtensionCall
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetPopup(windowIdentifier, tabIdentifier, popup), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -647,7 +647,7 @@ void WebExtensionAPIAction::openPopup(WebPageProxyIdentifier webPageProxyIdentif
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionOpenPopup(webPageProxyIdentifier, windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
@@ -85,7 +85,7 @@ void WebExtensionAPIAlarms::createAlarm(NSString *name, NSDictionary *alarmInfo,
     auto *periodNumber = objectForKey<NSNumber>(alarmInfo, periodInMinutesKey);
 
     if (whenNumber && delayNumber) {
-        *outExceptionString = toErrorString(nullString(), @"info", @"it cannot specify both 'delayInMinutes' and 'when'");
+        *outExceptionString = toErrorString(nullString(), @"info", @"it cannot specify both 'delayInMinutes' and 'when'").createNSString().autorelease();
         return;
     }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
@@ -81,7 +81,7 @@ void WebExtensionAPIDeclarativeNetRequest::updateEnabledRulesets(NSDictionary *o
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestUpdateEnabledRulesets(rulesetsToEnable, rulesetsToDisable), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -113,7 +113,7 @@ void WebExtensionAPIDeclarativeNetRequest::updateDynamicRules(NSDictionary *opti
     for (NSDictionary *ruleDictionary in rulesToAdd) {
         if (![[_WKWebExtensionDeclarativeNetRequestRule  alloc] initWithDictionary:ruleDictionary errorString:&ruleErrorString]) {
             ASSERT(ruleErrorString);
-            *outExceptionString = toErrorString(nullString(), addRulesKey, @"an error with rule at index %lu: %@", index, ruleErrorString);
+            *outExceptionString = toErrorString(nullString(), addRulesKey, @"an error with rule at index %lu: %@", index, ruleErrorString).createNSString().autorelease();
             return;
         }
 
@@ -132,7 +132,7 @@ void WebExtensionAPIDeclarativeNetRequest::updateDynamicRules(NSDictionary *opti
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestUpdateDynamicRules(WTFMove(rulesToAddJSON), WTFMove(ruleIDsToRemove)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -159,11 +159,11 @@ void WebExtensionAPIDeclarativeNetRequest::getDynamicRules(NSDictionary *filter,
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestGetDynamicRules(WTFMove(ruleIDs)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
-        callback->call(parseJSON(result.value(), JSONOptions::FragmentsAllowed));
+        callback->call(parseJSON(result.value().createNSString().get(), JSONOptions::FragmentsAllowed));
     }, extensionContext().identifier());
 }
 
@@ -184,7 +184,7 @@ void WebExtensionAPIDeclarativeNetRequest::updateSessionRules(NSDictionary *opti
     for (NSDictionary *ruleDictionary in rulesToAdd) {
         if (![[_WKWebExtensionDeclarativeNetRequestRule  alloc] initWithDictionary:ruleDictionary errorString:&ruleErrorString]) {
             ASSERT(ruleErrorString);
-            *outExceptionString = toErrorString(nullString(), addRulesKey, @"an error with rule at index %lu: %@", index, ruleErrorString);
+            *outExceptionString = toErrorString(nullString(), addRulesKey, @"an error with rule at index %lu: %@", index, ruleErrorString).createNSString().autorelease();
             return;
         }
 
@@ -203,7 +203,7 @@ void WebExtensionAPIDeclarativeNetRequest::updateSessionRules(NSDictionary *opti
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestUpdateSessionRules(WTFMove(rulesToAddJSON), WTFMove(ruleIDsToRemove)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -230,11 +230,11 @@ void WebExtensionAPIDeclarativeNetRequest::getSessionRules(NSDictionary *filter,
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestGetSessionRules(WTFMove(ruleIDs)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
-        callback->call(parseJSON(result.value(), JSONOptions::FragmentsAllowed));
+        callback->call(parseJSON(result.value().createNSString().get(), JSONOptions::FragmentsAllowed));
     }, extensionContext().identifier());
 }
 
@@ -244,7 +244,7 @@ static NSDictionary *toWebAPI(const Vector<WebExtensionMatchedRuleParameters>& m
 
     for (auto& matchedRule : matchedRules) {
         [matchedRuleArray addObject:@{
-            @"request": @{ @"url": matchedRule.url.string() },
+            @"request": @{ @"url": matchedRule.url.string().createNSString().get() },
             @"timeStamp": @(floor(matchedRule.timeStamp.secondsSinceEpoch().milliseconds())),
             @"tabId": @(toWebAPI(matchedRule.tabIdentifier))
         }];
@@ -259,7 +259,7 @@ void WebExtensionAPIDeclarativeNetRequest::getMatchedRules(NSDictionary *filter,
     bool hasActiveTabPermission = extensionContext().hasPermission("activeTab"_s);
 
     if (!hasFeedbackPermission && !hasActiveTabPermission) {
-        *outExceptionString = toErrorString(nullString(), nullString(), @"either the 'declarativeNetRequestFeedback' or 'activeTab' permission is required");
+        *outExceptionString = toErrorString(nullString(), nullString(), @"either the 'declarativeNetRequestFeedback' or 'activeTab' permission is required").createNSString().autorelease();
         return;
     }
 
@@ -279,7 +279,7 @@ void WebExtensionAPIDeclarativeNetRequest::getMatchedRules(NSDictionary *filter,
     NSNumber *tabID = objectForKey<NSNumber>(filter, getMatchedRulesTabIDKey);
     auto optionalTabIdentifier = tabID ? toWebExtensionTabIdentifier(tabID.doubleValue) : std::nullopt;
     if (tabID && !isValid(optionalTabIdentifier)) {
-        *outExceptionString = toErrorString(nullString(), getMatchedRulesTabIDKey, @"%@ is not a valid tab identifier", tabID);
+        *outExceptionString = toErrorString(nullString(), getMatchedRulesTabIDKey, @"%@ is not a valid tab identifier", tabID).createNSString().autorelease();
         return;
     }
 
@@ -290,7 +290,7 @@ void WebExtensionAPIDeclarativeNetRequest::getMatchedRules(NSDictionary *filter,
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestGetMatchedRules(optionalTabIdentifier, optionalTimeStamp), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Vector<WebExtensionMatchedRuleParameters>, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -338,13 +338,13 @@ void WebExtensionAPIDeclarativeNetRequest::setExtensionActionOptions(NSDictionar
         NSNumber *tabID = objectForKey<NSNumber>(tabUpdateDictionary, actionCountTabIDKey);
         auto tabIdentifier = toWebExtensionTabIdentifier(tabID.doubleValue);
         if (!isValid(tabIdentifier)) {
-            *outExceptionString = toErrorString(nullString(), actionCountTabIDKey, @"%@ is not a valid tab identifier", tabID);
+            *outExceptionString = toErrorString(nullString(), actionCountTabIDKey, @"%@ is not a valid tab identifier", tabID).createNSString().autorelease();
             return;
         }
 
         WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestIncrementActionCount(tabIdentifier.value(), objectForKey<NSNumber>(tabUpdateDictionary, actionCountIncrementKey).doubleValue), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
             if (!result) {
-                callback->reportError(result.error());
+                callback->reportError(result.error().createNSString().get());
                 return;
             }
 
@@ -355,7 +355,7 @@ void WebExtensionAPIDeclarativeNetRequest::setExtensionActionOptions(NSDictionar
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestDisplayActionCountAsBadgeText(objectForKey<NSNumber>(options, actionCountDisplayActionCountAsBadgeTextKey).boolValue), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
@@ -68,14 +68,14 @@ void WebExtensionAPIDevToolsInspectedWindow::eval(WebPageProxyIdentifier webPage
         frameURL = URL { url };
 
         if (!frameURL.value().isValid()) {
-            *outExceptionString = toErrorString(nullString(), frameURLKey, @"'%@' is not a valid URL", url);
+            *outExceptionString = toErrorString(nullString(), frameURLKey, @"'%@' is not a valid URL", url).createNSString().autorelease();
             return;
         }
     }
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DevToolsInspectedWindowEval(webPageProxyIdentifier, expression, frameURL), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Expected<JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>, WebExtensionError>&& result) mutable {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsNetworkCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsNetworkCocoa.mm
@@ -54,10 +54,10 @@ void WebExtensionContextProxy::dispatchDevToolsNetworkNavigatedEvent(const URL& 
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/network/onNavigated
 
-    NSString *urlString = url.string();
+    RetainPtr urlString = url.string().createNSString();
 
     enumerateNamespaceObjects([&](auto& namespaceObject) {
-        namespaceObject.devtools().network().onNavigated().invokeListenersWithArgument(urlString);
+        namespaceObject.devtools().network().onNavigated().invokeListenersWithArgument(urlString.get());
     });
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsPanelsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsPanelsCocoa.mm
@@ -54,7 +54,7 @@ void WebExtensionAPIDevToolsPanels::createPanel(WebPageProxyIdentifier webPagePr
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DevToolsPanelsCreate(webPageProxyIdentifier, title, iconPath, pagePath), [this, protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Inspector::ExtensionTabID, WebExtensionError>&& result) mutable {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
@@ -66,7 +66,7 @@ bool WebExtensionAPIExtension::parseViewFilters(NSDictionary *filter, std::optio
         else if ([typeString isEqualToString:tabKey])
             viewType = ViewType::Tab;
         else {
-            *outExceptionString = toErrorString(nullString(), typeKey, @"it must specify either 'popup' or 'tab'");
+            *outExceptionString = toErrorString(nullString(), typeKey, @"it must specify either 'popup' or 'tab'").createNSString().autorelease();
             return false;
         }
     }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm
@@ -57,7 +57,7 @@ NSString *WebExtensionAPILocalization::getMessage(NSString* messageName, id subs
 
     RefPtr localization = extensionContext().localization();
     if (!localization)
-        return emptyString();
+        return @"";
 
     NSArray<NSString *> *substitutionsArray;
     if ([substitutions isKindOfClass:NSString.class])
@@ -70,7 +70,7 @@ NSString *WebExtensionAPILocalization::getMessage(NSString* messageName, id subs
 
     auto substitutionsVector = makeVector<String>(substitutionsArray);
 
-    return localization->localizedStringForKey(messageName, substitutionsVector);
+    return localization->localizedStringForKey(messageName, substitutionsVector).createNSString().autorelease();
 }
 
 NSString *WebExtensionAPILocalization::getUILanguage()

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
@@ -93,20 +93,20 @@ void WebExtensionAPIPermissions::request(NSDictionary *details, Ref<WebExtension
 
     if (!validatePermissionsDetails(permissions, origins, matchPatterns, apiName, &errorMessage)) {
         // Chrome reports this error as callback error and not an exception, so do the same.
-        callback->reportError(toErrorString(apiName, nullString(), errorMessage));
+        callback->reportError(toErrorString(apiName, nullString(), errorMessage).createNSString().get());
         return;
     }
 
     if (!WebCore::UserGestureIndicator::processingUserGesture()) {
         // Chrome reports this error as callback error and not an exception, so do the same.
-        callback->reportError(toErrorString(apiName, nullString(), @"must be called during a user gesture"));
+        callback->reportError(toErrorString(apiName, nullString(), @"must be called during a user gesture").createNSString().get());
         return;
     }
 
     if (!verifyRequestedPermissions(permissions, matchPatterns, apiName, &errorMessage)) {
         // Chrome reports these errors as callback errors and not exceptions, so do the same. Instead of round tripping
         // to the UI process, we can answer this here and report the error right away.
-        callback->reportError(toErrorString(apiName, nullString(), errorMessage));
+        callback->reportError(toErrorString(apiName, nullString(), errorMessage).createNSString().get());
         return;
     }
 
@@ -129,13 +129,13 @@ void WebExtensionAPIPermissions::remove(NSDictionary *details, Ref<WebExtensionC
     WebExtension::MatchPatternSet matchPatterns;
     if (!validatePermissionsDetails(permissions, origins, matchPatterns, apiName, &errorMessage)) {
         // Chrome reports this error as callback error and not an exception, so do the same.
-        callback->reportError(toErrorString(apiName, nullString(), errorMessage));
+        callback->reportError(toErrorString(apiName, nullString(), errorMessage).createNSString().get());
         return;
     }
 
     if (!verifyRequestedPermissions(permissions, matchPatterns, apiName, &errorMessage)) {
         // Chrome reports this error as callback error and not an exception, so do the same.
-        callback->reportError(toErrorString(apiName, nullString(), errorMessage));
+        callback->reportError(toErrorString(apiName, nullString(), errorMessage).createNSString().get());
         return;
     }
 
@@ -171,14 +171,14 @@ bool WebExtensionAPIPermissions::verifyRequestedPermissions(HashSet<String>& per
 
     if ([callingAPIName isEqualToString:@"permissions.remove()"]) {
         if (permissions.size() && permissions.intersectionWith(allowedPermissions).size()) {
-            *outExceptionString = toErrorString(nullString(), permissionsKey, @"required permissions cannot be removed");
+            *outExceptionString = toErrorString(nullString(), permissionsKey, @"required permissions cannot be removed").createNSString().autorelease();
             return false;
         }
 
         for (auto& requestedPattern : matchPatterns) {
             for (auto& allowedPattern : allowedHostPermissions) {
                 if (allowedPattern->matchesPattern(requestedPattern, { WebExtensionMatchPattern::Options::IgnorePaths })) {
-                    *outExceptionString = toErrorString(nullString(), originsKey, @"required permissions cannot be removed");
+                    *outExceptionString = toErrorString(nullString(), originsKey, @"required permissions cannot be removed").createNSString().autorelease();
                     return false;
                 }
             }
@@ -191,9 +191,9 @@ bool WebExtensionAPIPermissions::verifyRequestedPermissions(HashSet<String>& per
     bool requestingPermissionsNotDeclaredInManifest = (permissions.size() && !permissions.isSubset(allowedPermissions)) || (matchPatterns.size() && !allowedHostPermissions.size());
     if (requestingPermissionsNotDeclaredInManifest) {
         if ([callingAPIName isEqualToString:@"permissions.remove()"])
-            *outExceptionString = toErrorString(nullString(), permissionsKey, @"only permissions specified in the manifest may be removed");
+            *outExceptionString = toErrorString(nullString(), permissionsKey, @"only permissions specified in the manifest may be removed").createNSString().autorelease();
         else
-            *outExceptionString = toErrorString(nullString(), permissionsKey, @"only permissions specified in the manifest may be requested");
+            *outExceptionString = toErrorString(nullString(), permissionsKey, @"only permissions specified in the manifest may be requested").createNSString().autorelease();
         return false;
     }
 
@@ -208,9 +208,9 @@ bool WebExtensionAPIPermissions::verifyRequestedPermissions(HashSet<String>& per
 
         if (!matchFound) {
             if ([callingAPIName isEqualToString:@"permissions.remove()"])
-                *outExceptionString = toErrorString(nullString(), originsKey, @"only permissions specified in the manifest may be removed");
+                *outExceptionString = toErrorString(nullString(), originsKey, @"only permissions specified in the manifest may be removed").createNSString().autorelease();
             else
-                *outExceptionString = toErrorString(nullString(), originsKey, @"only permissions specified in the manifest may be requested");
+                *outExceptionString = toErrorString(nullString(), originsKey, @"only permissions specified in the manifest may be requested").createNSString().autorelease();
             return false;
         }
     }
@@ -222,7 +222,7 @@ bool WebExtensionAPIPermissions::validatePermissionsDetails(HashSet<String>& per
 {
     for (auto& permission : permissions) {
         if (!WebExtension::supportedPermissions().contains(permission)) {
-            *outExceptionString = toErrorString(nullString(), permissionsKey, @"'%@' is not a valid permission", permission.createNSString().get());
+            *outExceptionString = toErrorString(nullString(), permissionsKey, @"'%@' is not a valid permission", permission.createNSString().get()).createNSString().autorelease();
             return false;
         }
     }
@@ -230,7 +230,7 @@ bool WebExtensionAPIPermissions::validatePermissionsDetails(HashSet<String>& per
     for (auto& origin : origins) {
         auto pattern = WebExtensionMatchPattern::getOrCreate(origin);
         if (!pattern || !pattern->isSupported()) {
-            *outExceptionString = toErrorString(nullString(), originsKey, @"'%@' is not a valid pattern", origin.createNSString().get());
+            *outExceptionString = toErrorString(nullString(), originsKey, @"'%@' is not a valid pattern", origin.createNSString().get()).createNSString().autorelease();
             return false;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
@@ -103,7 +103,7 @@ void WebExtensionAPIPort::remove()
 
 NSString *WebExtensionAPIPort::name()
 {
-    return m_name;
+    return m_name.createNSString().autorelease();
 }
 
 NSDictionary *WebExtensionAPIPort::sender()
@@ -126,12 +126,12 @@ void WebExtensionAPIPort::postMessage(WebFrame& frame, NSString *message, NSStri
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/Port#postmessage
 
     if (isDisconnected()) {
-        *outExceptionString = toErrorString(nullString(), nullString(), @"the port is disconnected");
+        *outExceptionString = toErrorString(nullString(), nullString(), @"the port is disconnected").createNSString().autorelease();
         return;
     }
 
     if (message.length > webExtensionMaxMessageLength) {
-        *outExceptionString = toErrorString(nullString(), @"message", @"it exceeded the maximum allowed length");
+        *outExceptionString = toErrorString(nullString(), @"message", @"it exceeded the maximum allowed length").createNSString().autorelease();
         return;
     }
 
@@ -220,7 +220,7 @@ void WebExtensionContextProxy::dispatchPortMessageEvent(std::optional<WebPagePro
     if (ports.isEmpty())
         return;
 
-    id message = parseJSON(messageJSON, { JSONOptions::FragmentsAllowed });
+    id message = parseJSON(messageJSON.createNSString().get(), { JSONOptions::FragmentsAllowed });
 
     for (Ref port : ports) {
         // Don't send the message to other ports in the same page as the sender.

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
@@ -185,7 +185,7 @@ NSString *WebExtensionAPIRuntime::runtimeIdentifier()
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/id
 
-    return extensionContext().uniqueIdentifier();
+    return extensionContext().uniqueIdentifier().createNSString().autorelease();
 }
 
 void WebExtensionAPIRuntime::getPlatformInfo(Ref<WebExtensionCallbackHandler>&& callback)
@@ -227,7 +227,7 @@ void WebExtensionAPIRuntime::getBackgroundPage(Ref<WebExtensionCallbackHandler>&
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::RuntimeGetBackgroundPage(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<std::optional<WebCore::PageIdentifier>, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -275,7 +275,7 @@ void WebExtensionAPIRuntime::openOptionsPage(Ref<WebExtensionCallbackHandler>&& 
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::RuntimeOpenOptionsPage(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -304,13 +304,13 @@ void WebExtensionAPIRuntime::sendMessage(WebPageProxyIdentifier webPageProxyIden
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage
 
     if (messageJSON.length > webExtensionMaxMessageLength) {
-        *outExceptionString = toErrorString(nullString(), @"message", @"it exceeded the maximum allowed length");
+        *outExceptionString = toErrorString(nullString(), @"message", @"it exceeded the maximum allowed length").createNSString().autorelease();
         return;
     }
 
     auto documentIdentifier = toDocumentIdentifier(frame);
     if (!documentIdentifier) {
-        *outExceptionString = toErrorString(nullString(), nullString(), @"an unexpected error occured");
+        *outExceptionString = toErrorString(nullString(), nullString(), @"an unexpected error occured").createNSString().autorelease();
         return;
     }
 
@@ -328,11 +328,11 @@ void WebExtensionAPIRuntime::sendMessage(WebPageProxyIdentifier webPageProxyIden
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::RuntimeSendMessage(extensionID, messageJSON, senderParameters), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
-        callback->call(parseJSON(result.value(), JSONOptions::FragmentsAllowed));
+        callback->call(parseJSON(result.value().createNSString().get(), JSONOptions::FragmentsAllowed));
     }, extensionContext().identifier());
 }
 
@@ -342,7 +342,7 @@ RefPtr<WebExtensionAPIPort> WebExtensionAPIRuntime::connect(WebPageProxyIdentifi
 
     auto documentIdentifier = toDocumentIdentifier(frame);
     if (!documentIdentifier) {
-        *outExceptionString = toErrorString(nullString(), nullString(), @"an unexpected error occured");
+        *outExceptionString = toErrorString(nullString(), nullString(), @"an unexpected error occured").createNSString().autorelease();
         return nullptr;
     }
 
@@ -368,7 +368,7 @@ RefPtr<WebExtensionAPIPort> WebExtensionAPIRuntime::connect(WebPageProxyIdentifi
         if (result)
             return;
 
-        port->setError(runtime().reportError(result.error(), globalContext.get()));
+        port->setError(runtime().reportError(result.error().createNSString().get(), globalContext.get()));
         port->disconnect();
     }, extensionContext().identifier());
 
@@ -381,11 +381,11 @@ void WebExtensionAPIRuntime::sendNativeMessage(WebFrame& frame, NSString *applic
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::RuntimeSendNativeMessage(applicationID, messageJSON), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
-        callback->call(parseJSON(result.value(), JSONOptions::FragmentsAllowed));
+        callback->call(parseJSON(result.value().createNSString().get(), JSONOptions::FragmentsAllowed));
     }, extensionContext().identifier());
 }
 
@@ -399,7 +399,7 @@ RefPtr<WebExtensionAPIPort> WebExtensionAPIRuntime::connectNative(WebPageProxyId
         if (result)
             return;
 
-        port->setError(runtime().reportError(result.error(), globalContext.get()));
+        port->setError(runtime().reportError(result.error().createNSString().get(), globalContext.get()));
         port->disconnect();
     }, extensionContext().identifier());
 
@@ -411,13 +411,13 @@ void WebExtensionAPIWebPageRuntime::sendMessage(WebPage& page, WebFrame& frame, 
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage
 
     if (messageJSON.length > webExtensionMaxMessageLength) {
-        *outExceptionString = toErrorString(nullString(), @"message", @"it exceeded the maximum allowed length");
+        *outExceptionString = toErrorString(nullString(), @"message", @"it exceeded the maximum allowed length").createNSString().autorelease();
         return;
     }
 
     auto documentIdentifier = toDocumentIdentifier(frame);
     if (!documentIdentifier) {
-        *outExceptionString = toErrorString(nullString(), nullString(), @"an unexpected error occured");
+        *outExceptionString = toErrorString(nullString(), nullString(), @"an unexpected error occured").createNSString().autorelease();
         return;
     }
 
@@ -447,7 +447,7 @@ void WebExtensionAPIWebPageRuntime::sendMessage(WebPage& page, WebFrame& frame, 
             return;
         }
 
-        callback->call(parseJSON(result.value(), JSONOptions::FragmentsAllowed));
+        callback->call(parseJSON(result.value().createNSString().get(), JSONOptions::FragmentsAllowed));
     }, destinationExtensionContext->identifier());
 }
 
@@ -461,7 +461,7 @@ RefPtr<WebExtensionAPIPort> WebExtensionAPIWebPageRuntime::connect(WebPage& page
 
     auto documentIdentifier = toDocumentIdentifier(frame);
     if (!documentIdentifier) {
-        *outExceptionString = toErrorString(nullString(), nullString(), @"an unexpected error occured");
+        *outExceptionString = toErrorString(nullString(), nullString(), @"an unexpected error occured").createNSString().autorelease();
         return nullptr;
     }
 
@@ -495,7 +495,7 @@ RefPtr<WebExtensionAPIPort> WebExtensionAPIWebPageRuntime::connect(WebPage& page
         if (result)
             return;
 
-        port->setError(runtime().reportError(result.error(), globalContext.get()));
+        port->setError(runtime().reportError(result.error().createNSString().get(), globalContext.get()));
         port->disconnect();
     }, destinationExtensionContext->identifier());
 
@@ -624,7 +624,7 @@ void WebExtensionContextProxy::internalDispatchRuntimeMessageEvent(WebExtensionC
         return;
     }
 
-    id message = parseJSON(messageJSON, JSONOptions::FragmentsAllowed);
+    id message = parseJSON(messageJSON.createNSString().get(), JSONOptions::FragmentsAllowed);
     auto *senderInfo = toWebAPI(senderParameters, baseURL());
     auto sourceContentWorldType = senderParameters.contentWorldType;
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
@@ -103,11 +103,11 @@ void WebExtensionAPIStorageArea::get(WebPageProxyIdentifier webPageProxyIdentifi
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageGet(webPageProxyIdentifier, m_type, keysVector), [keysWithDefaultValues, protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
-        NSDictionary *data = parseJSON(result.value());
+        NSDictionary *data = parseJSON(result.value().createNSString().get());
         NSDictionary<NSString *, id> *deserializedData = mapObjects(data, ^id(NSString *key, NSString *jsonString) {
             return parseJSON(jsonString, JSONOptions::FragmentsAllowed);
         });
@@ -121,7 +121,7 @@ void WebExtensionAPIStorageArea::getKeys(WebPageProxyIdentifier webPageProxyIden
 {
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageGetKeys(webPageProxyIdentifier, m_type), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Vector<String>, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -147,7 +147,7 @@ void WebExtensionAPIStorageArea::getBytesInUse(WebPageProxyIdentifier webPagePro
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageGetBytesInUse(webPageProxyIdentifier, m_type, keysVector), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<size_t, WebExtensionError>&& result) {
         if (!result)
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
         else
             callback->call(@(result.value()));
     }, extensionContext().identifier());
@@ -183,18 +183,18 @@ void WebExtensionAPIStorageArea::set(WebPageProxyIdentifier webPageProxyIdentifi
     });
 
     if (keyWithError) {
-        *outExceptionString = toErrorString(nullString(), adoptNS([[NSString alloc] initWithFormat:@"items[`%@`]", keyWithError]).get(), @"it is not JSON-serializable");
+        *outExceptionString = toErrorString(nullString(), adoptNS([[NSString alloc] initWithFormat:@"items[`%@`]", keyWithError]).get(), @"it is not JSON-serializable").createNSString().autorelease();
         return;
     }
 
     if (m_type == WebExtensionDataType::Sync && anyItemsExceedQuota(serializedData, webExtensionStorageAreaSyncQuotaBytesPerItem, &keyWithError)) {
-        *outExceptionString = toErrorString(nullString(), adoptNS([[NSString alloc] initWithFormat:@"items[`%@`]", keyWithError]).get(), @"it exceeded maximum size for a single item");
+        *outExceptionString = toErrorString(nullString(), adoptNS([[NSString alloc] initWithFormat:@"items[`%@`]", keyWithError]).get(), @"it exceeded maximum size for a single item").createNSString().autorelease();
         return;
     }
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageSet(webPageProxyIdentifier, m_type, encodeJSONString(serializedData)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result)
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
         else
             callback->call();
     }, extensionContext().identifier());
@@ -211,7 +211,7 @@ void WebExtensionAPIStorageArea::remove(WebPageProxyIdentifier webPageProxyIdent
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageRemove(webPageProxyIdentifier, m_type, keysVector), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result)
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
         else
             callback->call();
     }, extensionContext().identifier());
@@ -221,7 +221,7 @@ void WebExtensionAPIStorageArea::clear(WebPageProxyIdentifier webPageProxyIdenti
 {
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageClear(webPageProxyIdentifier, m_type), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result)
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
         else
             callback->call();
     }, extensionContext().identifier());
@@ -242,7 +242,7 @@ void WebExtensionAPIStorageArea::setAccessLevel(WebPageProxyIdentifier webPagePr
 
     NSString *accessLevelString = accessOptions[accessLevelKey];
     if (![accessLevelString isEqualToString:accessLevelTrustedContexts] && ![accessLevelString isEqualToString:accessLevelTrustedAndUntrustedContexts]) {
-        *outExceptionString = toErrorString(nullString(), @"accessLevel", @"it must specify either 'TRUSTED_CONTEXTS' or 'TRUSTED_AND_UNTRUSTED_CONTEXTS'");
+        *outExceptionString = toErrorString(nullString(), @"accessLevel", @"it must specify either 'TRUSTED_CONTEXTS' or 'TRUSTED_AND_UNTRUSTED_CONTEXTS'").createNSString().autorelease();
         return;
     }
 
@@ -250,7 +250,7 @@ void WebExtensionAPIStorageArea::setAccessLevel(WebPageProxyIdentifier webPagePr
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageSetAccessLevel(webPageProxyIdentifier, m_type, accessLevel), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result)
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
         else
             callback->call();
     }, extensionContext().identifier());

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm
@@ -112,12 +112,12 @@ void WebExtensionContextProxy::dispatchStorageChangedEvent(const String& changes
     if (!hasDOMWrapperWorld(contentWorldType))
         return;
 
-    id changes = parseJSON(changesJSON);
-    auto areaName = toAPIString(dataType);
+    RetainPtr changes = parseJSON(changesJSON.createNSString().get());
+    RetainPtr areaName = toAPIString(dataType).createNSString();
 
     enumerateFramesAndNamespaceObjects([&](WebFrame&, auto& namespaceObject) {
-        namespaceObject.storage().onChanged().invokeListenersWithArgument(changes, areaName);
-        namespaceObject.storage().storageAreaForType(dataType).onChanged().invokeListenersWithArgument(changes, areaName);
+        namespaceObject.storage().onChanged().invokeListenersWithArgument(changes.get(), areaName.get());
+        namespaceObject.storage().storageAreaForType(dataType).onChanged().invokeListenersWithArgument(changes.get(), areaName.get());
     }, toDOMWrapperWorld(contentWorldType));
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -212,7 +212,7 @@ bool WebExtensionAPITabs::parseTabCreateOptions(NSDictionary *options, WebExtens
         parameters.windowIdentifier = toWebExtensionWindowIdentifier(windowId.doubleValue);
 
         if (!parameters.windowIdentifier || !isValid(parameters.windowIdentifier.value())) {
-            *outExceptionString = toErrorString(nullString(), windowIdKey, @"'%@' is not a window identifier", windowId);
+            *outExceptionString = toErrorString(nullString(), windowIdKey, @"'%@' is not a window identifier", windowId).createNSString().autorelease();
             return false;
         }
     }
@@ -248,7 +248,7 @@ bool WebExtensionAPITabs::parseTabUpdateOptions(NSDictionary *options, WebExtens
         parameters.url = URL { extensionContext().baseURL(), url };
 
         if (!parameters.url.value().isValid()) {
-            *outExceptionString = toErrorString(nullString(), urlKey, @"'%@' is not a valid URL", url);
+            *outExceptionString = toErrorString(nullString(), urlKey, @"'%@' is not a valid URL", url).createNSString().autorelease();
             return false;
         }
     }
@@ -257,7 +257,7 @@ bool WebExtensionAPITabs::parseTabUpdateOptions(NSDictionary *options, WebExtens
         parameters.parentTabIdentifier = toWebExtensionTabIdentifier(openerTabId.doubleValue);
 
         if (!parameters.parentTabIdentifier || !isValid(parameters.parentTabIdentifier.value())) {
-            *outExceptionString = toErrorString(nullString(), openerTabIdKey, @"'%@' is not a tab identifier", openerTabId);
+            *outExceptionString = toErrorString(nullString(), openerTabIdKey, @"'%@' is not a tab identifier", openerTabId).createNSString().autorelease();
             return false;
         }
     }
@@ -326,7 +326,7 @@ bool WebExtensionAPITabs::parseTabQueryOptions(NSDictionary *options, WebExtensi
         parameters.windowIdentifier = toWebExtensionWindowIdentifier(windowId.doubleValue);
 
         if (!parameters.windowIdentifier || !isValid(parameters.windowIdentifier.value())) {
-            *outExceptionString = toErrorString(nullString(), windowIdKey, @"'%@' is not a window identifier", windowId);
+            *outExceptionString = toErrorString(nullString(), windowIdKey, @"'%@' is not a window identifier", windowId).createNSString().autorelease();
             return false;
         }
 
@@ -350,7 +350,7 @@ bool WebExtensionAPITabs::parseTabQueryOptions(NSDictionary *options, WebExtensi
         else if ([status isEqualToString:completeKey])
             parameters.loading = false;
         else {
-            *outExceptionString = toErrorString(nullString(), statusKey, @"it must specify either 'loading' or 'complete'");
+            *outExceptionString = toErrorString(nullString(), statusKey, @"it must specify either 'loading' or 'complete'").createNSString().autorelease();
             return false;
         }
     }
@@ -364,7 +364,7 @@ bool WebExtensionAPITabs::parseTabQueryOptions(NSDictionary *options, WebExtensi
         for (auto& patternString : parameters.urlPatterns.value()) {
             auto pattern = WebExtensionMatchPattern::getOrCreate(patternString);
             if (!pattern || !pattern->isSupported()) {
-                *outExceptionString = toErrorString(nullString(), urlKey, @"'%@' is not a valid pattern", patternString.createNSString().get());
+                *outExceptionString = toErrorString(nullString(), urlKey, @"'%@' is not a valid pattern", patternString.createNSString().get()).createNSString().autorelease();
                 return false;
             }
         }
@@ -430,14 +430,14 @@ bool WebExtensionAPITabs::parseCaptureVisibleTabOptions(NSDictionary *options, W
         else if ([format isEqualToString:jpegValue])
             imageFormat = WebExtensionTab::ImageFormat::JPEG;
         else {
-            *outExceptionString = toErrorString(nullString(), formatKey, @"it must specify either 'png' or 'jpeg'");
+            *outExceptionString = toErrorString(nullString(), formatKey, @"it must specify either 'png' or 'jpeg'").createNSString().autorelease();
             return false;
         }
     }
 
     if (NSNumber *quality = objectForKey<NSNumber>(options, qualityKey)) {
         if (quality.integerValue < 0 || quality.integerValue > 100) {
-            *outExceptionString = toErrorString(nullString(), qualityKey, @"it must specify a value between 0 and 100");
+            *outExceptionString = toErrorString(nullString(), qualityKey, @"it must specify a value between 0 and 100").createNSString().autorelease();
             return false;
         }
 
@@ -458,14 +458,14 @@ bool WebExtensionAPITabs::parseSendMessageOptions(NSDictionary *options, WebExte
         return false;
 
     if (options[frameIdKey] && options[documentIdKey]) {
-        *outExceptionString = toErrorString(nullString(), sourceKey, @"it cannot specify both 'frameId' and 'documentId'");
+        *outExceptionString = toErrorString(nullString(), sourceKey, @"it cannot specify both 'frameId' and 'documentId'").createNSString().autorelease();
         return false;
     }
 
     if (NSNumber *frameIdentifier = options[frameIdKey]) {
         auto identifier = toWebExtensionFrameIdentifier(frameIdentifier.doubleValue);
         if (!isValid(identifier)) {
-            *outExceptionString = toErrorString(nullString(), frameIdKey, @"'%@' is not a frame identifier", frameIdentifier);
+            *outExceptionString = toErrorString(nullString(), frameIdKey, @"'%@' is not a frame identifier", frameIdentifier).createNSString().autorelease();
             return false;
         }
 
@@ -475,7 +475,7 @@ bool WebExtensionAPITabs::parseSendMessageOptions(NSDictionary *options, WebExte
     if (NSString *documentIdentifier = options[documentIdKey]) {
         auto parsedUUID = WTF::UUID::parse(String(documentIdentifier));
         if (!parsedUUID) {
-            *outExceptionString = toErrorString(nullString(), documentIdKey, @"'%@' is not a document identifier", documentIdentifier);
+            *outExceptionString = toErrorString(nullString(), documentIdKey, @"'%@' is not a document identifier", documentIdentifier).createNSString().autorelease();
             return false;
         }
 
@@ -518,28 +518,28 @@ bool WebExtensionAPITabs::parseScriptOptions(NSDictionary *options, WebExtension
         return false;
 
     if (options[fileKey] && options[codeKey]) {
-        *outExceptionString = toErrorString(nullString(), @"details", @"it cannot specify both 'file' and 'code'");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it cannot specify both 'file' and 'code'").createNSString().autorelease();
         return false;
     }
 
     if (!options[fileKey] && !options[codeKey]) {
-        *outExceptionString = toErrorString(nullString(), @"details", @"it must specify either 'file' or 'code'");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it must specify either 'file' or 'code'").createNSString().autorelease();
         return false;
     }
 
     bool allFrames = boolForKey(options, allFramesKey, false);
     if (allFrames && options[frameIdKey]) {
-        *outExceptionString = toErrorString(nullString(), @"details", @"it cannot specify both 'allFrames' and 'frameId'");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it cannot specify both 'allFrames' and 'frameId'").createNSString().autorelease();
         return false;
     }
 
     if (options[frameIdKey] && options[documentIdKey]) {
-        *outExceptionString = toErrorString(nullString(), @"details", @"it cannot specify both 'frameId' and 'documentId'");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it cannot specify both 'frameId' and 'documentId'").createNSString().autorelease();
         return false;
     }
 
     if (allFrames && options[documentIdKey]) {
-        *outExceptionString = toErrorString(nullString(), @"details", @"it cannot specify both 'allFrames' and 'documentId'");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it cannot specify both 'allFrames' and 'documentId'").createNSString().autorelease();
         return false;
     }
 
@@ -552,7 +552,7 @@ bool WebExtensionAPITabs::parseScriptOptions(NSDictionary *options, WebExtension
     if (NSString *documentIdentifer = options[documentIdKey]) {
         auto parsedUUID = WTF::UUID::parse(String(documentIdentifer));
         if (!parsedUUID) {
-            *outExceptionString = toErrorString(nullString(), documentIdKey, @"'%@' is not a valid document identifier", documentIdentifer);
+            *outExceptionString = toErrorString(nullString(), documentIdKey, @"'%@' is not a valid document identifier", documentIdentifer).createNSString().autorelease();
             return false;
         }
 
@@ -562,7 +562,7 @@ bool WebExtensionAPITabs::parseScriptOptions(NSDictionary *options, WebExtension
     if (NSNumber *frameID = options[frameIdKey]) {
         auto frameIdentifier = toWebExtensionFrameIdentifier(frameID.doubleValue);
         if (!isValid(frameIdentifier)) {
-            *outExceptionString = toErrorString(nullString(), frameIdKey, @"'%@' is not a frame identifier", frameID);
+            *outExceptionString = toErrorString(nullString(), frameIdKey, @"'%@' is not a frame identifier", frameID).createNSString().autorelease();
             return false;
         }
 
@@ -576,7 +576,7 @@ bool WebExtensionAPITabs::parseScriptOptions(NSDictionary *options, WebExtension
         else if ([origin isEqualToString:authorValue])
             parameters.styleLevel = WebCore::UserStyleLevel::Author;
         else {
-            *outExceptionString = toErrorString(nullString(), cssOriginKey, @"it must specify either 'author' or 'user'");
+            *outExceptionString = toErrorString(nullString(), cssOriginKey, @"it must specify either 'author' or 'user'").createNSString().autorelease();
             return false;
         }
     }
@@ -588,11 +588,11 @@ bool isValid(std::optional<WebExtensionTabIdentifier> identifier, NSString **out
 {
     if (UNLIKELY(!isValid(identifier))) {
         if (isNone(identifier))
-            *outExceptionString = toErrorString(nullString(), @"tabId", @"'tabs.TAB_ID_NONE' is not allowed");
+            *outExceptionString = toErrorString(nullString(), @"tabId", @"'tabs.TAB_ID_NONE' is not allowed").createNSString().autorelease();
         else if (identifier)
-            *outExceptionString = toErrorString(nullString(), @"tabId", @"'%llu' is not a tab identifier", identifier.value().toUInt64());
+            *outExceptionString = toErrorString(nullString(), @"tabId", @"'%llu' is not a tab identifier", identifier.value().toUInt64()).createNSString().autorelease();
         else
-            *outExceptionString = toErrorString(nullString(), @"tabId", @"it is not a tab identifier");
+            *outExceptionString = toErrorString(nullString(), @"tabId", @"it is not a tab identifier").createNSString().autorelease();
         return false;
     }
 
@@ -622,7 +622,7 @@ void WebExtensionAPITabs::createTab(WebPageProxyIdentifier webPageProxyIdentifie
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsCreate(webPageProxyIdentifier, WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<std::optional<WebExtensionTabParameters>, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -640,7 +640,7 @@ void WebExtensionAPITabs::query(WebPageProxyIdentifier webPageProxyIdentifier, N
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsQuery(webPageProxyIdentifier, WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Vector<WebExtensionTabParameters>, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -658,7 +658,7 @@ void WebExtensionAPITabs::get(double tabID, Ref<WebExtensionCallbackHandler>&& c
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsGet(tabIdentifer.value()), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<std::optional<WebExtensionTabParameters>, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -672,7 +672,7 @@ void WebExtensionAPITabs::getCurrent(WebPageProxyIdentifier webPageProxyIdentifi
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsGetCurrent(webPageProxyIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<std::optional<WebExtensionTabParameters>, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -694,7 +694,7 @@ void WebExtensionAPITabs::getSelected(WebPageProxyIdentifier webPageProxyIdentif
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsQuery(webPageProxyIdentifier, WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Vector<WebExtensionTabParameters>, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -724,7 +724,7 @@ void WebExtensionAPITabs::duplicate(double tabID, NSDictionary *properties, Ref<
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsDuplicate(tabIdentifer.value(), WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<std::optional<WebExtensionTabParameters>, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -746,7 +746,7 @@ void WebExtensionAPITabs::update(WebPageProxyIdentifier webPageProxyIdentifier, 
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsUpdate(webPageProxyIdentifier, tabIdentifer, WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<std::optional<WebExtensionTabParameters>, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -766,7 +766,7 @@ void WebExtensionAPITabs::remove(NSObject *tabIDs, Ref<WebExtensionCallbackHandl
     if (NSNumber *tabID = dynamic_objc_cast<NSNumber>(tabIDs)) {
         auto tabIdentifer = toWebExtensionTabIdentifier(tabID.doubleValue);
         if (!isValid(tabIdentifer)) {
-            *outExceptionString = toErrorString(nullString(), @"tabIDs", @"'%@' is not a tab identifier", tabID);
+            *outExceptionString = toErrorString(nullString(), @"tabIDs", @"'%@' is not a tab identifier", tabID).createNSString().autorelease();
             return;
         }
 
@@ -777,7 +777,7 @@ void WebExtensionAPITabs::remove(NSObject *tabIDs, Ref<WebExtensionCallbackHandl
         for (NSNumber *tabID in tabIDArray) {
             auto tabIdentifer = toWebExtensionTabIdentifier(tabID.doubleValue);
             if (!isValid(tabIdentifer)) {
-                *outExceptionString = toErrorString(nullString(), @"tabIDs", @"'%@' is not a tab identifier", tabID);
+                *outExceptionString = toErrorString(nullString(), @"tabIDs", @"'%@' is not a tab identifier", tabID).createNSString().autorelease();
                 return;
             }
 
@@ -787,7 +787,7 @@ void WebExtensionAPITabs::remove(NSObject *tabIDs, Ref<WebExtensionCallbackHandl
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsRemove(WTFMove(identifiers)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -817,7 +817,7 @@ void WebExtensionAPITabs::reload(WebPageProxyIdentifier webPageProxyIdentifier, 
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsReload(webPageProxyIdentifier, tabIdentifer, reloadFromOrigin), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -835,7 +835,7 @@ void WebExtensionAPITabs::goBack(WebPageProxyIdentifier webPageProxyIdentifier, 
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsGoBack(webPageProxyIdentifier, tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -853,7 +853,7 @@ void WebExtensionAPITabs::goForward(WebPageProxyIdentifier webPageProxyIdentifie
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsGoForward(webPageProxyIdentifier, tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -871,7 +871,7 @@ void WebExtensionAPITabs::getZoom(WebPageProxyIdentifier webPageProxyIdentifier,
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsGetZoom(webPageProxyIdentifier, tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<double, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -889,7 +889,7 @@ void WebExtensionAPITabs::setZoom(WebPageProxyIdentifier webPageProxyIdentifier,
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsSetZoom(webPageProxyIdentifier, tabIdentifer, zoomFactor), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -907,7 +907,7 @@ void WebExtensionAPITabs::detectLanguage(WebPageProxyIdentifier webPageProxyIden
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsDetectLanguage(webPageProxyIdentifier, tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -916,7 +916,7 @@ void WebExtensionAPITabs::detectLanguage(WebPageProxyIdentifier webPageProxyIden
             return;
         }
 
-        callback->call(result.value());
+        callback->call(result.value().createNSString().get());
     }, extensionContext().identifier());
 }
 
@@ -930,7 +930,7 @@ void WebExtensionAPITabs::toggleReaderMode(WebPageProxyIdentifier webPageProxyId
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsToggleReaderMode(webPageProxyIdentifier, tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -954,7 +954,7 @@ void WebExtensionAPITabs::captureVisibleTab(WebPageProxyIdentifier webPageProxyI
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsCaptureVisibleTab(webPageProxyIdentifier, windowIdentifier, imageFormat, imageQuality), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<URL, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -963,7 +963,7 @@ void WebExtensionAPITabs::captureVisibleTab(WebPageProxyIdentifier webPageProxyI
             return;
         }
 
-        callback->call(result.value().string());
+        callback->call(result.value().string().createNSString().get());
     }, extensionContext().identifier());
 }
 
@@ -976,13 +976,13 @@ void WebExtensionAPITabs::sendMessage(WebFrame& frame, double tabID, NSString *m
         return;
 
     if (messageJSON.length > webExtensionMaxMessageLength) {
-        *outExceptionString = toErrorString(nullString(), @"message", @"it exceeded the maximum allowed length");
+        *outExceptionString = toErrorString(nullString(), @"message", @"it exceeded the maximum allowed length").createNSString().autorelease();
         return;
     }
 
     auto documentIdentifier = toDocumentIdentifier(frame);
     if (!documentIdentifier) {
-        *outExceptionString = toErrorString(@"runtime.sendMessage()", nullString(), @"an unexpected error occured");
+        *outExceptionString = toErrorString(@"runtime.sendMessage()", nullString(), @"an unexpected error occured").createNSString().autorelease();
         return;
     }
 
@@ -1002,11 +1002,11 @@ void WebExtensionAPITabs::sendMessage(WebFrame& frame, double tabID, NSString *m
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsSendMessage(tabIdentifer.value(), messageJSON, targetParameters, senderParameters), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
-        callback->call(parseJSON(result.value(), JSONOptions::FragmentsAllowed));
+        callback->call(parseJSON(result.value().createNSString().get(), JSONOptions::FragmentsAllowed));
     }, extensionContext().identifier());
 }
 
@@ -1020,7 +1020,7 @@ RefPtr<WebExtensionAPIPort> WebExtensionAPITabs::connect(WebFrame& frame, JSCont
 
     auto documentIdentifier = toDocumentIdentifier(frame);
     if (!documentIdentifier) {
-        *outExceptionString = toErrorString(nullString(), nullString(), @"an unexpected error occured");
+        *outExceptionString = toErrorString(nullString(), nullString(), @"an unexpected error occured").createNSString().autorelease();
         return nullptr;
     }
 
@@ -1047,7 +1047,7 @@ RefPtr<WebExtensionAPIPort> WebExtensionAPITabs::connect(WebFrame& frame, JSCont
         if (result)
             return;
 
-        port->setError(runtime().reportError(result.error(), globalContext.get()));
+        port->setError(runtime().reportError(result.error().createNSString().get(), globalContext.get()));
         port->disconnect();
     }, extensionContext().identifier());
 
@@ -1068,7 +1068,7 @@ void WebExtensionAPITabs::executeScript(WebPageProxyIdentifier webPageProxyIdent
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsExecuteScript(webPageProxyIdentifier, tabIdentifier, parameters), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Vector<WebExtensionScriptInjectionResultParameters>, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -1090,7 +1090,7 @@ void WebExtensionAPITabs::insertCSS(WebPageProxyIdentifier webPageProxyIdentifie
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsInsertCSS(webPageProxyIdentifier, tabIdentifier, parameters), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -1112,7 +1112,7 @@ void WebExtensionAPITabs::removeCSS(WebPageProxyIdentifier webPageProxyIdentifie
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsRemoveCSS(webPageProxyIdentifier, tabIdentifier, parameters), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
@@ -216,7 +216,7 @@ bool WebExtensionAPIWindows::parseWindowTypesFilter(NSDictionary *options, Optio
         windowTypeFilter.remove(WindowTypeFilter::Popup);
 
     if (!windowTypeFilter) {
-        *outExceptionString = toErrorString(nullString(), windowTypesKey, @"it must specify either 'normal', 'popup', or both.");
+        *outExceptionString = toErrorString(nullString(), windowTypesKey, @"it must specify either 'normal', 'popup', or both.").createNSString().autorelease();
         return false;
     }
 
@@ -231,7 +231,7 @@ bool WebExtensionAPIWindows::parseWindowTypeFilter(NSString *windowType, OptionS
         windowTypeFilter.add(WindowTypeFilter::Popup);
 
     if (!windowTypeFilter) {
-        *outExceptionString = toErrorString(nullString(), sourceKey, @"it must specify either 'normal' or 'popup'");
+        *outExceptionString = toErrorString(nullString(), sourceKey, @"it must specify either 'normal' or 'popup'").createNSString().autorelease();
         return false;
     }
 
@@ -275,7 +275,7 @@ bool WebExtensionAPIWindows::parseWindowCreateOptions(NSDictionary *options, Web
         tabParameters.url = URL { extensionContext().baseURL(), url };
 
         if (!tabParameters.url.value().isValid()) {
-            *outExceptionString = toErrorString(nullString(), urlKey, @"'%@' is not a valid URL", url);
+            *outExceptionString = toErrorString(nullString(), urlKey, @"'%@' is not a valid URL", url).createNSString().autorelease();
             return false;
         }
 
@@ -289,7 +289,7 @@ bool WebExtensionAPIWindows::parseWindowCreateOptions(NSDictionary *options, Web
             tabParameters.url = URL { extensionContext().baseURL(), url };
 
             if (!tabParameters.url.value().isValid()) {
-                *outExceptionString = toErrorString(nullString(), urlKey, @"'%@' is not a valid URL", url);
+                *outExceptionString = toErrorString(nullString(), urlKey, @"'%@' is not a valid URL", url).createNSString().autorelease();
                 return false;
             }
 
@@ -329,7 +329,7 @@ bool WebExtensionAPIWindows::parseWindowUpdateOptions(NSDictionary *options, Web
         parameters.state = toStateImpl(state);
 
         if (!parameters.state) {
-            *outExceptionString = toErrorString(nullString(), stateKey, @"it must specify 'normal', 'minimized', 'maximized', or 'fullscreen'");
+            *outExceptionString = toErrorString(nullString(), stateKey, @"it must specify 'normal', 'minimized', 'maximized', or 'fullscreen'").createNSString().autorelease();
             return false;
         }
     }
@@ -344,7 +344,7 @@ bool WebExtensionAPIWindows::parseWindowUpdateOptions(NSDictionary *options, Web
 
     if (left || top || width || height) {
         if (parameters.state && parameters.state.value() != WebExtensionWindow::State::Normal) {
-            *outExceptionString = toErrorString(nullString(), sourceKey, @"when 'top', 'left', 'width', or 'height' are specified, 'state' must specify 'normal'.");
+            *outExceptionString = toErrorString(nullString(), sourceKey, @"when 'top', 'left', 'width', or 'height' are specified, 'state' must specify 'normal'.").createNSString().autorelease();
             return false;
         }
 
@@ -365,11 +365,11 @@ bool isValid(std::optional<WebExtensionWindowIdentifier> identifier, NSString **
 {
     if (UNLIKELY(!isValid(identifier))) {
         if (isNone(identifier))
-            *outExceptionString = toErrorString(nullString(), @"windowId", @"'windows.WINDOW_ID_NONE' is not allowed");
+            *outExceptionString = toErrorString(nullString(), @"windowId", @"'windows.WINDOW_ID_NONE' is not allowed").createNSString().autorelease();
         else if (identifier)
-            *outExceptionString = toErrorString(nullString(), @"windowId", @"'%llu' is not a window identifier", identifier.value().toUInt64());
+            *outExceptionString = toErrorString(nullString(), @"windowId", @"'%llu' is not a window identifier", identifier.value().toUInt64()).createNSString().autorelease();
         else
-            *outExceptionString = toErrorString(nullString(), @"windowId", @"it is not a window identifier");
+            *outExceptionString = toErrorString(nullString(), @"windowId", @"it is not a window identifier").createNSString().autorelease();
         return false;
     }
 
@@ -400,7 +400,7 @@ void WebExtensionAPIWindows::createWindow(NSDictionary *data, Ref<WebExtensionCa
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsCreate(WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<std::optional<WebExtensionWindowParameters>, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -423,7 +423,7 @@ void WebExtensionAPIWindows::get(WebPageProxyIdentifier webPageProxyIdentifier, 
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsGet(webPageProxyIdentifier, windowIdentifer.value(), filter, populate), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<WebExtensionWindowParameters, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -442,7 +442,7 @@ void WebExtensionAPIWindows::getCurrent(WebPageProxyIdentifier webPageProxyIdent
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsGet(webPageProxyIdentifier, WebExtensionWindowConstants::CurrentIdentifier, filter, populate), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<WebExtensionWindowParameters, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -461,7 +461,7 @@ void WebExtensionAPIWindows::getLastFocused(NSDictionary *info, Ref<WebExtension
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsGetLastFocused(filter, populate), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<WebExtensionWindowParameters, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -480,7 +480,7 @@ void WebExtensionAPIWindows::getAll(NSDictionary *info, Ref<WebExtensionCallback
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsGetAll(filter, populate), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Vector<WebExtensionWindowParameters>, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -502,7 +502,7 @@ void WebExtensionAPIWindows::update(double windowID, NSDictionary *info, Ref<Web
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsUpdate(windowIdentifer.value(), WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<WebExtensionWindowParameters, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -520,7 +520,7 @@ void WebExtensionAPIWindows::remove(double windowID, Ref<WebExtensionCallbackHan
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsRemove(windowIdentifer.value()), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm
@@ -153,7 +153,7 @@ static NSString * const portsKey = @"ports";
         ASSERT([rawValue isKindOfClass:NSString.class]);
 
         if (!(_value = [NSRegularExpression regularExpressionWithPattern:rawValue options:0 error:nil])) {
-            *outErrorMessage = toErrorString(nullString(), originAndPathMatchesKey, @"'%@' is not a valid regular expression", rawValue);
+            *outErrorMessage = toErrorString(nullString(), originAndPathMatchesKey, @"'%@' is not a valid regular expression", rawValue).createNSString().autorelease();
             return nil;
         }
 
@@ -181,21 +181,21 @@ static NSString * const portsKey = @"ports";
             if (NSNumber *number = dynamic_objc_cast<NSNumber>(portOrRange)) {
                 NSInteger integerValue = number.integerValue;
                 if (integerValue < 0 || integerValue > maximumPortNumber) {
-                    *outErrorMessage = toErrorString(nullString(), portsKey, @"'%zd' is not a valid port", integerValue);
+                    *outErrorMessage = toErrorString(nullString(), portsKey, @"'%zd' is not a valid port", integerValue).createNSString().autorelease();
                     return nil;
                 }
 
                 [ports addIndex:(NSUInteger)integerValue];
             } else if (NSArray<NSNumber *> *rangeArray = dynamic_objc_cast<NSArray>(portOrRange)) {
                 if (rangeArray.count != 2) {
-                    *outErrorMessage = toErrorString(nullString(), portsKey, @"a port range must specify 2 numbers");
+                    *outErrorMessage = toErrorString(nullString(), portsKey, @"a port range must specify 2 numbers").createNSString().autorelease();
                     return nil;
                 }
 
                 for (NSNumber *number in rangeArray) {
                     NSInteger integerValue = number.integerValue;
                     if (integerValue < 0 || integerValue > maximumPortNumber) {
-                        *outErrorMessage = toErrorString(nullString(), portsKey, @"'%zd' is not a valid port", integerValue);
+                        *outErrorMessage = toErrorString(nullString(), portsKey, @"'%zd' is not a valid port", integerValue).createNSString().autorelease();
                         return nil;
                     }
                 }
@@ -203,7 +203,7 @@ static NSString * const portsKey = @"ports";
                 NSUInteger firstPort = rangeArray[0].unsignedIntegerValue;
                 NSUInteger lastPort = rangeArray[1].unsignedIntegerValue;
                 if (firstPort >= lastPort) {
-                    *outErrorMessage = toErrorString(nullString(), portsKey, @"'%zd-%zd' is not a valid port range", firstPort, lastPort);
+                    *outErrorMessage = toErrorString(nullString(), portsKey, @"'%zd-%zd' is not a valid port range", firstPort, lastPort).createNSString().autorelease();
                     return nil;
                 }
 

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm
@@ -132,7 +132,7 @@ static NSArray<WKWebExtensionMatchPattern *> *toMatchPatterns(NSArray<NSString *
         WKWebExtensionMatchPattern *pattern = [[WKWebExtensionMatchPattern alloc] initWithString:rawPattern error:&error];
         if (!pattern) {
             if (outErrorMessage)
-                *outErrorMessage = toErrorString(nullString(), urlsKey, @"'%@' is an invalid match pattern. %@", rawPattern, error.localizedDescription);
+                *outErrorMessage = toErrorString(nullString(), urlsKey, @"'%@' is an invalid match pattern. %@", rawPattern, error.localizedDescription).createNSString().autorelease();
             return nil;
         }
 
@@ -165,7 +165,7 @@ static NSNumber *toResourceType(NSString *typeString, NSString **outErrorMessage
 
     NSNumber *typeAsNumber = validTypes[typeString];
     if (!typeAsNumber) {
-        *outErrorMessage = toErrorString(nullString(), typesKey, @"'%@' is an unknown resource type", typeString);
+        *outErrorMessage = toErrorString(nullString(), typesKey, @"'%@' is an unknown resource type", typeString).createNSString().autorelease();
         return nil;
     }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
@@ -154,7 +154,7 @@
     auto* coreFrame = _frame->coreLocalFrame();
     if (!coreFrame)
         return nil;
-    return coreFrame->document()->securityOrigin().toString();
+    return coreFrame->document()->securityOrigin().toString().createNSString().autorelease();
 }
 
 static RetainPtr<NSArray> collectIcons(WebCore::LocalFrame* frame, OptionSet<WebCore::LinkIconType> iconTypes)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm
@@ -60,7 +60,7 @@
 
 - (NSString *)text
 {
-    return _rangeHandle->text();
+    return _rangeHandle->text().createNSString().autorelease();
 }
 
 #if TARGET_OS_IPHONE

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.mm
@@ -68,7 +68,7 @@
 
 - (NSString *)name
 {
-    return _world->name();
+    return _world->name().createNSString().autorelease();
 }
 
 - (WebKit::InjectedBundleScriptWorld&)_scriptWorld

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMElement.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMElement.mm
@@ -48,7 +48,7 @@
 
 - (NSString *)tagName
 {
-    return downcast<WebCore::Element>(*_impl).tagName();
+    return downcast<WebCore::Element>(*_impl).tagName().createNSString().autorelease();
 }
 
 @end

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMRange.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMRange.mm
@@ -119,7 +119,7 @@
 {
     auto range = makeSimpleRange(*_impl);
     range.start.document().updateLayout();
-    return plainText(range);
+    return plainText(range).createNSString().autorelease();
 }
 
 - (BOOL)isCollapsed

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMText.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMText.mm
@@ -33,7 +33,7 @@
 
 - (NSString *)data
 {
-    return downcast<WebCore::Text>(*_impl).data();
+    return downcast<WebCore::Text>(*_impl).data().createNSString().autorelease();
 }
 
 - (void)setData:(NSString *)data

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
@@ -492,7 +492,7 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
             if ([formDelegate respondsToSelector:@selector(_webProcessPlugInBrowserContextController:willSendSubmitEventToForm:inFrame:targetFrame:values:)]) {
                 auto valueMap = adoptNS([[NSMutableDictionary alloc] initWithCapacity:values.size()]);
                 for (const auto& pair : values)
-                    [valueMap setObject:pair.second forKey:pair.first];
+                    [valueMap setObject:pair.second.createNSString().get() forKey:pair.first.createNSString().get()];
                 [formDelegate _webProcessPlugInBrowserContextController:controller.get() willSendSubmitEventToForm:wrapper(*WebKit::InjectedBundleNodeHandle::getOrCreate(formElement).get())
                     inFrame:wrapper(*sourceFrame) targetFrame:wrapper(*targetFrame) values:valueMap.get()];
             }
@@ -508,7 +508,7 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
             if ([formDelegate respondsToSelector:@selector(_webProcessPlugInBrowserContextController:willSubmitForm:toFrame:fromFrame:withValues:)]) {
                 auto valueMap = adoptNS([[NSMutableDictionary alloc] initWithCapacity:values.size()]);
                 for (const auto& pair : values)
-                    [valueMap setObject:pair.second forKey:pair.first];
+                    [valueMap setObject:pair.second.createNSString().get() forKey:pair.first.createNSString().get()];
                 userData = API::Object::fromNSObject([formDelegate _webProcessPlugInBrowserContextController:controller.get() willSubmitForm:wrapper(*WebKit::InjectedBundleNodeHandle::getOrCreate(formElement).get()) toFrame:wrapper(*frame) fromFrame:wrapper(*sourceFrame) withValues:valueMap.get()]);
             }
         }
@@ -615,7 +615,7 @@ static inline WKEditorInsertAction toWK(WebCore::EditorInsertAction action)
                 return true;
 
             RetainPtr controller = m_controller.get();
-            return [controller->_editingDelegate.get() _webProcessPlugInBrowserContextController:controller.get() shouldInsertText:text replacingRange:wrapper(*WebKit::createHandle(rangeToReplace)) givenAction:toWK(action)];
+            return [controller->_editingDelegate.get() _webProcessPlugInBrowserContextController:controller.get() shouldInsertText:text.createNSString().get() replacingRange:wrapper(*WebKit::createHandle(rangeToReplace)) givenAction:toWK(action)];
         }
 
         bool shouldChangeSelectedRange(WebKit::WebPage&, const std::optional<WebCore::SimpleRange>& fromRange, const std::optional<WebCore::SimpleRange>& toRange, WebCore::Affinity affinity, bool stillSelecting) final
@@ -737,7 +737,7 @@ static inline WKEditorInsertAction toWK(WebCore::EditorInsertAction action)
 
 - (NSString *)_groupIdentifier
 {
-    return _page->pageGroup()->identifier();
+    return _page->pageGroup()->identifier().createNSString().autorelease();
 }
 
 @end

--- a/Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
@@ -118,7 +118,7 @@ bool InjectedBundle::initialize(const WebProcessCreationParameters& parameters, 
         }
     }
 
-    m_platformBundle = adoptNS([[NSBundle alloc] initWithPath:m_path]);
+    m_platformBundle = adoptNS([[NSBundle alloc] initWithPath:m_path.createNSString().get()]);
     if (!m_platformBundle) {
         WTFLogAlways("InjectedBundle::load failed - Could not create the bundle.\n");
         return false;
@@ -261,7 +261,7 @@ void InjectedBundle::setBundleParameter(const String& key, std::span<const uint8
     if (!m_bundleParameters && parameter)
         m_bundleParameters = adoptNS([[WKWebProcessBundleParameters alloc] initWithDictionary:@{ }]);
 
-    [m_bundleParameters setParameter:parameter forKey:key];
+    [m_bundleParameters setParameter:parameter forKey:key.createNSString().get()];
 }
 
 void InjectedBundle::setBundleParameters(std::span<const uint8_t> value)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
@@ -59,7 +59,7 @@ void PDFPluginChoiceAnnotation::updateGeometry()
 
 void PDFPluginChoiceAnnotation::commit()
 {
-    annotation().widgetStringValue = downcast<HTMLSelectElement>(element())->value();
+    annotation().widgetStringValue = downcast<HTMLSelectElement>(element())->value().createNSString().get();
 
     PDFPluginAnnotation::commit();
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
@@ -111,7 +111,7 @@ void PDFPluginTextAnnotation::updateGeometry()
 
 void PDFPluginTextAnnotation::commit()
 {
-    annotation().widgetStringValue = value();
+    annotation().widgetStringValue = value().createNSString().get();
     PDFPluginAnnotation::commit();
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
@@ -76,8 +76,8 @@ static void changeWordCase(WebPage* page, NSString *(*changeCase)(NSString *))
 
     frame->editor().command("selectWord"_s).execute();
 
-    NSString *selectedString = frame->displayStringModifiedByEncoding(frame->editor().selectedText());
-    page->replaceSelectionWithText(frame.get(), changeCase(selectedString));
+    RetainPtr selectedString = frame->displayStringModifiedByEncoding(frame->editor().selectedText()).createNSString();
+    page->replaceSelectionWithText(frame.get(), changeCase(selectedString.get()));
 }
 
 void WebEditorClient::uppercaseWord()

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieJarCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieJarCocoa.mm
@@ -62,7 +62,7 @@ String WebCookieJar::cookiesInPartitionedCookieStorage(const WebCore::Document& 
         return { };
 
     __block RetainPtr<NSArray> cookies;
-    [m_partitionedStorageForDOMCookies.get() _getCookiesForURL:cookieURL.createNSURL().get() mainDocumentURL:firstPartyURL.createNSURL().get() partition:partition policyProperties:policyProperties(sameSiteInfo, cookieURL).get() completionHandler:^(NSArray *result) {
+    [m_partitionedStorageForDOMCookies.get() _getCookiesForURL:cookieURL.createNSURL().get() mainDocumentURL:firstPartyURL.createNSURL().get() partition:partition.createNSString().get() policyProperties:policyProperties(sameSiteInfo, cookieURL).get() completionHandler:^(NSArray *result) {
         cookies = result;
     }];
 
@@ -93,7 +93,7 @@ void WebCookieJar::setCookiesInPartitionedCookieStorage(const WebCore::Document&
     if (partition.isEmpty())
         return;
 
-    NSHTTPCookie *cookie = [NSHTTPCookie _cookieForSetCookieString:cookieString forURL:cookieURL.createNSURL().get() partition:partition];
+    NSHTTPCookie *cookie = [NSHTTPCookie _cookieForSetCookieString:cookieString.createNSString().get() forURL:cookieURL.createNSURL().get() partition:partition.createNSString().get()];
     if (!cookie || ![[cookie name] length] || [cookie isHTTPOnly])
         return;
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
@@ -498,7 +498,7 @@ static RetainPtr<CAAnimation> createAnimation(CALayer *layer, RemoteLayerTreeHos
     RetainPtr<CAAnimation> caAnimation;
     switch (properties.animationType) {
     case PlatformCAAnimation::AnimationType::Basic: {
-        auto basicAnimation = [CABasicAnimation animationWithKeyPath:properties.keyPath];
+        RetainPtr basicAnimation = [CABasicAnimation animationWithKeyPath:properties.keyPath.createNSString().get()];
 
         if (properties.keyValues.size() > 1) {
             [basicAnimation setFromValue:animationValueFromKeyframeValue(properties.keyValues[0]).get()];
@@ -508,7 +508,7 @@ static RetainPtr<CAAnimation> createAnimation(CALayer *layer, RemoteLayerTreeHos
         if (properties.timingFunctions.size())
             [basicAnimation setTimingFunction:toCAMediaTimingFunction(properties.timingFunctions[0].get(), properties.reverseTimingFunctions)];
 
-        caAnimation = basicAnimation;
+        caAnimation = WTFMove(basicAnimation);
         break;
     }
     case PlatformCAAnimation::AnimationType::Group: {
@@ -527,7 +527,7 @@ static RetainPtr<CAAnimation> createAnimation(CALayer *layer, RemoteLayerTreeHos
         break;
     }
     case PlatformCAAnimation::AnimationType::Keyframe: {
-        auto keyframeAnimation = [CAKeyframeAnimation animationWithKeyPath:properties.keyPath];
+        RetainPtr keyframeAnimation = [CAKeyframeAnimation animationWithKeyPath:properties.keyPath.createNSString().get()];
 
         if (properties.keyValues.size()) {
             [keyframeAnimation setValues:createNSArray(properties.keyValues, [] (auto& value) {
@@ -550,11 +550,11 @@ static RetainPtr<CAAnimation> createAnimation(CALayer *layer, RemoteLayerTreeHos
             }).get()];
         }
 
-        caAnimation = keyframeAnimation;
+        caAnimation = WTFMove(keyframeAnimation);
         break;
     }
     case PlatformCAAnimation::AnimationType::Spring: {
-        auto springAnimation = [CASpringAnimation animationWithKeyPath:properties.keyPath];
+        RetainPtr springAnimation = [CASpringAnimation animationWithKeyPath:properties.keyPath.createNSString().get()];
 
         if (properties.keyValues.size() > 1) {
             [springAnimation setFromValue:animationValueFromKeyframeValue(properties.keyValues[0]).get()];
@@ -571,7 +571,7 @@ static RetainPtr<CAAnimation> createAnimation(CALayer *layer, RemoteLayerTreeHos
                 [springAnimation setInitialVelocity:function->initialVelocity()];
             }
         }
-        caAnimation = springAnimation;
+        caAnimation = WTFMove(springAnimation);
         break;
     }
     }
@@ -622,7 +622,7 @@ static void addAnimationToLayer(CALayer *layer, RemoteLayerTreeHost* layerTreeHo
         return;
     }
 
-    [layer addAnimation:createAnimation(layer, layerTreeHost, properties).get() forKey:key];
+    [layer addAnimation:createAnimation(layer, layerTreeHost, properties).get() forKey:key.createNSString().get()];
     [layer setInheritsTiming:NO];
 }
 
@@ -631,7 +631,7 @@ void PlatformCAAnimationRemote::updateLayerAnimations(CALayer *layer, RemoteLaye
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
     for (const auto& value : animationsToRemove)
-        [layer removeAnimationForKey:value];
+        [layer removeAnimationForKey:value.createNSString().get()];
 
     for (const auto& keyAnimationPair : animationsToAdd)
         addAnimationToLayer(layer, layerTreeHost, keyAnimationPair.first, keyAnimationPair.second);

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
@@ -301,7 +301,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         if ([attribute isEqualToString:@"AXDataDetectorTypeAtPoint"]) {
             String stringValue;
             if (protectedSelf->m_page->corePage()->pageOverlayController().copyAccessibilityAttributeStringValueForPoint(attribute, point, stringValue))
-                value = adoptNS([[NSString alloc] initWithString:stringValue]);
+                value = stringValue.createNSString();
         }
         return value;
     }).autorelease();

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -981,8 +981,8 @@ static NSURL *origin(WebPage& page)
     auto rootFrameOriginString = page.rootFrameOriginString();
     // +[NSURL URLWithString:] returns nil when its argument is malformed. It's unclear when we would have a malformed URL here,
     // but it happens in practice according to <rdar://problem/14173389>. Leaving an assertion in to catch a reproducible case.
-    ASSERT([NSURL URLWithString:rootFrameOriginString]);
-    return [NSURL URLWithString:rootFrameOriginString];
+    ASSERT([NSURL URLWithString:rootFrameOriginString.createNSString().get()]);
+    return [NSURL URLWithString:rootFrameOriginString.createNSString().get()];
 }
 
 static Vector<String> activePagesOrigins(const HashMap<PageIdentifier, RefPtr<WebPage>>& pageMap)
@@ -1529,7 +1529,7 @@ void WebProcess::postNotification(const String& message, std::optional<uint64_t>
 
 void WebProcess::postObserverNotification(const String& message)
 {
-    [[NSNotificationCenter defaultCenter] postNotificationName:message object:nil];
+    [[NSNotificationCenter defaultCenter] postNotificationName:message.createNSString().get() object:nil];
 }
 
 void WebProcess::setNotifyState(const String& name, uint64_t state)

--- a/Source/WebKit/webpushd/ApplePushServiceConnection.mm
+++ b/Source/WebKit/webpushd/ApplePushServiceConnection.mm
@@ -70,7 +70,7 @@ namespace WebPushD {
 
 ApplePushServiceConnection::ApplePushServiceConnection(const String& incomingPushServiceName)
 {
-    m_connection = adoptNS([[APSConnection alloc] initWithEnvironmentName:APSEnvironmentProduction namedDelegatePort:incomingPushServiceName queue:dispatch_get_main_queue()]);
+    m_connection = adoptNS([[APSConnection alloc] initWithEnvironmentName:APSEnvironmentProduction namedDelegatePort:incomingPushServiceName.createNSString().get() queue:dispatch_get_main_queue()]);
     m_delegate = adoptNS([[_WKAPSConnectionDelegate alloc] initWithConnection:this]);
     [m_connection setDelegate:m_delegate.get()];
 }
@@ -82,7 +82,7 @@ ApplePushServiceConnection::~ApplePushServiceConnection()
 
 static RetainPtr<APSURLTokenInfo> makeTokenInfo(const String& topic, const Vector<uint8_t>& vapidPublicKey)
 {
-    return adoptNS([[APSURLTokenInfo alloc] initWithTopic:topic vapidPublicKey:toNSData(vapidPublicKey).get()]);
+    return adoptNS([[APSURLTokenInfo alloc] initWithTopic:topic.createNSString().get() vapidPublicKey:toNSData(vapidPublicKey).get()]);
 }
 
 void ApplePushServiceConnection::subscribe(const String& topic, const Vector<uint8_t>& vapidPublicKey, SubscribeHandler&& subscribeHandler)


### PR DESCRIPTION
#### 84b0ff1674276cd7e3221d0a10a405ee1134fc15
<pre>
Reduce the number of implicit conversion from String to NSString in the project
<a href="https://bugs.webkit.org/show_bug.cgi?id=291481">https://bugs.webkit.org/show_bug.cgi?id=291481</a>

Reviewed by Geoffrey Garen and Darin Adler.

Reduce the number of implicit conversion from String to NSString in the project.
Use createNSString() instead, which makes it clearer that we are allocating a
new string and which returns a RetainPtr instead of an autoreleased object.

* Source/WTF/wtf/cocoa/FileSystemCocoa.mm:
(WTF::FileSystemImpl::isSafeToUseMemoryMapForPath):
(WTF::FileSystemImpl::makeSafeToUseMemoryMapForPath):
* Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm:
(WebCore::attributeStringSetLanguage):
(WebCore::attributedStringSetCompositionAttributes):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityDOMIdentifier]):
(-[WebAccessibilityObjectWrapper _accessibilityWebRoleAsString]):
(-[WebAccessibilityObjectWrapper accessibilityPopupValue]):
(-[WebAccessibilityObjectWrapper accessibilityLanguage]):
(-[WebAccessibilityObjectWrapper interactiveVideoDescription]):
(-[WebAccessibilityObjectWrapper accessibilityRoleDescription]):
(-[WebAccessibilityObjectWrapper accessibilityBrailleLabel]):
(-[WebAccessibilityObjectWrapper accessibilityBrailleRoleDescription]):
(-[WebAccessibilityObjectWrapper accessibilityLabel]):
(-[WebAccessibilityObjectWrapper accessibilityDatetimeValue]):
(-[WebAccessibilityObjectWrapper accessibilityPlaceholderValue]):
(-[WebAccessibilityObjectWrapper accessibilityValue]):
(-[WebAccessibilityObjectWrapper accessibilityHint]):
(-[WebAccessibilityObjectWrapper _accessibilityPhotoDescription]):
(-[WebAccessibilityObjectWrapper accessibilityLinkRelationshipType]):
(-[WebAccessibilityObjectWrapper stringForTextMarkers:]):
(-[WebAccessibilityObjectWrapper stringForRange:]):
(-[WebAccessibilityObjectWrapper accessibilityExpandedTextValue]):
(-[WebAccessibilityObjectWrapper accessibilityIdentifier]):
(-[WebAccessibilityObjectWrapper accessibilityARIALiveRegionStatus]):
(-[WebAccessibilityObjectWrapper accessibilityARIARelevantStatus]):
(-[WebAccessibilityObjectWrapper accessibilityInvalidStatus]):
(-[WebAccessibilityObjectWrapper accessibilityCurrentState]):
(-[WebAccessibilityObjectWrapper accessibilityMathFencedOpenString]):
(-[WebAccessibilityObjectWrapper accessibilityMathFencedCloseString]):
* Source/WebCore/editing/cocoa/DataDetection.mm:
(WebCore::processDataDetectorScannerResults):
* Source/WebCore/editing/ios/EditorIOS.mm:
(WebCore::Editor::writeImageToPasteboard):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL):
(WebCore::exernalDeviceDisplayNameForPlayer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::wirelessPlaybackTargetName const):
* Source/WebCore/platform/ios/PasteboardIOS.mm:
(WebCore::shouldTreatAsAttachmentByDefault):
(WebCore::Pasteboard::readRespectingUTIFidelities):
(WebCore::cocoaTypeFromHTMLClipboardType):
(WebCore::Pasteboard::addHTMLClipboardTypesForCocoaType):
* Source/WebCore/platform/ios/PlatformPasteboardIOS.mm:
(WebCore::addRepresentationsForPlainText):
(WebCore::PlatformPasteboard::write):
(WebCore::PlatformPasteboard::readBuffer const):
* Source/WebCore/platform/ios/ValidationBubbleIOS.mm:
(WebCore::ValidationBubble::ValidationBubble):
(WebCore::ValidationBubble::show):
* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm:
(WebCore::VideoPresentationInterfaceAVKitLegacy::updateRouteSharingPolicy):
(WebCore::VideoPresentationInterfaceAVKitLegacy::setupPlayerViewController):
* Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.mm:
(WebCore::AVAudioSessionCaptureDeviceManager::setPreferredAudioSessionDeviceIDs):
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::setupSession):
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::iconForAttachment):
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::ShaderModule::createLibrary):
* Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm:
(WebKit::GPUProcess::additionalStateForDiagnosticReport const):
* Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm:
(WebKit::Download::resume):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm:
(WebKit::PCM::NetworkLoader::start):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::applySniffingPoliciesAndBindRequestToInferfaceIfNeeded):
(WebKit::NetworkDataTaskCocoa::setPendingDownloadLocation):
* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::deleteHSTSCacheForHostNames):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::NetworkSessionCocoa):
(WebKit::NetworkSessionCocoa::addWebPageNetworkParameters):
(WebKit::NetworkSessionCocoa::deleteAlternativeServicesForHostNames):
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm:
(WebKit::NetworkTaskCocoa::setCookieTransformForThirdPartyRequest):
(WebKit::NetworkTaskCocoa::updateTaskWithStoragePartitionIdentifier):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.mm:
(WebKit::isKnownTracker):
* Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm:
(WebKit::requestVisualTranslation):
* Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm:
(WebKit::toNSError):
(WebKit::PaymentAuthorizationPresenter::completePaymentMethodSelection):
(WebKit::PaymentAuthorizationPresenter::completePaymentSession):
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::ResourceMonitorURLsController::getSource):
* Source/WebKit/Platform/mac/MenuUtilities.mm:
(WebKit::menuItemForTelephoneNumber):
(WebKit::menuForTelephoneNumber):
* Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm:
(URLFromString):
(-[_WKHitTestResult linkLocalDataMIMEType]):
(-[_WKHitTestResult linkLabel]):
(-[_WKHitTestResult linkTitle]):
(-[_WKHitTestResult lookupText]):
(-[_WKHitTestResult linkSuggestedFilename]):
(-[_WKHitTestResult imageSuggestedFilename]):
(-[_WKHitTestResult imageMIMEType]):
* Source/WebKit/Shared/ApplePay/cocoa/AutomaticReloadPaymentRequestCocoa.mm:
(WebKit::platformAutomaticReloadPaymentRequest):
* Source/WebKit/Shared/ApplePay/cocoa/DeferredPaymentRequestCocoa.mm:
(WebKit::platformDeferredPaymentRequest):
* Source/WebKit/Shared/ApplePay/cocoa/DisbursementRequestCocoa.mm:
(WebKit::platformDisbursementRequest):
* Source/WebKit/Shared/ApplePay/cocoa/PaymentSetupConfigurationCocoa.mm:
(WebKit::toPlatformConfiguration):
* Source/WebKit/Shared/ApplePay/cocoa/PaymentTokenContextCocoa.mm:
(WebKit::platformPaymentTokenContext):
* Source/WebKit/Shared/ApplePay/cocoa/RecurringPaymentRequestCocoa.mm:
(WebKit::platformRecurringPaymentRequest):
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::WebPaymentCoordinatorProxy::platformCanMakePaymentsWithActiveCard):
(WebKit::WebPaymentCoordinatorProxy::platformOpenPaymentSetup):
(WebKit::toPKShippingMethod):
(WebKit::toNSSet):
(WebKit::WebPaymentCoordinatorProxy::platformPaymentRequest):
(WebKit::WebPaymentCoordinatorProxy::platformSetPaymentRequestUserAgent):
* Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm:
(WebKit::AuxiliaryProcess::decodePreferenceValue):
(WebKit::AuxiliaryProcess::setPreferenceValue):
* Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.mm:
(WebKit::CoreIPCAVOutputContext::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCContacts.mm:
(WebKit::nsArrayFromVectorOfLabeledValues):
(WebKit::CoreIPCCNContact::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCError.mm:
(WebKit::CoreIPCError::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCLocale.mm:
(WebKit::CoreIPCLocale::isValidIdentifier):
(WebKit::CoreIPCLocale::CoreIPCLocale):
(WebKit::CoreIPCLocale::canonicalLocaleStringReplacement):
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm:
(WebKit::CoreIPCNSURLRequest::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCPresentationIntent.mm:
(WebKit::CoreIPCPresentationIntent::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCString.h:
(WebKit::CoreIPCString::toID const):
* Source/WebKit/Shared/Cocoa/RevealItem.mm:
(WebKit::RevealItem::item const):
* Source/WebKit/Shared/Cocoa/WebIconUtilities.mm:
(WebKit::iconForFiles):
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm:
(WebKit::validateDictionary):
(WebKit::validateObject):
(WebKit::toJSError):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
* Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm:
(-[WKObservablePageState title]):
* Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm:
(API::Attachment::mimeType const):
(API::Attachment::utiType const):
(API::Attachment::setFileWrapperAndUpdateContentType):
(API::Attachment::updateFromSerializedRepresentation):
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm:
(-[WKBackForwardListItem title]):
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleList.mm:
(-[WKContentRuleList identifier]):
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm:
(-[WKContentRuleListStore _getContentRuleListSourceForIdentifier:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm:
(-[WKContentWorld name]):
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm:
(-[_WKContentWorldConfiguration name]):
* Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKError.mm:
(localizedDescriptionForErrorCode):
* Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm:
(-[WKFrameInfo _title]):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm:
(-[WKNavigationAction _targetFrameName]):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationData.mm:
(-[WKNavigationData title]):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm:
(-[WKNavigationResponse _proxyName]):
* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(-[WKPreferences _fixedPitchFontFamily]):
(-[WKPreferences _defaultTextEncodingName]):
(-[WKPreferences _standardFontFamily]):
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
(-[WKProcessPool _javaScriptConfigurationDirectory]):
* Source/WebKit/UIProcess/API/Cocoa/WKSecurityOrigin.mm:
(-[WKSecurityOrigin protocol]):
(-[WKSecurityOrigin host]):
* Source/WebKit/UIProcess/API/Cocoa/WKUserScript.mm:
(-[WKUserScript source]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.mm:
(-[WKWebExtensionAction label]):
(-[WKWebExtensionAction badgeText]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm:
(-[WKWebExtensionCommand identifier]):
(-[WKWebExtensionCommand title]):
(-[WKWebExtensionCommand activationKey]):
(-[WKWebExtensionCommand _shortcut]):
(-[WKWebExtensionCommand _userVisibleShortcut]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm:
(-[WKWebExtensionContext uniqueIdentifier]):
(toAPI):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfiguration.mm:
(-[WKWebExtensionControllerConfiguration _storageDirectoryPath]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataRecord.mm:
(-[WKWebExtensionDataRecord displayName]):
(-[WKWebExtensionDataRecord uniqueIdentifier]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.mm:
(-[WKWebExtensionMatchPattern scheme]):
(-[WKWebExtensionMatchPattern host]):
(-[WKWebExtensionMatchPattern path]):
(-[WKWebExtensionMatchPattern string]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePort.mm:
(-[WKWebExtensionMessagePort applicationIdentifier]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(nsErrorFromExceptionDetails):
(-[WKWebView title]):
(-[WKWebView customUserAgent]):
(-[WKWebView _storeAppHighlight:]):
(-[WKWebView _proxyName]):
(-[WKWebView _startTextManipulationsWithConfiguration:completion:]):
(+[WKWebView _stringForFind]):
(-[WKWebView _getInformationFromImageData:completionHandler:]):
(-[WKWebView _MIMEType]):
(-[WKWebView _userAgent]):
(-[WKWebView _applicationNameForUserAgent]):
(-[WKWebView _remoteInspectionNameOverride]):
(-[WKWebView _saveResources:suggestedFileName:completionHandler:]):
(-[WKWebView _archiveWithConfiguration:completionHandler:]):
(-[WKWebView _getContentsAsStringWithCompletionHandler:]):
(-[WKWebView _getContentsAsStringWithCompletionHandlerKeepIPCConnectionAliveForTesting:]):
(-[WKWebView _getContentsOfAllFramesAsStringWithCompletionHandler:]):
(-[WKWebView _setInputDelegate:]):
(-[WKWebView _getProcessDisplayNameWithCompletionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration encodeWithCoder:]):
(-[WKWebViewConfiguration _maskedURLSchemes]):
(-[WKWebViewConfiguration _allowedNetworkHosts]):
(-[WKWebViewConfiguration _overrideContentSecurityPolicy]):
(-[WKWebViewConfiguration _mediaContentTypesRequiringHardwareSupport]):
(-[WKWebViewConfiguration _processDisplayName]):
(-[WKWebViewConfiguration _attributedBundleIdentifier]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _caLayerTreeAsText]):
(-[WKWebView _requestActiveNowPlayingSessionInfo:]):
(-[WKWebView _setNowPlayingMetadataObserver:]):
(-[WKWebView _scrollingTreeAsText]):
(-[WKWebView _scrollbarStateForScrollingNodeID:processID:isVertical:]):
(-[WKWebView _dumpPrivateClickMeasurement:]):
(-[WKWebView _createMediaSessionCoordinatorForTesting:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences _activeContentRuleListActionPatterns]):
(-[WKWebpagePreferences _customUserAgent]):
(-[WKWebpagePreferences _customUserAgentAsSiteSpecificQuirks]):
(-[WKWebpagePreferences _customNavigatorPlatform]):
(-[WKWebpagePreferences _applicationNameForUserAgentWithModernCompatibility]):
(-[WKWebpagePreferences _visibilityAdjustmentSelectorsIncludingShadowHosts]):
(-[WKWebpagePreferences _visibilityAdjustmentSelectors]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm:
(-[WKWebsiteDataRecord displayName]):
(-[WKWebsiteDataRecord _originsStrings]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _setResourceLoadStatisticsTestingCallback:]):
(-[WKWebsiteDataStore _getAllBackgroundFetchIdentifiers:]):
(-[WKWebsiteDataStore _originDirectoryForTesting:topOrigin:type:completionHandler:]):
(-[WKWebsiteDataStore _webPushPartition]):
(-[WKWebsiteDataStore _setCompletionHandlerForRemovalFromNetworkProcess:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm:
(-[_WKApplicationManifestIcon initWithCoreIcon:]):
(-[_WKApplicationManifestShortcut initWithCoreShortcut:]):
(-[_WKApplicationManifest categories]):
* Source/WebKit/UIProcess/API/Cocoa/_WKAttachment.mm:
(-[_WKAttachmentInfo initWithAttachment:]):
(-[_WKAttachment uniqueIdentifier]):
* Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSession.mm:
(-[_WKAutomationSession sessionIdentifier]):
* Source/WebKit/UIProcess/API/Cocoa/_WKCustomHeaderFields.mm:
(-[_WKCustomHeaderFields fields]):
* Source/WebKit/UIProcess/API/Cocoa/_WKFeature.mm:
(-[_WKFeature name]):
(-[_WKFeature key]):
(-[_WKFeature details]):
* Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm:
(-[_WKInspector registerExtensionWithID:extensionBundleIdentifier:displayName:completionHandler:]):
(-[_WKInspector unregisterExtension:completionHandler:]):
(-[_WKInspector showExtensionTabWithIdentifier:completionHandler:]):
(-[_WKInspector navigateExtensionTabWithIdentifier:toURL:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.mm:
(-[_WKInspectorConfiguration applyToWebViewConfiguration:]):
(-[_WKInspectorConfiguration copyWithZone:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorDebuggableInfo.mm:
(-[_WKInspectorDebuggableInfo targetPlatformName]):
(-[_WKInspectorDebuggableInfo targetBuildVersion]):
(-[_WKInspectorDebuggableInfo targetProductVersion]):
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm:
(-[_WKInspectorExtension createTabWithName:tabIconURL:sourceURL:completionHandler:]):
(-[_WKInspectorExtension evaluateScript:frameURL:contextSecurityOrigin:useContentScriptContext:completionHandler:]):
(-[_WKInspectorExtension evaluateScript:inTabWithIdentifier:completionHandler:]):
(-[_WKInspectorExtension navigateToURL:inTabWithIdentifier:completionHandler:]):
(-[_WKInspectorExtension reloadIgnoringCache:userAgent:injectedScript:completionHandler:]):
(-[_WKInspectorExtension extensionID]):
* Source/WebKit/UIProcess/API/Cocoa/_WKLinkIconParameters.mm:
(-[_WKLinkIconParameters _initWithLinkIcon:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm:
(-[_WKProcessPoolConfiguration injectedBundleURL]):
(-[_WKProcessPoolConfiguration timeZoneOverride]):
* Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm:
(-[_WKRemoteWebInspectorViewController registerExtensionWithID:extensionBundleIdentifier:displayName:completionHandler:]):
(-[_WKRemoteWebInspectorViewController unregisterExtension:completionHandler:]):
(-[_WKRemoteWebInspectorViewController showExtensionTabWithIdentifier:completionHandler:]):
(-[_WKRemoteWebInspectorViewController navigateExtensionTabWithIdentifier:toURL:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.mm:
(-[_WKResourceLoadInfo originalHTTPMethod]):
* Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadStatisticsFirstParty.mm:
(-[_WKResourceLoadStatisticsFirstParty firstPartyDomain]):
* Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadStatisticsThirdParty.mm:
(-[_WKResourceLoadStatisticsThirdParty thirdPartyDomain]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm:
(-[_WKTargetedElementInfo selectorsIncludingShadowHosts]):
(-[_WKTargetedElementInfo renderedText]):
(-[_WKTargetedElementInfo searchableText]):
(-[_WKTargetedElementInfo screenReaderText]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextRun.mm:
(-[_WKTextRun text]):
* Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm:
(-[_WKUserStyleSheet source]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm:
(-[_WKWebAuthenticationAssertionResponse name]):
(-[_WKWebAuthenticationAssertionResponse displayName]):
(-[_WKWebAuthenticationAssertionResponse group]):
(-[_WKWebAuthenticationAssertionResponse accessGroup]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(-[_WKWebAuthenticationPanel relyingPartyID]):
(-[_WKWebAuthenticationPanel userName]):
(getAllLocalAuthenticatorCredentialsImpl):
(+[_WKWebAuthenticationPanel importLocalAuthenticatorWithAccessGroup:credential:error:]):
(-[_WKWebAuthenticationPanel makeCredentialWithChallenge:origin:options:completionHandler:]):
(-[_WKWebAuthenticationPanel makeCredentialWithMediationRequirement:clientDataHash:options:completionHandler:]):
(-[_WKWebAuthenticationPanel getAssertionWithChallenge:origin:options:completionHandler:]):
(-[_WKWebAuthenticationPanel getAssertionWithMediationRequirement:clientDataHash:options:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.mm:
(-[_WKWebPushDaemonConnection subscribeToPushServiceForScope:applicationServerKey:completionHandler:]):
(-[_WKWebPushDaemonConnection unsubscribeFromPushServiceForScope:completionHandler:]):
(-[_WKWebPushDaemonConnection getSubscriptionForScope:completionHandler:]):
(-[_WKWebPushDaemonConnection getNotifications:tag:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushMessage.mm:
(-[_WKWebPushMessage partition]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm:
(-[_WKWebsiteDataStoreConfiguration _webStorageDirectory]):
(-[_WKWebsiteDataStoreConfiguration _indexedDBDatabaseDirectory]):
(-[_WKWebsiteDataStoreConfiguration networkCacheDirectory]):
(-[_WKWebsiteDataStoreConfiguration deviceIdHashSaltsStorageDirectory]):
(-[_WKWebsiteDataStoreConfiguration _webSQLDatabaseDirectory]):
(-[_WKWebsiteDataStoreConfiguration _cookieStorageFile]):
(-[_WKWebsiteDataStoreConfiguration _resourceLoadStatisticsDirectory]):
(-[_WKWebsiteDataStoreConfiguration _cacheStorageDirectory]):
(-[_WKWebsiteDataStoreConfiguration _serviceWorkerRegistrationDirectory]):
(-[_WKWebsiteDataStoreConfiguration sourceApplicationBundleIdentifier]):
(-[_WKWebsiteDataStoreConfiguration sourceApplicationSecondaryIdentifier]):
(-[_WKWebsiteDataStoreConfiguration applicationCacheDirectory]):
(-[_WKWebsiteDataStoreConfiguration applicationCacheFlatFileSubdirectoryName]):
(-[_WKWebsiteDataStoreConfiguration mediaCacheDirectory]):
(-[_WKWebsiteDataStoreConfiguration mediaKeysStorageDirectory]):
(-[_WKWebsiteDataStoreConfiguration hstsStorageDirectory]):
(-[_WKWebsiteDataStoreConfiguration alternativeServicesStorageDirectory]):
(-[_WKWebsiteDataStoreConfiguration generalStorageDirectory]):
(-[_WKWebsiteDataStoreConfiguration webPushPartitionString]):
(-[_WKWebsiteDataStoreConfiguration _resourceMonitorThrottlerDirectory]):
(-[_WKWebsiteDataStoreConfiguration boundInterfaceIdentifier]):
(-[_WKWebsiteDataStoreConfiguration dataConnectionServiceType]):
(-[_WKWebsiteDataStoreConfiguration pcmMachServiceName]):
(-[_WKWebsiteDataStoreConfiguration webPushMachServiceName]):
* Source/WebKit/UIProcess/Automation/cocoa/WebAutomationSessionCocoa.mm:
(WebKit::WebAutomationSession::platformGenerateLocalFilePathForRemoteFile):
* Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm:
(WebKit::WebAutomationSession::markEventAsSynthesizedForAutomation):
(WebKit::WebAutomationSession::wasEventSynthesizedForAutomation):
(WebKit::WebAutomationSession::platformSimulateKeyboardInteraction):
(WebKit::WebAutomationSession::platformSimulateKeySequence):
* Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm:
(WebKit::AutomationSessionClient::unloadWebExtension):
(WebKit::AutomationSessionClient::setUserInputForCurrentJavaScriptPromptOnPage):
* Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm:
(WebKit::browsingDetailsText):
* Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.mm:
(WebKit::DiagnosticLoggingClient::logDiagnosticMessage):
(WebKit::DiagnosticLoggingClient::logDiagnosticMessageWithResult):
(WebKit::DiagnosticLoggingClient::logDiagnosticMessageWithValue):
(WebKit::DiagnosticLoggingClient::logDiagnosticMessageWithEnhancedPrivacy):
(WebKit::DiagnosticLoggingClient::logDiagnosticMessageWithValueDictionary):
(WebKit::DiagnosticLoggingClient::logDiagnosticMessageWithDomain):
* Source/WebKit/UIProcess/Cocoa/FindClient.mm:
(WebKit::FindClient::didCountStringMatches):
(WebKit::FindClient::didFindString):
(WebKit::FindClient::didFailToFindString):
* Source/WebKit/UIProcess/Cocoa/GlobalFindInPageState.mm:
(WebKit::updateStringForFind):
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm:
(WebKit::GroupActivitiesCoordinator::trackIdentifierChanged):
* Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm:
(WebKit::LegacyDownloadClient::didCreateDestination):
(WebKit::LegacyDownloadClient::decideDestinationWithSuggestedFilename):
* Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm:
(WebKit::allowButtonText):
(WebKit::doNotAllowButtonText):
(WebKit::checkSpeechRecognitionServiceAvailability):
* Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm:
(WebKit::ModelElementController::modelElementCreateRemotePreview):
(WebKit::ModelElementController::modelElementLoadRemotePreview):
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::NavigationClient::contentRuleListNotification):
(WebKit::NavigationState::NavigationClient::didPromptForStorageAccess):
(WebKit::NavigationState::NavigationClient::decidePolicyForSOAuthorizationLoad):
(WebKit::NavigationState::HistoryClient::didUpdateHistoryTitle):
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::didInsertAttachment):
* Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm:
(WebKit::ProcessAssertion::init):
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::UIClient::runJavaScriptAlert):
(WebKit::UIDelegate::UIClient::runJavaScriptConfirm):
(WebKit::UIDelegate::UIClient::runJavaScriptPrompt):
(WebKit::UIDelegate::UIClient::requestStorageAccessConfirm):
(WebKit::UIDelegate::UIClient::runBeforeUnloadConfirmPanel):
(WebKit::UIDelegate::UIClient::exceededDatabaseQuota):
(WebKit::UIDelegate::UIClient::drawHeader):
(WebKit::UIDelegate::UIClient::drawFooter):
(WebKit::UIDelegate::UIClient::saveDataToFileInDownloadsFolder):
(WebKit::UIDelegate::UIClient::requestWebAuthenticationConditonalMediationRegistration):
(WebKit::UIDelegate::UIClient::queryPermission):
* Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm:
(-[WKRotationCoordinatorObserver start:layer:]):
* Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm:
(appendFilesAsShareableURLs):
(-[WKShareSheet presentWithParameters:inRect:completionHandler:]):
(+[WKShareSheet setQuarantineInformationForFilePath:]):
* Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm:
(WebKit::presentStorageAccessAlertSSOQuirk):
* Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.mm:
(WebKit::createWKTextItem):
(WebKit::createItemWithChildren):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::createSandboxExtensionsIfNeeded):
(WebKit::WebPageProxy::platformRegisterAttachment):
(WebKit::WebPageProxy::startApplePayAMSUISession):
(WebKit::WebPageProxy::isQuarantinedAndNotUserApproved):
* Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm:
(WebKit::WebPasteboardProxy::getPasteboardPathnamesForType):
* Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm:
(WebKit::makeKey):
(WebKit::WebPreferences::platformGetStringUserValueForKey):
(WebKit::WebPreferences::platformGetBoolUserValueForKey):
(WebKit::WebPreferences::platformGetUInt32UserValueForKey):
(WebKit::WebPreferences::platformGetDoubleUserValueForKey):
(WebKit::debugUserDefaultsValue):
(WebKit::WebPreferences::platformUpdateStringValueForKey):
(WebKit::WebPreferences::platformUpdateBoolValueForKey):
(WebKit::WebPreferences::platformUpdateUInt32ValueForKey):
(WebKit::WebPreferences::platformUpdateDoubleValueForKey):
(WebKit::WebPreferences::platformUpdateFloatValueForKey):
(WebKit::WebPreferences::platformDeleteKey):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::platformInitializeNetworkProcess):
* Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm:
(-[_WKWarningView addContent]):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionContext::declarativeNetRequestToggleRulesets):
(WebKit::WebExtensionContext::declarativeNetRequestDynamicRulesStore):
(WebKit::WebExtensionContext::declarativeNetRequestSessionRulesStore):
(WebKit::WebExtensionContext::declarativeNetRequestUpdateDynamicRules):
(WebKit::WebExtensionContext::declarativeNetRequestUpdateSessionRules):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm:
(WebKit::WebExtensionContext::firePortMessageEventsIfNeeded):
(WebKit::WebExtensionContext::sendQueuedNativePortMessagesIfNeeded):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::runtimeSendNativeMessage):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm:
(WebKit::WebExtensionContext::createInjectedContentForScripts):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsExecuteScript):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionControllerAPITestCocoa.mm:
(WebKit::WebExtensionController::testResult):
(WebKit::WebExtensionController::testEqual):
(WebKit::WebExtensionController::testLogMessage):
(WebKit::WebExtensionController::testSentMessage):
(WebKit::WebExtensionController::testAdded):
(WebKit::WebExtensionController::testStarted):
(WebKit::WebExtensionController::testFinished):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::popupWebViewInspectionName):
(WebKit::WebExtensionAction::setPopupWebViewInspectionName):
(WebKit::WebExtensionAction::popupWebView):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::WebExtension):
(WebKit::WebExtension::manifestDictionary):
(WebKit::WebExtension::bestIcon):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm:
(WebKit::WebExtensionCommand::userVisibleShortcut const):
(WebKit::WebExtensionCommand::platformMenuItem const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::createError):
(WebKit::WebExtensionContext::load):
(WebKit::WebExtensionContext::readStateFromPath):
(WebKit::WebExtensionContext::writeStateToStorage const):
(WebKit::WebExtensionContext::singleMenuItemOrExtensionItemWithSubmenu const):
(WebKit::WebExtensionContext::processDisplayName):
(WebKit::WebExtensionContext::backgroundWebViewInspectionName):
(WebKit::WebExtensionContext::setBackgroundWebViewInspectionName):
(WebKit::WebExtensionContext::determineInstallReasonDuringLoad):
(WebKit::WebExtensionContext::addInjectedContent):
(WebKit::computeStringHashForContentBlockerRules):
(WebKit::WebExtensionContext::compileDeclarativeNetRequestRules):
(WebKit::WebExtensionContext::registeredContentScriptsStore):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::getDataRecords):
(WebKit::WebExtensionController::getDataRecord):
(WebKit::WebExtensionController::removeData):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::executeScript):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm:
(WebKit::WebExtensionMenuItem::platformMenuItem const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm:
(WebKit::WebExtensionURLSchemeHandler::platformStartTask):
* Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm:
(WebKit::InspectorExtensionDelegate::InspectorExtensionClient::didShowExtensionTab):
(WebKit::InspectorExtensionDelegate::InspectorExtensionClient::didHideExtensionTab):
(WebKit::InspectorExtensionDelegate::InspectorExtensionClient::didNavigateExtensionTab):
* Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm:
(WebKit::RemoteWebInspectorUIProxy::platformSave):
(WebKit::RemoteWebInspectorUIProxy::platformOpenURLExternally):
(WebKit::RemoteWebInspectorUIProxy::platformRevealFileExternally):
* Source/WebKit/UIProcess/Inspector/mac/WKInspectorResourceURLSchemeHandler.mm:
(-[WKInspectorResourceURLSchemeHandler mainResourceURLsForCSP]):
(-[WKInspectorResourceURLSchemeHandler webView:startURLSchemeTask:]):
* Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm:
(-[WKInspectorViewController webViewConfiguration]):
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(-[WKWebInspectorUISaveController initWithSaveDatas:savePanel:]):
(-[WKWebInspectorUISaveController content]):
(-[WKWebInspectorUISaveController _updateSavePanel]):
(WebKit::WebInspectorUIProxy::platformCreateFrontendWindow):
(WebKit::WebInspectorUIProxy::platformRevealFileExternally):
(WebKit::WebInspectorUIProxy::platformSave):
* Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm:
(WebKit::MediaUsageManagerCocoa::updateMediaUsage):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticator::continueMakeCredentialAfterUserVerification):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm:
(WebKit::LocalConnection::verifyUser):
(WebKit::LocalConnection::createCredentialPrivateKey const):
(WebKit::LocalConnection::getExistingCredentials):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::WebAuthenticatorCoordinatorProxy::requestsForRegistration):
(WebKit::WebAuthenticatorCoordinatorProxy::requestsForAssertion):
(WebKit::toASCExtensions):
(WebKit::configureRegistrationRequestContext):
(WebKit::configureAssertionOptions):
(WebKit::configurationAssertionRequestContext):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.mm:
(WebKit::MockCcidService::nextReply):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.mm:
(WebKit::MockLocalConnection::createCredentialPrivateKey const):
(WebKit::MockLocalConnection::getExistingCredentials):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm:
(WebKit::MockNfcService::transceive):
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm:
(WebKit::privateKeyFromBase64):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/ScreenTimeWebsiteDataSupport.mm:
(WebKit::ScreenTimeWebsiteDataSupport::getScreenTimeURLs):
(WebKit::ScreenTimeWebsiteDataSupport::removeScreenTimeData):
(WebKit::ScreenTimeWebsiteDataSupport::removeScreenTimeDataWithInterval):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::removeDataStoreWithIdentifierImpl):
(WebKit::WebsiteDataStore::defaultGeneralStorageDirectory):
(WebKit::WebsiteDataStore::tempDirectoryFileSystemRepresentation):
(WebKit::WebsiteDataStore::cacheDirectoryFileSystemRepresentation):
(WebKit::WebsiteDataStore::websiteDataDirectoryFileSystemRepresentation):
* Source/WebKit/UIProcess/mac/CorrectionPanel.mm:
(WebKit::CorrectionPanel::recordAutocorrectionResponse):
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::setPromisedDataForImage):
(WebKit::PageClientImpl::executeSavedCommandBySelector):
(WebKit::PageClientImpl::handleControlledElementIDResponse):
* Source/WebKit/UIProcess/mac/TextCheckerMac.mm:
(WebKit::TextChecker::updateSpellingUIWithMisspelledWord):
(WebKit::TextChecker::updateSpellingUIWithGrammarString):
(WebKit::TextChecker::getGuessesForWord):
(WebKit::TextChecker::learnWord):
(WebKit::TextChecker::ignoreWord):
* Source/WebKit/UIProcess/mac/WKImmediateActionController.mm:
(-[WKImmediateActionController _animationControllerForDataDetectedLink]):
* Source/WebKit/UIProcess/mac/WKRevealItemPresenter.mm:
(-[WKRevealItemPresenter showContextMenu]):
* Source/WebKit/UIProcess/mac/WKTextFinderClient.mm:
(-[WKTextFinderClient getSelectedText:]):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::WebContextMenuProxyMac::setupServicesMenu):
(WebKit::WebContextMenuProxyMac::appendRemoveBackgroundItemToControlledImageMenuIfNeeded):
(WebKit::createMenuActionItem):
(WebKit::WebContextMenuProxyMac::getContextMenuItem):
* Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm:
(-[WKDataListSuggestionsController tableView:viewForTableColumn:row:]):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::speak):
(WebKit::WebPageProxy::searchTheWeb):
(WebKit::WebPageProxy::showPDFContextMenu):
(WebKit::WebPageProxy::showImageInQuickLookPreviewPanel):
* Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm:
(WebKit::WebPopupMenuProxyMac::populate):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(-[WKTextListTouchBarViewController initWithWebViewImpl:]):
(WebKit::WebViewImpl::printOperationWithPrintInfo):
(WebKit::WebViewImpl::writeSelectionToPasteboard):
(WebKit::WebViewImpl::validateUserInterfaceItem):
(WebKit::WebViewImpl::startSpeaking):
(WebKit::WebViewImpl::requestCandidatesForSelectionIfNeeded):
(WebKit::WebViewImpl::handleRequestedCandidates):
(WebKit::WebViewImpl::stringForToolTip):
(WebKit::WebViewImpl::startDrag):
(WebKit::WebViewImpl::setPromisedDataForImage):
(WebKit::WebViewImpl::provideDataForPasteboard):
(WebKit::WebViewImpl::namesOfPromisedFilesDroppedAtDestination):
(WebKit::WebViewImpl::requestDOMPasteAccess):
(WebKit::WebViewImpl::nowPlayingMediaTitleAndArtist):
(WebKit::WebViewImpl::updateMediaTouchBar):
(WebKit::WebViewImpl::handleContextMenuTranslation):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm:
(WebKit::WebExtensionAPIAction::parseActionDetails):
(WebKit::WebExtensionAPIAction::getTitle):
(WebKit::WebExtensionAPIAction::setTitle):
(WebKit::WebExtensionAPIAction::getBadgeText):
(WebKit::WebExtensionAPIAction::setBadgeText):
(WebKit::WebExtensionAPIAction::enable):
(WebKit::WebExtensionAPIAction::disable):
(WebKit::WebExtensionAPIAction::isEnabled):
(WebKit::dataURLFromImageData):
(WebKit::WebExtensionAPIAction::parseIconPath):
(WebKit::WebExtensionAPIAction::parseIconPathsDictionary):
(WebKit::WebExtensionAPIAction::parseIconImageDataDictionary):
(WebKit::WebExtensionAPIAction::parseIconVariants):
(WebKit::WebExtensionAPIAction::setIcon):
(WebKit::WebExtensionAPIAction::getPopup):
(WebKit::WebExtensionAPIAction::setPopup):
(WebKit::WebExtensionAPIAction::openPopup):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm:
(WebKit::WebExtensionAPIAlarms::createAlarm):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm:
(WebKit::toWebAPI):
(WebKit::WebExtensionAPICookies::parseCookieDetails):
(WebKit::WebExtensionAPICookies::get):
(WebKit::WebExtensionAPICookies::getAll):
(WebKit::WebExtensionAPICookies::set):
(WebKit::WebExtensionAPICookies::remove):
(WebKit::WebExtensionAPICookies::getAllCookieStores):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionAPIDeclarativeNetRequest::updateEnabledRulesets):
(WebKit::WebExtensionAPIDeclarativeNetRequest::updateDynamicRules):
(WebKit::WebExtensionAPIDeclarativeNetRequest::getDynamicRules):
(WebKit::WebExtensionAPIDeclarativeNetRequest::updateSessionRules):
(WebKit::WebExtensionAPIDeclarativeNetRequest::getSessionRules):
(WebKit::toWebAPI):
(WebKit::WebExtensionAPIDeclarativeNetRequest::getMatchedRules):
(WebKit::WebExtensionAPIDeclarativeNetRequest::setExtensionActionOptions):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm:
(WebKit::WebExtensionAPIDevToolsInspectedWindow::eval):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsNetworkCocoa.mm:
(WebKit::WebExtensionContextProxy::dispatchDevToolsNetworkNavigatedEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsPanelsCocoa.mm:
(WebKit::WebExtensionAPIDevToolsPanels::createPanel):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm:
(WebKit::WebExtensionAPIExtension::parseViewFilters):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm:
(WebKit::WebExtensionAPILocalization::getMessage):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm:
(WebKit::toMenuIdentifierWebAPI):
(WebKit::WebExtensionAPIMenus::parseCreateAndUpdateProperties):
(WebKit::WebExtensionAPIMenus::createMenu):
(WebKit::WebExtensionAPIMenus::update):
(WebKit::WebExtensionAPIMenus::remove):
(WebKit::WebExtensionAPIMenus::removeAll):
(WebKit::WebExtensionContextProxy::dispatchMenusClickedEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm:
(WebKit::WebExtensionAPIPermissions::request):
(WebKit::WebExtensionAPIPermissions::remove):
(WebKit::WebExtensionAPIPermissions::verifyRequestedPermissions):
(WebKit::WebExtensionAPIPermissions::validatePermissionsDetails):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm:
(WebKit::WebExtensionAPIPort::name):
(WebKit::WebExtensionAPIPort::postMessage):
(WebKit::WebExtensionContextProxy::dispatchPortMessageEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntime::runtimeIdentifier):
(WebKit::WebExtensionAPIRuntime::getBackgroundPage):
(WebKit::WebExtensionAPIRuntime::openOptionsPage):
(WebKit::WebExtensionAPIRuntime::sendMessage):
(WebKit::WebExtensionAPIRuntime::connect):
(WebKit::WebExtensionAPIRuntime::sendNativeMessage):
(WebKit::WebExtensionAPIRuntime::connectNative):
(WebKit::WebExtensionAPIWebPageRuntime::sendMessage):
(WebKit::WebExtensionAPIWebPageRuntime::connect):
(WebKit::WebExtensionContextProxy::internalDispatchRuntimeMessageEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm:
(WebKit::toWebAPI):
(WebKit::WebExtensionAPIScripting::executeScript):
(WebKit::WebExtensionAPIScripting::insertCSS):
(WebKit::WebExtensionAPIScripting::removeCSS):
(WebKit::WebExtensionAPIScripting::registerContentScripts):
(WebKit::WebExtensionAPIScripting::getRegisteredContentScripts):
(WebKit::WebExtensionAPIScripting::updateContentScripts):
(WebKit::WebExtensionAPIScripting::unregisterContentScripts):
(WebKit::WebExtensionAPIScripting::parseStyleLevel):
(WebKit::WebExtensionAPIScripting::parseExecutionWorld):
(WebKit::WebExtensionAPIScripting::parseTargetInjectionOptions):
(WebKit::WebExtensionAPIScripting::parseScriptInjectionOptions):
(WebKit::WebExtensionAPIScripting::parseCSSInjectionOptions):
(WebKit::WebExtensionAPIScripting::parseRegisteredContentScripts):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm:
(WebKit::WebExtensionAPIStorageArea::get):
(WebKit::WebExtensionAPIStorageArea::getKeys):
(WebKit::WebExtensionAPIStorageArea::getBytesInUse):
(WebKit::WebExtensionAPIStorageArea::set):
(WebKit::WebExtensionAPIStorageArea::remove):
(WebKit::WebExtensionAPIStorageArea::clear):
(WebKit::WebExtensionAPIStorageArea::setAccessLevel):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm:
(WebKit::WebExtensionContextProxy::dispatchStorageChangedEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::parseTabCreateOptions):
(WebKit::WebExtensionAPITabs::parseTabUpdateOptions):
(WebKit::WebExtensionAPITabs::parseTabQueryOptions):
(WebKit::WebExtensionAPITabs::parseCaptureVisibleTabOptions):
(WebKit::WebExtensionAPITabs::parseSendMessageOptions):
(WebKit::WebExtensionAPITabs::parseScriptOptions):
(WebKit::isValid):
(WebKit::WebExtensionAPITabs::createTab):
(WebKit::WebExtensionAPITabs::query):
(WebKit::WebExtensionAPITabs::get):
(WebKit::WebExtensionAPITabs::getCurrent):
(WebKit::WebExtensionAPITabs::getSelected):
(WebKit::WebExtensionAPITabs::duplicate):
(WebKit::WebExtensionAPITabs::update):
(WebKit::WebExtensionAPITabs::remove):
(WebKit::WebExtensionAPITabs::reload):
(WebKit::WebExtensionAPITabs::goBack):
(WebKit::WebExtensionAPITabs::goForward):
(WebKit::WebExtensionAPITabs::getZoom):
(WebKit::WebExtensionAPITabs::setZoom):
(WebKit::WebExtensionAPITabs::detectLanguage):
(WebKit::WebExtensionAPITabs::toggleReaderMode):
(WebKit::WebExtensionAPITabs::captureVisibleTab):
(WebKit::WebExtensionAPITabs::sendMessage):
(WebKit::WebExtensionAPITabs::connect):
(WebKit::WebExtensionAPITabs::executeScript):
(WebKit::WebExtensionAPITabs::insertCSS):
(WebKit::WebExtensionAPITabs::removeCSS):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm:
(WebKit::WebExtensionAPITest::addTest):
(WebKit::WebExtensionContextProxy::dispatchTestMessageEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm:
(WebKit::toWebAPI):
(WebKit::WebExtensionAPIWebNavigation::getAllFrames):
(WebKit::WebExtensionAPIWebNavigation::getFrame):
(WebKit::WebExtensionContextProxy::dispatchWebNavigationEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm:
(WebKit::webRequestDetailsForResourceLoad):
(WebKit::convertHeaderFieldsToWebExtensionFormat):
(WebKit::headersReceivedDetails):
(WebKit::WebExtensionContextProxy::resourceLoadDidPerformHTTPRedirection):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm:
(WebKit::WebExtensionAPIWindows::parseWindowTypesFilter):
(WebKit::WebExtensionAPIWindows::parseWindowTypeFilter):
(WebKit::WebExtensionAPIWindows::parseWindowCreateOptions):
(WebKit::WebExtensionAPIWindows::parseWindowUpdateOptions):
(WebKit::isValid):
(WebKit::WebExtensionAPIWindows::createWindow):
(WebKit::WebExtensionAPIWindows::get):
(WebKit::WebExtensionAPIWindows::getCurrent):
(WebKit::WebExtensionAPIWindows::getLastFocused):
(WebKit::WebExtensionAPIWindows::getAll):
(WebKit::WebExtensionAPIWindows::update):
(WebKit::WebExtensionAPIWindows::remove):
* Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm:
(-[_WKWebExtensionWebNavigationURLPredicate initWithTypeString:value:outErrorMessage:]):
* Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm:
(toResourceType):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm:
(-[WKWebProcessPlugInFrame _securityOrigin]):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm:
(-[WKWebProcessPlugInRangeHandle text]):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.mm:
(-[WKWebProcessPlugInScriptWorld name]):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMElement.mm:
(-[WKDOMElement tagName]):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMRange.mm:
(-[WKDOMRange text]):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMText.mm:
(-[WKDOMText data]):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm:
(-[WKWebProcessPlugInBrowserContextController _setFormDelegate:]):
(-[WKWebProcessPlugInBrowserContextController _setEditingDelegate:]):
(-[WKWebProcessPlugInBrowserContextController _groupIdentifier]):
* Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm:
(WebKit::InjectedBundle::initialize):
(WebKit::InjectedBundle::setBundleParameter):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm:
(WebKit::PDFPluginChoiceAnnotation::commit):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm:
(WebKit::PDFPluginTextAnnotation::commit):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::teardown):
(WebKit::UnifiedPDFPlugin::installPDFDocument):
(WebKit::UnifiedPDFPlugin::attemptToUnlockPDF):
(WebKit::UnifiedPDFPlugin::countFindMatches):
(WebKit::UnifiedPDFPlugin::findString):
(WebKit::UnifiedPDFPlugin::collectFindMatchRects):
(WebKit::UnifiedPDFPlugin::findTextMatches):
(WebKit::UnifiedPDFPlugin::setTextAnnotationValueForTesting):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm:
(WebKit::changeWordCase):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieJarCocoa.mm:
(WebKit::WebCookieJar::cookiesInPartitionedCookieStorage const):
(WebKit::WebCookieJar::setCookiesInPartitionedCookieStorage):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm:
(WebKit::createAnimation):
(WebKit::addAnimationToLayer):
(WebKit::PlatformCAAnimationRemote::updateLayerAnimations):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm:
(-[WKAccessibilityWebPageObject accessibilityDataDetectorValue:point:]):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::origin):
(WebKit::WebProcess::postObserverNotification):
* Source/WebKit/webpushd/ApplePushServiceConnection.mm:
(WebPushD::ApplePushServiceConnection::ApplePushServiceConnection):
(WebPushD::makeTokenInfo):

Canonical link: <a href="https://commits.webkit.org/293651@main">https://commits.webkit.org/293651@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d4c48876c9569446e7626e0b3e9268d805914a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99511 "11 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104642 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50113 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101552 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27594 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75744 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32844 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102518 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14812 "Found 2 new test failures: fast/events/onunload-not-on-body.html fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89856 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56103 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14609 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7841 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49472 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92194 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84542 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107000 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98130 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26625 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19435 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84706 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26987 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86060 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84223 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21369 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28899 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6596 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20415 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26565 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31766 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121746 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26385 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34004 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29698 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27952 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->