### PR TITLE
Web Automation: introduce shorter error handling macros

### DIFF
--- a/Source/WebKit/UIProcess/Automation/WebAutomationSessionMacros.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSessionMacros.h
@@ -59,6 +59,22 @@ do { \
     return makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME_AND_DETAILS(errorName, detailsString)); \
 } while (false)
 
+#define SYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(condition, errorName, detailsString) \
+do { \
+    if (condition) { \
+        return makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME_AND_DETAILS(errorName, detailsString)); \
+    } \
+} while (false)
+
+#define ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF_SET(optionalError) \
+do { \
+    if (optionalError.has_value()) { \
+        callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_MESSAGE(optionalError.value()))); \
+        return; \
+    } \
+} while (false)
+
+
 #define ASYNC_FAIL_WITH_PREDEFINED_ERROR(errorName) \
 do { \
     callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME(errorName))); \
@@ -77,4 +93,12 @@ do { \
 do { \
     callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME_AND_DETAILS(errorName, detailsString))); \
     return; \
+} while (false)
+
+#define ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(condition, errorName, detailsString) \
+do { \
+    if (condition) { \
+        callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME_AND_DETAILS(errorName, detailsString))); \
+        return; \
+    } \
 } while (false)

--- a/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
+++ b/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
@@ -54,8 +54,7 @@ using namespace WebCore;
 void WebAutomationSession::inspectBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, std::optional<bool>&& enableAutoCapturing, Inspector::CommandCallback<void>&& callback)
 {
     auto page = webPageProxyForHandle(handle);
-    if (!page)
-        ASYNC_FAIL_WITH_PREDEFINED_ERROR(WindowNotFound);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!page, WindowNotFound);
 
     if (auto pendingCallback = m_pendingInspectorCallbacksPerPage.take(page->identifier()))
         pendingCallback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME(Timeout)));


### PR DESCRIPTION
#### 1b27533ed665c04ed7c591f4599a30e617704e89
<pre>
Web Automation: introduce shorter error handling macros
<a href="https://bugs.webkit.org/show_bug.cgi?id=291565">https://bugs.webkit.org/show_bug.cgi?id=291565</a>

Reviewed by Devin Rousso.

Deploy more uses of FAIL_WITH_PREDEFINED_ERROR_IF() style macros to
shorten Automation command implementations.

No change in behavior, covered by existing tests.

* Source/WebKit/UIProcess/Automation/WebAutomationSessionMacros.h:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::terminate):
(WebKit::WebAutomationSession::getBrowsingContext):
(WebKit::WebAutomationSession::createBrowsingContext):
(WebKit::WebAutomationSession::closeBrowsingContext):
(WebKit::WebAutomationSession::deleteSession):
(WebKit::WebAutomationSession::switchToBrowsingContext):
(WebKit::WebAutomationSession::setWindowFrameOfBrowsingContext):
(WebKit::WebAutomationSession::waitForNavigationToComplete):
(WebKit::WebAutomationSession::respondToPendingPageNavigationCallbacksWithTimeout):
(WebKit::WebAutomationSession::respondToPendingFrameNavigationCallbacksWithTimeout):
(WebKit::WebAutomationSession::maximizeWindowOfBrowsingContext):
(WebKit::WebAutomationSession::hideWindowOfBrowsingContext):
(WebKit::WebAutomationSession::navigateBrowsingContext):
(WebKit::WebAutomationSession::goBackInBrowsingContext):
(WebKit::WebAutomationSession::goForwardInBrowsingContext):
(WebKit::WebAutomationSession::reloadBrowsingContext):
(WebKit::WebAutomationSession::willClosePage):
Adopt new macros.

(WebKit::WebAutomationSession::evaluateJavaScriptFunction):
Convert the error case to early return. Start using the variant
ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF_SET to bail if an optional ErrorString is set.

(WebKit::WebAutomationSession::resolveChildFrameHandle):
Introduce a local variable for readability.

(WebKit::WebAutomationSession::resolveParentFrameHandle):
(WebKit::WebAutomationSession::computeElementLayout):
(WebKit::WebAutomationSession::getComputedRole):
(WebKit::WebAutomationSession::getComputedLabel):
(WebKit::WebAutomationSession::selectOptionElement):
(WebKit::WebAutomationSession::isShowingJavaScriptDialog):
(WebKit::WebAutomationSession::dismissCurrentJavaScriptDialog):
(WebKit::WebAutomationSession::acceptCurrentJavaScriptDialog):
(WebKit::WebAutomationSession::messageOfCurrentJavaScriptDialog):
Introduce a local variable for readability in dialog methods.

(WebKit::WebAutomationSession::setUserInputForCurrentJavaScriptPrompt):
(WebKit::WebAutomationSession::setFilesToSelectForFileUpload):
Introduce a local variable for readability.

(WebKit::WebAutomationSession::setFilesForInputFileUpload):
(WebKit::WebAutomationSession::getAllCookies):
(WebKit::WebAutomationSession::deleteSingleCookie):
(WebKit::WebAutomationSession::addSingleCookie):
(WebKit::WebAutomationSession::deleteAllCookies):
(WebKit::WebAutomationSession::setSessionPermissions):
(WebKit::WebAutomationSession::removeVirtualAuthenticator):
(WebKit::WebAutomationSession::loadWebExtension):
(WebKit::WebAutomationSession::unloadWebExtension):
(WebKit::WebAutomationSession::generateTestReport):
(WebKit::WebAutomationSession::viewportInViewCenterPointOfElement):

(WebKit::WebAutomationSession::performMouseInteraction):
(WebKit::WebAutomationSession::performKeyboardInteractions):
(WebKit::WebAutomationSession::performInteractionSequence):
Convert the error case to early return.

(WebKit::WebAutomationSession::cancelInteractionSequence):
(WebKit::WebAutomationSession::takeScreenshot):

* Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm:
(WebKit::WebAutomationSession::inspectBrowsingContext):

Canonical link: <a href="https://commits.webkit.org/293758@main">https://commits.webkit.org/293758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a455e525790a5755e826d3eefb4b1f52277ab69

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104829 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50294 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75898 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32993 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14963 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90033 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56258 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14763 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49655 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84711 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8104 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107189 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26813 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19583 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84857 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86237 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84375 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21455 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29052 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6763 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20628 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26754 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31959 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26569 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29884 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28138 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->