### PR TITLE
Address Safer cpp failures in svg/SVGTextLayoutAttributesBuilder

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -137,7 +137,6 @@ rendering/TextPainter.h
 rendering/line/LineWidth.h
 rendering/style/StyleCachedImage.cpp
 rendering/svg/SVGRenderingContext.h
-rendering/svg/SVGTextLayoutAttributesBuilder.h
 style/StyleBuilderState.h
 style/StyleScope.h
 svg/properties/SVGAnimationAdditiveListFunctionImpl.h

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -77,7 +77,6 @@ plugins/PluginData.h
 rendering/RenderQuote.cpp
 rendering/TextBoxPainter.h
 rendering/style/StyleGeneratedImage.cpp
-rendering/svg/SVGTextLayoutAttributesBuilder.h
 rendering/updating/RenderTreeUpdater.h
 style/ClassChangeInvalidation.cpp
 style/ElementRuleCollector.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1174,7 +1174,6 @@ rendering/svg/SVGLayerTransformComputation.h
 rendering/svg/SVGRenderTreeAsText.cpp
 rendering/svg/SVGRenderingContext.cpp
 rendering/svg/SVGTextBoxPainter.cpp
-rendering/svg/SVGTextLayoutAttributesBuilder.cpp
 rendering/svg/legacy/LegacyRenderSVGEllipse.cpp
 rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp
 rendering/svg/legacy/LegacyRenderSVGImage.cpp

--- a/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp
@@ -180,11 +180,12 @@ static inline void updateCharacterData(unsigned i, float& lastRotation, SVGChara
 
 void SVGTextLayoutAttributesBuilder::fillCharacterDataMap(const TextPosition& position)
 {
-    const auto& xList = position.element->x();
-    const auto& yList = position.element->y();
-    const auto& dxList = position.element->dx();
-    const auto& dyList = position.element->dy();
-    const auto& rotateList = position.element->rotate();
+    RefPtr element = position.element.get();
+    const auto& xList = element->x();
+    const auto& yList = element->y();
+    const auto& dxList = element->dx();
+    const auto& dyList = element->dy();
+    const auto& rotateList = element->rotate();
 
     unsigned xListSize = xList.size();
     unsigned yListSize = yList.size();
@@ -195,8 +196,7 @@ void SVGTextLayoutAttributesBuilder::fillCharacterDataMap(const TextPosition& po
         return;
 
     float lastRotation = SVGTextLayoutAttributes::emptyValue();
-    RefPtr positionElement = position.element;
-    SVGLengthContext lengthContext(positionElement.get());
+    SVGLengthContext lengthContext(element.get());
     for (unsigned i = 0; i < position.length; ++i) {
         const SVGLengthList* xListPtr = i < xListSize ? &xList : nullptr;
         const SVGLengthList* yListPtr = i < yListSize ? &yList : nullptr;

--- a/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "SVGTextMetricsBuilder.h"
+#include "SVGTextPositioningElement.h"
 
 namespace WebCore {
 
@@ -27,7 +28,6 @@ class RenderBoxModelObject;
 class RenderObject;
 class RenderSVGInlineText;
 class RenderSVGText;
-class SVGTextPositioningElement;
 
 // SVGTextLayoutAttributesBuilder performs the first layout phase for SVG text.
 //
@@ -52,14 +52,14 @@ public:
 
 private:
     struct TextPosition {
-        TextPosition(SVGTextPositioningElement* newElement = 0, unsigned newStart = 0, unsigned newLength = 0)
+        TextPosition(SVGTextPositioningElement* newElement, unsigned newStart = 0, unsigned newLength = 0)
             : element(newElement)
             , start(newStart)
             , length(newLength)
         {
         }
 
-        SVGTextPositioningElement* element;
+        CheckedPtr<SVGTextPositioningElement> element;
         unsigned start;
         unsigned length;
     };


### PR DESCRIPTION
#### ad2d9fb985fd4dec6f9ff07e338361bbba679d71
<pre>
Address Safer cpp failures in svg/SVGTextLayoutAttributesBuilder
<a href="https://bugs.webkit.org/show_bug.cgi?id=291494">https://bugs.webkit.org/show_bug.cgi?id=291494</a>
<a href="https://rdar.apple.com/problem/149169746">rdar://problem/149169746</a>

Reviewed by Chris Dumez.

Fix clang static analyzer warnings in svg/SVGTextLayoutAttributesBuilder.

* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp:
(WebCore::SVGTextLayoutAttributesBuilder::collectTextPositioningElements):
(WebCore::SVGTextLayoutAttributesBuilder::buildCharacterDataMap):
(WebCore::SVGTextLayoutAttributesBuilder::fillCharacterDataMap):
* Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.h:
(WebCore::SVGTextLayoutAttributesBuilder::TextPosition::TextPosition):

Canonical link: <a href="https://commits.webkit.org/293803@main">https://commits.webkit.org/293803@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6ab51ba17f918649510cd8d10fd7beb8516e10e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99619 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104750 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50215 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101660 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19666 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75832 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32929 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102626 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14992 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89952 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56191 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14793 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7938 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49579 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84733 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8023 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107109 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26734 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19518 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84792 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27098 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86156 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84309 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21484 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28980 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6690 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/20525 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26674 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31877 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26493 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29805 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28059 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->