### PR TITLE
Fix CoreIPC fuzz blocker uncaught exception

### DIFF
--- a/Source/WebKit/Shared/cf/CoreIPCCFDictionary.mm
+++ b/Source/WebKit/Shared/cf/CoreIPCCFDictionary.mm
@@ -64,7 +64,8 @@ RetainPtr<CFDictionaryRef> CoreIPCCFDictionary::createCFDictionary() const
     for (auto& pair : *m_vector) {
         auto key = pair.key.toID();
         auto value = pair.value.toID();
-        if (key && value)
+        RetainPtr<Protocol> nsCopying = @protocol(NSCopying);
+        if (key && [key conformsToProtocol:nsCopying.get()] && value)
             [result setObject:value.get() forKey:key.get()];
     }
     return (__bridge CFDictionaryRef)result.get();


### PR DESCRIPTION
#### 22b3dab6b6aed36caeb8ced69aa8f006b93d0044
<pre>
Fix CoreIPC fuzz blocker uncaught exception
<a href="https://bugs.webkit.org/show_bug.cgi?id=291551">https://bugs.webkit.org/show_bug.cgi?id=291551</a>
<a href="https://rdar.apple.com/149213357">rdar://149213357</a>

Reviewed by NOBODY (OOPS!).

Check that the key conforms to NSCopying protocol before use in
NSMutableDictionary.

* Source/WebKit/Shared/cf/CoreIPCCFDictionary.mm:
(WebKit::CoreIPCCFDictionary::createCFDictionary const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22b3dab6b6aed36caeb8ced69aa8f006b93d0044

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19570 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9856 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105049 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50503 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76065 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33151 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102929 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90237 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56423 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14967 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49872 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84891 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8311 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107410 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27035 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19755 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85019 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27397 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86437 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84542 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29220 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6939 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/20854 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26972 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32199 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26783 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30099 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28342 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->