### PR TITLE
update-webkit-win-libs.py: Specify a release tag instead of the latest release for reproducible builds

### DIFF
--- a/Tools/Scripts/update-webkit-win-libs.py
+++ b/Tools/Scripts/update-webkit-win-libs.py
@@ -34,6 +34,7 @@ download = importlib.import_module('download-github-release')
 repo = 'WebKitForWindows/WebKitRequirements'
 file = 'WebKitRequirementsWin64.zip'
 output = os.getenv('WEBKIT_LIBRARIES', 'WebKitLibraries/win')
+release_tag = 'v2025.04.02'
 options = [repo, file, '-o', output]
 
 if os.getenv('GITHUB_TOKEN'):
@@ -43,7 +44,9 @@ if os.getenv('GITHUB_TOKEN'):
 config_path = os.path.join(output, file) + '.config'
 if os.path.exists(config_path):
     with open(config_path) as config_file:
-        options += ['-r', json.load(config_file)['tag_name']]
+        release_tag = json.load(config_file)['tag_name']
+
+options += ['-r', release_tag]
 
 result = download.main(options)
 


### PR DESCRIPTION
#### d5d6a662ce7e47a31cb7ad9bb9d71349178be532
<pre>
update-webkit-win-libs.py: Specify a release tag instead of the latest release for reproducible builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=291499">https://bugs.webkit.org/show_bug.cgi?id=291499</a>

Reviewed by NOBODY (OOPS!).

WebKit repository should specify a certain release tag to download
WebKitRequirementsWin64.zip for reproducible builds.

* Tools/Scripts/update-webkit-win-libs.py:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5d6a662ce7e47a31cb7ad9bb9d71349178be532

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99517 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104648 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50119 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27600 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75750 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32852 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102524 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89855 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56109 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14611 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7840 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49478 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84544 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107006 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26631 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19438 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84711 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26993 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86059 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84228 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28901 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6595 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20422 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26571 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26391 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29704 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27958 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->