### PR TITLE
[WPE] Drag gesture is overscrolling

### DIFF
--- a/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
+++ b/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
@@ -182,7 +182,24 @@ WebWheelEvent WebEventFactory::createWebWheelEvent(WPEEvent* event, WebWheelEven
     auto wheelTicks = FloatSize(deltaX, deltaY);
     FloatSize delta;
     if (hasPreciseScrollingDeltas) {
-        static const double wpeScrollDeltaMultiplier = 2.5;
+        double wpeScrollDeltaMultiplier;
+
+        switch (wpe_event_get_input_source(event)) {
+        case WPE_INPUT_SOURCE_MOUSE:
+        case WPE_INPUT_SOURCE_PEN:
+        case WPE_INPUT_SOURCE_KEYBOARD:
+        case WPE_INPUT_SOURCE_TOUCHPAD:
+        case WPE_INPUT_SOURCE_TRACKPOINT:
+            wpeScrollDeltaMultiplier = 2.5;
+            break;
+        case WPE_INPUT_SOURCE_TOUCHSCREEN:
+        case WPE_INPUT_SOURCE_TABLET_PAD:
+            wpeScrollDeltaMultiplier = 1.0;
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+
         delta = wheelTicks.scaled(wpeScrollDeltaMultiplier);
     } else {
         auto* view = wpe_event_get_view(event);

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
@@ -426,7 +426,7 @@ void ViewPlatform::handleGesture(WPEEvent* event)
     case WPE_GESTURE_DRAG:
         if (double x, y, dx, dy; wpe_gesture_controller_get_gesture_position(gestureController, &x, &y) && wpe_gesture_controller_get_gesture_delta(gestureController, &dx, &dy)) {
             GRefPtr<WPEEvent> simulatedScrollEvent = adoptGRef(wpe_event_scroll_new(
-                m_wpeView.get(), WPE_INPUT_SOURCE_MOUSE, 0, static_cast<WPEModifiers>(0), dx, dy, TRUE, FALSE, x, y
+                m_wpeView.get(), WPE_INPUT_SOURCE_TOUCHSCREEN, 0, static_cast<WPEModifiers>(0), dx, dy, TRUE, FALSE, x, y
             ));
             auto phase = wpe_gesture_controller_is_drag_begin(gestureController)
                 ? WebWheelEvent::Phase::PhaseBegan


### PR DESCRIPTION
#### bbe2bab9e62bf03df2e7d15b108d4ce3a1089ade
<pre>
[WPE] Drag gesture is overscrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=291562">https://bugs.webkit.org/show_bug.cgi?id=291562</a>

Reviewed by Patrick Griffis.

The wpeScrollDeltaMultiplier constant tries to mimic GTK&apos;s own
MAGIC_SCROLL_FACTOR value from GtkScrolledWindow. However, GTK
only applies this factor for touchpad and mouse scroll events,
whereas WPE applies it to everything - including touch drag
events. This leads to drag gestures overscrolling.

Fix that by differentiating the wpeScrollDeltaMultiplier value
between gestures and non-gestures. For gestures, neutralize it
to 1.0; for non-gestures, keep the current value of 2.5.

This is done by changing the input source type of the synthetic
scroll event to WPE_INPUT_SOURCE_TOUCHSCREEN. This is then used
by WebEventFactory::createWebWheelEvent() to select the correct
scroll factor.

* Source/WebKit/Shared/NativeWebWheelEvent.h:
* Source/WebKit/Shared/libwpe/WebEventFactory.h:
* Source/WebKit/Shared/wpe/NativeWebWheelEventWPE.cpp:
(WebKit::NativeWebWheelEvent::NativeWebWheelEvent):
* Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp:
(WebKit::WebEventFactory::createWebWheelEvent):
* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp:
(WKWPE::ViewPlatform::handleGesture):

Canonical link: <a href="https://commits.webkit.org/293775@main">https://commits.webkit.org/293775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c59253244abb3cf8efee9a1fae93bc0da20f59f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9631 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104843 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50308 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19651 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27796 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75909 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33002 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14977 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56269 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14777 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49669 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84721 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107203 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26827 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19595 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84867 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27191 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86246 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84385 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21466 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29064 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6772 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20652 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26768 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31974 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26583 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29897 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28152 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->