### PR TITLE
[Writing Tools] Remove uses of the old WritingToolsAllowedInputOptions API in favor of WritingToolsResultOptions

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/WritingToolsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/WritingToolsSPI.h
@@ -43,14 +43,12 @@ constexpr auto PlatformWritingToolsBehaviorDefault = NSWritingToolsBehaviorDefau
 constexpr auto PlatformWritingToolsBehaviorLimited = NSWritingToolsBehaviorLimited;
 constexpr auto PlatformWritingToolsBehaviorComplete = NSWritingToolsBehaviorComplete;
 
-// FIXME: (rdar://130540028) Remove uses of the old WritingToolsAllowedInputOptions API in favor of the new WritingToolsResultOptions API, and remove staging.
+using PlatformWritingToolsResultOptions = NSWritingToolsResultOptions;
 
-using PlatformWritingToolsResultOptions = NSUInteger;
-
-constexpr auto PlatformWritingToolsResultPlainText = (PlatformWritingToolsResultOptions)(1 << 0);
-constexpr auto PlatformWritingToolsResultRichText = (PlatformWritingToolsResultOptions)(1 << 1);
-constexpr auto PlatformWritingToolsResultList = (PlatformWritingToolsResultOptions)(1 << 2);
-constexpr auto PlatformWritingToolsResultTable = (PlatformWritingToolsResultOptions)(1 << 3);
+constexpr auto PlatformWritingToolsResultPlainText = NSWritingToolsResultPlainText;
+constexpr auto PlatformWritingToolsResultRichText = NSWritingToolsResultRichText;
+constexpr auto PlatformWritingToolsResultList = NSWritingToolsResultList;
+constexpr auto PlatformWritingToolsResultTable = NSWritingToolsResultTable;
 
 #else
 
@@ -63,14 +61,12 @@ constexpr auto PlatformWritingToolsBehaviorDefault = UIWritingToolsBehaviorDefau
 constexpr auto PlatformWritingToolsBehaviorLimited = UIWritingToolsBehaviorLimited;
 constexpr auto PlatformWritingToolsBehaviorComplete = UIWritingToolsBehaviorComplete;
 
-// FIXME: (rdar://130540028) Remove uses of the old WritingToolsAllowedInputOptions API in favor of the new WritingToolsResultOptions API, and remove staging.
+using PlatformWritingToolsResultOptions = UIWritingToolsResultOptions;
 
-using PlatformWritingToolsResultOptions = NSUInteger;
-
-constexpr auto PlatformWritingToolsResultPlainText = (PlatformWritingToolsResultOptions)(1 << 0);
-constexpr auto PlatformWritingToolsResultRichText = (PlatformWritingToolsResultOptions)(1 << 1);
-constexpr auto PlatformWritingToolsResultList = (PlatformWritingToolsResultOptions)(1 << 2);
-constexpr auto PlatformWritingToolsResultTable = (PlatformWritingToolsResultOptions)(1 << 3);
+constexpr auto PlatformWritingToolsResultPlainText = UIWritingToolsResultPlainText;
+constexpr auto PlatformWritingToolsResultRichText = UIWritingToolsResultRichText;
+constexpr auto PlatformWritingToolsResultList = UIWritingToolsResultList;
+constexpr auto PlatformWritingToolsResultTable = UIWritingToolsResultTable;
 
 #endif
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2344,12 +2344,6 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
     return PlatformWritingToolsResultPlainText | PlatformWritingToolsResultRichText | PlatformWritingToolsResultList | PlatformWritingToolsResultTable;
 }
 
-// FIXME: (rdar://130540028) Remove uses of the old WritingToolsAllowedInputOptions API in favor of the new WritingToolsResultOptions API, and remove staging.
-- (PlatformWritingToolsResultOptions)writingToolsAllowedInputOptions
-{
-    return [self allowedWritingToolsResultOptions];
-}
-
 - (PlatformWritingToolsBehavior)writingToolsBehavior
 {
     return WebKit::convertToPlatformWritingToolsBehavior(_page->writingToolsBehavior());

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -479,15 +479,7 @@ struct PerWebProcessState {
 
 - (void)_proofreadingSessionUpdateState:(WebCore::WritingTools::TextSuggestionState)state forSuggestionWithUUID:(NSUUID *)replacementUUID;
 
-#if PLATFORM(MAC)
-// FIXME: (rdar://130540028) Remove uses of the old WritingToolsAllowedInputOptions API in favor of the new WritingToolsResultOptions API, and remove staging.
-- (PlatformWritingToolsResultOptions)writingToolsAllowedInputOptions;
 - (PlatformWritingToolsResultOptions)allowedWritingToolsResultOptions;
-#else
-// FIXME: (rdar://130540028) Remove uses of the old WritingToolsAllowedInputOptions API in favor of the new WritingToolsResultOptions API, and remove staging.
-- (PlatformWritingToolsResultOptions)writingToolsAllowedInputOptions;
-- (PlatformWritingToolsResultOptions)allowedWritingToolsResultOptions;
-#endif
 
 - (void)_didEndPartialIntelligenceTextAnimation;
 - (BOOL)_writingToolsTextReplacementsFinished;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -13978,12 +13978,6 @@ inline static NSString *extendSelectionCommand(UITextLayoutDirection direction)
     [self reloadInputViews];
 }
 
-// FIXME: (rdar://130540028) Remove uses of the old WritingToolsAllowedInputOptions API in favor of the new WritingToolsResultOptions API, and remove staging.
-- (PlatformWritingToolsResultOptions)writingToolsAllowedInputOptions
-{
-    return [_webView allowedWritingToolsResultOptions];
-}
-
 - (PlatformWritingToolsResultOptions)allowedWritingToolsResultOptions
 {
     return [_webView allowedWritingToolsResultOptions];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -125,21 +125,6 @@ WEAK_IMPORT_OBJC_CLASS(WTTextSuggestion);
 
 @end
 
-// FIXME: (rdar://130540028) Remove uses of the old WritingToolsAllowedInputOptions API in favor of the new WritingToolsResultOptions API, and remove staging.
-#if PLATFORM(IOS_FAMILY)
-@protocol UITextInput_Staging130540028 <UITextInput>
-
-- (PlatformWritingToolsResultOptions)allowedWritingToolsResultOptions;
-
-@end
-#else
-@protocol NSTextInputTraits_Staging130540028 <NSTextInputTraits>
-
-- (PlatformWritingToolsResultOptions)allowedWritingToolsResultOptions;
-
-@end
-#endif
-
 @interface WKWebViewConfiguration (Staging_135210076)
 
 #if PLATFORM(IOS_FAMILY)
@@ -224,9 +209,9 @@ using PlatformTextPlaceholder = NSTextPlaceholder;
 - (PlatformWritingToolsResultOptions)allowedWritingToolsResultOptionsForTesting
 {
 #if PLATFORM(IOS_FAMILY)
-    return [(id<UITextInput_Staging130540028>)[self textInputContentView] allowedWritingToolsResultOptions];
+    return [[self textInputContentView] allowedWritingToolsResultOptions];
 #else
-    return [(id<NSTextInputTraits_Staging130540028>)self allowedWritingToolsResultOptions];
+    return [(id<NSTextInputTraits>)self allowedWritingToolsResultOptions];
 #endif
 }
 


### PR DESCRIPTION
#### 6d60f111d10df56182c668743bfa8814729a9fa9
<pre>
[Writing Tools] Remove uses of the old WritingToolsAllowedInputOptions API in favor of WritingToolsResultOptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=291496">https://bugs.webkit.org/show_bug.cgi?id=291496</a>
<a href="https://rdar.apple.com/149171129">rdar://149171129</a>

Reviewed by Wenson Hsieh.

Also remove staging which hasn&apos;t been needed in quite a while.

* Source/WebCore/PAL/pal/spi/cocoa/WritingToolsSPI.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView writingToolsAllowedInputOptions]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView writingToolsAllowedInputOptions]): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(-[WritingToolsWKWebView allowedWritingToolsResultOptionsForTesting]):

Canonical link: <a href="https://commits.webkit.org/293696@main">https://commits.webkit.org/293696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e2033551c4bdc68f48165024c52ec9421000d8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104787 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50253 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101698 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27740 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/75859 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32957 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102664 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/14925 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89986 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56218 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14725 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/7972 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49614 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8057 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107146 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26772 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84818 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27136 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86190 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84336 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21407 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29013 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/6719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20564 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26712 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31915 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26527 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29843 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28097 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->