### PR TITLE
Sync `the-css-user-agent-style-sheet-and-presentational-hints` from WPT upstream

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7883,3 +7883,5 @@ webkit.org/b/290133 [ Debug ] svg/dom/SVGGeometry-isPointInFill-with-null-path.h
 
 # The color input only has a swatch overlay on macOS
 fast/forms/color/input-color-swatch-overlay-appearance.html [ Skip ]
+
+imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/pre-margin-block.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -9895,6 +9895,7 @@
         "web-platform-tests/html/rendering/replaced-elements/the-textarea-element/textarea-padding-iend-overlaps-content-001-ref.html",
         "web-platform-tests/html/rendering/replaced-elements/the-textarea-element/textarea-padding-istart-moves-content-001-ref.html",
         "web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/body-bgcolor-attribute-change-ref.html",
+        "web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/pre-margin-block-ref.html",
         "web-platform-tests/html/rendering/the-details-element/details-display-type-001-ref2.html",
         "web-platform-tests/html/rendering/the-details-element/details-display-type-002-ref.html",
         "web-platform-tests/html/rendering/the-details-element/details-page-break-after-1-print.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/pre-margin-block-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/pre-margin-block-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style>
+html {
+  writing-mode: vertical-rl;
+}
+blockquote, figure, listing, p, plaintext, pre, xmp {
+  margin-block: 1em;
+}
+</style>
+
+<pre>pre</pre>
+<xmp>xmp</xmp>
+<listing>listing</listing>
+<blockquote>blockquote</blockquote>
+<figure>figure</figure>
+<p>p</p>
+<plaintext>plaintext

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/pre-margin-block-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/pre-margin-block-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style>
+html {
+  writing-mode: vertical-rl;
+}
+blockquote, figure, listing, p, plaintext, pre, xmp {
+  margin-block: 1em;
+}
+</style>
+
+<pre>pre</pre>
+<xmp>xmp</xmp>
+<listing>listing</listing>
+<blockquote>blockquote</blockquote>
+<figure>figure</figure>
+<p>p</p>
+<plaintext>plaintext

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/pre-margin-block.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/pre-margin-block.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="https://html.spec.whatwg.org/multipage/rendering.html#the-css-user-agent-style-sheet-and-presentational-hints">
+<link rel=help href="https://issues.chromium.org/issues/407315792">
+<link rel=match href="pre-margin-block-ref.html">
+
+<!--
+This is a test for the following UA style rule in the HTML spec:
+
+blockquote, figure, listing, p, plaintext, pre, xmp {
+  margin-block: 1em;
+}
+-->
+
+<style>
+html {
+  writing-mode: vertical-rl;
+}
+</style>
+
+<pre>pre</pre>
+<xmp>xmp</xmp>
+<listing>listing</listing>
+<blockquote>blockquote</blockquote>
+<figure>figure</figure>
+<p>p</p>
+<plaintext>plaintext

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/w3c-import.log
@@ -20,3 +20,6 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/mouse-cursor-imagemap.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/no-help-cursor-on-links-wrapped-in-svg.historical.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/no-help-cursor-on-links.historical.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/pre-margin-block-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/pre-margin-block-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/pre-margin-block.html


### PR DESCRIPTION
#### dc61176f529b671151070ee43a20f5f76d9380bc
<pre>
Sync `the-css-user-agent-style-sheet-and-presentational-hints` from WPT upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=291485">https://bugs.webkit.org/show_bug.cgi?id=291485</a>
<a href="https://rdar.apple.com/149156460">rdar://149156460</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/1c34cd9b042b2705d0de6794da020b61298624cc">https://github.com/web-platform-tests/wpt/commit/1c34cd9b042b2705d0de6794da020b61298624cc</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/pre-margin-block.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/pre-margin-block-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/pre-margin-block-expected.html:

Canonical link: <a href="https://commits.webkit.org/293658@main">https://commits.webkit.org/293658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/085d2c9c86a3083d17728ca7dd201fba76ff5d4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19136 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9389 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104617 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50088 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19424 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27569 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75724 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32825 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14790 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89832 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56083 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14587 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7816 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49447 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84516 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106975 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26600 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84684 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26962 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86036 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84201 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28877 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6572 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20380 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16198 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26540 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26360 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29673 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27927 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->