### PR TITLE
Make 'run-benchmark' support collecting PGO profiles from multiple locations

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py
@@ -72,7 +72,7 @@ class BrowserDriver:
         return get_driver_binary_path(self.browser_name)
 
     @property
-    def pgo_profile_output_directory(self):
+    def pgo_profile_output_directories(self):
         raise NotImplementedError()
 
     def prepare_pgo_profile_collection(self):

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_browser_driver.py
@@ -204,9 +204,11 @@ class OSXBrowserDriver(BrowserDriver):
         return temp_args
 
     def prepare_pgo_profile_collection(self):
-        shutil.rmtree(self.pgo_profile_output_directory, ignore_errors=True)
-        os.mkdir(self.pgo_profile_output_directory)
+        for directory in self.pgo_profile_output_directories:
+            shutil.rmtree(directory, ignore_errors=True)
+            os.mkdir(directory)
 
     def collect_pgo_profile(self, destination):
-        _log.info(f'Copying PGO profiles from {self.pgo_profile_output_directory} to {destination}')
-        shutil.copytree(self.pgo_profile_output_directory, destination, dirs_exist_ok=True)
+        _log.info(f'Copying PGO profiles from {self.pgo_profile_output_directories} to {destination}')
+        for directory in self.pgo_profile_output_directories:
+            shutil.copytree(directory, destination, dirs_exist_ok=True)

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_safari_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_safari_driver.py
@@ -112,5 +112,5 @@ class OSXSafariDriver(OSXBrowserDriver):
             _log.error('Reset safari window size failed - Error: {}'.format(error))
 
     @property
-    def pgo_profile_output_directory(self):
-        return '/private/tmp/WebKitPGO'
+    def pgo_profile_output_directories(self):
+        return ['/private/tmp/WebKitPGO']


### PR DESCRIPTION
#### 6e43dc1a9c2df77c2f68129880ce69a24a030173
<pre>
Make &apos;run-benchmark&apos; support collecting PGO profiles from multiple locations
<a href="https://bugs.webkit.org/show_bug.cgi?id=291512">https://bugs.webkit.org/show_bug.cgi?id=291512</a>
<a href="https://rdar.apple.com/149191082">rdar://149191082</a>

Reviewed by Jonathan Bedard.

Relax run-benchmark script assumption that PGO profiles from browser is always written to a single location.
This is required to support iOS PGO collection after 293291@main.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py:
(BrowserDriver.pgo_profile_output_directories):
(BrowserDriver.pgo_profile_output_directory): Deleted.
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_browser_driver.py:
(OSXBrowserDriver.prepare_pgo_profile_collection):
(OSXBrowserDriver.collect_pgo_profile):
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_safari_driver.py:
(OSXSafariDriver.pgo_profile_output_directories):
(OSXSafariDriver.pgo_profile_output_directory): Deleted.

Canonical link: <a href="https://commits.webkit.org/293687@main">https://commits.webkit.org/293687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/905c1ed3f378f1fc0aa122ed0e348d481bc9532c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104731 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50198 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101641 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75817 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32916 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102607 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14874 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56176 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/99073 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14672 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7920 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49561 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84613 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8006 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107090 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26714 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19504 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84777 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27077 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86139 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84294 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21401 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28963 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6674 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20509 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26656 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26474 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29786 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28039 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->