### PR TITLE
Remove GraphicsContext::useDarkAppearance()

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -167,9 +167,6 @@ public:
     bool drawLuminanceMask() const { return m_state.drawLuminanceMask(); }
     void setDrawLuminanceMask(bool drawLuminanceMask) { m_state.setDrawLuminanceMask(drawLuminanceMask); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::DrawLuminanceMask)); }
 
-    bool useDarkAppearance() const { return m_state.useDarkAppearance(); }
-    void setUseDarkAppearance(bool useDarkAppearance) { m_state.setUseDarkAppearance(useDarkAppearance); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::UseDarkAppearance)); }
-
     virtual const GraphicsContextState& state() const { return m_state; }
     void mergeLastChanges(const GraphicsContextState&, const std::optional<GraphicsContextState>& lastDrawingState = std::nullopt);
     void mergeAllChanges(const GraphicsContextState&);

--- a/Source/WebCore/platform/graphics/GraphicsContextState.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.cpp
@@ -126,9 +126,6 @@ void GraphicsContextState::mergeSingleChange(const GraphicsContextState& state, 
     case toIndex(Change::DrawLuminanceMask).value:
         mergeChange(&GraphicsContextState::m_drawLuminanceMask);
         break;
-    case toIndex(Change::UseDarkAppearance).value:
-        mergeChange(&GraphicsContextState::m_useDarkAppearance);
-        break;
     default:
         RELEASE_ASSERT_NOT_REACHED();
     }
@@ -163,7 +160,6 @@ void GraphicsContextState::mergeAllChanges(const GraphicsContextState& state)
     mergeChange(Change::ShouldSubpixelQuantizeFonts, &GraphicsContextState::m_shouldSubpixelQuantizeFonts);
     mergeChange(Change::ShadowsIgnoreTransforms,     &GraphicsContextState::m_shadowsIgnoreTransforms);
     mergeChange(Change::DrawLuminanceMask,           &GraphicsContextState::m_drawLuminanceMask);
-    mergeChange(Change::UseDarkAppearance,           &GraphicsContextState::m_useDarkAppearance);
 }
 
 static ASCIILiteral stateChangeName(GraphicsContextState::Change change)
@@ -216,9 +212,6 @@ static ASCIILiteral stateChangeName(GraphicsContextState::Change change)
 
     case GraphicsContextState::Change::DrawLuminanceMask:
         return "draw-luminance-mask"_s;
-
-    case GraphicsContextState::Change::UseDarkAppearance:
-        return "use-dark-appearance"_s;
     }
 
     RELEASE_ASSERT_NOT_REACHED();
@@ -253,7 +246,6 @@ TextStream& GraphicsContextState::dump(TextStream& ts) const
     dump(Change::ShouldSubpixelQuantizeFonts,   &GraphicsContextState::m_shouldSubpixelQuantizeFonts);
     dump(Change::ShadowsIgnoreTransforms,       &GraphicsContextState::m_shadowsIgnoreTransforms);
     dump(Change::DrawLuminanceMask,             &GraphicsContextState::m_drawLuminanceMask);
-    dump(Change::UseDarkAppearance,             &GraphicsContextState::m_useDarkAppearance);
     return ts;
 }
 

--- a/Source/WebCore/platform/graphics/GraphicsContextState.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.h
@@ -58,7 +58,6 @@ public:
         ShouldSubpixelQuantizeFonts = 1 << 13,
         ShadowsIgnoreTransforms     = 1 << 14,
         DrawLuminanceMask           = 1 << 15,
-        UseDarkAppearance           = 1 << 16,
     };
     using ChangeFlags = OptionSet<Change>;
 
@@ -142,9 +141,6 @@ public:
     bool drawLuminanceMask() const { return m_drawLuminanceMask; }
     void setDrawLuminanceMask(bool drawLuminanceMask) { setProperty(Change::DrawLuminanceMask, &GraphicsContextState::m_drawLuminanceMask, drawLuminanceMask); }
 
-    bool useDarkAppearance() const { return m_useDarkAppearance; }
-    void setUseDarkAppearance(bool useDarkAppearance) { setProperty(Change::UseDarkAppearance, &GraphicsContextState::m_useDarkAppearance, useDarkAppearance); }
-    
     void mergeLastChanges(const GraphicsContextState&, const std::optional<GraphicsContextState>& lastDrawingState = std::nullopt);
     void mergeSingleChange(const GraphicsContextState&, ChangeIndex, const std::optional<GraphicsContextState>& lastDrawingState = std::nullopt);
     void mergeAllChanges(const GraphicsContextState&);
@@ -198,7 +194,6 @@ private:
     bool m_shouldSubpixelQuantizeFonts { true };
     bool m_shadowsIgnoreTransforms { false };
     bool m_drawLuminanceMask { false };
-    bool m_useDarkAppearance { false };
 
     Purpose m_purpose { Purpose::Initial };
 };

--- a/Source/WebCore/rendering/TextPaintStyle.cpp
+++ b/Source/WebCore/rendering/TextPaintStyle.cpp
@@ -50,7 +50,6 @@ bool TextPaintStyle::operator==(const TextPaintStyle& other) const
 {
     return fillColor == other.fillColor && strokeColor == other.strokeColor && emphasisMarkColor == other.emphasisMarkColor
         && strokeWidth == other.strokeWidth && paintOrder == other.paintOrder && lineJoin == other.lineJoin
-        && useDarkAppearance == other.useDarkAppearance
         && lineCap == other.lineCap && miterLimit == other.miterLimit;
 }
 
@@ -75,7 +74,6 @@ TextPaintStyle computeTextPaintStyle(const RenderText& renderer, const RenderSty
 {
     auto& frame = renderer.frame();
     TextPaintStyle paintStyle;
-    paintStyle.useDarkAppearance = frame.document() ? frame.document()->useDarkAppearance(&lineStyle) : false;
 
     auto viewportSize = frame.view() ? frame.view()->size() : IntSize();
     paintStyle.strokeWidth = lineStyle.computedStrokeWidth(viewportSize);
@@ -182,7 +180,6 @@ void updateGraphicsContext(GraphicsContext& context, const TextPaintStyle& paint
         context.setTextDrawingMode(newMode);
         mode = newMode;
     }
-    context.setUseDarkAppearance(paintStyle.useDarkAppearance);
 
     Color fillColor = fillColorType == UseEmphasisMarkColor ? paintStyle.emphasisMarkColor : paintStyle.fillColor;
     if (mode.contains(TextDrawingMode::Fill) && (fillColor != context.fillColor()))

--- a/Source/WebCore/rendering/TextPaintStyle.h
+++ b/Source/WebCore/rendering/TextPaintStyle.h
@@ -50,7 +50,6 @@ struct TextPaintStyle {
     float strokeWidth { 0 };
     // This is not set for -webkit-text-fill-color.
     bool hasExplicitlySetFillColor { false };
-    bool useDarkAppearance { false };
     PaintOrder paintOrder { PaintOrder::Normal };
     LineJoin lineJoin { LineJoin::Miter };
     LineCap lineCap { LineCap::Butt };

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -284,11 +284,6 @@ void RemoteDisplayListRecorder::setDrawLuminanceMask(bool value)
     context().setDrawLuminanceMask(value);
 }
 
-void RemoteDisplayListRecorder::setUseDarkAppearance(bool value)
-{
-    context().setUseDarkAppearance(value);
-}
-
 void RemoteDisplayListRecorder::setLineCap(LineCap lineCap)
 {
     context().setLineCap(lineCap);

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
@@ -92,7 +92,6 @@ public:
     void setShouldSubpixelQuantizeFonts(bool);
     void setShadowsIgnoreTransforms(bool);
     void setDrawLuminanceMask(bool);
-    void setUseDarkAppearance(bool);
     void setLineCap(WebCore::LineCap);
     void setLineDash(WebCore::DashArray&&, float dashOffset);
     void setLineJoin(WebCore::LineJoin);

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
@@ -60,7 +60,6 @@ messages -> RemoteDisplayListRecorder Stream {
     SetShouldSubpixelQuantizeFonts(bool shouldQuantize) StreamBatched
     SetShadowsIgnoreTransforms(bool shouldIgnore) StreamBatched
     SetDrawLuminanceMask(bool shouldDraw) StreamBatched
-    SetUseDarkAppearance(bool shouldUse) StreamBatched
     SetLineCap(enum:uint8_t WebCore::LineCap lineCap) StreamBatched
     SetLineDash(WebCore::DashArray dashArray, float dashOffset) StreamBatched
     SetLineJoin(enum:uint8_t WebCore::LineJoin lineJoin) StreamBatched

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -746,8 +746,6 @@ void RemoteDisplayListRecorderProxy::appendStateChangeItemIfNecessary()
         send(Messages::RemoteDisplayListRecorder::SetShouldSubpixelQuantizeFonts(state.shouldSubpixelQuantizeFonts()));
     if (changes.contains(GraphicsContextState::Change::DrawLuminanceMask))
         send(Messages::RemoteDisplayListRecorder::SetDrawLuminanceMask(state.drawLuminanceMask()));
-    if (changes.contains(GraphicsContextState::Change::UseDarkAppearance))
-        send(Messages::RemoteDisplayListRecorder::SetUseDarkAppearance(state.useDarkAppearance()));
 
     state.didApplyChanges();
     currentState().lastDrawingState = state;


### PR DESCRIPTION
#### 8a486091674cf28c34907fec0b5aa0ec09e43ef0
<pre>
Remove GraphicsContext::useDarkAppearance()
<a href="https://bugs.webkit.org/show_bug.cgi?id=291553">https://bugs.webkit.org/show_bug.cgi?id=291553</a>
<a href="https://rdar.apple.com/149262356">rdar://149262356</a>

Reviewed by Aditya Keerthi.

`GraphicsContext::useDarkAppearance()` is unused, so remove it.

* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::useDarkAppearance const): Deleted.
(WebCore::GraphicsContext::setUseDarkAppearance): Deleted.
* Source/WebCore/platform/graphics/GraphicsContextState.cpp:
(WebCore::GraphicsContextState::mergeSingleChange):
(WebCore::GraphicsContextState::mergeAllChanges):
(WebCore::stateChangeName):
(WebCore::GraphicsContextState::dump const):
* Source/WebCore/platform/graphics/GraphicsContextState.h:
(WebCore::GraphicsContextState::useDarkAppearance const): Deleted.
(WebCore::GraphicsContextState::setUseDarkAppearance): Deleted.
* Source/WebCore/rendering/TextPaintStyle.cpp:
(WebCore::TextPaintStyle::operator== const):
(WebCore::computeTextPaintStyle):
(WebCore::updateGraphicsContext):
* Source/WebCore/rendering/TextPaintStyle.h:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::setUseDarkAppearance): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::appendStateChangeItemIfNecessary):

Canonical link: <a href="https://commits.webkit.org/293709@main">https://commits.webkit.org/293709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64c904a57f8c6c7a366d118e051f86efff11775b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9578 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104796 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50261 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101708 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27750 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75867 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32965 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102674 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14929 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89991 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56227 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14729 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7977 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49623 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8062 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107156 "Hash 64c904a5 for PR 44085 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19551 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/107156 "Hash 64c904a5 for PR 44085 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27145 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86195 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/107156 "Hash 64c904a5 for PR 44085 does not build (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21415 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29019 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6724 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20571 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26722 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31925 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26537 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29852 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28106 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->