### PR TITLE
[SaferCpp] Address issues in WKPage.cpp

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -30,7 +30,6 @@ UIProcess/API/C/WKNotificationManager.cpp
 UIProcess/API/C/WKNotificationPermissionRequest.cpp
 UIProcess/API/C/WKOpenPanelParametersRef.cpp
 UIProcess/API/C/WKOpenPanelResultListener.cpp
-UIProcess/API/C/WKPage.cpp
 UIProcess/API/C/WKPageConfigurationRef.cpp
 UIProcess/API/C/WKProtectionSpace.cpp
 UIProcess/API/C/WKQueryPermissionResultCallback.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -2,7 +2,6 @@ UIProcess/API/C/WKContext.cpp
 UIProcess/API/C/WKContextMenuListener.cpp
 UIProcess/API/C/WKFrame.cpp
 UIProcess/API/C/WKInspector.cpp
-UIProcess/API/C/WKPage.cpp
 UIProcess/API/C/WKUserScriptRef.cpp
 UIProcess/API/C/WKWebsiteDataStoreRef.cpp
 UIProcess/API/C/mac/WKPagePrivateMac.mm

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -196,7 +196,7 @@ WKTypeID WKPageGetTypeID()
 
 WKContextRef WKPageGetContext(WKPageRef pageRef)
 {
-    return toAPI(&toImpl(pageRef)->configuration().processPool());
+    return toAPI(&toProtectedImpl(pageRef)->configuration().processPool());
 }
 
 WKPageGroupRef WKPageGetPageGroup(WKPageRef pageRef)
@@ -206,66 +206,66 @@ WKPageGroupRef WKPageGetPageGroup(WKPageRef pageRef)
 
 WKPageConfigurationRef WKPageCopyPageConfiguration(WKPageRef pageRef)
 {
-    return toAPILeakingRef(toImpl(pageRef)->configuration().copy());
+    return toAPILeakingRef(toProtectedImpl(pageRef)->configuration().copy());
 }
 
 void WKPageLoadURL(WKPageRef pageRef, WKURLRef URLRef)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->loadRequest(URL { toWTFString(URLRef) });
+    toProtectedImpl(pageRef)->loadRequest(URL { toWTFString(URLRef) });
 }
 
 void WKPageLoadURLWithShouldOpenExternalURLsPolicy(WKPageRef pageRef, WKURLRef URLRef, bool shouldOpenExternalURLs)
 {
     CRASH_IF_SUSPENDED;
     WebCore::ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy = shouldOpenExternalURLs ? WebCore::ShouldOpenExternalURLsPolicy::ShouldAllow : WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow;
-    toImpl(pageRef)->loadRequest(URL { toWTFString(URLRef) }, shouldOpenExternalURLsPolicy);
+    toProtectedImpl(pageRef)->loadRequest(URL { toWTFString(URLRef) }, shouldOpenExternalURLsPolicy);
 }
 
 void WKPageLoadURLWithUserData(WKPageRef pageRef, WKURLRef URLRef, WKTypeRef userDataRef)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->loadRequest(URL { toWTFString(URLRef) }, WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow, WebCore::IsPerformingHTTPFallback::No, nullptr, toImpl(userDataRef));
+    toProtectedImpl(pageRef)->loadRequest(URL { toWTFString(URLRef) }, WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow, WebCore::IsPerformingHTTPFallback::No, nullptr, toImpl(userDataRef));
 }
 
 void WKPageLoadURLRequest(WKPageRef pageRef, WKURLRequestRef urlRequestRef)
 {
     CRASH_IF_SUSPENDED;
-    auto resourceRequest = toImpl(urlRequestRef)->resourceRequest();
-    toImpl(pageRef)->loadRequest(WTFMove(resourceRequest));
+    auto resourceRequest = toProtectedImpl(urlRequestRef)->resourceRequest();
+    toProtectedImpl(pageRef)->loadRequest(WTFMove(resourceRequest));
 }
 
 void WKPageLoadURLRequestWithUserData(WKPageRef pageRef, WKURLRequestRef urlRequestRef, WKTypeRef userDataRef)
 {
     CRASH_IF_SUSPENDED;
-    auto resourceRequest = toImpl(urlRequestRef)->resourceRequest();
-    toImpl(pageRef)->loadRequest(WTFMove(resourceRequest), WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow, WebCore::IsPerformingHTTPFallback::No, nullptr, toImpl(userDataRef));
+    auto resourceRequest = toProtectedImpl(urlRequestRef)->resourceRequest();
+    toProtectedImpl(pageRef)->loadRequest(WTFMove(resourceRequest), WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow, WebCore::IsPerformingHTTPFallback::No, nullptr, toImpl(userDataRef));
 }
 
 void WKPageLoadFile(WKPageRef pageRef, WKURLRef fileURL, WKURLRef resourceDirectoryURL)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->loadFile(toWTFString(fileURL), toWTFString(resourceDirectoryURL));
+    toProtectedImpl(pageRef)->loadFile(toWTFString(fileURL), toWTFString(resourceDirectoryURL));
 }
 
 void WKPageLoadFileWithUserData(WKPageRef pageRef, WKURLRef fileURL, WKURLRef resourceDirectoryURL, WKTypeRef userDataRef)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->loadFile(toWTFString(fileURL), toWTFString(resourceDirectoryURL), toImpl(userDataRef));
+    toProtectedImpl(pageRef)->loadFile(toWTFString(fileURL), toWTFString(resourceDirectoryURL), toProtectedImpl(userDataRef));
 }
 
 void WKPageLoadData(WKPageRef pageRef, WKDataRef dataRef, WKStringRef MIMETypeRef, WKStringRef encodingRef, WKURLRef baseURLRef)
 {
     CRASH_IF_SUSPENDED;
     // FIXME: Use WebCore::DataSegment::Provider to remove this unnecessary copy.
-    toImpl(pageRef)->loadData(WebCore::SharedBuffer::create(toImpl(dataRef)->span()), toWTFString(MIMETypeRef), toWTFString(encodingRef), toWTFString(baseURLRef));
+    toProtectedImpl(pageRef)->loadData(WebCore::SharedBuffer::create(toProtectedImpl(dataRef)->span()), toWTFString(MIMETypeRef), toWTFString(encodingRef), toWTFString(baseURLRef));
 }
 
 void WKPageLoadDataWithUserData(WKPageRef pageRef, WKDataRef dataRef, WKStringRef MIMETypeRef, WKStringRef encodingRef, WKURLRef baseURLRef, WKTypeRef userDataRef)
 {
     CRASH_IF_SUSPENDED;
     // FIXME: Use WebCore::DataSegment::Provider to remove this unnecessary copy.
-    toImpl(pageRef)->loadData(WebCore::SharedBuffer::create(toImpl(dataRef)->span()), toWTFString(MIMETypeRef), toWTFString(encodingRef), toWTFString(baseURLRef), toImpl(userDataRef));
+    toProtectedImpl(pageRef)->loadData(WebCore::SharedBuffer::create(toProtectedImpl(dataRef)->span()), toWTFString(MIMETypeRef), toWTFString(encodingRef), toWTFString(baseURLRef), toImpl(userDataRef));
 }
 
 static String encodingOf(const String& string)
@@ -293,7 +293,7 @@ static void loadString(WKPageRef pageRef, WKStringRef stringRef, const String& m
 {
     String string = toWTFString(stringRef);
     // FIXME: Use WebCore::DataSegment::Provider to remove this unnecessary copy.
-    toImpl(pageRef)->loadData(WebCore::SharedBuffer::create(dataFrom(string)), mimeType, encodingOf(string), baseURL, toImpl(userDataRef));
+    toProtectedImpl(pageRef)->loadData(WebCore::SharedBuffer::create(dataFrom(string)), mimeType, encodingOf(string), baseURL, toImpl(userDataRef));
 }
 
 void WKPageLoadHTMLString(WKPageRef pageRef, WKStringRef htmlStringRef, WKURLRef baseURLRef)
@@ -318,7 +318,7 @@ void WKPageLoadAlternateHTMLStringWithUserData(WKPageRef pageRef, WKStringRef ht
 {
     CRASH_IF_SUSPENDED;
     String string = toWTFString(htmlStringRef);
-    toImpl(pageRef)->loadAlternateHTML(dataReferenceFrom(string), encodingOf(string), URL { toWTFString(baseURLRef) }, URL { toWTFString(unreachableURLRef) }, toImpl(userDataRef));
+    toProtectedImpl(pageRef)->loadAlternateHTML(dataReferenceFrom(string), encodingOf(string), URL { toWTFString(baseURLRef) }, URL { toWTFString(unreachableURLRef) }, toImpl(userDataRef));
 }
 
 void WKPageLoadPlainTextString(WKPageRef pageRef, WKStringRef plainTextStringRef)
@@ -344,7 +344,7 @@ void WKPageLoadWebArchiveDataWithUserData(WKPageRef, WKDataRef, WKTypeRef)
 void WKPageStopLoading(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->stopLoading();
+    toProtectedImpl(pageRef)->stopLoading();
 }
 
 void WKPageReload(WKPageRef pageRef)
@@ -356,31 +356,31 @@ void WKPageReload(WKPageRef pageRef)
         reloadOptions.add(WebCore::ReloadOption::ExpiredOnly);
 #endif
 
-    toImpl(pageRef)->reload(reloadOptions);
+    toProtectedImpl(pageRef)->reload(reloadOptions);
 }
 
 void WKPageReloadWithoutContentBlockers(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->reload(WebCore::ReloadOption::DisableContentBlockers);
+    toProtectedImpl(pageRef)->reload(WebCore::ReloadOption::DisableContentBlockers);
 }
 
 void WKPageReloadFromOrigin(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->reload(WebCore::ReloadOption::FromOrigin);
+    toProtectedImpl(pageRef)->reload(WebCore::ReloadOption::FromOrigin);
 }
 
 void WKPageReloadExpiredOnly(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->reload(WebCore::ReloadOption::ExpiredOnly);
+    toProtectedImpl(pageRef)->reload(WebCore::ReloadOption::ExpiredOnly);
 }
 
 bool WKPageTryClose(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    return toImpl(pageRef)->tryClose();
+    return toProtectedImpl(pageRef)->tryClose();
 }
 
 void WKPagePermissionChanged(WKStringRef permissionName, WKStringRef originString)
@@ -395,29 +395,29 @@ void WKPagePermissionChanged(WKStringRef permissionName, WKStringRef originStrin
 
 void WKPageClose(WKPageRef pageRef)
 {
-    toImpl(pageRef)->close();
+    toProtectedImpl(pageRef)->close();
 }
 
 bool WKPageIsClosed(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->isClosed();
+    return toProtectedImpl(pageRef)->isClosed();
 }
 
 void WKPageGoForward(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->goForward();
+    toProtectedImpl(pageRef)->goForward();
 }
 
 bool WKPageCanGoForward(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->backForwardList().forwardItem();
+    return toProtectedImpl(pageRef)->backForwardList().forwardItem();
 }
 
 void WKPageGoBack(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    auto& page = *toImpl(pageRef);
+    auto& page = *toProtectedImpl(pageRef);
     if (RefPtr pageClient = page.pageClient(); pageClient->hasBrowsingWarning()) {
         WKPageReload(pageRef);
         return;
@@ -427,53 +427,53 @@ void WKPageGoBack(WKPageRef pageRef)
 
 bool WKPageCanGoBack(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->backForwardList().backItem();
+    return toProtectedImpl(pageRef)->backForwardList().backItem();
 }
 
 void WKPageGoToBackForwardListItem(WKPageRef pageRef, WKBackForwardListItemRef itemRef)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->goToBackForwardItem(*toImpl(itemRef));
+    toProtectedImpl(pageRef)->goToBackForwardItem(*toProtectedImpl(itemRef));
 }
 
 void WKPageTryRestoreScrollPosition(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->tryRestoreScrollPosition();
+    toProtectedImpl(pageRef)->tryRestoreScrollPosition();
 }
 
 WKBackForwardListRef WKPageGetBackForwardList(WKPageRef pageRef)
 {
-    return toAPI(&toImpl(pageRef)->backForwardList());
+    return toAPI(&toProtectedImpl(pageRef)->backForwardList());
 }
 
 bool WKPageWillHandleHorizontalScrollEvents(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->willHandleHorizontalScrollEvents();
+    return toProtectedImpl(pageRef)->willHandleHorizontalScrollEvents();
 }
 
 void WKPageUpdateWebsitePolicies(WKPageRef pageRef, WKWebsitePoliciesRef websitePoliciesRef)
 {
     CRASH_IF_SUSPENDED;
-    RELEASE_ASSERT_WITH_MESSAGE(!toImpl(websitePoliciesRef)->websiteDataStore(), "Setting WebsitePolicies.websiteDataStore is only supported during WKFramePolicyListenerUseWithPolicies().");
-    RELEASE_ASSERT_WITH_MESSAGE(!toImpl(websitePoliciesRef)->userContentController(), "Setting WebsitePolicies.userContentController is only supported during WKFramePolicyListenerUseWithPolicies().");
-    auto data = toImpl(websitePoliciesRef)->data();
-    toImpl(pageRef)->updateWebsitePolicies(WTFMove(data));
+    RELEASE_ASSERT_WITH_MESSAGE(!toProtectedImpl(websitePoliciesRef)->websiteDataStore(), "Setting WebsitePolicies.websiteDataStore is only supported during WKFramePolicyListenerUseWithPolicies().");
+    RELEASE_ASSERT_WITH_MESSAGE(!toProtectedImpl(websitePoliciesRef)->userContentController(), "Setting WebsitePolicies.userContentController is only supported during WKFramePolicyListenerUseWithPolicies().");
+    auto data = toProtectedImpl(websitePoliciesRef)->data();
+    toProtectedImpl(pageRef)->updateWebsitePolicies(WTFMove(data));
 }
 
 WKStringRef WKPageCopyTitle(WKPageRef pageRef)
 {
-    return toCopiedAPI(toImpl(pageRef)->pageLoadState().title());
+    return toCopiedAPI(toProtectedImpl(pageRef)->pageLoadState().title());
 }
 
 WKFrameRef WKPageGetMainFrame(WKPageRef pageRef)
 {
-    return toAPI(toImpl(pageRef)->mainFrame());
+    return toAPI(toProtectedImpl(pageRef)->mainFrame());
 }
 
 WKFrameRef WKPageGetFocusedFrame(WKPageRef pageRef)
 {
-    return toAPI(toImpl(pageRef)->focusedFrame());
+    return toAPI(toProtectedImpl(pageRef)->focusedFrame());
 }
 
 WKFrameRef WKPageGetFrameSetLargestFrame(WKPageRef pageRef)
@@ -483,78 +483,78 @@ WKFrameRef WKPageGetFrameSetLargestFrame(WKPageRef pageRef)
 
 uint64_t WKPageGetRenderTreeSize(WKPageRef page)
 {
-    return toImpl(page)->renderTreeSize();
+    return toProtectedImpl(page)->renderTreeSize();
 }
 
 WKWebsiteDataStoreRef WKPageGetWebsiteDataStore(WKPageRef page)
 {
-    return toAPI(&toImpl(page)->websiteDataStore());
+    return toAPI(&toProtectedImpl(page)->websiteDataStore());
 }
 
 WKInspectorRef WKPageGetInspector(WKPageRef pageRef)
 {
-    return toAPI(toImpl(pageRef)->inspector());
+    return toAPI(toProtectedImpl(pageRef)->inspector());
 }
 
 double WKPageGetEstimatedProgress(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->estimatedProgress();
+    return toProtectedImpl(pageRef)->estimatedProgress();
 }
 
 WKStringRef WKPageCopyUserAgent(WKPageRef pageRef)
 {
-    return toCopiedAPI(toImpl(pageRef)->userAgent());
+    return toCopiedAPI(toProtectedImpl(pageRef)->userAgent());
 }
 
 WKStringRef WKPageCopyApplicationNameForUserAgent(WKPageRef pageRef)
 {
-    return toCopiedAPI(toImpl(pageRef)->applicationNameForUserAgent());
+    return toCopiedAPI(toProtectedImpl(pageRef)->applicationNameForUserAgent());
 }
 
 void WKPageSetApplicationNameForUserAgent(WKPageRef pageRef, WKStringRef applicationNameRef)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setApplicationNameForUserAgent(toWTFString(applicationNameRef));
+    toProtectedImpl(pageRef)->setApplicationNameForUserAgent(toWTFString(applicationNameRef));
 }
 
 WKStringRef WKPageCopyCustomUserAgent(WKPageRef pageRef)
 {
-    return toCopiedAPI(toImpl(pageRef)->customUserAgent());
+    return toCopiedAPI(toProtectedImpl(pageRef)->customUserAgent());
 }
 
 void WKPageSetCustomUserAgent(WKPageRef pageRef, WKStringRef userAgentRef)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setCustomUserAgent(toWTFString(userAgentRef));
+    toProtectedImpl(pageRef)->setCustomUserAgent(toWTFString(userAgentRef));
 }
 
 bool WKPageSupportsTextEncoding(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->supportsTextEncoding();
+    return toProtectedImpl(pageRef)->supportsTextEncoding();
 }
 
 WKStringRef WKPageCopyCustomTextEncodingName(WKPageRef pageRef)
 {
-    return toCopiedAPI(toImpl(pageRef)->customTextEncodingName());
+    return toCopiedAPI(toProtectedImpl(pageRef)->customTextEncodingName());
 }
 
 void WKPageSetCustomTextEncodingName(WKPageRef pageRef, WKStringRef encodingNameRef)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setCustomTextEncodingName(toWTFString(encodingNameRef));
+    toProtectedImpl(pageRef)->setCustomTextEncodingName(toWTFString(encodingNameRef));
 }
 
 void WKPageTerminate(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    Ref<WebProcessProxy> protectedProcessProxy(toImpl(pageRef)->legacyMainFrameProcess());
+    Ref<WebProcessProxy> protectedProcessProxy(toProtectedImpl(pageRef)->legacyMainFrameProcess());
     protectedProcessProxy->requestTermination(ProcessTerminationReason::RequestedByClient);
 }
 
 void WKPageResetStateBetweenTests(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    if (RefPtr pageForTesting = toImpl(pageRef)->pageForTesting())
+    if (RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting())
         pageForTesting->resetStateBetweenTests();
 }
 
@@ -576,7 +576,7 @@ WKTypeRef WKPageCopySessionState(WKPageRef pageRef, void* context, WKPageSession
     bool shouldReturnData = !(reinterpret_cast<uintptr_t>(context) & 1);
     context = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(context) & ~1);
 
-    auto sessionState = toImpl(pageRef)->sessionState([pageRef, context, filter](WebBackForwardListItem& item) {
+    auto sessionState = toProtectedImpl(pageRef)->sessionState([pageRef, context, filter](WebBackForwardListItem& item) {
         if (filter) {
             if (!filter(pageRef, WKPageGetSessionBackForwardListItemValueType(), toAPI(&item), context))
                 return false;
@@ -600,16 +600,16 @@ static void restoreFromSessionState(WKPageRef pageRef, WKTypeRef sessionStateRef
     SessionState sessionState;
 
     // FIXME: This is for backwards compatibility with Safari. Remove it once Safari no longer depends on it.
-    if (toImpl(sessionStateRef)->type() == API::Object::Type::Data) {
-        if (!decodeLegacySessionState(toImpl(static_cast<WKDataRef>(sessionStateRef))->span(), sessionState))
+    if (toProtectedImpl(sessionStateRef)->type() == API::Object::Type::Data) {
+        if (!decodeLegacySessionState(toProtectedImpl(static_cast<WKDataRef>(sessionStateRef))->span(), sessionState))
             return;
     } else {
-        ASSERT(toImpl(sessionStateRef)->type() == API::Object::Type::SessionState);
+        ASSERT(toProtectedImpl(sessionStateRef)->type() == API::Object::Type::SessionState);
 
-        sessionState = toImpl(static_cast<WKSessionStateRef>(sessionStateRef))->sessionState();
+        sessionState = toProtectedImpl(static_cast<WKSessionStateRef>(sessionStateRef))->sessionState();
     }
 
-    toImpl(pageRef)->restoreFromSessionState(WTFMove(sessionState), navigate);
+    toProtectedImpl(pageRef)->restoreFromSessionState(WTFMove(sessionState), navigate);
 }
 
 void WKPageRestoreFromSessionState(WKPageRef pageRef, WKTypeRef sessionStateRef)
@@ -626,42 +626,42 @@ void WKPageRestoreFromSessionStateWithoutNavigation(WKPageRef pageRef, WKTypeRef
 
 double WKPageGetTextZoomFactor(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->textZoomFactor();
+    return toProtectedImpl(pageRef)->textZoomFactor();
 }
 
 double WKPageGetBackingScaleFactor(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->deviceScaleFactor();
+    return toProtectedImpl(pageRef)->deviceScaleFactor();
 }
 
 void WKPageSetCustomBackingScaleFactor(WKPageRef pageRef, double customScaleFactor)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setCustomDeviceScaleFactor(customScaleFactor, [] { });
+    toProtectedImpl(pageRef)->setCustomDeviceScaleFactor(customScaleFactor, [] { });
 }
 
 void WKPageSetCustomBackingScaleFactorWithCallback(WKPageRef pageRef, double customScaleFactor, void* context, WKPageSetCustomBackingScaleFactorFunction completionHandler)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setCustomDeviceScaleFactor(customScaleFactor, [context, completionHandler] {
+    toProtectedImpl(pageRef)->setCustomDeviceScaleFactor(customScaleFactor, [context, completionHandler] {
         completionHandler(context);
     });
 }
 
 bool WKPageSupportsTextZoom(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->supportsTextZoom();
+    return toProtectedImpl(pageRef)->supportsTextZoom();
 }
 
 void WKPageSetTextZoomFactor(WKPageRef pageRef, double zoomFactor)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setTextZoomFactor(zoomFactor);
+    toProtectedImpl(pageRef)->setTextZoomFactor(zoomFactor);
 }
 
 double WKPageGetPageZoomFactor(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->pageZoomFactor();
+    return toProtectedImpl(pageRef)->pageZoomFactor();
 }
 
 void WKPageSetPageZoomFactor(WKPageRef pageRef, double zoomFactor)
@@ -669,170 +669,170 @@ void WKPageSetPageZoomFactor(WKPageRef pageRef, double zoomFactor)
     CRASH_IF_SUSPENDED;
     if (zoomFactor <= 0)
         return;
-    toImpl(pageRef)->setPageZoomFactor(zoomFactor);
+    toProtectedImpl(pageRef)->setPageZoomFactor(zoomFactor);
 }
 
 void WKPageSetPageAndTextZoomFactors(WKPageRef pageRef, double pageZoomFactor, double textZoomFactor)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setPageAndTextZoomFactors(pageZoomFactor, textZoomFactor);
+    toProtectedImpl(pageRef)->setPageAndTextZoomFactors(pageZoomFactor, textZoomFactor);
 }
 
 void WKPageSetScaleFactor(WKPageRef pageRef, double scale, WKPoint origin)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->scalePage(scale, toIntPoint(origin), [] { });
+    toProtectedImpl(pageRef)->scalePage(scale, toIntPoint(origin), [] { });
 }
 
 double WKPageGetScaleFactor(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->pageScaleFactor();
+    return toProtectedImpl(pageRef)->pageScaleFactor();
 }
 
 void WKPageSetUseFixedLayout(WKPageRef pageRef, bool fixed)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setUseFixedLayout(fixed);
+    toProtectedImpl(pageRef)->setUseFixedLayout(fixed);
 }
 
 void WKPageSetFixedLayoutSize(WKPageRef pageRef, WKSize size)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setFixedLayoutSize(toIntSize(size));
+    toProtectedImpl(pageRef)->setFixedLayoutSize(toIntSize(size));
 }
 
 bool WKPageUseFixedLayout(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->useFixedLayout();
+    return toProtectedImpl(pageRef)->useFixedLayout();
 }
 
 WKSize WKPageFixedLayoutSize(WKPageRef pageRef)
 {
-    return toAPI(toImpl(pageRef)->fixedLayoutSize());
+    return toAPI(toProtectedImpl(pageRef)->fixedLayoutSize());
 }
 
 void WKPageListenForLayoutMilestones(WKPageRef pageRef, WKLayoutMilestones milestones)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->listenForLayoutMilestones(toLayoutMilestones(milestones));
+    toProtectedImpl(pageRef)->listenForLayoutMilestones(toLayoutMilestones(milestones));
 }
 
 bool WKPageHasHorizontalScrollbar(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->hasHorizontalScrollbar();
+    return toProtectedImpl(pageRef)->hasHorizontalScrollbar();
 }
 
 bool WKPageHasVerticalScrollbar(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->hasVerticalScrollbar();
+    return toProtectedImpl(pageRef)->hasVerticalScrollbar();
 }
 
 void WKPageSetSuppressScrollbarAnimations(WKPageRef pageRef, bool suppressAnimations)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setSuppressScrollbarAnimations(suppressAnimations);
+    toProtectedImpl(pageRef)->setSuppressScrollbarAnimations(suppressAnimations);
 }
 
 bool WKPageAreScrollbarAnimationsSuppressed(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->areScrollbarAnimationsSuppressed();
+    return toProtectedImpl(pageRef)->areScrollbarAnimationsSuppressed();
 }
 
 bool WKPageIsPinnedToLeftSide(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->pinnedState().left();
+    return toProtectedImpl(pageRef)->pinnedState().left();
 }
 
 bool WKPageIsPinnedToRightSide(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->pinnedState().right();
+    return toProtectedImpl(pageRef)->pinnedState().right();
 }
 
 bool WKPageIsPinnedToTopSide(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->pinnedState().top();
+    return toProtectedImpl(pageRef)->pinnedState().top();
 }
 
 bool WKPageIsPinnedToBottomSide(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->pinnedState().bottom();
+    return toProtectedImpl(pageRef)->pinnedState().bottom();
 }
 
 bool WKPageRubberBandsAtLeft(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->rubberBandableEdges().left();
+    return toProtectedImpl(pageRef)->rubberBandableEdges().left();
 }
 
 void WKPageSetRubberBandsAtLeft(WKPageRef pageRef, bool rubberBandsAtLeft)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setRubberBandsAtLeft(rubberBandsAtLeft);
+    toProtectedImpl(pageRef)->setRubberBandsAtLeft(rubberBandsAtLeft);
 }
 
 bool WKPageRubberBandsAtRight(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->rubberBandableEdges().right();
+    return toProtectedImpl(pageRef)->rubberBandableEdges().right();
 }
 
 void WKPageSetRubberBandsAtRight(WKPageRef pageRef, bool rubberBandsAtRight)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setRubberBandsAtRight(rubberBandsAtRight);
+    toProtectedImpl(pageRef)->setRubberBandsAtRight(rubberBandsAtRight);
 }
 
 bool WKPageRubberBandsAtTop(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->rubberBandableEdges().top();
+    return toProtectedImpl(pageRef)->rubberBandableEdges().top();
 }
 
 void WKPageSetRubberBandsAtTop(WKPageRef pageRef, bool rubberBandsAtTop)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setRubberBandsAtTop(rubberBandsAtTop);
+    toProtectedImpl(pageRef)->setRubberBandsAtTop(rubberBandsAtTop);
 }
 
 bool WKPageRubberBandsAtBottom(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->rubberBandableEdges().bottom();
+    return toProtectedImpl(pageRef)->rubberBandableEdges().bottom();
 }
 
 void WKPageSetRubberBandsAtBottom(WKPageRef pageRef, bool rubberBandsAtBottom)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setRubberBandsAtBottom(rubberBandsAtBottom);
+    toProtectedImpl(pageRef)->setRubberBandsAtBottom(rubberBandsAtBottom);
 }
 
 bool WKPageVerticalRubberBandingIsEnabled(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->verticalRubberBandingIsEnabled();
+    return toProtectedImpl(pageRef)->verticalRubberBandingIsEnabled();
 }
 
 void WKPageSetEnableVerticalRubberBanding(WKPageRef pageRef, bool enableVerticalRubberBanding)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setEnableVerticalRubberBanding(enableVerticalRubberBanding);
+    toProtectedImpl(pageRef)->setEnableVerticalRubberBanding(enableVerticalRubberBanding);
 }
 
 bool WKPageHorizontalRubberBandingIsEnabled(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->horizontalRubberBandingIsEnabled();
+    return toProtectedImpl(pageRef)->horizontalRubberBandingIsEnabled();
 }
 
 void WKPageSetEnableHorizontalRubberBanding(WKPageRef pageRef, bool enableHorizontalRubberBanding)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setEnableHorizontalRubberBanding(enableHorizontalRubberBanding);
+    toProtectedImpl(pageRef)->setEnableHorizontalRubberBanding(enableHorizontalRubberBanding);
 }
 
 void WKPageSetBackgroundExtendsBeyondPage(WKPageRef pageRef, bool backgroundExtendsBeyondPage)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setBackgroundExtendsBeyondPage(backgroundExtendsBeyondPage);
+    toProtectedImpl(pageRef)->setBackgroundExtendsBeyondPage(backgroundExtendsBeyondPage);
 }
 
 bool WKPageBackgroundExtendsBeyondPage(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->backgroundExtendsBeyondPage();
+    return toProtectedImpl(pageRef)->backgroundExtendsBeyondPage();
 }
 
 void WKPageSetPaginationMode(WKPageRef pageRef, WKPaginationMode paginationMode)
@@ -858,12 +858,12 @@ void WKPageSetPaginationMode(WKPageRef pageRef, WKPaginationMode paginationMode)
     default:
         return;
     }
-    toImpl(pageRef)->setPaginationMode(mode);
+    toProtectedImpl(pageRef)->setPaginationMode(mode);
 }
 
 WKPaginationMode WKPageGetPaginationMode(WKPageRef pageRef)
 {
-    switch (toImpl(pageRef)->paginationMode()) {
+    switch (toProtectedImpl(pageRef)->paginationMode()) {
     case WebCore::Pagination::Mode::Unpaginated:
         return kWKPaginationModeUnpaginated;
     case WebCore::Pagination::Mode::LeftToRightPaginated:
@@ -883,34 +883,34 @@ WKPaginationMode WKPageGetPaginationMode(WKPageRef pageRef)
 void WKPageSetPaginationBehavesLikeColumns(WKPageRef pageRef, bool behavesLikeColumns)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setPaginationBehavesLikeColumns(behavesLikeColumns);
+    toProtectedImpl(pageRef)->setPaginationBehavesLikeColumns(behavesLikeColumns);
 }
 
 bool WKPageGetPaginationBehavesLikeColumns(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->paginationBehavesLikeColumns();
+    return toProtectedImpl(pageRef)->paginationBehavesLikeColumns();
 }
 
 void WKPageSetPageLength(WKPageRef pageRef, double pageLength)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setPageLength(pageLength);
+    toProtectedImpl(pageRef)->setPageLength(pageLength);
 }
 
 double WKPageGetPageLength(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->pageLength();
+    return toProtectedImpl(pageRef)->pageLength();
 }
 
 void WKPageSetGapBetweenPages(WKPageRef pageRef, double gap)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setGapBetweenPages(gap);
+    toProtectedImpl(pageRef)->setGapBetweenPages(gap);
 }
 
 double WKPageGetGapBetweenPages(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->gapBetweenPages();
+    return toProtectedImpl(pageRef)->gapBetweenPages();
 }
 
 void WKPageSetPaginationLineGridEnabled(WKPageRef, bool)
@@ -924,70 +924,70 @@ bool WKPageGetPaginationLineGridEnabled(WKPageRef)
 
 unsigned WKPageGetPageCount(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->pageCount();
+    return toProtectedImpl(pageRef)->pageCount();
 }
 
 bool WKPageCanDelete(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->canDelete();
+    return toProtectedImpl(pageRef)->canDelete();
 }
 
 bool WKPageHasSelectedRange(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->hasSelectedRange();
+    return toProtectedImpl(pageRef)->hasSelectedRange();
 }
 
 bool WKPageIsContentEditable(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->isContentEditable();
+    return toProtectedImpl(pageRef)->isContentEditable();
 }
 
 void WKPageSetMaintainsInactiveSelection(WKPageRef pageRef, bool newValue)
 {
     CRASH_IF_SUSPENDED;
-    return toImpl(pageRef)->setMaintainsInactiveSelection(newValue);
+    return toProtectedImpl(pageRef)->setMaintainsInactiveSelection(newValue);
 }
 
 void WKPageCenterSelectionInVisibleArea(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    return toImpl(pageRef)->centerSelectionInVisibleArea();
+    return toProtectedImpl(pageRef)->centerSelectionInVisibleArea();
 }
 
 void WKPageFindStringMatches(WKPageRef pageRef, WKStringRef string, WKFindOptions options, unsigned maxMatchCount)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->findStringMatches(toImpl(string)->string(), toFindOptions(options), maxMatchCount);
+    toProtectedImpl(pageRef)->findStringMatches(toProtectedImpl(string)->string(), toFindOptions(options), maxMatchCount);
 }
 
 void WKPageGetImageForFindMatch(WKPageRef pageRef, int32_t matchIndex)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->getImageForFindMatch(matchIndex);
+    toProtectedImpl(pageRef)->getImageForFindMatch(matchIndex);
 }
 
 void WKPageSelectFindMatch(WKPageRef pageRef, int32_t matchIndex)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->selectFindMatch(matchIndex);
+    toProtectedImpl(pageRef)->selectFindMatch(matchIndex);
 }
 
 void WKPageFindString(WKPageRef pageRef, WKStringRef string, WKFindOptions options, unsigned maxMatchCount)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->findString(toImpl(string)->string(), toFindOptions(options), maxMatchCount);
+    toProtectedImpl(pageRef)->findString(toProtectedImpl(string)->string(), toFindOptions(options), maxMatchCount);
 }
 
 void WKPageHideFindUI(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->hideFindUI();
+    toProtectedImpl(pageRef)->hideFindUI();
 }
 
 void WKPageCountStringMatches(WKPageRef pageRef, WKStringRef string, WKFindOptions options, unsigned maxMatchCount)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->countStringMatches(toImpl(string)->string(), toFindOptions(options), maxMatchCount);
+    toProtectedImpl(pageRef)->countStringMatches(toProtectedImpl(string)->string(), toFindOptions(options), maxMatchCount);
 }
 
 void WKPageSetPageContextMenuClient(WKPageRef pageRef, const WKPageContextMenuClientBase* wkClient)
@@ -1031,7 +1031,7 @@ void WKPageSetPageContextMenuClient(WKPageRef pageRef, const WKPageContextMenuCl
             } else
                 m_client.getContextMenuFromProposedMenu_deprecatedForUseWithV0(toAPI(&page), toAPI(API::Array::create(WTFMove(proposedMenuItems)).ptr()), &newMenu, toAPI(userData), m_client.base.clientInfo);
 
-            RefPtr<API::Array> array = adoptRef(toImpl(newMenu));
+            RefPtr<API::Array> array = toProtectedImpl(newMenu);
 
             Vector<Ref<WebContextMenuItem>> customMenu;
             size_t newSize = array ? array->size() : 0;
@@ -1082,7 +1082,7 @@ void WKPageSetPageContextMenuClient(WKPageRef pageRef, const WKPageContextMenuCl
         }
     };
 
-    toImpl(pageRef)->setContextMenuClient(makeUnique<ContextMenuClient>(wkClient));
+    toProtectedImpl(pageRef)->setContextMenuClient(makeUnique<ContextMenuClient>(wkClient));
 #else
     UNUSED_PARAM(pageRef);
     UNUSED_PARAM(wkClient);
@@ -1091,7 +1091,7 @@ void WKPageSetPageContextMenuClient(WKPageRef pageRef, const WKPageContextMenuCl
 
 void WKPageSetPageDiagnosticLoggingClient(WKPageRef pageRef, const WKPageDiagnosticLoggingClientBase* wkClient)
 {
-    toImpl(pageRef)->setDiagnosticLoggingClient(makeUnique<WebPageDiagnosticLoggingClient>(wkClient));
+    toProtectedImpl(pageRef)->setDiagnosticLoggingClient(makeUnique<WebPageDiagnosticLoggingClient>(wkClient));
 }
 
 void WKPageSetPageFindClient(WKPageRef pageRef, const WKPageFindClientBase* wkClient)
@@ -1130,7 +1130,7 @@ void WKPageSetPageFindClient(WKPageRef pageRef, const WKPageFindClientBase* wkCl
         }
     };
 
-    toImpl(pageRef)->setFindClient(makeUnique<FindClient>(wkClient));
+    toProtectedImpl(pageRef)->setFindClient(makeUnique<FindClient>(wkClient));
 }
 
 void WKPageSetPageFindMatchesClient(WKPageRef pageRef, const WKPageFindMatchesClientBase* wkClient)
@@ -1167,13 +1167,13 @@ void WKPageSetPageFindMatchesClient(WKPageRef pageRef, const WKPageFindMatchesCl
         }
     };
 
-    toImpl(pageRef)->setFindMatchesClient(makeUnique<FindMatchesClient>(wkClient));
+    toProtectedImpl(pageRef)->setFindMatchesClient(makeUnique<FindMatchesClient>(wkClient));
 }
 
 void WKPageSetPageInjectedBundleClient(WKPageRef pageRef, const WKPageInjectedBundleClientBase* wkClient)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setInjectedBundleClient(wkClient);
+    toProtectedImpl(pageRef)->setInjectedBundleClient(wkClient);
 }
 
 class CompletionListener : public API::ObjectImpl<API::Object::Type::CompletionListener> {
@@ -1198,7 +1198,7 @@ WK_ADD_API_MAPPING(WKCompletionListenerRef, CompletionListener);
 
 void WKCompletionListenerComplete(WKCompletionListenerRef listener)
 {
-    toImpl(listener)->complete();
+    toProtectedImpl(listener)->complete();
 }
 
 void WKPageSetFullScreenClientForTesting(WKPageRef pageRef, const WKPageFullScreenClientBase* client)
@@ -1209,8 +1209,8 @@ void WKPageSetFullScreenClientForTesting(WKPageRef pageRef, const WKPageFullScre
         WTF_MAKE_FAST_ALLOCATED;
         WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FullScreenClientForTesting);
     public:
-        FullScreenClientForTesting(const WKPageFullScreenClientBase* client, WebPageProxy* page)
-            : m_page(page)
+        FullScreenClientForTesting(const WKPageFullScreenClientBase* client, RefPtr<WebPageProxy>&& page)
+            : m_page(WTFMove(page))
         {
             initialize(client);
         }
@@ -1259,8 +1259,8 @@ void WKPageSetFullScreenClientForTesting(WKPageRef pageRef, const WKPageFullScre
     };
     [[maybe_unused]] FullScreenClientForTesting::WTFDidOverrideDeleteForCheckedPtr makeGCCHappy { 0 };
 
-    auto fullscreenClient = client ? makeUnique<FullScreenClientForTesting>(client, toImpl(pageRef)) : nullptr;
-    toImpl(pageRef)->setFullScreenClientForTesting(WTFMove(fullscreenClient));
+    auto fullscreenClient = client ? makeUnique<FullScreenClientForTesting>(client, toProtectedImpl(pageRef)) : nullptr;
+    toProtectedImpl(pageRef)->setFullScreenClientForTesting(WTFMove(fullscreenClient));
 #else
     UNUSED_PARAM(client);
 #endif
@@ -1270,7 +1270,7 @@ void WKPageRequestExitFullScreen(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
 #if ENABLE(FULLSCREEN_API)
-    if (RefPtr manager = toImpl(pageRef)->fullScreenManager())
+    if (RefPtr manager = toProtectedImpl(pageRef)->fullScreenManager())
         manager->requestExitFullScreen();
 #endif
 }
@@ -1278,7 +1278,7 @@ void WKPageRequestExitFullScreen(WKPageRef pageRef)
 void WKPageSetPageFormClient(WKPageRef pageRef, const WKPageFormClientBase* wkClient)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setFormClient(makeUnique<WebFormClient>(wkClient));
+    toProtectedImpl(pageRef)->setFormClient(makeUnique<WebFormClient>(wkClient));
 }
 
 void WKPageSetPageLoaderClient(WKPageRef pageRef, const WKPageLoaderClientBase* wkClient)
@@ -1422,7 +1422,7 @@ void WKPageSetPageLoaderClient(WKPageRef pageRef, const WKPageLoaderClientBase* 
         }
     };
 
-    WebPageProxy* webPageProxy = toImpl(pageRef);
+    RefPtr<WebPageProxy> webPageProxy = toProtectedImpl(pageRef);
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     // GCC 10 gets confused here and warns that WKPageSetPagePolicyClient is deprecated when we call
@@ -1511,7 +1511,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     // GCC 10 gets confused here and warns that WKPageSetPagePolicyClient is deprecated when we call
     // makeUnique<PolicyClient>(). This seems to be a GCC bug. It's not really appropriate to use
     // ALLOW_DEPRECATED_DECLARATIONS_BEGIN/END here because we are not using a deprecated symbol.
-    toImpl(pageRef)->setPolicyClient(makeUnique<PolicyClient>(wkClient));
+    toProtectedImpl(pageRef)->setPolicyClient(makeUnique<PolicyClient>(wkClient));
 ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
@@ -1678,7 +1678,7 @@ WKTypeID WKPageRunBeforeUnloadConfirmPanelResultListenerGetTypeID()
 
 void WKPageRunBeforeUnloadConfirmPanelResultListenerCall(WKPageRunBeforeUnloadConfirmPanelResultListenerRef listener, bool result)
 {
-    toImpl(listener)->call(result);
+    toProtectedImpl(listener)->call(result);
 }
 
 WKTypeID WKPageRunJavaScriptAlertResultListenerGetTypeID()
@@ -1688,7 +1688,7 @@ WKTypeID WKPageRunJavaScriptAlertResultListenerGetTypeID()
 
 void WKPageRunJavaScriptAlertResultListenerCall(WKPageRunJavaScriptAlertResultListenerRef listener)
 {
-    toImpl(listener)->call();
+    toProtectedImpl(listener)->call();
 }
 
 WKTypeID WKPageRunJavaScriptConfirmResultListenerGetTypeID()
@@ -1698,7 +1698,7 @@ WKTypeID WKPageRunJavaScriptConfirmResultListenerGetTypeID()
 
 void WKPageRunJavaScriptConfirmResultListenerCall(WKPageRunJavaScriptConfirmResultListenerRef listener, bool result)
 {
-    toImpl(listener)->call(result);
+    toProtectedImpl(listener)->call(result);
 }
 
 WKTypeID WKPageRunJavaScriptPromptResultListenerGetTypeID()
@@ -1708,7 +1708,7 @@ WKTypeID WKPageRunJavaScriptPromptResultListenerGetTypeID()
 
 void WKPageRunJavaScriptPromptResultListenerCall(WKPageRunJavaScriptPromptResultListenerRef listener, WKStringRef result)
 {
-    toImpl(listener)->call(toWTFString(result));
+    toProtectedImpl(listener)->call(toWTFString(result));
 }
 
 WKTypeID WKPageRequestStorageAccessConfirmResultListenerGetTypeID()
@@ -1718,7 +1718,7 @@ WKTypeID WKPageRequestStorageAccessConfirmResultListenerGetTypeID()
 
 void WKPageRequestStorageAccessConfirmResultListenerCall(WKPageRequestStorageAccessConfirmResultListenerRef listener, bool result)
 {
-    toImpl(listener)->call(result);
+    toProtectedImpl(listener)->call(result);
 }
 
 void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient)
@@ -1738,7 +1738,7 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
             auto& windowFeatures = *configuration->windowFeatures();
             if (m_client.createNewPage) {
                 auto apiWindowFeatures = API::WindowFeatures::create(windowFeatures);
-                return completionHandler(adoptRef(toImpl(m_client.createNewPage(toAPI(&page), toAPI(configuration.ptr()), toAPI(navigationAction.ptr()), toAPI(apiWindowFeatures.ptr()), m_client.base.clientInfo))));
+                return completionHandler(toProtectedImpl(m_client.createNewPage(toAPI(&page), toAPI(configuration.ptr()), toAPI(navigationAction.ptr()), toAPI(apiWindowFeatures.ptr()), m_client.base.clientInfo)));
             }
         
             if (m_client.createNewPage_deprecatedForUseWithV1 || m_client.createNewPage_deprecatedForUseWithV0) {
@@ -1775,11 +1775,11 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
 
                 if (m_client.createNewPage_deprecatedForUseWithV1) {
                     Ref<API::URLRequest> request = API::URLRequest::create(navigationAction->request());
-                    return completionHandler(adoptRef(toImpl(m_client.createNewPage_deprecatedForUseWithV1(toAPI(&page), toAPI(request.ptr()), toAPI(featuresMap.ptr()), toAPI(navigationAction->modifiers()), toAPI(navigationAction->mouseButton()), m_client.base.clientInfo))));
+                    return completionHandler(toProtectedImpl(m_client.createNewPage_deprecatedForUseWithV1(toAPI(&page), toAPI(request.ptr()), toAPI(featuresMap.ptr()), toAPI(navigationAction->modifiers()), toAPI(navigationAction->mouseButton()), m_client.base.clientInfo)));
                 }
     
                 ASSERT(m_client.createNewPage_deprecatedForUseWithV0);
-                return completionHandler(adoptRef(toImpl(m_client.createNewPage_deprecatedForUseWithV0(toAPI(&page), toAPI(featuresMap.ptr()), toAPI(navigationAction->modifiers()), toAPI(navigationAction->mouseButton()), m_client.base.clientInfo))));
+                return completionHandler(toProtectedImpl(m_client.createNewPage_deprecatedForUseWithV0(toAPI(&page), toAPI(featuresMap.ptr()), toAPI(navigationAction->modifiers()), toAPI(navigationAction->mouseButton()), m_client.base.clientInfo)));
             }
 
             completionHandler(nullptr);
@@ -1906,7 +1906,7 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
 
             if (m_client.runJavaScriptPrompt_deprecatedForUseWithV5) {
                 RefPtr<API::SecurityOrigin> securityOrigin = API::SecurityOrigin::create(frameInfo.securityOrigin);
-                RefPtr<API::String> string = adoptRef(toImpl(m_client.runJavaScriptPrompt_deprecatedForUseWithV5(toAPI(&page), toAPI(message.impl()), toAPI(defaultValue.impl()), toAPI(frame), toAPI(securityOrigin.get()), m_client.base.clientInfo)));
+                RefPtr<API::String> string = toProtectedImpl(m_client.runJavaScriptPrompt_deprecatedForUseWithV5(toAPI(&page), toAPI(message.impl()), toAPI(defaultValue.impl()), toAPI(frame), toAPI(securityOrigin.get()), m_client.base.clientInfo));
                 
                 if (string)
                     completionHandler(string->string());
@@ -1916,7 +1916,7 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
             }
             
             if (m_client.runJavaScriptPrompt_deprecatedForUseWithV0) {
-                RefPtr<API::String> string = adoptRef(toImpl(m_client.runJavaScriptPrompt_deprecatedForUseWithV0(toAPI(&page), toAPI(message.impl()), toAPI(defaultValue.impl()), toAPI(frame), m_client.base.clientInfo)));
+                RefPtr<API::String> string = toProtectedImpl(m_client.runJavaScriptPrompt_deprecatedForUseWithV0(toAPI(&page), toAPI(message.impl()), toAPI(defaultValue.impl()), toAPI(frame), m_client.base.clientInfo));
                 
                 if (string)
                     completionHandler(string->string());
@@ -2374,7 +2374,7 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
         }
     };
 
-    toImpl(pageRef)->setUIClient(makeUnique<UIClient>(wkClient));
+    toProtectedImpl(pageRef)->setUIClient(makeUnique<UIClient>(wkClient));
 }
 
 void WKPageSetPageNavigationClient(WKPageRef pageRef, const WKPageNavigationClientBase* wkClient)
@@ -2496,7 +2496,7 @@ void WKPageSetPageNavigationClient(WKPageRef pageRef, const WKPageNavigationClie
         void legacyWebCryptoMasterKey(WebKit::WebPageProxy& page, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&& completionHandler) override
         {
             if (m_client.copyWebCryptoMasterKey) {
-                if (auto data = adoptRef(toImpl(m_client.copyWebCryptoMasterKey(toAPI(&page), m_client.base.clientInfo))))
+                if (auto data = toProtectedImpl(m_client.copyWebCryptoMasterKey(toAPI(&page), m_client.base.clientInfo)))
                     return completionHandler(Vector(data->span()));
             }
             return completionHandler(defaultWebCryptoMasterKey());
@@ -2574,7 +2574,7 @@ void WKPageSetPageNavigationClient(WKPageRef pageRef, const WKPageNavigationClie
 #endif
     };
 
-    WebPageProxy* webPageProxy = toImpl(pageRef);
+    RefPtr<WebPageProxy> webPageProxy = toProtectedImpl(pageRef);
 
     webPageProxy->setNavigationClient(makeUniqueRef<NavigationClient>(wkClient));
 }
@@ -2748,17 +2748,17 @@ void WKPageSetPageStateClient(WKPageRef pageRef, WKPageStateClientBase* client)
 {
     CRASH_IF_SUSPENDED;
     if (client)
-        toImpl(pageRef)->setPageLoadStateObserver(StateClient::create(client));
+        toProtectedImpl(pageRef)->setPageLoadStateObserver(StateClient::create(client));
     else
-        toImpl(pageRef)->setPageLoadStateObserver(nullptr);
+        toProtectedImpl(pageRef)->setPageLoadStateObserver(nullptr);
 }
 
 void WKPageEvaluateJavaScriptInMainFrame(WKPageRef pageRef, WKStringRef scriptRef, void* context, WKPageEvaluateJavaScriptFunction callback)
 {
     CRASH_IF_SUSPENDED;
 
-    toImpl(pageRef)->runJavaScriptInMainFrame(WebKit::RunJavaScriptParameters {
-        toImpl(scriptRef)->string(),
+    toProtectedImpl(pageRef)->runJavaScriptInMainFrame(WebKit::RunJavaScriptParameters {
+        toProtectedImpl(scriptRef)->string(),
         JSC::SourceTaintedOrigin::Untainted,
         URL { },
         WebCore::RunAsAsyncFunction::No,
@@ -2785,37 +2785,37 @@ static CompletionHandler<void(const String&)> toStringCallback(void* context, vo
 void WKPageRenderTreeExternalRepresentation(WKPageRef pageRef, void* context, WKPageRenderTreeExternalRepresentationFunction callback)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->getRenderTreeExternalRepresentation(toStringCallback(context, callback));
+    toProtectedImpl(pageRef)->getRenderTreeExternalRepresentation(toStringCallback(context, callback));
 }
 
 void WKPageGetSourceForFrame(WKPageRef pageRef, WKFrameRef frameRef, void* context, WKPageGetSourceForFrameFunction callback)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->getSourceForFrame(toImpl(frameRef), toStringCallback(context, callback));
+    toProtectedImpl(pageRef)->getSourceForFrame(toImpl(frameRef), toStringCallback(context, callback));
 }
 
 void WKPageGetContentsAsString(WKPageRef pageRef, void* context, WKPageGetContentsAsStringFunction callback)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->getContentsAsString(ContentAsStringIncludesChildFrames::No, toStringCallback(context, callback));
+    toProtectedImpl(pageRef)->getContentsAsString(ContentAsStringIncludesChildFrames::No, toStringCallback(context, callback));
 }
 
 void WKPageGetBytecodeProfile(WKPageRef pageRef, void* context, WKPageGetBytecodeProfileFunction callback)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->getBytecodeProfile(toStringCallback(context, callback));
+    toProtectedImpl(pageRef)->getBytecodeProfile(toStringCallback(context, callback));
 }
 
 void WKPageGetSamplingProfilerOutput(WKPageRef pageRef, void* context, WKPageGetSamplingProfilerOutputFunction callback)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->getSamplingProfilerOutput(toStringCallback(context, callback));
+    toProtectedImpl(pageRef)->getSamplingProfilerOutput(toStringCallback(context, callback));
 }
 
 void WKPageGetSelectionAsWebArchiveData(WKPageRef pageRef, void* context, WKPageGetSelectionAsWebArchiveDataFunction callback)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->getSelectionAsWebArchiveData([context, callback] (API::Data* data) {
+    toProtectedImpl(pageRef)->getSelectionAsWebArchiveData([context, callback] (API::Data* data) {
         callback(toAPI(data), nullptr, context);
     });
 }
@@ -2824,7 +2824,7 @@ void WKPageGetContentsAsMHTMLData(WKPageRef pageRef, void* context, WKPageGetCon
 {
     CRASH_IF_SUSPENDED;
 #if ENABLE(MHTML)
-    toImpl(pageRef)->getContentsAsMHTMLData([context, callback] (API::Data* data) {
+    toProtectedImpl(pageRef)->getContentsAsMHTMLData([context, callback] (API::Data* data) {
         callback(toAPI(data), nullptr, context);
     });
 #else
@@ -2837,14 +2837,14 @@ void WKPageGetContentsAsMHTMLData(WKPageRef pageRef, void* context, WKPageGetCon
 void WKPageForceRepaint(WKPageRef pageRef, void* context, WKPageForceRepaintFunction callback)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->updateRenderingWithForcedRepaint([context, callback]() {
+    toProtectedImpl(pageRef)->updateRenderingWithForcedRepaint([context, callback]() {
         callback(nullptr, context);
     });
 }
 
 WK_EXPORT WKURLRef WKPageCopyPendingAPIRequestURL(WKPageRef pageRef)
 {
-    const String& pendingAPIRequestURL = toImpl(pageRef)->pageLoadState().pendingAPIRequestURL();
+    const String& pendingAPIRequestURL = toProtectedImpl(pageRef)->pageLoadState().pendingAPIRequestURL();
 
     if (pendingAPIRequestURL.isNull())
         return nullptr;
@@ -2854,29 +2854,29 @@ WK_EXPORT WKURLRef WKPageCopyPendingAPIRequestURL(WKPageRef pageRef)
 
 WKURLRef WKPageCopyActiveURL(WKPageRef pageRef)
 {
-    return toCopiedURLAPI(toImpl(pageRef)->pageLoadState().activeURL());
+    return toCopiedURLAPI(toProtectedImpl(pageRef)->pageLoadState().activeURL());
 }
 
 WKURLRef WKPageCopyProvisionalURL(WKPageRef pageRef)
 {
-    return toCopiedURLAPI(toImpl(pageRef)->pageLoadState().provisionalURL());
+    return toCopiedURLAPI(toProtectedImpl(pageRef)->pageLoadState().provisionalURL());
 }
 
 WKURLRef WKPageCopyCommittedURL(WKPageRef pageRef)
 {
-    return toCopiedURLAPI(toImpl(pageRef)->pageLoadState().url());
+    return toCopiedURLAPI(toProtectedImpl(pageRef)->pageLoadState().url());
 }
 
 WKStringRef WKPageCopyStandardUserAgentWithApplicationName(WKStringRef applicationName)
 {
-    return toCopiedAPI(WebPageProxy::standardUserAgent(toImpl(applicationName)->string()));
+    return toCopiedAPI(WebPageProxy::standardUserAgent(toProtectedImpl(applicationName)->string()));
 }
 
 void WKPageValidateCommand(WKPageRef pageRef, WKStringRef command, void* context, WKPageValidateCommandCallback callback)
 {
     CRASH_IF_SUSPENDED;
-    auto commandName = toImpl(command)->string();
-    toImpl(pageRef)->validateCommand(commandName, [context, callback, commandName](bool isEnabled, int32_t state) {
+    auto commandName = toProtectedImpl(command)->string();
+    toProtectedImpl(pageRef)->validateCommand(commandName, [context, callback, commandName](bool isEnabled, int32_t state) {
         callback(toAPI(API::String::create(commandName).ptr()), isEnabled, state, nullptr, context);
     });
 }
@@ -2884,7 +2884,7 @@ void WKPageValidateCommand(WKPageRef pageRef, WKStringRef command, void* context
 void WKPageExecuteCommand(WKPageRef pageRef, WKStringRef command)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->executeEditCommand(toImpl(command)->string());
+    toProtectedImpl(pageRef)->executeEditCommand(toProtectedImpl(command)->string());
 }
 
 static PrintInfo printInfoFromWKPrintInfo(const WKPrintInfo& printInfo)
@@ -2899,7 +2899,7 @@ static PrintInfo printInfoFromWKPrintInfo(const WKPrintInfo& printInfo)
 void WKPageComputePagesForPrinting(WKPageRef pageRef, WKFrameRef frame, WKPrintInfo printInfo, WKPageComputePagesForPrintingFunction callback, void* context)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->computePagesForPrinting(toImpl(frame)->frameID(), printInfoFromWKPrintInfo(printInfo), [context, callback](const Vector<WebCore::IntRect>& rects, double scaleFactor, const WebCore::FloatBoxExtent& computedPageMargin) {
+    toProtectedImpl(pageRef)->computePagesForPrinting(toProtectedImpl(frame)->frameID(), printInfoFromWKPrintInfo(printInfo), [context, callback](const Vector<WebCore::IntRect>& rects, double scaleFactor, const WebCore::FloatBoxExtent& computedPageMargin) {
         Vector<WKRect> wkRects(rects.size());
         for (size_t i = 0; i < rects.size(); ++i)
             wkRects[i] = toAPI(rects[i]);
@@ -2911,7 +2911,7 @@ void WKPageComputePagesForPrinting(WKPageRef pageRef, WKFrameRef frame, WKPrintI
 void WKPageDrawPagesToPDF(WKPageRef pageRef, WKFrameRef frame, WKPrintInfo printInfo, uint32_t first, uint32_t count, WKPageDrawToPDFFunction callback, void* context)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->drawPagesToPDF(*toImpl(frame), printInfoFromWKPrintInfo(printInfo), first, count, [context, callback] (API::Data* data) {
+    toProtectedImpl(pageRef)->drawPagesToPDF(*toProtectedImpl(frame), printInfoFromWKPrintInfo(printInfo), first, count, [context, callback] (API::Data* data) {
         callback(toAPI(data), nullptr, context);
     });
 }
@@ -2920,30 +2920,30 @@ void WKPageDrawPagesToPDF(WKPageRef pageRef, WKFrameRef frame, WKPrintInfo print
 void WKPageBeginPrinting(WKPageRef pageRef, WKFrameRef frame, WKPrintInfo printInfo)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->beginPrinting(toImpl(frame), printInfoFromWKPrintInfo(printInfo));
+    toProtectedImpl(pageRef)->beginPrinting(toImpl(frame), printInfoFromWKPrintInfo(printInfo));
 }
 
 void WKPageEndPrinting(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->endPrinting();
+    toProtectedImpl(pageRef)->endPrinting();
 }
 
 bool WKPageGetIsControlledByAutomation(WKPageRef page)
 {
-    return toImpl(page)->isControlledByAutomation();
+    return toProtectedImpl(page)->isControlledByAutomation();
 }
 
 void WKPageSetControlledByAutomation(WKPageRef pageRef, bool controlled)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setControlledByAutomation(controlled);
+    toProtectedImpl(pageRef)->setControlledByAutomation(controlled);
 }
 
 bool WKPageGetAllowsRemoteInspection(WKPageRef page)
 {
 #if ENABLE(REMOTE_INSPECTOR)
-    return toImpl(page)->inspectable();
+    return toProtectedImpl(page)->inspectable();
 #else
     UNUSED_PARAM(page);
     return false;
@@ -2954,7 +2954,7 @@ void WKPageSetAllowsRemoteInspection(WKPageRef pageRef, bool allow)
 {
     CRASH_IF_SUSPENDED;
 #if ENABLE(REMOTE_INSPECTOR)
-    toImpl(pageRef)->setInspectable(allow);
+    toProtectedImpl(pageRef)->setInspectable(allow);
 #else
     UNUSED_PARAM(pageRef);
     UNUSED_PARAM(allow);
@@ -2963,7 +2963,7 @@ void WKPageSetAllowsRemoteInspection(WKPageRef pageRef, bool allow)
 
 void WKPageShowWebInspectorForTesting(WKPageRef pageRef)
 {
-    RefPtr<WebInspectorUIProxy> inspector = toImpl(pageRef)->inspector();
+    RefPtr<WebInspectorUIProxy> inspector = toProtectedImpl(pageRef)->inspector();
     inspector->markAsUnderTest();
     inspector->show();
 }
@@ -2971,7 +2971,7 @@ void WKPageShowWebInspectorForTesting(WKPageRef pageRef)
 void WKPageSetMediaVolume(WKPageRef pageRef, float volume)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setMediaVolume(volume);
+    toProtectedImpl(pageRef)->setMediaVolume(volume);
 }
 
 void WKPageSetMuted(WKPageRef pageRef, WKMediaMutedState mutedState)
@@ -3004,25 +3004,25 @@ void WKPageSetMuted(WKPageRef pageRef, WKMediaMutedState mutedState)
     if (mutedState & kWKMediaMicrophoneCaptureUnmuted)
         coreState.remove(WebCore::MediaProducerMutedState::AudioCaptureIsMuted);
 
-    toImpl(pageRef)->setMuted(coreState, WebKit::WebPageProxy::FromApplication::Yes);
+    toProtectedImpl(pageRef)->setMuted(coreState, WebKit::WebPageProxy::FromApplication::Yes);
 }
 
 void WKPageSetMediaCaptureEnabled(WKPageRef pageRef, bool enabled)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setMediaCaptureEnabled(enabled);
+    toProtectedImpl(pageRef)->setMediaCaptureEnabled(enabled);
 }
 
 bool WKPageGetMediaCaptureEnabled(WKPageRef page)
 {
-    return toImpl(page)->mediaCaptureEnabled();
+    return toProtectedImpl(page)->mediaCaptureEnabled();
 }
 
 void WKPageDidAllowPointerLock(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
 #if ENABLE(POINTER_LOCK)
-    toImpl(pageRef)->didAllowPointerLock();
+    toProtectedImpl(pageRef)->didAllowPointerLock();
 #else
     UNUSED_PARAM(pageRef);
 #endif
@@ -3032,7 +3032,7 @@ void WKPageClearUserMediaState(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
 #if ENABLE(MEDIA_STREAM)
-    toImpl(pageRef)->clearUserMediaState();
+    toProtectedImpl(pageRef)->clearUserMediaState();
 #else
     UNUSED_PARAM(pageRef);
 #endif
@@ -3042,7 +3042,7 @@ void WKPageDidDenyPointerLock(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
 #if ENABLE(POINTER_LOCK)
-    toImpl(pageRef)->didDenyPointerLock();
+    toProtectedImpl(pageRef)->didDenyPointerLock();
 #else
     UNUSED_PARAM(pageRef);
 #endif
@@ -3050,15 +3050,15 @@ void WKPageDidDenyPointerLock(WKPageRef pageRef)
 
 void WKPagePostMessageToInjectedBundle(WKPageRef pageRef, WKStringRef messageNameRef, WKTypeRef messageBodyRef)
 {
-    toImpl(pageRef)->postMessageToInjectedBundle(toImpl(messageNameRef)->string(), toImpl(messageBodyRef));
+    toProtectedImpl(pageRef)->postMessageToInjectedBundle(toProtectedImpl(messageNameRef)->string(), toImpl(messageBodyRef));
 }
 
 WKArrayRef WKPageCopyRelatedPages(WKPageRef pageRef)
 {
     Vector<RefPtr<API::Object>> relatedPages;
 
-    for (Ref page : toImpl(pageRef)->protectedLegacyMainFrameProcess()->pages()) {
-        if (page.ptr() != toImpl(pageRef))
+    for (Ref page : toProtectedImpl(pageRef)->protectedLegacyMainFrameProcess()->pages()) {
+        if (page.ptr() != toProtectedImpl(pageRef))
             relatedPages.append(WTFMove(page));
     }
 
@@ -3067,8 +3067,8 @@ WKArrayRef WKPageCopyRelatedPages(WKPageRef pageRef)
 
 WKFrameRef WKPageLookUpFrameFromHandle(WKPageRef pageRef, WKFrameHandleRef handleRef)
 {
-    auto page = toImpl(pageRef);
-    auto frame = WebFrameProxy::webFrame(toImpl(handleRef)->frameID());
+    auto page = toProtectedImpl(pageRef);
+    auto frame = WebFrameProxy::webFrame(toProtectedImpl(handleRef)->frameID());
     if (!frame || frame->page() != page)
         return nullptr;
 
@@ -3078,14 +3078,14 @@ WKFrameRef WKPageLookUpFrameFromHandle(WKPageRef pageRef, WKFrameHandleRef handl
 void WKPageSetMayStartMediaWhenInWindow(WKPageRef pageRef, bool mayStartMedia)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setMayStartMediaWhenInWindow(mayStartMedia);
+    toProtectedImpl(pageRef)->setMayStartMediaWhenInWindow(mayStartMedia);
 }
 
 void WKPageSelectContextMenuItem(WKPageRef pageRef, WKContextMenuItemRef item, WKFrameInfoRef frameInfo)
 {
     CRASH_IF_SUSPENDED;
 #if ENABLE(CONTEXT_MENUS)
-    toImpl(pageRef)->contextMenuItemSelected((toImpl(item)->data()), toImpl(frameInfo)->frameInfoData());
+    toProtectedImpl(pageRef)->contextMenuItemSelected((toProtectedImpl(item)->data()), toProtectedImpl(frameInfo)->frameInfoData());
 #else
     UNUSED_PARAM(pageRef);
     UNUSED_PARAM(item);
@@ -3094,7 +3094,7 @@ void WKPageSelectContextMenuItem(WKPageRef pageRef, WKContextMenuItemRef item, W
 
 WKScrollPinningBehavior WKPageGetScrollPinningBehavior(WKPageRef page)
 {
-    ScrollPinningBehavior pinning = toImpl(page)->scrollPinningBehavior();
+    ScrollPinningBehavior pinning = toProtectedImpl(page)->scrollPinningBehavior();
     
     switch (pinning) {
     case WebCore::ScrollPinningBehavior::DoNotPin:
@@ -3128,28 +3128,28 @@ void WKPageSetScrollPinningBehavior(WKPageRef pageRef, WKScrollPinningBehavior p
         ASSERT_NOT_REACHED();
     }
     
-    toImpl(pageRef)->setScrollPinningBehavior(corePinning);
+    toProtectedImpl(pageRef)->setScrollPinningBehavior(corePinning);
 }
 
 bool WKPageGetAddsVisitedLinks(WKPageRef page)
 {
-    return toImpl(page)->addsVisitedLinks();
+    return toProtectedImpl(page)->addsVisitedLinks();
 }
 
 void WKPageSetAddsVisitedLinks(WKPageRef pageRef, bool addsVisitedLinks)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setAddsVisitedLinks(addsVisitedLinks);
+    toProtectedImpl(pageRef)->setAddsVisitedLinks(addsVisitedLinks);
 }
 
 bool WKPageIsPlayingAudio(WKPageRef page)
 {
-    return toImpl(page)->isPlayingAudio();
+    return toProtectedImpl(page)->isPlayingAudio();
 }
 
 WKMediaState WKPageGetMediaState(WKPageRef page)
 {
-    WebCore::MediaProducerMediaStateFlags coreState = toImpl(page)->reportedMediaState();
+    WebCore::MediaProducerMediaStateFlags coreState = toProtectedImpl(page)->reportedMediaState();
     WKMediaState state = kWKMediaIsNotPlaying;
 
     if (coreState & WebCore::MediaProducerMediaState::IsPlayingAudio)
@@ -3179,14 +3179,14 @@ WKMediaState WKPageGetMediaState(WKPageRef page)
 void WKPageClearWheelEventTestMonitor(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    if (RefPtr pageForTesting = toImpl(pageRef)->pageForTesting())
+    if (RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting())
         pageForTesting->clearWheelEventTestMonitor();
 }
 
 void WKPageCallAfterNextPresentationUpdate(WKPageRef pageRef, void* context, WKPagePostPresentationUpdateFunction callback)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->callAfterNextPresentationUpdate([context, callback] {
+    toProtectedImpl(pageRef)->callAfterNextPresentationUpdate([context, callback] {
         callback(nullptr, context);
     });
 }
@@ -3195,24 +3195,24 @@ void WKPageSetIgnoresViewportScaleLimits(WKPageRef pageRef, bool ignoresViewport
 {
     CRASH_IF_SUSPENDED;
 #if ENABLE(META_VIEWPORT)
-    toImpl(pageRef)->setForceAlwaysUserScalable(ignoresViewportScaleLimits);
+    toProtectedImpl(pageRef)->setForceAlwaysUserScalable(ignoresViewportScaleLimits);
 #endif
 }
 
 void WKPageSetUseDarkAppearanceForTesting(WKPageRef pageRef, bool useDarkAppearance)
 {
-    toImpl(pageRef)->setUseDarkAppearanceForTesting(useDarkAppearance);
+    toProtectedImpl(pageRef)->setUseDarkAppearanceForTesting(useDarkAppearance);
 }
 
 ProcessID WKPageGetProcessIdentifier(WKPageRef page)
 {
-    return toImpl(page)->legacyMainFrameProcessID();
+    return toProtectedImpl(page)->legacyMainFrameProcessID();
 }
 
 ProcessID WKPageGetGPUProcessIdentifier(WKPageRef page)
 {
 #if ENABLE(GPU_PROCESS)
-    RefPtr gpuProcess = toImpl(page)->configuration().processPool().gpuProcess();
+    RefPtr gpuProcess = toProtectedImpl(page)->configuration().processPool().gpuProcess();
     if (!gpuProcess)
         return 0;
     return gpuProcess->processID();
@@ -3225,7 +3225,7 @@ void WKPageGetApplicationManifest(WKPageRef pageRef, void* context, WKPageGetApp
 {
     CRASH_IF_SUSPENDED;
 #if ENABLE(APPLICATION_MANIFEST)
-    toImpl(pageRef)->getApplicationManifest([function, context](const std::optional<WebCore::ApplicationManifest>& manifest) {
+    toProtectedImpl(pageRef)->getApplicationManifest([function, context](const std::optional<WebCore::ApplicationManifest>& manifest) {
         function(context);
     });
 #else
@@ -3237,7 +3237,7 @@ void WKPageGetApplicationManifest(WKPageRef pageRef, void* context, WKPageGetApp
 void WKPageDumpPrivateClickMeasurement(WKPageRef pageRef, WKPageDumpPrivateClickMeasurementFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(nullptr, callbackContext);
 
@@ -3249,7 +3249,7 @@ void WKPageDumpPrivateClickMeasurement(WKPageRef pageRef, WKPageDumpPrivateClick
 void WKPageClearPrivateClickMeasurement(WKPageRef pageRef, WKPageClearPrivateClickMeasurementFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3261,7 +3261,7 @@ void WKPageClearPrivateClickMeasurement(WKPageRef pageRef, WKPageClearPrivateCli
 void WKPageSetPrivateClickMeasurementOverrideTimerForTesting(WKPageRef pageRef, bool value, WKPageSetPrivateClickMeasurementOverrideTimerForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3273,7 +3273,7 @@ void WKPageSetPrivateClickMeasurementOverrideTimerForTesting(WKPageRef pageRef, 
 void WKPageMarkAttributedPrivateClickMeasurementsAsExpiredForTesting(WKPageRef pageRef, WKPageMarkAttributedPrivateClickMeasurementsAsExpiredForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3285,7 +3285,7 @@ void WKPageMarkAttributedPrivateClickMeasurementsAsExpiredForTesting(WKPageRef p
 void WKPageSetPrivateClickMeasurementEphemeralMeasurementForTesting(WKPageRef pageRef, bool value, WKPageSetPrivateClickMeasurementEphemeralMeasurementForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3297,7 +3297,7 @@ void WKPageSetPrivateClickMeasurementEphemeralMeasurementForTesting(WKPageRef pa
 void WKPageSimulatePrivateClickMeasurementSessionRestart(WKPageRef pageRef, WKPageSimulatePrivateClickMeasurementSessionRestartFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3309,7 +3309,7 @@ void WKPageSimulatePrivateClickMeasurementSessionRestart(WKPageRef pageRef, WKPa
 void WKPageSetPrivateClickMeasurementTokenPublicKeyURLForTesting(WKPageRef pageRef, WKURLRef URLRef, WKPageSetPrivateClickMeasurementTokenPublicKeyURLForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3321,7 +3321,7 @@ void WKPageSetPrivateClickMeasurementTokenPublicKeyURLForTesting(WKPageRef pageR
 void WKPageSetPrivateClickMeasurementTokenSignatureURLForTesting(WKPageRef pageRef, WKURLRef URLRef, WKPageSetPrivateClickMeasurementTokenSignatureURLForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3333,7 +3333,7 @@ void WKPageSetPrivateClickMeasurementTokenSignatureURLForTesting(WKPageRef pageR
 void WKPageSetPrivateClickMeasurementAttributionReportURLsForTesting(WKPageRef pageRef, WKURLRef sourceURL, WKURLRef destinationURL, WKPageSetPrivateClickMeasurementAttributionReportURLsForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3345,7 +3345,7 @@ void WKPageSetPrivateClickMeasurementAttributionReportURLsForTesting(WKPageRef p
 void WKPageMarkPrivateClickMeasurementsAsExpiredForTesting(WKPageRef pageRef, WKPageMarkPrivateClickMeasurementsAsExpiredForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3357,7 +3357,7 @@ void WKPageMarkPrivateClickMeasurementsAsExpiredForTesting(WKPageRef pageRef, WK
 void WKPageSetPCMFraudPreventionValuesForTesting(WKPageRef pageRef, WKStringRef unlinkableToken, WKStringRef secretToken, WKStringRef signature, WKStringRef keyID, WKPageSetPCMFraudPreventionValuesForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3369,7 +3369,7 @@ void WKPageSetPCMFraudPreventionValuesForTesting(WKPageRef pageRef, WKStringRef 
 void WKPageSetPrivateClickMeasurementAppBundleIDForTesting(WKPageRef pageRef, WKStringRef appBundleIDForTesting, WKPageSetPrivateClickMeasurementAppBundleIDForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3381,7 +3381,7 @@ void WKPageSetPrivateClickMeasurementAppBundleIDForTesting(WKPageRef pageRef, WK
 void WKPageSetMockCameraOrientationForTesting(WKPageRef pageRef, uint64_t rotation, WKStringRef persistentId)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setMediaCaptureRotationForTesting(rotation, toWTFString(persistentId));
+    toProtectedImpl(pageRef)->setMediaCaptureRotationForTesting(rotation, toWTFString(persistentId));
 }
 
 bool WKPageIsMockRealtimeMediaSourceCenterEnabled(WKPageRef)
@@ -3397,14 +3397,14 @@ void WKPageSetMockCaptureDevicesInterrupted(WKPageRef pageRef, bool isCameraInte
 {
     CRASH_IF_SUSPENDED;
 #if ENABLE(MEDIA_STREAM) && ENABLE(GPU_PROCESS)
-    auto preferences = toImpl(pageRef)->protectedPreferences();
+    auto preferences = toProtectedImpl(pageRef)->protectedPreferences();
     if (preferences->useGPUProcessForMediaEnabled()) {
-        Ref gpuProcess = toImpl(pageRef)->configuration().processPool().ensureGPUProcess();
+        Ref gpuProcess = toProtectedImpl(pageRef)->configuration().processPool().ensureGPUProcess();
         gpuProcess->setMockCaptureDevicesInterrupted(isCameraInterrupted, isMicrophoneInterrupted);
     }
 #endif
 #if ENABLE(MEDIA_STREAM) && USE(GSTREAMER)
-    toImpl(pageRef)->setMockCaptureDevicesInterrupted(isCameraInterrupted, isMicrophoneInterrupted);
+    toProtectedImpl(pageRef)->setMockCaptureDevicesInterrupted(isCameraInterrupted, isMicrophoneInterrupted);
 #endif
 }
 
@@ -3413,17 +3413,17 @@ void WKPageTriggerMockCaptureConfigurationChange(WKPageRef pageRef, bool forCame
     CRASH_IF_SUSPENDED;
 #if ENABLE(MEDIA_STREAM)
 #if USE(GSTREAMER)
-    toImpl(pageRef)->triggerMockCaptureConfigurationChange(forCamera, forMicrophone, forDisplay);
+    toProtectedImpl(pageRef)->triggerMockCaptureConfigurationChange(forCamera, forMicrophone, forDisplay);
 #else
     MockRealtimeMediaSourceCenter::singleton().triggerMockCaptureConfigurationChange(forCamera, forMicrophone, forDisplay);
 #endif // USE(GSTREAMER)
 
 #if ENABLE(GPU_PROCESS)
-    auto preferences = toImpl(pageRef)->protectedPreferences();
+    auto preferences = toProtectedImpl(pageRef)->protectedPreferences();
     if (!preferences->useGPUProcessForMediaEnabled())
         return;
 
-    Ref gpuProcess = toImpl(pageRef)->configuration().processPool().ensureGPUProcess();
+    Ref gpuProcess = toProtectedImpl(pageRef)->configuration().processPool().ensureGPUProcess();
     gpuProcess->triggerMockCaptureConfigurationChange(forCamera, forMicrophone, forDisplay);
 #endif // ENABLE(GPU_PROCESS)
 
@@ -3433,7 +3433,7 @@ void WKPageTriggerMockCaptureConfigurationChange(WKPageRef pageRef, bool forCame
 void WKPageLoadedSubresourceDomains(WKPageRef pageRef, WKPageLoadedSubresourceDomainsFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->getLoadedSubresourceDomains([callbackContext, callback](Vector<RegistrableDomain>&& domains) {
+    toProtectedImpl(pageRef)->getLoadedSubresourceDomains([callbackContext, callback](Vector<RegistrableDomain>&& domains) {
         Vector<RefPtr<API::Object>> apiDomains = WTF::map(domains, [](auto& domain) -> RefPtr<API::Object> {
             return API::String::create(String(domain.string()));
         });
@@ -3444,52 +3444,52 @@ void WKPageLoadedSubresourceDomains(WKPageRef pageRef, WKPageLoadedSubresourceDo
 void WKPageClearLoadedSubresourceDomains(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->clearLoadedSubresourceDomains();
+    toProtectedImpl(pageRef)->clearLoadedSubresourceDomains();
 }
 
 void WKPageSetMediaCaptureReportingDelayForTesting(WKPageRef pageRef, double delay)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->setMediaCaptureReportingDelay(Seconds(delay));
+    toProtectedImpl(pageRef)->setMediaCaptureReportingDelay(Seconds(delay));
 }
 
 void WKPageDispatchActivityStateUpdateForTesting(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    if (RefPtr pageForTesting = toImpl(pageRef)->pageForTesting())
+    if (RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting())
         pageForTesting->dispatchActivityStateUpdate();
 }
 
 void WKPageClearNotificationPermissionState(WKPageRef pageRef)
 {
 #if ENABLE(NOTIFICATIONS)
-    toImpl(pageRef)->clearNotificationPermissionState();
+    toProtectedImpl(pageRef)->clearNotificationPermissionState();
 #endif
 }
 
 void WKPageExecuteCommandForTesting(WKPageRef pageRef, WKStringRef command, WKStringRef value)
 {
-    toImpl(pageRef)->executeEditCommand(toImpl(command)->string(), toImpl(value)->string());
+    toProtectedImpl(pageRef)->executeEditCommand(toProtectedImpl(command)->string(), toProtectedImpl(value)->string());
 }
 
 bool WKPageIsEditingCommandEnabledForTesting(WKPageRef pageRef, WKStringRef command)
 {
-    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return false;
 
-    return pageForTesting->isEditingCommandEnabled(toImpl(command)->string());
+    return pageForTesting->isEditingCommandEnabled(toProtectedImpl(command)->string());
 }
 
 void WKPageSetPermissionLevelForTesting(WKPageRef pageRef, WKStringRef origin, bool allowed)
 {
-    if (RefPtr pageForTesting = toImpl(pageRef)->pageForTesting())
-        pageForTesting->setPermissionLevel(toImpl(origin)->string(), allowed);
+    if (RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting())
+        pageForTesting->setPermissionLevel(toProtectedImpl(origin)->string(), allowed);
 }
 
 void WKPageSetObscuredContentInsetsForTesting(WKPageRef pageRef, float top, float right, float bottom, float left, void* context, WKPageSetObscuredContentInsetsForTestingFunction callback)
 {
-    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(context);
 
@@ -3500,14 +3500,14 @@ void WKPageSetObscuredContentInsetsForTesting(WKPageRef pageRef, float top, floa
 
 void WKPageSetPageScaleFactorForTesting(WKPageRef pageRef, float scaleFactor, WKPoint point, void* context, WKPageSetPageScaleFactorForTestingFunction completionHandler)
 {
-    toImpl(pageRef)->scalePage(scaleFactor, toIntPoint(point), [context, completionHandler] {
+    toProtectedImpl(pageRef)->scalePage(scaleFactor, toIntPoint(point), [context, completionHandler] {
         completionHandler(context);
     });
 }
 
 void WKPageClearBackForwardListForTesting(WKPageRef pageRef, void* context, WKPageClearBackForwardListForTestingFunction completionHandler)
 {
-    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return completionHandler(context);
 
@@ -3518,7 +3518,7 @@ void WKPageClearBackForwardListForTesting(WKPageRef pageRef, void* context, WKPa
 
 void WKPageSetTracksRepaintsForTesting(WKPageRef pageRef, void* context, bool trackRepaints, WKPageSetTracksRepaintsForTestingFunction completionHandler)
 {
-    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return completionHandler(context);
 
@@ -3529,7 +3529,7 @@ void WKPageSetTracksRepaintsForTesting(WKPageRef pageRef, void* context, bool tr
 
 void WKPageDisplayAndTrackRepaintsForTesting(WKPageRef pageRef, void* context, WKPageDisplayAndTrackRepaintsForTestingFunction completionHandler)
 {
-    RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return completionHandler(context);
 
@@ -3540,7 +3540,7 @@ void WKPageDisplayAndTrackRepaintsForTesting(WKPageRef pageRef, void* context, W
 
 void WKPageFindStringForTesting(WKPageRef pageRef, void* context, WKStringRef string, WKFindOptions options, unsigned maxMatchCount, WKPageFindStringForTestingFunction completionHandler)
 {
-    toImpl(pageRef)->findString(toWTFString(string), toFindOptions(options), maxMatchCount, [context, completionHandler] (bool found) {
+    toProtectedImpl(pageRef)->findString(toWTFString(string), toFindOptions(options), maxMatchCount, [context, completionHandler] (bool found) {
         completionHandler(found, context);
     });
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2111,7 +2111,7 @@ void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& proces
     });
 }
 
-RefPtr<API::Navigation> WebPageProxy::loadFile(const String& fileURLString, const String& resourceDirectoryURLString, bool isAppInitiated, API::Object* userData)
+RefPtr<API::Navigation> WebPageProxy::loadFile(const String& fileURLString, const String& resourceDirectoryURLString, bool isAppInitiated, RefPtr<API::Object> userData)
 {
     WEBPAGEPROXY_RELEASE_LOG(Loading, "loadFile:");
 
@@ -2167,7 +2167,7 @@ RefPtr<API::Navigation> WebPageProxy::loadFile(const String& fileURLString, cons
     loadParameters.navigationID = navigation->navigationID();
     loadParameters.request = WTFMove(request);
     loadParameters.shouldOpenExternalURLsPolicy = ShouldOpenExternalURLsPolicy::ShouldNotAllow;
-    loadParameters.userData = UserData(legacyMainFrameProcess().transformObjectsToHandles(userData).get());
+    loadParameters.userData = UserData(legacyMainFrameProcess().transformObjectsToHandles(userData.get()).get());
     loadParameters.publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(loadParameters.request.url());
     loadParameters.isRequestFromClientOrUserInput = isAppInitiated;
     Ref process = m_legacyMainFrameProcess;
@@ -2193,7 +2193,7 @@ RefPtr<API::Navigation> WebPageProxy::loadFile(const String& fileURLString, cons
     return navigation;
 }
 
-RefPtr<API::Navigation> WebPageProxy::loadData(Ref<WebCore::SharedBuffer>&& data, const String& type, const String& encoding, const String& baseURL, API::Object* userData, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy)
+RefPtr<API::Navigation> WebPageProxy::loadData(Ref<WebCore::SharedBuffer>&& data, const String& type, const String& encoding, const String& baseURL, RefPtr<API::Object> userData, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy)
 {
     WEBPAGEPROXY_RELEASE_LOG(Loading, "loadData:");
 
@@ -2210,16 +2210,16 @@ RefPtr<API::Navigation> WebPageProxy::loadData(Ref<WebCore::SharedBuffer>&& data
     if (!hasRunningProcess())
         launchProcess(Site(URL(baseURL)), ProcessLaunchReason::InitialProcess);
 
-    Ref navigation = protectedNavigationState()->createLoadDataNavigation(legacyMainFrameProcess().coreProcessIdentifier(), makeUnique<API::SubstituteData>(Vector(data->span()), type, encoding, baseURL, userData));
+    Ref navigation = protectedNavigationState()->createLoadDataNavigation(legacyMainFrameProcess().coreProcessIdentifier(), makeUnique<API::SubstituteData>(Vector(data->span()), type, encoding, baseURL, userData.get()));
 
     if (shouldForceForegroundPriorityForClientNavigation())
         navigation->setClientNavigationActivity(legacyMainFrameProcess().protectedThrottler()->foregroundActivity("Client navigation"_s));
 
-    loadDataWithNavigationShared(protectedLegacyMainFrameProcess(), m_webPageID, navigation, WTFMove(data), type, encoding, baseURL, userData, ShouldTreatAsContinuingLoad::No, isNavigatingToAppBoundDomain(), std::nullopt, shouldOpenExternalURLsPolicy, SubstituteData::SessionHistoryVisibility::Hidden);
+    loadDataWithNavigationShared(protectedLegacyMainFrameProcess(), m_webPageID, navigation, WTFMove(data), type, encoding, baseURL, userData.get(), ShouldTreatAsContinuingLoad::No, isNavigatingToAppBoundDomain(), std::nullopt, shouldOpenExternalURLsPolicy, SubstituteData::SessionHistoryVisibility::Hidden);
     return navigation;
 }
 
-RefPtr<API::Navigation> WebPageProxy::loadData(Ref<WebCore::SharedBuffer>&& data, const String& type, const String& encoding, const String& baseURL, API::Object* userData)
+RefPtr<API::Navigation> WebPageProxy::loadData(Ref<WebCore::SharedBuffer>&& data, const String& type, const String& encoding, const String& baseURL, RefPtr<API::Object> userData)
 {
     return loadData(WTFMove(data), type, encoding, baseURL, userData, ShouldOpenExternalURLsPolicy::ShouldNotAllow);
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -889,9 +889,9 @@ public:
     RefPtr<API::Navigation> loadRequest(WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy, WebCore::IsPerformingHTTPFallback);
     RefPtr<API::Navigation> loadRequest(WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy, WebCore::IsPerformingHTTPFallback, std::unique_ptr<NavigationActionData>&&, API::Object* userData = nullptr);
 
-    RefPtr<API::Navigation> loadFile(const String& fileURL, const String& resourceDirectoryURL, bool isAppInitiated = true, API::Object* userData = nullptr);
-    RefPtr<API::Navigation> loadData(Ref<WebCore::SharedBuffer>&&, const String& MIMEType, const String& encoding, const String& baseURL, API::Object* userData = nullptr);
-    RefPtr<API::Navigation> loadData(Ref<WebCore::SharedBuffer>&&, const String& MIMEType, const String& encoding, const String& baseURL, API::Object* userData, WebCore::ShouldOpenExternalURLsPolicy);
+    RefPtr<API::Navigation> loadFile(const String& fileURL, const String& resourceDirectoryURL, bool isAppInitiated = true, RefPtr<API::Object> userData = nullptr);
+    RefPtr<API::Navigation> loadData(Ref<WebCore::SharedBuffer>&&, const String& MIMEType, const String& encoding, const String& baseURL, RefPtr<API::Object> userData = nullptr);
+    RefPtr<API::Navigation> loadData(Ref<WebCore::SharedBuffer>&&, const String& MIMEType, const String& encoding, const String& baseURL, RefPtr<API::Object> userData, WebCore::ShouldOpenExternalURLsPolicy);
     RefPtr<API::Navigation> loadSimulatedRequest(WebCore::ResourceRequest&&, WebCore::ResourceResponse&&, Ref<WebCore::SharedBuffer>&&);
     void loadAlternateHTML(Ref<WebCore::DataSegment>&&, const String& encoding, const URL& baseURL, const URL& unreachableURL, API::Object* userData = nullptr);
     void navigateToPDFLinkWithSimulatedClick(const String& url, WebCore::IntPoint documentPoint, WebCore::IntPoint screenPoint);


### PR DESCRIPTION
#### 060530a8b8bad5a2fb680b1f10237fc107846513
<pre>
[SaferCpp] Address issues in WKPage.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=291502">https://bugs.webkit.org/show_bug.cgi?id=291502</a>
<a href="https://rdar.apple.com/149179175">rdar://149179175</a>

Reviewed by NOBODY (OOPS!).

Address SaferCPP issues in WKPage.cpp

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageGetContext):
(WKPageCopyPageConfiguration):
(WKPageLoadURL):
(WKPageLoadURLWithShouldOpenExternalURLsPolicy):
(WKPageLoadURLWithUserData):
(WKPageLoadURLRequest):
(WKPageLoadURLRequestWithUserData):
(WKPageLoadFile):
(WKPageLoadFileWithUserData):
(WKPageLoadData):
(WKPageLoadDataWithUserData):
(loadString):
(WKPageLoadAlternateHTMLStringWithUserData):
(WKPageStopLoading):
(WKPageReload):
(WKPageReloadWithoutContentBlockers):
(WKPageReloadFromOrigin):
(WKPageReloadExpiredOnly):
(WKPageTryClose):
(WKPageClose):
(WKPageIsClosed):
(WKPageGoForward):
(WKPageCanGoForward):
(WKPageGoBack):
(WKPageCanGoBack):
(WKPageGoToBackForwardListItem):
(WKPageTryRestoreScrollPosition):
(WKPageGetBackForwardList):
(WKPageWillHandleHorizontalScrollEvents):
(WKPageUpdateWebsitePolicies):
(WKPageCopyTitle):
(WKPageGetMainFrame):
(WKPageGetFocusedFrame):
(WKPageGetRenderTreeSize):
(WKPageGetWebsiteDataStore):
(WKPageGetInspector):
(WKPageGetEstimatedProgress):
(WKPageCopyUserAgent):
(WKPageCopyApplicationNameForUserAgent):
(WKPageSetApplicationNameForUserAgent):
(WKPageCopyCustomUserAgent):
(WKPageSetCustomUserAgent):
(WKPageSupportsTextEncoding):
(WKPageCopyCustomTextEncodingName):
(WKPageSetCustomTextEncodingName):
(WKPageTerminate):
(WKPageResetStateBetweenTests):
(WKPageCopySessionState):
(restoreFromSessionState):
(WKPageGetTextZoomFactor):
(WKPageGetBackingScaleFactor):
(WKPageSetCustomBackingScaleFactor):
(WKPageSetCustomBackingScaleFactorWithCallback):
(WKPageSupportsTextZoom):
(WKPageSetTextZoomFactor):
(WKPageGetPageZoomFactor):
(WKPageSetPageZoomFactor):
(WKPageSetPageAndTextZoomFactors):
(WKPageSetScaleFactor):
(WKPageGetScaleFactor):
(WKPageSetUseFixedLayout):
(WKPageSetFixedLayoutSize):
(WKPageUseFixedLayout):
(WKPageFixedLayoutSize):
(WKPageListenForLayoutMilestones):
(WKPageHasHorizontalScrollbar):
(WKPageHasVerticalScrollbar):
(WKPageSetSuppressScrollbarAnimations):
(WKPageAreScrollbarAnimationsSuppressed):
(WKPageIsPinnedToLeftSide):
(WKPageIsPinnedToRightSide):
(WKPageIsPinnedToTopSide):
(WKPageIsPinnedToBottomSide):
(WKPageRubberBandsAtLeft):
(WKPageSetRubberBandsAtLeft):
(WKPageRubberBandsAtRight):
(WKPageSetRubberBandsAtRight):
(WKPageRubberBandsAtTop):
(WKPageSetRubberBandsAtTop):
(WKPageRubberBandsAtBottom):
(WKPageSetRubberBandsAtBottom):
(WKPageVerticalRubberBandingIsEnabled):
(WKPageSetEnableVerticalRubberBanding):
(WKPageHorizontalRubberBandingIsEnabled):
(WKPageSetEnableHorizontalRubberBanding):
(WKPageSetBackgroundExtendsBeyondPage):
(WKPageBackgroundExtendsBeyondPage):
(WKPageSetPaginationMode):
(WKPageGetPaginationMode):
(WKPageSetPaginationBehavesLikeColumns):
(WKPageGetPaginationBehavesLikeColumns):
(WKPageSetPageLength):
(WKPageGetPageLength):
(WKPageSetGapBetweenPages):
(WKPageGetGapBetweenPages):
(WKPageGetPageCount):
(WKPageCanDelete):
(WKPageHasSelectedRange):
(WKPageIsContentEditable):
(WKPageSetMaintainsInactiveSelection):
(WKPageCenterSelectionInVisibleArea):
(WKPageFindStringMatches):
(WKPageGetImageForFindMatch):
(WKPageSelectFindMatch):
(WKPageFindString):
(WKPageHideFindUI):
(WKPageCountStringMatches):
(WKPageSetPageContextMenuClient):
(WKPageSetPageDiagnosticLoggingClient):
(WKPageSetPageFindClient):
(WKPageSetPageFindMatchesClient):
(WKPageSetPageInjectedBundleClient):
(WKCompletionListenerComplete):
(WKPageSetFullScreenClientForTesting):
(WKPageRequestExitFullScreen):
(WKPageSetPageFormClient):
(WKPageSetPageLoaderClient):
(WKPageSetPagePolicyClient):
(WKPageRunBeforeUnloadConfirmPanelResultListenerCall):
(WKPageRunJavaScriptAlertResultListenerCall):
(WKPageRunJavaScriptConfirmResultListenerCall):
(WKPageRunJavaScriptPromptResultListenerCall):
(WKPageRequestStorageAccessConfirmResultListenerCall):
(WKPageSetPageUIClient):
(WKPageSetPageNavigationClient):
(WKPageSetPageStateClient):
(WKPageEvaluateJavaScriptInMainFrame):
(WKPageRenderTreeExternalRepresentation):
(WKPageGetSourceForFrame):
(WKPageGetContentsAsString):
(WKPageGetBytecodeProfile):
(WKPageGetSamplingProfilerOutput):
(WKPageGetSelectionAsWebArchiveData):
(WKPageGetContentsAsMHTMLData):
(WKPageForceRepaint):
(WKPageCopyPendingAPIRequestURL):
(WKPageCopyActiveURL):
(WKPageCopyProvisionalURL):
(WKPageCopyCommittedURL):
(WKPageCopyStandardUserAgentWithApplicationName):
(WKPageValidateCommand):
(WKPageExecuteCommand):
(WKPageComputePagesForPrinting):
(WKPageDrawPagesToPDF):
(WKPageBeginPrinting):
(WKPageEndPrinting):
(WKPageGetIsControlledByAutomation):
(WKPageSetControlledByAutomation):
(WKPageGetAllowsRemoteInspection):
(WKPageSetAllowsRemoteInspection):
(WKPageShowWebInspectorForTesting):
(WKPageSetMediaVolume):
(WKPageSetMuted):
(WKPageSetMediaCaptureEnabled):
(WKPageGetMediaCaptureEnabled):
(WKPageDidAllowPointerLock):
(WKPageClearUserMediaState):
(WKPageDidDenyPointerLock):
(WKPagePostMessageToInjectedBundle):
(WKPageCopyRelatedPages):
(WKPageLookUpFrameFromHandle):
(WKPageSetMayStartMediaWhenInWindow):
(WKPageSelectContextMenuItem):
(WKPageGetScrollPinningBehavior):
(WKPageSetScrollPinningBehavior):
(WKPageGetAddsVisitedLinks):
(WKPageSetAddsVisitedLinks):
(WKPageIsPlayingAudio):
(WKPageGetMediaState):
(WKPageClearWheelEventTestMonitor):
(WKPageCallAfterNextPresentationUpdate):
(WKPageSetIgnoresViewportScaleLimits):
(WKPageSetUseDarkAppearanceForTesting):
(WKPageGetProcessIdentifier):
(WKPageGetGPUProcessIdentifier):
(WKPageGetApplicationManifest):
(WKPageDumpPrivateClickMeasurement):
(WKPageClearPrivateClickMeasurement):
(WKPageSetPrivateClickMeasurementOverrideTimerForTesting):
(WKPageMarkAttributedPrivateClickMeasurementsAsExpiredForTesting):
(WKPageSetPrivateClickMeasurementEphemeralMeasurementForTesting):
(WKPageSimulatePrivateClickMeasurementSessionRestart):
(WKPageSetPrivateClickMeasurementTokenPublicKeyURLForTesting):
(WKPageSetPrivateClickMeasurementTokenSignatureURLForTesting):
(WKPageSetPrivateClickMeasurementAttributionReportURLsForTesting):
(WKPageMarkPrivateClickMeasurementsAsExpiredForTesting):
(WKPageSetPCMFraudPreventionValuesForTesting):
(WKPageSetPrivateClickMeasurementAppBundleIDForTesting):
(WKPageSetMockCameraOrientationForTesting):
(WKPageSetMockCaptureDevicesInterrupted):
(WKPageTriggerMockCaptureConfigurationChange):
(WKPageLoadedSubresourceDomains):
(WKPageClearLoadedSubresourceDomains):
(WKPageSetMediaCaptureReportingDelayForTesting):
(WKPageDispatchActivityStateUpdateForTesting):
(WKPageClearNotificationPermissionState):
(WKPageExecuteCommandForTesting):
(WKPageIsEditingCommandEnabledForTesting):
(WKPageSetPermissionLevelForTesting):
(WKPageSetObscuredContentInsetsForTesting):
(WKPageSetPageScaleFactorForTesting):
(WKPageClearBackForwardListForTesting):
(WKPageSetTracksRepaintsForTesting):
(WKPageDisplayAndTrackRepaintsForTesting):
(WKPageFindStringForTesting):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::loadFile):
(WebKit::WebPageProxy::loadData):
* Source/WebKit/UIProcess/WebPageProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/060530a8b8bad5a2fb680b1f10237fc107846513

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104660 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50131 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27612 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75760 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32862 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14825 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89868 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56119 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14622 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49490 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84556 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107018 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26643 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19450 "Found 1 new test failure: http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84721 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27005 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84238 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28911 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6608 "Found 1 new test failure: http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20434 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26583 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31784 "Found 25 new failures in UIProcess/API/C/WKPage.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26403 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29716 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27970 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->