### PR TITLE
SWServer can create its background fetch engine within its destructor

### DIFF
--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -82,6 +82,11 @@ Ref<SWServer> SWServer::create(SWServerDelegate& delegate, UniqueRef<SWOriginSto
 
 SWServer::~SWServer()
 {
+    close();
+}
+
+void SWServer::close()
+{
     // Destroy the remaining connections before the SWServer gets destroyed since they have a raw pointer
     // to the server and since they try to unregister clients from the server in their destructor.
     auto connections = WTFMove(m_connections);

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -164,6 +164,8 @@ public:
     WEBCORE_EXPORT static Ref<SWServer> create(SWServerDelegate&, UniqueRef<SWOriginStore>&&, bool processTerminationDelayEnabled, String&& registrationDatabaseDirectory, PAL::SessionID, bool shouldRunServiceWorkersOnMainThreadForTesting, bool hasServiceWorkerEntitlement, std::optional<unsigned> overrideServiceWorkerRegistrationCountTestingValue, ServiceWorkerIsInspectable);
     WEBCORE_EXPORT ~SWServer();
 
+    WEBCORE_EXPORT void close();
+
     WEBCORE_EXPORT void clearAll(CompletionHandler<void()>&&);
     WEBCORE_EXPORT void clear(const SecurityOriginData&, CompletionHandler<void()>&&);
     WEBCORE_EXPORT void clear(const ClientOrigin&, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -260,6 +260,9 @@ void NetworkSession::invalidateAndCancel()
         m_cache = nullptr;
         FileSystem::markPurgeable(networkCacheDirectory);
     }
+
+    if (auto server = std::exchange(m_swServer, { }))
+        server->close();
 }
 
 void NetworkSession::destroyPrivateClickMeasurementStore(CompletionHandler<void()>&& completionHandler)


### PR DESCRIPTION
#### b03cebd1a4c2df50737c3c15d1bd31612f4d528b
<pre>
SWServer can create its background fetch engine within its destructor
<a href="https://rdar.apple.com/145610350">rdar://145610350</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291516">https://bugs.webkit.org/show_bug.cgi?id=291516</a>

Reviewed by Chris Dumez.

SWServer can be destroyed as part of NetworkSession destructor.
But the background fetch engine can be created at that time when clearing a registration.
To prevent this, we are now closing the SWServer when the NetworkSession is destroyed.

* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::~SWServer):
(WebCore::SWServer::close):
* Source/WebCore/workers/service/server/SWServer.h:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::invalidateAndCancel):

Canonical link: <a href="https://commits.webkit.org/293721@main">https://commits.webkit.org/293721@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/711bbe935592dacdf5f5940b2a82ac2e83878980

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9479 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104685 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50156 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101595 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19492 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75784 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32885 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102561 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14844 "Found 1 new test failure: fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89915 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56143 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14641 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7900 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49515 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84581 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7986 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107043 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26668 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19468 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84745 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27031 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86119 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84262 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21427 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28932 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6654 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20463 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26608 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31809 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26428 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29741 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27995 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->