### PR TITLE
[SaferCpp] Address issues in WKWebsitePolicies

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -37,7 +37,6 @@ UIProcess/API/C/WKSpeechRecognitionPermissionCallback.cpp
 UIProcess/API/C/WKUserContentControllerRef.cpp
 UIProcess/API/C/WKWebsiteDataStoreConfigurationRef.cpp
 UIProcess/API/C/WKWebsiteDataStoreRef.cpp
-UIProcess/API/C/WKWebsitePolicies.cpp
 UIProcess/API/C/mac/WKPagePrivateMac.mm
 UIProcess/API/Cocoa/WKContentWorld.mm
 UIProcess/API/Cocoa/WKDownload.mm

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.cpp
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.cpp
@@ -59,6 +59,11 @@ Ref<WebsitePolicies> WebsitePolicies::copy() const
 
 WebsitePolicies::~WebsitePolicies() = default;
 
+RefPtr<WebKit::WebsiteDataStore> WebsitePolicies::protectedWebsiteDataStore() const
+{
+    return m_websiteDataStore;
+}
+
 void WebsitePolicies::setWebsiteDataStore(RefPtr<WebKit::WebsiteDataStore>&& websiteDataStore)
 {
     m_websiteDataStore = WTFMove(websiteDataStore);
@@ -80,4 +85,3 @@ bool WebsitePolicies::lockdownModeEnabled() const
 }
 
 }
-

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
@@ -71,6 +71,7 @@ public:
     WebKit::WebsitePopUpPolicy popUpPolicy() const { return m_data.popUpPolicy; }
     void setPopUpPolicy(WebKit::WebsitePopUpPolicy policy) { m_data.popUpPolicy = policy; }
 
+    RefPtr<WebKit::WebsiteDataStore> protectedWebsiteDataStore() const;
     WebKit::WebsiteDataStore* websiteDataStore() const { return m_websiteDataStore.get(); }
     void setWebsiteDataStore(RefPtr<WebKit::WebsiteDataStore>&&);
     

--- a/Source/WebKit/UIProcess/API/C/WKWebsitePolicies.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKWebsitePolicies.cpp
@@ -50,12 +50,12 @@ WKWebsitePoliciesRef WKWebsitePoliciesCreate()
 void WKWebsitePoliciesSetContentBlockersEnabled(WKWebsitePoliciesRef websitePolicies, bool enabled)
 {
     auto defaultEnablement = enabled ? WebCore::ContentExtensionDefaultEnablement::Enabled : WebCore::ContentExtensionDefaultEnablement::Disabled;
-    toImpl(websitePolicies)->setContentExtensionEnablement({ defaultEnablement, { } });
+    toProtectedImpl(websitePolicies)->setContentExtensionEnablement({ defaultEnablement, { } });
 }
 
 bool WKWebsitePoliciesGetContentBlockersEnabled(WKWebsitePoliciesRef websitePolicies)
 {
-    return toImpl(websitePolicies)->contentExtensionEnablement().first == WebCore::ContentExtensionDefaultEnablement::Enabled;
+    return toProtectedImpl(websitePolicies)->contentExtensionEnablement().first == WebCore::ContentExtensionDefaultEnablement::Enabled;
 }
 
 WK_EXPORT WKDictionaryRef WKWebsitePoliciesCopyCustomHeaderFields(WKWebsitePoliciesRef)
@@ -82,13 +82,13 @@ void WKWebsitePoliciesSetAllowedAutoplayQuirks(WKWebsitePoliciesRef websitePolic
     if (allowedQuirks & kWKWebsiteAutoplayQuirkPerDocumentAutoplayBehavior)
         quirks.add(WebsiteAutoplayQuirk::PerDocumentAutoplayBehavior);
 
-    toImpl(websitePolicies)->setAllowedAutoplayQuirks(quirks);
+    toProtectedImpl(websitePolicies)->setAllowedAutoplayQuirks(quirks);
 }
 
 WKWebsiteAutoplayQuirk WKWebsitePoliciesGetAllowedAutoplayQuirks(WKWebsitePoliciesRef websitePolicies)
 {
     WKWebsiteAutoplayQuirk quirks = 0;
-    auto allowedQuirks = toImpl(websitePolicies)->allowedAutoplayQuirks();
+    auto allowedQuirks = toProtectedImpl(websitePolicies)->allowedAutoplayQuirks();
 
     if (allowedQuirks.contains(WebsiteAutoplayQuirk::SynthesizedPauseEvents))
         quirks |= kWKWebsiteAutoplayQuirkSynthesizedPauseEvents;
@@ -107,7 +107,7 @@ WKWebsiteAutoplayQuirk WKWebsitePoliciesGetAllowedAutoplayQuirks(WKWebsitePolici
 
 WKWebsiteAutoplayPolicy WKWebsitePoliciesGetAutoplayPolicy(WKWebsitePoliciesRef websitePolicies)
 {
-    switch (toImpl(websitePolicies)->autoplayPolicy()) {
+    switch (toProtectedImpl(websitePolicies)->autoplayPolicy()) {
     case WebKit::WebsiteAutoplayPolicy::Default:
         return kWKWebsiteAutoplayPolicyDefault;
     case WebsiteAutoplayPolicy::Allow:
@@ -125,16 +125,16 @@ void WKWebsitePoliciesSetAutoplayPolicy(WKWebsitePoliciesRef websitePolicies, WK
 {
     switch (policy) {
     case kWKWebsiteAutoplayPolicyDefault:
-        toImpl(websitePolicies)->setAutoplayPolicy(WebsiteAutoplayPolicy::Default);
+        toProtectedImpl(websitePolicies)->setAutoplayPolicy(WebsiteAutoplayPolicy::Default);
         return;
     case kWKWebsiteAutoplayPolicyAllow:
-        toImpl(websitePolicies)->setAutoplayPolicy(WebsiteAutoplayPolicy::Allow);
+        toProtectedImpl(websitePolicies)->setAutoplayPolicy(WebsiteAutoplayPolicy::Allow);
         return;
     case kWKWebsiteAutoplayPolicyAllowWithoutSound:
-        toImpl(websitePolicies)->setAutoplayPolicy(WebsiteAutoplayPolicy::AllowWithoutSound);
+        toProtectedImpl(websitePolicies)->setAutoplayPolicy(WebsiteAutoplayPolicy::AllowWithoutSound);
         return;
     case kWKWebsiteAutoplayPolicyDeny:
-        toImpl(websitePolicies)->setAutoplayPolicy(WebsiteAutoplayPolicy::Deny);
+        toProtectedImpl(websitePolicies)->setAutoplayPolicy(WebsiteAutoplayPolicy::Deny);
         return;
     }
     ASSERT_NOT_REACHED();
@@ -142,7 +142,7 @@ void WKWebsitePoliciesSetAutoplayPolicy(WKWebsitePoliciesRef websitePolicies, WK
 
 WKWebsitePopUpPolicy WKWebsitePoliciesGetPopUpPolicy(WKWebsitePoliciesRef websitePolicies)
 {
-    switch (toImpl(websitePolicies)->popUpPolicy()) {
+    switch (toProtectedImpl(websitePolicies)->popUpPolicy()) {
     case WebsitePopUpPolicy::Default:
         return kWKWebsitePopUpPolicyDefault;
     case WebsitePopUpPolicy::Allow:
@@ -158,13 +158,13 @@ void WKWebsitePoliciesSetPopUpPolicy(WKWebsitePoliciesRef websitePolicies, WKWeb
 {
     switch (policy) {
     case kWKWebsitePopUpPolicyDefault:
-        toImpl(websitePolicies)->setPopUpPolicy(WebsitePopUpPolicy::Default);
+        toProtectedImpl(websitePolicies)->setPopUpPolicy(WebsitePopUpPolicy::Default);
         return;
     case kWKWebsitePopUpPolicyAllow:
-        toImpl(websitePolicies)->setPopUpPolicy(WebsitePopUpPolicy::Allow);
+        toProtectedImpl(websitePolicies)->setPopUpPolicy(WebsitePopUpPolicy::Allow);
         return;
     case kWKWebsitePopUpPolicyBlock:
-        toImpl(websitePolicies)->setPopUpPolicy(WebsitePopUpPolicy::Block);
+        toProtectedImpl(websitePolicies)->setPopUpPolicy(WebsitePopUpPolicy::Block);
         return;
     }
     ASSERT_NOT_REACHED();
@@ -172,11 +172,10 @@ void WKWebsitePoliciesSetPopUpPolicy(WKWebsitePoliciesRef websitePolicies, WKWeb
 
 WKWebsiteDataStoreRef WKWebsitePoliciesGetDataStore(WKWebsitePoliciesRef websitePolicies)
 {
-    return toAPI(toImpl(websitePolicies)->websiteDataStore());
+    return toAPI(toProtectedImpl(websitePolicies)->protectedWebsiteDataStore().get());
 }
 
 void WKWebsitePoliciesSetDataStore(WKWebsitePoliciesRef websitePolicies, WKWebsiteDataStoreRef websiteDataStore)
 {
-    toImpl(websitePolicies)->setWebsiteDataStore(toImpl(websiteDataStore));
+    toProtectedImpl(websitePolicies)->setWebsiteDataStore(toProtectedImpl(websiteDataStore));
 }
-


### PR DESCRIPTION
#### 1b93f4469b6e2e4f897596b23712d5b8cfb79d39
<pre>
[SaferCpp] Address issues in WKWebsitePolicies
<a href="https://bugs.webkit.org/show_bug.cgi?id=291509">https://bugs.webkit.org/show_bug.cgi?id=291509</a>
<a href="https://rdar.apple.com/149187300">rdar://149187300</a>

Reviewed by Chris Dumez.

Address more SaferCpp fails in WKWebsitePolicies.cpp

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/APIWebsitePolicies.cpp:
(API::WebsitePolicies::protectedWebsiteDataStore const):
* Source/WebKit/UIProcess/API/APIWebsitePolicies.h:
* Source/WebKit/UIProcess/API/C/WKWebsitePolicies.cpp:
(WKWebsitePoliciesSetContentBlockersEnabled):
(WKWebsitePoliciesGetContentBlockersEnabled):
(WKWebsitePoliciesSetAllowedAutoplayQuirks):
(WKWebsitePoliciesGetAllowedAutoplayQuirks):
(WKWebsitePoliciesGetAutoplayPolicy):
(WKWebsitePoliciesSetAutoplayPolicy):
(WKWebsitePoliciesGetPopUpPolicy):
(WKWebsitePoliciesSetPopUpPolicy):
(WKWebsitePoliciesGetDataStore):
(WKWebsitePoliciesSetDataStore):

Canonical link: <a href="https://commits.webkit.org/293690@main">https://commits.webkit.org/293690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c06af98f3e41977eaf3b2a895523c04948a64c9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104763 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50228 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27715 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75840 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32938 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14899 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89960 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56199 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14698 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49592 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8031 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107122 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26747 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19524 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84798 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27111 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86164 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84317 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21403 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28990 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6694 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20536 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26687 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31890 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26502 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29818 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28072 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->