### PR TITLE
[Experiment] Experiment with removing CachedImage from CSSImageValue

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2701,6 +2701,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/ScopedName.h
     style/StyleChange.h
     style/StyleInterpolationClient.h
+    style/StyleResourceStore.h
     style/StyleScope.h
     style/StyleScopeOrdinal.h
     style/StyleUpdate.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3128,6 +3128,7 @@ style/StyleRelations.cpp
 style/StyleResolveForDocument.cpp
 style/StyleResolveForFont.cpp
 style/StyleResolver.cpp
+style/StyleResourceStore.cpp
 style/StyleScope.cpp
 style/StyleScopeRuleSets.cpp
 style/StyleSheetContentsCache.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -4994,6 +4994,7 @@
 		BC8BF15A1058141800A40A07 /* UserStyleSheetTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = BC8BF1591058141800A40A07 /* UserStyleSheetTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC8C8FAE0DDCD31B00B592F4 /* RenderStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = BC8C8FAC0DDCD31B00B592F4 /* RenderStyle.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC926F810C0552470082776B /* JSHTMLFrameSetElement.h in Headers */ = {isa = PBXBuildFile; fileRef = BC926F7F0C0552470082776B /* JSHTMLFrameSetElement.h */; };
+		BC929E822DAC1DD000311094 /* StyleResourceStore.h in Headers */ = {isa = PBXBuildFile; fileRef = BC929E7F2DAAD7CD00311094 /* StyleResourceStore.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC9439C3116CF4940048C750 /* JSNodeCustom.h in Headers */ = {isa = PBXBuildFile; fileRef = BC9439C2116CF4940048C750 /* JSNodeCustom.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC94D14F0C275C68006BC617 /* JSHistory.h in Headers */ = {isa = PBXBuildFile; fileRef = BC94D14D0C275C68006BC617 /* JSHistory.h */; };
 		BC94D1540C275C8B006BC617 /* History.h in Headers */ = {isa = PBXBuildFile; fileRef = BC94D1510C275C8B006BC617 /* History.h */; };
@@ -18375,6 +18376,8 @@
 		BC8C8FAC0DDCD31B00B592F4 /* RenderStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderStyle.h; sourceTree = "<group>"; };
 		BC926F7E0C0552470082776B /* JSHTMLFrameSetElement.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = JSHTMLFrameSetElement.cpp; sourceTree = "<group>"; };
 		BC926F7F0C0552470082776B /* JSHTMLFrameSetElement.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = JSHTMLFrameSetElement.h; sourceTree = "<group>"; };
+		BC929E7F2DAAD7CD00311094 /* StyleResourceStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleResourceStore.h; sourceTree = "<group>"; };
+		BC929E812DAADB0200311094 /* StyleResourceStore.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleResourceStore.cpp; sourceTree = "<group>"; };
 		BC9439C2116CF4940048C750 /* JSNodeCustom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSNodeCustom.h; sourceTree = "<group>"; };
 		BC94D1070C274F88006BC617 /* PlatformScreenMac.mm */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.objcpp; path = PlatformScreenMac.mm; sourceTree = "<group>"; };
 		BC94D14C0C275C68006BC617 /* JSHistory.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = JSHistory.cpp; sourceTree = "<group>"; };
@@ -37496,6 +37499,8 @@
 				E4D68EB317B4DBDC00CBDCA8 /* StyleResolveForFont.h */,
 				E139866115478474001E3F65 /* StyleResolver.cpp */,
 				E139866215478474001E3F65 /* StyleResolver.h */,
+				BC929E812DAADB0200311094 /* StyleResourceStore.cpp */,
+				BC929E7F2DAAD7CD00311094 /* StyleResourceStore.h */,
 				E461D65C1BB0C7F000CB5645 /* StyleScope.cpp */,
 				E461D65E1BB0C80D00CB5645 /* StyleScope.h */,
 				E4D86E6B2640394C00B62425 /* StyleScopeOrdinal.h */,
@@ -44587,6 +44592,7 @@
 				E4D58EB517B4DBDC00CBDCA8 /* StyleResolveForDocument.h in Headers */,
 				E4D68EB517B4DBDC00CBDCA8 /* StyleResolveForFont.h in Headers */,
 				E139866415478474001E3F65 /* StyleResolver.h in Headers */,
+				BC929E822DAC1DD000311094 /* StyleResourceStore.h in Headers */,
 				E4BBED4D14FCDBA1003F0B98 /* StyleRule.h in Headers */,
 				E4946EAF156E64DD00D3297F /* StyleRuleImport.h in Headers */,
 				0F94F37E23661626003AA5C7 /* StyleRuleType.h in Headers */,

--- a/Source/WebCore/css/CSSImageValue.cpp
+++ b/Source/WebCore/css/CSSImageValue.cpp
@@ -43,10 +43,9 @@ CSSImageValue::CSSImageValue()
 {
 }
 
-CSSImageValue::CSSImageValue(CSS::URL&& location, AtomString&& initiatorType)
+CSSImageValue::CSSImageValue(CSS::URL&& location)
     : CSSValue(ClassType::Image)
     , m_location(WTFMove(location))
-    , m_initiatorType(WTFMove(initiatorType))
 {
 }
 
@@ -55,82 +54,26 @@ Ref<CSSImageValue> CSSImageValue::create()
     return adoptRef(*new CSSImageValue);
 }
 
-Ref<CSSImageValue> CSSImageValue::create(CSS::URL location, AtomString initiatorType)
+Ref<CSSImageValue> CSSImageValue::create(CSS::URL location)
 {
-    return adoptRef(*new CSSImageValue(WTFMove(location), WTFMove(initiatorType)));
+    return adoptRef(*new CSSImageValue(WTFMove(location)));
 }
 
 Ref<CSSImageValue> CSSImageValue::create(WTF::URL imageURL, AtomString initiatorType)
 {
-    return create(CSS::URL { .specified = imageURL.string(), .resolved = WTFMove(imageURL), .modifiers = { } }, WTFMove(initiatorType));
+    return create(CSS::URL { .specified = imageURL.string(), .resolved = WTFMove(imageURL), .modifiers = { .initiatorType = WTFMove(initiatorType) } });
 }
 
 CSSImageValue::~CSSImageValue() = default;
-
-Ref<CSSImageValue> CSSImageValue::copyForComputedStyle(const CSS::URL& resolvedURL) const
-{
-    if (resolvedURL == m_location)
-        return const_cast<CSSImageValue&>(*this);
-
-    auto result = create(resolvedURL);
-    result->m_cachedImage = m_cachedImage;
-    result->m_initiatorType = m_initiatorType;
-    result->m_unresolvedValue = const_cast<CSSImageValue*>(this);
-    return result;
-}
 
 bool CSSImageValue::isLoadedFromOpaqueSource() const
 {
     return m_location.modifiers.loadedFromOpaqueSource == LoadedFromOpaqueSource::Yes;
 }
 
-bool CSSImageValue::isPending() const
-{
-    return !m_cachedImage;
-}
-
 RefPtr<StyleImage> CSSImageValue::createStyleImage(const Style::BuilderState& state) const
 {
-    auto styleLocation = Style::toStyle(m_location, state);
-    if (styleLocation.resolved == m_location.resolved)
-        return StyleCachedImage::create(WTFMove(styleLocation), const_cast<CSSImageValue&>(*this));
-
-    // FIXME: This case can only happen when a element from a document with no baseURL has an inline style with a relative image URL in it and has been moved to a document with a non-null baseURL. Instead of re-resolving in this case, moved elements with this kind of inline style should have their inline style re-parsed.
-
-    auto newLocation = m_location;
-    newLocation.resolved = styleLocation.resolved;
-    auto result = create(WTFMove(newLocation));
-    result->m_cachedImage = m_cachedImage;
-    result->m_initiatorType = m_initiatorType;
-    result->m_unresolvedValue = const_cast<CSSImageValue*>(this);
-    return StyleCachedImage::create(WTFMove(styleLocation), WTFMove(result));
-}
-
-CachedImage* CSSImageValue::loadImage(CachedResourceLoader& loader, const ResourceLoaderOptions& options)
-{
-    if (!m_cachedImage) {
-        ASSERT(loader.document());
-
-        ResourceLoaderOptions loadOptions = options;
-        CSS::applyModifiersToLoaderOptions(m_location.modifiers, loadOptions);
-
-        CachedResourceRequest request(ResourceRequest(m_location.resolved), loadOptions);
-        if (m_initiatorType.isEmpty())
-            request.setInitiatorType(cachedResourceRequestInitiatorTypes().css);
-        else
-            request.setInitiatorType(m_initiatorType);
-        if (options.mode == FetchOptions::Mode::Cors)
-            request.updateForAccessControl(*loader.document());
-        m_cachedImage = loader.requestImage(WTFMove(request)).value_or(nullptr);
-        for (auto imageValue = this; (imageValue = imageValue->m_unresolvedValue.get()); )
-            imageValue->m_cachedImage = m_cachedImage;
-    }
-    return m_cachedImage.value().get();
-}
-
-bool CSSImageValue::customTraverseSubresources(NOESCAPE const Function<bool(const CachedResource&)>& handler) const
-{
-    return m_cachedImage && *m_cachedImage && handler(**m_cachedImage);
+    return state.document().resourceStore()->ensureImage(Style::toStyle(m_location, state));
 }
 
 bool CSSImageValue::customMayDependOnBaseURL() const
@@ -155,11 +98,6 @@ Ref<DeprecatedCSSOMValue> CSSImageValue::createDeprecatedCSSOMWrapper(CSSStyleDe
 {
     // We expose CSSImageValues as URI primitive values in CSSOM to maintain old behavior.
     return DeprecatedCSSOMPrimitiveValue::create(CSSURLValue::create(m_location), styleDeclaration);
-}
-
-bool CSSImageValue::knownToBeOpaque(const RenderElement& renderer) const
-{
-    return m_cachedImage.value_or(nullptr) && (**m_cachedImage).currentFrameKnownToBeOpaque(&renderer);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSImageValue.h
+++ b/Source/WebCore/css/CSSImageValue.h
@@ -43,15 +43,10 @@ class BuilderState;
 class CSSImageValue final : public CSSValue {
 public:
     static Ref<CSSImageValue> create();
-    static Ref<CSSImageValue> create(CSS::URL, AtomString initiatorType = { });
+    static Ref<CSSImageValue> create(CSS::URL);
     static Ref<CSSImageValue> create(WTF::URL, AtomString initiatorType = { });
     ~CSSImageValue();
 
-    Ref<CSSImageValue> copyForComputedStyle(const CSS::URL& resolvedURL) const;
-
-    bool isPending() const;
-    CachedImage* loadImage(CachedResourceLoader&, const ResourceLoaderOptions&);
-    CachedImage* cachedImage() const { return m_cachedImage ? m_cachedImage.value().get() : nullptr; }
 
     // Take care when using this, and read https://drafts.csswg.org/css-values/#relative-urls
     const CSS::URL& url() const { return m_location; }
@@ -60,12 +55,9 @@ public:
 
     Ref<DeprecatedCSSOMValue> createDeprecatedCSSOMWrapper(CSSStyleDeclaration&) const;
 
-    bool customTraverseSubresources(NOESCAPE const Function<bool(const CachedResource&)>&) const;
     bool customMayDependOnBaseURL() const;
 
     bool equals(const CSSImageValue&) const;
-
-    bool knownToBeOpaque(const RenderElement&) const;
 
     RefPtr<StyleImage> createStyleImage(const Style::BuilderState&) const;
 
@@ -82,11 +74,9 @@ public:
 
 private:
     CSSImageValue();
-    CSSImageValue(CSS::URL&&, AtomString&&);
+    CSSImageValue(CSS::URL&&);
 
     CSS::URL m_location;
-    std::optional<CachedResourceHandle<CachedImage>> m_cachedImage;
-    AtomString m_initiatorType;
     RefPtr<CSSImageValue> m_unresolvedValue;
     bool m_isInvalid { false };
 };

--- a/Source/WebCore/css/typedom/CSSStyleImageValue.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleImageValue.cpp
@@ -30,24 +30,38 @@
 #include "config.h"
 #include "CSSStyleImageValue.h"
 
+#include "CSSImageValue.h"
 #include "CSSSerializationContext.h"
 #include "Document.h"
-
+#include "StyleCachedImage.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(CSSStyleImageValue);
 
-CSSStyleImageValue::CSSStyleImageValue(Ref<CSSImageValue>&& cssValue, Document* document)
+CSSStyleImageValue::CSSStyleImageValue(Ref<CSSImageValue>&& cssValue, Document& document)
     : m_cssValue(WTFMove(cssValue))
-    , m_document(document)
+    , m_styleImage(document.resourceStore()->ensureImage(Style::toStyleWithScriptExecutionContext(m_cssValue->url(), document)))
+    , m_document(&document)
 {
 }
+
+CSSStyleImageValue::~CSSStyleImageValue() = default;
 
 void CSSStyleImageValue::serialize(StringBuilder& builder, OptionSet<SerializationArguments>) const
 {
     builder.append(m_cssValue->cssText(CSS::defaultSerializationContext()));
+}
+
+CachedImage* CSSStyleImageValue::image()
+{
+    return m_styleImage->cachedImage();
+}
+
+bool CSSStyleImageValue::isLoadedFromOpaqueSource() const
+{
+    return m_cssValue->isLoadedFromOpaqueSource();
 }
 
 Document* CSSStyleImageValue::document() const

--- a/Source/WebCore/css/typedom/CSSStyleImageValue.h
+++ b/Source/WebCore/css/typedom/CSSStyleImageValue.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "CSSImageValue.h"
 #include "CSSStyleValue.h"
 #include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
@@ -33,21 +32,25 @@
 
 namespace WebCore {
 
+class CSSImageValue;
+class CachedImage;
 class Document;
+class StyleImage;
 class WeakPtrImplWithEventTargetData;
 
 class CSSStyleImageValue final : public CSSStyleValue {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSStyleImageValue);
 public:
-    static Ref<CSSStyleImageValue> create(Ref<CSSImageValue>&& cssValue, Document* document)
+    static Ref<CSSStyleImageValue> create(Ref<CSSImageValue>&& cssValue, Document& document)
     {
         return adoptRef(*new CSSStyleImageValue(WTFMove(cssValue), document));
     }
+    virtual ~CSSStyleImageValue();
 
     void serialize(StringBuilder&, OptionSet<SerializationArguments>) const final;
 
-    CachedImage* image() { return m_cssValue->cachedImage(); }
-    bool isLoadedFromOpaqueSource() const { return m_cssValue->isLoadedFromOpaqueSource(); }
+    CachedImage* image();
+    bool isLoadedFromOpaqueSource() const;
     Document* document() const;
     
     CSSStyleValueType getType() const final { return CSSStyleValueType::CSSStyleImageValue; }
@@ -55,9 +58,10 @@ public:
     RefPtr<CSSValue> toCSSValue() const final;
 
 private:
-    CSSStyleImageValue(Ref<CSSImageValue>&&, Document*);
+    CSSStyleImageValue(Ref<CSSImageValue>&&, Document&);
 
     Ref<CSSImageValue> m_cssValue;
+    Ref<StyleImage> m_styleImage;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 };
 

--- a/Source/WebCore/css/typedom/CSSStyleValue.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValue.cpp
@@ -43,10 +43,10 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(CSSStyleValue);
 
-ExceptionOr<Ref<CSSStyleValue>> CSSStyleValue::parse(const Document& document, const AtomString& property, const String& cssText)
+ExceptionOr<Ref<CSSStyleValue>> CSSStyleValue::parse(Document& document, const AtomString& property, const String& cssText)
 {
     constexpr bool parseMultiple = false;
-    auto parseResult = CSSStyleValueFactory::parseStyleValue(property, cssText, parseMultiple, { document });
+    auto parseResult = CSSStyleValueFactory::parseStyleValue(document, property, cssText, parseMultiple);
     if (parseResult.hasException())
         return parseResult.releaseException();
     
@@ -59,10 +59,10 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValue::parse(const Document& document, c
     return WTFMove(returnValue.at(0));
 }
 
-ExceptionOr<Vector<Ref<CSSStyleValue>>> CSSStyleValue::parseAll(const Document& document, const AtomString& property, const String& cssText)
+ExceptionOr<Vector<Ref<CSSStyleValue>>> CSSStyleValue::parseAll(Document& document, const AtomString& property, const String& cssText)
 {
     constexpr bool parseMultiple = true;
-    return CSSStyleValueFactory::parseStyleValue(property, cssText, parseMultiple, { document });
+    return CSSStyleValueFactory::parseStyleValue(document, property, cssText, parseMultiple);
 }
 
 Ref<CSSStyleValue> CSSStyleValue::create(RefPtr<CSSValue>&& cssValue, String&& property)

--- a/Source/WebCore/css/typedom/CSSStyleValue.h
+++ b/Source/WebCore/css/typedom/CSSStyleValue.h
@@ -116,8 +116,8 @@ IGNORE_GCC_WARNINGS_END
 
     virtual CSSStyleValueType getType() const { return CSSStyleValueType::CSSStyleValue; }
 
-    static ExceptionOr<Ref<CSSStyleValue>> parse(const Document&, const AtomString&, const String&);
-    static ExceptionOr<Vector<Ref<CSSStyleValue>>> parseAll(const Document&, const AtomString&, const String&);
+    static ExceptionOr<Ref<CSSStyleValue>> parse(Document&, const AtomString&, const String&);
+    static ExceptionOr<Vector<Ref<CSSStyleValue>>> parseAll(Document&, const AtomString&, const String&);
 
     static Ref<CSSStyleValue> create(RefPtr<CSSValue>&&, String&& = String());
     static Ref<CSSStyleValue> create();

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.h
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.h
@@ -44,10 +44,10 @@ class StylePropertyShorthand;
 
 class CSSStyleValueFactory {
 public:
-    static ExceptionOr<Ref<CSSStyleValue>> reifyValue(const CSSValue&, std::optional<CSSPropertyID>, Document* = nullptr);
-    static ExceptionOr<Vector<Ref<CSSStyleValue>>> parseStyleValue(const AtomString&, const String&, bool parseMultiple, const CSSParserContext&);
-    static RefPtr<CSSStyleValue> constructStyleValueForShorthandSerialization(const String&, const CSSParserContext&);
-    static ExceptionOr<Vector<Ref<CSSStyleValue>>> vectorFromStyleValuesOrStrings(const AtomString& property, FixedVector<std::variant<RefPtr<CSSStyleValue>, String>>&& values, const CSSParserContext&);
+    static ExceptionOr<Ref<CSSStyleValue>> reifyValue(Document&, const CSSValue&, std::optional<CSSPropertyID>);
+    static ExceptionOr<Vector<Ref<CSSStyleValue>>> parseStyleValue(Document&, const AtomString&, const String&, bool parseMultiple);
+    static RefPtr<CSSStyleValue> constructStyleValueForShorthandSerialization(Document&, const String&);
+    static ExceptionOr<Vector<Ref<CSSStyleValue>>> vectorFromStyleValuesOrStrings(Document&, const AtomString& property, FixedVector<std::variant<RefPtr<CSSStyleValue>, String>>&&);
 
     static RefPtr<CSSStyleValue> constructStyleValueForCustomPropertySyntaxValue(const CSSCustomPropertyValue::SyntaxValue&);
 
@@ -55,8 +55,8 @@ protected:
     CSSStyleValueFactory() = delete;
 
 private:
-    static ExceptionOr<RefPtr<CSSValue>> extractCSSValue(const CSSPropertyID&, const String&, const CSSParserContext&);
-    static ExceptionOr<RefPtr<CSSStyleValue>> extractShorthandCSSValues(const CSSPropertyID&, const String&, const CSSParserContext&);
+    static ExceptionOr<RefPtr<CSSValue>> extractCSSValue(Document&, const CSSPropertyID&, const String&);
+    static ExceptionOr<RefPtr<CSSStyleValue>> extractShorthandCSSValues(Document&, const CSSPropertyID&, const String&);
     static ExceptionOr<Ref<CSSUnparsedValue>> extractCustomCSSValues(const String&);
 };
 

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
@@ -106,12 +106,12 @@ Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> ComputedStylePropertyMap
     ComputedStyleExtractor extractor { element.get() };
     values.appendContainerWithMapping(exposedComputedCSSPropertyIDs, [&](auto propertyID) {
         auto value = extractor.propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::No, ComputedStyleExtractor::PropertyValueType::Computed);
-        return makeKeyValuePair(nameString(propertyID), StylePropertyMapReadOnly::reifyValueToVector(WTFMove(value), propertyID, document));
+        return makeKeyValuePair(nameString(propertyID), StylePropertyMapReadOnly::reifyValueToVector(document, WTFMove(value), propertyID));
     });
 
     for (auto* map : { &nonInheritedCustomProperties, &inheritedCustomProperties }) {
         map->forEach([&](auto& it) {
-            values.append(makeKeyValuePair(it.key, StylePropertyMapReadOnly::reifyValueToVector(const_cast<CSSCustomPropertyValue*>(it.value.get()), std::nullopt, document)));
+            values.append(makeKeyValuePair(it.key, StylePropertyMapReadOnly::reifyValueToVector(document, const_cast<CSSCustomPropertyValue*>(it.value.get()), std::nullopt)));
             return IterationStatus::Continue;
         });
     }

--- a/Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp
@@ -67,7 +67,7 @@ auto DeclaredStylePropertyMap::entries(ScriptExecutionContext* context) const ->
 
     auto& document = downcast<Document>(*context);
     return map(styleRule->properties(), [&] (auto propertyReference) {
-        return StylePropertyMapEntry { propertyReference.cssName(), reifyValueToVector(RefPtr<CSSValue> { propertyReference.value() }, propertyReference.id(), document) };
+        return StylePropertyMapEntry { propertyReference.cssName(), reifyValueToVector(document, RefPtr<CSSValue> { propertyReference.value() }, propertyReference.id()) };
     });
 }
 

--- a/Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.cpp
@@ -71,7 +71,7 @@ auto HashMapStylePropertyMapReadOnly::entries(ScriptExecutionContext* context) c
 
     return WTF::map(m_map, [&](auto& entry) -> StylePropertyMapEntry {
         auto& [propertyName, cssValue] = entry;
-        return makeKeyValuePair(propertyName,  Vector<RefPtr<CSSStyleValue>> { reifyValue(cssValue.get(), cssPropertyID(propertyName), *document) });
+        return makeKeyValuePair(propertyName,  Vector<RefPtr<CSSStyleValue>> { reifyValue(*document, cssValue.get(), cssPropertyID(propertyName)) });
     });
 }
 

--- a/Source/WebCore/css/typedom/InlineStylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/InlineStylePropertyMap.cpp
@@ -83,7 +83,7 @@ auto InlineStylePropertyMap::entries(ScriptExecutionContext* context) const -> V
 
     auto& document = downcast<Document>(*context);
     return map(*inlineStyle, [&document] (auto property) {
-        return StylePropertyMapEntry(property.cssName(), reifyValueToVector(RefPtr<CSSValue> { property.value() }, property.id(), document));
+        return StylePropertyMapEntry(property.cssName(), reifyValueToVector(document, RefPtr<CSSValue> { property.value() }, property.id()));
     });
 }
 

--- a/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp
@@ -61,7 +61,7 @@ ExceptionOr<MainThreadStylePropertyMapReadOnly::CSSStyleValueOrUndefined> MainTh
         return { std::monostate { } };
 
     if (isCustomPropertyName(property)) {
-        if (auto value = reifyValue(customPropertyValue(property), std::nullopt, *document))
+        if (auto value = reifyValue(*document, customPropertyValue(property), std::nullopt))
             return { WTFMove(value) };
 
         return { std::monostate { } };
@@ -72,13 +72,13 @@ ExceptionOr<MainThreadStylePropertyMapReadOnly::CSSStyleValueOrUndefined> MainTh
         return Exception { ExceptionCode::TypeError, makeString("Invalid property "_s, property) };
 
     if (isShorthand(propertyID)) {
-        if (auto value = CSSStyleValueFactory::constructStyleValueForShorthandSerialization(shorthandPropertySerialization(propertyID), { *document }))
+        if (auto value = CSSStyleValueFactory::constructStyleValueForShorthandSerialization(*document, shorthandPropertySerialization(propertyID)))
             return { WTFMove(value) };
 
         return { std::monostate { } };
     }
 
-    if (auto value = reifyValue(propertyValue(propertyID), propertyID, *document))
+    if (auto value = reifyValue(*document, propertyValue(propertyID), propertyID))
         return { WTFMove(value) };
 
     return { std::monostate { } };
@@ -92,19 +92,19 @@ ExceptionOr<Vector<RefPtr<CSSStyleValue>>> MainThreadStylePropertyMapReadOnly::g
         return Vector<RefPtr<CSSStyleValue>> { };
 
     if (isCustomPropertyName(property))
-        return reifyValueToVector(customPropertyValue(property), std::nullopt, *document);
+        return reifyValueToVector(*document, customPropertyValue(property), std::nullopt);
 
     auto propertyID = cssPropertyID(property);
     if (!isExposed(propertyID, &document->settings()))
         return Exception { ExceptionCode::TypeError, makeString("Invalid property "_s, property) };
 
     if (isShorthand(propertyID)) {
-        if (RefPtr value = CSSStyleValueFactory::constructStyleValueForShorthandSerialization(shorthandPropertySerialization(propertyID), { *document }))
+        if (RefPtr value = CSSStyleValueFactory::constructStyleValueForShorthandSerialization(*document, shorthandPropertySerialization(propertyID)))
             return Vector<RefPtr<CSSStyleValue>> { WTFMove(value) };
         return Vector<RefPtr<CSSStyleValue>> { };
     }
 
-    return reifyValueToVector(propertyValue(propertyID), propertyID, *document);
+    return reifyValueToVector(*document, propertyValue(propertyID), propertyID);
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-has

--- a/Source/WebCore/css/typedom/StylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/StylePropertyMap.cpp
@@ -66,7 +66,7 @@ static RefPtr<CSSValue> cssValueFromStyleValues(CSSPropertyID propertyID, Vector
 ExceptionOr<void> StylePropertyMap::set(Document& document, const AtomString& property, FixedVector<std::variant<RefPtr<CSSStyleValue>, String>>&& values)
 {
     if (isCustomPropertyName(property)) {
-        auto styleValuesOrException = CSSStyleValueFactory::vectorFromStyleValuesOrStrings(property, WTFMove(values), { document });
+        auto styleValuesOrException = CSSStyleValueFactory::vectorFromStyleValuesOrStrings(document, property, WTFMove(values));
         if (styleValuesOrException.hasException())
             return styleValuesOrException.releaseException();
         auto styleValues = styleValuesOrException.releaseReturnValue();
@@ -100,7 +100,7 @@ ExceptionOr<void> StylePropertyMap::set(Document& document, const AtomString& pr
         return { };
     }
 
-    auto styleValuesOrException = CSSStyleValueFactory::vectorFromStyleValuesOrStrings(property, WTFMove(values), { document });
+    auto styleValuesOrException = CSSStyleValueFactory::vectorFromStyleValuesOrStrings(document, property, WTFMove(values));
     if (styleValuesOrException.hasException())
         return styleValuesOrException.releaseException();
     auto styleValues = styleValuesOrException.releaseReturnValue();
@@ -164,7 +164,7 @@ ExceptionOr<void> StylePropertyMap::append(Document& document, const AtomString&
     else if (currentValue)
         list.append(currentValue.releaseNonNull());
 
-    auto styleValuesOrException = CSSStyleValueFactory::vectorFromStyleValuesOrStrings(property, WTFMove(values), { document });
+    auto styleValuesOrException = CSSStyleValueFactory::vectorFromStyleValuesOrStrings(document, property, WTFMove(values));
     if (styleValuesOrException.hasException())
         return styleValuesOrException.releaseException();
 

--- a/Source/WebCore/css/typedom/StylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/StylePropertyMapReadOnly.cpp
@@ -44,15 +44,15 @@
 
 namespace WebCore {
 
-RefPtr<CSSStyleValue> StylePropertyMapReadOnly::reifyValue(RefPtr<CSSValue>&& value, std::optional<CSSPropertyID> propertyID, Document& document)
+RefPtr<CSSStyleValue> StylePropertyMapReadOnly::reifyValue(Document& document, RefPtr<CSSValue>&& value, std::optional<CSSPropertyID> propertyID)
 {
     if (!value)
         return nullptr;
-    auto result = CSSStyleValueFactory::reifyValue(value.releaseNonNull(), propertyID, &document);
+    auto result = CSSStyleValueFactory::reifyValue(document, value.releaseNonNull(), propertyID);
     return (result.hasException() ? nullptr : RefPtr<CSSStyleValue> { result.releaseReturnValue() });
 }
 
-Vector<RefPtr<CSSStyleValue>> StylePropertyMapReadOnly::reifyValueToVector(RefPtr<CSSValue>&& value, std::optional<CSSPropertyID> propertyID, Document& document)
+Vector<RefPtr<CSSStyleValue>> StylePropertyMapReadOnly::reifyValueToVector(Document& document, RefPtr<CSSValue>&& value, std::optional<CSSPropertyID> propertyID)
 {
     if (!value)
         return { };
@@ -75,10 +75,10 @@ Vector<RefPtr<CSSStyleValue>> StylePropertyMapReadOnly::reifyValueToVector(RefPt
 
     auto* valueList = dynamicDowncast<CSSValueList>(*value);
     if (!valueList || (propertyID && !CSSProperty::isListValuedProperty(*propertyID)))
-        return { StylePropertyMapReadOnly::reifyValue(WTFMove(value), propertyID, document) };
+        return { StylePropertyMapReadOnly::reifyValue(document, WTFMove(value), propertyID) };
 
     return WTF::map(*valueList, [&](auto& item) {
-        return StylePropertyMapReadOnly::reifyValue(Ref { const_cast<CSSValue&>(item) }, propertyID, document);
+        return StylePropertyMapReadOnly::reifyValue(document, Ref { const_cast<CSSValue&>(item) }, propertyID);
     });
 }
 

--- a/Source/WebCore/css/typedom/StylePropertyMapReadOnly.h
+++ b/Source/WebCore/css/typedom/StylePropertyMapReadOnly.h
@@ -69,8 +69,8 @@ public:
     virtual ExceptionOr<bool> has(ScriptExecutionContext&, const AtomString&) const = 0;
     virtual unsigned size() const = 0;
 
-    static RefPtr<CSSStyleValue> reifyValue(RefPtr<CSSValue>&&, std::optional<CSSPropertyID>, Document&);
-    static Vector<RefPtr<CSSStyleValue>> reifyValueToVector(RefPtr<CSSValue>&&, std::optional<CSSPropertyID>, Document&);
+    static RefPtr<CSSStyleValue> reifyValue(Document&, RefPtr<CSSValue>&&, std::optional<CSSPropertyID>);
+    static Vector<RefPtr<CSSStyleValue>> reifyValueToVector(Document&, RefPtr<CSSValue>&&, std::optional<CSSPropertyID>);
 
 protected:
     virtual Vector<StylePropertyMapEntry> entries(ScriptExecutionContext*) const = 0;

--- a/Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp
@@ -52,12 +52,12 @@ Ref<CSSTransformComponent> CSSMatrixComponent::create(Ref<DOMMatrixReadOnly>&& m
     return adoptRef(*new CSSMatrixComponent(WTFMove(matrix), is2D ? Is2D::Yes : Is2D::No));
 }
 
-ExceptionOr<Ref<CSSTransformComponent>> CSSMatrixComponent::create(Ref<const CSSFunctionValue> cssFunctionValue)
+ExceptionOr<Ref<CSSTransformComponent>> CSSMatrixComponent::create(Ref<const CSSFunctionValue> cssFunctionValue, Document& document)
 {
     auto makeMatrix = [&](NOESCAPE const Function<Ref<CSSTransformComponent>(Vector<double>&&)>& create, size_t expectedNumberOfComponents) -> ExceptionOr<Ref<CSSTransformComponent>> {
         Vector<double> components;
         for (auto& componentCSSValue : cssFunctionValue.get()) {
-            auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue, std::nullopt);
+            auto valueOrException = CSSStyleValueFactory::reifyValue(document, componentCSSValue, std::nullopt);
             if (valueOrException.hasException())
                 return valueOrException.releaseException();
             RefPtr unitValue = dynamicDowncast<CSSUnitValue>(valueOrException.releaseReturnValue());

--- a/Source/WebCore/css/typedom/transform/CSSPerspective.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSPerspective.cpp
@@ -71,7 +71,7 @@ ExceptionOr<Ref<CSSPerspective>> CSSPerspective::create(CSSPerspectiveValue leng
     return adoptRef(*new CSSPerspective(checkedLength.releaseReturnValue()));
 }
 
-ExceptionOr<Ref<CSSPerspective>> CSSPerspective::create(Ref<const CSSFunctionValue> cssFunctionValue)
+ExceptionOr<Ref<CSSPerspective>> CSSPerspective::create(Ref<const CSSFunctionValue> cssFunctionValue, Document& document)
 {
     if (cssFunctionValue->name() != CSSValuePerspective) {
         ASSERT_NOT_REACHED();
@@ -83,7 +83,7 @@ ExceptionOr<Ref<CSSPerspective>> CSSPerspective::create(Ref<const CSSFunctionVal
         return Exception { ExceptionCode::TypeError, "Unexpected number of values."_s };
     }
 
-    auto keywordOrNumeric = CSSStyleValueFactory::reifyValue(*cssFunctionValue->item(0), std::nullopt);
+    auto keywordOrNumeric = CSSStyleValueFactory::reifyValue(document, *cssFunctionValue->item(0), std::nullopt);
     if (keywordOrNumeric.hasException())
         return keywordOrNumeric.releaseException();
     auto& keywordOrNumericValue = keywordOrNumeric.returnValue().get();

--- a/Source/WebCore/css/typedom/transform/CSSPerspective.h
+++ b/Source/WebCore/css/typedom/transform/CSSPerspective.h
@@ -34,12 +34,13 @@ namespace WebCore {
 template<typename> class ExceptionOr;
 class CSSFunctionValue;
 using CSSPerspectiveValue = std::variant<RefPtr<CSSNumericValue>, String, RefPtr<CSSKeywordValue>>;
+class Document;
 
 class CSSPerspective : public CSSTransformComponent {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSPerspective);
 public:
     static ExceptionOr<Ref<CSSPerspective>> create(CSSPerspectiveValue);
-    static ExceptionOr<Ref<CSSPerspective>> create(Ref<const CSSFunctionValue>);
+    static ExceptionOr<Ref<CSSPerspective>> create(Ref<const CSSFunctionValue>, Document&);
 
     virtual ~CSSPerspective();
 

--- a/Source/WebCore/css/typedom/transform/CSSRotate.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSRotate.cpp
@@ -72,12 +72,12 @@ ExceptionOr<Ref<CSSRotate>> CSSRotate::create(Ref<CSSNumericValue> angle)
         WTFMove(angle)));
 }
 
-ExceptionOr<Ref<CSSRotate>> CSSRotate::create(Ref<const CSSFunctionValue> cssFunctionValue)
+ExceptionOr<Ref<CSSRotate>> CSSRotate::create(Ref<const CSSFunctionValue> cssFunctionValue, Document& document)
 {
     auto makeRotate = [&](NOESCAPE const Function<ExceptionOr<Ref<CSSRotate>>(Vector<RefPtr<CSSNumericValue>>&&)>& create, size_t expectedNumberOfComponents) -> ExceptionOr<Ref<CSSRotate>> {
         Vector<RefPtr<CSSNumericValue>> components;
         for (auto& componentCSSValue : cssFunctionValue.get()) {
-            auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue, std::nullopt);
+            auto valueOrException = CSSStyleValueFactory::reifyValue(document, componentCSSValue, std::nullopt);
             if (valueOrException.hasException())
                 return valueOrException.releaseException();
             RefPtr numericValue = dynamicDowncast<CSSNumericValue>(valueOrException.releaseReturnValue());

--- a/Source/WebCore/css/typedom/transform/CSSRotate.h
+++ b/Source/WebCore/css/typedom/transform/CSSRotate.h
@@ -31,6 +31,7 @@
 namespace WebCore {
 
 class CSSFunctionValue;
+class Document;
 
 template<typename> class ExceptionOr;
 
@@ -39,7 +40,7 @@ class CSSRotate : public CSSTransformComponent {
 public:
     static ExceptionOr<Ref<CSSRotate>> create(CSSNumberish, CSSNumberish, CSSNumberish, Ref<CSSNumericValue>);
     static ExceptionOr<Ref<CSSRotate>> create(Ref<CSSNumericValue>);
-    static ExceptionOr<Ref<CSSRotate>> create(Ref<const CSSFunctionValue>);
+    static ExceptionOr<Ref<CSSRotate>> create(Ref<const CSSFunctionValue>, Document&);
 
     CSSNumberish x() { return { m_x.ptr() }; }
     CSSNumberish y() { return { m_y.ptr() }; }

--- a/Source/WebCore/css/typedom/transform/CSSScale.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSScale.cpp
@@ -63,12 +63,12 @@ ExceptionOr<Ref<CSSScale>> CSSScale::create(CSSNumberish x, CSSNumberish y, std:
     return adoptRef(*new CSSScale(z ? Is2D::No : Is2D::Yes, WTFMove(rectifiedX), WTFMove(rectifiedY), WTFMove(rectifiedZ)));
 }
 
-ExceptionOr<Ref<CSSScale>> CSSScale::create(Ref<const CSSFunctionValue> cssFunctionValue)
+ExceptionOr<Ref<CSSScale>> CSSScale::create(Ref<const CSSFunctionValue> cssFunctionValue, Document& document)
 {
     auto makeScale = [&](NOESCAPE const Function<ExceptionOr<Ref<CSSScale>>(Vector<RefPtr<CSSNumericValue>>&&)>& create, size_t minNumberOfComponents, std::optional<size_t> maxNumberOfComponents = std::nullopt) -> ExceptionOr<Ref<CSSScale>> {
         Vector<RefPtr<CSSNumericValue>> components;
         for (auto& componentCSSValue : cssFunctionValue.get()) {
-            auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue, std::nullopt);
+            auto valueOrException = CSSStyleValueFactory::reifyValue(document, componentCSSValue, std::nullopt);
             if (valueOrException.hasException())
                 return valueOrException.releaseException();
             RefPtr numericValue = dynamicDowncast<CSSNumericValue>(valueOrException.releaseReturnValue());

--- a/Source/WebCore/css/typedom/transform/CSSScale.h
+++ b/Source/WebCore/css/typedom/transform/CSSScale.h
@@ -31,6 +31,7 @@
 namespace WebCore {
 
 class CSSFunctionValue;
+class Document;
 
 template<typename> class ExceptionOr;
 
@@ -38,7 +39,7 @@ class CSSScale : public CSSTransformComponent {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSScale);
 public:
     static ExceptionOr<Ref<CSSScale>> create(CSSNumberish x, CSSNumberish y, std::optional<CSSNumberish>&& z);
-    static ExceptionOr<Ref<CSSScale>> create(Ref<const CSSFunctionValue>);
+    static ExceptionOr<Ref<CSSScale>> create(Ref<const CSSFunctionValue>, Document&);
 
     void serialize(StringBuilder&) const final;
     ExceptionOr<Ref<DOMMatrix>> toMatrix() final;

--- a/Source/WebCore/css/typedom/transform/CSSSkew.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSSkew.cpp
@@ -51,7 +51,7 @@ ExceptionOr<Ref<CSSSkew>> CSSSkew::create(Ref<CSSNumericValue> ax, Ref<CSSNumeri
     return adoptRef(*new CSSSkew(WTFMove(ax), WTFMove(ay)));
 }
 
-ExceptionOr<Ref<CSSSkew>> CSSSkew::create(Ref<const CSSFunctionValue> cssFunctionValue)
+ExceptionOr<Ref<CSSSkew>> CSSSkew::create(Ref<const CSSFunctionValue> cssFunctionValue, Document& document)
 {
     if (cssFunctionValue->name() != CSSValueSkew) {
         ASSERT_NOT_REACHED();
@@ -60,7 +60,7 @@ ExceptionOr<Ref<CSSSkew>> CSSSkew::create(Ref<const CSSFunctionValue> cssFunctio
 
     Vector<Ref<CSSNumericValue>> components;
     for (auto& componentCSSValue : cssFunctionValue.get()) {
-        auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue, std::nullopt);
+        auto valueOrException = CSSStyleValueFactory::reifyValue(document, componentCSSValue, std::nullopt);
         if (valueOrException.hasException())
             return valueOrException.releaseException();
         RefPtr numericValue = dynamicDowncast<CSSNumericValue>(valueOrException.releaseReturnValue());

--- a/Source/WebCore/css/typedom/transform/CSSSkew.h
+++ b/Source/WebCore/css/typedom/transform/CSSSkew.h
@@ -31,6 +31,7 @@
 namespace WebCore {
 
 class CSSFunctionValue;
+class Document;
 
 template<typename> class ExceptionOr;
 
@@ -38,7 +39,7 @@ class CSSSkew : public CSSTransformComponent {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSSkew);
 public:
     static ExceptionOr<Ref<CSSSkew>> create(Ref<CSSNumericValue>, Ref<CSSNumericValue>);
-    static ExceptionOr<Ref<CSSSkew>> create(Ref<const CSSFunctionValue>);
+    static ExceptionOr<Ref<CSSSkew>> create(Ref<const CSSFunctionValue>, Document&);
 
     const CSSNumericValue& ax() const { return m_ax.get(); }
     const CSSNumericValue& ay() const { return m_ay.get(); }

--- a/Source/WebCore/css/typedom/transform/CSSSkewX.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSSkewX.cpp
@@ -49,7 +49,7 @@ ExceptionOr<Ref<CSSSkewX>> CSSSkewX::create(Ref<CSSNumericValue> ax)
     return adoptRef(*new CSSSkewX(WTFMove(ax)));
 }
 
-ExceptionOr<Ref<CSSSkewX>> CSSSkewX::create(Ref<const CSSFunctionValue> cssFunctionValue)
+ExceptionOr<Ref<CSSSkewX>> CSSSkewX::create(Ref<const CSSFunctionValue> cssFunctionValue, Document& document)
 {
     if (cssFunctionValue->name() != CSSValueSkewX) {
         ASSERT_NOT_REACHED();
@@ -61,7 +61,7 @@ ExceptionOr<Ref<CSSSkewX>> CSSSkewX::create(Ref<const CSSFunctionValue> cssFunct
         return Exception { ExceptionCode::TypeError, "Unexpected number of values."_s };
     }
 
-    auto valueOrException = CSSStyleValueFactory::reifyValue(*cssFunctionValue->item(0), std::nullopt);
+    auto valueOrException = CSSStyleValueFactory::reifyValue(document, *cssFunctionValue->item(0), std::nullopt);
     if (valueOrException.hasException())
         return valueOrException.releaseException();
     RefPtr numericValue = dynamicDowncast<CSSNumericValue>(valueOrException.releaseReturnValue());

--- a/Source/WebCore/css/typedom/transform/CSSSkewX.h
+++ b/Source/WebCore/css/typedom/transform/CSSSkewX.h
@@ -31,6 +31,7 @@
 namespace WebCore {
 
 class CSSFunctionValue;
+class Document;
 
 template<typename> class ExceptionOr;
 
@@ -38,7 +39,7 @@ class CSSSkewX : public CSSTransformComponent {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSSkewX);
 public:
     static ExceptionOr<Ref<CSSSkewX>> create(Ref<CSSNumericValue>);
-    static ExceptionOr<Ref<CSSSkewX>> create(Ref<const CSSFunctionValue>);
+    static ExceptionOr<Ref<CSSSkewX>> create(Ref<const CSSFunctionValue>, Document&);
 
     const CSSNumericValue& ax() const { return m_ax.get(); }
     ExceptionOr<void> setAx(Ref<CSSNumericValue>);

--- a/Source/WebCore/css/typedom/transform/CSSSkewY.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSSkewY.cpp
@@ -49,7 +49,7 @@ ExceptionOr<Ref<CSSSkewY>> CSSSkewY::create(Ref<CSSNumericValue> ay)
     return adoptRef(*new CSSSkewY(WTFMove(ay)));
 }
 
-ExceptionOr<Ref<CSSSkewY>> CSSSkewY::create(Ref<const CSSFunctionValue> cssFunctionValue)
+ExceptionOr<Ref<CSSSkewY>> CSSSkewY::create(Ref<const CSSFunctionValue> cssFunctionValue, Document& document)
 {
     if (cssFunctionValue->name() != CSSValueSkewY) {
         ASSERT_NOT_REACHED();
@@ -61,7 +61,7 @@ ExceptionOr<Ref<CSSSkewY>> CSSSkewY::create(Ref<const CSSFunctionValue> cssFunct
         return Exception { ExceptionCode::TypeError, "Unexpected number of values."_s };
     }
 
-    auto valueOrException = CSSStyleValueFactory::reifyValue(*cssFunctionValue->item(0), std::nullopt);
+    auto valueOrException = CSSStyleValueFactory::reifyValue(document, *cssFunctionValue->item(0), std::nullopt);
     if (valueOrException.hasException())
         return valueOrException.releaseException();
     RefPtr numericValue = dynamicDowncast<CSSNumericValue>(valueOrException.releaseReturnValue());

--- a/Source/WebCore/css/typedom/transform/CSSSkewY.h
+++ b/Source/WebCore/css/typedom/transform/CSSSkewY.h
@@ -31,6 +31,7 @@
 namespace WebCore {
 
 class CSSFunctionValue;
+class Document;
 
 template<typename> class ExceptionOr;
 
@@ -38,7 +39,7 @@ class CSSSkewY : public CSSTransformComponent {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSSkewY);
 public:
     static ExceptionOr<Ref<CSSSkewY>> create(Ref<CSSNumericValue>);
-    static ExceptionOr<Ref<CSSSkewY>> create(Ref<const CSSFunctionValue>);
+    static ExceptionOr<Ref<CSSSkewY>> create(Ref<const CSSFunctionValue>, Document&);
 
     const CSSNumericValue& ay() const { return m_ay.get(); }
     ExceptionOr<void> setAy(Ref<CSSNumericValue>);

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
@@ -53,7 +53,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(CSSTransformValue);
 
-static ExceptionOr<Ref<CSSTransformComponent>> createTransformComponent(Ref<const CSSFunctionValue> functionValue)
+static ExceptionOr<Ref<CSSTransformComponent>> createTransformComponent(Ref<const CSSFunctionValue> functionValue, Document& document)
 {
     auto makeTransformComponent = [&](auto exceptionOrTransformComponent) -> ExceptionOr<Ref<CSSTransformComponent>> {
         if (exceptionOrTransformComponent.hasException())
@@ -67,43 +67,43 @@ static ExceptionOr<Ref<CSSTransformComponent>> createTransformComponent(Ref<cons
     case CSSValueTranslateZ:
     case CSSValueTranslate:
     case CSSValueTranslate3d:
-        return makeTransformComponent(CSSTranslate::create(WTFMove(functionValue)));
+        return makeTransformComponent(CSSTranslate::create(WTFMove(functionValue), document));
     case CSSValueScaleX:
     case CSSValueScaleY:
     case CSSValueScaleZ:
     case CSSValueScale:
     case CSSValueScale3d:
-        return makeTransformComponent(CSSScale::create(WTFMove(functionValue)));
+        return makeTransformComponent(CSSScale::create(WTFMove(functionValue), document));
     case CSSValueRotateX:
     case CSSValueRotateY:
     case CSSValueRotateZ:
     case CSSValueRotate:
     case CSSValueRotate3d:
-        return makeTransformComponent(CSSRotate::create(WTFMove(functionValue)));
+        return makeTransformComponent(CSSRotate::create(WTFMove(functionValue), document));
     case CSSValueSkewX:
-        return makeTransformComponent(CSSSkewX::create(WTFMove(functionValue)));
+        return makeTransformComponent(CSSSkewX::create(WTFMove(functionValue), document));
     case CSSValueSkewY:
-        return makeTransformComponent(CSSSkewY::create(WTFMove(functionValue)));
+        return makeTransformComponent(CSSSkewY::create(WTFMove(functionValue), document));
     case CSSValueSkew:
-        return makeTransformComponent(CSSSkew::create(WTFMove(functionValue)));
+        return makeTransformComponent(CSSSkew::create(WTFMove(functionValue), document));
     case CSSValuePerspective:
-        return makeTransformComponent(CSSPerspective::create(WTFMove(functionValue)));
+        return makeTransformComponent(CSSPerspective::create(WTFMove(functionValue), document));
     case CSSValueMatrix:
     case CSSValueMatrix3d:
-        return makeTransformComponent(CSSMatrixComponent::create(WTFMove(functionValue)));
+        return makeTransformComponent(CSSMatrixComponent::create(WTFMove(functionValue), document));
     default:
         return Exception { ExceptionCode::TypeError, "Unexpected function value type"_s };
     }
 }
 
-ExceptionOr<Ref<CSSTransformValue>> CSSTransformValue::create(Ref<const CSSTransformListValue> list)
+ExceptionOr<Ref<CSSTransformValue>> CSSTransformValue::create(Ref<const CSSTransformListValue> list, Document& document)
 {
     Vector<Ref<CSSTransformComponent>> components;
     for (auto& value : list.get()) {
         RefPtr functionValue = dynamicDowncast<CSSFunctionValue>(value);
         if (!functionValue)
             return Exception { ExceptionCode::TypeError, "Expected only function values in a transform list."_s };
-        auto component = createTransformComponent(functionValue.releaseNonNull());
+        auto component = createTransformComponent(functionValue.releaseNonNull(), document);
         if (component.hasException())
             return component.releaseException();
         components.append(component.releaseReturnValue());

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.h
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.h
@@ -34,12 +34,13 @@ namespace WebCore {
 class CSSTransformComponent;
 class CSSTransformListValue;
 class DOMMatrix;
+class Document;
 template<typename> class ExceptionOr;
 
 class CSSTransformValue final : public CSSStyleValue {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSTransformValue);
 public:
-    static ExceptionOr<Ref<CSSTransformValue>> create(Ref<const CSSTransformListValue>);
+    static ExceptionOr<Ref<CSSTransformValue>> create(Ref<const CSSTransformListValue>, Document&);
     static ExceptionOr<Ref<CSSTransformValue>> create(Vector<Ref<CSSTransformComponent>>&&);
 
     virtual ~CSSTransformValue();

--- a/Source/WebCore/css/typedom/transform/CSSTranslate.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSTranslate.cpp
@@ -58,12 +58,12 @@ ExceptionOr<Ref<CSSTranslate>> CSSTranslate::create(Ref<CSSNumericValue> x, Ref<
     return adoptRef(*new CSSTranslate(is2D, WTFMove(x), WTFMove(y), z.releaseNonNull()));
 }
 
-ExceptionOr<Ref<CSSTranslate>> CSSTranslate::create(Ref<const CSSFunctionValue> cssFunctionValue)
+ExceptionOr<Ref<CSSTranslate>> CSSTranslate::create(Ref<const CSSFunctionValue> cssFunctionValue, Document& document)
 {
     auto makeTranslate = [&](NOESCAPE const Function<ExceptionOr<Ref<CSSTranslate>>(Vector<Ref<CSSNumericValue>>&&)>& create, size_t minNumberOfComponents, std::optional<size_t> maxNumberOfComponents = std::nullopt) -> ExceptionOr<Ref<CSSTranslate>> {
         Vector<Ref<CSSNumericValue>> components;
         for (auto& componentCSSValue : cssFunctionValue.get()) {
-            auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue, std::nullopt);
+            auto valueOrException = CSSStyleValueFactory::reifyValue(document, componentCSSValue, std::nullopt);
             if (valueOrException.hasException())
                 return valueOrException.releaseException();
             RefPtr numericValue = dynamicDowncast<CSSNumericValue>(valueOrException.releaseReturnValue());

--- a/Source/WebCore/css/typedom/transform/CSSTranslate.h
+++ b/Source/WebCore/css/typedom/transform/CSSTranslate.h
@@ -31,6 +31,7 @@
 namespace WebCore {
 
 class CSSFunctionValue;
+class Document;
 
 template<typename> class ExceptionOr;
 
@@ -38,7 +39,7 @@ class CSSTranslate : public CSSTransformComponent {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSTranslate);
 public:
     static ExceptionOr<Ref<CSSTranslate>> create(Ref<CSSNumericValue> x, Ref<CSSNumericValue> y, RefPtr<CSSNumericValue> z);
-    static ExceptionOr<Ref<CSSTranslate>> create(Ref<const CSSFunctionValue>);
+    static ExceptionOr<Ref<CSSTranslate>> create(Ref<const CSSFunctionValue>, Document&);
 
     const CSSNumericValue& x() const { return m_x.get(); }
     const CSSNumericValue& y() const { return m_y.get(); }

--- a/Source/WebCore/css/values/primitives/CSSURLModifiers.h
+++ b/Source/WebCore/css/values/primitives/CSSURLModifiers.h
@@ -26,6 +26,7 @@
 
 #include "CSSValueTypes.h"
 #include "LoadedFromOpaqueSource.h"
+#include <wtf/Hasher.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -71,6 +72,9 @@ struct URLModifiers {
     // This is not a parsed value, but is implicit from context the modifiers were parsed with.
     LoadedFromOpaqueSource loadedFromOpaqueSource { LoadedFromOpaqueSource::No };
 
+    // This is not a parsed value, but is added in some cases to override the default initiator type.
+    AtomString initiatorType { nullAtom() };
+
     bool operator==(const URLModifiers&) const = default;
 };
 
@@ -82,6 +86,24 @@ template<size_t I> const auto& get(const URLModifiers& value)
         return value.integrity;
     else if constexpr (I == 2)
         return value.referrerpolicy;
+}
+
+inline void add(Hasher& hasher, const URLModifiers& value)
+{
+    add(hasher, value.crossorigin.has_value());
+    if (value.crossorigin)
+        add(hasher, value.crossorigin->parameters.index());
+
+    add(hasher, value.integrity.has_value());
+    if (value.integrity)
+        add(hasher, value.integrity->parameters);
+
+    add(hasher, value.referrerpolicy.has_value());
+    if (value.referrerpolicy)
+        add(hasher, value.referrerpolicy->parameters.index());
+
+    add(hasher, value.loadedFromOpaqueSource);
+    add(hasher, value.initiatorType);
 }
 
 // Applies `URLModifiers` to `ResourceLoaderOptions`.

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -662,6 +662,7 @@ Document::Document(LocalFrame* frame, const Settings& settings, const URL& url, 
     , m_isNonRenderedPlaceholder(constructionFlags.contains(ConstructionFlag::NonRenderedPlaceholder))
     , m_frameIdentifier(frame ? std::optional(frame->frameID()) : std::nullopt)
     , m_syncData(DocumentSyncData::create())
+    , m_resourceStore(Style::ResourceStore::create())
 {
     setEventTargetFlag(EventTargetFlag::IsConnected);
     addToDocumentsMap();

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -51,6 +51,7 @@
 #include "ScriptExecutionContext.h"
 #include "SpatialBackdropSource.h"
 #include "StringWithDirection.h"
+#include "StyleResourceStore.h"
 #include "Supplementable.h"
 #include "TextIndicator.h"
 #include "Timer.h"
@@ -1998,6 +1999,7 @@ public:
     void attributeAddedToElement(const QualifiedName& attribute);
     void elementDisconnectedFromDocument(const Element&);
 
+    Ref<Style::ResourceStore> resourceStore() const { return m_resourceStore; }
 
 protected:
     enum class ConstructionFlag : uint8_t {
@@ -2731,6 +2733,8 @@ private:
     mutable RefPtr<CSSCalc::RandomCachingKeyMap> m_randomCachingKeyMap;
 
     Ref<DocumentSyncData> m_syncData;
+
+    Ref<Style::ResourceStore> m_resourceStore;
 }; // class Document
 
 Element* eventTargetElementForDocument(Document*);

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -310,7 +310,11 @@ void PageSerializer::retrieveResourcesForProperties(const StyleProperties* style
         if (!cssValue)
             continue;
 
-        auto* image = cssValue->cachedImage();
+        auto styleImage = document->resourceStore()->image(Style::toStyleWithScriptExecutionContext(cssValue->url(), *document));
+        if (!styleImage)
+            continue;
+
+        auto* image = styleImage->cachedImage();
         if (!image)
             continue;
 

--- a/Source/WebCore/rendering/style/StyleCachedImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCachedImage.cpp
@@ -26,6 +26,9 @@
 
 #include "CSSImageValue.h"
 #include "CachedImage.h"
+#include "CachedResourceLoader.h"
+#include "CachedResourceRequest.h"
+#include "CachedResourceRequestInitiatorTypes.h"
 #include "ReferencedSVGResources.h"
 #include "RenderElement.h"
 #include "RenderObjectInlines.h"
@@ -42,43 +45,35 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(StyleCachedImage);
 
-Ref<StyleCachedImage> StyleCachedImage::create(Style::URL&& url, Ref<CSSImageValue>&& cssValue, float scaleFactor)
+Ref<StyleCachedImage> StyleCachedImage::create(Style::URL&& url, float scaleFactor)
 {
-    return adoptRef(*new StyleCachedImage(WTFMove(url), WTFMove(cssValue), scaleFactor));
+    return adoptRef(*new StyleCachedImage(WTFMove(url), scaleFactor));
 }
 
-Ref<StyleCachedImage> StyleCachedImage::create(const Style::URL& url, const Ref<CSSImageValue>& cssValue, float scaleFactor)
+Ref<StyleCachedImage> StyleCachedImage::create(const Style::URL& url, float scaleFactor)
 {
-    return adoptRef(*new StyleCachedImage(url, cssValue, scaleFactor));
+    return adoptRef(*new StyleCachedImage(url, scaleFactor));
 }
 
 Ref<StyleCachedImage> StyleCachedImage::copyOverridingScaleFactor(StyleCachedImage& other, float scaleFactor)
 {
     if (other.m_scaleFactor == scaleFactor)
         return other;
-    return StyleCachedImage::create(other.m_url, other.m_cssValue, scaleFactor);
+    return StyleCachedImage::create(other.m_url, scaleFactor);
 }
 
-StyleCachedImage::StyleCachedImage(Style::URL&& url, Ref<CSSImageValue>&& cssValue, float scaleFactor)
+StyleCachedImage::StyleCachedImage(Style::URL&& url, float scaleFactor)
     : StyleImage { Type::CachedImage }
     , m_url { WTFMove(url) }
-    , m_cssValue { WTFMove(cssValue) }
     , m_scaleFactor { scaleFactor }
 {
-    m_cachedImage = m_cssValue->cachedImage();
-    if (m_cachedImage)
-        m_isPending = false;
 }
 
-StyleCachedImage::StyleCachedImage(const Style::URL& url, const Ref<CSSImageValue>& cssValue, float scaleFactor)
+StyleCachedImage::StyleCachedImage(const Style::URL& url, float scaleFactor)
     : StyleImage { Type::CachedImage }
     , m_url { url }
-    , m_cssValue { cssValue }
     , m_scaleFactor { scaleFactor }
 {
-    m_cachedImage = m_cssValue->cachedImage();
-    if (m_cachedImage)
-        m_isPending = false;
 }
 
 StyleCachedImage::~StyleCachedImage() = default;
@@ -95,8 +90,6 @@ bool StyleCachedImage::equals(const StyleCachedImage& other) const
         return true;
     if (m_scaleFactor != other.m_scaleFactor)
         return false;
-    if (m_cssValue.ptr() == other.m_cssValue.ptr() || m_cssValue->equals(other.m_cssValue.get()))
-        return true;
     if (m_cachedImage && m_cachedImage == other.m_cachedImage)
         return true;
     return false;
@@ -190,7 +183,22 @@ void StyleCachedImage::load(CachedResourceLoader& loader, const ResourceLoaderOp
 {
     ASSERT(m_isPending);
     m_isPending = false;
-    m_cachedImage = m_cssValue->loadImage(loader, options);
+
+    if (!m_cachedImage) {
+        ASSERT(loader.document());
+
+        ResourceLoaderOptions loadOptions = options;
+        CSS::applyModifiersToLoaderOptions(m_url.modifiers, loadOptions);
+
+        CachedResourceRequest request(ResourceRequest(m_url.resolved), loadOptions);
+        if (m_url.modifiers.initiatorType.isEmpty())
+            request.setInitiatorType(cachedResourceRequestInitiatorTypes().css);
+        else
+            request.setInitiatorType(m_url.modifiers.initiatorType);
+        if (options.mode == FetchOptions::Mode::Cors)
+            request.updateForAccessControl(*loader.document());
+        m_cachedImage = loader.requestImage(WTFMove(request)).value_or(nullptr);
+    }
 }
 
 CachedImage* StyleCachedImage::cachedImage() const
@@ -200,7 +208,7 @@ CachedImage* StyleCachedImage::cachedImage() const
 
 Ref<CSSValue> StyleCachedImage::computedStyleValue(const RenderStyle& style) const
 {
-    return m_cssValue->copyForComputedStyle(Style::toCSS(m_url, style));
+    return CSSImageValue::create(Style::toCSS(m_url, style));
 }
 
 bool StyleCachedImage::canRender(const RenderElement* renderer, float multiplier) const

--- a/Source/WebCore/rendering/style/StyleCachedImage.h
+++ b/Source/WebCore/rendering/style/StyleCachedImage.h
@@ -30,7 +30,6 @@
 namespace WebCore {
 
 class CSSValue;
-class CSSImageValue;
 class CachedImage;
 class Document;
 class LegacyRenderSVGResourceContainer;
@@ -41,8 +40,8 @@ class TreeScope;
 class StyleCachedImage final : public StyleImage {
     WTF_MAKE_TZONE_ALLOCATED(StyleCachedImage);
 public:
-    static Ref<StyleCachedImage> create(Style::URL&&, Ref<CSSImageValue>&&, float scaleFactor = 1);
-    static Ref<StyleCachedImage> create(const Style::URL&, const Ref<CSSImageValue>&, float scaleFactor = 1);
+    static Ref<StyleCachedImage> create(Style::URL&&, float scaleFactor = 1);
+    static Ref<StyleCachedImage> create(const Style::URL&, float scaleFactor = 1);
     static Ref<StyleCachedImage> copyOverridingScaleFactor(StyleCachedImage&, float scaleFactor);
     virtual ~StyleCachedImage();
 
@@ -78,8 +77,8 @@ public:
     Style::URL url() const final;
 
 private:
-    StyleCachedImage(Style::URL&&, Ref<CSSImageValue>&&, float);
-    StyleCachedImage(const Style::URL&, const Ref<CSSImageValue>&, float);
+    StyleCachedImage(Style::URL&&, float scaleFactor);
+    StyleCachedImage(const Style::URL&, float scaleFactor);
 
     LegacyRenderSVGResourceContainer* uncheckedRenderSVGResource(TreeScope&, const AtomString& fragment) const;
     LegacyRenderSVGResourceContainer* uncheckedRenderSVGResource(const RenderElement*) const;
@@ -88,7 +87,6 @@ private:
     bool isRenderSVGResource(const RenderElement*) const;
 
     Style::URL m_url;
-    Ref<CSSImageValue> m_cssValue;
     bool m_isPending { true };
     mutable float m_scaleFactor { 1 };
     mutable CachedResourceHandle<CachedImage> m_cachedImage;

--- a/Source/WebCore/rendering/style/StyleCursorImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCursorImage.cpp
@@ -111,10 +111,8 @@ ImageWithScale StyleCursorImage::selectBestFitImage(const Document& document)
             auto existingImageURL = cachedImage->url().resolved;
             auto updatedImageURL = document.completeURL(cursorElement->href());
 
-            if (existingImageURL != updatedImageURL) {
-                auto styleURL = Style::URL { .resolved = updatedImageURL, .modifiers = { } };
-                m_image = StyleCachedImage::create(styleURL, CSSImageValue::create(WTFMove(updatedImageURL)));
-            }
+            if (existingImageURL != updatedImageURL)
+                m_image = StyleCachedImage::create(Style::URL { .resolved = updatedImageURL, .modifiers = { } });
         }
     }
 

--- a/Source/WebCore/style/StyleResourceStore.cpp
+++ b/Source/WebCore/style/StyleResourceStore.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2016 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleResourceStore.h"
+
+#include "StyleCachedImage.h"
+
+#define CACHE_STYLE_IMAGES 1
+
+namespace WebCore {
+namespace Style {
+
+Ref<ResourceStore> ResourceStore::create()
+{
+    return adoptRef(*new ResourceStore);
+}
+
+ResourceStore::ResourceStore() = default;
+ResourceStore::~ResourceStore() = default;
+
+RefPtr<StyleCachedImage> ResourceStore::image(const URL& location)
+{
+#if CACHE_STYLE_IMAGES
+    return m_images.get(location).get();
+#else
+    return StyleCachedImage::create(location);
+#endif
+}
+
+Ref<StyleCachedImage> ResourceStore::ensureImage(const URL& location)
+{
+#if CACHE_STYLE_IMAGES
+    // NOTE: Can't use m_images.ensure() because the value is WeakPtr and a
+    // will be destroyed by the time the function returns.
+
+    RefPtr existingImage = m_images.get(location).get();
+    if (existingImage)
+        return existingImage.releaseNonNull();
+
+    auto newImage = StyleCachedImage::create(location);
+    m_images.add(location, newImage.ptr());
+    return newImage;
+#else
+    return StyleCachedImage::create(location);
+#endif
+}
+
+} // namespace Style
+} // namespace WebCore
+
+#undef CACHE_STYLE_IMAGES

--- a/Source/WebCore/style/StyleResourceStore.h
+++ b/Source/WebCore/style/StyleResourceStore.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -16,7 +16,6 @@
  * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
  * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
  * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
@@ -25,40 +24,31 @@
 
 #pragma once
 
-#include "CSSMatrixComponentOptions.h"
-#include "CSSTransformComponent.h"
-#include <wtf/TZoneMalloc.h>
+#include "StyleURL.h"
+#include <wtf/RefCounted.h>
+#include <wtf/WeakHashMap.h>
 
 namespace WebCore {
 
-class CSSFunctionValue;
-class DOMMatrixReadOnly;
-class Document;
-template<typename> class ExceptionOr;
+class StyleCachedImage;
 
-class CSSMatrixComponent : public CSSTransformComponent {
-    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSMatrixComponent);
+namespace Style {
+
+// Document scoped store for resources referenced by styles.
+
+class ResourceStore : public RefCounted<ResourceStore> {
 public:
-    static Ref<CSSTransformComponent> create(Ref<DOMMatrixReadOnly>&&, CSSMatrixComponentOptions&& = { });
-    static ExceptionOr<Ref<CSSTransformComponent>> create(Ref<const CSSFunctionValue>, Document&);
+    static Ref<ResourceStore> create();
+    ~ResourceStore();
 
-    DOMMatrix& matrix();
-    void setMatrix(Ref<DOMMatrix>&&);
-
-    void serialize(StringBuilder&) const final;
-    ExceptionOr<Ref<DOMMatrix>> toMatrix() final;
-    
-    CSSTransformType getType() const final { return CSSTransformType::MatrixComponent; }
-
-    RefPtr<CSSValue> toCSSValue() const final;
+    RefPtr<StyleCachedImage> image(const URL&);
+    Ref<StyleCachedImage> ensureImage(const URL&);
 
 private:
-    CSSMatrixComponent(Ref<DOMMatrixReadOnly>&&, Is2D);
-    Ref<DOMMatrix> m_matrix;
+    ResourceStore();
+
+    HashMap<Style::URL, WeakPtr<StyleCachedImage>> m_images;
 };
 
+} // namespace Style
 } // namespace WebCore
-
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::CSSMatrixComponent)
-    static bool isType(const WebCore::CSSTransformComponent& transform) { return transform.getType() == WebCore::CSSTransformType::MatrixComponent; }
-SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/style/values/primitives/StyleURL.h
+++ b/Source/WebCore/style/values/primitives/StyleURL.h
@@ -26,6 +26,7 @@
 
 #include "CSSURL.h"
 #include "StyleValueTypes.h"
+#include <wtf/URLHash.h>
 
 namespace WebCore {
 
@@ -51,6 +52,11 @@ template<size_t I> const auto& get(const URL& value)
         return value.modifiers;
 }
 
+inline void add(Hasher& hasher, const URL& value)
+{
+    add(hasher, value.resolved, value.modifiers);
+}
+
 // MARK: Conversion
 
 // Special conversion function for use by filters and font-face code.
@@ -67,3 +73,48 @@ TextStream& operator<<(TextStream&, const URL&);
 } // namespace WebCore
 
 DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::URL, 2)
+
+namespace WTF {
+
+struct StyleURLHash {
+    static unsigned hash(const WebCore::Style::URL& value)
+    {
+        return computeHash(value);
+    }
+
+    static bool equal(const WebCore::Style::URL& a, const WebCore::Style::URL& b)
+    {
+        return a == b;
+    }
+
+    static constexpr bool safeToCompareToEmptyOrDeleted = false;
+};
+
+template<> struct HashTraits<WebCore::Style::URL> : GenericHashTraits<WebCore::Style::URL> {
+    static WebCore::Style::URL emptyValue()
+    {
+        return WebCore::Style::URL { .resolved = { }, .modifiers = { } };
+    }
+
+    static bool isEmptyValue(const WebCore::Style::URL& value)
+    {
+        return value.resolved.isNull();
+    }
+
+    static void constructDeletedValue(WebCore::Style::URL& slot)
+    {
+        new (NotNull, &slot.resolved) WTF::URL(WTF::HashTableDeletedValue);
+    }
+
+    static bool isDeletedValue(const WebCore::Style::URL& slot)
+    {
+        return slot.resolved.isHashTableDeletedValue();
+    }
+
+    static const bool hasIsEmptyValueFunction = true;
+    static const bool emptyValueIsZero = false;
+};
+
+template<> struct DefaultHash<WebCore::Style::URL> : StyleURLHash { };
+
+} // namespace WTF


### PR DESCRIPTION
#### 676ad4f76b79e79e4eb36e837e2bc515ddb3a82f
<pre>
[Experiment] Experiment with removing CachedImage from CSSImageValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=291493">https://bugs.webkit.org/show_bug.cgi?id=291493</a>

Reviewed by NOBODY (OOPS!).

WIP FOR BOTS

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSImageValue.cpp:
* Source/WebCore/css/CSSImageValue.h:
* Source/WebCore/css/typedom/CSSStyleImageValue.cpp:
* Source/WebCore/css/typedom/CSSStyleImageValue.h:
* Source/WebCore/css/typedom/CSSStyleValue.cpp:
* Source/WebCore/css/typedom/CSSStyleValue.h:
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
* Source/WebCore/css/typedom/CSSStyleValueFactory.h:
* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp:
* Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp:
* Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.cpp:
* Source/WebCore/css/typedom/InlineStylePropertyMap.cpp:
* Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp:
* Source/WebCore/css/typedom/StylePropertyMap.cpp:
* Source/WebCore/css/typedom/StylePropertyMapReadOnly.cpp:
* Source/WebCore/css/typedom/StylePropertyMapReadOnly.h:
* Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp:
* Source/WebCore/css/typedom/transform/CSSMatrixComponent.h:
* Source/WebCore/css/typedom/transform/CSSPerspective.cpp:
* Source/WebCore/css/typedom/transform/CSSPerspective.h:
* Source/WebCore/css/typedom/transform/CSSRotate.cpp:
* Source/WebCore/css/typedom/transform/CSSRotate.h:
* Source/WebCore/css/typedom/transform/CSSScale.cpp:
* Source/WebCore/css/typedom/transform/CSSScale.h:
* Source/WebCore/css/typedom/transform/CSSSkew.cpp:
* Source/WebCore/css/typedom/transform/CSSSkew.h:
* Source/WebCore/css/typedom/transform/CSSSkewX.cpp:
* Source/WebCore/css/typedom/transform/CSSSkewX.h:
* Source/WebCore/css/typedom/transform/CSSSkewY.cpp:
* Source/WebCore/css/typedom/transform/CSSSkewY.h:
* Source/WebCore/css/typedom/transform/CSSTransformValue.cpp:
* Source/WebCore/css/typedom/transform/CSSTransformValue.h:
* Source/WebCore/css/typedom/transform/CSSTranslate.cpp:
* Source/WebCore/css/typedom/transform/CSSTranslate.h:
* Source/WebCore/css/values/primitives/CSSURLModifiers.h:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/PageSerializer.cpp:
* Source/WebCore/rendering/style/StyleCachedImage.cpp:
* Source/WebCore/rendering/style/StyleCachedImage.h:
* Source/WebCore/rendering/style/StyleCursorImage.cpp:
* Source/WebCore/style/StyleResourceStore.cpp: Added.
* Source/WebCore/style/StyleResourceStore.h: Added.
* Source/WebCore/style/values/primitives/StyleURL.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/676ad4f76b79e79e4eb36e837e2bc515ddb3a82f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104696 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50167 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101606 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27648 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75798 "Found 9 new test failures: fast/css/mask-box-image-parsing.html http/tests/cache/stylesheet-sharing.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-image-interpolation.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/border-image-source-interpolation.html imported/w3c/web-platform-tests/css/css-lists/animations/list-style-image-interpolation.html imported/w3c/web-platform-tests/css/css-masking/animations/mask-border-source-interpolation.html imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32894 "Found 2 new test failures: fast/css/mask-box-image-parsing.html http/tests/cache/stylesheet-sharing.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102572 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14852 "Found 2 new test failures: fast/css/mask-box-image-parsing.html http/tests/cache/stylesheet-sharing.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89905 "Found 7 new API test failures: TestWebKitAPI.WebArchive.SaveResourcesLink, TestWebKitAPI.WebArchive.SaveResourcesResponsiveImages, TestWebKitAPI.WebArchive.SaveResourcesInlineStyle, TestWebKitAPI.WebArchive.SaveResourcesCSSMediaRule, TestWebKitAPI.WebArchive.SaveResourcesStyle, TestWebKitAPI.WebArchive.SaveResourcesCSSSupportsRule, TestWebKitAPI.WebArchive.SaveResourcesCSSImportRule (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56157 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14649 "Found 7 new test failures: imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-image-interpolation.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/border-image-source-interpolation.html imported/w3c/web-platform-tests/css/css-content/parsing/content-computed.html imported/w3c/web-platform-tests/css/css-lists/animations/list-style-image-interpolation.html imported/w3c/web-platform-tests/css/css-masking/animations/mask-border-source-interpolation.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7890 "Found 12 new test failures: fast/css/mask-box-image-parsing.html http/tests/cache/stylesheet-sharing.html http/tests/webarchive/test-css-url-encoding-shift-jis.html http/tests/webarchive/test-css-url-encoding-utf-8.html http/tests/webarchive/test-css-url-encoding.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-image-interpolation.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/border-image-source-interpolation.html imported/w3c/web-platform-tests/css/css-content/parsing/content-computed.html imported/w3c/web-platform-tests/css/css-lists/animations/list-style-image-interpolation.html imported/w3c/web-platform-tests/css/css-masking/animations/mask-border-source-interpolation.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49526 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84589 "Found 7 new API test failures: TestWebKitAPI.WebArchive.SaveResourcesInlineStyle, TestWebKitAPI.WebArchive.SaveResourcesLink, TestWebKitAPI.WebArchive.SaveResourcesResponsiveImages, TestWebKitAPI.WebArchive.SaveResourcesCSSMediaRule, TestWebKitAPI.WebArchive.SaveResourcesStyle, TestWebKitAPI.WebArchive.SaveResourcesCSSSupportsRule, TestWebKitAPI.WebArchive.SaveResourcesCSSImportRule (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7976 "Found 12 new test failures: fast/css/mask-box-image-parsing.html http/tests/cache/stylesheet-sharing.html http/tests/webarchive/test-css-url-encoding-shift-jis.html http/tests/webarchive/test-css-url-encoding-utf-8.html http/tests/webarchive/test-css-url-encoding.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-image-interpolation.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/border-image-source-interpolation.html imported/w3c/web-platform-tests/css/css-content/parsing/content-computed.html imported/w3c/web-platform-tests/css/css-lists/animations/list-style-image-interpolation.html imported/w3c/web-platform-tests/css/css-masking/animations/mask-border-source-interpolation.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107054 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26679 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19479 "Found 12 new test failures: fast/css/mask-box-image-parsing.html http/tests/cache/stylesheet-sharing.html http/tests/webarchive/test-css-url-encoding-shift-jis.html http/tests/webarchive/test-css-url-encoding-utf-8.html http/tests/webarchive/test-css-url-encoding.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-image-interpolation.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/border-image-source-interpolation.html imported/w3c/web-platform-tests/css/css-content/parsing/content-computed.html imported/w3c/web-platform-tests/css/css-lists/animations/list-style-image-interpolation.html imported/w3c/web-platform-tests/css/css-masking/animations/mask-border-source-interpolation.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84759 "Found 8 new test failures: fast/css/mask-box-image-parsing.html http/tests/cache/stylesheet-sharing.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-image-interpolation.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/border-image-source-interpolation.html imported/w3c/web-platform-tests/css/css-lists/animations/list-style-image-interpolation.html imported/w3c/web-platform-tests/css/css-masking/animations/mask-border-source-interpolation.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27042 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86109 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84276 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28939 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6645 "Found 12 new test failures: fast/css/mask-box-image-parsing.html http/tests/cache/stylesheet-sharing.html http/tests/webarchive/test-css-url-encoding-shift-jis.html http/tests/webarchive/test-css-url-encoding-utf-8.html http/tests/webarchive/test-css-url-encoding.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-image-interpolation.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/border-image-source-interpolation.html imported/w3c/web-platform-tests/css/css-content/parsing/content-computed.html imported/w3c/web-platform-tests/css/css-lists/animations/list-style-image-interpolation.html imported/w3c/web-platform-tests/css/css-masking/animations/mask-border-source-interpolation.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20477 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26619 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31820 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26439 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29752 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28006 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->