### PR TITLE
Reduce unsafe lambdas in WebCore/page

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -58,13 +58,8 @@ html/track/TrackBase.cpp
 inspector/InspectorOverlay.cpp
 inspector/agents/page/PageDOMDebuggerAgent.cpp
 loader/NetscapePlugInStreamLoader.cpp
-page/EventSource.cpp
 page/ImageAnalysisQueue.cpp
-page/LocalDOMWindow.cpp
-page/Quirks.cpp
-page/ScreenOrientation.cpp
 page/ShareDataReader.cpp
-page/UserMessageHandlersNamespace.cpp
 page/cocoa/ResourceUsageOverlayCocoa.mm
 page/csp/ContentSecurityPolicy.cpp
 platform/RemoteCommandListener.cpp

--- a/Source/WebCore/dom/ActiveDOMObject.h
+++ b/Source/WebCore/dom/ActiveDOMObject.h
@@ -94,7 +94,7 @@ public:
         T& object() { return m_thisObject.get(); }
 
     private:
-        Ref<T> m_thisObject;
+        const Ref<T> m_thisObject;
     };
 
     template<class T> Ref<PendingActivity<T>> makePendingActivity(T& thisObject)

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -573,10 +573,10 @@ class EmptyStorageNamespaceProvider final : public StorageNamespaceProvider {
 };
 
 class EmptyUserContentProvider final : public UserContentProvider {
-    void forEachUserScript(Function<void(DOMWrapperWorld&, const UserScript&)>&&) const final { }
-    void forEachUserStyleSheet(Function<void(const UserStyleSheet&)>&&) const final { }
+    void forEachUserScript(NOESCAPE const Function<void(DOMWrapperWorld&, const UserScript&)>&) const final { }
+    void forEachUserStyleSheet(NOESCAPE const Function<void(const UserStyleSheet&)>&) const final { }
 #if ENABLE(USER_MESSAGE_HANDLERS)
-    void forEachUserMessageHandler(Function<void(const UserMessageHandlerDescriptor&)>&&) const final { }
+    void forEachUserMessageHandler(NOESCAPE const Function<void(const UserMessageHandlerDescriptor&)>&) const final { }
 #endif
 #if ENABLE(CONTENT_EXTENSIONS)
     ContentExtensions::ContentExtensionsBackend& userContentExtensionBackend() final { static NeverDestroyed<ContentExtensions::ContentExtensionsBackend> backend; return backend.get(); };

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -417,9 +417,9 @@ void EventSource::resume()
 
     m_isSuspendedForBackForwardCache = false;
     if (std::exchange(m_shouldReconnectOnResume, false)) {
-        scriptExecutionContext()->postTask([this, pendingActivity = makePendingActivity(*this)](ScriptExecutionContext&) {
-            if (!isContextStopped())
-                scheduleReconnect();
+        scriptExecutionContext()->postTask([pendingActivity = makePendingActivity(*this)](ScriptExecutionContext&) {
+            if (!pendingActivity->object().isContextStopped())
+                pendingActivity->object().scheduleReconnect();
         });
     }
 }

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -746,7 +746,7 @@ void LocalFrame::injectUserScripts(UserScriptInjectionTime injectionTime)
         return;
 
     RefPtr page = this->page();
-    page->protectedUserContentProvider()->forEachUserScript([this, protectedThis = Ref { *this }, injectionTime] (DOMWrapperWorld& world, const UserScript& script) {
+    page->protectedUserContentProvider()->forEachUserScript([this, injectionTime](DOMWrapperWorld& world, const UserScript& script) {
         if (script.injectionTime() == injectionTime)
             injectUserScriptImmediately(world, script);
     });

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1118,13 +1118,13 @@ Quirks::StorageAccessResult Quirks::triggerOptionalStorageAccessQuirk(Element& e
 
         // If the click is synthetic, the user has already gone through the storage access flow and we should not request again.
         if (isStorageAccessQuirkDomainAndElement(document->url(), element) && isSyntheticClick == IsSyntheticClick::No) {
-            return requestStorageAccessAndHandleClick([element = WeakPtr { element }, platformEvent, eventType, detail, relatedTarget] (ShouldDispatchClick shouldDispatchClick) mutable {
+            return requestStorageAccessAndHandleClick([element = WeakPtr { element }, platformEvent, eventType, detail, relatedTarget = WeakPtr { relatedTarget }] (ShouldDispatchClick shouldDispatchClick) mutable {
                 RefPtr protectedElement { element.get() };
                 if (!protectedElement)
                     return;
 
                 if (shouldDispatchClick == ShouldDispatchClick::Yes)
-                    protectedElement->dispatchMouseEvent(platformEvent, eventType, detail, relatedTarget, IsSyntheticClick::Yes);
+                    protectedElement->dispatchMouseEvent(platformEvent, eventType, detail, relatedTarget.get(), IsSyntheticClick::Yes);
             });
         }
     }

--- a/Source/WebCore/page/ScreenOrientation.cpp
+++ b/Source/WebCore/page/ScreenOrientation.cpp
@@ -137,8 +137,8 @@ void ScreenOrientation::lock(LockType lockType, Ref<DeferredPromise>&& promise)
         });
     }
     manager->setLockPromise(*this, WTFMove(promise));
-    manager->lock(lockType, [this, protectedThis = makePendingActivity(*this)](std::optional<Exception>&& exception) mutable {
-        queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [exception = WTFMove(exception)](auto& orientation) mutable {
+    manager->lock(lockType, [pendingActivity = makePendingActivity(*this)](std::optional<Exception>&& exception) mutable {
+        queueTaskKeepingObjectAlive(pendingActivity->object(), TaskSource::DOMManipulation, [exception = WTFMove(exception)](auto& orientation) mutable {
             auto* manager = orientation.manager();
             if (!manager)
                 return;

--- a/Source/WebCore/page/UserContentController.cpp
+++ b/Source/WebCore/page/UserContentController.cpp
@@ -46,7 +46,7 @@ UserContentController::UserContentController() = default;
 
 UserContentController::~UserContentController() = default;
 
-void UserContentController::forEachUserScript(Function<void(DOMWrapperWorld&, const UserScript&)>&& functor) const
+void UserContentController::forEachUserScript(NOESCAPE const Function<void(DOMWrapperWorld&, const UserScript&)>& functor) const
 {
     for (const auto& worldAndUserScriptVector : m_userScripts) {
         auto& world = *worldAndUserScriptVector.key.get();
@@ -55,7 +55,7 @@ void UserContentController::forEachUserScript(Function<void(DOMWrapperWorld&, co
     }
 }
 
-void UserContentController::forEachUserStyleSheet(Function<void(const UserStyleSheet&)>&& functor) const
+void UserContentController::forEachUserStyleSheet(NOESCAPE const Function<void(const UserStyleSheet&)>& functor) const
 {
     for (auto& styleSheetVector : m_userStyleSheets.values()) {
         for (const auto& styleSheet : *styleSheetVector)
@@ -64,7 +64,7 @@ void UserContentController::forEachUserStyleSheet(Function<void(const UserStyleS
 }
 
 #if ENABLE(USER_MESSAGE_HANDLERS)
-void UserContentController::forEachUserMessageHandler(Function<void(const UserMessageHandlerDescriptor&)>&&) const
+void UserContentController::forEachUserMessageHandler(NOESCAPE const Function<void(const UserMessageHandlerDescriptor&)>&) const
 {
 }
 #endif

--- a/Source/WebCore/page/UserContentController.h
+++ b/Source/WebCore/page/UserContentController.h
@@ -50,10 +50,10 @@ private:
     UserContentController();
 
     // UserContentProvider
-    void forEachUserScript(Function<void(DOMWrapperWorld&, const UserScript&)>&&) const final;
-    void forEachUserStyleSheet(Function<void(const UserStyleSheet&)>&&) const final;
+    void forEachUserScript(NOESCAPE const Function<void(DOMWrapperWorld&, const UserScript&)>&) const final;
+    void forEachUserStyleSheet(NOESCAPE const Function<void(const UserStyleSheet&)>&) const final;
 #if ENABLE(USER_MESSAGE_HANDLERS)
-    void forEachUserMessageHandler(Function<void(const UserMessageHandlerDescriptor&)>&&) const final;
+    void forEachUserMessageHandler(NOESCAPE const Function<void(const UserMessageHandlerDescriptor&)>&) const final;
 #endif
 #if ENABLE(CONTENT_EXTENSIONS)
     ContentExtensions::ContentExtensionsBackend& userContentExtensionBackend() override { return m_contentExtensionBackend; }

--- a/Source/WebCore/page/UserContentProvider.h
+++ b/Source/WebCore/page/UserContentProvider.h
@@ -69,10 +69,10 @@ public:
     WEBCORE_EXPORT UserContentProvider();
     WEBCORE_EXPORT virtual ~UserContentProvider();
 
-    virtual void forEachUserScript(Function<void(DOMWrapperWorld&, const UserScript&)>&&) const = 0;
-    virtual void forEachUserStyleSheet(Function<void(const UserStyleSheet&)>&&) const = 0;
+    virtual void forEachUserScript(NOESCAPE const Function<void(DOMWrapperWorld&, const UserScript&)>&) const = 0;
+    virtual void forEachUserStyleSheet(NOESCAPE const Function<void(const UserStyleSheet&)>&) const = 0;
 #if ENABLE(USER_MESSAGE_HANDLERS)
-    virtual void forEachUserMessageHandler(Function<void(const UserMessageHandlerDescriptor&)>&&) const = 0;
+    virtual void forEachUserMessageHandler(NOESCAPE const Function<void(const UserMessageHandlerDescriptor&)>&) const = 0;
 #endif
 #if ENABLE(CONTENT_EXTENSIONS)
     virtual ContentExtensions::ContentExtensionsBackend& userContentExtensionBackend() = 0;

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -603,7 +603,7 @@ void WebUserContentController::removeAllUserContent()
     }
 }
 
-void WebUserContentController::forEachUserScript(Function<void(WebCore::DOMWrapperWorld&, const WebCore::UserScript&)>&& functor) const
+void WebUserContentController::forEachUserScript(NOESCAPE const Function<void(WebCore::DOMWrapperWorld&, const WebCore::UserScript&)>& functor) const
 {
     for (const auto& worldAndUserScriptVector : m_userScripts) {
         auto& world = worldAndUserScriptVector.key->coreWorld();
@@ -612,7 +612,7 @@ void WebUserContentController::forEachUserScript(Function<void(WebCore::DOMWrapp
     }
 }
 
-void WebUserContentController::forEachUserStyleSheet(Function<void(const WebCore::UserStyleSheet&)>&& functor) const
+void WebUserContentController::forEachUserStyleSheet(NOESCAPE const Function<void(const WebCore::UserStyleSheet&)>& functor) const
 {
     for (auto& styleSheetVector : m_userStyleSheets.values()) {
         for (const auto& identifierUserStyleSheetPair : styleSheetVector)
@@ -621,7 +621,7 @@ void WebUserContentController::forEachUserStyleSheet(Function<void(const WebCore
 }
 
 #if ENABLE(USER_MESSAGE_HANDLERS)
-void WebUserContentController::forEachUserMessageHandler(Function<void(const WebCore::UserMessageHandlerDescriptor&)>&& functor) const
+void WebUserContentController::forEachUserMessageHandler(NOESCAPE const Function<void(const WebCore::UserMessageHandlerDescriptor&)>& functor) const
 {
     for (auto& userMessageHandlerVector : m_userMessageHandlers.values()) {
         for (auto& pair : userMessageHandlerVector)

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.h
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.h
@@ -85,10 +85,10 @@ private:
     explicit WebUserContentController(UserContentControllerIdentifier);
 
     // WebCore::UserContentProvider
-    void forEachUserScript(Function<void(WebCore::DOMWrapperWorld&, const WebCore::UserScript&)>&&) const final;
-    void forEachUserStyleSheet(Function<void(const WebCore::UserStyleSheet&)>&&) const final;
+    void forEachUserScript(NOESCAPE const Function<void(WebCore::DOMWrapperWorld&, const WebCore::UserScript&)>&) const final;
+    void forEachUserStyleSheet(NOESCAPE const Function<void(const WebCore::UserStyleSheet&)>&) const final;
 #if ENABLE(USER_MESSAGE_HANDLERS)
-    void forEachUserMessageHandler(Function<void(const WebCore::UserMessageHandlerDescriptor&)>&&) const final;
+    void forEachUserMessageHandler(NOESCAPE const Function<void(const WebCore::UserMessageHandlerDescriptor&)>&) const final;
 #endif
 #if ENABLE(CONTENT_EXTENSIONS)
     WebCore::ContentExtensions::ContentExtensionsBackend& userContentExtensionBackend() override { return m_contentExtensionBackend; }


### PR DESCRIPTION
#### f1d3ddb2c13d65eb1a84e0a87ee2c6aa277cb7af
<pre>
Reduce unsafe lambdas in WebCore/page
<a href="https://bugs.webkit.org/show_bug.cgi?id=291559">https://bugs.webkit.org/show_bug.cgi?id=291559</a>

Reviewed by Chris Dumez.

As per Safer CPP Guidelines:

- <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#capture-protectedthis-or-weakthis-in-asynchronous-lambdas-where-you-need-to-use-this">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#capture-protectedthis-or-weakthis-in-asynchronous-lambdas-where-you-need-to-use-this</a>
- <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#annotate-noescape-when-a-function-uses-a-lambda-synchronously">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#annotate-noescape-when-a-function-uses-a-lambda-synchronously</a>

* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/dom/ActiveDOMObject.h:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/page/EventSource.cpp:
(WebCore::EventSource::resume):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::injectUserScripts):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::triggerOptionalStorageAccessQuirk const):
* Source/WebCore/page/ScreenOrientation.cpp:
(WebCore::ScreenOrientation::lock):
* Source/WebCore/page/UserContentController.cpp:
(WebCore::UserContentController::forEachUserScript const):
(WebCore::UserContentController::forEachUserStyleSheet const):
(WebCore::UserContentController::forEachUserMessageHandler const):
* Source/WebCore/page/UserContentController.h:
* Source/WebCore/page/UserContentProvider.h:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
(WebKit::WebUserContentController::forEachUserScript const):
(WebKit::WebUserContentController::forEachUserStyleSheet const):
(WebKit::WebUserContentController::forEachUserMessageHandler const):
* Source/WebKit/WebProcess/UserContent/WebUserContentController.h:

Canonical link: <a href="https://commits.webkit.org/293749@main">https://commits.webkit.org/293749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/060790a87e9b806331d0c0805170ff70b4ed9a0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99722 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9641 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104852 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50317 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101763 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19674 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75919 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33012 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102729 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14997 "Found 1 new test failure: fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90052 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56279 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14800 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8038 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49677 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84738 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8123 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107212 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26836 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19602 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84874 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27200 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86256 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84392 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29073 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6781 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20658 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16236 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26777 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31984 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26591 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29906 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28161 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->