### PR TITLE
Drop remaining implicit conversions from WTF::String to NSString *

### DIFF
--- a/Source/JavaScriptCore/inspector/scripts/codegen/generate_objc_backend_dispatcher_implementation.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/generate_objc_backend_dispatcher_implementation.py
@@ -213,6 +213,8 @@ class ObjCBackendDispatcherImplementationGenerator(ObjCGenerator):
                 objc_type = 'std::optional<%s>' % objc_type
             param_expression = in_param_expression(in_param_name, parameter)
             import_expression = self.objc_protocol_import_expression_for_parameter(param_expression, domain, command.command_name, parameter)
+            if objc_type == "NSString *":
+                import_expression = import_expression + ".createNSString().autorelease()"
             if not parameter.is_optional:
                 lines.append('    %s = %s;' % (join_type_and_name(objc_type, objc_in_param_name), import_expression))
 

--- a/Source/JavaScriptCore/inspector/scripts/codegen/objc_generator.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/objc_generator.py
@@ -370,7 +370,7 @@ class ObjCGenerator(Generator):
         category = ObjCTypeCategory.category_for_type(var_type)
         if category in [ObjCTypeCategory.Simple, ObjCTypeCategory.String]:
             if isinstance(var_type, EnumType):
-                return 'toProtocolString(%s)' % var_name
+                return 'toProtocolString(%s).createNSString().get()' % var_name
             return var_name
         if category == ObjCTypeCategory.Object:
             return '[%s toJSONObject]' % var_name
@@ -422,7 +422,7 @@ class ObjCGenerator(Generator):
         category = ObjCTypeCategory.category_for_type(member.type)
         if category in [ObjCTypeCategory.Simple, ObjCTypeCategory.String]:
             if isinstance(member.type, EnumType):
-                return 'toProtocolString(%s)' % sub_expression
+                return 'toProtocolString(%s).createNSString().get()' % sub_expression
             return sub_expression
         if category == ObjCTypeCategory.Object:
             return sub_expression

--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -730,7 +730,7 @@ NSArray *LocalFrame::interpretationsForCurrentRoot() const
 
     // There are no phrases with alternatives, so there is just one interpretation.
     if (markersInRoot.isEmpty())
-        return @[plainText(rangeOfRootContents)];
+        return @[plainText(rangeOfRootContents).createNSString().get()];
 
     // The number of interpretations will be i1 * i2 * ... * iN, where iX is the number of interpretations for the Xth phrase with alternatives.
     size_t interpretationsCount = 1;

--- a/Source/WebCore/platform/cocoa/CoreLocationGeolocationProvider.mm
+++ b/Source/WebCore/platform/cocoa/CoreLocationGeolocationProvider.mm
@@ -72,7 +72,7 @@ SOFT_LINK_CONSTANT(CoreLocation, kCLLocationAccuracyHundredMeters, double)
 
 #if USE(APPLE_INTERNAL_SDK) && HAVE(CORE_LOCATION_WEBSITE_IDENTIFIERS) && defined(CL_HAS_RADAR_88834301)
     if (!websiteIdentifier.isEmpty())
-        _locationManager = adoptNS([allocCLLocationManagerInstance() initWithWebsiteIdentifier:websiteIdentifier]);
+        _locationManager = adoptNS([allocCLLocationManagerInstance() initWithWebsiteIdentifier:websiteIdentifier.createNSString().get()]);
 #else
     UNUSED_PARAM(websiteIdentifier);
 #endif

--- a/Source/WebCore/platform/ios/PasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PasteboardIOS.mm
@@ -536,7 +536,7 @@ Vector<String> Pasteboard::readPlatformValuesAsStrings(const String& domType, in
     auto values = strategy.allStringsForType(cocoaType.get(), pasteboardName, context());
     if ([cocoaType isEqualToString:UTTypePlainText.identifier]) {
         values = values.map([&] (auto& value) -> String {
-            return [value precomposedStringWithCanonicalMapping];
+            return [value.createNSString() precomposedStringWithCanonicalMapping];
         });
     }
 

--- a/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
@@ -139,7 +139,7 @@ void GPUProcess::platformInitializeGPUProcess(GPUProcessCreationParameters& para
     }
 
 #if USE(SANDBOX_EXTENSIONS_FOR_CACHE_AND_TEMP_DIRECTORY_ACCESS) && USE(EXTENSIONKIT)
-    MTLSetShaderCachePath(parameters.containerCachesDirectory);
+    MTLSetShaderCachePath(parameters.containerCachesDirectory.createNSString().get());
 #endif
 }
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1491,7 +1491,7 @@ NetworkSessionCocoa::NetworkSessionCocoa(NetworkProcess& networkProcess, const N
 
 #if PLATFORM(IOS_FAMILY)
     if (!m_dataConnectionServiceType.isEmpty())
-        configuration.get()._CTDataConnectionServiceType = m_dataConnectionServiceType;
+        configuration.get()._CTDataConnectionServiceType = m_dataConnectionServiceType.createNSString().get();
 #endif
 
 #if ENABLE(LEGACY_CUSTOM_PROTOCOL_MANAGER)
@@ -2246,9 +2246,9 @@ void NetworkSessionCocoa::donateToSKAdNetwork(WebCore::PrivateClickMeasurement&&
 #if HAVE(SKADNETWORK_v4)
     auto config = adoptNS([ASDInstallWebAttributionParamsConfig new]);
     config.get().appAdamId = @(*pcm.adamID());
-    config.get().adNetworkRegistrableDomain = pcm.destinationSite().registrableDomain.string();
-    config.get().impressionId = pcm.ephemeralSourceNonce()->nonce;
-    config.get().sourceWebRegistrableDomain = pcm.sourceSite().registrableDomain.string();
+    config.get().adNetworkRegistrableDomain = pcm.destinationSite().registrableDomain.string().createNSString().get();
+    config.get().impressionId = pcm.ephemeralSourceNonce()->nonce.createNSString().get();
+    config.get().sourceWebRegistrableDomain = pcm.sourceSite().registrableDomain.string().createNSString().get();
     config.get().version = @"4.0";
     config.get().attributionContext = AttributionTypeDefault;
 #if HAVE(AD_ATTRIBUTION_KIT_PRIVATE_BROWSING)

--- a/Source/WebKit/Platform/mac/MenuUtilities.mm
+++ b/Source/WebKit/Platform/mac/MenuUtilities.mm
@@ -127,7 +127,7 @@ NSMenuItem *menuItemForTelephoneNumber(const String& telephoneNumber)
     for (NSMenuItem *item in proposedMenuItems.get()) {
         RetainPtr action = actionForMenuItem(item);
         if ([action.get().actionUTI hasPrefix:@"com.apple.dial"]) {
-            item.title = formattedPhoneNumberString(telephoneNumber);
+            item.title = formattedPhoneNumberString(telephoneNumber.createNSString().get());
             return item;
         }
     }

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -356,7 +356,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if PLATFORM(IOS_FAMILY)
     auto& serviceType = client->paymentCoordinatorCTDataConnectionServiceType(*this);
     if (!serviceType.isEmpty() && [result respondsToSelector:@selector(setCTDataConnectionServiceType:)])
-        [result setCTDataConnectionServiceType:serviceType];
+        [result setCTDataConnectionServiceType:serviceType.createNSString().get()];
 #endif
 
 #if HAVE(PASSKIT_INSTALLMENTS)

--- a/Source/WebKit/Shared/ios/WebAutocorrectionData.mm
+++ b/Source/WebKit/Shared/ios/WebAutocorrectionData.mm
@@ -40,7 +40,7 @@ WebAutocorrectionData::WebAutocorrectionData(Vector<WebCore::FloatRect>&& textRe
 {
     this->textRects = WTFMove(textRects);
     if (fontName.has_value())
-        this->font = [UIFont fontWithName:WTFMove(*fontName) size:pointSize];
+        this->font = [UIFont fontWithName:fontName->createNSString().get() size:pointSize];
     else
         this->font = [UIFont systemFontOfSize:pointSize weight:weight];
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfo.mm
@@ -72,9 +72,9 @@
     
     _URL = information.url.createNSURL();
     _imageURL = information.imageURL.createNSURL();
-    _imageMIMEType = information.imageMIMEType;
+    _imageMIMEType = information.imageMIMEType.createNSString().get();
     _interactionLocation = information.request.point;
-    _title = information.title;
+    _title = information.title.createNSString().get();
     _boundingRect = information.bounds;
     
     if (information.isAttachment)
@@ -87,7 +87,7 @@
         _type = _WKActivatedElementTypeUnspecified;
     
     _image = information.image;
-    _ID = information.idAttribute;
+    _ID = information.idAttribute.createNSString().get();
     _animatedImage = information.isAnimatedImage;
     _isAnimating = information.isAnimating;
     _canShowAnimationControls = information.canShowAnimationControls;
@@ -137,7 +137,7 @@
     Vector<WebCore::ElementAnimationContext> animationsAtPoint;
 #endif
 
-    return [self _initWithType:type URL:url imageURL:imageURL location:information.request.point title:information.title ID:information.idAttribute rect:information.bounds image:image imageMIMEType:information.imageMIMEType isAnimatedImage:information.isAnimatedImage isAnimating:information.isAnimating canShowAnimationControls:information.canShowAnimationControls animationsUnderElement:animationsAtPoint userInfo:userInfo];
+    return [self _initWithType:type URL:url imageURL:imageURL location:information.request.point title:information.title.createNSString().get() ID:information.idAttribute.createNSString().get() rect:information.bounds image:image imageMIMEType:information.imageMIMEType.createNSString().get() isAnimatedImage:information.isAnimatedImage isAnimating:information.isAnimating canShowAnimationControls:information.canShowAnimationControls animationsUnderElement:animationsAtPoint userInfo:userInfo];
 }
 #endif // PLATFORM(IOS_FAMILY)
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKElementAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKElementAction.mm
@@ -142,30 +142,30 @@ static void addToReadingList(NSURL *targetURL, NSString *title)
 
 + (instancetype)_elementActionWithType:(_WKElementActionType)type customTitle:(NSString *)customTitle assistant:(WKActionSheetAssistant *)assistant disabled:(BOOL)disabled
 {
-    NSString *title = @"";
+    RetainPtr title = @"";
     WKElementActionHandlerInternal handler = nil;
     switch (type) {
     case _WKElementActionTypeCopy:
-        title = WEB_UI_STRING_KEY("Copy", "Copy (ActionSheet)", "Title for Copy Link and Image or Copy Image action button");
+        title = WEB_UI_STRING_KEY("Copy", "Copy (ActionSheet)", "Title for Copy Link and Image or Copy Image action button").createNSString();
         handler = ^(WKActionSheetAssistant *assistant, _WKActivatedElementInfo *actionInfo) {
             [assistant handleElementActionWithType:type element:actionInfo needsInteraction:YES];
         };
         break;
     case _WKElementActionTypeOpen:
-        title = WEB_UI_STRING("Open", "Title for Open Link action button");
+        title = WEB_UI_STRING("Open", "Title for Open Link action button").createNSString();
         handler = ^(WKActionSheetAssistant *assistant, _WKActivatedElementInfo *actionInfo) {
             [assistant handleElementActionWithType:type element:actionInfo needsInteraction:YES];
         };
         break;
     case _WKElementActionTypeSaveImage:
-        title = WEB_UI_STRING("Save to Photos", "Title for Save to Photos action button");
+        title = WEB_UI_STRING("Save to Photos", "Title for Save to Photos action button").createNSString();
         handler = ^(WKActionSheetAssistant *assistant, _WKActivatedElementInfo *actionInfo) {
             [assistant handleElementActionWithType:type element:actionInfo needsInteraction:YES];
         };
         break;
 #if ENABLE(SPATIAL_IMAGE_DETECTION)
     case _WKElementActionTypeViewSpatial:
-        title = WEB_UI_STRING("View Spatial Photo", "Title for View Spatial Photo action button");
+        title = WEB_UI_STRING("View Spatial Photo", "Title for View Spatial Photo action button").createNSString();
         handler = ^(WKActionSheetAssistant *assistant, _WKActivatedElementInfo *actionInfo) {
             [assistant handleElementActionWithType:type element:actionInfo needsInteraction:YES];
         };
@@ -173,14 +173,14 @@ static void addToReadingList(NSURL *targetURL, NSString *title)
 #endif
 #if HAVE(SAFARI_SERVICES_FRAMEWORK)
     case _WKElementActionTypeAddToReadingList:
-        title = WEB_UI_STRING("Add to Reading List", "Title for Add to Reading List action button");
+        title = WEB_UI_STRING("Add to Reading List", "Title for Add to Reading List action button").createNSString();
         handler = ^(WKActionSheetAssistant *, _WKActivatedElementInfo *actionInfo) {
             addToReadingList(actionInfo.URL, actionInfo.title);
         };
         break;
 #endif
     case _WKElementActionTypeShare:
-        title = WEB_UI_STRING("Share…", "Title for Share action button");
+        title = WEB_UI_STRING("Share…", "Title for Share action button").createNSString();
         handler = ^(WKActionSheetAssistant *assistant, _WKActivatedElementInfo *actionInfo) {
             [assistant handleElementActionWithType:type element:actionInfo needsInteraction:NO];
         };
@@ -190,7 +190,7 @@ static void addToReadingList(NSURL *targetURL, NSString *title)
         break;
     case _WKElementActionTypeImageExtraction:
 #if ENABLE(IMAGE_ANALYSIS)
-        title = WEB_UI_STRING("Show Text", "Title for Show Text action button");
+        title = WEB_UI_STRING("Show Text", "Title for Show Text action button").createNSString();
         handler = ^(WKActionSheetAssistant *assistant, _WKActivatedElementInfo *actionInfo) {
             [assistant handleElementActionWithType:type element:actionInfo needsInteraction:YES];
         };
@@ -198,7 +198,7 @@ static void addToReadingList(NSURL *targetURL, NSString *title)
         break;
     case _WKElementActionTypeRevealImage:
 #if ENABLE(IMAGE_ANALYSIS)
-        title = WebCore::contextMenuItemTagLookUpImage();
+        title = WebCore::contextMenuItemTagLookUpImage().createNSString();
         handler = ^(WKActionSheetAssistant *assistant, _WKActivatedElementInfo *actionInfo) {
             [assistant handleElementActionWithType:type element:actionInfo needsInteraction:YES];
         };
@@ -206,7 +206,7 @@ static void addToReadingList(NSURL *targetURL, NSString *title)
         break;
     case _WKElementActionTypeCopyCroppedImage:
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
-        title = WebCore::contextMenuItemTagCopySubject();
+        title = WebCore::contextMenuItemTagCopySubject().createNSString();
         handler = ^(WKActionSheetAssistant *assistant, _WKActivatedElementInfo *actionInfo) {
             [assistant handleElementActionWithType:type element:actionInfo needsInteraction:YES];
         };
@@ -214,7 +214,7 @@ static void addToReadingList(NSURL *targetURL, NSString *title)
         break;
     case _WKElementActionPlayAnimation:
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
-        title = WEB_UI_STRING("Play Animation", "Title for play animation action button or context menu item");
+        title = WEB_UI_STRING("Play Animation", "Title for play animation action button or context menu item").createNSString();
         handler = ^(WKActionSheetAssistant *assistant, _WKActivatedElementInfo *actionInfo) {
             [assistant handleElementActionWithType:type element:actionInfo needsInteraction:YES];
         };
@@ -222,7 +222,7 @@ static void addToReadingList(NSURL *targetURL, NSString *title)
         break;
     case _WKElementActionPauseAnimation:
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
-        title = WEB_UI_STRING("Pause Animation", "Title for pause animation action button or context menu item");
+        title = WEB_UI_STRING("Pause Animation", "Title for pause animation action button or context menu item").createNSString();
         handler = ^(WKActionSheetAssistant *assistant, _WKActivatedElementInfo *actionInfo) {
             [assistant handleElementActionWithType:type element:actionInfo needsInteraction:YES];
         };
@@ -233,7 +233,7 @@ static void addToReadingList(NSURL *targetURL, NSString *title)
         return nil;
     }
 
-    return adoptNS([[self alloc] _initWithTitle:(customTitle ? customTitle : title) actionHandler:handler type:type assistant:assistant disabled:disabled]).autorelease();
+    return adoptNS([[self alloc] _initWithTitle:(customTitle ? customTitle : title.get()) actionHandler:handler type:type assistant:assistant disabled:disabled]).autorelease();
 }
 
 + (instancetype)_elementActionWithType:(_WKElementActionType)type info:(_WKActivatedElementInfo *)info assistant:(WKActionSheetAssistant *)assistant
@@ -243,10 +243,10 @@ static void addToReadingList(NSURL *targetURL, NSString *title)
 
 + (instancetype)_elementActionWithType:(_WKElementActionType)type info:(_WKActivatedElementInfo *)info assistant:(WKActionSheetAssistant *)assistant disabled:(BOOL)disabled
 {
-    NSString *customTitle = nil;
+    RetainPtr<NSString> customTitle;
     if (type == _WKElementActionTypeCopy && info.type == _WKActivatedElementTypeLink && !info._isImage)
-        customTitle = WEB_UI_STRING_KEY("Copy Link", "Copy Link (ActionSheet)", "Title for Copy Link button");
-    return [self _elementActionWithType:type customTitle:customTitle assistant:assistant disabled:disabled];
+        customTitle = WEB_UI_STRING_KEY("Copy Link", "Copy Link (ActionSheet)", "Title for Copy Link button").createNSString();
+    return [self _elementActionWithType:type customTitle:customTitle.get() assistant:assistant disabled:disabled];
 }
 
 + (instancetype)elementActionWithType:(_WKElementActionType)type customTitle:(NSString *)customTitle

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -509,7 +509,7 @@ static CGSize roundScrollViewContentSize(const WebKit::WebPageProxy& page, CGSiz
         [_customContentView removeFromSuperview];
         [_customContentFixedOverlayView removeFromSuperview];
 
-        _customContentView = adoptNS([[representationClass alloc] web_initWithFrame:self.bounds webView:self mimeType:mimeType]);
+        _customContentView = adoptNS([[representationClass alloc] web_initWithFrame:self.bounds webView:self mimeType:mimeType.createNSString().get()]);
         _customContentFixedOverlayView = adoptNS([[UIView alloc] initWithFrame:self.bounds]);
         [_customContentFixedOverlayView layer].name = @"CustomContentFixedOverlay";
         [_customContentFixedOverlayView setUserInteractionEnabled:NO];
@@ -553,7 +553,7 @@ static CGSize roundScrollViewContentSize(const WebKit::WebPageProxy& page, CGSiz
 - (void)_didFinishLoadingDataForCustomContentProviderWithSuggestedFilename:(const String&)suggestedFilename data:(NSData *)data
 {
     ASSERT(_customContentView);
-    [_customContentView web_setContentProviderData:data suggestedFilename:suggestedFilename];
+    [_customContentView web_setContentProviderData:data suggestedFilename:suggestedFilename.createNSString().get()];
 
     // FIXME: It may make more sense for custom content providers to invoke this when they're ready,
     // because there's no guarantee that all custom content providers will lay out synchronously.
@@ -3982,7 +3982,7 @@ static bool isLockdownModeWarningNeeded()
         return nil;
 
     URL destinationURL { makeString("https://"_s, attribution->destinationDomain) };
-    return adoptNS([[UIEventAttribution alloc] initWithSourceIdentifier:attribution->sourceID destinationURL:destinationURL.createNSURL().get() sourceDescription:attribution->sourceDescription purchaser:attribution->purchaser]).autorelease();
+    return adoptNS([[UIEventAttribution alloc] initWithSourceIdentifier:attribution->sourceID destinationURL:destinationURL.createNSURL().get() sourceDescription:attribution->sourceDescription.createNSString().get() purchaser:attribution->purchaser.createNSString().get()]).autorelease();
 #else
     return nil;
 #endif

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -310,7 +310,7 @@ static void dumpUIView(TextStream& ts, UIView *view)
         dumpUIView(ts, self);
     }
 
-    return ts.release();
+    return ts.release().createNSString().autorelease();
 }
 
 - (NSString *)_scrollbarState:(unsigned long long)rawScrollingNodeID processID:(unsigned long long)processID isVertical:(bool)isVertical
@@ -325,9 +325,9 @@ static void dumpUIView(TextStream& ts, UIView *view)
             TextStream::GroupScope scope(ts);
             ts << ([_scrollView showsHorizontalScrollIndicator] ? ""_s : "none"_s);
         }
-        return ts.release();
+        return ts.release().createNSString().autorelease();
     }
-    return _page->scrollbarStateForScrollingNodeID(scrollingNodeID, isVertical);
+    return _page->scrollbarStateForScrollingNodeID(scrollingNodeID, isVertical).createNSString().autorelease();
 }
 
 - (NSNumber *)_stableStateOverride

--- a/Source/WebKit/UIProcess/Automation/ios/WebAutomationSessionIOS.mm
+++ b/Source/WebKit/UIProcess/Automation/ios/WebAutomationSessionIOS.mm
@@ -117,8 +117,8 @@ void WebAutomationSession::platformSimulateKeyboardInteraction(WebPageProxy& pag
             }
         },
         [&] (CharKey charKey) {
-            characters = charKey;
-            unmodifiedCharacters = charKey;
+            characters = charKey.createNSString();
+            unmodifiedCharacters = characters;
         }
     );
 
@@ -167,10 +167,10 @@ void WebAutomationSession::platformSimulateKeySequence(WebPageProxy& page, const
     // This command is more similar to the 'insertText:' editing command, except
     // that this emits keyup/keydown/keypress events for roughly each character.
     // This API should move more towards that direction in the future.
-    NSString *text = keySequence;
+    RetainPtr text = keySequence.createNSString();
     BOOL isTabKey = [text isEqualToString:@"\t"];
 
-    [text enumerateSubstringsInRange:NSMakeRange(0, text.length) options:NSStringEnumerationByComposedCharacterSequences usingBlock:^(NSString *substring, NSRange substringRange, NSRange enclosingRange, BOOL *stop) {
+    [text enumerateSubstringsInRange:NSMakeRange(0, text.get().length) options:NSStringEnumerationByComposedCharacterSequences usingBlock:^(NSString *substring, NSRange substringRange, NSRange enclosingRange, BOOL *stop) {
         auto keyDownEvent = adoptNS([[::WebEvent alloc] initWithKeyEventType:WebEventKeyDown timeStamp:CFAbsoluteTimeGetCurrent() characters:substring charactersIgnoringModifiers:substring modifiers:m_currentModifiers isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:0 isTabKey:isTabKey]);
         [eventsToBeSent addObject:keyDownEvent.get()];
         auto keyUpEvent = adoptNS([[::WebEvent alloc] initWithKeyEventType:WebEventKeyUp timeStamp:CFAbsoluteTimeGetCurrent() characters:substring charactersIgnoringModifiers:substring modifiers:m_currentModifiers isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:0 isTabKey:isTabKey]);

--- a/Source/WebKit/UIProcess/Cocoa/CoreTelephonyUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/CoreTelephonyUtilities.mm
@@ -91,7 +91,7 @@ bool shouldAllowAutoFillForCellularIdentifiers(const URL& topURL)
         return lastQueriedHostResult;
 
     NSError *error = nil;
-    BOOL result = [client isAutofilleSIMIdAllowedForDomain:host error:&error];
+    BOOL result = [client isAutofilleSIMIdAllowedForDomain:host.createNSString().get() error:&error];
     if (error && !std::exchange(hasLogged, true)) {
         RELEASE_LOG_ERROR(Telephony, "Failed to query cellular AutoFill status: %{public}@", error);
         return false;

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -1422,7 +1422,7 @@ void NavigationState::NavigationClient::didStartLoadForQuickLookDocumentInMainFr
     if (!navigationDelegate)
         return;
 
-    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() didStartLoadForQuickLookDocumentInMainFrameWithFileName:fileName uti:uti];
+    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() didStartLoadForQuickLookDocumentInMainFrameWithFileName:fileName.createNSString().get() uti:uti.createNSString().get()];
 }
 
 void NavigationState::NavigationClient::didFinishLoadForQuickLookDocumentInMainFrame(const FragmentedSharedBuffer& buffer)

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -130,13 +130,13 @@ static NSString * const _WKARQLWebsiteURLParameterKey = @"ARQLWebsiteURLParamete
     _itemProvider = adoptNS([[NSItemProvider alloc] init]);
     // FIXME: We are launching the preview controller before getting a response from the resource, which
     // means we don't actually know the real MIME type yet.
-    NSString *contentType = WebCore::UTIFromMIMEType("model/vnd.usdz+zip"_s);
+    RetainPtr contentType = WebCore::UTIFromMIMEType("model/vnd.usdz+zip"_s).createNSString();
 
 #if HAVE(ARKIT_QUICK_LOOK_PREVIEW_ITEM)
     RetainPtr previewItem = adoptNS([WebKit::allocARQuickLookPreviewItemInstance() initWithFileAtURL:_downloadedURL.createNSURL().get()]);
     [previewItem setCanonicalWebPageURL:_originatingPageURL.createNSURL().get()];
 
-    _item = adoptNS([allocARQuickLookWebKitItemInstance() initWithPreviewItemProvider:_itemProvider.get() contentType:contentType previewTitle:@"Preview" fileSize:@(0) previewItem:previewItem.get()]);
+    _item = adoptNS([allocARQuickLookWebKitItemInstance() initWithPreviewItemProvider:_itemProvider.get() contentType:contentType.get() previewTitle:@"Preview" fileSize:@(0) previewItem:previewItem.get()]);
     [_item setDelegate:self];
 
     if ([_item respondsToSelector:(@selector(setAdditionalParameters:))]) {
@@ -150,7 +150,7 @@ static NSString * const _WKARQLWebsiteURLParameterKey = @"ARQLWebsiteURLParamete
     [_item setUseLoadingTimeout:NO];
 
     WeakObjCPtr<_WKPreviewControllerDataSource> weakSelf { self };
-    [_itemProvider registerItemForTypeIdentifier:contentType loadHandler:[weakSelf = WTFMove(weakSelf)] (NSItemProviderCompletionHandler completionHandler, Class expectedValueClass, NSDictionary * options) {
+    [_itemProvider registerItemForTypeIdentifier:contentType.get() loadHandler:[weakSelf = WTFMove(weakSelf)] (NSItemProviderCompletionHandler completionHandler, Class expectedValueClass, NSDictionary * options) {
         if (auto strongSelf = weakSelf.get()) {
             // If the download happened instantly, the call to finish might have come before this
             // loadHandler. In that case, call the completionHandler here.

--- a/Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm
@@ -166,7 +166,7 @@ SOFT_LINK_CLASS(ContactsUI, CNContactPickerViewController)
 #if HAVE(CNCONTACTPICKERVIEWCONTROLLER)
     _contactPickerViewController = adoptNS([allocCNContactPickerViewControllerInstance() init]);
     [_contactPickerViewController setDelegate:_contactPickerDelegate.get()];
-    [_contactPickerViewController setPrompt:requestData.url];
+    [_contactPickerViewController setPrompt:requestData.url.createNSString().get()];
 
     auto presentationViewController = [_webView _wk_viewControllerForFullScreenPresentation];
     [presentationViewController presentViewController:_contactPickerViewController.get() animated:YES completion:[weakSelf = WeakObjCPtr<WKContactPicker>(self)] {

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -1107,7 +1107,7 @@ static bool isLockdownModeEnabledBySystemIgnoringCaching()
         return false;
 
 #if PLATFORM(IOS_FAMILY)
-    if (processHasContainer() && [_WKSystemPreferences isCaptivePortalModeIgnored:pathForProcessContainer()])
+    if (processHasContainer() && [_WKSystemPreferences isCaptivePortalModeIgnored:pathForProcessContainer().createNSString().get()])
         return false;
 #endif
     

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxyCocoa.mm
@@ -45,7 +45,7 @@ void DownloadProxy::publishProgress(const URL& url)
         return;
 
 #if HAVE(MODERN_DOWNLOADPROGRESS)
-    RetainPtr localURL = adoptNS([[NSURL alloc] initFileURLWithPath:url.fileSystemPath() relativeToURL:nil]);
+    RetainPtr localURL = adoptNS([[NSURL alloc] initFileURLWithPath:url.fileSystemPath().createNSString().get() relativeToURL:nil]);
     NSError *error = nil;
     RetainPtr bookmark = [localURL bookmarkDataWithOptions:NSURLBookmarkCreationMinimalBookmark includingResourceValuesForKeys:nil relativeToURL:nil error:&error];
     m_dataStore->networkProcess().send(Messages::NetworkProcess::PublishDownloadProgress(m_downloadID, url, span(bookmark.get()), UseDownloadPlaceholder::No, activityAccessToken().span()), 0);
@@ -85,7 +85,7 @@ void DownloadProxy::didStartUpdatingProgress()
 
 Vector<uint8_t> DownloadProxy::bookmarkDataForURL(const URL& url)
 {
-    RetainPtr localURL = adoptNS([[NSURL alloc] initFileURLWithPath:url.fileSystemPath() relativeToURL:nil]);
+    RetainPtr localURL = adoptNS([[NSURL alloc] initFileURLWithPath:url.fileSystemPath().createNSString().get() relativeToURL:nil]);
     NSError *error = nil;
     RetainPtr bookmark = [localURL bookmarkDataWithOptions:NSURLBookmarkCreationMinimalBookmark includingResourceValuesForKeys:nil relativeToURL:nil error:&error];
     return span(bookmark.get());

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -394,7 +394,7 @@ static void* kvoContext = &kvoContext;
     self.popoverPresentationController.delegate = self;
 
     UINavigationItem *navigationItem = self.navigationItem;
-    navigationItem.title = extensionContext->protectedExtension()->displayName();
+    navigationItem.title = extensionContext->protectedExtension()->displayName().createNSString().get();
     navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(_dismissPopup)];
 
     [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(_viewControllerDismissalTransitionDidEnd:) name:UIPresentationControllerDismissalTransitionDidEndNotification object:nil];

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
@@ -287,7 +287,7 @@ CocoaMenuItem *WebExtensionCommand::platformMenuItem() const
 
     return result;
 #else
-    return [UIAction actionWithTitle:description() image:nil identifier:nil handler:makeBlockPtr([this, protectedThis = Ref { *this }](UIAction *) mutable {
+    return [UIAction actionWithTitle:description().createNSString().get() image:nil identifier:nil handler:makeBlockPtr([this, protectedThis = Ref { *this }](UIAction *) mutable {
         if (RefPtr context = extensionContext())
             context->performCommand(const_cast<WebExtensionCommand&>(*this), WebExtensionContext::UserTriggered::Yes);
     }).get()];
@@ -300,12 +300,12 @@ UIKeyCommand *WebExtensionCommand::keyCommand() const
     if (activationKey().isEmpty())
         return nil;
 
-    return [_WKWebExtensionKeyCommand commandWithTitle:description() image:nil input:activationKey() modifierFlags:modifierFlags().toRaw() identifier:identifier()];
+    return [_WKWebExtensionKeyCommand commandWithTitle:description().createNSString().get() image:nil input:activationKey().createNSString().get() modifierFlags:modifierFlags().toRaw() identifier:identifier().createNSString().get()];
 }
 
 bool WebExtensionCommand::matchesKeyCommand(UIKeyCommand *keyCommand) const
 {
-    return keyCommand.modifierFlags == modifierFlags().toRaw() && [keyCommand.input isEqual:activationKey()] && [keyCommand.propertyList[@"identifier"] isEqual:identifier()];
+    return keyCommand.modifierFlags == modifierFlags().toRaw() && [keyCommand.input isEqual:activationKey().createNSString().get()] && [keyCommand.propertyList[@"identifier"] isEqual:identifier().createNSString().get()];
 }
 #endif
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -3130,7 +3130,7 @@ CocoaMenuItem *WebExtensionContext::singleMenuItemOrExtensionItemWithSubmenu(con
     if (menuItems.count == 1)
         return menuItems.firstObject;
 
-    return [UIMenu menuWithTitle:protectedExtension()->displayShortName() children:menuItems];
+    return [UIMenu menuWithTitle:protectedExtension()->displayShortName().createNSString().get() children:menuItems];
 #endif
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm
@@ -327,7 +327,7 @@ CocoaMenuItem *WebExtensionMenuItem::platformMenuItem(const WebExtensionMenuItem
 
     // iOS does not support sub-menus that are disabled or hidden, so return a normal action in that case.
     if (submenuItems().isEmpty() || !isEnabled() || !isVisible()) {
-        auto *action = [UIAction actionWithTitle:processedTitle image:toCocoaImage(icon({ 20, 20 })) identifier:nil handler:makeBlockPtr([this, protectedThis = Ref { *this }, contextParameters](UIAction *) mutable {
+        auto *action = [UIAction actionWithTitle:processedTitle.createNSString().get() image:toCocoaImage(icon({ 20, 20 })) identifier:nil handler:makeBlockPtr([this, protectedThis = Ref { *this }, contextParameters](UIAction *) mutable {
             if (RefPtr context = extensionContext())
                 context->performMenuItem(const_cast<WebExtensionMenuItem&>(*this), contextParameters, WebExtensionContext::UserTriggered::Yes);
         }).get()];
@@ -344,7 +344,7 @@ CocoaMenuItem *WebExtensionMenuItem::platformMenuItem(const WebExtensionMenuItem
         return action;
     }
 
-    return [UIMenu menuWithTitle:processedTitle image:toCocoaImage(icon({ 20, 20 })) identifier:nil options:0 children:submenuItemArray];
+    return [UIMenu menuWithTitle:processedTitle.createNSString().get() image:toCocoaImage(icon({ 20, 20 })) identifier:nil options:0 children:submenuItemArray];
 #endif
 }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
@@ -52,12 +52,12 @@ AuthenticatorPresenterCoordinator::AuthenticatorPresenterCoordinator(const Authe
 #if HAVE(ASC_AUTH_UI)
     m_context = adoptNS([allocASCAuthorizationPresentationContextInstance() initWithRequestContext:nullptr appIdentifier:nullptr]);
     if ([getASCAuthorizationPresentationContextClass() instancesRespondToSelector:@selector(setServiceName:)])
-        [m_context setServiceName:rpId];
+        [m_context setServiceName:rpId.createNSString().get()];
 
     switch (type) {
     case ClientDataType::Create: {
         auto options = adoptNS([allocASCPublicKeyCredentialCreationOptionsInstance() init]);
-        [options setUserName:username];
+        [options setUserName:username.createNSString().get()];
 
         if (transports.contains(AuthenticatorTransport::Internal))
             [m_context addLoginChoice:adoptNS([allocASCPlatformPublicKeyCredentialLoginChoiceInstance() initRegistrationChoiceWithOptions:options.get()]).get()];
@@ -229,7 +229,7 @@ void AuthenticatorPresenterCoordinator::selectAssertionResponse(Vector<Ref<Authe
             if (response->userHandle())
                 userHandle = toNSData(response->userHandle()->span());
 
-            auto loginChoice = adoptNS([allocASCSecurityKeyPublicKeyCredentialLoginChoiceInstance() initWithName:response->name() displayName:response->displayName() userHandle:userHandle.get()]);
+            auto loginChoice = adoptNS([allocASCSecurityKeyPublicKeyCredentialLoginChoiceInstance() initWithName:response->name().createNSString().get() displayName:response->displayName().createNSString().get() userHandle:userHandle.get()]);
             [loginChoices addObject:loginChoice.get()];
 
             m_credentials.add(response->name(), WTFMove(response));
@@ -246,7 +246,7 @@ void AuthenticatorPresenterCoordinator::selectAssertionResponse(Vector<Ref<Authe
             if (response->userHandle())
                 userHandle = toNSData(response->userHandle()->span());
 
-            auto loginChoice = adoptNS([allocASCPlatformPublicKeyCredentialLoginChoiceInstance() initWithName:response->name() displayName:response->displayName() userHandle:userHandle.get()]);
+            auto loginChoice = adoptNS([allocASCPlatformPublicKeyCredentialLoginChoiceInstance() initWithName:response->name().createNSString().get() displayName:response->displayName().createNSString().get() userHandle:userHandle.get()]);
             [m_context addLoginChoice:loginChoice.get()];
 
             m_credentials.add(response->name(), WTFMove(response));

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -1156,7 +1156,7 @@ void WebAuthenticatorCoordinatorProxy::performRequestLegacy(RetainPtr<ASCCredent
     }
 
     if (RefPtr pageClient = webPageProxy->pageClient())
-        requestContext.get().windowSceneIdentifier = pageClient->sceneID();
+        requestContext.get().windowSceneIdentifier = pageClient->sceneID().createNSString().get();
 
     [m_proxy performAuthorizationRequestsForContext:requestContext.get() withCompletionHandler:makeBlockPtr([weakThis = WeakPtr { *this }, handler = WTFMove(handler)](id<ASCCredentialProtocol> credential, NSError *error) mutable {
         callOnMainRunLoop([weakThis, handler = WTFMove(handler), credential = retainPtr(credential), error = retainPtr(error)] () mutable {

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -495,7 +495,7 @@ void PageClientImpl::relayAccessibilityNotification(const String& notificationNa
 {
     auto contentView = this->contentView();
     if ([contentView respondsToSelector:@selector(accessibilityRelayNotification:notificationData:)])
-        [contentView accessibilityRelayNotification:notificationName notificationData:notificationData.get()];
+        [contentView accessibilityRelayNotification:notificationName.createNSString().get() notificationData:notificationData.get()];
 }
 
 IntRect PageClientImpl::rootViewToAccessibilityScreen(const IntRect& rect)
@@ -542,7 +542,7 @@ void PageClientImpl::doneDeferringTouchEnd(bool preventNativeGestures)
 
 void PageClientImpl::requestTextRecognition(const URL& imageURL, ShareableBitmap::Handle&& imageData, const String& sourceLanguageIdentifier, const String& targetLanguageIdentifier, CompletionHandler<void(TextRecognitionResult&&)>&& completion)
 {
-    [contentView() requestTextRecognition:imageURL.createNSURL().get() imageData:WTFMove(imageData) sourceLanguageIdentifier:sourceLanguageIdentifier targetLanguageIdentifier:targetLanguageIdentifier completionHandler:WTFMove(completion)];
+    [contentView() requestTextRecognition:imageURL.createNSURL().get() imageData:WTFMove(imageData) sourceLanguageIdentifier:sourceLanguageIdentifier.createNSString().get() targetLanguageIdentifier:targetLanguageIdentifier.createNSString().get() completionHandler:WTFMove(completion)];
 }
 
 #endif // ENABLE(IMAGE_ANALYSIS)
@@ -738,7 +738,7 @@ void PageClientImpl::reconcileEnclosingScrollViewContentOffset(EditorState& stat
 
 void PageClientImpl::showPlaybackTargetPicker(bool hasVideo, const IntRect& elementRect, WebCore::RouteSharingPolicy policy, const String& contextUID)
 {
-    [contentView() _showPlaybackTargetPicker:hasVideo fromRect:elementRect routeSharingPolicy:policy routingContextUID:contextUID];
+    [contentView() _showPlaybackTargetPicker:hasVideo fromRect:elementRect routeSharingPolicy:policy routingContextUID:contextUID.createNSString().get()];
 }
 
 bool PageClientImpl::handleRunOpenPanel(WebPageProxy*, WebFrameProxy*, const FrameInfoData& frameInfo, API::OpenPanelParameters* parameters, WebOpenPanelResultListenerProxy* listener)
@@ -1097,7 +1097,7 @@ void PageClientImpl::requestPasswordForQuickLookDocument(const String& fileName,
         return;
     }
 
-    [webView _showPasswordViewWithDocumentName:fileName passwordHandler:passwordHandler.get()];
+    [webView _showPasswordViewWithDocumentName:fileName.createNSString().get() passwordHandler:passwordHandler.get()];
 }
 #endif
 

--- a/Source/WebKit/UIProcess/ios/WKPasswordView.mm
+++ b/Source/WebKit/UIProcess/ios/WKPasswordView.mm
@@ -123,9 +123,9 @@ const CGFloat passwordEntryFieldPadding = 10;
 - (void)showPasswordFailureAlert
 {
     [[_passwordView passwordField] setText:@""];
-    auto alert = WebKit::createUIAlertController(WEB_UI_STRING("The document could not be opened with that password.", "document password failure alert message"), @"");
+    auto alert = WebKit::createUIAlertController(WEB_UI_STRING("The document could not be opened with that password.", "document password failure alert message").createNSString().get(), @"");
 
-    UIAlertAction *defaultAction = [UIAlertAction actionWithTitle:WEB_UI_STRING_KEY("OK", "OK (password failure alert)", "OK button label in document password failure alert") style:UIAlertActionStyleDefault handler:[](UIAlertAction *) { }];
+    UIAlertAction *defaultAction = [UIAlertAction actionWithTitle:WEB_UI_STRING_KEY("OK", "OK (password failure alert)", "OK button label in document password failure alert").createNSString().get() style:UIAlertActionStyleDefault handler:[](UIAlertAction *) { }];
 
     [alert addAction:defaultAction];
 

--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
@@ -218,7 +218,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HideEditMenuScope);
     auto tileGridContainerName = WebCore::TileController::tileGridContainerLayerName();
     [subviews enumerateObjectsUsingBlock:^(UIView *view, NSUInteger index, BOOL* stop) {
         RetainPtr compositingView = dynamic_objc_cast<WKCompositingView>(view);
-        if ([[compositingView layer].name isEqualToString:tileGridContainerName]) {
+        if ([[compositingView layer].name isEqualToString:tileGridContainerName.createNSString().get()]) {
             indexAfterTileGridContainer = index + 1;
             *stop = YES;
         }

--- a/Source/WebKit/UIProcess/ios/WKUSDPreviewView.mm
+++ b/Source/WebKit/UIProcess/ios/WKUSDPreviewView.mm
@@ -47,12 +47,12 @@
 SOFT_LINK_PRIVATE_FRAMEWORK(AssetViewer);
 SOFT_LINK_CLASS(AssetViewer, ASVThumbnailView);
 
-static NSString *getUTIForUSDMIMEType(const String& mimeType)
+static RetainPtr<NSString> getUTIForUSDMIMEType(const String& mimeType)
 {
     if (!WebCore::MIMETypeRegistry::isUSDMIMEType(mimeType))
         return nil;
 
-    return WebCore::UTIFromMIMEType(mimeType);
+    return WebCore::UTIFromMIMEType(mimeType).createNSString();
 }
 
 @interface WKUSDPreviewView () <ASVThumbnailViewDelegate>
@@ -92,9 +92,9 @@ static NSString *getUTIForUSDMIMEType(const String& mimeType)
     _suggestedFilename = adoptNS([filename copy]);
     _data = adoptNS([data copy]);
 
-    NSString *contentType = getUTIForUSDMIMEType(_mimeType.get());
+    RetainPtr contentType = getUTIForUSDMIMEType(_mimeType.get());
 
-    _item = adoptNS([PAL::allocQLItemInstance() initWithDataProvider:self contentType:contentType previewTitle:_suggestedFilename.get()]);
+    _item = adoptNS([PAL::allocQLItemInstance() initWithDataProvider:self contentType:contentType.get() previewTitle:_suggestedFilename.get()]);
     [_item setUseLoadingTimeout:NO];
 
     _thumbnailView = adoptNS([allocASVThumbnailViewInstance() init]);

--- a/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
@@ -77,11 +77,11 @@ static NSString *appDisplayName()
     return displayName;
 }
 
-static NSString *getToken(const WebCore::SecurityOriginData& securityOrigin, NSURL *requestingURL)
+static RetainPtr<NSString> getToken(const WebCore::SecurityOriginData& securityOrigin, NSURL *requestingURL)
 {
     if ([requestingURL isFileURL])
         return [requestingURL path];
-    return securityOrigin.host();
+    return securityOrigin.host().createNSString();
 }
 
 struct PermissionRequest {
@@ -173,22 +173,22 @@ struct PermissionRequest {
         RetainPtr<NSString> message;
 
     IGNORE_WARNINGS_BEGIN("format-nonliteral")
-        RetainPtr title = adoptNS([[NSString alloc] initWithFormat:WEB_UI_STRING("“%@” would like to use your current location.", "Prompt for a webpage to request location access. The parameter is the domain for the webpage."), _activeChallenge->token.get()]);
+        RetainPtr title = adoptNS([[NSString alloc] initWithFormat:WEB_UI_STRING("“%@” would like to use your current location.", "Prompt for a webpage to request location access. The parameter is the domain for the webpage.").createNSString().get(), _activeChallenge->token.get()]);
         if (appHasPreciseLocationPermission())
-            message = adoptNS([[NSString alloc] initWithFormat:WEB_UI_STRING("This website will use your precise location because “%@” currently has access to your precise location.", "Message informing the user that the website will have precise location data"), applicationName]);
+            message = adoptNS([[NSString alloc] initWithFormat:WEB_UI_STRING("This website will use your precise location because “%@” currently has access to your precise location.", "Message informing the user that the website will have precise location data").createNSString().get(), applicationName]);
         else
-            message = adoptNS([[NSString alloc] initWithFormat:WEB_UI_STRING("This website will use your approximate location because “%@” currently has access to your approximate location.", "Message informing the user that the website will have approximate location data"), applicationName]);
+            message = adoptNS([[NSString alloc] initWithFormat:WEB_UI_STRING("This website will use your approximate location because “%@” currently has access to your approximate location.", "Message informing the user that the website will have approximate location data").createNSString().get(), applicationName]);
     IGNORE_WARNINGS_END
 
-        NSString *allowActionTitle = WEB_UI_STRING("Allow", "Action authorizing a webpage to access the user’s location.");
-        NSString *denyActionTitle = WEB_UI_STRING_KEY("Don’t Allow", "Don’t Allow (website location dialog)", "Action denying a webpage access to the user’s location.");
+        RetainPtr allowActionTitle = WEB_UI_STRING("Allow", "Action authorizing a webpage to access the user’s location.").createNSString();
+        RetainPtr denyActionTitle = WEB_UI_STRING_KEY("Don’t Allow", "Don’t Allow (website location dialog)", "Action denying a webpage access to the user’s location.").createNSString();
 
         RetainPtr alert = WebKit::createUIAlertController(title.get(), message.get());
-        UIAlertAction *denyAction = [UIAlertAction actionWithTitle:denyActionTitle style:UIAlertActionStyleDefault handler:[weakSelf = WeakObjCPtr<WKWebGeolocationPolicyDecider>(self)](UIAlertAction *) mutable {
+        UIAlertAction *denyAction = [UIAlertAction actionWithTitle:denyActionTitle.get() style:UIAlertActionStyleDefault handler:[weakSelf = WeakObjCPtr<WKWebGeolocationPolicyDecider>(self)](UIAlertAction *) mutable {
             if (auto strongSelf = weakSelf.get())
                 [strongSelf _finishActiveChallenge:NO];
         }];
-        UIAlertAction *allowAction = [UIAlertAction actionWithTitle:allowActionTitle style:UIAlertActionStyleDefault handler:[weakSelf = WeakObjCPtr<WKWebGeolocationPolicyDecider>(self)](UIAlertAction *) mutable {
+        UIAlertAction *allowAction = [UIAlertAction actionWithTitle:allowActionTitle.get() style:UIAlertActionStyleDefault handler:[weakSelf = WeakObjCPtr<WKWebGeolocationPolicyDecider>(self)](UIAlertAction *) mutable {
             if (auto strongSelf = weakSelf.get())
                 [strongSelf _finishActiveChallenge:YES];
         }];

--- a/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
@@ -197,7 +197,7 @@ void WebDataListSuggestionsDropdownIOS::didSelectOption(const String& selectedOp
     NSMutableArray *suggestions = [NSMutableArray array];
 
     for (const auto& suggestion : _suggestions) {
-        [suggestions addObject:[WKDataListTextSuggestion textSuggestionWithInputText:suggestion.value]];
+        [suggestions addObject:[WKDataListTextSuggestion textSuggestionWithInputText:suggestion.value.createNSString().get()]];
         if (suggestions.count == 3)
             break;
     }
@@ -288,7 +288,7 @@ void WebDataListSuggestionsDropdownIOS::didSelectOption(const String& selectedOp
 
 - (NSString *)pickerView:(UIPickerView *)pickerView titleForRow:(NSInteger)row forComponent:(NSInteger)component
 {
-    return [self suggestionAtIndex:row];
+    return [self suggestionAtIndex:row].createNSString().autorelease();
 }
 
 - (void)invalidate
@@ -374,7 +374,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     [super didSelectOptionAtIndex:index];
     [[_popover popoverController] dismissPopoverAnimated:YES];
-    self.view.dataListTextSuggestions = @[ [WKDataListTextSuggestion textSuggestionWithInputText:[self suggestionAtIndex:index]] ];
+    self.view.dataListTextSuggestions = @[ [WKDataListTextSuggestion textSuggestionWithInputText:[self suggestionAtIndex:index].createNSString().get()] ];
 }
 
 @end
@@ -403,7 +403,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!cell)
         cell = adoptNS([[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:suggestionCellReuseIdentifier]);
 
-    [cell textLabel].text = [self.control suggestionAtIndex:indexPath.row];
+    [cell textLabel].text = [self.control suggestionAtIndex:indexPath.row].createNSString().get();
     [cell textLabel].lineBreakMode = NSLineBreakByTruncatingTail;
     [cell textLabel].textAlignment = [self.control textAlignment];
 
@@ -537,14 +537,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     NSMutableArray *suggestions = [NSMutableArray arrayWithCapacity:self.suggestionsCount];
 
     for (NSInteger index = 0; index < self.suggestionsCount; index++) {
-        UIAction *suggestionAction = [UIAction actionWithTitle:[self suggestionAtIndex:index] image:nil identifier:nil handler:[weakSelf = WeakObjCPtr<WKDataListSuggestionsDropdown>(self), index] (UIAction *) {
+        UIAction *suggestionAction = [UIAction actionWithTitle:[self suggestionAtIndex:index].createNSString().get() image:nil identifier:nil handler:[weakSelf = WeakObjCPtr<WKDataListSuggestionsDropdown>(self), index] (UIAction *) {
             auto strongSelf = weakSelf.get();
             if (!strongSelf)
                 return;
 
             [strongSelf didSelectOptionAtIndex:index];
         }];
-        suggestionAction.subtitle = [self suggestionLabelAtIndex:index];
+        suggestionAction.subtitle = [self suggestionLabelAtIndex:index].createNSString().get();
 
         [suggestions addObject:suggestionAction];
     }

--- a/Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm
@@ -266,7 +266,7 @@ const CGFloat toolbarBottomMarginSmall = 2;
     [_contentView setTranslatesAutoresizingMaskIntoConstraints:NO];
 
 #if USE(UITOOLBAR_FOR_DATE_PICKER_ACCESSORY_VIEW)
-    auto resetButton = adoptNS([[UIBarButtonItem alloc] initWithTitle:WEB_UI_STRING_KEY("Reset", "Reset Button Date/Time Context Menu", "Reset button in date input context menu") style:UIBarButtonItemStylePlain target:self action:@selector(resetDatePicker)]);
+    auto resetButton = adoptNS([[UIBarButtonItem alloc] initWithTitle:WEB_UI_STRING_KEY("Reset", "Reset Button Date/Time Context Menu", "Reset button in date input context menu").createNSString().get() style:UIBarButtonItemStylePlain target:self action:@selector(resetDatePicker)]);
     auto doneButton = adoptNS([[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(dismissDatePicker)]);
 
     [_contentView accessoryView].items = @[ resetButton.get(), UIBarButtonItem.flexibleSpaceItem, doneButton.get() ];

--- a/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
@@ -350,7 +350,7 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
 
     // Currently no value for the <input>. Start the picker with the current time.
     // Also, update the actual <input> value.
-    _initialValue = _view.focusedElementInformation.value;
+    _initialValue = _view.focusedElementInformation.value.createNSString().get();
     [self setDateTimePickerToInitialValue];
     [self showDateTimePicker];
 }

--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
@@ -244,7 +244,7 @@ static NSString * firstUTIThatConformsTo(NSArray<NSString *> *typeIdentifiers, U
 #else
     _progressController = adoptNS([allocPUActivityProgressControllerInstance() init]);
 #endif
-    [_progressController setTitle:WEB_UI_STRING_KEY("Preparing…", "Preparing (file upload)", "Title for file upload progress view")];
+    [_progressController setTitle:WEB_UI_STRING_KEY("Preparing…", "Preparing (file upload)", "Title for file upload progress view").createNSString().get()];
     [_progressController showAnimated:YES allowDelay:YES];
 
     [_progressController setCancellationHandler:makeBlockPtr([weakSelf = WeakObjCPtr<WKFileUploadMediaTranscoder>(self)] {
@@ -505,13 +505,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     Ref<API::Array> acceptMimeTypes = parameters->acceptMIMETypes();
     NSMutableArray *mimeTypes = [NSMutableArray arrayWithCapacity:acceptMimeTypes->size()];
     for (auto mimeType : acceptMimeTypes->elementsOfType<API::String>())
-        [mimeTypes addObject:mimeType->string()];
+        [mimeTypes addObject:mimeType->string().createNSString().get()];
 
     Ref<API::Array> acceptFileExtensions = parameters->acceptFileExtensions();
     for (auto extension : acceptFileExtensions->elementsOfType<API::String>()) {
         String mimeType = WebCore::MIMETypeRegistry::mimeTypeForExtension(extension->stringView().substring(1));
         if (!mimeType.isEmpty())
-            [mimeTypes addObject:mimeType];
+            [mimeTypes addObject:mimeType.createNSString().get()];
     }
 
     _acceptedUTIs = UTIsForMIMETypes(mimeTypes);
@@ -699,14 +699,14 @@ static NSSet<NSString *> *UTIsForMIMETypes(NSArray *mimeTypes)
 - (NSString *)_chooseFilesButtonLabel
 {
     if (_allowMultipleFiles)
-        return WebCore::fileButtonChooseMultipleFilesLabel();
+        return WebCore::fileButtonChooseMultipleFilesLabel().createNSString().autorelease();
 
-    return WebCore::fileButtonChooseFileLabel();
+    return WebCore::fileButtonChooseFileLabel().createNSString().autorelease();
 }
 
 - (NSString *)_photoLibraryButtonLabel
 {
-    return WEB_UI_STRING_KEY("Photo Library", "Photo Library (file upload action sheet)", "File Upload alert sheet button string for choosing an existing media item from the Photo Library");
+    return WEB_UI_STRING_KEY("Photo Library", "Photo Library (file upload action sheet)", "File Upload alert sheet button string for choosing an existing media item from the Photo Library").createNSString().autorelease();
 }
 
 - (NSString *)_cameraButtonLabel
@@ -714,12 +714,12 @@ static NSSet<NSString *> *UTIsForMIMETypes(NSArray *mimeTypes)
     ASSERT(_allowedImagePickerTypes.containsAny({ WKFileUploadPanelImagePickerType::Image, WKFileUploadPanelImagePickerType::Video }));
 
     if (_allowedImagePickerTypes.containsAll({ WKFileUploadPanelImagePickerType::Image, WKFileUploadPanelImagePickerType::Video }))
-        return WEB_UI_STRING_KEY("Take Photo or Video", "Take Photo or Video (file upload action sheet)", "File Upload alert sheet camera button string for taking photos or videos");
+        return WEB_UI_STRING_KEY("Take Photo or Video", "Take Photo or Video (file upload action sheet)", "File Upload alert sheet camera button string for taking photos or videos").createNSString().autorelease();
 
     if (_allowedImagePickerTypes.contains(WKFileUploadPanelImagePickerType::Video))
-        return WEB_UI_STRING_KEY("Take Video", "Take Video (file upload action sheet)", "File Upload alert sheet camera button string for taking only videos");
+        return WEB_UI_STRING_KEY("Take Video", "Take Video (file upload action sheet)", "File Upload alert sheet camera button string for taking only videos").createNSString().autorelease();
 
-    return WEB_UI_STRING_KEY("Take Photo", "Take Photo (file upload action sheet)", "File Upload alert sheet camera button string for taking only photos");
+    return WEB_UI_STRING_KEY("Take Photo", "Take Photo (file upload action sheet)", "File Upload alert sheet camera button string for taking only photos").createNSString().autorelease();
 }
 
 #if USE(UICONTEXTMENU)
@@ -958,14 +958,14 @@ static NSSet<NSString *> *UTIsForMIMETypes(NSArray *mimeTypes)
 
 #pragma mark - UIDocumentPickerControllerDelegate implementation
 
-static NSString *displayStringForDocumentsAtURLs(NSArray<NSURL *> *urls)
+static RetainPtr<NSString> displayStringForDocumentsAtURLs(NSArray<NSURL *> *urls)
 {
     auto urlsCount = urls.count;
     ASSERT(urlsCount);
     if (urlsCount == 1)
         return urls[0].lastPathComponent;
 
-    return WebCore::multipleFileUploadText(urlsCount);
+    return WebCore::multipleFileUploadText(urlsCount).createNSString();
 }
 
 - (void)documentPicker:(UIDocumentPickerViewController *)controller didPickDocumentsAtURLs:(NSArray<NSURL *> *)urlsFromUIKit
@@ -1002,7 +1002,7 @@ static NSString *displayStringForDocumentsAtURLs(NSArray<NSURL *> *urls)
 
         [retainedSelf->_view _removeTemporaryDirectoriesWhenDeallocated:std::exchange(retainedSelf->_temporaryUploadedFileURLs, { })];
         RunLoop::protectedMain()->dispatch([retainedSelf = WTFMove(retainedSelf), maybeMovedURLs = WTFMove(maybeMovedURLs)] {
-            [retainedSelf _chooseFiles:maybeMovedURLs.get() displayString:displayStringForDocumentsAtURLs(maybeMovedURLs.get()) iconImage:WebKit::iconForFiles({ maybeMovedURLs.get()[0].absoluteString }).get()];
+            [retainedSelf _chooseFiles:maybeMovedURLs.get() displayString:displayStringForDocumentsAtURLs(maybeMovedURLs.get()).get() iconImage:WebKit::iconForFiles({ maybeMovedURLs.get()[0].absoluteString }).get()];
         });
     }).get());
 }

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
@@ -81,7 +81,7 @@ static const float GroupOptionTextColorAlpha = 0.5;
     if (!(self = [self init]))
         return nil;
 
-    auto trimmedText = adoptNS([item.text mutableCopy]);
+    RetainPtr trimmedText = adoptNS([item.text.createNSString() mutableCopy]);
     CFStringTrimWhitespace((CFMutableStringRef)trimmedText.get());
 
     [[self titleLabel] setText:trimmedText.get()];
@@ -107,7 +107,7 @@ static const float GroupOptionTextColorAlpha = 0.5;
     if (!(self = [self init]))
         return nil;
 
-    auto trimmedText = adoptNS([item.text mutableCopy]);
+    RetainPtr trimmedText = adoptNS([item.text.createNSString() mutableCopy]);
     CFStringTrimWhitespace((CFMutableStringRef)trimmedText.get());
 
     [[self titleLabel] setText:trimmedText.get()];
@@ -429,7 +429,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return nil;
 
     const OptionItem& option = [_view focusedSelectElementOptions][row];
-    auto trimmedText = adoptNS([option.text mutableCopy]);
+    RetainPtr trimmedText = adoptNS([option.text.createNSString() mutableCopy]);
     CFStringTrimWhitespace((CFMutableStringRef)trimmedText.get());
 
     auto attributedString = adoptNS([[NSMutableAttributedString alloc] initWithString:trimmedText.get()]);
@@ -583,7 +583,7 @@ static constexpr auto removeLineLimitForChildrenMenuOption = static_cast<UIMenuO
 - (UIMenu *)createMenu
 {
     if (!_view.focusedSelectElementOptions.size()) {
-        UIAction *emptyAction = [UIAction actionWithTitle:WEB_UI_STRING_KEY("No Options", "No Options Select Popover", "Empty select list") image:nil identifier:nil handler:^(__kindof UIAction *action) { }];
+        UIAction *emptyAction = [UIAction actionWithTitle:WEB_UI_STRING_KEY("No Options", "No Options Select Popover", "Empty select list").createNSString().get() image:nil identifier:nil handler:^(__kindof UIAction *action) { }];
         emptyAction.attributes = UIMenuElementAttributesDisabled;
         return [UIMenu menuWithTitle:@"" children:@[emptyAction]];
     }
@@ -596,7 +596,7 @@ static constexpr auto removeLineLimitForChildrenMenuOption = static_cast<UIMenuO
         auto& optionItem = _view.focusedSelectElementOptions[currentIndex];
         if (optionItem.isGroup) {
             auto groupID = optionItem.parentGroupID;
-            NSString *groupText = optionItem.text;
+            RetainPtr groupText = optionItem.text.createNSString();
             NSMutableArray *groupedItems = [NSMutableArray array];
 
             currentIndex++;
@@ -611,7 +611,7 @@ static constexpr auto removeLineLimitForChildrenMenuOption = static_cast<UIMenuO
                 currentIndex++;
             }
 
-            UIMenu *groupMenu = [UIMenu menuWithTitle:groupText image:nil identifier:nil options:UIMenuOptionsDisplayInline | removeLineLimitForChildrenMenuOption children:groupedItems];
+            UIMenu *groupMenu = [UIMenu menuWithTitle:groupText.get() image:nil identifier:nil options:UIMenuOptionsDisplayInline | removeLineLimitForChildrenMenuOption children:groupedItems];
             [items addObject:groupMenu];
             continue;
         }
@@ -627,7 +627,7 @@ static constexpr auto removeLineLimitForChildrenMenuOption = static_cast<UIMenuO
 
 - (UIAction *)actionForOptionItem:(const OptionItem&)option withIndex:(NSInteger)optionIndex
 {
-    UIAction *optionAction = [UIAction actionWithTitle:option.text image:nil identifier:nil handler:^(__kindof UIAction *action) {
+    UIAction *optionAction = [UIAction actionWithTitle:option.text.createNSString().get() image:nil identifier:nil handler:^(__kindof UIAction *action) {
         [self didSelectOptionIndex:optionIndex];
     }];
 
@@ -1029,7 +1029,7 @@ static NSString *optionCellReuseIdentifier = @"WKSelectPickerTableViewCell";
 
         groupCount++;
         if (option.isGroup && groupCount == section)
-            return option.text;
+            return option.text.createNSString().autorelease();
     }
 
     return nil;
@@ -1125,7 +1125,7 @@ static NSString *optionCellReuseIdentifier = @"WKSelectPickerTableViewCell";
 
     if (_contentView.focusedSelectElementOptions.isEmpty()) {
         [cell textLabel].enabled = NO;
-        [cell textLabel].text = WEB_UI_STRING_KEY("No Options", "No Options Select Popover", "Empty select list");
+        [cell textLabel].text = WEB_UI_STRING_KEY("No Options", "No Options Select Popover", "Empty select list").createNSString().get();
         [cell setUserInteractionEnabled:NO];
         [cell imageView].image = nil;
         return cell.autorelease();
@@ -1135,7 +1135,7 @@ static NSString *optionCellReuseIdentifier = @"WKSelectPickerTableViewCell";
     if (!option)
         return cell.autorelease();
 
-    [cell textLabel].text = option->text;
+    [cell textLabel].text = option->text.createNSString().get();
     [cell textLabel].enabled = !option->disabled;
     [cell setUserInteractionEnabled:!option->disabled];
     [cell imageView].preferredSymbolConfiguration = [UIImageSymbolConfiguration configurationWithTextStyle:UIFontTextStyleBody scale:UIImageSymbolScaleLarge];

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPopover.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPopover.mm
@@ -134,7 +134,7 @@ static RetainPtr<NSString> stringWithWritingDirection(NSString *string, NSWritin
     // For that reason we have to override what the system thinks.
     if (writingDirection == NSWritingDirectionRightToLeft)
         self.view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-    [self setTitle:stringWithWritingDirection(_contentView.focusedElementInformation.title, writingDirection, override).get()];
+    [self setTitle:stringWithWritingDirection(_contentView.focusedElementInformation.title.createNSString().get(), writingDirection, override).get()];
 
     return self;
 }
@@ -194,7 +194,7 @@ static RetainPtr<NSString> stringWithWritingDirection(NSString *string, NSWritin
             continue;
         groupCount++;
         if (item.isGroup && groupCount == section)
-            return item.text;
+            return item.text.createNSString().autorelease();
     }
     return nil;
 }
@@ -203,7 +203,7 @@ static RetainPtr<NSString> stringWithWritingDirection(NSString *string, NSWritin
 {
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     // FIXME: <rdar://131638865> UITableViewCell.textLabel is deprecated.
-    [cell.textLabel setText:item.text];
+    [cell.textLabel setText:item.text.createNSString().get()];
     [cell.textLabel setEnabled:!item.disabled];
 ALLOW_DEPRECATED_DECLARATIONS_END
     [cell setSelectionStyle:item.disabled ? UITableViewCellSelectionStyleNone : UITableViewCellSelectionStyleBlue];
@@ -259,7 +259,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     
     if (_contentView.focusedElementInformation.selectOptions.isEmpty()) {
         [cell textLabel].enabled = NO;
-        [cell textLabel].text = WEB_UI_STRING_KEY("No Options", "No Options Select Popover", "Empty select list");
+        [cell textLabel].text = WEB_UI_STRING_KEY("No Options", "No Options Select Popover", "Empty select list").createNSString().get();
         [cell setAccessoryType:UITableViewCellAccessoryNone];
         [cell setSelectionStyle:UITableViewCellSelectionStyleNone];
         return cell.autorelease();

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -717,7 +717,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (NSString *)location
 {
-    return _location;
+    return _location.createNSString().autorelease();
 }
 
 - (void)setLocation:(NSString *)location
@@ -1135,7 +1135,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         page->suspendActiveDOMObjectsAndAnimations();
     }
 
-    UIAlertAction* exitAction = [UIAlertAction actionWithTitle:WEB_UI_STRING_KEY("Exit Full Screen", "Exit Full Screen (Element Full Screen)", "Full Screen Deceptive Website Exit Action") style:UIAlertActionStyleCancel handler:^(UIAlertAction * action) {
+    UIAlertAction* exitAction = [UIAlertAction actionWithTitle:WEB_UI_STRING_KEY("Exit Full Screen", "Exit Full Screen (Element Full Screen)", "Full Screen Deceptive Website Exit Action").createNSString().get() style:UIAlertActionStyleCancel handler:^(UIAlertAction * action) {
         [self _cancelAction:action];
         if (RefPtr page = self._webView._page.get()) {
             page->resumeActiveDOMObjectsAndAnimations();
@@ -1143,7 +1143,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         }
     }];
 
-    UIAlertAction* stayAction = [UIAlertAction actionWithTitle:WEB_UI_STRING_KEY("Stay in Full Screen", "Stay in Full Screen (Element Full Screen)", "Full Screen Deceptive Website Stay Action") style:UIAlertActionStyleDefault handler:^(UIAlertAction * action) {
+    UIAlertAction* stayAction = [UIAlertAction actionWithTitle:WEB_UI_STRING_KEY("Stay in Full Screen", "Stay in Full Screen (Element Full Screen)", "Full Screen Deceptive Website Stay Action").createNSString().get() style:UIAlertActionStyleDefault handler:^(UIAlertAction * action) {
         if (RefPtr page = self._webView._page.get()) {
             page->resumeActiveDOMObjectsAndAnimations();
             page->resumeAllMediaPlayback([] { });

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5706,7 +5706,7 @@ void WebPage::requestDocumentEditingContext(DocumentEditingContextRequest&& requ
         if (wantsAttributedText)
             return editingAttributedStringReplacingNoBreakSpace(*range, textBehaviors, { IncludedElement::Images, IncludedElement::Attachments });
 
-        return AttributedString::fromNSAttributedString(adoptNS([[NSAttributedString alloc] initWithString:plainTextReplacingNoBreakSpace(*range, textBehaviors)]));
+        return AttributedString::fromNSAttributedString(adoptNS([[NSAttributedString alloc] initWithString:plainTextReplacingNoBreakSpace(*range, textBehaviors).createNSString().get()]));
     };
 
     DocumentEditingContext context;
@@ -5718,7 +5718,7 @@ void WebPage::requestDocumentEditingContext(DocumentEditingContextRequest&& requ
         auto markedTextLength = context.markedText.string.length();
 
         ptrdiff_t distanceToSelectionStart = distanceBetweenPositions(rangeOfInterestInSelection.start, compositionVisiblePositionRange.start);
-        ptrdiff_t distanceToSelectionEnd = distanceToSelectionStart + [context.selectedText.string length];
+        ptrdiff_t distanceToSelectionEnd = distanceToSelectionStart + [context.selectedText.string.createNSString() length];
 
         distanceToSelectionStart = clampTo<ptrdiff_t>(distanceToSelectionStart, 0, markedTextLength);
         distanceToSelectionEnd = clampTo<ptrdiff_t>(distanceToSelectionEnd, 0, markedTextLength);
@@ -5730,7 +5730,7 @@ void WebPage::requestDocumentEditingContext(DocumentEditingContextRequest&& requ
         };
     } else if (auto* suggestion = frame->editor().writingSuggestionData()) {
         if (auto suffix = suggestion->content(); !suffix.isEmpty()) {
-            context.markedText = AttributedString::fromNSAttributedString(adoptNS([[NSAttributedString alloc] initWithString:WTFMove(suffix)]));
+            context.markedText = AttributedString::fromNSAttributedString(adoptNS([[NSAttributedString alloc] initWithString:suffix.createNSString().get()]));
             context.selectedRangeInMarkedText = { 0, 0 };
         }
     }

--- a/Source/WebKit/webpushd/WebClipCache.mm
+++ b/Source/WebKit/webpushd/WebClipCache.mm
@@ -170,7 +170,7 @@ static RetainPtr<NSArray> loadWebClipCachePropertyList(NSString *path)
 
 void WebClipCache::load()
 {
-    RetainPtr entries = loadWebClipCachePropertyList(m_path);
+    RetainPtr entries = loadWebClipCachePropertyList(m_path.createNSString().get());
     if (!entries)
         return;
 
@@ -247,7 +247,7 @@ bool WebClipCache::isWebClipVisible(const String& bundleIdentifier, const String
     if (bundleIdentifier == "com.apple.SafariViewService"_s)
         return true;
 
-    UIWebClip *webClip = [UIWebClip webClipWithIdentifier:webClipIdentifier];
+    UIWebClip *webClip = [UIWebClip webClipWithIdentifier:webClipIdentifier.createNSString().get()];
     if (![webClip respondsToSelector:@selector(trustedClientBundleIdentifiers)])
         return true;
 

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.mm
@@ -113,14 +113,14 @@ void WebChromeClientIOS::focus()
 void WebChromeClientIOS::runJavaScriptAlert(LocalFrame& frame, const WTF::String& message)
 {
     WebThreadLockPushModal();
-    [[webView() _UIDelegateForwarder] webView:webView() runJavaScriptAlertPanelWithMessage:message initiatedByFrame:kit(&frame)];
+    [[webView() _UIDelegateForwarder] webView:webView() runJavaScriptAlertPanelWithMessage:message.createNSString().get() initiatedByFrame:kit(&frame)];
     WebThreadLockPopModal();
 }
 
 bool WebChromeClientIOS::runJavaScriptConfirm(LocalFrame& frame, const WTF::String& message)
 {
     WebThreadLockPushModal();
-    bool result = [[webView() _UIDelegateForwarder] webView:webView() runJavaScriptConfirmPanelWithMessage:message initiatedByFrame:kit(&frame)];
+    bool result = [[webView() _UIDelegateForwarder] webView:webView() runJavaScriptConfirmPanelWithMessage:message.createNSString().get() initiatedByFrame:kit(&frame)];
     WebThreadLockPopModal();
     return result;
 }
@@ -128,7 +128,7 @@ bool WebChromeClientIOS::runJavaScriptConfirm(LocalFrame& frame, const WTF::Stri
 bool WebChromeClientIOS::runJavaScriptPrompt(LocalFrame& frame, const WTF::String& prompt, const WTF::String& defaultText, WTF::String& result)
 {
     WebThreadLockPushModal();
-    result = [[webView() _UIDelegateForwarder] webView:webView() runJavaScriptTextInputPanelWithPrompt:prompt defaultText:defaultText initiatedByFrame:kit(&frame)];
+    result = [[webView() _UIDelegateForwarder] webView:webView() runJavaScriptTextInputPanelWithPrompt:prompt.createNSString().get() defaultText:defaultText.createNSString().get() initiatedByFrame:kit(&frame)];
     WebThreadLockPopModal();
     return !result.isNull();
 }

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebMIMETypeRegistry.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebMIMETypeRegistry.mm
@@ -35,12 +35,12 @@ using WebCore::MIMETypeRegistry;
 
 + (NSString *)mimeTypeForExtension:(NSString *)extension
 {
-    return MIMETypeRegistry::mimeTypeForExtension(String(extension));
+    return MIMETypeRegistry::mimeTypeForExtension(String(extension)).createNSString().autorelease();
 }
 
 + (NSString *)preferredExtensionForMIMEType:(NSString *)mimeType
 {
-    return MIMETypeRegistry::preferredExtensionForMIMEType(mimeType);
+    return MIMETypeRegistry::preferredExtensionForMIMEType(mimeType).createNSString().autorelease();
 }
 
 + (BOOL)isSupportedImageMIMEType:(NSString *)mimeType

--- a/Source/WebKitLegacy/mac/DOM/DOM.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOM.mm
@@ -413,7 +413,7 @@ id <DOMEventTarget> kit(EventTarget* target)
     auto* link = [self _linkElement];
     if (!link)
         return nil;
-    return link->textContent();
+    return link->textContent().createNSString().autorelease();
 }
 
 - (NSString *)hrefTitle
@@ -421,7 +421,7 @@ id <DOMEventTarget> kit(EventTarget* target)
     auto* link = [self _linkElement];
     if (!is<HTMLElement>(link))
         return nil;
-    return link->document().displayStringModifiedByEncoding(downcast<HTMLElement>(*link).title());
+    return link->document().displayStringModifiedByEncoding(downcast<HTMLElement>(*link).title()).createNSString().autorelease();
 }
 
 - (CGRect)boundingFrame

--- a/Source/WebKitLegacy/mac/DOM/DOMUIKitExtensions.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMUIKitExtensions.mm
@@ -393,7 +393,7 @@ static WebCore::Node* firstNodeAfter(const WebCore::BoundaryPoint& point)
     auto* cachedImage = core(self)->cachedImage();
     if (!cachedImage || !cachedImage->image())
         return nil;
-    return cachedImage->response().mimeType();
+    return cachedImage->response().mimeType().createNSString().autorelease();
 }
 
 @end

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -1939,13 +1939,13 @@ RefPtr<WebCore::LegacyPreviewLoaderClient> WebFrameLoaderClient::createPreviewLo
     if (![m_webFrame webView].preferences.quickLookDocumentSavingEnabled)
         return nullptr;
 
-    NSString *filePath = WebCore::createTemporaryFileForQuickLook(fileName);
+    RetainPtr filePath = WebCore::createTemporaryFileForQuickLook(fileName.createNSString().get());
     if (!filePath)
         return nullptr;
 
-    auto documentWriter = adoptRef(*new QuickLookDocumentWriter(filePath));
+    auto documentWriter = adoptRef(*new QuickLookDocumentWriter(filePath.get()));
 
-    [m_webFrame provisionalDataSource]._quickLookContent = @{ WebQuickLookFileNameKey : filePath, WebQuickLookUTIKey : uti };
+    [m_webFrame provisionalDataSource]._quickLookContent = @{ WebQuickLookFileNameKey : filePath.get(), WebQuickLookUTIKey : uti.createNSString().get() };
     [m_webFrame provisionalDataSource]._quickLookPreviewLoaderClient = documentWriter.ptr();
     return documentWriter;
 }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebSecurityOrigin.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebSecurityOrigin.mm
@@ -80,7 +80,7 @@ using namespace WebCore;
 #if PLATFORM(IOS_FAMILY)
 - (NSString *)toString
 {
-    return reinterpret_cast<SecurityOrigin*>(_private)->toString();
+    return reinterpret_cast<SecurityOrigin*>(_private)->toString().createNSString().autorelease();
 }
 #endif
 

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -1785,7 +1785,7 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
     PAL::TextEncoding encoding(textEncodingName);
     if (!encoding.isValid())
         encoding = PAL::WindowsLatin1Encoding();
-    return encoding.decode(span(data));
+    return encoding.decode(span(data)).createNSString().autorelease();
 }
 
 - (NSRect)caretRectAtNode:(DOMNode *)node offset:(int)offset affinity:(NSSelectionAffinity)affinity

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -1940,7 +1940,7 @@ static WebCore::ApplicationCacheStorage& webApplicationCacheStorage()
     else
         _private->textIndicatorData = adoptNS([[WebUITextIndicatorData alloc] initWithImage:image scale:_private->page->deviceScaleFactor()]);
     _private->draggedLinkURL = dragItem.url.isEmpty() ? RetainPtr<NSURL>() : dragItem.url.createNSURL();
-    _private->draggedLinkTitle = dragItem.title.isEmpty() ? nil : (NSString *)dragItem.title;
+    _private->draggedLinkTitle = dragItem.title.isEmpty() ? nil : dragItem.title.createNSString().get();
     _private->dragPreviewFrameInRootViewCoordinates = dragItem.dragPreviewFrameInRootViewCoordinates;
     _private->dragSourceAction = kit(dragItem.sourceAction);
 }
@@ -7717,7 +7717,7 @@ static NSAppleEventDescriptor* aeDescFromJSValue(JSC::JSGlobalObject* lexicalGlo
 #if PLATFORM(IOS_FAMILY)
 - (void)removeVisitedLink:(NSURL *)url
 {
-    _private->group->visitedLinkStore().removeVisitedLink(URL(url).string());
+    _private->group->visitedLinkStore().removeVisitedLink(URL(url).string().createNSString().get());
 }
 #endif
 

--- a/Tools/DumpRenderTree/ios/UIScriptControllerIOS.mm
+++ b/Tools/DumpRenderTree/ios/UIScriptControllerIOS.mm
@@ -142,7 +142,7 @@ JSObjectRef UIScriptControllerIOS::contentVisibleRect() const
 
 void UIScriptControllerIOS::copyText(JSStringRef text)
 {
-    UIPasteboard.generalPasteboard.string = text->string();
+    UIPasteboard.generalPasteboard.string = text->string().createNSString().get();
 }
 
 int64_t UIScriptControllerIOS::pasteboardChangeCount() const

--- a/Tools/DumpRenderTree/mac/UIScriptControllerMac.mm
+++ b/Tools/DumpRenderTree/mac/UIScriptControllerMac.mm
@@ -173,7 +173,7 @@ void UIScriptControllerMac::copyText(JSStringRef text)
 {
     NSPasteboard *pasteboard = NSPasteboard.generalPasteboard;
     [pasteboard declareTypes:@[NSPasteboardTypeString] owner:nil];
-    [pasteboard setString:text->string() forType:NSPasteboardTypeString];
+    [pasteboard setString:text->string().createNSString().get() forType:NSPasteboardTypeString];
 }
 
 void UIScriptControllerMac::setSpellCheckerResults(JSValueRef results)
@@ -245,7 +245,7 @@ void UIScriptControllerMac::sendEventStream(JSStringRef eventsJSON, JSValueRef c
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
 
     auto jsonString = eventsJSON->string();
-    auto eventInfo = dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:[(NSString *)jsonString dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingMutableContainers | NSJSONReadingMutableLeaves error:nil]);
+    auto eventInfo = dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:[jsonString.createNSString() dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingMutableContainers | NSJSONReadingMutableLeaves error:nil]);
     if (!eventInfo || ![eventInfo isKindOfClass:[NSDictionary class]]) {
         WTFLogAlways("JSON is not convertible to a dictionary");
         return;

--- a/Tools/TestWebKitAPI/PlatformUtilities.h
+++ b/Tools/TestWebKitAPI/PlatformUtilities.h
@@ -33,6 +33,8 @@
 
 #include "Utilities.h"
 #include <string>
+#include <wtf/text/ASCIILiteral.h>
+#include <wtf/text/WTFString.h>
 
 #if PLATFORM(COCOA) && defined(__OBJC__)
 #import "TestNSBundleExtras.h"
@@ -57,6 +59,9 @@ namespace TestWebKitAPI {
 namespace Util {
 
 std::string toSTD(const char*);
+ALWAYS_INLINE std::string toSTD(ASCIILiteral literal) { return toSTD(literal.characters()); }
+ALWAYS_INLINE std::string toSTD(const String& string) { return toSTD(string.utf8().data()); }
+
 #if USE(FOUNDATION)
 std::string toSTD(NSString *);
 bool jsonMatchesExpectedValues(NSString *jsonString, NSDictionary *expected);

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -643,9 +643,9 @@
 		A14FC58B1B89927100D107EB /* ContentFilteringPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = A14FC5891B89927100D107EB /* ContentFilteringPlugIn.mm */; };
 		A170E3AA2ABA7857009EA799 /* VectorCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = A170E3A22ABA7857009EA799 /* VectorCocoa.mm */; };
 		A17191AD2CD2DB090088944E /* WKWebViewLogging.mm in Sources */ = {isa = PBXBuildFile; fileRef = A17191AC2CD2DB090088944E /* WKWebViewLogging.mm */; };
-		A176D24B2D6D2A4E00C63915 /* GPUExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2472D6D295400C63915 /* GPUExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		A176D24C2D6D2A4E00C63915 /* NetworkingExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2482D6D295400C63915 /* NetworkingExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		A176D24D2D6D2A4E00C63915 /* WebContentExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2492D6D295400C63915 /* WebContentExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A176D24B2D6D2A4E00C63915 /* GPUExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2472D6D295400C63915 /* GPUExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A176D24C2D6D2A4E00C63915 /* NetworkingExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2482D6D295400C63915 /* NetworkingExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A176D24D2D6D2A4E00C63915 /* WebContentExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2492D6D295400C63915 /* WebContentExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A1798B7F22431D2B000764BD /* libWebCoreTestSupport.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = A1798B7E22431D2B000764BD /* libWebCoreTestSupport.dylib */; };
 		A1798B8522433647000764BD /* WebProcessPlugInWithInternals.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1798B8422433647000764BD /* WebProcessPlugInWithInternals.mm */; };
 		A17991881E1C994E00A505ED /* SharedBuffer.mm in Sources */ = {isa = PBXBuildFile; fileRef = A17991861E1C994E00A505ED /* SharedBuffer.mm */; };
@@ -2662,6 +2662,8 @@
 		465E2806255B2A690063A787 /* GPUProcess.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = GPUProcess.mm; sourceTree = "<group>"; };
 		466AF38826FE393200CE2EB8 /* ServiceWorkerPagePlugIn.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ServiceWorkerPagePlugIn.mm; sourceTree = "<group>"; };
 		466C3842210637CE006A88DE /* notify-resourceLoadObserver.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "notify-resourceLoadObserver.html"; sourceTree = "<group>"; };
+		466CB9FE2DADC4A200B32457 /* libWTF.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libWTF.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		466CBA072DADC50A00B32457 /* libWTF.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libWTF.a; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS19.0.Internal.sdk/usr/local/lib/libWTF.a; sourceTree = DEVELOPER_DIR; };
 		467C565121B5ECDF0057516D /* GetSessionCookie.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = GetSessionCookie.html; sourceTree = "<group>"; };
 		467C565221B5ECDF0057516D /* SetSessionCookie.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = SetSessionCookie.html; sourceTree = "<group>"; };
 		468BC454226539C800A36C96 /* open-window-then-write-to-it.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "open-window-then-write-to-it.html"; sourceTree = "<group>"; };
@@ -5123,6 +5125,8 @@
 				7B9FC5A928A38F2E007570E7 /* libWebKitIPC.a */,
 				7B9FC5CC28A52DC0007570E7 /* libWebKitPlatform.a */,
 				3A5DDB2028D54269004DA950 /* libwgsl.a */,
+				466CB9FE2DADC4A200B32457 /* libWTF.a */,
+				466CBA072DADC50A00B32457 /* libWTF.a */,
 				7C83E0291D0A5CDF00FEBCF3 /* libWTF.a */,
 				578CBD66204FB2C70083B9F2 /* LocalAuthentication.framework */,
 				516281282325C45400BB7E42 /* PDFKit.framework */,

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -826,15 +826,15 @@ String certDataBase64(""
 
 static RetainPtr<SecCertificateRef> createCertificate()
 {
-    NSData *certData = [[NSData alloc] initWithBase64EncodedString:certDataBase64 options:0];
-    auto cert = adoptCF(SecCertificateCreateWithData(kCFAllocatorDefault, (CFDataRef)certData));
+    RetainPtr certData = adoptNS([[NSData alloc] initWithBase64EncodedString:certDataBase64.createNSString().get() options:0]);
+    auto cert = adoptCF(SecCertificateCreateWithData(kCFAllocatorDefault, (CFDataRef)certData.get()));
     EXPECT_NOT_NULL(cert);
     return cert;
 }
 
 static RetainPtr<SecKeyRef> createPrivateKey()
 {
-    NSData * keyData = [[NSData alloc] initWithBase64EncodedString:privateKeyDataBase64 options:0];
+    RetainPtr keyData = adoptNS([[NSData alloc] initWithBase64EncodedString:privateKeyDataBase64.createNSString().get() options:0]);
 
     NSDictionary *keyAttrs = @{
         (id)kSecAttrKeyType: (id)kSecAttrKeyTypeRSA,
@@ -842,7 +842,7 @@ static RetainPtr<SecKeyRef> createPrivateKey()
         (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPrivate
     };
 
-    auto privateKey = adoptCF(SecKeyCreateWithData((CFDataRef)keyData, (CFDictionaryRef)keyAttrs, NULL));
+    auto privateKey = adoptCF(SecKeyCreateWithData((CFDataRef)keyData.get(), (CFDictionaryRef)keyAttrs, NULL));
     EXPECT_NOT_NULL(privateKey);
     return privateKey;
 }
@@ -1529,13 +1529,13 @@ TEST(IPCSerialization, SecTrustRef)
     NSDictionary *appleCertificatePlist = @{
         @"anchorsOnly" : @(NO),
         @"certificates" : @[
-            [[NSData alloc] initWithBase64EncodedString:cert1 options:0],
-            [[NSData alloc] initWithBase64EncodedString:cert2 options:0]
+            [[NSData alloc] initWithBase64EncodedString:cert1.createNSString().get() options:0],
+            [[NSData alloc] initWithBase64EncodedString:cert2.createNSString().get() options:0]
         ],
         @"chain" : @[
-            [[NSData alloc] initWithBase64EncodedString:chain1 options:0],
-            [[NSData alloc] initWithBase64EncodedString:chain2 options:0],
-            [[NSData alloc] initWithBase64EncodedString:chain3 options:0],
+            [[NSData alloc] initWithBase64EncodedString:chain1.createNSString().get() options:0],
+            [[NSData alloc] initWithBase64EncodedString:chain2.createNSString().get() options:0],
+            [[NSData alloc] initWithBase64EncodedString:chain3.createNSString().get() options:0],
         ],
         @"details" : @[
             @{ },
@@ -1566,10 +1566,10 @@ TEST(IPCSerialization, SecTrustRef)
                     @"DuplicateExtension" : @(YES),
                     @"ExtendedKeyUsage" : @[
                         [NSData new],
-                        [[NSData alloc] initWithBase64EncodedString:extendedKeyUsage1 options:0],
-                        [[NSData alloc] initWithBase64EncodedString:extendedKeyUsage2 options:0],
-                        [[NSData alloc] initWithBase64EncodedString:extendedKeyUsage3 options:0],
-                        [[NSData alloc] initWithBase64EncodedString:extendedKeyUsage4 options:0],
+                        [[NSData alloc] initWithBase64EncodedString:extendedKeyUsage1.createNSString().get() options:0],
+                        [[NSData alloc] initWithBase64EncodedString:extendedKeyUsage2.createNSString().get() options:0],
+                        [[NSData alloc] initWithBase64EncodedString:extendedKeyUsage3.createNSString().get() options:0],
+                        [[NSData alloc] initWithBase64EncodedString:extendedKeyUsage4.createNSString().get() options:0],
                     ],
                     @"GrayListedLeaf" : @(YES),
                     @"IdLinkage" : @(YES),
@@ -1623,7 +1623,7 @@ TEST(IPCSerialization, SecTrustRef)
             [NSData dataWithBytes:"BBBB" length:strlen("BBBB")]
         ],
         @"anchors" : @[
-            [[NSData alloc] initWithBase64EncodedString:cert1 options:0]
+            [[NSData alloc] initWithBase64EncodedString:cert1.createNSString().get() options:0]
         ],
         @"trustedLogs" : @[
             [NSData dataWithBytes:"CCCC" length:strlen("CCCC")]

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/SharedBuffer.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/SharedBuffer.mm
@@ -64,7 +64,7 @@ TEST_F(FragmentedSharedBufferTest, createNSDataArray)
         expectDataArraysEqual(@[ helloData ], SharedBuffer::create(helloData)->createNSDataArray().get());
         expectDataArraysEqual(@[ worldData ], SharedBuffer::create((__bridge CFDataRef)worldData)->createNSDataArray().get());
 
-        expectDataArraysEqual(@[ [NSData dataWithContentsOfFile:tempFilePath()] ], SharedBuffer::createWithContentsOfFile(tempFilePath())->createNSDataArray().get());
+        expectDataArraysEqual(@[ [NSData dataWithContentsOfFile:tempFilePath().createNSString().get()] ], SharedBuffer::createWithContentsOfFile(tempFilePath())->createNSDataArray().get());
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/MediaSessionCoordinatorTest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/MediaSessionCoordinatorTest.mm
@@ -233,7 +233,7 @@ public:
 
     void loadPageAndBecomeReady(const String& pageName)
     {
-        [_webView synchronouslyLoadTestPageNamed:pageName];
+        [_webView synchronouslyLoadTestPageNamed:pageName.createNSString().get()];
 
         bool canplaythrough = false;
         [webView() performAfterReceivingMessage:@"canplaythrough event" action:[&] {
@@ -245,7 +245,7 @@ public:
 
     void runScriptWithUserGesture(const String& script)
     {
-        [_webView objectByEvaluatingJavaScriptWithUserGesture:script];
+        [_webView objectByEvaluatingJavaScriptWithUserGesture:script.createNSString().get()];
     }
 
     void play()
@@ -268,7 +268,7 @@ public:
     {
         for (auto event : events) {
             auto eventMessage = makeString(event, " event"_s);
-            [webView() performAfterReceivingMessage:eventMessage action:[this, eventMessage = WTFMove(eventMessage)] {
+            [webView() performAfterReceivingMessage:eventMessage.createNSString().get() action:[this, eventMessage = WTFMove(eventMessage)] {
                 _eventListenersCalled.add(eventMessage);
             }];
         }
@@ -307,8 +307,9 @@ public:
     {
         for (auto handler : handlers) {
             auto handlerMessage = makeString(handler, suffix);
-            [_messageHandlers addObject:handlerMessage];
-            [webView() performAfterReceivingMessage:handlerMessage action:[this, handlerMessage = WTFMove(handlerMessage)] {
+            RetainPtr nsHandlerMessage = handlerMessage.createNSString();
+            [_messageHandlers addObject:nsHandlerMessage.get()];
+            [webView() performAfterReceivingMessage:nsHandlerMessage.get() action:[this, handlerMessage = WTFMove(handlerMessage)] {
                 _sessionMessagesPosted.add(handlerMessage);
             }];
         }

--- a/Tools/TestWebKitAPI/Tests/WebKit/OverrideAppleLanguagesPreference.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/OverrideAppleLanguagesPreference.mm
@@ -93,7 +93,7 @@ public:
     ~AppleLanguagesTest()
     {
         // Restore previous system language.
-        system([NSString stringWithFormat:@"defaults write NSGlobalDomain AppleLanguages '%@'", (NSString *)m_savedAppleLanguages].UTF8String);
+        system(adoptNS([[NSString alloc] initWithFormat:@"defaults write NSGlobalDomain AppleLanguages '%@'", m_savedAppleLanguages.createNSString().get()]).get().UTF8String);
     }
 
 private:

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
@@ -478,22 +478,22 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<vo
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
     EXPECT_FALSE([lastNavigation _isUserInitiated]);
     EXPECT_TRUE(webView.get().backForwardList.currentItem._wasCreatedByJSWithoutUserInteraction);
-    NSString *expectedURLString = makeString(String(url2.absoluteString), "#a"_s);
-    EXPECT_WK_STREQ([lastNavigation _request].URL.absoluteString.UTF8String, expectedURLString.UTF8String);
+    RetainPtr expectedURLString = makeString(String(url2.absoluteString), "#a"_s).createNSString();
+    EXPECT_WK_STREQ([lastNavigation _request].URL.absoluteString.UTF8String, expectedURLString.get().UTF8String);
 
     navigate(webView.get(), "location.pathname + '#b'"_s);
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
     EXPECT_FALSE([lastNavigation _isUserInitiated]);
     EXPECT_TRUE(webView.get().backForwardList.currentItem._wasCreatedByJSWithoutUserInteraction);
-    expectedURLString = makeString(String(url2.absoluteString), "#b"_s);
-    EXPECT_WK_STREQ([lastNavigation _request].URL.absoluteString.UTF8String, expectedURLString.UTF8String);
+    expectedURLString = makeString(String(url2.absoluteString), "#b"_s).createNSString();
+    EXPECT_WK_STREQ([lastNavigation _request].URL.absoluteString.UTF8String, expectedURLString.get().UTF8String);
 
     navigate(webView.get(), "location.pathname + '#c'"_s);
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
     EXPECT_FALSE([lastNavigation _isUserInitiated]);
     EXPECT_TRUE(webView.get().backForwardList.currentItem._wasCreatedByJSWithoutUserInteraction);
-    expectedURLString = makeString(String(url2.absoluteString), "#c"_s);
-    EXPECT_WK_STREQ([lastNavigation _request].URL.absoluteString.UTF8String, expectedURLString.UTF8String);
+    expectedURLString = makeString(String(url2.absoluteString), "#c"_s).createNSString();
+    EXPECT_WK_STREQ([lastNavigation _request].URL.absoluteString.UTF8String, expectedURLString.get().UTF8String);
 
     [webView loadRequest:[NSURLRequest requestWithURL:url3]];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
@@ -507,8 +507,8 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<vo
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
     // We should go back to url2#c.
-    expectedURLString = makeString(String(url2.absoluteString), "#c"_s);
-    EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.UTF8String);
+    expectedURLString = makeString(String(url2.absoluteString), "#c"_s).createNSString();
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
     EXPECT_EQ([webView backForwardList].backList.count, 4U);
     EXPECT_EQ([webView backForwardList].forwardList.count, 1U);
 
@@ -526,8 +526,8 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<vo
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
     // We should get to the latest url2 URL, that is url2#c.
-    expectedURLString = makeString(String(url2.absoluteString), "#c"_s);
-    EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.UTF8String);
+    expectedURLString = makeString(String(url2.absoluteString), "#c"_s).createNSString();
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
     EXPECT_EQ([webView backForwardList].backList.count, 4U);
     EXPECT_EQ([webView backForwardList].forwardList.count, 1U);
 
@@ -544,15 +544,15 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<vo
     [webView _evaluateJavaScriptWithoutUserGesture:@"history.back();" completionHandler:^(id, NSError *) { }];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
-    expectedURLString = makeString(String(url2.absoluteString), "#c"_s);
-    EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.UTF8String);
+    expectedURLString = makeString(String(url2.absoluteString), "#c"_s).createNSString();
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
     EXPECT_EQ([webView backForwardList].backList.count, 4U);
     EXPECT_EQ([webView backForwardList].forwardList.count, 1U);
 
     [webView _evaluateJavaScriptWithoutUserGesture:@"history.back();" completionHandler:^(id, NSError *) { }];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
-    expectedURLString = makeString(String(url2.absoluteString), "#b"_s);
-    EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.UTF8String);
+    expectedURLString = makeString(String(url2.absoluteString), "#b"_s).createNSString();
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
     EXPECT_EQ([webView backForwardList].backList.count, 3U);
     EXPECT_EQ([webView backForwardList].forwardList.count, 2U);
 }
@@ -560,14 +560,14 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<vo
 TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGesturePushState)
 {
     runBackForwardNavigationSkipsItemsWithoutUserGestureTest([](WKWebView* webView, ASCIILiteral destination) {
-        [webView _evaluateJavaScriptWithoutUserGesture:makeString("history.pushState(null, document.title, "_s, destination, ");"_s) completionHandler:nil];
+        [webView _evaluateJavaScriptWithoutUserGesture:makeString("history.pushState(null, document.title, "_s, destination, ");"_s).createNSString().get() completionHandler:nil];
     });
 }
 
 TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGestureFragment)
 {
     runBackForwardNavigationSkipsItemsWithoutUserGestureTest([](WKWebView* webView, ASCIILiteral destination) {
-        [webView _evaluateJavaScriptWithoutUserGesture:makeString("location.href = "_s, destination, ";"_s) completionHandler:nil];
+        [webView _evaluateJavaScriptWithoutUserGesture:makeString("location.href = "_s, destination, ";"_s).createNSString().get() completionHandler:nil];
     });
 }
 
@@ -581,7 +581,7 @@ TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGesturePushSta
             didRunScript = true;
         }];
         TestWebKitAPI::Util::run(&didRunScript);
-        [webView _evaluateJavaScriptWithoutUserGesture:makeString("history.pushState(null, document.title, "_s, destination, ");"_s) completionHandler:nil];
+        [webView _evaluateJavaScriptWithoutUserGesture:makeString("history.pushState(null, document.title, "_s, destination, ");"_s).createNSString().get() completionHandler:nil];
     });
 }
 
@@ -689,8 +689,8 @@ static void runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest(Function
     // Add back/forward list items without user gestures.
     navigate(webView.get(), "#a"_s);
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
-    NSString *expectedURLString = makeString(String(url2.absoluteString), "#a"_s);
-    EXPECT_WK_STREQ([lastNavigation _request].URL.absoluteString.UTF8String, expectedURLString.UTF8String);
+    RetainPtr expectedURLString = makeString(String(url2.absoluteString), "#a"_s).createNSString();
+    EXPECT_WK_STREQ([lastNavigation _request].URL.absoluteString.UTF8String, expectedURLString.get().UTF8String);
 
     auto* lastURL = [webView URL];
     EXPECT_FALSE([lastURL isEqual:url2]);
@@ -715,8 +715,8 @@ static void runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest(Function
 
     [webView goForward];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
-    expectedURLString = makeString(String(url2.absoluteString), "#a"_s);
-    EXPECT_WK_STREQ([lastNavigation _request].URL.absoluteString.UTF8String, expectedURLString.UTF8String);
+    expectedURLString = makeString(String(url2.absoluteString), "#a"_s).createNSString();
+    EXPECT_WK_STREQ([lastNavigation _request].URL.absoluteString.UTF8String, expectedURLString.get().UTF8String);
 
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, lastURL.absoluteString.UTF8String);
 }
@@ -724,14 +724,14 @@ static void runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest(Function
 TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsWithUserGesturePushState)
 {
     runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest([](WKWebView *webView, ASCIILiteral fragment) {
-        [webView evaluateJavaScript:makeString("history.pushState(null, document.title, location.pathname + '"_s, fragment, "');"_s) completionHandler:nil];
+        [webView evaluateJavaScript:makeString("history.pushState(null, document.title, location.pathname + '"_s, fragment, "');"_s).createNSString().get() completionHandler:nil];
     });
 }
 
 TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsWithUserGestureFragment)
 {
     runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest([](WKWebView *webView, ASCIILiteral fragment) {
-        [webView evaluateJavaScript:makeString("location.href = location.pathname + '"_s, fragment, "';"_s) completionHandler:nil];
+        [webView evaluateJavaScript:makeString("location.href = location.pathname + '"_s, fragment, "';"_s).createNSString().get() completionHandler:nil];
     });
 }
 
@@ -739,7 +739,7 @@ TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsFromLoadRequest)
 {
     runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest([](WKWebView *webView, ASCIILiteral fragment) {
         auto newURLString = makeString(String([webView URL].absoluteString), fragment);
-        [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:(NSString *)newURLString]]];
+        [webView loadRequest:adoptNS([[NSURLRequest alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:newURLString.createNSString().get()]).get()]).get()];
     });
 }
 
@@ -747,7 +747,7 @@ TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsWithRecentUserGestu
 {
     runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest([](WKWebView *webView, ASCIILiteral fragment) {
         // Call pushState() in a setTimeout() so that it has a recent user gesture but not a current one.
-        [webView evaluateJavaScript:makeString("setTimeout(() => { history.pushState(null, document.title, location.pathname + '"_s, fragment, "'); }, 0);"_s) completionHandler:nil];
+        [webView evaluateJavaScript:makeString("setTimeout(() => { history.pushState(null, document.title, location.pathname + '"_s, fragment, "'); }, 0);"_s).createNSString().get() completionHandler:nil];
     });
 }
 
@@ -755,7 +755,7 @@ TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsWithRecentUserGestu
 {
     runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest([](WKWebView *webView, ASCIILiteral fragment) {
         // Do fragment navigation in a setTimeout() so that it has a recent user gesture but not a current one.
-        [webView evaluateJavaScript:makeString("setTimeout(() => { location.href = location.pathname + '"_s, fragment, "'; }, 0);"_s) completionHandler:nil];
+        [webView evaluateJavaScript:makeString("setTimeout(() => { location.href = location.pathname + '"_s, fragment, "'; }, 0);"_s).createNSString().get() completionHandler:nil];
     });
 }
 
@@ -776,8 +776,8 @@ TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipUpdatedItemWithRecentUse
     [navigationDelegate waitForDidFinishNavigation];
 
     // Page navigated to #fragment before the load event.
-    NSString *expectedURLString = makeString(String(url2.absoluteString), "#fragment"_s);
-    EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.UTF8String);
+    RetainPtr expectedURLString = makeString(String(url2.absoluteString), "#fragment"_s).createNSString();
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
 
     // Navigate with a user gesture.
     [webView evaluateJavaScript:@"location.href = location.pathname + '#otherFragment';" completionHandler:nil];
@@ -787,7 +787,7 @@ TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipUpdatedItemWithRecentUse
     [webView goBack];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
-    EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.UTF8String);
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
 }
 
 TEST(WKBackForwardList, BackNavigationHijacking)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CookiePrivateBrowsing.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CookiePrivateBrowsing.mm
@@ -146,7 +146,7 @@ TEST(WebKit, CookieCachePruning)
     auto view = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     for (unsigned i = 0; i < 100; ++i) {
-        [view synchronouslyLoadHTMLString:@"foo" baseURL:[NSURL URLWithString:makeString("http://foo"_s, i, ".example.com/"_s)]];
+        [view synchronouslyLoadHTMLString:@"foo" baseURL:adoptNS([[NSURL alloc] initWithString:makeString("http://foo"_s, i, ".example.com/"_s).createNSString().get()]).get()];
 
         __block bool doneEvaluatingJavaScript = false;
         [view evaluateJavaScript:@"document.cookie;" completionHandler:^(id _Nullable cookie, NSError * _Nullable error) {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm
@@ -897,7 +897,7 @@ TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_LimitContextToEdi
             "  <p style='font-size:500px;'>hello world</p>"
             "  <input style='position: absolute; top: 100px; left: 100px;' value='foo' />"
             "</body>"_s
-        })];
+        }.createNSString().get())];
         [webView stringByEvaluatingJavaScript:@"document.querySelector('input').focus()"];
         [webView stringByEvaluatingJavaScript:@"document.querySelector('input').select()"];
 
@@ -924,7 +924,7 @@ TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_LimitContextToVis
         "        getSelection().selectAllChildren(document.getElementById('target'));"
         "    </script>"
         "</body>"_s
-    })];
+    }.createNSString().get())];
 
     auto trimmedComponentsSeparatedByNewlines = [](const String& string) {
         auto components = string.split('\n');
@@ -1572,7 +1572,7 @@ TEST(DocumentEditingContext, CharacterRectsInEditableWebView)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 320, 568)]);
     [webView _setEditable:YES];
-    [webView synchronouslyLoadHTMLString:makeString("<meta name='viewport' content='width=device-width, initial-scale=1'><body>"_s, longTextString, "</body>"_s)];
+    [webView synchronouslyLoadHTMLString:makeString("<meta name='viewport' content='width=device-width, initial-scale=1'><body>"_s, longTextString, "</body>"_s).createNSString().get()];
     [webView objectByEvaluatingJavaScript:@"getSelection().setPosition(document.body, 0)"];
     [webView waitForNextPresentationUpdate];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
@@ -118,7 +118,7 @@ IGNORE_WARNINGS_END
     EXPECT_TRUE(!_destinationPath.isEmpty());
 
     *allowOverwrite = YES;
-    return _destinationPath;
+    return _destinationPath.createNSString().autorelease();
 }
 
 - (void)_downloadDidFinish:(_WKDownload *)download
@@ -126,7 +126,7 @@ IGNORE_WARNINGS_END
     EXPECT_EQ(_download, download);
     EXPECT_EQ(expectedUserInitiatedState, download.wasUserInitiated);
     EXPECT_TRUE(_expectedContentLength == NSURLResponseUnknownLength || static_cast<uint64_t>(_expectedContentLength) == _receivedContentLength);
-    EXPECT_TRUE([[NSFileManager defaultManager] contentsEqualAtPath:_destinationPath andPath:[sourceURL path]]);
+    EXPECT_TRUE([[NSFileManager defaultManager] contentsEqualAtPath:_destinationPath.createNSString().get() andPath:[sourceURL path]]);
     FileSystem::deleteFile(_destinationPath);
     isDone = true;
 }
@@ -422,7 +422,7 @@ IGNORE_WARNINGS_END
     EXPECT_TRUE(!_destinationPath.isEmpty());
 
     *allowOverwrite = YES;
-    return _destinationPath;
+    return _destinationPath.createNSString().autorelease();
 }
 
 - (void)_downloadDidFinish:(_WKDownload *)download
@@ -432,7 +432,7 @@ IGNORE_WARNINGS_END
     EXPECT_TRUE(_expectedContentLength == NSURLResponseUnknownLength || static_cast<uint64_t>(_expectedContentLength) == _receivedContentLength);
     NSString* expectedContent = @"{\"x\":42,\"s\":\"hello, world\"}";
     NSData* expectedData = [expectedContent dataUsingEncoding:NSUTF8StringEncoding];
-    EXPECT_TRUE([[[NSFileManager defaultManager] contentsAtPath:_destinationPath] isEqualToData:expectedData]);
+    EXPECT_TRUE([[[NSFileManager defaultManager] contentsAtPath:_destinationPath.createNSString().get()] isEqualToData:expectedData]);
     FileSystem::deleteFile(_destinationPath);
     isDone = true;
 }
@@ -479,7 +479,7 @@ IGNORE_WARNINGS_END
     _destinationPath = FileSystem::createTemporaryFile("TestWebKitAPI"_s);
     EXPECT_TRUE(!_destinationPath.isEmpty());
     *allowOverwrite = YES;
-    return _destinationPath;
+    return _destinationPath.createNSString().autorelease();
 }
 
 - (void)_download:(_WKDownload *)download didReceiveServerRedirectToURL:(NSURL *)url
@@ -652,7 +652,7 @@ TEST(_WKDownload, DownloadCanceledWhileDecidingDestination)
     _destinationPath = FileSystem::createTemporaryFile(String { filename });
     EXPECT_TRUE(!_destinationPath.isEmpty());
 
-    completionHandler(YES, _destinationPath);
+    completionHandler(YES, _destinationPath.createNSString().get());
 }
 
 - (void)_downloadDidFinish:(_WKDownload *)download
@@ -1126,7 +1126,7 @@ TEST(WebKit, DownloadNavigationResponseFromMemoryCache)
 
 - (void)download:(WKDownload *)download decideDestinationUsingResponse:(NSURLResponse *)response suggestedFilename:(NSString *)suggestedFilename completionHandler:(void (^)(NSURL *destination))completionHandler
 {
-    _path = FileSystem::createTemporaryFile("TestWebKitAPI"_s);
+    _path = FileSystem::createTemporaryFile("TestWebKitAPI"_s).createNSString().get();
     EXPECT_TRUE(_path && [_path.get() length]);
     FileSystem::deleteFile(String(_path.get()));
 
@@ -2008,7 +2008,7 @@ TEST(WKDownload, ResumeWithExtraInitialDataOnDisk)
         NSError *error = nil;
         [[NSFileManager defaultManager] removeItemAtURL:expectedDownloadFile error:&error];
         EXPECT_NULL(error);
-        EXPECT_TRUE([[(NSString *)makeString(longString<3000>('b'), longString<2000>('c')) dataUsingEncoding:NSUTF8StringEncoding] writeToURL:expectedDownloadFile atomically:YES]);
+        EXPECT_TRUE([[makeString(longString<3000>('b'), longString<2000>('c')).createNSString() dataUsingEncoding:NSUTF8StringEncoding] writeToURL:expectedDownloadFile atomically:YES]);
     });
 
     checkFileContents(expectedDownloadFile, makeString(longString<3000>('b'), longString<2000>('c'), longString<5000>('d')));

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DownloadProgress.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DownloadProgress.mm
@@ -388,7 +388,7 @@ static void* progressObservingContext = &progressObservingContext;
 {
     EXPECT_EQ(download, m_download.get());
 
-    RetainPtr<NSString> path = (NSString *)FileSystem::createTemporaryFile("TestWebKitAPI"_s);
+    RetainPtr path = FileSystem::createTemporaryFile("TestWebKitAPI"_s).createNSString();
     EXPECT_TRUE(path && [path.get() length]);
 
     completionHandler(YES, path.get());

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/HistoryDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/HistoryDelegate.mm
@@ -80,8 +80,8 @@ TEST(HistoryDelegate, NonpersistentDataStoreDoesNotSendHistoryEvents)
     [webView _setHistoryDelegate:historyDelegate.get()];
 
     auto mainURL = makeString("http://localhost:"_s, server.port(), "/"_s);
-    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:mainURL]];
-    [webView loadRequest:request];
+    RetainPtr request = adoptNS([[NSURLRequest alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:mainURL.createNSString().get()]).get()]);
+    [webView loadRequest:request.get()];
     [webView _test_waitForDidFinishNavigation];
     TestWebKitAPI::Util::spinRunLoop();
 
@@ -107,23 +107,23 @@ TEST(HistoryDelegate, NonpersistentDataStoreSendsHistoryEventsWhenAllowingPrivac
     [webView _setHistoryDelegate:historyDelegate.get()];
 
     auto mainURL = makeString("http://localhost:"_s, server.port(), "/"_s);
-    auto url = [NSURL URLWithString:mainURL];
-    NSURLRequest *request = [NSURLRequest requestWithURL:url];
-    [webView loadRequest:request];
+    RetainPtr url = adoptNS([[NSURL alloc] initWithString:mainURL.createNSString().get()]);
+    RetainPtr request = adoptNS([[NSURLRequest alloc] initWithURL:url.get()]);
+    [webView loadRequest:request.get()];
 
     TestWebKitAPI::Util::waitFor([&] {
         return historyDelegate->lastNavigationData && historyDelegate->lastUpdatedTitle;
     });
 
-    EXPECT_NS_EQUAL([historyDelegate->lastNavigationData originalRequest], request);
-    EXPECT_NS_EQUAL([historyDelegate->lastNavigationData originalRequest].URL, url);
+    EXPECT_NS_EQUAL([historyDelegate->lastNavigationData originalRequest], request.get());
+    EXPECT_NS_EQUAL([historyDelegate->lastNavigationData originalRequest].URL, url.get());
     EXPECT_NS_EQUAL(historyDelegate->lastUpdatedTitle.get(), @"Page Title");
 
     auto sourceURL = makeString("http://localhost:"_s, server.port(), "/server_redirect_source"_s);
     auto destinationURL = makeString("http://localhost:"_s, server.port(), "/server_redirect_destination"_s);
-    url = [NSURL URLWithString:sourceURL];
-    request = [NSURLRequest requestWithURL:url];
-    [webView loadRequest:request];
+    url = adoptNS([[NSURL alloc] initWithString:sourceURL.createNSString().get()]);
+    request = adoptNS([[NSURLRequest alloc] initWithURL:url.get()]);
+    [webView loadRequest:request.get()];
     [webView _test_waitForDidFinishNavigation];
     TestWebKitAPI::Util::spinRunLoop();
 
@@ -152,23 +152,23 @@ TEST(HistoryDelegate, PersistentDataStoreSendsHistoryEvents)
     [webView _setHistoryDelegate:historyDelegate.get()];
 
     auto mainURL = makeString("http://localhost:"_s, server.port(), "/"_s);
-    auto url = [NSURL URLWithString:mainURL];
-    NSURLRequest *request = [NSURLRequest requestWithURL:url];
-    [webView loadRequest:request];
+    RetainPtr url = adoptNS([[NSURL alloc] initWithString:mainURL.createNSString().get()]);
+    RetainPtr request = adoptNS([[NSURLRequest alloc] initWithURL:url.get()]);
+    [webView loadRequest:request.get()];
 
     TestWebKitAPI::Util::waitFor([&] {
         return historyDelegate->lastNavigationData && historyDelegate->lastUpdatedTitle;
     });
 
-    EXPECT_NS_EQUAL([historyDelegate->lastNavigationData originalRequest], request);
-    EXPECT_NS_EQUAL([historyDelegate->lastNavigationData originalRequest].URL, url);
+    EXPECT_NS_EQUAL([historyDelegate->lastNavigationData originalRequest], request.get());
+    EXPECT_NS_EQUAL([historyDelegate->lastNavigationData originalRequest].URL, url.get());
     EXPECT_NS_EQUAL(historyDelegate->lastUpdatedTitle.get(), @"Page Title");
 
     auto sourceURL = makeString("http://localhost:"_s, server.port(), "/server_redirect_source"_s);
     auto destinationURL = makeString("http://localhost:"_s, server.port(), "/server_redirect_destination"_s);
-    url = [NSURL URLWithString:sourceURL];
-    request = [NSURLRequest requestWithURL:url];
-    [webView loadRequest:request];
+    url = adoptNS([[NSURL alloc] initWithString:sourceURL.createNSString().get()]);
+    request = adoptNS([[NSURLRequest alloc] initWithURL:url.get()]);
+    [webView loadRequest:request.get()];
     [webView _test_waitForDidFinishNavigation];
     TestWebKitAPI::Util::spinRunLoop();
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBCheckpointWAL.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBCheckpointWAL.mm
@@ -101,7 +101,7 @@ TEST(IndexedDB, CheckpointsWALAutomatically)
     TestWebKitAPI::Util::run(&done);
     RetainPtr indexedDBDirectory = [NSURL fileURLWithPath:indexedDBDirectoryString.get() isDirectory:YES];
     String databaseHash = WebCore::SQLiteFileSystem::computeHashForFileName("test-wal-checkpoint"_s);
-    RetainPtr indexedDBDatabaseDirectory = [indexedDBDirectory URLByAppendingPathComponent:databaseHash];
+    RetainPtr indexedDBDatabaseDirectory = [indexedDBDirectory URLByAppendingPathComponent:databaseHash.createNSString().get()];
     RetainPtr indexedDBDatabaseFile = [indexedDBDatabaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3"];
     RetainPtr indexedDBDatabaseWAL = [indexedDBDatabaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3-wal"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBIndexUpgradeToV2.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBIndexUpgradeToV2.mm
@@ -63,9 +63,9 @@ TEST(IndexedDB, IndexUpgradeToV2)
     NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"IndexUpgrade" withExtension:@"sqlite3"];
     NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"IndexUpgrade" withExtension:@"blob"];
 
-    NSString *hash = WebCore::SQLiteFileSystem::computeHashForFileName("index-upgrade-test"_s);
+    RetainPtr hash = WebCore::SQLiteFileSystem::computeHashForFileName("index-upgrade-test"_s).createNSString();
     NSString *originDirectory = @"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/WebsiteData/IndexedDB/v1/file__0/";
-    NSString *databaseDirectory = [[originDirectory stringByAppendingString:hash] stringByExpandingTildeInPath];
+    NSString *databaseDirectory = [[originDirectory stringByAppendingString:hash.get()] stringByExpandingTildeInPath];
     NSURL *targetURL = [NSURL fileURLWithPath:databaseDirectory];
     [[NSFileManager defaultManager] removeItemAtURL:targetURL error:nil];
     [[NSFileManager defaultManager] createDirectoryAtURL:targetURL withIntermediateDirectories:YES attributes:nil error:nil];
@@ -99,7 +99,7 @@ static void runMultipleIndicesTestWithDatabase(NSString* databaseName)
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
-    RetainPtr databaseDirectory = [[NSURL fileURLWithPath:originDirectoryString.get() isDirectory:YES] URLByAppendingPathComponent:hash];
+    RetainPtr databaseDirectory = [[NSURL fileURLWithPath:originDirectoryString.get() isDirectory:YES] URLByAppendingPathComponent:hash.createNSString().get()];
     [[NSFileManager defaultManager] removeItemAtURL:databaseDirectory.get() error:nil];
     [[NSFileManager defaultManager] createDirectoryAtURL:databaseDirectory.get() withIntermediateDirectories:YES attributes:nil error:nil];
     [[NSFileManager defaultManager] copyItemAtURL:url.get() toURL:[databaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3"] error:nil];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBObjectStoreInfoUpgradeToV2.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBObjectStoreInfoUpgradeToV2.mm
@@ -61,9 +61,9 @@ TEST(IndexedDB, IDBObjectStoreInfoUpgradeToV2)
     // Copy database files with old ObjectStoreInfo schema to the database directory.
     NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"IDBObjectStoreInfoUpgrade" withExtension:@"sqlite3"];
 
-    NSString *hash = WebCore::SQLiteFileSystem::computeHashForFileName("objectstoreinfo-upgrade-test"_s);
+    RetainPtr hash = WebCore::SQLiteFileSystem::computeHashForFileName("objectstoreinfo-upgrade-test"_s).createNSString();
     NSString *originDirectory = @"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/WebsiteData/IndexedDB/v1/file__0/";
-    NSString *databaseDirectory = [[originDirectory stringByAppendingString:hash] stringByExpandingTildeInPath];
+    NSString *databaseDirectory = [[originDirectory stringByAppendingString:hash.get()] stringByExpandingTildeInPath];
     NSURL *targetURL = [NSURL fileURLWithPath:databaseDirectory];
     [[NSFileManager defaultManager] removeItemAtURL:targetURL error:nil];
     [[NSFileManager defaultManager] createDirectoryAtURL:targetURL withIntermediateDirectories:YES attributes:nil error:nil];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IconLoadingDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IconLoadingDelegate.mm
@@ -110,8 +110,8 @@ TEST(IconLoading, DefaultFavicon)
     webView.get()._iconLoadingDelegate = iconDelegate.get();
 
     auto mainURL = makeString("http://localhost:"_s, server.port(), "/"_s);
-    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:mainURL]];
-    [webView loadRequest:request];
+    RetainPtr request = adoptNS([[NSURLRequest alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:mainURL.createNSString().get()]).get()]);
+    [webView loadRequest:request.get()];
 
     TestWebKitAPI::Util::run(&doneWithIcons);
     TestWebKitAPI::Util::run(&iconDelegate.get()->receivedFaviconDataCallback);
@@ -151,8 +151,8 @@ TEST(IconLoading, AlreadyCachedIcon)
     webView.get()._iconLoadingDelegate = iconDelegate.get();
 
     auto mainURL = makeString("http://localhost:"_s, server.port(), "/"_s);
-    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:mainURL]];
-    [webView loadRequest:request];
+    RetainPtr request = adoptNS([[NSURLRequest alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:mainURL.createNSString().get()]).get()]);
+    [webView loadRequest:request.get()];
 
     TestWebKitAPI::Util::run(&iconDelegate.get()->receivedFaviconDataCallback);
 
@@ -162,8 +162,8 @@ TEST(IconLoading, AlreadyCachedIcon)
     iconDelegate.get()->receivedFaviconData = nil;
 
     // Load another main resource that results in the same icon being loaded (which should come from the memory cache).
-    request = [NSURLRequest requestWithURL:[NSURL URLWithString:makeString(mainURL, "main"_s)]];
-    [webView loadRequest:request];
+    request = adoptNS([[NSURLRequest alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:makeString(mainURL, "main"_s).createNSString().get()]).get()]);
+    [webView loadRequest:request.get()];
 
     TestWebKitAPI::Util::run(&iconDelegate.get()->receivedFaviconDataCallback);
 
@@ -187,8 +187,8 @@ TEST(IconLoading, IconLoadCancelledCallback)
     webView.get()._iconLoadingDelegate = iconDelegate.get();
 
     auto mainURL = makeString("http://localhost:"_s, server.port(), "/"_s);
-    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:mainURL]];
-    [webView loadRequest:request];
+    RetainPtr request = adoptNS([[NSURLRequest alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:mainURL.createNSString().get()]).get()]);
+    [webView loadRequest:request.get()];
 
     TestWebKitAPI::Util::run(&doneWithIcons);
 
@@ -216,8 +216,8 @@ TEST(IconLoading, IconLoadCancelledCallback2)
     webView.get()._iconLoadingDelegate = iconDelegate.get();
 
     auto mainURL = makeString("http://localhost:"_s, server.port(), "/"_s);
-    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:mainURL]];
-    [webView loadRequest:request];
+    RetainPtr request = adoptNS([[NSURLRequest alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:mainURL.createNSString().get()]).get()]);
+    [webView loadRequest:request.get()];
 
     TestWebKitAPI::Util::run(&iconDelegate.get()->didSaveCallback);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ImageAnalysisTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ImageAnalysisTests.mm
@@ -362,7 +362,7 @@ static void invokeRemoveBackgroundAction(TestWKWebView *webView)
 
     auto menuBuilder = adoptNS([[TestUIMenuBuilder alloc] init]);
     [webView buildMenuWithBuilder:menuBuilder.get()];
-    [[menuBuilder actionWithTitle:WebCore::contextMenuItemTitleRemoveBackground()] performWithSender:nil target:nil];
+    [[menuBuilder actionWithTitle:WebCore::contextMenuItemTitleRemoveBackground().createNSString().get()] performWithSender:nil target:nil];
     [webView waitForNextPresentationUpdate];
 }
 
@@ -379,7 +379,7 @@ TEST(ImageAnalysisTests, RemoveBackgroundUsingContextMenu)
 
     auto menuBuilder = adoptNS([[TestUIMenuBuilder alloc] init]);
     [webView buildMenuWithBuilder:menuBuilder.get()];
-    EXPECT_NOT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTitleRemoveBackground()]);
+    EXPECT_NOT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTitleRemoveBackground().createNSString().get()]);
 }
 
 TEST(ImageAnalysisTests, MenuControllerItems)
@@ -402,7 +402,7 @@ TEST(ImageAnalysisTests, MenuControllerItems)
 
     auto menuBuilder = adoptNS([[TestUIMenuBuilder alloc] init]);
     [webView buildMenuWithBuilder:menuBuilder.get()];
-    EXPECT_NOT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTitleRemoveBackground()]);
+    EXPECT_NOT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTitleRemoveBackground().createNSString().get()]);
 
     [webView selectAll:nil];
     [webView waitForNextPresentationUpdate];
@@ -410,7 +410,7 @@ TEST(ImageAnalysisTests, MenuControllerItems)
 
     [menuBuilder reset];
     [webView buildMenuWithBuilder:menuBuilder.get()];
-    EXPECT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTitleRemoveBackground()]);
+    EXPECT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTitleRemoveBackground().createNSString().get()]);
 
     [webView objectByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(document.body, 0, image.parentNode, nodeIndex + 1);"];
     [webView waitForNextPresentationUpdate];
@@ -418,7 +418,7 @@ TEST(ImageAnalysisTests, MenuControllerItems)
 
     [menuBuilder reset];
     [webView buildMenuWithBuilder:menuBuilder.get()];
-    EXPECT_NOT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTitleRemoveBackground()]);
+    EXPECT_NOT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTitleRemoveBackground().createNSString().get()]);
 }
 
 static RetainPtr<TestWKWebView> runMarkupTest(NSString *testPage, NSString *scriptToSelectText, Function<void(TestWKWebView *, NSString *)>&& checkWebView = { })
@@ -483,7 +483,7 @@ TEST(ImageAnalysisTests, AllowRemoveBackgroundOnce)
     auto menuBuilder = adoptNS([TestUIMenuBuilder new]);
     [webView buildMenuWithBuilder:menuBuilder.get()];
 
-    EXPECT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTitleRemoveBackground()]);
+    EXPECT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTitleRemoveBackground().createNSString().get()]);
 }
 
 #endif // ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS) && PLATFORM(IOS_FAMILY)
@@ -506,7 +506,7 @@ TEST(ImageAnalysisTests, RemoveBackgroundItemInServicesMenu)
     RetainPtr timer = [NSTimer timerWithTimeInterval:0.1 repeats:YES block:^(NSTimer *) {
         NSMenu *menu = [webView _activeMenu];
         for (NSMenuItem *item in menu.itemArray) {
-            if ([item.title isEqualToString:WebCore::contextMenuItemTitleRemoveBackground()]) {
+            if ([item.title isEqualToString:WebCore::contextMenuItemTitleRemoveBackground().createNSString().get()]) {
                 foundRemoveBackgroundItem = true;
                 [menu cancelTracking];
                 break;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBFileName.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBFileName.mm
@@ -83,24 +83,24 @@ static void runTest()
     NSString *existingDatabaseName = @"IndexedDBTest";
     NSString *createdDatabaseName = @"IndexedDBOther";
     NSString *unusedDatabaseName = @"IndexedDBUnused";
-    NSString *existingDatbaseHash = WebCore::SQLiteFileSystem::computeHashForFileName(String { existingDatabaseName });
-    NSString *createdDatabaseHash = WebCore::SQLiteFileSystem::computeHashForFileName(String { createdDatabaseName });
-    NSString *unusedDatabaseHash = WebCore::SQLiteFileSystem::computeHashForFileName(String { createdDatabaseName });
+    RetainPtr existingDatbaseHash = WebCore::SQLiteFileSystem::computeHashForFileName(String { existingDatabaseName }).createNSString();
+    RetainPtr createdDatabaseHash = WebCore::SQLiteFileSystem::computeHashForFileName(String { createdDatabaseName }).createNSString();
+    RetainPtr unusedDatabaseHash = WebCore::SQLiteFileSystem::computeHashForFileName(String { createdDatabaseName }).createNSString();
     NSURL *idbRootURL = [websiteDataStoreConfiguration.get() _indexedDBDatabaseDirectory];
     NSURL *oldVersionDirectoryURL = [idbRootURL URLByAppendingPathComponent:@"v0"];
     NSURL *newVersionDirectoryURL = [idbRootURL URLByAppendingPathComponent:@"v1"];
     NSURL *oldVersionOriginDirectoryURL = [oldVersionDirectoryURL URLByAppendingPathComponent: @"file__0"];
     NSURL *newVersionOriginDirectoryURL = [newVersionDirectoryURL URLByAppendingPathComponent: @"file__0"];
     NSURL *oldVersionUnusedDatabaseDirectoryURL = [oldVersionOriginDirectoryURL URLByAppendingPathComponent:unusedDatabaseName];
-    NSURL *newVersionUnusedDatabaseDirectoryURL = [newVersionOriginDirectoryURL URLByAppendingPathComponent:unusedDatabaseHash];
+    NSURL *newVersionUnusedDatabaseDirectoryURL = [newVersionOriginDirectoryURL URLByAppendingPathComponent:unusedDatabaseHash.get()];
     EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:oldVersionUnusedDatabaseDirectoryURL.path]);
     EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:newVersionUnusedDatabaseDirectoryURL.path]);
     
     // For database that is opened after upgrade, its file should only be in v1.
     NSURL *oldVersionExistingDatabaseDirectoryURL = [oldVersionOriginDirectoryURL URLByAppendingPathComponent: existingDatabaseName];
-    NSURL *newVersionExistingDatabaseDirectoryURL = [newVersionOriginDirectoryURL URLByAppendingPathComponent: existingDatbaseHash];
+    NSURL *newVersionExistingDatabaseDirectoryURL = [newVersionOriginDirectoryURL URLByAppendingPathComponent: existingDatbaseHash.get()];
     NSURL *oldVersionCreatedDatabaseDirectoryURL = [oldVersionOriginDirectoryURL URLByAppendingPathComponent: createdDatabaseName];
-    NSURL *newVersionCreatedDatabaseDirectoryURL = [newVersionOriginDirectoryURL URLByAppendingPathComponent: createdDatabaseHash];
+    NSURL *newVersionCreatedDatabaseDirectoryURL = [newVersionOriginDirectoryURL URLByAppendingPathComponent: createdDatabaseHash.get()];
     EXPECT_FALSE([defaultFileManager fileExistsAtPath:oldVersionExistingDatabaseDirectoryURL.path]);
     EXPECT_TRUE([defaultFileManager fileExistsAtPath:newVersionExistingDatabaseDirectoryURL.path]);
     EXPECT_FALSE([defaultFileManager fileExistsAtPath:oldVersionCreatedDatabaseDirectoryURL.path]);
@@ -168,7 +168,7 @@ static void createDirectories(StringView testName)
         return;
 
     [defaultFileManager removeItemAtURL:existingDatabaseDirectoryURL.get() error:nil];
-    RetainPtr v1ExistingDatabaseDirectoryURL = [NSURL fileURLWithPath:[NSString pathWithComponents:@[idbRootURL.get().path, newVersion.get(), fileOrigin.get(), existingDatabaseHash]]];
+    RetainPtr v1ExistingDatabaseDirectoryURL = [NSURL fileURLWithPath:[NSString pathWithComponents:@[idbRootURL.get().path, newVersion.get(), fileOrigin.get(), existingDatabaseHash.createNSString().get()]]];
     [defaultFileManager createDirectoryAtURL:v1ExistingDatabaseDirectoryURL.get() withIntermediateDirectories:YES attributes:nil error:&error];
     EXPECT_NULL(error);
     [defaultFileManager copyItemAtURL:resourceDatabaseFileURL.get() toURL:[v1ExistingDatabaseDirectoryURL URLByAppendingPathComponent:@"IndexedDB.sqlite3"] error:&error];
@@ -181,7 +181,7 @@ static void createDirectories(StringView testName)
     EXPECT_NULL(error);
     [defaultFileManager copyItemAtURL:resourceDatabaseFileURL.get() toURL:[appleDatabaseDirectoryURL URLByAppendingPathComponent:@"IndexedDB.sqlite3"] error:&error];
     EXPECT_NULL(error);
-    RetainPtr v1WebKitOriginDatabaseDirectoryURL = [NSURL fileURLWithPath:[NSString pathWithComponents:@[idbRootURL.get().path, newVersion.get(), @"https_webkit.org_0", existingDatabaseHash]]];
+    RetainPtr v1WebKitOriginDatabaseDirectoryURL = [NSURL fileURLWithPath:[NSString pathWithComponents:@[idbRootURL.get().path, newVersion.get(), @"https_webkit.org_0", existingDatabaseHash.createNSString().get()]]];
     [defaultFileManager createDirectoryAtURL:v1WebKitOriginDatabaseDirectoryURL.get() withIntermediateDirectories:YES attributes:nil error:&error];
     EXPECT_NULL(error);
     [defaultFileManager copyItemAtURL:resourceDatabaseFileURL.get() toURL:[v1WebKitOriginDatabaseDirectoryURL URLByAppendingPathComponent:@"IndexedDB.sqlite3"] error:&error];
@@ -189,8 +189,8 @@ static void createDirectories(StringView testName)
     if (testName == "API"_s)
         return;
 
-    EXPECT_WK_STREQ("collision", testName.toString());
-    RetainPtr v1CreatedDatabaseDirectoryURL = [NSURL fileURLWithPath:[NSString pathWithComponents:@[idbRootURL.get().path, newVersion.get(), fileOrigin.get(), createdDatabaseHash]]];
+    EXPECT_WK_STREQ("collision", testName.utf8().data());
+    RetainPtr v1CreatedDatabaseDirectoryURL = [NSURL fileURLWithPath:[NSString pathWithComponents:@[idbRootURL.get().path, newVersion.get(), fileOrigin.get(), createdDatabaseHash.createNSString().get()]]];
     [defaultFileManager createDirectoryAtURL:v1CreatedDatabaseDirectoryURL.get() withIntermediateDirectories:YES attributes:nil error:&error];
     EXPECT_NULL(error);
     [defaultFileManager copyItemAtURL:resourceDatabaseFileURL.get() toURL:[v1CreatedDatabaseDirectoryURL URLByAppendingPathComponent:@"IndexedDB.sqlite3"] error:&error];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm
@@ -320,7 +320,7 @@ TEST(IndexedDB, IndexedDBThirdPartyStorageLayout)
     }];
     TestWebKitAPI::Util::run(&done);
     RetainPtr webkitIframeRootDirectory = [NSURL fileURLWithPath:directoryString.get() isDirectory:YES];
-    RetainPtr webkitIframeDatabaseDirectory = [webkitIframeRootDirectory URLByAppendingPathComponent:databaseHash];
+    RetainPtr webkitIframeDatabaseDirectory = [webkitIframeRootDirectory URLByAppendingPathComponent:databaseHash.createNSString().get()];
     RetainPtr webkitIframeDatabaseFile = [webkitIframeDatabaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3"];
 
     done = false;
@@ -365,10 +365,10 @@ TEST(IndexedDB, MigrateThirdPartyDataToGeneralStorageDirectory)
     NSURL *wrongWebkitIframeDatabaseDirectory = [webkitOriginDirectory URLByAppendingPathComponent:@"IndexedDB/iframe__0"];
     NSURL *webkitIframeOriginDirectory = [generalStorageDirectory URLByAppendingPathComponent:@"EAO66s8JvCWNn4D3YQut5pXfiGF_UXNZGvMGN6aKILg/vudvbMlKXj1m6RibnVvc8PdAdcXZsNE6ON_Al7yqOsg"];
     NSURL *webkitIframeOriginFile = [webkitIframeOriginDirectory URLByAppendingPathComponent:@"origin"];
-    NSString *hashedDatabaseName = WebCore::SQLiteFileSystem::computeHashForFileName("IndexedDBThirdPartyFrameHasAccess"_s);
-    NSURL *webkitIframeDatabaseFile= [NSURL fileURLWithPath:[NSString pathWithComponents:@[webkitIframeOriginDirectory.path, @"IndexedDB", hashedDatabaseName, @"IndexedDB.sqlite3"]]];
+    RetainPtr hashedDatabaseName = WebCore::SQLiteFileSystem::computeHashForFileName("IndexedDBThirdPartyFrameHasAccess"_s).createNSString();
+    NSURL *webkitIframeDatabaseFile= [NSURL fileURLWithPath:[NSString pathWithComponents:@[webkitIframeOriginDirectory.path, @"IndexedDB", hashedDatabaseName.get(), @"IndexedDB.sqlite3"]]];
     NSURL *idbDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/IndexedDB" stringByExpandingTildeInPath] isDirectory:YES];
-    NSURL *oldWebkitIframeDatabaseDirectory = [NSURL fileURLWithPath:[NSString pathWithComponents:@[idbDirectory.path, @"v1/http_webkit.org_0/iframe__0", hashedDatabaseName]]];
+    NSURL *oldWebkitIframeDatabaseDirectory = [NSURL fileURLWithPath:[NSString pathWithComponents:@[idbDirectory.path, @"v1/http_webkit.org_0/iframe__0", hashedDatabaseName.get()]]];
     NSURL *oldWebkitIframeDatabaseFile = [oldWebkitIframeDatabaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3"];
 
     NSFileManager *fileManager = [NSFileManager defaultManager];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBTempFileSize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBTempFileSize.mm
@@ -70,7 +70,7 @@ TEST(IndexedDB, IndexedDBTempFileSize)
     TestWebKitAPI::Util::run(&readyToContinue);
     RetainPtr databaseRootDirectory = [NSURL fileURLWithPath:databaseRootDirectoryString.get() isDirectory:YES];
     String hash = WebCore::SQLiteFileSystem::computeHashForFileName("IndexedDBTempFileSize"_s);
-    RetainPtr databaseDirectory = [databaseRootDirectory URLByAppendingPathComponent:hash];
+    RetainPtr databaseDirectory = [databaseRootDirectory URLByAppendingPathComponent:hash.createNSString().get()];
     RetainPtr walFilePath = [databaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3-wal"];
 
     RetainPtr types = adoptNS([[NSSet alloc] initWithObjects:WKWebsiteDataTypeIndexedDBDatabases, nil]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaSession.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaSession.mm
@@ -183,8 +183,9 @@ public:
     {
         for (auto event : events) {
             auto eventMessage = makeString(event, " event"_s);
-            [_messageHandlers addObject:eventMessage];
-            [webView() performAfterReceivingMessage:eventMessage action:[this, eventMessage = WTFMove(eventMessage)] {
+            RetainPtr nsEventMessage = eventMessage.createNSString();
+            [_messageHandlers addObject:nsEventMessage.get()];
+            [webView() performAfterReceivingMessage:nsEventMessage.get() action:[this, eventMessage = WTFMove(eventMessage)] {
                 _eventListenersCalled.add(eventMessage);
             }];
         }
@@ -216,8 +217,9 @@ public:
     {
         for (auto handler : handlers) {
             auto handlerMessage = makeString(handler, " handler"_s);
-            [_messageHandlers addObject:handlerMessage];
-            [webView() performAfterReceivingMessage:handlerMessage action:[this, handlerMessage = WTFMove(handlerMessage)] {
+            RetainPtr nsHandleMessage = handlerMessage.createNSString();
+            [_messageHandlers addObject:nsHandleMessage.get()];
+            [webView() performAfterReceivingMessage:nsHandleMessage.get() action:[this, handlerMessage = WTFMove(handlerMessage)] {
                 _mediaSessionHandlersCalled.add(handlerMessage);
             }];
         }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
@@ -1791,29 +1791,29 @@ TEST(WKNavigation, HTTPSFirstLocalHostIPAddress)
         finishedSuccessfully = true;
     };
     [webView setNavigationDelegate:delegate.get()];
-    auto url = makeString("http://localhost:"_s, httpServer.port(), "/notsecure"_s);
-    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:url]]];
+    RetainPtr url = makeString("http://localhost:"_s, httpServer.port(), "/notsecure"_s).createNSString();
+    [webView loadRequest:adoptNS([[NSURLRequest alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:url.get()]).get()]).get()];
     TestWebKitAPI::Util::run(&finishedSuccessfully);
 
     EXPECT_EQ(errorCode, 0);
     EXPECT_TRUE(finishedSuccessfully);
     EXPECT_FALSE(didReceiveAuthenticationChallenge);
     EXPECT_EQ(loadCount, 1);
-    EXPECT_WK_STREQ(url, [webView URL].absoluteString);
+    EXPECT_WK_STREQ(url.get(), [webView URL].absoluteString);
 
     errorCode = 0;
     finishedSuccessfully = false;
     didReceiveAuthenticationChallenge = false;
     loadCount = 0;
-    url = makeString("http://127.0.0.1:"_s, httpServer.port(), "/notsecure"_s);
-    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:url]]];
+    url = makeString("http://127.0.0.1:"_s, httpServer.port(), "/notsecure"_s).createNSString();
+    [webView loadRequest:adoptNS([[NSURLRequest alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:url.get()]).get()]).get()];
     TestWebKitAPI::Util::run(&finishedSuccessfully);
 
     EXPECT_EQ(errorCode, 0);
     EXPECT_TRUE(finishedSuccessfully);
     EXPECT_FALSE(didReceiveAuthenticationChallenge);
     EXPECT_EQ(loadCount, 1);
-    EXPECT_WK_STREQ(url, [webView URL].absoluteString);
+    EXPECT_WK_STREQ(url.get(), [webView URL].absoluteString);
 }
 
 TEST(WKNavigation, HTTPSOnlyInitialLoad)
@@ -3123,7 +3123,7 @@ TEST(WKNavigation, PreferredHTTPSPolicyAutomaticHTTPFallbackLocalHostIPAddress)
     };
     [webView setNavigationDelegate:delegate.get()];
     auto url = makeString("http://localhost:"_s, httpServer.port(), "/notsecure"_s);
-    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:url]]];
+    [webView loadRequest:adoptNS([[NSURLRequest alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:url.createNSString().get()]).get()]).get()];
     TestWebKitAPI::Util::run(&finishedSuccessfully);
 
     EXPECT_EQ(errorCode, 0);
@@ -3137,7 +3137,7 @@ TEST(WKNavigation, PreferredHTTPSPolicyAutomaticHTTPFallbackLocalHostIPAddress)
     didReceiveAuthenticationChallenge = false;
     loadCount = 0;
     url = makeString("http://127.0.0.1:"_s, httpServer.port(), "/notsecure"_s);
-    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:url]]];
+    [webView loadRequest:adoptNS([[NSURLRequest alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:url.createNSString().get()]).get()]).get()];
     TestWebKitAPI::Util::run(&finishedSuccessfully);
 
     EXPECT_EQ(errorCode, 0);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NetworkProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NetworkProcess.mm
@@ -333,7 +333,7 @@ static void waitUntilNetworkProcessIsResponsive(WKWebView *webView1, WKWebView *
     // The first WebProcess tries setting a cookie until the second Webview is able to see it.
     auto expectedCookieString = makeString("TEST="_s, createVersion4UUIDString());
     auto setTestCookieString = makeString("setInterval(() => { document.cookie='"_s, expectedCookieString, "'; }, 100);"_s);
-    [webView1 evaluateJavaScript:(NSString *)setTestCookieString completionHandler: [&] (id result, NSError *error) {
+    [webView1 evaluateJavaScript:setTestCookieString.createNSString().get() completionHandler: [&] (id result, NSError *error) {
         EXPECT_TRUE(!error);
     }];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PermissionsAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PermissionsAPI.mm
@@ -126,8 +126,8 @@ TEST(PermissionsAPI, DataURL)
     for (size_t cptr = 0; cptr < sizeof(script) - 1; ++cptr)
         urlEncodeIfNeeded(script[cptr], buffer);
 
-    auto request = [NSURLRequest requestWithURL:[NSURL URLWithString:buffer.toString()]];
-    [webView loadRequest:request];
+    RetainPtr request = adoptNS([[NSURLRequest alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:buffer.toString().createNSString().get()]).get()]);
+    [webView loadRequest:request.get()];
     TestWebKitAPI::Util::run(&didReceiveMessage);
     EXPECT_FALSE(didReceiveQueryPermission);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
@@ -279,7 +279,7 @@ TEST(PushAPI, firePushEventDataStoreDelegate)
 
     RetainPtr<FirePushEventDataStoreDelegate> delegate = adoptNS([FirePushEventDataStoreDelegate new]);
     delegate.get().permissions = @{
-        (NSString *)server.origin() : @YES
+        server.origin().createNSString().get() : @YES
     };
     [configuration websiteDataStore]._delegate = delegate.get();
 
@@ -387,7 +387,7 @@ TEST(PushAPI, testSilentFlag)
 
     RetainPtr<FirePushEventDataStoreDelegate> delegate = adoptNS([FirePushEventDataStoreDelegate new]);
     delegate.get().permissions = @{
-        (NSString *)server.origin() : @YES
+        server.origin().createNSString().get() : @YES
     };
     [configuration websiteDataStore]._delegate = delegate.get();
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
@@ -1161,8 +1161,8 @@ TEST(ResourceLoadStatistics, DataSummaryWithCachedProcess)
     [webView setNavigationDelegate:delegate.get()];
 
     for (unsigned i = 0; i < maxSuspendedPageCount + 1; i++) {
-        NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:makeString("resource-load-statistics://www.domain-"_s, i, ".com"_s)]];
-        [webView loadRequest:request];
+        RetainPtr request = adoptNS([[NSURLRequest alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:makeString("resource-load-statistics://www.domain-"_s, i, ".com"_s).createNSString().get()]).get()]);
+        [webView loadRequest:request.get()];
         [delegate waitForDidFinishNavigation];
 
         EXPECT_EQ(i + 1, [processPool _webProcessCount]);
@@ -1170,8 +1170,8 @@ TEST(ResourceLoadStatistics, DataSummaryWithCachedProcess)
         EXPECT_FALSE([processPool _hasPrewarmedWebProcess]);
     }
     
-    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:makeString("resource-load-statistics://www.domain-"_s, maxSuspendedPageCount + 1, ".com"_s)]];
-    [webView loadRequest:request];
+    RetainPtr request = adoptNS([[NSURLRequest alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:makeString("resource-load-statistics://www.domain-"_s, maxSuspendedPageCount + 1, ".com"_s).createNSString().get()]).get()]);
+    [webView loadRequest:request.get()];
     [delegate waitForDidFinishNavigation];
 
     // This will timeout if waiting for IPC from a cached process.

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
@@ -681,7 +681,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed2)
     [webView _loadRequest:[NSURLRequest requestWithURL:testURL.createNSURL().get()] shouldOpenExternalURLs:YES];
 #elif PLATFORM(IOS) || PLATFORM(VISION)
     // Here we force RedirectSOAuthorizationSession to go to the with user gestures route.
-    [webView evaluateJavaScript: [NSString stringWithFormat:@"location = '%@'", (id)testURL.string()] completionHandler:nil];
+    [webView evaluateJavaScript:adoptNS([[NSString alloc] initWithFormat:@"location = '%@'", testURL.string().createNSString().get()]).get() completionHandler:nil];
 #endif
     Util::run(&authorizationPerformed);
 #if PLATFORM(MAC)
@@ -714,7 +714,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed3)
     [webView _loadRequest:[NSURLRequest requestWithURL:testURL.createNSURL().get()] shouldOpenExternalURLs:YES];
 #elif PLATFORM(IOS) || PLATFORM(VISION)
     // Here we force RedirectSOAuthorizationSession to go to the with user gestures route.
-    [webView evaluateJavaScript: [NSString stringWithFormat:@"location = '%@'", (id)testURL.string()] completionHandler:nil];
+    [webView evaluateJavaScript:adoptNS([[NSString alloc] initWithFormat:@"location = '%@'", testURL.string().createNSString().get()]).get() completionHandler:nil];
 #endif
     Util::run(&authorizationPerformed);
     EXPECT_TRUE(gAuthorization.enableEmbeddedAuthorizationViewController);
@@ -1119,7 +1119,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithRedirectionAndCookie)
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.createNSURL().get()]];
 #elif PLATFORM(IOS) || PLATFORM(VISION)
     // Here we force RedirectSOAuthorizationSession to go to the with user gestures route.
-    [webView evaluateJavaScript: [NSString stringWithFormat:@"location = '%@'", (id)testURL.string()] completionHandler:nil];
+    [webView evaluateJavaScript:adoptNS([[NSString alloc] initWithFormat:@"location = '%@'", testURL.string().createNSString().get()]).get() completionHandler:nil];
 #endif
     Util::run(&authorizationPerformed);
 #if PLATFORM(MAC)
@@ -1160,7 +1160,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithDifferentOrigin)
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     URL redirectURL { "https://www.example.com"_str };
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:redirectURL.createNSURL().get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : redirectURL.string() }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:redirectURL.createNSURL().get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : redirectURL.string().createNSString().get() }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
     EXPECT_WK_STREQ(testURL.get().absoluteString, finalURL);
@@ -1970,7 +1970,7 @@ TEST(SOAuthorizationPopUp, NoInterceptions)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:testURL.get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:testURL.get()];
     Util::run(&navigationCompleted);
 
     [delegate setShouldOpenExternalSchemes:true];
@@ -2002,7 +2002,7 @@ TEST(SOAuthorizationPopUp, NoInterceptionsSubFrame)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:baseURL.get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
     Util::run(&navigationCompleted);
 
     // The new window will not navigate to the testURL as the iframe has an opaque origin.
@@ -2045,7 +2045,7 @@ TEST(SOAuthorizationPopUp, InterceptionError)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:baseURL.get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
     Util::run(&navigationCompleted);
 
     [delegate setShouldOpenExternalSchemes:true];
@@ -2086,7 +2086,7 @@ TEST(SOAuthorizationPopUp, InterceptionCancel)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:baseURL.get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
     Util::run(&navigationCompleted);
 
 #if PLATFORM(MAC)
@@ -2122,7 +2122,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByItself)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:baseURL.get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
     Util::run(&navigationCompleted);
 
 #if PLATFORM(MAC)
@@ -2160,7 +2160,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByParent)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:baseURL.get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
     Util::run(&navigationCompleted);
 
 #if PLATFORM(MAC)
@@ -2198,7 +2198,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByWebKit)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:baseURL.get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
     Util::run(&navigationCompleted);
 
 #if PLATFORM(MAC)
@@ -2232,7 +2232,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedWithOtherHttpStatusCode)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:baseURL.get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
     Util::run(&navigationCompleted);
 
     [delegate setShouldOpenExternalSchemes:true];
@@ -2277,7 +2277,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedWithCookie)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:baseURL.get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
     Util::run(&navigationCompleted);
 
 #if PLATFORM(MAC)
@@ -2315,7 +2315,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedTwice)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:baseURL.get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
     Util::run(&navigationCompleted);
 
     for (int i = 0; i < 2; i++) {
@@ -2355,7 +2355,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedSuppressActiveSession)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:baseURL.get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
     Util::run(&navigationCompleted);
 
 #if PLATFORM(MAC)
@@ -2377,7 +2377,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedSuppressActiveSession)
     configureSOAuthorizationWebView(newWebView.get(), delegate.get());
 
     navigationCompleted = false;
-    [newWebView loadHTMLString:testHtml baseURL:baseURL.get()];
+    [newWebView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
     Util::run(&navigationCompleted);
 
     authorizationPerformed = false;
@@ -2425,7 +2425,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedNewWindowNavigation)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:baseURL.get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
     Util::run(&navigationCompleted);
 
 #if PLATFORM(MAC)
@@ -2458,7 +2458,7 @@ TEST(SOAuthorizationPopUp, AuthorizationOptions)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:URL { "http://www.webkit.org"_str }.createNSURL().get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:URL { "http://www.webkit.org"_str }.createNSURL().get()];
     Util::run(&navigationCompleted);
 
 #if PLATFORM(MAC)
@@ -2484,7 +2484,7 @@ TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyIgnore)
     configureSOAuthorizationWebView(webView.get(), delegate.get());
     [delegate setAllowSOAuthorizationLoad:false];
 
-    [webView loadHTMLString:testHtml baseURL:URL { "http://www.webkit.org"_str }.createNSURL().get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:URL { "http://www.webkit.org"_str }.createNSURL().get()];
     Util::run(&navigationCompleted);
 
 #if PLATFORM(MAC)
@@ -2515,7 +2515,7 @@ TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyAllowAsync)
     configureSOAuthorizationWebView(webView.get(), delegate.get());
     [delegate setIsAsyncExecution:true];
 
-    [webView loadHTMLString:testHtml baseURL:baseURL.get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
     Util::run(&navigationCompleted);
 
 #if PLATFORM(MAC)
@@ -2551,7 +2551,7 @@ TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyIgnoreAsync)
     [delegate setAllowSOAuthorizationLoad:false];
     [delegate setIsAsyncExecution:true];
 
-    [webView loadHTMLString:testHtml baseURL:URL { "http://www.webkit.org"_str }.createNSURL().get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:URL { "http://www.webkit.org"_str }.createNSURL().get()];
     Util::run(&navigationCompleted);
 
 #if PLATFORM(MAC)
@@ -2579,7 +2579,7 @@ TEST(SOAuthorizationSubFrame, NoInterceptions)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:baseURL.get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
     Util::run(&allMessagesReceived);
     EXPECT_FALSE(policyForAppSSOPerformed);
 }
@@ -2595,7 +2595,7 @@ TEST(SOAuthorizationSubFrame, NoInterceptionsNonAppleFirstPartyMainFrame)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:URL { "http://www.webkit.org"_str }.createNSURL().get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:URL { "http://www.webkit.org"_str }.createNSURL().get()];
     // Try to wait until the iframe load is finished.
     Util::runFor(0.5_s);
     // Make sure we don't intercept the iframe.
@@ -2621,7 +2621,7 @@ TEST(SOAuthorizationSubFrame, InterceptionError)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:baseURL.get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
     Util::run(&allMessagesReceived);
 
     checkAuthorizationOptions(false, "file://"_s, 2);
@@ -2653,7 +2653,7 @@ TEST(SOAuthorizationSubFrame, InterceptionCancel)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:baseURL.get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
     Util::run(&allMessagesReceived);
 
     checkAuthorizationOptions(false, "file://"_s, 2);
@@ -2684,7 +2684,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSuccess)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:nil];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:nil];
     Util::run(&allMessagesReceived);
 
     checkAuthorizationOptions(false, "null"_s, 2);
@@ -2716,7 +2716,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSucceedWithOtherHttpStatusCode)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:baseURL.get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
     Util::run(&allMessagesReceived);
 
     checkAuthorizationOptions(false, "file://"_s, 2);
@@ -2751,7 +2751,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookie)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:[NSURL URLWithString:@"http://example.com"]];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:adoptNS([[NSURL alloc] initWithString:@"http://example.com"]).get()];
     Util::run(&allMessagesReceived);
 
     checkAuthorizationOptions(false, "http://example.com"_s, 2);
@@ -2781,7 +2781,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookieButCSPDeny)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:nil];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:nil];
     Util::run(&allMessagesReceived);
 
     checkAuthorizationOptions(false, "null"_s, 2);
@@ -2812,7 +2812,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookieButXFrameDeny)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:nil];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:nil];
     Util::run(&allMessagesReceived);
 
     checkAuthorizationOptions(false, "null"_s, 2);
@@ -2850,7 +2850,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSuccessTwice)
 
         [messageHandler resetExpectations:@[@"http://www.example.com", @"SOAuthorizationDidStart"]];
 
-        [webView loadHTMLString:testHtml baseURL:nil];
+        [webView loadHTMLString:testHtml.createNSString().get() baseURL:nil];
         Util::run(&allMessagesReceived);
 
         checkAuthorizationOptions(false, "null"_s, 2);
@@ -2882,7 +2882,7 @@ TEST(SOAuthorizationSubFrame, AuthorizationOptions)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:URL { "http://www.apple.com"_str }.createNSURL().get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:URL { "http://www.apple.com"_str }.createNSURL().get()];
     Util::run(&allMessagesReceived);
 
     checkAuthorizationOptions(false, "http://www.apple.com"_s, 2);
@@ -2901,7 +2901,7 @@ TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyIgnore)
     configureSOAuthorizationWebView(webView.get(), delegate.get());
     [delegate setAllowSOAuthorizationLoad:false];
 
-    [webView loadHTMLString:testHtml baseURL:URL { "http://www.apple.com"_str }.createNSURL().get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:URL { "http://www.apple.com"_str }.createNSURL().get()];
     // Try to wait until the iframe load is finished.
     Util::runFor(0.5_s);
     // Make sure we don't intercept the iframe.
@@ -2931,7 +2931,7 @@ TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyAllowAsync)
     configureSOAuthorizationWebView(webView.get(), delegate.get());
     [delegate setIsAsyncExecution:true];
 
-    [webView loadHTMLString:testHtml baseURL:nil];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:nil];
     Util::run(&allMessagesReceived);
 
     checkAuthorizationOptions(false, "null"_s, 2);
@@ -2959,7 +2959,7 @@ TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyIgnoreAsync)
     [delegate setAllowSOAuthorizationLoad:false];
     [delegate setIsAsyncExecution:true];
 
-    [webView loadHTMLString:testHtml baseURL:URL("http://www.apple.com"_s).createNSURL().get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:URL("http://www.apple.com"_s).createNSURL().get()];
     // Try to wait until the iframe load is finished.
     Util::runFor(0.5_s);
     // Make sure we don't intercept the iframe.
@@ -2979,14 +2979,14 @@ TEST(SOAuthorizationSubFrame, InterceptionErrorWithReferrer)
             "Content-Length: %d\r\n\r\n"
             "%@",
             parentHtml.length(),
-            (id)parentHtml
+            parentHtml.createNSString().get()
         ];
         RetainPtr<NSString> secondResponse = [NSString stringWithFormat:
             @"HTTP/1.1 200 OK\r\n"
             "Content-Length: %d\r\n\r\n"
             "%@",
             frameHtml.length(),
-            (id)frameHtml
+            frameHtml.createNSString().get()
         ];
 
         connection.receiveHTTPRequest([=](Vector<char>&&) {
@@ -2999,14 +2999,15 @@ TEST(SOAuthorizationSubFrame, InterceptionErrorWithReferrer)
     });
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto origin = makeString("http://127.0.0.1:"_s, server.port());
+    RetainPtr nsOrigin = origin.createNSString();
 
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[origin, @"SOAuthorizationDidStart", origin, @"SOAuthorizationDidCancel", origin, @"Hello.", origin, makeString("Referrer: "_s, origin, '/')]]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[nsOrigin.get(), @"SOAuthorizationDidStart", nsOrigin.get(), @"SOAuthorizationDidCancel", nsOrigin.get(), @"Hello.", nsOrigin.get(), makeString("Referrer: "_s, origin, '/').createNSString().get()]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView _loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:(id)origin]] shouldOpenExternalURLs:NO];
+    [webView _loadRequest:adoptNS([[NSURLRequest alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:nsOrigin.get()]).get()]).get() shouldOpenExternalURLs:NO];
 
     Util::run(&authorizationPerformed);
     EXPECT_TRUE(policyForAppSSOPerformed);
@@ -3033,7 +3034,7 @@ TEST(SOAuthorizationSubFrame, InterceptionErrorMessageOrder)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:baseURL.get()];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
     Util::run(&authorizationPerformed);
     EXPECT_TRUE(policyForAppSSOPerformed);
     [gDelegate authorization:gAuthorization didCompleteWithError:adoptNS([[NSError alloc] initWithDomain:NSCocoaErrorDomain code:0 userInfo:nil]).get()];
@@ -3057,7 +3058,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSuccessMessageOrder)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:nil];
+    [webView loadHTMLString:testHtml.createNSString().get() baseURL:nil];
     Util::run(&authorizationPerformed);
     EXPECT_TRUE(policyForAppSSOPerformed);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SampledPageTopColor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SampledPageTopColor.mm
@@ -106,7 +106,7 @@ static void waitForSampledPageTopColorToChange(TestWKWebView *webView, Function<
 static void waitForSampledPageTopColorToChangeForHTML(TestWKWebView *webView, String&& html)
 {
     waitForSampledPageTopColorToChange(webView, [webView, html = WTFMove(html)] () mutable {
-        [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:WTFMove(html)];
+        [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:html.createNSString().get()];
     });
 }
 
@@ -130,7 +130,7 @@ TEST(SampledPageTopColor, ZeroMaxDifference)
     auto webView = createWebViewWithSampledPageTopColorMaxDifference(0);
     EXPECT_NULL([webView _sampledPageTopColor]);
 
-    [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:createHTMLGradientWithColorStops("right"_s, { "red"_s, "red"_s })];
+    [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:createHTMLGradientWithColorStops("right"_s, { "red"_s, "red"_s }).createNSString().get()];
     EXPECT_NULL([webView _sampledPageTopColor]);
 }
 
@@ -139,7 +139,7 @@ TEST(SampledPageTopColor, NegativeMaxDifference)
     auto webView = createWebViewWithSampledPageTopColorMaxDifference(-5);
     EXPECT_NULL([webView _sampledPageTopColor]);
 
-    [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:createHTMLGradientWithColorStops("right"_s, { "red"_s, "red"_s })];
+    [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:createHTMLGradientWithColorStops("right"_s, { "red"_s, "red"_s }).createNSString().get()];
     EXPECT_NULL([webView _sampledPageTopColor]);
 }
 
@@ -203,7 +203,7 @@ TEST(SampledPageTopColor, DifferentColorsWithMiddleOutlierAboveMaxDifference)
         "lab(100% 0 0)"_s, // outlier
         "lab(3% 0 0)"_s,
         "lab(4% 0 0)"_s,
-    })];
+    }).createNSString().get()];
     EXPECT_NULL([webView _sampledPageTopColor]);
 }
 
@@ -238,7 +238,7 @@ TEST(SampledPageTopColor, DifferentColorsIndividuallyAboveMaxDifference)
         "lab(30% 0 0)"_s,
         "lab(40% 0 0)"_s,
         "lab(50% 0 0)"_s,
-    })];
+    }).createNSString().get()];
     EXPECT_NULL([webView _sampledPageTopColor]);
 }
 
@@ -253,7 +253,7 @@ TEST(SampledPageTopColor, DifferentColorsCumulativelyAboveMaxDifference)
         "lab(5% 0 0)"_s,
         "lab(7% 0 0)"_s,
         "lab(9% 0 0)"_s,
-    })];
+    }).createNSString().get()];
     EXPECT_NULL([webView _sampledPageTopColor]);
 }
 
@@ -269,7 +269,7 @@ TEST(SampledPageTopColor, VerticalGradientBelowMaxDifference)
         "lab(4% 0 0)"_s,
         "lab(5% 0 0)"_s,
         "lab(6% 0 0)"_s,
-    })];
+    }).createNSString().get()];
     auto components = CGColorGetComponents([webView _sampledPageTopColor].CGColor);
     EXPECT_IN_RANGE(components[0], 0.01, 0.02);
     EXPECT_IN_RANGE(components[1], 0.01, 0.02);
@@ -282,7 +282,7 @@ TEST(SampledPageTopColor, VerticalGradientAboveMaxDifference)
     auto webView = createWebViewWithSampledPageTopColorMaxDifference(5, 100);
     EXPECT_NULL([webView _sampledPageTopColor]);
 
-    [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:createHTMLGradientWithColorStops("bottom"_s, { "red"_s, "blue"_s })];
+    [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:createHTMLGradientWithColorStops("bottom"_s, { "red"_s, "blue"_s }).createNSString().get()];
     EXPECT_NULL([webView _sampledPageTopColor]);
 }
 
@@ -423,7 +423,7 @@ TEST(SampledPageTopColor, DISABLED_DisplayP3)
         "color(display-p3 0.97 0 0)"_s,
         "color(display-p3 0.96 0 0)"_s,
         "color(display-p3 0.95 0 0)"_s,
-    })];
+    }).createNSString().get()];
 
     auto components = CGColorGetComponents([webView _sampledPageTopColor].CGColor);
     EXPECT_IN_RANGE(components[0], 0.3, 0.4);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
@@ -777,7 +777,7 @@ TEST(ServiceWorkers, ThirdPartyRestoredFromDisk)
     String thirdPartyIframeURL = URL(server.requestWithLocalhost("/thirdPartyIframeWithSW.html"_s).URL).string();
     String injectFrameScript = makeString("let frame = document.createElement('iframe'); frame.src = '"_s, thirdPartyIframeURL, "'; document.body.append(frame);"_s);
     bool addedIframe = false;
-    [webView evaluateJavaScript:(NSString *)injectFrameScript completionHandler: [&] (id, NSError *error) {
+    [webView evaluateJavaScript:injectFrameScript.createNSString().get() completionHandler: [&] (id, NSError *error) {
         EXPECT_TRUE(!error);
         addedIframe = true;
     }];
@@ -811,7 +811,7 @@ TEST(ServiceWorkers, ThirdPartyRestoredFromDisk)
     String thirdPartyIframeURL2 = URL(server.requestWithLocalhost("/thirdPartyIframeWithSW2.html"_s).URL).string();
     String injectFrameScript2 = makeString("let frame = document.createElement('iframe'); frame.src = '"_s, thirdPartyIframeURL2, "'; document.body.append(frame);"_s);
     addedIframe = false;
-    [webView evaluateJavaScript:(NSString *)injectFrameScript2 completionHandler: [&] (id, NSError *error) {
+    [webView evaluateJavaScript:injectFrameScript2.createNSString().get() completionHandler: [&] (id, NSError *error) {
         EXPECT_TRUE(!error);
         addedIframe = true;
     }];
@@ -1649,8 +1649,8 @@ TEST(ServiceWorkers, ServiceWorkerAndCacheStorageSpecificDirectories)
     [webView loadRequest:server.request("/second.html"_s)];
     TestWebKitAPI::Util::run(&done);
     done = false;
-    NSString* tempDirectoryInUse = FileSystem::realPath(tempDirectory);
-    String expectedString = [NSString stringWithFormat:@"\"path\": \"%@\"", tempDirectoryInUse];
+    RetainPtr tempDirectoryInUse = FileSystem::realPath(tempDirectory).createNSString();
+    String expectedString = [NSString stringWithFormat:@"\"path\": \"%@\"", tempDirectoryInUse.get()];
     EXPECT_TRUE(retrievedString.contains(expectedString));
 
     [[configuration websiteDataStore] removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
@@ -1976,7 +1976,7 @@ TEST(ServiceWorkers, LockdownModeInServiceWorkerProcess)
         bool finishedRunningScript = false;
         done = false;
         auto js = makeString("worker.postMessage('"_s, jsToEvalInWorker,"');"_s);
-        [webView evaluateJavaScript:js completionHandler:[&] (id result, NSError *error) {
+        [webView evaluateJavaScript:js.createNSString().get() completionHandler:[&] (id result, NSError *error) {
             EXPECT_NULL(error);
             finishedRunningScript = true;
         }];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/StorageQuota.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/StorageQuota.mm
@@ -520,7 +520,7 @@ TEST(WebKit, DefaultQuota)
 
     // Storing 10 entries of 10 MB should not hit the default quota which is 1GB
     for (int i = 0; i < 10; ++i) {
-        [webView stringByEvaluatingJavaScript:"doTest(10)"_str];
+        [webView stringByEvaluatingJavaScript:@"doTest(10)"];
         [messageHandler setExpectedMessage: @"pass"];
         receivedMessage = false;
         Util::run(&receivedMessage);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/StoreBlobThenDelete.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/StoreBlobThenDelete.mm
@@ -73,7 +73,7 @@ TEST(IndexedDB, StoreBlobThenRemoveData)
     }];
     TestWebKitAPI::Util::run(&readyToContinue);
     RetainPtr originDirectory = [NSURL fileURLWithPath:originDirectoryString.get() isDirectory:YES];
-    RetainPtr databaseDirectory = [originDirectory URLByAppendingPathComponent:hash];
+    RetainPtr databaseDirectory = [originDirectory URLByAppendingPathComponent:hash.createNSString().get()];
     RetainPtr blobFileURL = [databaseDirectory URLByAppendingPathComponent:@"1.blob"];
     RetainPtr databaseFileURL = [databaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3"];
 
@@ -87,7 +87,7 @@ TEST(IndexedDB, StoreBlobThenRemoveData)
     // 2 - Move -wal and -shm files into that directory
     // 3 - Make sure the entire directory is deleted
     String fakeHash = WebCore::SQLiteFileSystem::computeHashForFileName("FakeDatabasePath"_s);
-    RetainPtr fakeDatabaseDirectory = [originDirectory URLByAppendingPathComponent:fakeHash];
+    RetainPtr fakeDatabaseDirectory = [originDirectory URLByAppendingPathComponent:fakeHash.createNSString().get()];
     RetainPtr fakeShmURL = [fakeDatabaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3-wal"];
     RetainPtr fakeWalURL = [fakeDatabaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3-shm"];
     [[NSFileManager defaultManager] createDirectoryAtURL:fakeDatabaseDirectory.get() withIntermediateDirectories:YES attributes:nil error:nil];
@@ -152,7 +152,7 @@ TEST(IndexedDB, StoreBlobThenDeleteDatabase)
     }];
     TestWebKitAPI::Util::run(&readyToContinue);
     RetainPtr originDirectory = [NSURL fileURLWithPath:originDirectoryString.get() isDirectory:YES];
-    RetainPtr databaseDirectory = [originDirectory URLByAppendingPathComponent:hash];
+    RetainPtr databaseDirectory = [originDirectory URLByAppendingPathComponent:hash.createNSString().get()];
     RetainPtr blobFileURL = [databaseDirectory URLByAppendingPathComponent:@"1.blob"];
     RetainPtr databaseFileURL = [databaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemPreview.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemPreview.mm
@@ -261,7 +261,7 @@ TEST(WebKit, SystemPreviewTriggered)
     [webView synchronouslyLoadTestPageNamed:@"system-preview-trigger"];
     Util::run(&hasTriggerInfo);
 
-    [webView _triggerSystemPreviewActionOnElement:elementID document:documentID page:pageID];
+    [webView _triggerSystemPreviewActionOnElement:elementID document:documentID.createNSString().get() page:pageID];
     Util::run(&wasTriggered);
 }
 
@@ -276,7 +276,7 @@ TEST(WebKit, SystemPreviewTriggeredOnDetachedElement)
     [webView synchronouslyLoadTestPageNamed:@"system-preview-trigger"];
     Util::run(&hasTriggerInfo);
 
-    [webView _triggerSystemPreviewActionOnElement:elementID document:documentID page:pageID];
+    [webView _triggerSystemPreviewActionOnElement:elementID document:documentID.createNSString().get() page:pageID];
     Util::run(&wasTriggeredByDetachedElement);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TLSDeprecation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TLSDeprecation.mm
@@ -255,7 +255,7 @@ TEST(TLSVersion, Preconnect)
     }, HTTPServer::Protocol::HttpsWithLegacyTLS);
 
     auto webView = adoptNS([WKWebView new]);
-    [webView loadHTMLString:makeString("<head><link rel='preconnect' href='https://127.0.0.1:"_s, server.port(), "/'></link></head>"_s) baseURL:nil];
+    [webView loadHTMLString:makeString("<head><link rel='preconnect' href='https://127.0.0.1:"_s, server.port(), "/'></link></head>"_s).createNSString().get() baseURL:nil];
 
     auto delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TimeZoneOverride.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TimeZoneOverride.mm
@@ -50,7 +50,7 @@ public:
     void runScriptAndExecuteCallback(const String& script, Function<void(id)>&& callback)
     {
         bool complete = false;
-        [_webView evaluateJavaScript:script completionHandler:[&] (id result, NSError *error) {
+        [_webView evaluateJavaScript:script.createNSString().get() completionHandler:[&] (id result, NSError *error) {
             EXPECT_NULL(error);
             callback(result);
             complete = true;
@@ -61,7 +61,7 @@ public:
     void callAsyncFunctionBody(const String& functionBody, Function<void(id)>&& callback)
     {
         bool complete = false;
-        [_webView callAsyncJavaScript:functionBody arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:[&] (id result, NSError *error) {
+        [_webView callAsyncJavaScript:functionBody.createNSString().get() arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:[&] (id result, NSError *error) {
             EXPECT_NULL(error);
             callback(result);
             complete = true;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
@@ -111,7 +111,7 @@ public:
 
     void synchronouslyLoadPDFDocument(String documentName)
     {
-        RetainPtr request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:documentName withExtension:@"pdf"]];
+        RetainPtr request = adoptNS([[NSURLRequest alloc] initWithURL:[NSBundle.test_resourcesBundle URLForResource:documentName.createNSString().get() withExtension:@"pdf"]]);
         [webView synchronouslyLoadRequest:request.get()];
         [[webView window] makeFirstResponder:webView.get()];
         [[webView window] makeKeyAndOrderFront:nil];
@@ -612,7 +612,7 @@ UNIFIED_PDF_TEST(DISABLED_RespectsPageFragment)
     auto path = makeString('/', fileName, ".pdf"_s);
     auto pathWithFragment = makeString(path, "#page=2"_s);
 
-    RetainPtr pdfURL = [NSBundle.test_resourcesBundle URLForResource:String { fileName } withExtension:@"pdf"];
+    RetainPtr pdfURL = [NSBundle.test_resourcesBundle URLForResource:fileName.createNSString().get() withExtension:@"pdf"];
     HTTPResponse response { [NSData dataWithContentsOfURL:pdfURL.get()] };
     HTTPServer server { { { path, response }, { pathWithFragment, response } } };
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentViewEditingActions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentViewEditingActions.mm
@@ -113,8 +113,8 @@ TEST(WebKit, DISABLED_AppHighlightsInImageOverlays)
 
     auto menuBuilder = adoptNS([[TestUIMenuBuilder alloc] init]);
     [webView buildMenuWithBuilder:menuBuilder.get()];
-    EXPECT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTagAddHighlightToNewQuickNote()]);
-    EXPECT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTagAddHighlightToCurrentQuickNote()]);
+    EXPECT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTagAddHighlightToNewQuickNote().createNSString().get()]);
+    EXPECT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTagAddHighlightToCurrentQuickNote().createNSString().get()]);
 
     [webView synchronouslyLoadTestPageNamed:@"simple" asStringWithBaseURL:[NSURL URLWithString:@"http://webkit.org/simple.html"]];
     [webView selectAll:nil];
@@ -122,8 +122,8 @@ TEST(WebKit, DISABLED_AppHighlightsInImageOverlays)
 
     [menuBuilder reset];
     [webView buildMenuWithBuilder:menuBuilder.get()];
-    EXPECT_NOT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTagAddHighlightToNewQuickNote()]);
-    EXPECT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTagAddHighlightToCurrentQuickNote()]);
+    EXPECT_NOT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTagAddHighlightToNewQuickNote().createNSString().get()]);
+    EXPECT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTagAddHighlightToCurrentQuickNote().createNSString().get()]);
 }
 
 #endif // ENABLE(APP_HIGHLIGHTS)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -924,7 +924,7 @@ public:
             dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:dataStoreIdentifier->createNSUUID().get()]);
         else
             dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
-        [dataStoreConfiguration setWebPushPartitionString:pushPartition];
+        [dataStoreConfiguration setWebPushPartitionString:pushPartition.createNSString().get()];
         [dataStoreConfiguration setProxyConfiguration:@{
             (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
             (NSString *)kCFStreamPropertyHTTPSProxyPort: @(m_server->port())
@@ -1010,7 +1010,7 @@ public:
     {
         NSError *error = nil;
         auto script = makeString("return await subscribe('"_s, key, "')"_s);
-        id obj = [m_webView objectByCallingAsyncFunction:script withArguments:@{ } error:&error];
+        id obj = [m_webView objectByCallingAsyncFunction:script.createNSString().get() withArguments:@{ } error:&error];
         return error ?: obj;
     }
 
@@ -1201,7 +1201,7 @@ public:
         };
         auto topic = WebCore::makePushTopic(subscriptionSetIdentifier, scope);
         id obj = @{
-            @"topic": (NSString *)topic,
+            @"topic": topic.createNSString().get(),
             @"userInfo": apsUserInfo
         };
 
@@ -1676,10 +1676,11 @@ TEST_F(WebPushDTest, UnsubscribesOnClearingWebsiteDataForOrigin)
         }];
         TestWebKitAPI::Util::run(&fetchedRecords);
 
+        RetainPtr vOrigin = v->origin().createNSString();
         WKWebsiteDataRecord *filteredRecord = nil;
         for (WKWebsiteDataRecord *record in records.get()) {
             for (NSString *originString in record._originsStrings) {
-                if ([originString isEqualToString:v->origin()]) {
+                if ([originString isEqualToString:vOrigin.get()]) {
                     filteredRecord = record;
                     break;
                 }
@@ -2100,7 +2101,7 @@ TEST_F(WebPushDInjectedPushTest, HandleInjectedAES128GCMPush)
 
     runTest(@"When I grow up, I want to be a watermelon", @{
         @"content_encoding": @"aes128gcm",
-        @"payload": (NSString *)payloadBase64
+        @"payload": payloadBase64.createNSString().get()
     });
 }
 
@@ -3022,7 +3023,7 @@ public:
         while (webViews().first()->mostRecentMessage().isEmpty())
             TestWebKitAPI::Util::runFor(0.05_s);
 
-        EXPECT_TRUE([(NSString *)webViews().first()->mostRecentMessage() isEqualToString:message]);
+        EXPECT_TRUE([webViews().first()->mostRecentMessage().createNSString() isEqualToString:message]);
     }
 
     void checkLastNotificationTitle(NSString *title)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
@@ -864,13 +864,13 @@ TEST(WebKit, MigrateIndexedDBDataToGeneralStorageDirectory)
     NSURL *indexedDBDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/IndexedDB" stringByExpandingTildeInPath] isDirectory:YES];
     NSURL *indexedDBOriginDirectory = [indexedDBDirectory URLByAppendingPathComponent:@"v1/https_webkit.org_0"];
     static constexpr auto indexedDBDatabaseName = "TestDatabase"_s;
-    NSString *hashedIndexedDBDatabaseName = WebCore::SQLiteFileSystem::computeHashForFileName(indexedDBDatabaseName);
-    NSURL *indexedDBDatabaseDirectory = [indexedDBOriginDirectory URLByAppendingPathComponent:hashedIndexedDBDatabaseName];
+    RetainPtr hashedIndexedDBDatabaseName = WebCore::SQLiteFileSystem::computeHashForFileName(indexedDBDatabaseName).createNSString();
+    NSURL *indexedDBDatabaseDirectory = [indexedDBOriginDirectory URLByAppendingPathComponent:hashedIndexedDBDatabaseName.get()];
     NSURL *indexedDBFile = [indexedDBDatabaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3"];
     NSURL *generalStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/Default" stringByExpandingTildeInPath] isDirectory:YES];
     NSURL *resourceSalt = [NSBundle.test_resourcesBundle URLForResource:@"general-storage-directory" withExtension:@"salt"];
     NSURL *newIndexedDBOriginDirectory = [generalStorageDirectory URLByAppendingPathComponent:@"YUn_wgR51VLVo9lc5xiivAzZ8TMmojoa0IbW323qibs/YUn_wgR51VLVo9lc5xiivAzZ8TMmojoa0IbW323qibs/IndexedDB/"];
-    NSURL *newIndexedDBDirectory = [newIndexedDBOriginDirectory URLByAppendingPathComponent:hashedIndexedDBDatabaseName];
+    NSURL *newIndexedDBDirectory = [newIndexedDBOriginDirectory URLByAppendingPathComponent:hashedIndexedDBDatabaseName.get()];
     NSURL *newIndexedDBFile = [newIndexedDBDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3"];
 
     NSFileManager *fileManager = [NSFileManager defaultManager];
@@ -1907,7 +1907,7 @@ TEST(WKWebsiteDataStore, FetchAndDeleteMediaKeysData)
     NSURL *customMediaKeysStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/MediaKeys" stringByExpandingTildeInPath] isDirectory:YES];
     WebCore::SecurityOriginData origin("https"_s, "webkit.org"_s, 443);
     NSFileManager *fileManager = [NSFileManager defaultManager];
-    NSURL *customWebKitDirectory = [customMediaKeysStorageDirectory URLByAppendingPathComponent:origin.databaseIdentifier()];
+    NSURL *customWebKitDirectory = [customMediaKeysStorageDirectory URLByAppendingPathComponent:origin.databaseIdentifier().createNSString().get()];
     [fileManager createDirectoryAtURL:customWebKitDirectory withIntermediateDirectories:YES attributes:nil error:nil];
     NSURL *customMediaKeysStorageFile = [customWebKitDirectory URLByAppendingPathComponent:@"SecureStop.plist"];
     [fileManager createFileAtPath:customMediaKeysStorageFile.path contents:nil attributes:nil];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -228,7 +228,7 @@ using PlatformTextPlaceholder = NSTextPlaceholder;
 {
     auto string = String { [self contentsAsString] };
     auto updatedString = makeStringByReplacingAll(string, noBreakSpace, space);
-    return (NSString *)updatedString;
+    return updatedString.createNSString().autorelease();
 }
 
 - (NSUInteger)transparentContentMarkerCount:(NSString *)evaluateNodeExpression

--- a/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
@@ -1101,8 +1101,8 @@ TEST(KeyboardInputTests, NoCrashWhenDiscardingMarkedText)
     [webView _setEditable:YES];
 
     auto navigateAndSetMarkedText = [&](const String& urlString) {
-        auto request = [NSURLRequest requestWithURL:[NSURL URLWithString:(NSString *)urlString]];
-        [webView loadSimulatedRequest:request responseHTMLString:@"<body>Hello world</body>"];
+        RetainPtr request = adoptNS([[NSURLRequest alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:urlString.createNSString().get()]).get()]);
+        [webView loadSimulatedRequest:request.get() responseHTMLString:@"<body>Hello world</body>"];
         [navigationDelegate waitForDidFinishNavigation];
         [webView selectAll:nil];
         [[webView textInputContentView] setMarkedText:@"Hello" selectedRange:NSMakeRange(0, 5)];

--- a/Tools/TestWebKitAPI/Tests/ios/Viewport.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/Viewport.mm
@@ -42,9 +42,9 @@
 
 namespace TestWebKitAPI {
 
-static inline String makeViewportMetaTag(unsigned viewportWidth, float initialScale)
+static inline RetainPtr<NSString> makeViewportMetaTag(unsigned viewportWidth, float initialScale)
 {
-    return makeString("<meta name='viewport' content='width="_s, viewportWidth, ", initial-scale="_s, initialScale, "'>"_s);
+    return makeString("<meta name='viewport' content='width="_s, viewportWidth, ", initial-scale="_s, initialScale, "'>"_s).createNSString();
 }
 
 TEST(Viewport, MinimumEffectiveDeviceWidthWithInitialScale)
@@ -53,7 +53,7 @@ TEST(Viewport, MinimumEffectiveDeviceWidthWithInitialScale)
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 690, 690)]);
 
-    [webView synchronouslyLoadHTMLString:makeViewportMetaTag(1000, 0.69)];
+    [webView synchronouslyLoadHTMLString:makeViewportMetaTag(1000, 0.69).get()];
     [webView waitForNextPresentationUpdate];
 
     [webView _setMinimumEffectiveDeviceWidth:1024];
@@ -78,8 +78,8 @@ TEST(Viewport, RespectInitialScaleExceptOnWikipediaDomain)
         auto expectedViewportScale = screenWidth / viewportWidth;
 
         auto request = [NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithUTF8String:requestURL.utf8().data()]]];
-        auto response = makeViewportMetaTag(viewportWidth, expectedViewportScale);
-        [webView loadSimulatedRequest:request responseHTMLString:response];
+        RetainPtr response = makeViewportMetaTag(viewportWidth, expectedViewportScale);
+        [webView loadSimulatedRequest:request responseHTMLString:response.get()];
         [navigationDelegate waitForDidFinishNavigation];
         [webView _doAfterNextPresentationUpdate:makeBlockPtr([&done, &webView, expectedViewportScale, scaleExpectation = WTFMove(scaleExpectation)]() mutable {
             [webView evaluateJavaScript:@"visualViewport.scale" completionHandler:makeBlockPtr([&done, expectedViewportScale, scaleExpectation = WTFMove(scaleExpectation)] (NSNumber *value, NSError *error) mutable {

--- a/Tools/TestWebKitAPI/cocoa/TestInspectorURLSchemeHandler.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestInspectorURLSchemeHandler.mm
@@ -80,14 +80,14 @@
             return;
         }
 
-        NSString *mimeType = WebCore::MIMETypeRegistry::mimeTypeForExtension(String(fileURLForRequest.pathExtension));
+        RetainPtr mimeType = WebCore::MIMETypeRegistry::mimeTypeForExtension(String(fileURLForRequest.pathExtension)).createNSString();
         if (!mimeType)
             mimeType = @"application/octet-stream";
 
         RetainPtr<NSMutableDictionary> headerFields = adoptNS(@{
             @"Access-Control-Allow-Origin": @"*",
             @"Content-Length": [NSString stringWithFormat:@"%zu", (size_t)fileData.length],
-            @"Content-Type": mimeType,
+            @"Content-Type": mimeType.get(),
         }.mutableCopy);
 
         RetainPtr<NSHTTPURLResponse> urlResponse = adoptNS([[NSHTTPURLResponse alloc] initWithURL:urlSchemeTask.request.URL statusCode:200 HTTPVersion:nil headerFields:headerFields.get()]);

--- a/Tools/TestWebKitAPI/ios/PreferredContentMode.mm
+++ b/Tools/TestWebKitAPI/ios/PreferredContentMode.mm
@@ -175,7 +175,7 @@ RetainPtr<ViewClass> setUpWebViewForPreferredContentModeTestingWithoutNavigation
     if (defaultContentMode)
         [configuration setDefaultWebpagePreferences:[WKWebpagePreferences preferencesWithContentMode:defaultContentMode.value()]];
     if (applicationNameForUserAgent)
-        [configuration setApplicationNameForUserAgent:applicationNameForUserAgent->isNull() ? nil : (NSString *)applicationNameForUserAgent.value()];
+        [configuration setApplicationNameForUserAgent:applicationNameForUserAgent->isNull() ? nil : applicationNameForUserAgent.value().createNSString().get()];
     auto webView = adoptNS([[ViewClass alloc] initWithFrame:CGRectMake(0, 0, size.width, size.height) configuration:configuration.get()]);
     EXPECT_TRUE([webView isKindOfClass:WKWebView.class]);
     return webView;

--- a/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
@@ -125,9 +125,9 @@ NSDictionary *searchPredicateForSearchCriteria(JSContextRef context, Accessibili
     [parameterizedAttribute setObject:@(resultsLimit) forKey:@"AXResultsLimit"];
 
     if (searchKey) {
-        id searchKeyParameter = nil;
+        RetainPtr<id> searchKeyParameter;
         if (JSValueIsString(context, searchKey))
-            searchKeyParameter = toWTFString(context, searchKey);
+            searchKeyParameter = toWTFString(context, searchKey).createNSString();
         else if (JSValueIsObject(context, searchKey)) {
             JSObjectRef searchKeyArray = JSValueToObject(context, searchKey, nullptr);
             unsigned searchKeyArrayLength = arrayLength(context, searchKeyArray);
@@ -135,15 +135,15 @@ NSDictionary *searchPredicateForSearchCriteria(JSContextRef context, Accessibili
                 auto searchKey = toWTFString(context, JSObjectGetPropertyAtIndex(context, searchKeyArray, i, nullptr));
                 if (!searchKeyParameter)
                     searchKeyParameter = [NSMutableArray array];
-                [searchKeyParameter addObject:searchKey];
+                [searchKeyParameter addObject:searchKey.createNSString().get()];
             }
         }
         if (searchKeyParameter)
-            [parameterizedAttribute setObject:searchKeyParameter forKey:@"AXSearchKey"];
+            [parameterizedAttribute setObject:searchKeyParameter.get() forKey:@"AXSearchKey"];
     }
 
     if (searchText && JSStringGetLength(searchText))
-        [parameterizedAttribute setObject:toWTFString(searchText) forKey:@"AXSearchText"];
+        [parameterizedAttribute setObject:toWTFString(searchText).createNSString().get() forKey:@"AXSearchText"];
 
     [parameterizedAttribute setObject:@(visibleOnly) forKey:@"AXVisibleOnly"];
     [parameterizedAttribute setObject:@(immediateDescendantsOnly) forKey:@"AXImmediateDescendantsOnly"];

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -300,12 +300,12 @@ static NSDictionary *selectTextParameterizedAttributeForCriteria(JSContextRef co
     if (searchStrings) {
         NSMutableArray *searchStringsParameter = [NSMutableArray array];
         if (JSValueIsString(context, searchStrings))
-            [searchStringsParameter addObject:toWTFString(context, searchStrings)];
+            [searchStringsParameter addObject:toWTFString(context, searchStrings).createNSString().get()];
         else {
             JSObjectRef searchStringsArray = JSValueToObject(context, searchStrings, nullptr);
             unsigned searchStringsArrayLength = arrayLength(context, searchStringsArray);
             for (unsigned i = 0; i < searchStringsArrayLength; ++i)
-                [searchStringsParameter addObject:toWTFString(context, JSObjectGetPropertyAtIndex(context, searchStringsArray, i, nullptr))];
+                [searchStringsParameter addObject:toWTFString(context, JSObjectGetPropertyAtIndex(context, searchStringsArray, i, nullptr)).createNSString().get()];
         }
         [parameterizedAttribute setObject:searchStringsParameter forKey:@"AXSelectTextSearchStrings"];
     }
@@ -329,12 +329,12 @@ static NSDictionary *searchTextParameterizedAttributeForCriteria(JSContextRef co
     if (searchStrings) {
         NSMutableArray *searchStringsParameter = [NSMutableArray array];
         if (JSValueIsString(context, searchStrings))
-            [searchStringsParameter addObject:toWTFString(context, searchStrings)];
+            [searchStringsParameter addObject:toWTFString(context, searchStrings).createNSString().get()];
         else {
             JSObjectRef searchStringsArray = JSValueToObject(context, searchStrings, nullptr);
             unsigned searchStringsArrayLength = arrayLength(context, searchStringsArray);
             for (unsigned i = 0; i < searchStringsArrayLength; ++i)
-                [searchStringsParameter addObject:toWTFString(context, JSObjectGetPropertyAtIndex(context, searchStringsArray, i, nullptr))];
+                [searchStringsParameter addObject:toWTFString(context, JSObjectGetPropertyAtIndex(context, searchStringsArray, i, nullptr)).createNSString().get()];
         }
         [parameterizedAttribute setObject:searchStringsParameter forKey:@"AXSearchTextSearchStrings"];
     }
@@ -368,13 +368,13 @@ static NSDictionary *textOperationParameterizedAttribute(JSContextRef context, J
     }
 
     if (JSValueIsString(context, replacementStrings))
-        [attributeParameters setObject:toWTFString(context, replacementStrings) forKey:@"AXTextOperationReplacementString"];
+        [attributeParameters setObject:toWTFString(context, replacementStrings).createNSString().get() forKey:@"AXTextOperationReplacementString"];
     else {
         NSMutableArray *individualReplacementStringsParameter = [NSMutableArray array];
         JSObjectRef replacementStringsArray = JSValueToObject(context, replacementStrings, nullptr);
         unsigned replacementStringsArrayLength = arrayLength(context, replacementStringsArray);
         for (unsigned i = 0; i < replacementStringsArrayLength; ++i)
-            [individualReplacementStringsParameter addObject:toWTFString(context, JSObjectGetPropertyAtIndex(context, replacementStringsArray, i, nullptr))];
+            [individualReplacementStringsParameter addObject:toWTFString(context, JSObjectGetPropertyAtIndex(context, replacementStringsArray, i, nullptr)).createNSString().get()];
 
         [attributeParameters setObject:individualReplacementStringsParameter forKey:@"AXTextOperationIndividualReplacementStrings"];
     }

--- a/Tools/WebKitTestRunner/cocoa/WKTextExtractionTestingHelpers.mm
+++ b/Tools/WebKitTestRunner/cocoa/WKTextExtractionTestingHelpers.mm
@@ -141,7 +141,7 @@ NSString *recursiveDescription(WKTextExtractionItem *item, IncludeRects includeR
 {
     TextStream stream { TextStream::LineMode::MultipleLine };
     buildRecursiveDescription(stream, item, includeRects);
-    return stream.release();
+    return stream.release().createNSString().autorelease();
 }
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm
+++ b/Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm
@@ -346,7 +346,7 @@ void PlatformWebView::addChromeInputField()
 
 void PlatformWebView::setTextInChromeInputField(const String& text)
 {
-    chromeInputField(m_window).text = text;
+    chromeInputField(m_window).text = text.createNSString().get();
 }
 
 void PlatformWebView::selectChromeInputField()

--- a/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
@@ -552,7 +552,7 @@ unsigned TestController::keyboardUpdateForChangedSelectionCount() const
 void TestController::setKeyboardInputModeIdentifier(const String& identifier)
 {
     m_inputModeSwizzlers.clear();
-    m_overriddenKeyboardInputMode = [UIKeyboardInputMode keyboardInputModeWithIdentifier:identifier];
+    m_overriddenKeyboardInputMode = [UIKeyboardInputMode keyboardInputModeWithIdentifier:identifier.createNSString().get()];
     if (!m_overriddenKeyboardInputMode) {
         ASSERT_NOT_REACHED();
         return;

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -415,7 +415,7 @@ void UIScriptControllerIOS::singleTapAtPointWithModifiers(WebCore::FloatPoint lo
     waitForSingleTapToReset();
 
     for (auto& modifierFlag : modifierFlags)
-        [[HIDEventGenerator sharedHIDEventGenerator] keyDown:modifierFlag];
+        [[HIDEventGenerator sharedHIDEventGenerator] keyDown:modifierFlag.createNSString().get()];
 
     [[HIDEventGenerator sharedHIDEventGenerator] tap:globalToContentCoordinates(webView(), location.x(), location.y()) completionBlock:[this, protectedThis = Ref { *this }, modifierFlags = WTFMove(modifierFlags), block = WTFMove(block)] () mutable {
         if (!m_context)
@@ -423,7 +423,7 @@ void UIScriptControllerIOS::singleTapAtPointWithModifiers(WebCore::FloatPoint lo
 
         for (size_t i = modifierFlags.size(); i; ) {
             --i;
-            [[HIDEventGenerator sharedHIDEventGenerator] keyUp:modifierFlags[i]];
+            [[HIDEventGenerator sharedHIDEventGenerator] keyUp:modifierFlags[i].createNSString().get()];
         }
         [[HIDEventGenerator sharedHIDEventGenerator] sendMarkerHIDEventWithCompletionBlock:block.get()];
     }];
@@ -489,7 +489,7 @@ void UIScriptControllerIOS::stylusTapAtPointWithModifiers(long x, long y, float 
 
     auto modifierFlags = parseModifierArray(m_context->jsContext(), modifierArray);
     for (auto& modifierFlag : modifierFlags)
-        [[HIDEventGenerator sharedHIDEventGenerator] keyDown:modifierFlag];
+        [[HIDEventGenerator sharedHIDEventGenerator] keyDown:modifierFlag.createNSString().get()];
 
     auto location = globalToContentCoordinates(webView(), x, y);
     [[HIDEventGenerator sharedHIDEventGenerator] stylusTapAtPoint:location azimuthAngle:azimuthAngle altitudeAngle:altitudeAngle pressure:pressure completionBlock:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID, modifierFlags = WTFMove(modifierFlags)] {
@@ -497,7 +497,7 @@ void UIScriptControllerIOS::stylusTapAtPointWithModifiers(long x, long y, float 
             return;
         for (size_t i = modifierFlags.size(); i; ) {
             --i;
-            [[HIDEventGenerator sharedHIDEventGenerator] keyUp:modifierFlags[i]];
+            [[HIDEventGenerator sharedHIDEventGenerator] keyUp:modifierFlags[i].createNSString().get()];
         }
         [[HIDEventGenerator sharedHIDEventGenerator] sendMarkerHIDEventWithCompletionBlock:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
             if (!m_context)
@@ -526,7 +526,7 @@ void UIScriptControllerIOS::sendEventStream(JSStringRef eventsJSON, JSValueRef c
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
 
     String jsonString = eventsJSON->string();
-    auto eventInfo = dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:[(NSString *)jsonString dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingMutableContainers | NSJSONReadingMutableLeaves error:nil]);
+    auto eventInfo = dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:[jsonString.createNSString() dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingMutableContainers | NSJSONReadingMutableLeaves error:nil]);
 
     auto *webView = this->webView();
     
@@ -632,7 +632,7 @@ void UIScriptControllerIOS::typeCharacterUsingHardwareKeyboard(JSStringRef chara
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
 
     // Assumes that the keyboard is already shown.
-    [[HIDEventGenerator sharedHIDEventGenerator] keyPress:toWTFString(character) completionBlock:makeBlockPtr([protectedThis = Ref { *this }, callbackID] {
+    [[HIDEventGenerator sharedHIDEventGenerator] keyPress:toWTFString(character).createNSString().get() completionBlock:makeBlockPtr([protectedThis = Ref { *this }, callbackID] {
         if (protectedThis->m_context)
             protectedThis->m_context->asyncTaskComplete(callbackID);
     }).get()];
@@ -653,7 +653,7 @@ void UIScriptControllerIOS::rawKeyDown(JSStringRef key)
 {
     // Key can be either a single Unicode code point or the name of a special key (e.g. "downArrow").
     // HIDEventGenerator knows how to map these special keys to the appropriate keycode.
-    [[HIDEventGenerator sharedHIDEventGenerator] keyDown:toWTFString(key)];
+    [[HIDEventGenerator sharedHIDEventGenerator] keyDown:toWTFString(key).createNSString().get()];
     [[HIDEventGenerator sharedHIDEventGenerator] sendMarkerHIDEventWithCompletionBlock:^{ /* Do nothing */ }];
 }
 
@@ -661,7 +661,7 @@ void UIScriptControllerIOS::rawKeyUp(JSStringRef key)
 {
     // Key can be either a single Unicode code point or the name of a special key (e.g. "downArrow").
     // HIDEventGenerator knows how to map these special keys to the appropriate keycode.
-    [[HIDEventGenerator sharedHIDEventGenerator] keyUp:toWTFString(key)];
+    [[HIDEventGenerator sharedHIDEventGenerator] keyUp:toWTFString(key).createNSString().get()];
     [[HIDEventGenerator sharedHIDEventGenerator] sendMarkerHIDEventWithCompletionBlock:^{ /* Do nothing */ }];
 }
 
@@ -673,14 +673,14 @@ void UIScriptControllerIOS::keyDown(JSStringRef character, JSValueRef modifierAr
     auto modifierFlags = parseModifierArray(m_context->jsContext(), modifierArray);
 
     for (auto& modifierFlag : modifierFlags)
-        [[HIDEventGenerator sharedHIDEventGenerator] keyDown:modifierFlag];
+        [[HIDEventGenerator sharedHIDEventGenerator] keyDown:modifierFlag.createNSString().get()];
 
-    [[HIDEventGenerator sharedHIDEventGenerator] keyDown:inputString];
-    [[HIDEventGenerator sharedHIDEventGenerator] keyUp:inputString];
+    [[HIDEventGenerator sharedHIDEventGenerator] keyDown:inputString.createNSString().get()];
+    [[HIDEventGenerator sharedHIDEventGenerator] keyUp:inputString.createNSString().get()];
 
     for (size_t i = modifierFlags.size(); i; ) {
         --i;
-        [[HIDEventGenerator sharedHIDEventGenerator] keyUp:modifierFlags[i]];
+        [[HIDEventGenerator sharedHIDEventGenerator] keyUp:modifierFlags[i].createNSString().get()];
     }
 
     [[HIDEventGenerator sharedHIDEventGenerator] sendMarkerHIDEventWithCompletionBlock:^{ /* Do nothing */ }];
@@ -885,13 +885,13 @@ void UIScriptControllerIOS::applyAutocorrection(JSStringRef newString, JSStringR
             }).get());
         });
         auto options = underline ? BETextReplacementOptionsAddUnderline : BETextReplacementOptionsNone;
-        [asyncInput replaceText:toWTFString(oldString) withText:toWTFString(newString) options:options completionHandler:completionWrapper.get()];
+        [asyncInput replaceText:toWTFString(oldString).createNSString().get() withText:toWTFString(newString).createNSString().get() options:options completionHandler:completionWrapper.get()];
         return;
     }
 #endif // USE(BROWSERENGINEKIT)
 
     auto contentView = static_cast<id<UIWKInteractionViewProtocol>>(platformContentView());
-    [contentView applyAutocorrection:toWTFString(newString) toString:toWTFString(oldString) shouldUnderline:underline withCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID](UIWKAutocorrectionRects *) {
+    [contentView applyAutocorrection:toWTFString(newString).createNSString().get() toString:toWTFString(oldString).createNSString().get() shouldUnderline:underline withCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID](UIWKAutocorrectionRects *) {
         dispatch_async(dispatch_get_main_queue(), makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
             // applyAutocorrection can call its completion handler synchronously,
             // which makes UIScriptController unhappy (see bug 172884).
@@ -1496,12 +1496,12 @@ JSObjectRef UIScriptControllerIOS::tapHighlightViewRect() const
 
 JSObjectRef UIScriptControllerIOS::attachmentInfo(JSStringRef jsAttachmentIdentifier)
 {
-    auto attachmentIdentifier = toWTFString(jsAttachmentIdentifier);
-    _WKAttachment *attachment = [webView() _attachmentForIdentifier:attachmentIdentifier];
+    RetainPtr attachmentIdentifier = toWTFString(jsAttachmentIdentifier).createNSString();
+    _WKAttachment *attachment = [webView() _attachmentForIdentifier:attachmentIdentifier.get()];
     _WKAttachmentInfo *attachmentInfo = attachment.info;
 
     NSDictionary *attachmentInfoDictionary = @{
-        @"id": attachmentIdentifier,
+        @"id": attachmentIdentifier.get(),
         @"name": attachmentInfo.name,
         @"contentType": attachmentInfo.contentType,
         @"filePath": attachmentInfo.filePath,
@@ -1571,7 +1571,7 @@ void UIScriptControllerIOS::doAfterDoubleTapDelay(JSValueRef callback)
 
 void UIScriptControllerIOS::copyText(JSStringRef text)
 {
-    UIPasteboard.generalPasteboard.string = text->string();
+    UIPasteboard.generalPasteboard.string = text->string().createNSString().get();
 }
 
 int64_t UIScriptControllerIOS::pasteboardChangeCount() const
@@ -1620,13 +1620,13 @@ bool UIScriptControllerIOS::isWebContentFirstResponder() const
 
 void UIScriptControllerIOS::setInlinePrediction(JSStringRef text, unsigned startIndex)
 {
-    NSString *plainText = text->string().substring(startIndex);
-    auto attributedText = adoptNS([[NSAttributedString alloc] initWithString:plainText attributes:@{
+    RetainPtr plainText = text->string().substring(startIndex).createNSString();
+    auto attributedText = adoptNS([[NSAttributedString alloc] initWithString:plainText.get() attributes:@{
         NSBackgroundColorAttributeName : UIColor.clearColor,
         NSForegroundColorAttributeName : UIColor.systemGrayColor,
     }]);
 
-    [UIKeyboardImpl.activeInstance setInlineCompletionAsMarkedText:attributedText.get() selectedRange:NSMakeRange(0, 0) inputString:plainText searchString:@""];
+    [UIKeyboardImpl.activeInstance setInlineCompletionAsMarkedText:attributedText.get() selectedRange:NSMakeRange(0, 0) inputString:plainText.get() searchString:@""];
 }
 
 void UIScriptControllerIOS::acceptInlinePrediction()

--- a/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
+++ b/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
@@ -652,7 +652,7 @@ void EventSenderProxy::leapForward(int milliseconds)
 
 void EventSenderProxy::keyDown(WKStringRef key, WKEventModifiers modifiers, unsigned keyLocation)
 {
-    RetainPtr<ModifierKeys> modifierKeys = [ModifierKeys modifierKeysWithKey:toWTFString(key) modifiers:buildModifierFlags(modifiers) keyLocation:keyLocation];
+    RetainPtr<ModifierKeys> modifierKeys = [ModifierKeys modifierKeysWithKey:toWTFString(key).createNSString().get() modifiers:buildModifierFlags(modifiers) keyLocation:keyLocation];
 
     NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown
         location:NSMakePoint(5, 5)
@@ -687,7 +687,7 @@ void EventSenderProxy::keyDown(WKStringRef key, WKEventModifiers modifiers, unsi
 
 void EventSenderProxy::rawKeyDown(WKStringRef key, WKEventModifiers modifiers, unsigned keyLocation)
 {
-    RetainPtr<ModifierKeys> modifierKeys = [ModifierKeys modifierKeysWithKey:toWTFString(key) modifiers:buildModifierFlags(modifiers) keyLocation:keyLocation];
+    RetainPtr<ModifierKeys> modifierKeys = [ModifierKeys modifierKeysWithKey:toWTFString(key).createNSString().get() modifiers:buildModifierFlags(modifiers) keyLocation:keyLocation];
 
     NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown
         location:NSMakePoint(5, 5)
@@ -707,7 +707,7 @@ void EventSenderProxy::rawKeyDown(WKStringRef key, WKEventModifiers modifiers, u
 
 void EventSenderProxy::rawKeyUp(WKStringRef key, WKEventModifiers modifiers, unsigned keyLocation)
 {
-    RetainPtr<ModifierKeys> modifierKeys = [ModifierKeys modifierKeysWithKey:toWTFString(key) modifiers:buildModifierFlags(modifiers) keyLocation:keyLocation];
+    RetainPtr<ModifierKeys> modifierKeys = [ModifierKeys modifierKeysWithKey:toWTFString(key).createNSString().get() modifiers:buildModifierFlags(modifiers) keyLocation:keyLocation];
 
     NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyUp
         location:NSMakePoint(5, 5)

--- a/Tools/WebKitTestRunner/mac/TestControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/TestControllerMac.mm
@@ -236,14 +236,14 @@ void TestController::configureContentExtensionForTest(const TestInvocation& test
 
     __block bool doneCompiling = false;
 
-    NSURL *tempDir;
+    RetainPtr<NSURL> tempDir;
     if (const char* dumpRenderTreeTemp = libraryPathForTesting()) {
         String temporaryFolder = String::fromUTF8(dumpRenderTreeTemp);
-        tempDir = [NSURL fileURLWithPath:[(NSString*)temporaryFolder stringByAppendingPathComponent:@"ContentExtensions"] isDirectory:YES];
+        tempDir = adoptNS([[NSURL alloc] initFileURLWithPath:[temporaryFolder.createNSString() stringByAppendingPathComponent:@"ContentExtensions"] isDirectory:YES]);
     } else
-        tempDir = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:@"ContentExtensions"] isDirectory:YES];
+        tempDir = adoptNS([[NSURL alloc] initFileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:@"ContentExtensions"] isDirectory:YES]);
 
-    [[WKContentRuleListStore storeWithURL:tempDir] compileContentRuleListForIdentifier:@"TestContentExtensions" encodedContentRuleList:contentExtensionString.get() completionHandler:^(WKContentRuleList *list, NSError *error)
+    [[WKContentRuleListStore storeWithURL:tempDir.get()] compileContentRuleListForIdentifier:@"TestContentExtensions" encodedContentRuleList:contentExtensionString.get() completionHandler:^(WKContentRuleList *list, NSError *error)
     {
         if (!error)
             [mainWebView()->platformView().configuration.userContentController addContentRuleList:list];

--- a/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
@@ -348,7 +348,7 @@ void UIScriptControllerMac::copyText(JSStringRef text)
 {
     NSPasteboard *pasteboard = NSPasteboard.generalPasteboard;
     [pasteboard declareTypes:@[NSPasteboardTypeString] owner:nil];
-    [pasteboard setString:text->string() forType:NSPasteboardTypeString];
+    [pasteboard setString:text->string().createNSString().get() forType:NSPasteboardTypeString];
 }
 
 static NSString *const TopLevelEventInfoKey = @"events";
@@ -388,7 +388,7 @@ void UIScriptControllerMac::sendEventStream(JSStringRef eventsJSON, JSValueRef c
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
 
     auto jsonString = eventsJSON->string();
-    auto eventInfo = dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:[(NSString *)jsonString dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingMutableContainers | NSJSONReadingMutableLeaves error:nil]);
+    auto eventInfo = dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:[jsonString.createNSString() dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingMutableContainers | NSJSONReadingMutableLeaves error:nil]);
     if (!eventInfo || ![eventInfo isKindOfClass:[NSDictionary class]]) {
         WTFLogAlways("JSON is not convertible to a dictionary");
         return;
@@ -486,8 +486,8 @@ void UIScriptControllerMac::setInlinePrediction(JSStringRef jsText, unsigned sta
         return;
 
     auto fullText = jsText->string();
-    RetainPtr markedText = adoptNS([[NSMutableAttributedString alloc] initWithString:fullText.left(startIndex)]);
-    [markedText appendAttributedString:adoptNS([[NSAttributedString alloc] initWithString:fullText.substring(startIndex) attributes:@{
+    RetainPtr markedText = adoptNS([[NSMutableAttributedString alloc] initWithString:fullText.left(startIndex).createNSString().get()]);
+    [markedText appendAttributedString:adoptNS([[NSAttributedString alloc] initWithString:fullText.substring(startIndex).createNSString().get() attributes:@{
         NSForegroundColorAttributeName : NSColor.grayColor,
         NSTextCompletionAttributeName : @YES
     }]).get()];


### PR DESCRIPTION
#### a739afebbd9ba184198f031ec8f004583b7c583b
<pre>
Drop remaining implicit conversions from WTF::String to NSString *
<a href="https://bugs.webkit.org/show_bug.cgi?id=291549">https://bugs.webkit.org/show_bug.cgi?id=291549</a>

Reviewed by Geoffrey Garen.

* Source/JavaScriptCore/inspector/scripts/codegen/generate_objc_backend_dispatcher_implementation.py:
(ObjCBackendDispatcherImplementationGenerator._generate_conversions_for_command):
* Source/JavaScriptCore/inspector/scripts/codegen/objc_generator.py:
(ObjCGenerator.objc_protocol_export_expression_for_variable):
(ObjCGenerator.objc_to_protocol_expression_for_member):
* Source/WebCore/page/ios/FrameIOS.mm:
(WebCore::LocalFrame::interpretationsForCurrentRoot const):
* Source/WebCore/platform/cocoa/CoreLocationGeolocationProvider.mm:
(-[WebCLLocationManager initWithWebsiteIdentifier:client:mode:]):
* Source/WebCore/platform/ios/PasteboardIOS.mm:
(WebCore::Pasteboard::readPlatformValuesAsStrings):
* Source/WebCore/platform/ios/PlatformPasteboardIOS.mm:
(WebCore::createItemProviderRegistrationList):
(WebCore::PlatformPasteboard::readString const):
(WebCore::PlatformPasteboard::containsURLStringSuitableForLoading):
* Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm:
(WebKit::GPUProcess::platformInitializeGPUProcess):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::NetworkSessionCocoa):
(WebKit::NetworkSessionCocoa::donateToSKAdNetwork):
* Source/WebKit/Platform/mac/MenuUtilities.mm:
(WebKit::menuItemForTelephoneNumber):
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::WebPaymentCoordinatorProxy::platformPaymentRequest):
* Source/WebKit/Shared/ios/WebAutocorrectionData.mm:
(WebKit::WebAutocorrectionData::WebAutocorrectionData):
* Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfo.mm:
(-[_WKActivatedElementInfo _initWithInteractionInformationAtPosition:isUsingAlternateURLForImage:userInfo:]):
(-[_WKActivatedElementInfo _initWithType:URL:imageURL:image:userInfo:information:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKElementAction.mm:
(+[_WKElementAction _elementActionWithType:customTitle:assistant:disabled:]):
(+[_WKElementAction _elementActionWithType:info:assistant:disabled:]):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _setHasCustomContentView:loadedMIMEType:]):
(-[WKWebView _didFinishLoadingDataForCustomContentProviderWithSuggestedFilename:data:]):
(-[WKWebView _uiEventAttribution]):
* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(-[WKWebView _uiViewTreeAsText]):
(-[WKWebView _scrollbarState:processID:isVertical:]):
* Source/WebKit/UIProcess/Automation/ios/WebAutomationSessionIOS.mm:
(WebKit::WebAutomationSession::platformSimulateKeyboardInteraction):
(WebKit::WebAutomationSession::platformSimulateKeySequence):
* Source/WebKit/UIProcess/Cocoa/CoreTelephonyUtilities.mm:
(WebKit::shouldAllowAutoFillForCellularIdentifiers):
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::NavigationClient::didStartLoadForQuickLookDocumentInMainFrame):
* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
* Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm:
(-[WKContactPicker presentWithRequestData:completionHandler:]):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::isLockdownModeEnabledBySystemIgnoringCaching):
* Source/WebKit/UIProcess/Downloads/DownloadProxyCocoa.mm:
(WebKit::DownloadProxy::publishProgress):
(WebKit::DownloadProxy::bookmarkDataForURL):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(-[_WKWebExtensionActionViewController initWithWebExtensionAction:]):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm:
(WebKit::WebExtensionCommand::platformMenuItem const):
(WebKit::WebExtensionCommand::keyCommand const):
(WebKit::WebExtensionCommand::matchesKeyCommand const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::singleMenuItemOrExtensionItemWithSubmenu const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm:
(WebKit::WebExtensionMenuItem::platformMenuItem const):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm:
(WebKit::AuthenticatorPresenterCoordinator::AuthenticatorPresenterCoordinator):
(WebKit::AuthenticatorPresenterCoordinator::selectAssertionResponse):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::relayAccessibilityNotification):
(WebKit::PageClientImpl::requestTextRecognition):
(WebKit::PageClientImpl::showPlaybackTargetPicker):
(WebKit::PageClientImpl::requestPasswordForQuickLookDocument):
* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm:
(-[WKActionSheetAssistant _createSheetWithElementActions:defaultTitle:showLinkTitle:]):
(-[WKActionSheetAssistant _appendAppLinkOpenActionsForURL:actions:elementInfo:]):
(-[WKActionSheetAssistant showDataDetectorsUIForPositionInformation:]):
(-[WKActionSheetAssistant _uiMenuElementsForMediaControlContextMenuItems:]):
(-[WKActionSheetAssistant showMediaControlsContextMenu:items:completionHandler:]):
(-[WKActionSheetAssistant contextMenuInteraction:configurationForMenuAtLocation:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(textRelativeToSelectionStart):
(-[WKFocusedElementInfo initWithFocusedElementInformation:isUserInitiated:userObject:]):
(-[WKContentView lookupForWebView:]):
(-[WKContentView shareForWebView:]):
(-[WKContentView translateForWebView:]):
(-[WKContentView promptForReplaceForWebView:]):
(-[WKContentView transliterateChineseForWebView:]):
(-[WKContentView accessibilityRetrieveSpeakSelectionContent]):
(-[WKContentView removeBackgroundMenu]):
(-[WKContentView textInRange:]):
(-[WKContentView _updateChangedSelection:]):
(-[WKContentView inputLabelText]):
(-[WKContentView actionSheetAssistant:shareElementWithImage:rect:]):
(-[WKContentView dataDetectionContextForPositionInformation:]):
(-[WKContentView _prepareToDragPromisedAttachment:]):
(-[WKContentView _autofillContext]):
(-[WKContentView appHighlightMenu]):
(-[WKContentView scrollToTextFragmentGenerationMenu]):
(createItemProvider):
(-[WKContentView selectTextForContextMenuWithLocationInView:completionHandler:]):
(-[WKContentView assignLegacyDataForContextMenuInteraction]):
(-[WKContentView continueContextMenuInteraction:]):
(-[WKContentView continueContextMenuInteractionWithDataDetectors:]):
(-[WKContentView _dataForPreviewItemController:atPosition:type:]):
* Source/WebKit/UIProcess/ios/WKPasswordView.mm:
(-[WKPasswordView showPasswordFailureAlert]):
* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:
(-[WKTextInteractionWrapper prepareToMoveSelectionContainer:]):
* Source/WebKit/UIProcess/ios/WKUSDPreviewView.mm:
(getUTIForUSDMIMEType):
(-[WKUSDPreviewView web_setContentProviderData:suggestedFilename:]):
* Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm:
(getToken):
(-[WKWebGeolocationPolicyDecider _executeNextChallenge]):
* Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm:
(-[WKDataListSuggestionsControl textSuggestions]):
(-[WKDataListSuggestionsPicker pickerView:titleForRow:forComponent:]):
(-[WKDataListSuggestionsPopover didSelectOptionAtIndex:]):
(-[WKDataListSuggestionsViewController tableView:cellForRowAtIndexPath:]):
(-[WKDataListSuggestionsDropdown _updateSuggestionsMenuElements]):
* Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm:
(-[WKDatePickerPopoverController viewDidLoad]):
* Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm:
(-[WKDateTimePicker controlBeginEditing]):
* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm:
(-[WKFileUploadMediaTranscoder start]):
(-[WKFileUploadPanel presentWithParameters:resultListener:]):
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm:
(-[WKOptionPickerCell initWithOptionItem:]):
(-[WKOptionGroupPickerCell initWithOptionItem:]):
(-[WKSelectSinglePicker pickerView:attributedTitleForRow:forComponent:]):
(-[WKSelectPicker createMenu]):
(-[WKSelectPicker actionForOptionItem:withIndex:]):
(-[WKSelectPickerTableViewController tableView:titleForHeaderInSection:]):
(-[WKSelectPickerTableViewController tableView:cellForRowAtIndexPath:]):
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPopover.mm:
(-[WKSelectTableViewController initWithView:hasGroups:]):
(-[WKSelectTableViewController tableView:titleForHeaderInSection:]):
(-[WKSelectTableViewController populateCell:withItem:]):
(-[WKSelectTableViewController tableView:cellForRowAtIndexPath:]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController location]):
(-[WKFullScreenViewController _showPhishingAlert]):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::requestDocumentEditingContext):
* Source/WebKit/webpushd/WebClipCache.mm:
(WebPushD::WebClipCache::load):
(WebPushD::WebClipCache::isWebClipVisible):
* Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.mm:
(WebChromeClientIOS::runJavaScriptAlert):
(WebChromeClientIOS::runJavaScriptConfirm):
(WebChromeClientIOS::runJavaScriptPrompt):
* Source/WebKitLegacy/ios/WebCoreSupport/WebMIMETypeRegistry.mm:
(+[WebMIMETypeRegistry mimeTypeForExtension:]):
(+[WebMIMETypeRegistry preferredExtensionForMIMEType:]):
* Source/WebKitLegacy/mac/DOM/DOM.mm:
(-[DOMNode hrefLabel]):
(-[DOMNode hrefTitle]):
* Source/WebKitLegacy/mac/DOM/DOMUIKitExtensions.mm:
(-[DOMHTMLImageElement mimeType]):
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::createPreviewLoaderClient):
* Source/WebKitLegacy/mac/WebCoreSupport/WebSecurityOrigin.mm:
(-[WebSecurityOrigin toString]):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(+[WebFrame stringWithData:textEncodingName:]):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _startDrag:]):
(-[WebView removeVisitedLink:]):
* Tools/DumpRenderTree/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::copyText):
* Tools/DumpRenderTree/mac/UIScriptControllerMac.mm:
(WTR::UIScriptControllerMac::copyText):
(WTR::UIScriptControllerMac::sendEventStream):
* Tools/TestWebKitAPI/PlatformUtilities.h:
(TestWebKitAPI::Util::toSTD):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(createCertificate):
(createPrivateKey):
(TEST(IPCSerialization, SecTrustRef)):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/SharedBuffer.mm:
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, createNSDataArray)):
* Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm:
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, ApplyNavigationalProtectionsAfterMultiplePSON)):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, DoNotHideReferrerInPopupWindow)):
(TestWebKitAPI::setUpWebViewForTestingQueryParameterHiding):
(TestWebKitAPI::setUpWebViewForTestingTrackerDomainBlocking):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, LinkPreconnectUsesEnhancedPrivacy)):
(TestWebKitAPI::webViewAfterCrossSiteNavigationWithReducedPrivacy):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, DoNotHideReferrerAfterReducingPrivacyProtections)):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, DoNotHideReferrerAfterReducingPrivacyProtectionsWithJSRedirect)):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, DoNotHideReferrerAfterReducingPrivacyProtectionsWithHTTPRedirect)):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, HideScreenMetricsFromBindings)):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, AddNoiseToWebAudioAPIsAfterMultiplePSON)):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, AddNoiseToWebAudioAPIsAfterReducingPrivacyProtectionsAndMultiplePSON)):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, Canvas2DQuirks)):
* Tools/TestWebKitAPI/Tests/WebKit/MediaSessionCoordinatorTest.mm:
(TestWebKitAPI::MediaSessionCoordinatorTest::loadPageAndBecomeReady):
(TestWebKitAPI::MediaSessionCoordinatorTest::runScriptWithUserGesture):
(TestWebKitAPI::MediaSessionCoordinatorTest::listenForEventMessages):
(TestWebKitAPI::MediaSessionCoordinatorTest::listenForMessagesPosted):
* Tools/TestWebKitAPI/Tests/WebKit/OverrideAppleLanguagesPreference.mm:
(AppleLanguagesTest::~AppleLanguagesTest):
* Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm:
(runBackForwardNavigationSkipsItemsWithoutUserGestureTest):
(TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGesturePushState)):
(TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGestureFragment)):
(TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGesturePushStateAfterEvaluateJS)):
(runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest):
(TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsWithUserGesturePushState)):
(TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsWithUserGestureFragment)):
(TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsFromLoadRequest)):
(TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsWithRecentUserGesturePushState)):
(TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsWithRecentUserGestureFragment)):
(TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipUpdatedItemWithRecentUserGesture)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CookiePrivateBrowsing.mm:
(TEST(WebKit, CookieCachePruning)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm:
(TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_LimitContextToEditableRoot)):
(TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_LimitContextToVisibleText)):
(TEST(DocumentEditingContext, CharacterRectsInEditableWebView)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm:
(-[DownloadDelegate _download:decideDestinationWithSuggestedFilename:allowOverwrite:]):
(-[DownloadDelegate _downloadDidFinish:]):
(-[BlobDownloadDelegate _download:decideDestinationWithSuggestedFilename:allowOverwrite:]):
(-[BlobDownloadDelegate _downloadDidFinish:]):
(-[RedirectedDownloadDelegate _download:decideDestinationWithSuggestedFilename:allowOverwrite:]):
(-[BlobWithUSDZExtensionDownloadDelegate _download:decideDestinationWithSuggestedFilename:completionHandler:]):
(-[DownloadCancelingDelegate download:decideDestinationUsingResponse:suggestedFilename:completionHandler:]):
(TestWebKitAPI::ResumeWithExtraInitialDataOnDisk)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DownloadProgress.mm:
(-[DownloadProgressTestRunner _download:decideDestinationWithSuggestedFilename:completionHandler:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/HistoryDelegate.mm:
(TEST(HistoryDelegate, NonpersistentDataStoreDoesNotSendHistoryEvents)):
(TEST(HistoryDelegate, NonpersistentDataStoreSendsHistoryEventsWhenAllowingPrivacySensitiveOperations)):
(TEST(HistoryDelegate, PersistentDataStoreSendsHistoryEvents)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBCheckpointWAL.mm:
(TEST(IndexedDB, CheckpointsWALAutomatically)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBIndexUpgradeToV2.mm:
(TEST(IndexedDB, IndexUpgradeToV2)):
(runMultipleIndicesTestWithDatabase):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBObjectStoreInfoUpgradeToV2.mm:
(TEST(IndexedDB, IDBObjectStoreInfoUpgradeToV2)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IconLoadingDelegate.mm:
(TEST(IconLoading, DefaultFavicon)):
(TEST(IconLoading, AlreadyCachedIcon)):
(TEST(IconLoading, IconLoadCancelledCallback)):
(TEST(IconLoading, IconLoadCancelledCallback2)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ImageAnalysisTests.mm:
(TestWebKitAPI::invokeRemoveBackgroundAction):
(TestWebKitAPI::TEST(ImageAnalysisTests, RemoveBackgroundUsingContextMenu)):
(TestWebKitAPI::TEST(ImageAnalysisTests, MenuControllerItems)):
(TestWebKitAPI::TEST(ImageAnalysisTests, AllowRemoveBackgroundOnce)):
(TestWebKitAPI::TEST(ImageAnalysisTests, RemoveBackgroundItemInServicesMenu)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBFileName.mm:
(runTest):
(createDirectories):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm:
(IndexedDBThirdPartyStorageLayout)):
(MigrateThirdPartyDataToGeneralStorageDirectory)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBTempFileSize.mm:
(TEST(IndexedDB, IndexedDBTempFileSize)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaSession.mm:
(TestWebKitAPI::MediaSessionTest::listenForEventMessages):
(TestWebKitAPI::MediaSessionTest::listenForSessionHandlerMessages):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm:
(TEST(WKNavigation, HTTPSFirstLocalHostIPAddress)):
(TEST(WKNavigation, PreferredHTTPSPolicyAutomaticHTTPFallbackLocalHostIPAddress)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NetworkProcess.mm:
(waitUntilNetworkProcessIsResponsive):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PermissionsAPI.mm:
(TestWebKitAPI::TEST(PermissionsAPI, DataURL)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
(-[PSONScheme webView:startURLSchemeTask:]):
((ProcessSwap, PSONRedirectionToExternal)):
((ProcessSwap, NumberOfCachedProcesses)):
((ProcessSwap, CrossOriginBlobNavigation)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm:
((PushAPI, firePushEventDataStoreDelegate)):
((PushAPI, testSilentFlag)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm:
(TEST(ResourceLoadStatistics, DataSummaryWithCachedProcess)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm:
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceed2)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceed3)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWithRedirectionAndCookie)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWithDifferentOrigin)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, NoInterceptions)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, NoInterceptionsSubFrame)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionError)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionCancel)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByItself)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByParent)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByWebKit)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedWithOtherHttpStatusCode)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedWithCookie)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedTwice)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedSuppressActiveSession)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedNewWindowNavigation)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, AuthorizationOptions)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyIgnore)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyAllowAsync)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyIgnoreAsync)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, NoInterceptions)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, NoInterceptionsNonAppleFirstPartyMainFrame)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionError)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionCancel)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSuccess)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSucceedWithOtherHttpStatusCode)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookie)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookieButCSPDeny)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookieButXFrameDeny)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSuccessTwice)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, AuthorizationOptions)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyIgnore)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyAllowAsync)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyIgnoreAsync)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionErrorWithReferrer)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionErrorMessageOrder)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSuccessMessageOrder)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SampledPageTopColor.mm:
(waitForSampledPageTopColorToChangeForHTML):
(TEST(SampledPageTopColor, ZeroMaxDifference)):
(TEST(SampledPageTopColor, NegativeMaxDifference)):
(TEST(SampledPageTopColor, DifferentColorsWithMiddleOutlierAboveMaxDifference)):
(TEST(SampledPageTopColor, DifferentColorsIndividuallyAboveMaxDifference)):
(TEST(SampledPageTopColor, DifferentColorsCumulativelyAboveMaxDifference)):
(TEST(SampledPageTopColor, VerticalGradientBelowMaxDifference)):
(TEST(SampledPageTopColor, VerticalGradientAboveMaxDifference)):
(TEST(SampledPageTopColor, DISABLED_DisplayP3)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm:
((ServiceWorkers, ThirdPartyRestoredFromDisk)):
((ServiceWorkers, ServiceWorkerAndCacheStorageSpecificDirectories)):
((ServiceWorkers, LockdownModeInServiceWorkerProcess)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/StorageQuota.mm:
((WebKit, DefaultQuota)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/StoreBlobThenDelete.mm:
(TEST(IndexedDB, StoreBlobThenRemoveData)):
(TEST(IndexedDB, StoreBlobThenDeleteDatabase)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemPreview.mm:
(TestWebKitAPI::TEST(WebKit, SystemPreviewTriggered)):
(TestWebKitAPI::TEST(WebKit, SystemPreviewTriggeredOnDetachedElement)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TLSDeprecation.mm:
(TestWebKitAPI::TEST(TLSVersion, Preconnect)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TimeZoneOverride.mm:
(TimeZoneOverrideTest::runScriptAndExecuteCallback):
(TimeZoneOverrideTest::callAsyncFunctionBody):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:
(TestWebKitAPI::UnifiedPDFWithKeyboardScrolling::synchronouslyLoadPDFDocument):
(TestWebKitAPI::UNIFIED_PDF_TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentViewEditingActions.mm:
(TEST(WebKit, DISABLED_AppHighlightsInImageOverlays)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::(WebPushDTest, UnsubscribesOnClearingWebsiteDataForOrigin)):
(TestWebKitAPI::(WebPushDInjectedPushTest, HandleInjectedAES128GCMPush)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm:
(TEST(WebKit, MigrateIndexedDBDataToGeneralStorageDirectory)):
((WKWebsiteDataStore, FetchAndDeleteMediaKeysData)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(-[WritingToolsWKWebView contentsAsStringWithoutNBSP]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm:
(-[TestWebAuthenticationPanelDelegate panel:requestPINWithRemainingRetries:completionHandler:]):
(TestWebKitAPI::WebCore::addKeyToKeychain):
(TestWebKitAPI::WebCore::cleanUpKeychain):
(TestWebKitAPI::TEST(WebAuthenticationPanel, SubFrameChangeLocationHidCancel)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, SubFrameDestructionHidCancel)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, MakeCredentialLA)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, MakeCredentialLAClientDataHashMediation)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, MakeCredentialLAAttestationFalback)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, ExportImportCredential)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, ExportImportDuplicateCredential)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, ImportMalformedCredential)):
* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:
(TestWebKitAPI::TEST(KeyboardInputTests, NoCrashWhenDiscardingMarkedText)):
* Tools/TestWebKitAPI/Tests/ios/Viewport.mm:
(TestWebKitAPI::makeViewportMetaTag):
(TestWebKitAPI::TEST(Viewport, MinimumEffectiveDeviceWidthWithInitialScale)):
(TestWebKitAPI::TEST(Viewport, RespectInitialScaleExceptOnWikipediaDomain)):
* Tools/TestWebKitAPI/cocoa/TestInspectorURLSchemeHandler.mm:
(-[TestInspectorURLSchemeHandler webView:startURLSchemeTask:]):
* Tools/TestWebKitAPI/ios/PreferredContentMode.mm:
* Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm:
(WTR::searchPredicateForSearchCriteria):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::selectTextParameterizedAttributeForCriteria):
(WTR::searchTextParameterizedAttributeForCriteria):
(WTR::textOperationParameterizedAttribute):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::cocoaPlatformInitialize):
(WTR::TestController::platformSetStatisticsCrossSiteLoadWithLinkDecoration):
(WTR::TestController::injectUserScript):
(WTR::TestController::addTestKeyToKeychain):
(WTR::TestController::cleanUpKeychain):
(WTR::TestController::keyExistsInKeychain):
(WTR::TestController::abortBackgroundFetch):
(WTR::TestController::pauseBackgroundFetch):
(WTR::TestController::resumeBackgroundFetch):
(WTR::TestController::simulateClickBackgroundFetch):
(WTR::TestController::backgroundFetchState):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::findString):
(WTR::UIScriptControllerCocoa::contentsOfUserInterfaceItem const):
(WTR::UIScriptControllerCocoa::insertAttachmentForFilePath):
(WTR::UIScriptControllerCocoa::fixedContainerEdgeColors const):
(WTR::UIScriptControllerCocoa::cookiesForDomain):
* Tools/WebKitTestRunner/cocoa/WKTextExtractionTestingHelpers.mm:
(WTR::recursiveDescription):
* Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm:
(WTR::PlatformWebView::setTextInChromeInputField):
* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
(WTR::TestController::setKeyboardInputModeIdentifier):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::singleTapAtPointWithModifiers):
(WTR::UIScriptControllerIOS::stylusTapAtPointWithModifiers):
(WTR::UIScriptControllerIOS::sendEventStream):
(WTR::UIScriptControllerIOS::typeCharacterUsingHardwareKeyboard):
(WTR::UIScriptControllerIOS::rawKeyDown):
(WTR::UIScriptControllerIOS::rawKeyUp):
(WTR::UIScriptControllerIOS::keyDown):
(WTR::UIScriptControllerIOS::applyAutocorrection):
(WTR::UIScriptControllerIOS::attachmentInfo):
(WTR::UIScriptControllerIOS::copyText):
(WTR::UIScriptControllerIOS::setInlinePrediction):
* Tools/WebKitTestRunner/mac/EventSenderProxy.mm:
(WTR::EventSenderProxy::keyDown):
(WTR::EventSenderProxy::rawKeyDown):
(WTR::EventSenderProxy::rawKeyUp):
* Tools/WebKitTestRunner/mac/TestControllerMac.mm:
(WTR::TestController::configureContentExtensionForTest):
* Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm:
(WTR::UIScriptControllerMac::copyText):
(WTR::UIScriptControllerMac::sendEventStream):
(WTR::UIScriptControllerMac::setInlinePrediction):

Canonical link: <a href="https://commits.webkit.org/293715@main">https://commits.webkit.org/293715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ad56fd49180c661917ebf876bb6f9db948ebd8d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99659 "11 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104789 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50255 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101700 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19598 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27742 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75860 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32960 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102666 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89988 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56219 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14724 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7974 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49616 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92339 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84684 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107148 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98277 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26774 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19547 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84819 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27138 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86192 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84337 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21423 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29015 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6721 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20566 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26714 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31917 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121893 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26529 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34045 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29845 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28099 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->