### PR TITLE
MatchResult should be refcounted

### DIFF
--- a/Source/WebCore/css/query/ContainerQueryFeatures.cpp
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.cpp
@@ -311,8 +311,9 @@ struct StyleFeatureSchema : public FeatureSchema {
             };
 
             auto dummyStyle = RenderStyle::clone(style);
+            auto dummyMatchResult = Style::MatchResult::create();
 
-            auto styleBuilder = Style::Builder { dummyStyle, WTFMove(builderContext), { }, { } };
+            auto styleBuilder = Style::Builder { dummyStyle, WTFMove(builderContext), dummyMatchResult, { } };
             return styleBuilder.resolveCustomPropertyForContainerQueries(*featureValue);
         }();
 

--- a/Source/WebCore/style/CustomPropertyRegistry.cpp
+++ b/Source/WebCore/style/CustomPropertyRegistry.cpp
@@ -198,7 +198,8 @@ auto CustomPropertyRegistry::parseInitialValue(const Document& document, const A
 
     // We don't need to provide a real context style since only computationally independent values are allowed (no 'em' etc).
     auto placeholderStyle = RenderStyle::create();
-    Style::Builder builder { placeholderStyle, { document, RenderStyle::defaultStyle() }, { }, { } };
+    auto placeholderMatchResult = MatchResult::create();
+    Style::Builder builder { placeholderStyle, { document, RenderStyle::defaultStyle() }, placeholderMatchResult, { } };
 
     auto initialValue = CSSPropertyParser::parseTypedCustomPropertyInitialValue(propertyName, syntax, tokenRange, builder.state(), { document });
     if (!initialValue)

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -102,7 +102,7 @@ ElementRuleCollector::ElementRuleCollector(const Element& element, const ScopeRu
     , m_userAgentMediaQueryStyle(ruleSets.userAgentMediaQueryStyle())
     , m_dynamicViewTransitionsStyle(ruleSets.dynamicViewTransitionsStyle())
     , m_selectorMatchingState(selectorMatchingState)
-    , m_result(makeUnique<MatchResult>(element.isLink()))
+    , m_result(MatchResult::create(element.isLink()))
 {
     ASSERT(!m_selectorMatchingState || m_selectorMatchingState->selectorFilter.parentStackIsConsistent(element.parentNode()));
 }
@@ -111,7 +111,7 @@ ElementRuleCollector::ElementRuleCollector(const Element& element, const RuleSet
     : m_element(element)
     , m_authorStyle(authorStyle)
     , m_selectorMatchingState(selectorMatchingState)
-    , m_result(makeUnique<MatchResult>(element.isLink()))
+    , m_result(MatchResult::create(element.isLink()))
 {
     ASSERT(!m_selectorMatchingState || m_selectorMatchingState->selectorFilter.parentStackIsConsistent(element.parentNode()));
 }
@@ -119,10 +119,10 @@ ElementRuleCollector::ElementRuleCollector(const Element& element, const RuleSet
 const MatchResult& ElementRuleCollector::matchResult() const
 {
     ASSERT(m_mode == SelectorChecker::Mode::ResolvingStyle);
-    return *m_result;
+    return m_result;
 }
 
-std::unique_ptr<MatchResult> ElementRuleCollector::releaseMatchResult()
+Ref<MatchResult> ElementRuleCollector::releaseMatchResult()
 {
     return WTFMove(m_result);
 }

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -69,7 +69,7 @@ public:
 
 
     const MatchResult& matchResult() const;
-    std::unique_ptr<MatchResult> releaseMatchResult();
+    Ref<MatchResult> releaseMatchResult();
 
     const Vector<RefPtr<const StyleRule>>& matchedRuleList() const;
 
@@ -138,7 +138,7 @@ private:
 
     // Output.
     Vector<RefPtr<const StyleRule>> m_matchedRuleList;
-    std::unique_ptr<MatchResult> m_result;
+    Ref<MatchResult> m_result;
     Relations m_styleRelations;
     PseudoIdSet m_matchedPseudoElementIds;
 };

--- a/Source/WebCore/style/MatchResult.h
+++ b/Source/WebCore/style/MatchResult.h
@@ -47,11 +47,8 @@ struct MatchedProperties {
     IsCacheable isCacheable { IsCacheable::Yes };
 };
 
-struct MatchResult {
-    WTF_MAKE_STRUCT_FAST_ALLOCATED;
-    MatchResult(bool isForLink = false)
-        : isForLink(isForLink)
-    { }
+struct MatchResult : RefCounted<MatchResult> {
+    static Ref<MatchResult> create(bool isForLink = false) { return adoptRef(*new MatchResult(isForLink)); }
 
     bool isForLink { false };
     bool isCompletelyNonCacheable { false };
@@ -63,8 +60,14 @@ struct MatchResult {
 
     bool isEmpty() const { return userAgentDeclarations.isEmpty() && userDeclarations.isEmpty() && authorDeclarations.isEmpty(); }
 
+    friend bool operator==(const RefCounted<MatchResult>&, const RefCounted<MatchResult>&) { return true; }
     friend bool operator==(const MatchResult&, const MatchResult&) = default;
     bool cacheablePropertiesEqual(const MatchResult&) const;
+
+private:
+    MatchResult(bool isForLink)
+        : isForLink(isForLink)
+    { }
 };
 
 inline bool operator==(const MatchedProperties& a, const MatchedProperties& b)

--- a/Source/WebCore/style/MatchResultCache.cpp
+++ b/Source/WebCore/style/MatchResultCache.cpp
@@ -36,7 +36,7 @@ namespace Style {
 MatchResultCache::MatchResultCache() = default;
 MatchResultCache::~MatchResultCache() = default;
 
-const MatchResult* MatchResultCache::get(const Element& element)
+RefPtr<const MatchResult> MatchResultCache::get(const Element& element)
 {
     auto it = m_cachedMatchResults.find(element);
     if (it == m_cachedMatchResults.end())
@@ -72,7 +72,7 @@ void MatchResultCache::update(const Element& element, const MatchResult& matchRe
     // selector matching when it gets mutated again.
     auto* styledElement = dynamicDowncast<StyledElement>(element);
     if (styledElement && styledElement->inlineStyle() && styledElement->inlineStyle()->isMutable())
-        m_cachedMatchResults.set(element, makeUniqueRef<MatchResult>(matchResult));
+        m_cachedMatchResults.set(element, &matchResult);
     else
         m_cachedMatchResults.remove(element);
 }

--- a/Source/WebCore/style/MatchResultCache.h
+++ b/Source/WebCore/style/MatchResultCache.h
@@ -42,11 +42,11 @@ public:
     MatchResultCache();
     ~MatchResultCache();
 
-    const MatchResult* get(const Element&);
+    RefPtr<const MatchResult> get(const Element&);
     void update(const Element&, const MatchResult&);
 
 private:
-    WeakHashMap<const Element, UniqueRef<MatchResult>, WeakPtrImplWithEventTargetData> m_cachedMatchResults;
+    WeakHashMap<const Element, RefPtr<const MatchResult>, WeakPtrImplWithEventTargetData> m_cachedMatchResults;
 };
 
 }

--- a/Source/WebCore/style/MatchedDeclarationsCache.cpp
+++ b/Source/WebCore/style/MatchedDeclarationsCache.cpp
@@ -143,7 +143,7 @@ const MatchedDeclarationsCache::Entry* MatchedDeclarationsCache::find(unsigned h
         return nullptr;
 
     auto& entry = it->value;
-    if (!matchResult.cacheablePropertiesEqual(entry.matchResult))
+    if (!matchResult.cacheablePropertiesEqual(*entry.matchResult))
         return nullptr;
 
     if (&entry.parentRenderStyle->inheritedCustomProperties() != &inheritedCustomProperties)
@@ -169,7 +169,7 @@ void MatchedDeclarationsCache::add(const RenderStyle& style, const RenderStyle& 
     ASSERT(hash);
     // Note that we don't cache the original RenderStyle instance. It may be further modified.
     // The RenderStyle in the cache is really just a holder for the substructures and never used as-is.
-    m_entries.add(hash, Entry { matchResult, RenderStyle::clonePtr(style), RenderStyle::clonePtr(parentStyle), userAgentAppearanceStyleCopy() });
+    m_entries.add(hash, Entry { &matchResult, RenderStyle::clonePtr(style), RenderStyle::clonePtr(parentStyle), userAgentAppearanceStyleCopy() });
 }
 
 void MatchedDeclarationsCache::remove(unsigned hash)
@@ -207,7 +207,7 @@ void MatchedDeclarationsCache::sweep()
     };
 
     m_entries.removeIf([&](auto& keyValue) {
-        auto& matchResult = keyValue.value.matchResult;
+        auto& matchResult = *keyValue.value.matchResult;
         return hasOneRef(matchResult.userAgentDeclarations) || hasOneRef(matchResult.userDeclarations) || hasOneRef(matchResult.authorDeclarations);
     });
 

--- a/Source/WebCore/style/MatchedDeclarationsCache.h
+++ b/Source/WebCore/style/MatchedDeclarationsCache.h
@@ -47,7 +47,7 @@ public:
     static unsigned computeHash(const MatchResult&, const StyleCustomPropertyData& inheritedCustomProperties);
 
     struct Entry {
-        MatchResult matchResult;
+        RefPtr<const MatchResult> matchResult;
         std::unique_ptr<const RenderStyle> renderStyle;
         std::unique_ptr<const RenderStyle> parentRenderStyle;
         std::unique_ptr<const RenderStyle> userAgentAppearanceStyle;

--- a/Source/WebCore/style/PageRuleCollector.cpp
+++ b/Source/WebCore/style/PageRuleCollector.cpp
@@ -85,7 +85,7 @@ void PageRuleCollector::matchPageRules(RuleSet* rules, bool isLeftPage, bool isF
 
     std::stable_sort(matchedPageRules.begin(), matchedPageRules.end(), comparePageRules);
 
-    m_result.authorDeclarations.appendContainerWithMapping(matchedPageRules, [](auto& pageRule) {
+    m_result->authorDeclarations.appendContainerWithMapping(matchedPageRules, [](auto& pageRule) {
         return MatchedProperties { pageRule->properties() };
     });
 }

--- a/Source/WebCore/style/PageRuleCollector.h
+++ b/Source/WebCore/style/PageRuleCollector.h
@@ -36,6 +36,7 @@ public:
     PageRuleCollector(ScopeRuleSets& ruleSets, WritingMode rootWritingMode)
         : m_ruleSets(ruleSets)
         , m_rootWritingMode(rootWritingMode)
+        , m_result(MatchResult::create())
     { }
 
     void matchAllPageRules(int pageIndex);
@@ -53,7 +54,7 @@ private:
     ScopeRuleSets& m_ruleSets;
     WritingMode m_rootWritingMode;
 
-    MatchResult m_result;
+    Ref<MatchResult> m_result;
 };
 
 } // namespace Style

--- a/Source/WebCore/style/ResolvedStyle.h
+++ b/Source/WebCore/style/ResolvedStyle.h
@@ -29,7 +29,7 @@ namespace Style {
 struct ResolvedStyle {
     std::unique_ptr<RenderStyle> style;
     std::unique_ptr<Relations> relations { };
-    std::unique_ptr<MatchResult> matchResult { };
+    RefPtr<const MatchResult> matchResult { };
 };
 
 } // namespace Style

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -352,7 +352,7 @@ ResolvedStyle Resolver::styleForElementWithCachedMatchResult(Element& element, c
     Adjuster adjuster(document(), *state.parentStyle(), context.parentBoxStyle, &element);
     adjuster.adjust(style, state.userAgentAppearanceStyle());
 
-    return { state.takeStyle(), { }, makeUnique<MatchResult>(matchResult) };
+    return { state.takeStyle(), { }, &matchResult };
 }
 
 std::unique_ptr<RenderStyle> Resolver::styleForKeyframe(Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, const StyleRuleKeyframe& keyframe, BlendingKeyframe& blendingKeyframe)


### PR DESCRIPTION
#### edd5525cc88cd24b1ced7b0f90de9296c7e1daa4
<pre>
MatchResult should be refcounted
<a href="https://bugs.webkit.org/show_bug.cgi?id=291522">https://bugs.webkit.org/show_bug.cgi?id=291522</a>
<a href="https://rdar.apple.com/149206577">rdar://149206577</a>

Reviewed by Alan Baradlay.

Avoid having to copy MatchResult for various caches.

* Source/WebCore/css/query/ContainerQueryFeatures.cpp:
* Source/WebCore/style/CustomPropertyRegistry.cpp:
(WebCore::Style::CustomPropertyRegistry::parseInitialValue):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::ElementRuleCollector):
(WebCore::Style::ElementRuleCollector::matchResult const):
(WebCore::Style::ElementRuleCollector::releaseMatchResult):
* Source/WebCore/style/ElementRuleCollector.h:
* Source/WebCore/style/MatchResult.h:
(WebCore::Style::MatchResult::create):
(WebCore::Style::MatchResult::operator==):
(WebCore::Style::MatchResult::MatchResult):
* Source/WebCore/style/MatchResultCache.cpp:
(WebCore::Style::MatchResultCache::get):
(WebCore::Style::MatchResultCache::update):
* Source/WebCore/style/MatchResultCache.h:
* Source/WebCore/style/MatchedDeclarationsCache.cpp:
(WebCore::Style::MatchedDeclarationsCache::find):
(WebCore::Style::MatchedDeclarationsCache::add):
(WebCore::Style::MatchedDeclarationsCache::sweep):
* Source/WebCore/style/MatchedDeclarationsCache.h:
* Source/WebCore/style/PageRuleCollector.cpp:
(WebCore::Style::PageRuleCollector::matchPageRules):
* Source/WebCore/style/PageRuleCollector.h:
(WebCore::Style::PageRuleCollector::PageRuleCollector):
* Source/WebCore/style/ResolvedStyle.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForElementWithCachedMatchResult):

Canonical link: <a href="https://commits.webkit.org/293701@main">https://commits.webkit.org/293701@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/093e3c179a102751980101950888e202f9877403

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9470 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104695 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50166 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101605 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19502 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75792 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32891 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89903 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56151 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14646 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7888 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49525 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84586 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7974 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107053 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26678 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19476 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84751 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27041 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86107 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84268 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21410 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28937 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6643 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20476 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26618 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31819 "Found 2 new failures in style/PropertyCascade.h, style/MatchResultCache.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26438 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29751 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28005 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->