### PR TITLE
Optimize Path::fastBoundingRect()

### DIFF
--- a/Source/WebCore/platform/graphics/FloatRect.cpp
+++ b/Source/WebCore/platform/graphics/FloatRect.cpp
@@ -154,12 +154,24 @@ void FloatRect::uniteIfNonZero(const FloatRect& other)
     uniteEvenIfEmpty(other);
 }
 
-void FloatRect::extend(const FloatPoint& p)
+void FloatRect::extend(FloatPoint p)
 {
     float minX = std::min(x(), p.x());
     float minY = std::min(y(), p.y());
     float maxX = std::max(this->maxX(), p.x());
     float maxY = std::max(this->maxY(), p.y());
+
+    setLocationAndSizeFromEdges(minX, minY, maxX, maxY);
+}
+
+void FloatRect::extend(FloatPoint minPoint, FloatPoint maxPoint)
+{
+    ASSERT(minPoint.x() <= maxPoint.x() && minPoint.y() <= maxPoint.y());
+
+    float minX = std::min(x(), minPoint.x());
+    float minY = std::min(y(), minPoint.y());
+    float maxX = std::max(this->maxX(), maxPoint.x());
+    float maxY = std::max(this->maxY(), maxPoint.y());
 
     setLocationAndSizeFromEdges(minX, minY, maxX, maxY);
 }

--- a/Source/WebCore/platform/graphics/FloatRect.h
+++ b/Source/WebCore/platform/graphics/FloatRect.h
@@ -188,7 +188,8 @@ public:
     WEBCORE_EXPORT void unite(const FloatRect&);
     void uniteEvenIfEmpty(const FloatRect&);
     void uniteIfNonZero(const FloatRect&);
-    WEBCORE_EXPORT void extend(const FloatPoint&);
+    WEBCORE_EXPORT void extend(FloatPoint);
+    void extend(FloatPoint minPoint, FloatPoint maxPoint);
 
     // Note, this doesn't match what IntRect::contains(IntPoint&) does; the int version
     // is really checking for containment of 1x1 rect, but that doesn't make sense with floats.

--- a/Source/WebCore/platform/graphics/GeometryUtilities.h
+++ b/Source/WebCore/platform/graphics/GeometryUtilities.h
@@ -111,6 +111,16 @@ struct RotatedRect {
 
 WEBCORE_EXPORT RotatedRect rotatedBoundingRectWithMinimumAngleOfRotation(const FloatQuad&, std::optional<float> minRotationInRadians = std::nullopt);
 
+static inline float min3(float a, float b, float c)
+{
+    return std::min(std::min(a, b), c);
+}
+
+static inline float max3(float a, float b, float c)
+{
+    return std::max(std::max(a, b), c);
+}
+
 static inline float min4(float a, float b, float c, float d)
 {
     return std::min(std::min(a, b), std::min(c, d));


### PR DESCRIPTION
#### cca3917b8294d93936438c5ad7969111c02321fa
<pre>
Optimize Path::fastBoundingRect()
<a href="https://bugs.webkit.org/show_bug.cgi?id=291552">https://bugs.webkit.org/show_bug.cgi?id=291552</a>
<a href="https://rdar.apple.com/149258802">rdar://149258802</a>

Reviewed by Cameron McCormack.

Calling `boundingRect.extend()` for every point does extra work, because it recomputes the
rect&apos;s origin and size every time. Instead, compute the min/max for all the points, and then
update the rect once. We can save another min/max comparison by adding a two-argument version
of FloatRect::extend() which assumes that the points are ordered.

I tested `FloatRect::extend(std::initializer_list&lt;FloatRect&gt;)` but this was a little slower.

In cases where the `extend()` arguments are rect corners, we can just use `uniteEvenIfEmpty()`.

* Source/WebCore/platform/graphics/FloatRect.cpp:
(WebCore::FloatRect::extend):
* Source/WebCore/platform/graphics/FloatRect.h:
* Source/WebCore/platform/graphics/GeometryUtilities.h:
(WebCore::min3):
(WebCore::max3):
* Source/WebCore/platform/graphics/PathSegmentData.cpp:
(WebCore::extendRect):
(WebCore::PathQuadCurveTo::extendFastBoundingRect const):
(WebCore::PathQuadCurveTo::extendBoundingRect const):
(WebCore::PathBezierCurveTo::extendFastBoundingRect const):
(WebCore::PathBezierCurveTo::extendBoundingRect const):
(WebCore::PathArcTo::extendFastBoundingRect const):
(WebCore::PathArcTo::extendBoundingRect const):
(WebCore::PathArc::extendFastBoundingRect const):
(WebCore::PathArc::extendBoundingRect const):
(WebCore::PathEllipse::extendFastBoundingRect const):
(WebCore::PathEllipseInRect::extendBoundingRect const):
(WebCore::PathRect::extendBoundingRect const):
(WebCore::PathRoundedRect::extendBoundingRect const):
(WebCore::PathContinuousRoundedRect::extendBoundingRect const):
(WebCore::PathDataQuadCurve::extendFastBoundingRect const):
(WebCore::PathDataQuadCurve::extendBoundingRect const):
(WebCore::PathDataBezierCurve::extendFastBoundingRect const):
(WebCore::PathDataBezierCurve::extendBoundingRect const):
(WebCore::PathDataArc::extendFastBoundingRect const):
(WebCore::PathDataArc::extendBoundingRect const):

Canonical link: <a href="https://commits.webkit.org/293710@main">https://commits.webkit.org/293710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d42ab8e6434b560da7db94986a9b2048e0dc199

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19310 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104790 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50256 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101702 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19599 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27744 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75864 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32959 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102668 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14926 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89989 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56223 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14726 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-fixed-ancestor-iframe.html imported/w3c/web-platform-tests/webstorage/storage_session_window_open.window.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7975 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49617 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8060 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107150 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26775 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19548 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84822 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27139 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86193 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84340 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21416 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29016 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6722 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20567 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26716 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31919 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26531 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29846 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28100 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->