### PR TITLE
Add a media session artwork service worker test

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mediasession/media-session-artwork-fetch-service-worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediasession/media-session-artwork-fetch-service-worker.js
@@ -1,0 +1,21 @@
+let port;
+onmessage = async e => {
+    await self.clients.claim();
+
+    port = e.data.port;
+    port.postMessage("Ready");
+}
+
+onfetch = e => {
+    const request = e.request;
+    if (port && request.url.endsWith(".jpg")) {
+       port.postMessage({ type: "fetch", info: {
+            url : request.url,
+            destination : request.destination,
+            mode : request.mode,
+            redirect : request.redirect,
+            referrerPolicy : request.referrerPolicy,
+            credentials : request.credentials
+       }});
+    }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/mediasession/media-session-artwork-fetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediasession/media-session-artwork-fetch.https-expected.txt
@@ -1,0 +1,7 @@
+
+
+PASS Setup service worker
+PASS Play some audio
+PASS Set same origin media metadata
+PASS Set cross origin media metadata
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediasession/media-session-artwork-fetch.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediasession/media-session-artwork-fetch.https.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src=/resources/testdriver.js></script>
+<script src=/resources/testdriver-vendor.js></script>
+<script src="/common/get-host-info.sub.js"></script>
+</head>
+<body>
+<audio controls loop id=audio></audio>
+<script>
+let port;
+
+function waitForState(test, worker, state)
+{
+    if (!worker || worker.state == undefined)
+        return Promise.reject(new Error('waitForState must be passed a ServiceWorker'));
+
+    if (worker.state === state)
+        return Promise.resolve(state);
+
+    return new Promise(function(resolve, reject) {
+      worker.addEventListener('statechange', function() {
+          if (worker.state === state)
+            resolve(state);
+        });
+        test.step_timeout(() => reject("waitForState timed out, worker state is " + worker.state), 5000);
+    });
+}
+
+promise_test(async test => {
+    let registration = await navigator.serviceWorker.getRegistration("");
+    let worker;
+    if (!registration) {
+       registration = await navigator.serviceWorker.register("media-session-artwork-fetch-service-worker.js", { scope: "" });
+       worker = registration.installing;
+       await waitForState(test, worker, "activated");
+    } else
+        worker = registration.active;
+
+    const channel = new MessageChannel();
+    worker.postMessage({ port: channel.port1 }, [channel.port1]);
+    port = channel.port2;
+
+    const result = await new Promise(resolve => port.onmessage = e => resolve(e.data));
+    assert_equals(result, "Ready");
+}, "Setup service worker");
+
+promise_test(async test => {
+    audio.src = "/media/sound_5.mp3";
+    if (window.testRunner && window.test_driver) {
+       let promise;
+       test_driver.bless("audio playback", () => {
+           promise = audio.play();
+       });
+       await promise;
+    } else
+       await audio.play();
+}, "Play some audio");
+
+const artworkResource = "/media/2048x1360-random.jpg";
+
+promise_test(async test => {
+    navigator.mediaSession.metadata = new MediaMetadata({title: "title", artist: "artist", album: "album", artwork: [{src: artworkResource}]});
+    const message = await new Promise(resolve => port.onmessage = e => resolve(e.data));
+
+    assert_equals(message.type, "fetch");
+
+    const request = message.info;
+    assert_equals(request.destination, "image");
+    assert_equals(request.mode, "no-cors");
+    assert_equals(request.redirect, "follow");
+    assert_equals(request.referrerPolicy, "strict-origin-when-cross-origin");
+    assert_equals(request.credentials, "include");
+
+    const url = new URL(artworkResource, window.location.href);
+    assert_equals(request.url, url + "");
+}, "Set same origin media metadata");
+
+promise_test(async test => {
+    // We make sure the previous test artwork is not loaded again.
+    navigator.mediaSession.metadata = new MediaMetadata({title: "title", artist: "artist", album: "album"});
+    await new Promise(resolve => test.step_timeout(resolve, 100));
+
+    const artworkSrc = get_host_info().HTTPS_REMOTE_ORIGIN + artworkResource;
+    navigator.mediaSession.metadata = new MediaMetadata({title: "title", artist: "artist", album: "album", artwork: [{src: artworkSrc}]});
+    const message = await new Promise(resolve => port.onmessage = e => resolve(e.data));
+
+    assert_equals(message.type, "fetch");
+
+    const request = message.info;
+    assert_equals(request.destination, "image");
+    assert_equals(request.mode, "no-cors");
+    assert_equals(request.redirect, "follow");
+    assert_equals(request.referrerPolicy, "strict-origin-when-cross-origin");
+    assert_equals(request.credentials, "include");
+    assert_equals(request.url, artworkSrc);
+}, "Set cross origin media metadata");
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -63,6 +63,7 @@ css-dark-mode [ Skip ]
 media/audioSession [ Skip ]
 
 http/wpt/mediasession [ Skip ]
+imported/w3c/web-platform-tests/mediasession/media-session-artwork-fetch.https.html [ Skip ]
 
 # Media Stream API testing is not supported for WK1 yet.
 fast/mediastream


### PR DESCRIPTION
#### c6334df8a9f85a364edb6d2a777bd919df16e589
<pre>
Add a media session artwork service worker test
<a href="https://rdar.apple.com/149279172">rdar://149279172</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291560">https://bugs.webkit.org/show_bug.cgi?id=291560</a>

Reviewed by Jean-Yves Avenard.

Test works in both Safari and Chrome.

* LayoutTests/imported/w3c/web-platform-tests/mediasession/media-session-artwork-fetch-service-worker.js: Added.
(onmessage.async e):
(onfetch.e.port.request.url.endsWith):
* LayoutTests/imported/w3c/web-platform-tests/mediasession/media-session-artwork-fetch.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediasession/media-session-artwork-fetch.https.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/293707@main">https://commits.webkit.org/293707@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f1eca75d8ed965c087a4100902995ae19453163

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104824 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50289 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19632 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27777 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75894 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32988 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102701 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14958 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90027 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56254 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14758 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8013 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49650 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8098 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107184 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26808 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19578 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84852 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27172 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86231 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84370 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21413 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29046 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6757 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20619 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26749 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26564 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29879 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28133 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->