### PR TITLE
Reduce unsafe lambdas in WebCore/Modules/applepay

### DIFF
--- a/Source/WebCore/Modules/applepay/ApplePaySetup.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePaySetup.cpp
@@ -76,9 +76,9 @@ void ApplePaySetup::getSetupFeatures(Document& document, SetupFeaturesPromise&& 
 
     m_setupFeaturesPromise = WTFMove(promise);
 
-    page->paymentCoordinator().getSetupFeatures(m_configuration, document.url(), [this, pendingActivity = makePendingActivity(*this)](Vector<Ref<ApplePaySetupFeature>>&& setupFeatures) {
-        if (m_setupFeaturesPromise)
-            std::exchange(m_setupFeaturesPromise, std::nullopt)->resolve(WTFMove(setupFeatures));
+    page->paymentCoordinator().getSetupFeatures(m_configuration, document.url(), [pendingActivity = makePendingActivity(*this)](Vector<Ref<ApplePaySetupFeature>>&& setupFeatures) {
+        if (pendingActivity->object().m_setupFeaturesPromise)
+            std::exchange(pendingActivity->object().m_setupFeaturesPromise, std::nullopt)->resolve(WTFMove(setupFeatures));
     });
 }
 
@@ -107,11 +107,10 @@ void ApplePaySetup::begin(Document& document, Vector<Ref<ApplePaySetupFeature>>&
     }
 
     m_beginPromise = WTFMove(promise);
-    m_pendingActivity = makePendingActivity(*this);
 
-    page->paymentCoordinator().beginApplePaySetup(m_configuration, page->mainFrameURL(), WTFMove(features), [this](bool result) {
-        if (m_beginPromise)
-            std::exchange(m_beginPromise, std::nullopt)->resolve(result);
+    page->paymentCoordinator().beginApplePaySetup(m_configuration, page->mainFrameURL(), WTFMove(features), [pendingActivity = makePendingActivity(*this)](bool result) {
+        if (pendingActivity->object().m_beginPromise)
+            std::exchange(pendingActivity->object().m_beginPromise, std::nullopt)->resolve(result);
     });
 }
 
@@ -138,8 +137,6 @@ void ApplePaySetup::stop()
 
     if (auto page = downcast<Document>(*scriptExecutionContext()).page())
         page->paymentCoordinator().endApplePaySetup();
-
-    m_pendingActivity = nullptr;
 }
 
 void ApplePaySetup::suspend(ReasonForSuspension)

--- a/Source/WebCore/Modules/applepay/ApplePaySetupWebCore.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySetupWebCore.h
@@ -64,7 +64,6 @@ private:
     ApplePaySetupConfiguration m_configuration;
     std::optional<SetupFeaturesPromise> m_setupFeaturesPromise;
     std::optional<BeginPromise> m_beginPromise;
-    RefPtr<PendingActivity<ApplePaySetup>> m_pendingActivity;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/applepay/PaymentCoordinator.cpp
+++ b/Source/WebCore/Modules/applepay/PaymentCoordinator.cpp
@@ -48,6 +48,7 @@
 
 #define PAYMENT_COORDINATOR_RELEASE_LOG_ERROR(fmt, ...) RELEASE_LOG_ERROR(ApplePay, "%p - PaymentCoordinator::" fmt, this, ##__VA_ARGS__)
 #define PAYMENT_COORDINATOR_RELEASE_LOG(fmt, ...) RELEASE_LOG(ApplePay, "%p - PaymentCoordinator::" fmt, this, ##__VA_ARGS__)
+#define PAYMENT_COORDINATOR_RELEASE_LOG_WITH_THIS(thisPointer, fmt, ...) RELEASE_LOG(ApplePay, "%p - PaymentCoordinator::" fmt, thisPointer, ##__VA_ARGS__)
 
 namespace WebCore {
 
@@ -81,11 +82,11 @@ bool PaymentCoordinator::canMakePayments()
 
 void PaymentCoordinator::canMakePaymentsWithActiveCard(Document& document, const String& merchantIdentifier, Function<void(bool)>&& completionHandler)
 {
-    m_client->canMakePaymentsWithActiveCard(merchantIdentifier, document.domain(), [this, weakThis = WeakPtr { *this }, document = WeakPtr<Document, WeakPtrImplWithEventTargetData> { document }, completionHandler = WTFMove(completionHandler)](bool canMakePayments) {
+    m_client->canMakePaymentsWithActiveCard(merchantIdentifier, document.domain(), [weakThis = WeakPtr { *this }, document = WeakPtr<Document, WeakPtrImplWithEventTargetData> { document }, completionHandler = WTFMove(completionHandler)](bool canMakePayments) {
         if (!weakThis)
             return completionHandler(false);
 
-        PAYMENT_COORDINATOR_RELEASE_LOG("canMakePaymentsWithActiveCard() -> %d", canMakePayments);
+        PAYMENT_COORDINATOR_RELEASE_LOG_WITH_THIS(weakThis.get(), "canMakePaymentsWithActiveCard() -> %d", canMakePayments);
 
         if (!canMakePayments)
             return completionHandler(false);
@@ -292,10 +293,10 @@ std::optional<String> PaymentCoordinator::validatedPaymentNetwork(Document&, uns
 void PaymentCoordinator::getSetupFeatures(const ApplePaySetupConfiguration& configuration, const URL& url, CompletionHandler<void(Vector<Ref<ApplePaySetupFeature>>&&)>&& completionHandler)
 {
     PAYMENT_COORDINATOR_RELEASE_LOG("getSetupFeatures()");
-    m_client->getSetupFeatures(configuration, url, [this, weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)](Vector<Ref<ApplePaySetupFeature>>&& features) mutable {
+    m_client->getSetupFeatures(configuration, url, [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)](Vector<Ref<ApplePaySetupFeature>>&& features) mutable {
         if (!weakThis)
             return;
-        PAYMENT_COORDINATOR_RELEASE_LOG("getSetupFeatures() completed (features: %zu)", features.size());
+        PAYMENT_COORDINATOR_RELEASE_LOG_WITH_THIS(weakThis.get(), "getSetupFeatures() completed (features: %zu)", features.size());
         completionHandler(WTFMove(features));
     });
 }
@@ -303,10 +304,10 @@ void PaymentCoordinator::getSetupFeatures(const ApplePaySetupConfiguration& conf
 void PaymentCoordinator::beginApplePaySetup(const ApplePaySetupConfiguration& configuration, const URL& url, Vector<Ref<ApplePaySetupFeature>>&& features, CompletionHandler<void(bool)>&& completionHandler)
 {
     PAYMENT_COORDINATOR_RELEASE_LOG("beginApplePaySetup()");
-    m_client->beginApplePaySetup(configuration, url, WTFMove(features), [this, weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)](bool success) mutable {
+    m_client->beginApplePaySetup(configuration, url, WTFMove(features), [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)](bool success) mutable {
         if (!weakThis)
             return;
-        PAYMENT_COORDINATOR_RELEASE_LOG("beginApplePaySetup() completed (success: %d)", success);
+        PAYMENT_COORDINATOR_RELEASE_LOG_WITH_THIS(weakThis.get(), "beginApplePaySetup() completed (success: %d)", success);
         completionHandler(success);
     });
 }

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -1,7 +1,5 @@
 Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
 Modules/WebGPU/Implementation/WebGPUImpl.cpp
-Modules/applepay/ApplePaySetup.cpp
-Modules/applepay/PaymentCoordinator.cpp
 Modules/cache/DOMCache.cpp
 Modules/cache/DOMCacheStorage.cpp
 Modules/encryptedmedia/MediaKeySession.cpp


### PR DESCRIPTION
#### bb6906e63249af8bc451169b64279e678ca8e5cc
<pre>
Reduce unsafe lambdas in WebCore/Modules/applepay
<a href="https://bugs.webkit.org/show_bug.cgi?id=291490">https://bugs.webkit.org/show_bug.cgi?id=291490</a>

Reviewed by Abrar Rahman Protyasha.

As per Safer CPP Guidelines:

- <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#capture-protectedthis-or-weakthis-in-asynchronous-lambdas-where-you-need-to-use-this">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#capture-protectedthis-or-weakthis-in-asynchronous-lambdas-where-you-need-to-use-this</a>

* Source/WebCore/Modules/applepay/ApplePaySetup.cpp:
(WebCore::ApplePaySetup::begin):
(WebCore::ApplePaySetup::stop):
* Source/WebCore/Modules/applepay/ApplePaySetupWebCore.h:
* Source/WebCore/Modules/applepay/PaymentCoordinator.cpp:
(WebCore::PaymentCoordinator::canMakePaymentsWithActiveCard):
(WebCore::PaymentCoordinator::getSetupFeatures):
(WebCore::PaymentCoordinator::beginApplePaySetup):
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/293716@main">https://commits.webkit.org/293716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26cbc80ce383dd624bf95e0577de95695fd84113

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104698 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50169 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101608 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75793 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32896 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14851 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89910 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56152 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14648 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7895 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49528 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84588 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7981 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107056 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26681 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19477 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84753 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27044 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86114 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84270 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28941 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6650 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20479 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16222 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26621 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31822 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26441 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29754 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28008 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->