### PR TITLE
[SaferCpp] Adopt more smartpointers in UIProcess/API/C/

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -36,9 +36,6 @@ UIProcess/API/C/WKProtectionSpace.cpp
 UIProcess/API/C/WKQueryPermissionResultCallback.cpp
 UIProcess/API/C/WKSpeechRecognitionPermissionCallback.cpp
 UIProcess/API/C/WKUserContentControllerRef.cpp
-UIProcess/API/C/WKUserContentExtensionStoreRef.cpp
-UIProcess/API/C/WKUserMediaPermissionCheck.cpp
-UIProcess/API/C/WKUserMediaPermissionRequest.cpp
 UIProcess/API/C/WKWebsiteDataStoreConfigurationRef.cpp
 UIProcess/API/C/WKWebsiteDataStoreRef.cpp
 UIProcess/API/C/WKWebsitePolicies.cpp

--- a/Source/WebKit/UIProcess/API/C/WKUserContentExtensionStoreRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKUserContentExtensionStoreRef.cpp
@@ -76,7 +76,7 @@ static inline WKUserContentExtensionStoreResult toResult(const std::error_code& 
 void WKUserContentExtensionStoreCompile(WKUserContentExtensionStoreRef store, WKStringRef identifier, WKStringRef jsonSource, void* context, WKUserContentExtensionStoreFunction callback)
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    toImpl(store)->compileContentRuleList(toWTFString(identifier), toWTFString(jsonSource), [context, callback](RefPtr<API::ContentRuleList> contentRuleList, std::error_code error) {
+    toProtectedImpl(store)->compileContentRuleList(toWTFString(identifier), toWTFString(jsonSource), [context, callback](RefPtr<API::ContentRuleList> contentRuleList, std::error_code error) {
         callback(error ? nullptr : toAPILeakingRef(WTFMove(contentRuleList)), toResult(error), context);
     });
 #else
@@ -88,7 +88,7 @@ void WKUserContentExtensionStoreCompile(WKUserContentExtensionStoreRef store, WK
 void WKUserContentExtensionStoreLookup(WKUserContentExtensionStoreRef store, WKStringRef identifier, void* context, WKUserContentExtensionStoreFunction callback)
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    toImpl(store)->lookupContentRuleList(toWTFString(identifier), [context, callback](RefPtr<API::ContentRuleList> contentRuleList, std::error_code error) {
+    toProtectedImpl(store)->lookupContentRuleList(toWTFString(identifier), [context, callback](RefPtr<API::ContentRuleList> contentRuleList, std::error_code error) {
         callback(error ? nullptr : toAPILeakingRef(WTFMove(contentRuleList)), toResult(error), context);
     });
 #else
@@ -99,7 +99,7 @@ void WKUserContentExtensionStoreLookup(WKUserContentExtensionStoreRef store, WKS
 void WKUserContentExtensionStoreRemove(WKUserContentExtensionStoreRef store, WKStringRef identifier, void* context, WKUserContentExtensionStoreFunction callback)
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    toImpl(store)->removeContentRuleList(toWTFString(identifier), [context, callback](std::error_code error) {
+    toProtectedImpl(store)->removeContentRuleList(toWTFString(identifier), [context, callback](std::error_code error) {
         callback(nullptr, toResult(error), context);
     });
 #else

--- a/Source/WebKit/UIProcess/API/C/WKUserMediaPermissionCheck.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKUserMediaPermissionCheck.cpp
@@ -46,5 +46,5 @@ WKTypeID WKUserMediaPermissionCheckGetTypeID()
 
 void WKUserMediaPermissionCheckSetUserMediaAccessInfo(WKUserMediaPermissionCheckRef userMediaPermissionRequestRef, WKStringRef, bool allowed)
 {
-    toImpl(userMediaPermissionRequestRef)->setUserMediaAccessInfo(allowed);
+    toProtectedImpl(userMediaPermissionRequestRef)->setUserMediaAccessInfo(allowed);
 }

--- a/Source/WebKit/UIProcess/API/C/WKUserMediaPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKUserMediaPermissionRequest.cpp
@@ -36,7 +36,7 @@ WKTypeID WKUserMediaPermissionRequestGetTypeID()
 
 void WKUserMediaPermissionRequestAllow(WKUserMediaPermissionRequestRef userMediaPermissionRequestRef, WKStringRef audioDeviceUID, WKStringRef videoDeviceUID)
 {
-    toImpl(userMediaPermissionRequestRef)->allow(toWTFString(audioDeviceUID), toWTFString(videoDeviceUID));
+    toProtectedImpl(userMediaPermissionRequestRef)->allow(toWTFString(audioDeviceUID), toWTFString(videoDeviceUID));
 }
 
 static UserMediaPermissionRequestProxy::UserMediaAccessDenialReason toWK(UserMediaPermissionRequestDenialReason reason)
@@ -72,14 +72,14 @@ static UserMediaPermissionRequestProxy::UserMediaAccessDenialReason toWK(UserMed
 
 void WKUserMediaPermissionRequestDeny(WKUserMediaPermissionRequestRef userMediaPermissionRequestRef, UserMediaPermissionRequestDenialReason reason)
 {
-    toImpl(userMediaPermissionRequestRef)->deny(toWK(reason));
+    toProtectedImpl(userMediaPermissionRequestRef)->deny(toWK(reason));
 }
 
 WKArrayRef WKUserMediaPermissionRequestVideoDeviceUIDs(WKUserMediaPermissionRequestRef userMediaPermissionRef)
 {
     WKMutableArrayRef array = WKMutableArrayCreate();
 #if ENABLE(MEDIA_STREAM)
-    for (auto& deviceUID : toImpl(userMediaPermissionRef)->videoDeviceUIDs())
+    for (auto& deviceUID : toProtectedImpl(userMediaPermissionRef)->videoDeviceUIDs())
         WKArrayAppendItem(array, toAPI(API::String::create(deviceUID).ptr()));
 #endif
     return array;
@@ -89,7 +89,7 @@ WKArrayRef WKUserMediaPermissionRequestAudioDeviceUIDs(WKUserMediaPermissionRequ
 {
     WKMutableArrayRef array = WKMutableArrayCreate();
 #if ENABLE(MEDIA_STREAM)
-    for (auto& deviceUID : toImpl(userMediaPermissionRef)->audioDeviceUIDs())
+    for (auto& deviceUID : toProtectedImpl(userMediaPermissionRef)->audioDeviceUIDs())
         WKArrayAppendItem(array, toAPI(API::String::create(deviceUID).ptr()));
 #endif
     return array;
@@ -97,15 +97,15 @@ WKArrayRef WKUserMediaPermissionRequestAudioDeviceUIDs(WKUserMediaPermissionRequ
 
 bool WKUserMediaPermissionRequestRequiresCameraCapture(WKUserMediaPermissionRequestRef userMediaPermissionRequestRef)
 {
-    return toImpl(userMediaPermissionRequestRef)->requiresVideoCapture();
+    return toProtectedImpl(userMediaPermissionRequestRef)->requiresVideoCapture();
 }
 
 bool WKUserMediaPermissionRequestRequiresDisplayCapture(WKUserMediaPermissionRequestRef userMediaPermissionRequestRef)
 {
-    return toImpl(userMediaPermissionRequestRef)->requiresDisplayCapture();
+    return toProtectedImpl(userMediaPermissionRequestRef)->requiresDisplayCapture();
 }
 
 bool WKUserMediaPermissionRequestRequiresMicrophoneCapture(WKUserMediaPermissionRequestRef userMediaPermissionRequestRef)
 {
-    return toImpl(userMediaPermissionRequestRef)->requiresAudioCapture();
+    return toProtectedImpl(userMediaPermissionRequestRef)->requiresAudioCapture();
 }


### PR DESCRIPTION
#### 10635c469f274c2d06c36f2295c6d4c00ad50c34
<pre>
[SaferCpp] Adopt more smartpointers in UIProcess/API/C/
<a href="https://bugs.webkit.org/show_bug.cgi?id=291510">https://bugs.webkit.org/show_bug.cgi?id=291510</a>
<a href="https://rdar.apple.com/149189251">rdar://149189251</a>

Reviewed by Chris Dumez.

Adopt more smart pointers in:

-UIProcess/API/C/WKUserContentExtensionStoreRef.cpp
-UIProcess/API/C/WKUserMediaPermissionCheck.cpp
-UIProcess/API/C/WKUserMediaPermissionRequest.cpp

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/C/WKUserContentExtensionStoreRef.cpp:
(WKUserContentExtensionStoreCompile):
(WKUserContentExtensionStoreLookup):
(WKUserContentExtensionStoreRemove):
* Source/WebKit/UIProcess/API/C/WKUserMediaPermissionCheck.cpp:
(WKUserMediaPermissionCheckSetUserMediaAccessInfo):
* Source/WebKit/UIProcess/API/C/WKUserMediaPermissionRequest.cpp:
(WKUserMediaPermissionRequestAllow):
(WKUserMediaPermissionRequestDeny):
(WKUserMediaPermissionRequestVideoDeviceUIDs):
(WKUserMediaPermissionRequestAudioDeviceUIDs):
(WKUserMediaPermissionRequestRequiresCameraCapture):
(WKUserMediaPermissionRequestRequiresDisplayCapture):
(WKUserMediaPermissionRequestRequiresMicrophoneCapture):

Canonical link: <a href="https://commits.webkit.org/293679@main">https://commits.webkit.org/293679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/495b8e050da068fc56a415d538b5a2b951727728

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104724 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50192 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27676 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75811 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32910 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14866 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89931 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56170 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14663 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49554 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84603 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107083 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26707 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19495 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84772 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27070 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86135 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84288 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21396 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28954 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/6670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20502 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26647 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31851 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26467 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29780 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28033 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->