### PR TITLE
MemoryBackingStoreTransaction::m_deletedIndexes should not track indexes by name

### DIFF
--- a/LayoutTests/storage/indexeddb/delete-indexes-with-same-name-expected.txt
+++ b/LayoutTests/storage/indexeddb/delete-indexes-with-same-name-expected.txt
@@ -1,0 +1,16 @@
+Deleting different indexes with same name.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+indexedDB = self.indexedDB || self.webkitIndexedDB || self.mozIndexedDB || self.msIndexedDB || self.OIndexedDB;
+
+indexedDB.deleteDatabase(dbname)
+indexedDB.open(dbname)
+objectStore1.deleteIndex('index')
+objectStore2.clear()
+objectStore2.deleteIndex('index')
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/delete-indexes-with-same-name-private-expected.txt
+++ b/LayoutTests/storage/indexeddb/delete-indexes-with-same-name-private-expected.txt
@@ -1,0 +1,16 @@
+Deleting different indexes with same name.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+indexedDB = self.indexedDB || self.webkitIndexedDB || self.mozIndexedDB || self.msIndexedDB || self.OIndexedDB;
+
+indexedDB.deleteDatabase(dbname)
+indexedDB.open(dbname)
+objectStore1.deleteIndex('index')
+objectStore2.clear()
+objectStore2.deleteIndex('index')
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/delete-indexes-with-same-name-private.html
+++ b/LayoutTests/storage/indexeddb/delete-indexes-with-same-name-private.html
@@ -1,0 +1,10 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/shared.js"></script>
+</head>
+<body>
+<script src="resources/delete-indexes-with-same-name.js"></script>
+</body>
+</html>

--- a/LayoutTests/storage/indexeddb/delete-indexes-with-same-name.html
+++ b/LayoutTests/storage/indexeddb/delete-indexes-with-same-name.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/shared.js"></script>
+</head>
+<body>
+<script src="resources/delete-indexes-with-same-name.js"></script>
+</body>
+</html>

--- a/LayoutTests/storage/indexeddb/resources/delete-indexes-with-same-name.js
+++ b/LayoutTests/storage/indexeddb/resources/delete-indexes-with-same-name.js
@@ -1,0 +1,49 @@
+if (this.importScripts) {
+    importScripts('../../../resources/js-test.js');
+    importScripts('shared.js');
+}
+
+description("Deleting different indexes with same name.");
+
+function prepareDatabase()
+{
+    database = event.target.result;
+
+    objectStore1 = database.createObjectStore('os1', { autoIncrement: true });
+    objectStore1.createIndex('index', 'x');
+    objectStore2 = database.createObjectStore('os2', { autoIncrement: true });
+    objectStore2.createIndex('index', 'x');
+}
+
+function upgradeDatabase()
+{
+    database = event.target.result;
+    version = database.version;
+    database.close();
+
+    openRequest = indexedDB.open(dbname, ++version);
+    openRequest.onupgradeneeded = deleteIndexes;
+    openRequest.onerror = unexpectedErrorCallback;
+}
+
+function deleteIndexes(event)
+{
+    database = event.target.result;
+    transaction = event.target.transaction;
+    transaction.onabort = finishJSTest;
+
+    objectStore1 = transaction.objectStore('os1');
+    evalAndLog("objectStore1.deleteIndex('index')");
+    objectStore2 = transaction.objectStore('os2');
+    evalAndLog("objectStore2.clear()");
+    evalAndLog("objectStore2.deleteIndex('index')");
+
+    // Perform an add operation to ensure delete requests are handled.
+    request = objectStore1.add({ x:1 });
+    request.onsuccess = () => {
+        transaction.abort();
+    };
+    request.onerror = unexpectedErrorCallback;
+}
+
+indexedDBTest(prepareDatabase, upgradeDatabase);

--- a/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
@@ -98,7 +98,7 @@ private:
     HashSet<RefPtr<MemoryIndex>> m_versionChangeAddedIndexes;
 
     HashMap<String, RefPtr<MemoryObjectStore>> m_deletedObjectStores;
-    HashMap<String, RefPtr<MemoryIndex>> m_deletedIndexes;
+    HashSet<RefPtr<MemoryIndex>> m_deletedIndexes;
     HashMap<MemoryObjectStore*, String> m_originalObjectStoreNames;
     HashMap<MemoryIndex*, String> m_originalIndexNames;
 


### PR DESCRIPTION
#### 9d6166d09630f34d4ba523ad0d52bb3d74fe2376
<pre>
MemoryBackingStoreTransaction::m_deletedIndexes should not track indexes by name
<a href="https://rdar.apple.com/141931985">rdar://141931985</a>

Reviewed by Chris Dumez.

According to spec (<a href="https://www.w3.org/TR/IndexedDB/#dom-idbobjectstore-createindex)">https://www.w3.org/TR/IndexedDB/#dom-idbobjectstore-createindex)</a>, index name is unique in its object
store. A transaction can operate on multiple object stores, so index name is not unique in transaction, and transaction
should not track indexes by name. To fix this, make MemoryBackingStoreTransaction::m_deletedIndexes a set instead of
a map.

Tests: storage/indexeddb/delete-indexes-with-same-name.html
       storage/indexeddb/delete-indexes-with-same-name-private.html

* LayoutTests/storage/indexeddb/delete-indexes-with-same-name-expected.txt: Added.
* LayoutTests/storage/indexeddb/delete-indexes-with-same-name-private-expected.txt: Added.
* LayoutTests/storage/indexeddb/delete-indexes-with-same-name-private.html: Added.
* LayoutTests/storage/indexeddb/delete-indexes-with-same-name.html: Added.
* LayoutTests/storage/indexeddb/resources/delete-indexes-with-same-name.js: Added.
(prepareDatabase):
(upgradeDatabase):
(deleteIndexes):
* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp:
(WebCore::IDBServer::MemoryBackingStoreTransaction::indexDeleted):
(WebCore::IDBServer::MemoryBackingStoreTransaction::objectStoreDeleted):
(WebCore::IDBServer::MemoryBackingStoreTransaction::abort):
* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h:

Originally-landed-as: 283286.616@safari-7620-branch (7ffc1f92efb2). <a href="https://rdar.apple.com/148116461">rdar://148116461</a>
Canonical link: <a href="https://commits.webkit.org/293685@main">https://commits.webkit.org/293685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69627784abf619ec0f663e4d5ccf2bdb575d8975

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19262 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9522 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104743 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50209 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19551 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27695 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75824 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32923 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102619 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14883 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89945 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56183 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14681 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/7931 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49572 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84621 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8016 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107102 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26727 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19514 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84783 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27091 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86149 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84300 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21399 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28972 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6684 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20519 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26667 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31870 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26486 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29799 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28052 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->