### PR TITLE
Devirtualize CanvasBase::cssParserContext

### DIFF
--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CSSParserContext.h"
 #include "CanvasNoiseInjection.h"
 #include "FloatRect.h"
 #include "IntSize.h"
@@ -61,8 +62,6 @@ class IntRect;
 class ScriptExecutionContext;
 class SecurityOrigin;
 class WebCoreOpaqueRoot;
-
-struct CSSParserContext;
 
 enum class ShouldApplyPostProcessingToDirtyRect : bool { No, Yes };
 
@@ -105,7 +104,7 @@ public:
 
     virtual CanvasRenderingContext* renderingContext() const = 0;
 
-    virtual const CSSParserContext& cssParserContext() const = 0;
+    const CSSParserContext& cssParserContext() const;
 
     void addObserver(CanvasObserver&);
     void removeObserver(CanvasObserver&);
@@ -156,6 +155,7 @@ protected:
     explicit CanvasBase(IntSize, ScriptExecutionContext&);
 
     virtual ScriptExecutionContext* canvasBaseScriptExecutionContext() const = 0;
+    virtual std::unique_ptr<CSSParserContext> createCSSParserContext() const = 0;
 
     virtual void setSize(const IntSize&);
 
@@ -173,6 +173,7 @@ private:
     mutable RefPtr<ImageBuffer> m_imageBuffer;
     mutable std::atomic<size_t> m_imageBufferMemoryCost { 0 };
     mutable std::unique_ptr<GraphicsContextStateSaver> m_contextStateSaver;
+    mutable std::unique_ptr<CSSParserContext> m_cssParserContext;
 
     String m_lastFillText;
 
@@ -191,6 +192,14 @@ private:
 };
 
 WebCoreOpaqueRoot root(CanvasBase*);
+
+
+inline const CSSParserContext& CanvasBase::cssParserContext() const
+{
+    if (UNLIKELY(!m_cssParserContext))
+        m_cssParserContext = createCSSParserContext();
+    return *m_cssParserContext;
+}
 
 } // namespace WebCore
 

--- a/Source/WebCore/html/CustomPaintCanvas.cpp
+++ b/Source/WebCore/html/CustomPaintCanvas.cpp
@@ -27,7 +27,6 @@
 #include "CustomPaintCanvas.h"
 
 #include "BitmapImage.h"
-#include "CSSParserContext.h"
 #include "CanvasRenderingContext.h"
 #include "ImageBitmap.h"
 #include "PaintRenderingContext2D.h"
@@ -99,12 +98,10 @@ void CustomPaintCanvas::clearCopiedImage() const
     m_copiedImage = nullptr;
 }
 
-const CSSParserContext& CustomPaintCanvas::cssParserContext() const
+std::unique_ptr<CSSParserContext> CustomPaintCanvas::createCSSParserContext() const
 {
     // FIXME: Rather than using a default CSSParserContext, there should be one exposed via ScriptExecutionContext.
-    if (!m_cssParserContext)
-        m_cssParserContext = WTF::makeUnique<CSSParserContext>(HTMLStandardMode);
-    return *m_cssParserContext;
+    return makeUnique<CSSParserContext>(HTMLStandardMode);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/CustomPaintCanvas.h
+++ b/Source/WebCore/html/CustomPaintCanvas.h
@@ -69,7 +69,7 @@ public:
     void queueTaskKeepingObjectAlive(TaskSource, Function<void(CanvasBase&)>&&) final { };
     void dispatchEvent(Event&) final { }
 
-    const CSSParserContext& cssParserContext() const final;
+    std::unique_ptr<CSSParserContext> createCSSParserContext() const final;
 
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
@@ -81,7 +81,6 @@ private:
 
     std::unique_ptr<PaintRenderingContext2D> m_context;
     mutable RefPtr<Image> m_copiedImage;
-    mutable std::unique_ptr<CSSParserContext> m_cssParserContext;
 };
 
 }

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -31,7 +31,6 @@
 #include "BitmapImage.h"
 #include "Blob.h"
 #include "BlobCallback.h"
-#include "CSSParserContext.h"
 #include "CanvasGradient.h"
 #include "CanvasPattern.h"
 #include "CanvasRenderingContext2D.h"
@@ -1025,11 +1024,9 @@ void HTMLCanvasElement::dispatchEvent(Event& event)
     Node::dispatchEvent(event);
 }
 
-const CSSParserContext& HTMLCanvasElement::cssParserContext() const
+std::unique_ptr<CSSParserContext> HTMLCanvasElement::createCSSParserContext() const
 {
-    if (!m_cssParserContext)
-        m_cssParserContext = WTF::makeUnique<CSSParserContext>(document());
-    return *m_cssParserContext;
+    return makeUnique<CSSParserContext>(document());
 }
 
 WebCoreOpaqueRoot root(HTMLCanvasElement* canvas)

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -120,7 +120,7 @@ public:
     ExceptionOr<Ref<MediaStream>> captureStream(std::optional<double>&& frameRequestRate);
 #endif
 
-    const CSSParserContext& cssParserContext() const final;
+    std::unique_ptr<CSSParserContext> createCSSParserContext() const final;
 
     Image* copiedImage() const final;
     void clearCopiedImage() const final;
@@ -191,7 +191,6 @@ private:
 
     std::unique_ptr<CanvasRenderingContext> m_context;
     mutable RefPtr<Image> m_copiedImage; // FIXME: This is temporary for platforms that have to copy the image buffer to render (and for CSSCanvasValue).
-    mutable std::unique_ptr<CSSParserContext> m_cssParserContext;
 };
 
 WebCoreOpaqueRoot root(HTMLCanvasElement*);

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -29,7 +29,6 @@
 #if ENABLE(OFFSCREEN_CANVAS)
 
 #include "BitmapImage.h"
-#include "CSSParserContext.h"
 #include "CSSValuePool.h"
 #include "CanvasRenderingContext.h"
 #include "Chrome.h"
@@ -466,12 +465,10 @@ void OffscreenCanvas::dispatchEvent(Event& event)
     EventDispatcher::dispatchEvent({ this }, event);
 }
 
-const CSSParserContext& OffscreenCanvas::cssParserContext() const
+std::unique_ptr<CSSParserContext> OffscreenCanvas::createCSSParserContext() const
 {
     // FIXME: Rather than using a default CSSParserContext, there should be one exposed via ScriptExecutionContext.
-    if (!m_cssParserContext)
-        m_cssParserContext = WTF::makeUnique<CSSParserContext>(HTMLStandardMode);
-    return *m_cssParserContext;
+    return makeUnique<CSSParserContext>(HTMLStandardMode);
 }
 
 }

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -128,7 +128,7 @@ public:
 
     CanvasRenderingContext* renderingContext() const final { return m_context.get(); }
 
-    const CSSParserContext& cssParserContext() const final;
+    std::unique_ptr<CSSParserContext> createCSSParserContext() const final;
 
     ExceptionOr<std::optional<OffscreenRenderingContext>> getContext(JSC::JSGlobalObject&, RenderingContextType, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments);
     ExceptionOr<RefPtr<ImageBitmap>> transferToImageBitmap();
@@ -174,8 +174,6 @@ private:
     mutable RefPtr<Image> m_copiedImage;
     bool m_detached { false };
     bool m_hasScheduledCommit { false };
-
-    mutable std::unique_ptr<CSSParserContext> m_cssParserContext;
 };
 
 }


### PR DESCRIPTION
#### 8fac5fb028719cfa8e6d2245f8034284d6360b39
<pre>
Devirtualize CanvasBase::cssParserContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=291520">https://bugs.webkit.org/show_bug.cgi?id=291520</a>
<a href="https://rdar.apple.com/149206385">rdar://149206385</a>

Reviewed by Tim Nguyen.

Only then creation of CSSParserContext is polymorphic, so rename
the virtual function to createCSSParserContext().

Frequent drawing typically spends time parsing the color, and as such
the virtual function overhead sometimes shows up in such traces.

* Source/WebCore/html/CanvasBase.h:
(WebCore::CanvasBase::cssParserContext const):
* Source/WebCore/html/CustomPaintCanvas.cpp:
(WebCore::CustomPaintCanvas::createCSSParserContext const):
(WebCore::CustomPaintCanvas::cssParserContext const): Deleted.
* Source/WebCore/html/CustomPaintCanvas.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::createCSSParserContext const):
(WebCore::HTMLCanvasElement::cssParserContext const): Deleted.
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::createCSSParserContext const):
(WebCore::OffscreenCanvas::cssParserContext const): Deleted.
* Source/WebCore/html/OffscreenCanvas.h:

Canonical link: <a href="https://commits.webkit.org/293681@main">https://commits.webkit.org/293681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7473c358de2698e74f996bee3467ab3c54796026

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19236 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104717 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50186 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101627 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27669 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75809 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32915 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89925 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56168 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14660 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7910 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49547 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84600 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107076 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84767 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27063 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86129 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84284 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21394 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28951 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6664 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20496 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26640 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31841 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26460 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29773 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28027 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->