### PR TITLE
AX: [AX Thread Text APIs] visible position text markers don't account for trimmed spaces

### DIFF
--- a/LayoutTests/accessibility/mac/caret-browsing-soft-line-breaks-expected.txt
+++ b/LayoutTests/accessibility/mac/caret-browsing-soft-line-breaks-expected.txt
@@ -1,0 +1,14 @@
+This tests caret browsing when text soft line breaks and has trimmed spaces.
+
+PASS: webArea.role === 'AXRole: AXWebArea'
+PASS: caretBrowsingEnabled(webArea) === false
+PASS: accessibilityController.enhancedAccessibilityEnabled === true
+PASS: caretBrowsingEnabled(webArea) === true
+PASS: string === 'Good'
+PASS: string === 'morning'
+PASS: string === 'world'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Good morning world

--- a/LayoutTests/accessibility/mac/caret-browsing-soft-line-breaks.html
+++ b/LayoutTests/accessibility/mac/caret-browsing-soft-line-breaks.html
@@ -1,0 +1,70 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="resources/accessibility-helper.js"></script>
+</head>
+<body id="body">
+
+<!-- 
+Rendered as:
+
+Good
+morning
+world
+
+-->
+
+<p id ="text" style="width: 80px" tabindex="0">Good morning world</p>
+
+<script>
+if (window.accessibilityController && window.eventSender) {
+    var output = "This tests caret browsing when text soft line breaks and has trimmed spaces.\n\n";
+    var webArea = clearSelectionAndFocusOnWebArea();
+
+    // Enable enhanced accessibility (necessary for accessibility specific selection handling).
+    accessibilityController.enableEnhancedAccessibility(true);
+    output += expect("accessibilityController.enhancedAccessibilityEnabled", "true");
+
+    setCaretBrowsingEnabled(webArea, true);
+    output += expect("caretBrowsingEnabled(webArea)", "true");
+
+    document.getElementById("text").focus();
+
+    // Navigate through "Hello" and verify
+    var string = "";
+    for (let i = 0; i < 4; i++) {
+        string += characterAtStartMarkerOfSelectedTextMarkerRange(webArea);
+        eventSender.keyDown("rightArrow");
+    }
+    output += expect("string", "'Good'")
+
+    // Move through the last character (live tree) or space character (isolated tree)
+    eventSender.keyDown("rightArrow");
+
+    // Navigate through "morning"
+    string = "";
+    for (let i = 0; i < 7; i++) {
+        string += characterAtStartMarkerOfSelectedTextMarkerRange(webArea);
+        eventSender.keyDown("rightArrow");
+    }
+    output += expect("string", "'morning'")
+
+    eventSender.keyDown("rightArrow");
+
+    // Navigate through "world"
+    string = "";
+    for (let i = 0; i < 5; i++) {
+        string += characterAtStartMarkerOfSelectedTextMarkerRange(webArea);
+        eventSender.keyDown("rightArrow");
+    }
+    output += expect("string", "'world'")
+
+    setCaretBrowsingEnabled(webArea, false);
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/resources/accessibility-helper.js
+++ b/LayoutTests/accessibility/mac/resources/accessibility-helper.js
@@ -14,6 +14,14 @@ function elementAtStartMarkerOfSelectedTextMarkerRange(webArea) {
     return element;
 }
 
+function characterAtStartMarkerOfSelectedTextMarkerRange(webArea) {
+    var range = webArea.selectedTextMarkerRange();
+    var start = webArea.startTextMarkerForTextMarkerRange(range);
+    var end = webArea.nextTextMarker(start);
+    var characterRange = webArea.textMarkerRangeForMarkers(start, end);
+    return webArea.stringForTextMarkerRange(characterRange);
+}
+
 function caretBrowsingEnabled(webArea) {
     return webArea.boolAttributeValue("AXCaretBrowsingEnabled");
 }


### PR DESCRIPTION
#### efb294f5df0971dd60d1440060f0f07a9ff7e5f4
<pre>
AX: [AX Thread Text APIs] visible position text markers don&apos;t account for trimmed spaces
<a href="https://bugs.webkit.org/show_bug.cgi?id=291547">https://bugs.webkit.org/show_bug.cgi?id=291547</a>
<a href="https://rdar.apple.com/149249815">rdar://149249815</a>

Reviewed by Tyler Wilcock.

In 293140@main, AXTextRuns started to include spaces that were trimmed at the end of runs. One fallout
from this is that when we convert Visible Positions to text markers, we don&apos;t take these trimmed spaces
into account. This means that in caret navigation, the text state change notifications that are being
sent don&apos;t properly account for these positions, creating some unexpected behavior.

To fix this, when converting from visible positions to text markers, we can look for DOM offset differences
when text box line&apos;s change, and determine when we have a trimmed space we need to account for. This is the
same mechanism we use to construct AXTextRuns.

* LayoutTests/accessibility/mac/caret-browsing-soft-line-breaks-expected.txt: Added.
* LayoutTests/accessibility/mac/caret-browsing-soft-line-breaks.html: Added.
* LayoutTests/accessibility/mac/resources/accessibility-helper.js:
(characterAtStartMarkerOfSelectedTextMarkerRange):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::textMarkerDataForVisiblePosition):

Canonical link: <a href="https://commits.webkit.org/293717@main">https://commits.webkit.org/293717@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4fbd19de211992e0a5aab8608c9b431a27a6e28

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19347 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9614 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104828 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50293 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101739 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27781 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75897 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32992 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102705 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14962 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90032 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56257 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14762 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8018 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49654 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8103 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107188 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26812 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19582 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84856 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27176 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86236 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84374 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21424 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29051 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6762 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20627 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26753 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31958 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26568 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29883 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28137 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->