### PR TITLE
Use WTF::Variant alias in html/canvas

### DIFF
--- a/Source/WebCore/html/canvas/CanvasPath.h
+++ b/Source/WebCore/html/canvas/CanvasPath.h
@@ -34,11 +34,14 @@
 
 namespace WebCore {
 
+template<typename... Types>
+using Variant = std::variant<Types...>;
+
 struct DOMPointInit;
 
 class CanvasPath {
 public:
-    using RadiusVariant = std::variant<double, DOMPointInit>;
+    using RadiusVariant = Variant<double, DOMPointInit>;
     virtual ~CanvasPath() = default;
 
     void closePath();

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -54,6 +54,9 @@
 
 namespace WebCore {
 
+template<typename... Types>
+using Variant = std::variant<Types...>;
+
 class ByteArrayPixelBuffer;
 class CachedImage;
 class CanvasLayerContextSwitcher;
@@ -72,8 +75,7 @@ class WebCodecsVideoFrame;
 
 struct DOMMatrix2DInit;
 
-
-using CanvasImageSource = std::variant<RefPtr<HTMLImageElement>
+using CanvasImageSource = Variant<RefPtr<HTMLImageElement>
     , RefPtr<SVGImageElement>
     , RefPtr<HTMLCanvasElement>
     , RefPtr<ImageBitmap>
@@ -213,7 +215,7 @@ public:
     void drawImageFromRect(HTMLImageElement&, float sx = 0, float sy = 0, float sw = 0, float sh = 0, float dx = 0, float dy = 0, float dw = 0, float dh = 0, const String& compositeOperation = emptyString());
     void clearCanvas();
 
-    using StyleVariant = std::variant<String, RefPtr<CanvasGradient>, RefPtr<CanvasPattern>>;
+    using StyleVariant = Variant<String, RefPtr<CanvasGradient>, RefPtr<CanvasPattern>>;
     StyleVariant strokeStyle() const;
     void setStrokeStyle(StyleVariant&&);
     StyleVariant fillStyle() const;
@@ -502,7 +504,7 @@ private:
     FloatRect m_dirtyRect;
     unsigned m_unrealizedSaveCount { 0 };
     bool m_usesCSSCompatibilityParseMode;
-    mutable std::variant<CachedContentsTransparent, CachedContentsUnknown, CachedContentsImageData> m_cachedContents;
+    mutable Variant<CachedContentsTransparent, CachedContentsUnknown, CachedContentsImageData> m_cachedContents;
     CanvasRenderingContext2DSettings m_settings;
     bool m_hasDeferredOperations { false };
 };

--- a/Source/WebCore/html/canvas/CanvasStyle.h
+++ b/Source/WebCore/html/canvas/CanvasStyle.h
@@ -34,6 +34,9 @@
 
 namespace WebCore {
 
+template<typename... Types>
+using Variant = std::variant<Types...>;
+
 class CanvasBase;
 class Document;
 class GraphicsContext;
@@ -77,7 +80,7 @@ public:
     }
 
 private:
-    std::variant<Color, Ref<CanvasGradient>, Ref<CanvasPattern>> m_style;
+    Variant<Color, Ref<CanvasGradient>, Ref<CanvasPattern>> m_style;
 };
 
 Color parseColor(const String& colorString, CanvasBase&);
@@ -85,23 +88,23 @@ Color parseColor(const String& colorString, ScriptExecutionContext&);
 
 inline RefPtr<CanvasGradient> CanvasStyle::canvasGradient() const
 {
-    if (!std::holds_alternative<Ref<CanvasGradient>>(m_style))
+    if (!holds_alternative<Ref<CanvasGradient>>(m_style))
         return nullptr;
-    return std::get<Ref<CanvasGradient>>(m_style).ptr();
+    return get<Ref<CanvasGradient>>(m_style).ptr();
 }
 
 inline RefPtr<CanvasPattern> CanvasStyle::canvasPattern() const
 {
-    if (!std::holds_alternative<Ref<CanvasPattern>>(m_style))
+    if (!holds_alternative<Ref<CanvasPattern>>(m_style))
         return nullptr;
-    return std::get<Ref<CanvasPattern>>(m_style).ptr();
+    return get<Ref<CanvasPattern>>(m_style).ptr();
 }
 
 inline String CanvasStyle::color() const
 {
-    if (!std::holds_alternative<Color>(m_style))
+    if (!holds_alternative<Color>(m_style))
         return String();
-    return serializationForHTML(std::get<Color>(m_style));
+    return serializationForHTML(get<Color>(m_style));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/GPUCanvasContext.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.h
@@ -38,6 +38,9 @@
 
 namespace WebCore {
 
+template<typename... Types>
+using Variant = std::variant<Types...>;
+
 class CanvasBase;
 class GPU;
 struct GPUCanvasConfiguration;
@@ -48,9 +51,9 @@ class GPUCanvasContext : public GPUBasedCanvasRenderingContext {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(GPUCanvasContext);
 public:
 #if ENABLE(OFFSCREEN_CANVAS)
-    using CanvasType = std::variant<RefPtr<HTMLCanvasElement>, RefPtr<OffscreenCanvas>>;
+    using CanvasType = Variant<RefPtr<HTMLCanvasElement>, RefPtr<OffscreenCanvas>>;
 #else
-    using CanvasType = std::variant<RefPtr<HTMLCanvasElement>>;
+    using CanvasType = Variant<RefPtr<HTMLCanvasElement>>;
 #endif
 
     static std::unique_ptr<GPUCanvasContext> create(CanvasBase&, GPU&);

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -43,15 +43,18 @@
 
 namespace WebCore {
 
+template<typename... Types>
+using Variant = std::variant<Types...>;
+
 class GPUDisplayBufferDisplayDelegate;
 
 class GPUCanvasContextCocoa final : public GPUCanvasContext {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(GPUCanvasContextCocoa);
 public:
 #if ENABLE(OFFSCREEN_CANVAS)
-    using CanvasType = std::variant<RefPtr<HTMLCanvasElement>, RefPtr<OffscreenCanvas>>;
+    using CanvasType = Variant<RefPtr<HTMLCanvasElement>, RefPtr<OffscreenCanvas>>;
 #else
-    using CanvasType = std::variant<RefPtr<HTMLCanvasElement>>;
+    using CanvasType = Variant<RefPtr<HTMLCanvasElement>>;
 #endif
 
     static std::unique_ptr<GPUCanvasContextCocoa> create(CanvasBase&, GPU&);

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
@@ -34,14 +34,17 @@
 
 namespace WebCore {
 
+template<typename... Types>
+using Variant = std::variant<Types...>;
+
 class ImageBitmap;
 class ImageBuffer;
 class OffscreenCanvas;
 
 #if ENABLE(OFFSCREEN_CANVAS)
-using ImageBitmapCanvas = std::variant<RefPtr<HTMLCanvasElement>, RefPtr<OffscreenCanvas>>;
+using ImageBitmapCanvas = Variant<RefPtr<HTMLCanvasElement>, RefPtr<OffscreenCanvas>>;
 #else
-using ImageBitmapCanvas = std::variant<RefPtr<HTMLCanvasElement>>;
+using ImageBitmapCanvas = Variant<RefPtr<HTMLCanvasElement>>;
 #endif
 
 class ImageBitmapRenderingContext final : public CanvasRenderingContext {

--- a/Source/WebCore/html/canvas/WebGLAny.h
+++ b/Source/WebCore/html/canvas/WebGLAny.h
@@ -36,6 +36,9 @@ class JSValue;
 
 namespace WebCore {
 
+template<typename... Types>
+using Variant = std::variant<Types...>;
+
 class JSDOMGlobalObject;
 class WebGLBuffer;
 class WebGLFramebuffer;
@@ -49,7 +52,7 @@ class WebGLTransformFeedback;
 class WebGLVertexArrayObject;
 class WebGLVertexArrayObjectOES;
 
-using WebGLAny = std::variant<
+using WebGLAny = Variant<
     std::nullptr_t,
     bool,
     int,

--- a/Source/WebCore/html/canvas/WebGLFramebuffer.h
+++ b/Source/WebCore/html/canvas/WebGLFramebuffer.h
@@ -42,6 +42,9 @@ class AbstractLocker;
 
 namespace WebCore {
 
+template<typename... Types>
+using Variant = std::variant<Types...>;
+
 class WebGLRenderbuffer;
 class WebGLTexture;
 
@@ -66,13 +69,13 @@ public:
         GCGLint layer;
         friend bool operator==(const TextureLayerAttachment&, const TextureLayerAttachment&) = default;
     };
-    using AttachmentEntry = std::variant<RefPtr<WebGLRenderbuffer>, TextureAttachment, TextureLayerAttachment>;
+    using AttachmentEntry = Variant<RefPtr<WebGLRenderbuffer>, TextureAttachment, TextureLayerAttachment>;
 
     void setAttachmentForBoundFramebuffer(GCGLenum target, GCGLenum attachment, AttachmentEntry);
 
     // Below are nonnull. RefPtr instead of Ref due to call site object identity
     // purposes, call site uses i.e pointer operator==.
-    using AttachmentObject = std::variant<RefPtr<WebGLRenderbuffer>, RefPtr<WebGLTexture>>;
+    using AttachmentObject = Variant<RefPtr<WebGLRenderbuffer>, RefPtr<WebGLTexture>>;
 
     // If an object is attached to the currently bound framebuffer, remove it.
     void removeAttachmentFromBoundFramebuffer(const AbstractLocker&, GCGLenum target, AttachmentObject);

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -85,6 +85,9 @@ class AbstractLocker;
 
 namespace WebCore {
 
+template<typename... Types>
+using Variant = std::variant<Types...>;
+
 class ANGLEInstancedArrays;
 class ByteArrayPixelBuffer;
 class EXTBlendMinMax;
@@ -159,9 +162,9 @@ class HTMLVideoElement;
 
 #if ENABLE(OFFSCREEN_CANVAS)
 class OffscreenCanvas;
-using WebGLCanvas = std::variant<RefPtr<HTMLCanvasElement>, RefPtr<OffscreenCanvas>>;
+using WebGLCanvas = Variant<RefPtr<HTMLCanvasElement>, RefPtr<OffscreenCanvas>>;
 #else
-using WebGLCanvas = std::variant<RefPtr<HTMLCanvasElement>>;
+using WebGLCanvas = Variant<RefPtr<HTMLCanvasElement>>;
 #endif
 
 #if ENABLE(MEDIA_STREAM)
@@ -197,7 +200,7 @@ public:
     void blendFunc(GCGLenum sfactor, GCGLenum dfactor);
     void blendFuncSeparate(GCGLenum srcRGB, GCGLenum dstRGB, GCGLenum srcAlpha, GCGLenum dstAlpha);
 
-    using BufferDataSource = std::variant<RefPtr<ArrayBuffer>, RefPtr<ArrayBufferView>>;
+    using BufferDataSource = Variant<RefPtr<ArrayBuffer>, RefPtr<ArrayBufferView>>;
     void bufferData(GCGLenum target, long long size, GCGLenum usage);
     void bufferData(GCGLenum target, std::optional<BufferDataSource>&&, GCGLenum usage);
     void bufferSubData(GCGLenum target, long long offset, BufferDataSource&&);
@@ -316,7 +319,7 @@ public:
     // These must be virtual so more validation can be added in WebGL 2.0.
     virtual void texImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&&);
 
-    using TexImageSource = std::variant<RefPtr<ImageBitmap>, RefPtr<ImageData>, RefPtr<HTMLImageElement>, RefPtr<HTMLCanvasElement>
+    using TexImageSource = Variant<RefPtr<ImageBitmap>, RefPtr<ImageData>, RefPtr<HTMLImageElement>, RefPtr<HTMLCanvasElement>
 #if ENABLE(VIDEO)
         , RefPtr<HTMLVideoElement>
 #endif
@@ -340,7 +343,7 @@ public:
     template <class TypedArray, class DataType>
     class TypedList {
     public:
-        using VariantType = std::variant<RefPtr<TypedArray>, Vector<DataType>>;
+        using VariantType = Variant<RefPtr<TypedArray>, Vector<DataType>>;
 
         TypedList(VariantType&& variant)
             : m_variant(WTFMove(variant))


### PR DESCRIPTION
#### 8b2cfafbb65683810291fd238fb86f689c1605cd
<pre>
Use WTF::Variant alias in html/canvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=291546">https://bugs.webkit.org/show_bug.cgi?id=291546</a>
<a href="https://rdar.apple.com/problem/149249315">rdar://problem/149249315</a>

Reviewed by NOBODY (OOPS!).

Adding std::variant aliases as per 293592@main as libc++&apos;s implmentation
generates suboptimal code, eventually it will be replaced with WTF::Variant.

* Source/WebCore/html/canvas/CanvasPath.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/html/canvas/CanvasStyle.h:
(WebCore::CanvasStyle::canvasGradient const):
(WebCore::CanvasStyle::canvasPattern const):
(WebCore::CanvasStyle::color const):
* Source/WebCore/html/canvas/GPUCanvasContext.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/ImageBitmapRenderingContext.h:
* Source/WebCore/html/canvas/WebGLAny.h:
* Source/WebCore/html/canvas/WebGLFramebuffer.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b2cfafbb65683810291fd238fb86f689c1605cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104780 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50246 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101691 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27733 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75862 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32953 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14918 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89982 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56221 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14718 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7968 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49608 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8053 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107139 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26765 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19540 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84815 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27129 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86186 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84333 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29009 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6715 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/20555 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26705 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31913 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26520 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29836 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28090 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->