### PR TITLE
[JSC] Optimize `Number.isSafeInteger` with DFG and FTL for Performance

### DIFF
--- a/JSTests/microbenchmarks/number-isSafeInteger.js
+++ b/JSTests/microbenchmarks/number-isSafeInteger.js
@@ -1,0 +1,24 @@
+(function () {
+  var result = 0;
+  var values = [
+    0,
+    1,
+    -1,
+    123.45,
+    -123.45,
+    Number.MAX_VALUE,
+    Number.MIN_VALUE,
+    Number.MAX_SAFE_INTEGER,
+    Number.MIN_SAFE_INTEGER,
+    Infinity,
+    NaN,
+  ];
+  for (var i = 0; i < testLoopCount; ++i) {
+    for (var j = 0; j < values.length; ++j) {
+      if (Number.isSafeInteger(values[j]))
+        result++;
+    }
+  }
+  if (result !== testLoopCount * 5)
+    throw "Error: bad result: " + result;
+})();

--- a/JSTests/stress/number-is-safe-integer.js
+++ b/JSTests/stress/number-is-safe-integer.js
@@ -1,0 +1,130 @@
+// Test for Number.isSafeInteger()
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Actual: ${actual}, Expected: ${expected}`);
+}
+
+shouldBe(Number.hasOwnProperty("isSafeInteger"), true);
+shouldBe(typeof Number.isSafeInteger, "function");
+
+// Function properties.
+shouldBe(Number.isSafeInteger.length, 1);
+shouldBe(Number.isSafeInteger.name, "isSafeInteger");
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(Object.getOwnPropertyDescriptor(Number, "isSafeInteger").configurable, true);
+    shouldBe(Object.getOwnPropertyDescriptor(Number, "isSafeInteger").enumerable, false);
+    shouldBe(Object.getOwnPropertyDescriptor(Number, "isSafeInteger").writable, true);
+
+    // Special
+    shouldBe(Number.isSafeInteger(), false);
+    shouldBe(Number.isSafeInteger(undefined), false);
+    shouldBe(Number.isSafeInteger(null), false);
+
+    // Numeric
+    shouldBe(Number.isSafeInteger(0), true);
+    shouldBe(Number.isSafeInteger(-0), true);
+    shouldBe(Number.isSafeInteger(1), true);
+    shouldBe(Number.isSafeInteger(-1), true);
+    shouldBe(Number.isSafeInteger(1.0), true);
+    shouldBe(Number.isSafeInteger(-1.0), true);
+    shouldBe(Number.isSafeInteger(1.0), true);
+    shouldBe(Number.isSafeInteger(-1.0), true);
+    shouldBe(Number.isSafeInteger(42), true);
+    shouldBe(Number.isSafeInteger(123.5), false);
+    shouldBe(Number.isSafeInteger(-123.5), false);
+    shouldBe(Number.isSafeInteger(1e10), true);
+    shouldBe(Number.isSafeInteger(-1e10), true);
+    shouldBe(Number.isSafeInteger(1.7e10), true);
+    shouldBe(Number.isSafeInteger(-1.7e10), true);
+    shouldBe(Number.isSafeInteger(1.7e-10), false);
+    shouldBe(Number.isSafeInteger(-1.7e-10), false);
+
+    shouldBe(Number.isSafeInteger(Number.MAX_VALUE), false);
+    shouldBe(Number.isSafeInteger(Number.MIN_VALUE), false);
+    shouldBe(Number.isSafeInteger(Number.MAX_SAFE_INTEGER), true);
+    shouldBe(Number.isSafeInteger(Number.MAX_SAFE_INTEGER + 1), false);
+    shouldBe(Number.isSafeInteger(Number.MIN_SAFE_INTEGER), true);
+    shouldBe(Number.isSafeInteger(Number.MIN_SAFE_INTEGER - 1), false);
+    shouldBe(Number.isSafeInteger(Math.PI), false);
+    shouldBe(Number.isSafeInteger(Math.E), false);
+    shouldBe(Number.isSafeInteger(Math.LOG2E), false);
+    shouldBe(Number.isSafeInteger(Math.LOG10E), false);
+    shouldBe(Number.isSafeInteger(Infinity), false);
+    shouldBe(Number.isSafeInteger(-Infinity), false);
+    shouldBe(Number.isSafeInteger(NaN), false);
+    shouldBe(Number.isSafeInteger(1, 3), true);
+    shouldBe(Number.isSafeInteger(1, 3.75), true);
+    shouldBe(Number.isSafeInteger(Infinity, 3), false);
+
+    // Non-numeric.
+    shouldBe(Number.isSafeInteger({}), false);
+    shouldBe(Number.isSafeInteger({ webkit: "cute" }), false);
+    shouldBe(Number.isSafeInteger([]), false);
+    shouldBe(Number.isSafeInteger([123]), false);
+    shouldBe(Number.isSafeInteger([1, 1]), false);
+    shouldBe(Number.isSafeInteger([NaN]), false);
+    shouldBe(Number.isSafeInteger(""), false);
+    shouldBe(Number.isSafeInteger("1"), false);
+    shouldBe(Number.isSafeInteger("x"), false);
+    shouldBe(Number.isSafeInteger("NaN"), false);
+    shouldBe(Number.isSafeInteger("Infinity"), false);
+    shouldBe(Number.isSafeInteger(true), false);
+    shouldBe(Number.isSafeInteger(false), false);
+    shouldBe(
+        Number.isSafeInteger(function () {}),
+        false
+    );
+    shouldBe(
+        Number.isSafeInteger(() => {}),
+        false
+    );
+    shouldBe(Number.isSafeInteger(Number.isSafeInteger), false);
+    shouldBe(Number.isSafeInteger(Number.isSafeInteger()), false);
+    shouldBe(Number.isSafeInteger(Symbol()), false);
+    shouldBe(Number.isSafeInteger(new Number(123)), false);
+    shouldBe(Number.isSafeInteger(new Number(-123)), false);
+    shouldBe(Number.isSafeInteger(new Number("123")), false);
+    shouldBe(Number.isSafeInteger(new Number(undefined)), false);
+    shouldBe(Number.isSafeInteger(new Number(null)), false);
+    shouldBe(Number.isSafeInteger(new Number(true)), false);
+    shouldBe(Number.isSafeInteger(new Number(false)), false);
+
+    // BigInt
+    shouldBe(Number.isSafeInteger(BigInt(123)), false);
+    shouldBe(Number.isSafeInteger(BigInt(-123)), false);
+    shouldBe(Number.isSafeInteger(BigInt("123")), false);
+    shouldBe(Number.isSafeInteger(BigInt("-123")), false);
+    shouldBe(Number.isSafeInteger(BigInt("0x1fffffffffffff")), false);
+    shouldBe(Number.isSafeInteger(BigInt("0o377777777777777777")), false);
+
+    // Type conversion shouldn not happen.
+    var objectWithNumberValueOf = {
+        valueOf: function () {
+            return 123;
+        },
+    };
+    var objectWithNaNValueOf = {
+        valueOf: function () {
+            return NaN;
+        },
+    };
+    shouldBe(Number.isSafeInteger(objectWithNumberValueOf), false);
+    shouldBe(Number.isSafeInteger(objectWithNaNValueOf), false);
+
+    var objectRecordConversionCalls = {
+        callList: [],
+        toString: function () {
+            this.callList.push("toString");
+            return "Bad";
+        },
+        valueOf: function () {
+            this.callList.push("valueOf");
+            return 12345;
+        },
+    };
+
+    shouldBe(Number.isSafeInteger(objectRecordConversionCalls), false);
+    shouldBe(objectRecordConversionCalls.callList.length, 0);
+}

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2079,6 +2079,24 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
     }
 
+    case NumberIsSafeInteger: {
+        AbstractValue& child = forNode(node->child1());
+        if (JSValue value = child.value()) {
+            if (value.isInt32()) {
+                setConstant(node, jsBoolean(true));
+                break;
+            }
+            if (!value.isDouble()) {
+                setConstant(node, jsBoolean(false));
+                break;
+            }
+            setConstant(node, jsBoolean(isSafeInteger(value.asDouble())));
+            break;
+        }
+        setNonCellTypeForNode(node, SpecBoolean);
+        break;
+    }
+
     case TypeOf: {
         JSValue child = forNode(node->child1()).value();
         AbstractValue& abstractChild = forNode(node->child1());

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3139,6 +3139,16 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             return CallOptimizationResult::Inlined;
         }
 
+        case NumberIsSafeIntegerIntrinsic: {
+            if (argumentCountIncludingThis < 2)
+                return CallOptimizationResult::DidNothing;
+
+            insertChecks();
+            setResult(addToGraph(NumberIsSafeInteger, get(virtualRegisterForArgumentIncludingThis(1, registerOffset))));
+
+            return CallOptimizationResult::Inlined;
+        }
+
         case RegExpExecIntrinsic: {
             if (argumentCountIncludingThis < 2)
                 return CallOptimizationResult::DidNothing;

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -275,6 +275,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
 
     case NumberIsFinite:
     case NumberIsNaN:
+    case NumberIsSafeInteger:
         def(PureValue(node));
         return;
 

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -277,6 +277,7 @@ bool doesGC(Graph& graph, Node* node)
     case WeakMapGet:
     case NumberIsNaN:
     case NumberIsFinite:
+    case NumberIsSafeInteger:
         return false;
 
 #if ASSERT_ENABLED

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -3305,6 +3305,19 @@ private:
             break;
         }
 
+        case NumberIsSafeInteger: {
+            if (node->child1()->shouldSpeculateInt32()) {
+                insertCheck<Int32Use>(node->child1().node());
+                m_graph.convertToConstant(node, jsBoolean(true));
+                break;
+            }
+            if (node->child1()->shouldSpeculateNumber()) {
+                fixEdge<DoubleRepUse>(node->child1());
+                break;
+            }
+            break;
+        }
+
         case SetCallee:
             fixEdge<CellUse>(node->child1());
             break;

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -463,6 +463,7 @@ namespace JSC { namespace DFG {
     macro(GlobalIsFinite, NodeMustGenerate | NodeResultBoolean) \
     macro(NumberIsFinite, NodeResultBoolean) \
     macro(NumberIsInteger, NodeResultBoolean) \
+    macro(NumberIsSafeInteger, NodeResultBoolean) \
     macro(IsObject, NodeResultBoolean) \
     macro(IsCallable, NodeResultBoolean) \
     macro(IsConstructor, NodeResultBoolean) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3870,13 +3870,22 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationNumberIsFinite, UCPUStrictInt32, (Enc
     return toUCPUStrictInt32(!!std::isfinite(argument.asNumber()));
 }
 
-
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationNumberIsNaN, UCPUStrictInt32, (EncodedJSValue value))
 {
     JSValue argument = JSValue::decode(value);
     if (!argument.isNumber())
         return toUCPUStrictInt32(0);
     return toUCPUStrictInt32(!!std::isnan(argument.asNumber()));
+}
+
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationNumberIsSafeInteger, UCPUStrictInt32, (EncodedJSValue value))
+{
+    JSValue argument = JSValue::decode(value);
+    if (argument.isInt32())
+        return toUCPUStrictInt32(1);
+    if (!argument.isDouble())
+        return toUCPUStrictInt32(0);
+    return toUCPUStrictInt32(!!isSafeInteger(argument.asDouble()));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationIsNaN, UCPUStrictInt32, (JSGlobalObject* globalObject, EncodedJSValue value))

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -413,6 +413,7 @@ JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationNumberIsFinite, UCPUStrictInt32, (En
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationNumberIsNaN, UCPUStrictInt32, (EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationIsFinite, UCPUStrictInt32, (JSGlobalObject*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationIsNaN, UCPUStrictInt32, (JSGlobalObject*, EncodedJSValue));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationNumberIsSafeInteger, UCPUStrictInt32, (EncodedJSValue));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationToIntegerOrInfinityDouble, EncodedJSValue, (double));
 JSC_DECLARE_JIT_OPERATION(operationToIntegerOrInfinityUntyped, EncodedJSValue, (JSGlobalObject*, EncodedJSValue));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationToLengthDouble, EncodedJSValue, (double));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1255,6 +1255,7 @@ private:
         case NumberIsNaN:
         case GlobalIsFinite:
         case NumberIsFinite:
+        case NumberIsSafeInteger:
         case IsObject:
         case IsCallable:
         case IsConstructor:

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -342,6 +342,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case ResolveRope:
     case NumberIsNaN:
     case NumberIsFinite:
+    case NumberIsSafeInteger:
     case StringIndexOf:
         return true;
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1797,6 +1797,7 @@ public:
     void compileNumberIsNaN(Node*);
     void compileGlobalIsFinite(Node*);
     void compileNumberIsFinite(Node*);
+    void compileNumberIsSafeInteger(Node*);
     void compileToIntegerOrInfinity(Node*);
     void compileToLength(Node*);
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -3820,6 +3820,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case NumberIsSafeInteger: {
+        compileNumberIsSafeInteger(node);
+        break;
+    }
+
     case IsObject: {
         compileIsObject(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -5330,6 +5330,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case NumberIsSafeInteger: {
+        compileNumberIsSafeInteger(node);
+        break;
+    }
+
     case MapHash: {
         switch (node->child1().useKind()) {
 #if USE(BIGINT32)

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -118,6 +118,7 @@ private:
         case NumberIsNaN:
         case GlobalIsFinite:
         case NumberIsFinite:
+        case NumberIsSafeInteger:
         case ParseInt:
         case ToIntegerOrInfinity:
         case ToLength:

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -313,6 +313,7 @@ inline CapabilityLevel canCompile(Node* node)
     case NumberIsNaN:
     case GlobalIsFinite:
     case NumberIsFinite:
+    case NumberIsSafeInteger:
     case IsObject:
     case IsCallable:
     case IsConstructor:

--- a/Source/JavaScriptCore/jit/ThunkGenerators.cpp
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.cpp
@@ -765,6 +765,16 @@ MacroAssemblerCodeRef<JITThunkPtrTag> numberIsFiniteThunkGenerator(VM& vm)
     return jit.finalize(vm.jitStubs->ctiNativeTailCall(vm), "Number.isFinite");
 }
 
+MacroAssemblerCodeRef<JITThunkPtrTag> numberIsSafeIntegerThunkGenerator(VM& vm)
+{
+    SpecializedThunkJIT jit(vm, 1);
+    jit.loadJSArgument(0, JSRInfo::jsRegT10);
+    jit.appendFailure(jit.branchIfNotInt32(JSRInfo::jsRegT10));
+    jit.moveTrustedValue(jsBoolean(true), JSRInfo::jsRegT10);
+    jit.returnJSValue(JSRInfo::jsRegT10);
+    return jit.finalize(vm.jitStubs->ctiNativeTailCall(vm), "Number.isSafeInteger");
+}
+
 MacroAssemblerCodeRef<JITThunkPtrTag> stringPrototypeCodePointAtThunkGenerator(VM& vm)
 {
     SpecializedThunkJIT jit(vm, 1);

--- a/Source/JavaScriptCore/jit/ThunkGenerators.h
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.h
@@ -80,6 +80,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> globalIsNaNThunkGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> numberIsNaNThunkGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> globalIsFiniteThunkGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> numberIsFiniteThunkGenerator(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> numberIsSafeIntegerThunkGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> absThunkGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> ceilThunkGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> expThunkGenerator(VM&);

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -128,6 +128,7 @@ namespace JSC {
     macro(NumberPrototypeToStringIntrinsic) \
     macro(NumberIsFiniteIntrinsic) \
     macro(NumberIsNaNIntrinsic) \
+    macro(NumberIsSafeIntegerIntrinsic) \
     macro(NumberIsIntegerIntrinsic) \
     macro(NumberConstructorIntrinsic) \
     macro(IMulIntrinsic) \

--- a/Source/JavaScriptCore/runtime/NumberConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/NumberConstructor.cpp
@@ -47,7 +47,7 @@ const ClassInfo NumberConstructor::s_info = { "Function"_s, &Base::s_info, &numb
 @begin numberConstructorTable
   isFinite       numberConstructorFuncIsFinite       DontEnum|Function 1 NumberIsFiniteIntrinsic
   isNaN          numberConstructorFuncIsNaN          DontEnum|Function 1 NumberIsNaNIntrinsic
-  isSafeInteger  numberConstructorFuncIsSafeInteger  DontEnum|Function 1
+  isSafeInteger  numberConstructorFuncIsSafeInteger  DontEnum|Function 1 NumberIsSafeIntegerIntrinsic
 @end
 */
 

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -658,6 +658,8 @@ static ThunkGenerator thunkGeneratorForIntrinsic(Intrinsic intrinsic)
         return globalIsFiniteThunkGenerator;
     case NumberIsFiniteIntrinsic:
         return numberIsFiniteThunkGenerator;
+    case NumberIsSafeIntegerIntrinsic:
+        return numberIsSafeIntegerThunkGenerator;
     case SqrtIntrinsic:
         return sqrtThunkGenerator;
     case AbsIntrinsic:


### PR DESCRIPTION
#### 75f7bb698ee95ce80e8b9c95f816a2d3cdce4e8b
<pre>
[JSC] Optimize `Number.isSafeInteger` with DFG and FTL for Performance
<a href="https://bugs.webkit.org/show_bug.cgi?id=291491">https://bugs.webkit.org/show_bug.cgi?id=291491</a>

Reviewed by Yusuke Suzuki.

Optimize `Number.isSafeInteger` with DFG and FTL for Performance

                        TipOfTree              Patched                Ratio
number-isSafeInteger    0.9238+-0.0566         0.7933+-0.0455         1.1645x faster

* JSTests/microbenchmarks/number-isSafeInteger.js: Added.
* JSTests/stress/number-is-safe-integer.js: Added.
(shouldBe):
(shouldBe.Number.isSafeInteger):
(objectWithNumberValueOf.valueOf):
(objectWithNaNValueOf.valueOf):
(objectRecordConversionCalls.toString):
(objectRecordConversionCalls.valueOf):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/jit/ThunkGenerators.cpp:
(JSC::numberIsSafeIntegerThunkGenerator):
* Source/JavaScriptCore/jit/ThunkGenerators.h:
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/NumberConstructor.cpp:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::thunkGeneratorForIntrinsic):

Canonical link: <a href="https://commits.webkit.org/296161@main">https://commits.webkit.org/296161@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/102ba1aada05bb90663667a8005b33c6ed2388d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111811 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57199 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34856 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80961 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109607 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21439 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96199 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61297 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20893 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14305 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56678 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/99243 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90778 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114672 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/105221 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33741 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24879 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90024 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34105 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92429 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89733 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34645 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12462 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/29368 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17396 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33666 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39079 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/129532 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33412 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35283 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36765 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35011 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->