### PR TITLE
[Cocoa] Adjust content inset background fill views for fixed container edges

### DIFF
--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.h
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.h
@@ -32,6 +32,7 @@
 
 namespace WebCore {
 class FloatQuad;
+enum class BoxSide : uint8_t;
 }
 
 @interface UIScrollView (WebKitInternal)
@@ -80,6 +81,7 @@ namespace WebKit {
 
 RetainPtr<UIAlertController> createUIAlertController(NSString *title, NSString *message);
 UIScrollView *scrollViewForTouches(NSSet<UITouch *> *);
+UIRectEdge uiRectEdgeForSide(WebCore::BoxSide);
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import "UIKitSPI.h"
+#import <WebCore/BoxSides.h>
 #import <WebCore/FloatPoint.h>
 #import <WebCore/FloatQuad.h>
 #import <wtf/BlockPtr.h>
@@ -350,6 +351,22 @@ UIScrollView *scrollViewForTouches(NSSet<UITouch *> *touches)
             return scrollView;
     }
     return nil;
+}
+
+UIRectEdge uiRectEdgeForSide(WebCore::BoxSide side)
+{
+    switch (side) {
+    case WebCore::BoxSide::Top:
+        return UIRectEdgeTop;
+    case WebCore::BoxSide::Right:
+        return UIRectEdgeRight;
+    case WebCore::BoxSide::Bottom:
+        return UIRectEdgeBottom;
+    case WebCore::BoxSide::Left:
+        return UIRectEdgeLeft;
+    }
+    ASSERT_NOT_REACHED();
+    return UIRectEdgeNone;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ios/WKScrollView.h
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.h
@@ -43,6 +43,10 @@
 - (BOOL)_setContentScrollInsetInternal:(UIEdgeInsets)insets;
 - (void)_setDecelerationRateInternal:(UIScrollViewDecelerationRate)rate;
 
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+- (void)_setFixedColorExtensionEdges:(UIRectEdge)edges;
+#endif
+
 - (void)_resetContentInset;
 @property (nonatomic, readonly) BOOL _contentInsetWasExternallyOverridden;
 

--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -136,6 +136,9 @@ static BOOL shouldForwardScrollViewDelegateMethodToExternalDelegate(SEL selector
     BOOL _backgroundColorSetByClient;
     BOOL _indicatorStyleSetByClient;
     BOOL _decelerationRateSetByClient;
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    BOOL _fixedColorExtensionEdgesSetByClient;
+#endif
 // FIXME: Likely we can remove this special case for watchOS.
 #if !PLATFORM(WATCHOS)
     BOOL _contentInsetAdjustmentBehaviorWasExternallyOverridden;
@@ -577,6 +580,10 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
 }
 
 #endif // HAVE(PEPPER_UI_CORE)
+
+#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/WKScrollViewAdditions.mm>)
+#import <WebKitAdditions/WKScrollViewAdditions.mm>
+#endif
 
 @end
 


### PR DESCRIPTION
#### ce53ae2a57311661937f5a7eec264bf6ff35daa9
<pre>
[Cocoa] Adjust content inset background fill views for fixed container edges
<a href="https://bugs.webkit.org/show_bug.cgi?id=291503">https://bugs.webkit.org/show_bug.cgi?id=291503</a>
<a href="https://rdar.apple.com/149178053">rdar://149178053</a>

Reviewed by Megan Gardner.

See below for more details.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _recalculateViewportSizesWithMinimumViewportInset:maximumViewportInset:throwOnInvalidInput:]):

Remove the call to `updateContentInsetFillViews()` here, now that `_updateFixedColorExtensionViews`
will also update content inset fill views on macOS.

(-[WKWebView _updateFixedColorExtensionViews]):

On iOS, keep track of all edges with fixed color extension views, and update `WKScrollView`
accordingly. On macOS, call through to `updateContentInsetFillViews()`.

* Source/WebKit/UIProcess/ios/UIKitUtilities.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(WebKit::uiRectEdgeForSide):
* Source/WebKit/UIProcess/ios/WKScrollView.h:
* Source/WebKit/UIProcess/ios/WKScrollView.mm:

Canonical link: <a href="https://commits.webkit.org/293661@main">https://commits.webkit.org/293661@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e041de0b53c2aa84a20f7ec0bd3291a83cefd4a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99527 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9431 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104658 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50129 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27610 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75758 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32863 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14822 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89867 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56117 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14619 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49488 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84553 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7938 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107016 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26641 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19448 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84719 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27003 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84236 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21377 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28909 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6607 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20432 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26581 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31782 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26401 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29714 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27968 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->