### PR TITLE
[JSC] Optimize `Array#copyWithin` for `ArrayWithStorage`

### DIFF
--- a/JSTests/microbenchmarks/array-prototype-copyWithin-storage-double.js
+++ b/JSTests/microbenchmarks/array-prototype-copyWithin-storage-double.js
@@ -1,0 +1,13 @@
+function test(array, target, start, end) {
+    array.copyWithin(target, start, end);
+}
+noInline(test);
+ 
+let array = new Array(1024);
+for (let j = 0; j < array.length; j++)
+ array[j] = j + 0.5;
+
+ensureArrayStorage(array);
+for (let i = 0; i < 1e5; i++) {
+    array.copyWithin(i % 512, 256, 768);
+}

--- a/JSTests/microbenchmarks/array-prototype-copyWithin-storage-int32.js
+++ b/JSTests/microbenchmarks/array-prototype-copyWithin-storage-int32.js
@@ -1,0 +1,13 @@
+function test(array, target, start, end) {
+    array.copyWithin(target, start, end);
+}
+noInline(test);
+ 
+let array = new Array(1024);
+for (let j = 0; j < array.length; j++)
+  array[j] = j;
+
+ensureArrayStorage(array);
+for (let i = 0; i < 1e5; i++) {
+    array.copyWithin(i % 512, 256, 768);
+}

--- a/JSTests/microbenchmarks/array-prototype-copyWithin-storage-string.js
+++ b/JSTests/microbenchmarks/array-prototype-copyWithin-storage-string.js
@@ -1,0 +1,13 @@
+function test(array, target, start, end) {
+    array.copyWithin(target, start, end);
+}
+noInline(test);
+ 
+let array = new Array(1024);
+for (let j = 0; j < array.length; j++)
+  array[j] = j.toString();
+
+ensureArrayStorage(array);
+for (let i = 0; i < 1e5; i++) {
+    array.copyWithin(i % 512, 256, 768);
+}

--- a/JSTests/stress/array-prototype-copyWithin-storage.js
+++ b/JSTests/stress/array-prototype-copyWithin-storage.js
@@ -1,0 +1,50 @@
+function sameArray(a, b) {
+    if (a.length !== b.length)
+        throw new Error(`Expected length ${b.length} but got ${a.length}`);
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i])
+            throw new Error(`${i}: Expected ${b[i]} but got ${a[i]}`);
+    }
+}
+
+{
+    const array = [1, 2, 3, 4, 5, 6, 7];
+    ensureArrayStorage(array);
+    sameArray(array.copyWithin(0, 1, 4), [2, 3, 4, 4, 5, 6, 7]);
+    sameArray(array.copyWithin(2, 3, 6), [2, 3, 4, 5, 6, 6, 7]);
+}
+
+{
+    const array = ["x", "y", "z", "a", "b", "c"];
+    ensureArrayStorage(array);
+    sameArray(array.copyWithin(0, -2, -1), ["b", "y", "z", "a", "b", "c"]);
+    sameArray(array.copyWithin(3, 1), ["b", "y", "z", "y", "z", "a"]);
+}
+
+{
+    const array = [10, 20, 30, 40, 50, 60];
+    ensureArrayStorage(array);
+    sameArray(array.copyWithin(4, 0, 2), [10, 20, 30, 40, 10, 20]);
+    sameArray(array.copyWithin(2, 1, 5), [10, 20, 20, 30, 40, 10]);
+}
+
+{
+    const array = [1, 2, 3, 4, 5];
+    ensureArrayStorage(array);
+    sameArray(array.copyWithin(1), [1, 1, 2, 3, 4]);
+    sameArray(array.copyWithin(), [1, 1, 2, 3, 4]);
+}
+
+{
+    const array = ["a", "b", "c", "d", "e", "f", "g", "h"];
+    ensureArrayStorage(array);
+    sameArray(array.copyWithin(2, 0, 6), ["a", "b", "a", "b", "c", "d", "e", "f"]);
+}
+
+{
+    const array = new Array(10).fill(0).map((_, i) => i + 1);
+    ensureArrayStorage(array);
+    sameArray(array.copyWithin(0, 3, 8), [4, 5, 6, 7, 8, 6, 7, 8, 9, 10]);
+    sameArray(array.copyWithin(1, 5, 9), [4, 6, 7, 8, 9, 6, 7, 8, 9, 10]);
+}
+


### PR DESCRIPTION
#### b943eb7cd0926ae4db85d1862234d46e715e9eeb
<pre>
[JSC] Optimize `Array#copyWithin` for `ArrayWithStorage`
<a href="https://bugs.webkit.org/show_bug.cgi?id=291486">https://bugs.webkit.org/show_bug.cgi?id=291486</a>

Reviewed by Yusuke Suzuki.

This patch optimizes `Array#copyWithin` if even `this` is `ArrayWithStorage`.

                                                  TipOfTree                  Patched

array-prototype-copyWithin-storage-double
                                              407.9980+-7.4170     ^      6.5783+-0.1772        ^ definitely 62.0217x faster
array-prototype-copyWithin-storage-string
                                              406.6376+-2.6330     ^      6.7657+-1.1691        ^ definitely 60.1024x faster
array-prototype-copyWithin-storage-int32      408.3301+-6.1160     ^      6.9799+-0.9965        ^ definitely 58.5012x faster

* JSTests/microbenchmarks/array-prototype-copyWithin-storage-int32.js: Added.
(test):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::fastCopywithin):

Canonical link: <a href="https://commits.webkit.org/293656@main">https://commits.webkit.org/293656@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd460da4a52a7c3ae7fce1d0769c65a84311cb32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99488 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9398 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104619 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50090 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75726 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32827 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102495 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14792 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89838 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56085 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14589 "4 new passes 7 flakes 1 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7823 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49449 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92171 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84519 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106977 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98107 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26602 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19415 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84687 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26964 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86042 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84204 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21374 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28879 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6578 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20383 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26542 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31743 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121723 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26362 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33996 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29675 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27929 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->