### PR TITLE
[SaferCpp] Adopt more smart pointers in UIProcess/API/C/ part 2

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -23,12 +23,9 @@ UIProcess/API/C/WKNotification.cpp
 UIProcess/API/C/WKNotificationManager.cpp
 UIProcess/API/C/WKNotificationPermissionRequest.cpp
 UIProcess/API/C/WKOpenPanelParametersRef.cpp
-UIProcess/API/C/WKOpenPanelResultListener.cpp
 UIProcess/API/C/WKPage.cpp
-UIProcess/API/C/WKPageConfigurationRef.cpp
 UIProcess/API/C/WKQueryPermissionResultCallback.cpp
 UIProcess/API/C/WKSpeechRecognitionPermissionCallback.cpp
-UIProcess/API/C/WKUserContentControllerRef.cpp
 UIProcess/API/C/WKWebsiteDataStoreConfigurationRef.cpp
 UIProcess/API/C/WKWebsiteDataStoreRef.cpp
 UIProcess/API/C/mac/WKPagePrivateMac.mm

--- a/Source/WebKit/UIProcess/API/C/WKOpenPanelResultListener.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKOpenPanelResultListener.cpp
@@ -59,16 +59,16 @@ static Vector<String> filePathsFromFileURLs(const API::Array& fileURLs)
 #if PLATFORM(IOS_FAMILY)
 void WKOpenPanelResultListenerChooseMediaFiles(WKOpenPanelResultListenerRef listenerRef, WKArrayRef fileURLsRef, WKStringRef displayString, WKDataRef iconImageDataRef)
 {
-    toImpl(listenerRef)->chooseFiles(filePathsFromFileURLs(*toImpl(fileURLsRef)), toImpl(displayString)->string(), toImpl(iconImageDataRef));
+    toProtectedImpl(listenerRef)->chooseFiles(filePathsFromFileURLs(*toProtectedImpl(fileURLsRef)), toProtectedImpl(displayString)->string(), toProtectedImpl(iconImageDataRef).get());
 }
 #endif
 
 void WKOpenPanelResultListenerChooseFiles(WKOpenPanelResultListenerRef listenerRef, WKArrayRef fileURLsRef, WKArrayRef allowedMimeTypesRef)
 {
-    toImpl(listenerRef)->chooseFiles(filePathsFromFileURLs(*toImpl(fileURLsRef)), toImpl(allowedMimeTypesRef)->toStringVector());
+    toProtectedImpl(listenerRef)->chooseFiles(filePathsFromFileURLs(*toProtectedImpl(fileURLsRef)), toProtectedImpl(allowedMimeTypesRef)->toStringVector());
 }
 
 void WKOpenPanelResultListenerCancel(WKOpenPanelResultListenerRef listenerRef)
 {
-    toImpl(listenerRef)->cancel();
+    toProtectedImpl(listenerRef)->cancel();
 }

--- a/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp
@@ -48,12 +48,12 @@ WKPageConfigurationRef WKPageConfigurationCreate()
 
 WKContextRef WKPageConfigurationGetContext(WKPageConfigurationRef configuration)
 {
-    return toAPI(toImpl(configuration)->processPool());
+    return toAPI(toProtectedImpl(configuration)->protectedProcessPool().get());
 }
 
 void WKPageConfigurationSetContext(WKPageConfigurationRef configuration, WKContextRef context)
 {
-    toImpl(configuration)->setProcessPool(toImpl(context));
+    toProtectedImpl(configuration)->setProcessPool(toProtectedImpl(context));
 }
 
 WKPageGroupRef WKPageConfigurationGetPageGroup(WKPageConfigurationRef)
@@ -67,65 +67,66 @@ void WKPageConfigurationSetPageGroup(WKPageConfigurationRef, WKPageGroupRef)
 
 WKUserContentControllerRef WKPageConfigurationGetUserContentController(WKPageConfigurationRef configuration)
 {
-    return toAPI(toImpl(configuration)->userContentController());
+    return toAPI(toProtectedImpl(configuration)->protectedUserContentController().get());
 }
 
 void WKPageConfigurationSetUserContentController(WKPageConfigurationRef configuration, WKUserContentControllerRef userContentController)
 {
-    toImpl(configuration)->setUserContentController(toImpl(userContentController));
+    toProtectedImpl(configuration)->setUserContentController(toProtectedImpl(userContentController));
 }
 
 WKPreferencesRef WKPageConfigurationGetPreferences(WKPageConfigurationRef configuration)
 {
-    return toAPI(toImpl(configuration)->preferences());
+    return toAPI(toProtectedImpl(configuration)->protectedPreferences().get());
 }
 
 void WKPageConfigurationSetPreferences(WKPageConfigurationRef configuration, WKPreferencesRef preferences)
 {
-    toImpl(configuration)->setPreferences(toImpl(preferences));
+    toProtectedImpl(configuration)->setPreferences(toProtectedImpl(preferences));
 }
 
 WKPageRef WKPageConfigurationGetRelatedPage(WKPageConfigurationRef configuration)
 {
-    return toAPI(toImpl(configuration)->relatedPage());
+    RefPtr relatedPage = toProtectedImpl(configuration)->relatedPage();
+    return toAPI(relatedPage.get());
 }
 
 void WKPageConfigurationSetRelatedPage(WKPageConfigurationRef configuration, WKPageRef relatedPage)
 {
-    toImpl(configuration)->setRelatedPage(toImpl(relatedPage));
+    toProtectedImpl(configuration)->setRelatedPage(toProtectedImpl(relatedPage));
 }
 
 WKWebsiteDataStoreRef WKPageConfigurationGetWebsiteDataStore(WKPageConfigurationRef configuration)
 {
-    return toAPI(toImpl(configuration)->websiteDataStore());
+    return toAPI(toProtectedImpl(configuration)->protectedWebsiteDataStore().get());
 }
 
 void WKPageConfigurationSetWebsiteDataStore(WKPageConfigurationRef configuration, WKWebsiteDataStoreRef websiteDataStore)
 {
-    toImpl(configuration)->setWebsiteDataStore(toImpl(websiteDataStore));
+    toProtectedImpl(configuration)->setWebsiteDataStore(toProtectedImpl(websiteDataStore));
 }
 
 void WKPageConfigurationSetInitialCapitalizationEnabled(WKPageConfigurationRef configuration, bool enabled)
 {
-    toImpl(configuration)->setInitialCapitalizationEnabled(enabled);
+    toProtectedImpl(configuration)->setInitialCapitalizationEnabled(enabled);
 }
 
 void WKPageConfigurationSetBackgroundCPULimit(WKPageConfigurationRef configuration, double cpuLimit)
 {
-    toImpl(configuration)->setCPULimit(cpuLimit);
+    toProtectedImpl(configuration)->setCPULimit(cpuLimit);
 }
 
 void WKPageConfigurationSetAllowTestOnlyIPC(WKPageConfigurationRef configuration, bool allowTestOnlyIPC)
 {
-    toImpl(configuration)->setAllowTestOnlyIPC(allowTestOnlyIPC);
+    toProtectedImpl(configuration)->setAllowTestOnlyIPC(allowTestOnlyIPC);
 }
 
 void WKPageConfigurationSetShouldSendConsoleLogsToUIProcessForTesting(WKPageConfigurationRef configuration, bool should)
 {
-    toImpl(configuration)->setShouldSendConsoleLogsToUIProcessForTesting(should);
+    toProtectedImpl(configuration)->setShouldSendConsoleLogsToUIProcessForTesting(should);
 }
 
 void WKPageConfigurationSetPortsForUpgradingInsecureSchemeForTesting(WKPageConfigurationRef configuration, uint16_t upgradeFromInsecurePort, uint16_t upgradeToSecurePort)
 {
-    toImpl(configuration)->setPortsForUpgradingInsecureSchemeForTesting(upgradeFromInsecurePort, upgradeToSecurePort);
+    toProtectedImpl(configuration)->setPortsForUpgradingInsecureSchemeForTesting(upgradeFromInsecurePort, upgradeToSecurePort);
 }

--- a/Source/WebKit/UIProcess/API/C/WKUserContentControllerRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKUserContentControllerRef.cpp
@@ -47,29 +47,29 @@ WKUserContentControllerRef WKUserContentControllerCreate()
 
 WKArrayRef WKUserContentControllerCopyUserScripts(WKUserContentControllerRef userContentControllerRef)
 {
-    return toAPILeakingRef(toImpl(userContentControllerRef)->userScripts().copy());
+    return toAPILeakingRef(toProtectedImpl(userContentControllerRef)->userScripts().copy());
 }
 
 void WKUserContentControllerAddUserScript(WKUserContentControllerRef userContentControllerRef, WKUserScriptRef userScriptRef)
 {
-    toImpl(userContentControllerRef)->addUserScript(*toImpl(userScriptRef), InjectUserScriptImmediately::No);
+    toProtectedImpl(userContentControllerRef)->addUserScript(*toProtectedImpl(userScriptRef), InjectUserScriptImmediately::No);
 }
 
 void WKUserContentControllerRemoveAllUserScripts(WKUserContentControllerRef userContentControllerRef)
 {
-    toImpl(userContentControllerRef)->removeAllUserScripts();
+    toProtectedImpl(userContentControllerRef)->removeAllUserScripts();
 }
 
 void WKUserContentControllerAddUserContentFilter(WKUserContentControllerRef userContentControllerRef, WKUserContentFilterRef userContentFilterRef)
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    toImpl(userContentControllerRef)->addContentRuleList(*toImpl(userContentFilterRef));
+    toProtectedImpl(userContentControllerRef)->addContentRuleList(*toProtectedImpl(userContentFilterRef));
 #endif
 }
 
 void WKUserContentControllerRemoveAllUserContentFilters(WKUserContentControllerRef userContentControllerRef)
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    toImpl(userContentControllerRef)->removeAllContentRuleLists();
+    toProtectedImpl(userContentControllerRef)->removeAllContentRuleLists();
 #endif
 }


### PR DESCRIPTION
#### ba0fd77805b3d3caab7158a7be31ac3686504119
<pre>
[SaferCpp] Adopt more smart pointers in UIProcess/API/C/ part 2
<a href="https://bugs.webkit.org/show_bug.cgi?id=291511">https://bugs.webkit.org/show_bug.cgi?id=291511</a>
<a href="https://rdar.apple.com/149191086">rdar://149191086</a>

Reviewed by Chris Dumez.

Adopt more smart pointers in:

-UIProcess/API/C/WKOpenPanelResultListener.cpp
-UIProcess/API/C/WKPageConfigurationRef.cpp
-UIProcess/API/C/WKProtectionSpace.cpp
-UIProcess/API/C/WKUserContentControllerRef.cpp

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/C/WKOpenPanelResultListener.cpp:
(WKOpenPanelResultListenerChooseMediaFiles):
(WKOpenPanelResultListenerChooseFiles):
(WKOpenPanelResultListenerCancel):
* Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp:
(WKPageConfigurationGetContext):
(WKPageConfigurationSetContext):
(WKPageConfigurationGetUserContentController):
(WKPageConfigurationSetUserContentController):
(WKPageConfigurationGetPreferences):
(WKPageConfigurationSetPreferences):
(WKPageConfigurationGetRelatedPage):
(WKPageConfigurationSetRelatedPage):
(WKPageConfigurationGetWebsiteDataStore):
(WKPageConfigurationSetWebsiteDataStore):
(WKPageConfigurationSetInitialCapitalizationEnabled):
(WKPageConfigurationSetBackgroundCPULimit):
(WKPageConfigurationSetAllowTestOnlyIPC):
(WKPageConfigurationSetShouldSendConsoleLogsToUIProcessForTesting):
(WKPageConfigurationSetPortsForUpgradingInsecureSchemeForTesting):
* Source/WebKit/UIProcess/API/C/WKUserContentControllerRef.cpp:
(WKUserContentControllerCopyUserScripts):
(WKUserContentControllerAddUserScript):
(WKUserContentControllerRemoveAllUserScripts):
(WKUserContentControllerAddUserContentFilter):
(WKUserContentControllerRemoveAllUserContentFilters):

Canonical link: <a href="https://commits.webkit.org/296568@main">https://commits.webkit.org/296568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f381a80520e493488c84889fc22b24e2aee5a0c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114100 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59239 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37117 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82741 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111839 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23238 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98081 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63180 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22659 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58799 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92612 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16264 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117220 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35941 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26554 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91752 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36314 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91559 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23316 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36468 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14224 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31803 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35840 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41367 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35541 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38885 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37227 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->