### PR TITLE
[JSC] Refactor loop unrolling to use CloneHelper with customizable successor cloning

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.cpp
@@ -154,6 +154,31 @@ Node* CloneHelper::cloneNodeImpl(BasicBlock* into, Node* node)
     RELEASE_ASSERT_NOT_REACHED();
 }
 
+BasicBlock* CloneHelper::blockClone(BasicBlock* block)
+{
+    auto iter = m_blockClones.find(block);
+    if (iter != m_blockClones.end())
+        return iter->value;
+    RELEASE_ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+void CloneHelper::finalize()
+{
+    if (!m_blockInsertionSet.execute()) {
+        m_graph.invalidateCFG();
+        m_graph.dethread();
+    }
+    m_graph.resetReachability();
+    m_graph.killUnreachableBlocks();
+}
+
+void CloneHelper::clear()
+{
+    m_blockClones.clear();
+    m_nodeClones.clear();
+}
+
 } } // namespace JSC::DFG
 
 #endif // ENABLE(DFG_JIT)

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.h
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.h
@@ -27,30 +27,93 @@
 
 #if ENABLE(DFG_JIT)
 
-#include "Forward.h"
+#include "DFGBlockInsertionSet.h"
+#include <wtf/HashMap.h>
 
 namespace JSC { namespace DFG {
 
-class Graph;
-class BasicBlock;
-struct Node;
-
 class CloneHelper {
 public:
-    CloneHelper(Graph& graph, UncheckedKeyHashMap<Node*, Node*>& nodeClones)
+    CloneHelper(Graph& graph)
         : m_graph(graph)
-        , m_nodeClones(nodeClones)
+        , m_blockInsertionSet(graph)
     {
+        ASSERT(graph.m_form == ThreadedCPS || graph.m_form == LoadStore);
     }
 
     static bool isNodeCloneable(Graph&, HashSet<Node*>&, Node*);
+
+    template<typename CustomizeSuccessors>
+    BasicBlock* cloneBlock(BasicBlock* const, const CustomizeSuccessors&);
+    BasicBlock* blockClone(BasicBlock*);
+
+    void clear();
+    void finalize();
+
+private:
     Node* cloneNode(BasicBlock*, Node*);
     Node* cloneNodeImpl(BasicBlock*, Node*);
 
-private:
     Graph& m_graph;
-    UncheckedKeyHashMap<Node*, Node*>& m_nodeClones;
+    BlockInsertionSet m_blockInsertionSet;
+    UncheckedKeyHashMap<Node*, Node*> m_nodeClones;
+    UncheckedKeyHashMap<BasicBlock*, BasicBlock*> m_blockClones;
 };
+
+template<typename CustomizeSuccessors>
+BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSuccessors& customizeSuccessors)
+{
+    auto iter = m_blockClones.find(block);
+    if (iter != m_blockClones.end())
+        return iter->value;
+
+    auto* clone = m_blockInsertionSet.insert(m_graph.numBlocks(), block->executionCount);
+    clone->cfaHasVisited = false;
+    clone->cfaDidFinish = false;
+    m_blockClones.add(block, clone);
+
+    // 1. Clone phis
+    clone->phis.resize(block->phis.size());
+    for (size_t i = 0; i < block->phis.size(); ++i) {
+        Node* bodyPhi = block->phis[i];
+        Node* phiClone = m_graph.addNode(bodyPhi->prediction(), bodyPhi->op(), bodyPhi->origin, OpInfo(bodyPhi->variableAccessData()));
+        m_nodeClones.add(bodyPhi, phiClone);
+        clone->phis[i] = phiClone;
+    }
+
+    // 2. Clone nodes.
+    for (Node* node : *block)
+        cloneNode(clone, node);
+
+    // 3. Clone variables and tail and head.
+    auto replaceOperands = [&](auto& nodes) ALWAYS_INLINE_LAMBDA {
+        for (uint32_t i = 0; i < nodes.size(); ++i) {
+            if (auto& node = nodes.at(i)) {
+                // This is used to update variablesAtHead (CPS BasicBlock Phis) and variablesAtTail
+                // (CPS BasicBlock Phis + locals). Thus, we must have a clone for each of them.
+                node = m_nodeClones.get(node);
+                ASSERT(node);
+            }
+        }
+    };
+    replaceOperands(clone->variablesAtTail = block->variablesAtTail);
+    replaceOperands(clone->variablesAtHead = block->variablesAtHead);
+
+    // 4. Clone successors. (predecessors will be fixed in the resetReachability of finalize)
+    if (!customizeSuccessors(clone)) {
+        ASSERT(clone->numSuccessors() == block->numSuccessors());
+        for (uint32_t i = 0; i < clone->numSuccessors(); ++i) {
+            auto& successor = clone->successor(i);
+            ASSERT(successor == block->successor(i));
+            successor = cloneBlock(successor, customizeSuccessors);
+        }
+    }
+
+#if ASSERT_ENABLED
+    clone->cloneSource = block;
+#endif
+    return clone;
+}
 
 #define FOR_EACH_NODE_CLONE_STATUS(CLONE_STATUS) \
     CLONE_STATUS(ArithAdd, Common) \


### PR DESCRIPTION
#### bfdfa7afbeb3e92ac37e2200bf6f986145f28f7f
<pre>
[JSC] Refactor loop unrolling to use CloneHelper with customizable successor cloning
<a href="https://bugs.webkit.org/show_bug.cgi?id=291507">https://bugs.webkit.org/show_bug.cgi?id=291507</a>
<a href="https://rdar.apple.com/149186877">rdar://149186877</a>

Reviewed by Yusuke Suzuki.

This patch refactors the loop unrolling logic to use a generalized CloneHelper that
supports customizable successor cloning via a template-based functor interface.

Previously, loop unrolling relied on inline logic with separate maps for cloning nodes
and blocks, along with manual handling of successor updates for the tail block.
This duplication made the logic harder to maintain and less reusable.

With this patch:
- CloneHelper::cloneBlock() now takes a functor to optionally override how successors are cloned.
- The successor cloning fallback is preserved when the functor returns false.
- Loop unrolling leverages this pattern to cleanly patch the tail block’s branch without relying on global state or flags.
- The code is now more concise, modular, and generalizable for future passes.

No behavior change is intended, and all CFG reconstruction logic is preserved via finalize().

* Source/JavaScriptCore/dfg/DFGCloneHelper.cpp:
(JSC::DFG::CloneHelper::blockClone):
(JSC::DFG::CloneHelper::finalize):
(JSC::DFG::CloneHelper::clear):
* Source/JavaScriptCore/dfg/DFGCloneHelper.h:
(JSC::DFG::CloneHelper::CloneHelper):
(JSC::DFG::CloneHelper::cloneBlock):
* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
(JSC::DFG::LoopUnrollingPhase::LoopUnrollingPhase):
(JSC::DFG::LoopUnrollingPhase::unrollLoop):
(JSC::DFG::LoopUnrollingPhase::makeBlock): Deleted.

Canonical link: <a href="https://commits.webkit.org/293672@main">https://commits.webkit.org/293672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44bc205bc456b87d202aee869e01defb52fbbafa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104697 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50168 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27649 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75791 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32893 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14854 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89904 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56150 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14651 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7889 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49527 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92249 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84591 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7975 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107055 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98185 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26680 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19478 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84752 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27043 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86108 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84269 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21385 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28938 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6644 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20478 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26620 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31821 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121801 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26440 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34026 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29753 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28007 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->