### PR TITLE
Pipe a non-null Document through CSS typedom reify

### DIFF
--- a/Source/WebCore/css/typedom/CSSStyleImageValue.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleImageValue.cpp
@@ -39,9 +39,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(CSSStyleImageValue);
 
-CSSStyleImageValue::CSSStyleImageValue(Ref<CSSImageValue>&& cssValue, Document* document)
+CSSStyleImageValue::CSSStyleImageValue(Ref<CSSImageValue>&& cssValue, Document& document)
     : m_cssValue(WTFMove(cssValue))
-    , m_document(document)
+    , m_document(&document)
 {
 }
 

--- a/Source/WebCore/css/typedom/CSSStyleImageValue.h
+++ b/Source/WebCore/css/typedom/CSSStyleImageValue.h
@@ -39,7 +39,7 @@ class WeakPtrImplWithEventTargetData;
 class CSSStyleImageValue final : public CSSStyleValue {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSStyleImageValue);
 public:
-    static Ref<CSSStyleImageValue> create(Ref<CSSImageValue>&& cssValue, Document* document)
+    static Ref<CSSStyleImageValue> create(Ref<CSSImageValue>&& cssValue, Document& document)
     {
         return adoptRef(*new CSSStyleImageValue(WTFMove(cssValue), document));
     }
@@ -55,7 +55,7 @@ public:
     RefPtr<CSSValue> toCSSValue() const final;
 
 private:
-    CSSStyleImageValue(Ref<CSSImageValue>&&, Document*);
+    CSSStyleImageValue(Ref<CSSImageValue>&&, Document&);
 
     Ref<CSSImageValue> m_cssValue;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;

--- a/Source/WebCore/css/typedom/CSSStyleValue.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValue.cpp
@@ -43,10 +43,10 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(CSSStyleValue);
 
-ExceptionOr<Ref<CSSStyleValue>> CSSStyleValue::parse(const Document& document, const AtomString& property, const String& cssText)
+ExceptionOr<Ref<CSSStyleValue>> CSSStyleValue::parse(Document& document, const AtomString& property, const String& cssText)
 {
     constexpr bool parseMultiple = false;
-    auto parseResult = CSSStyleValueFactory::parseStyleValue(property, cssText, parseMultiple, { document });
+    auto parseResult = CSSStyleValueFactory::parseStyleValue(document, property, cssText, parseMultiple);
     if (parseResult.hasException())
         return parseResult.releaseException();
     
@@ -59,10 +59,10 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValue::parse(const Document& document, c
     return WTFMove(returnValue.at(0));
 }
 
-ExceptionOr<Vector<Ref<CSSStyleValue>>> CSSStyleValue::parseAll(const Document& document, const AtomString& property, const String& cssText)
+ExceptionOr<Vector<Ref<CSSStyleValue>>> CSSStyleValue::parseAll(Document& document, const AtomString& property, const String& cssText)
 {
     constexpr bool parseMultiple = true;
-    return CSSStyleValueFactory::parseStyleValue(property, cssText, parseMultiple, { document });
+    return CSSStyleValueFactory::parseStyleValue(document, property, cssText, parseMultiple);
 }
 
 Ref<CSSStyleValue> CSSStyleValue::create(RefPtr<CSSValue>&& cssValue, String&& property)

--- a/Source/WebCore/css/typedom/CSSStyleValue.h
+++ b/Source/WebCore/css/typedom/CSSStyleValue.h
@@ -116,8 +116,8 @@ IGNORE_GCC_WARNINGS_END
 
     virtual CSSStyleValueType getType() const { return CSSStyleValueType::CSSStyleValue; }
 
-    static ExceptionOr<Ref<CSSStyleValue>> parse(const Document&, const AtomString&, const String&);
-    static ExceptionOr<Vector<Ref<CSSStyleValue>>> parseAll(const Document&, const AtomString&, const String&);
+    static ExceptionOr<Ref<CSSStyleValue>> parse(Document&, const AtomString&, const String&);
+    static ExceptionOr<Vector<Ref<CSSStyleValue>>> parseAll(Document&, const AtomString&, const String&);
 
     static Ref<CSSStyleValue> create(RefPtr<CSSValue>&&, String&& = String());
     static Ref<CSSStyleValue> create();

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.h
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.h
@@ -44,10 +44,10 @@ class StylePropertyShorthand;
 
 class CSSStyleValueFactory {
 public:
-    static ExceptionOr<Ref<CSSStyleValue>> reifyValue(const CSSValue&, std::optional<CSSPropertyID>, Document* = nullptr);
-    static ExceptionOr<Vector<Ref<CSSStyleValue>>> parseStyleValue(const AtomString&, const String&, bool parseMultiple, const CSSParserContext&);
-    static RefPtr<CSSStyleValue> constructStyleValueForShorthandSerialization(const String&, const CSSParserContext&);
-    static ExceptionOr<Vector<Ref<CSSStyleValue>>> vectorFromStyleValuesOrStrings(const AtomString& property, FixedVector<std::variant<RefPtr<CSSStyleValue>, String>>&& values, const CSSParserContext&);
+    static ExceptionOr<Ref<CSSStyleValue>> reifyValue(Document&, const CSSValue&, std::optional<CSSPropertyID>);
+    static ExceptionOr<Vector<Ref<CSSStyleValue>>> parseStyleValue(Document&, const AtomString&, const String&, bool parseMultiple);
+    static RefPtr<CSSStyleValue> constructStyleValueForShorthandSerialization(Document&, const String&);
+    static ExceptionOr<Vector<Ref<CSSStyleValue>>> vectorFromStyleValuesOrStrings(Document&, const AtomString& property, FixedVector<std::variant<RefPtr<CSSStyleValue>, String>>&&);
 
     static RefPtr<CSSStyleValue> constructStyleValueForCustomPropertySyntaxValue(const CSSCustomPropertyValue::SyntaxValue&);
 
@@ -55,8 +55,8 @@ protected:
     CSSStyleValueFactory() = delete;
 
 private:
-    static ExceptionOr<RefPtr<CSSValue>> extractCSSValue(const CSSPropertyID&, const String&, const CSSParserContext&);
-    static ExceptionOr<RefPtr<CSSStyleValue>> extractShorthandCSSValues(const CSSPropertyID&, const String&, const CSSParserContext&);
+    static ExceptionOr<RefPtr<CSSValue>> extractCSSValue(Document&, const CSSPropertyID&, const String&);
+    static ExceptionOr<RefPtr<CSSStyleValue>> extractShorthandCSSValues(Document&, const CSSPropertyID&, const String&);
     static ExceptionOr<Ref<CSSUnparsedValue>> extractCustomCSSValues(const String&);
 };
 

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
@@ -106,12 +106,12 @@ Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> ComputedStylePropertyMap
     ComputedStyleExtractor extractor { element.get() };
     values.appendContainerWithMapping(exposedComputedCSSPropertyIDs, [&](auto propertyID) {
         auto value = extractor.propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::No, ComputedStyleExtractor::PropertyValueType::Computed);
-        return makeKeyValuePair(nameString(propertyID), StylePropertyMapReadOnly::reifyValueToVector(WTFMove(value), propertyID, document));
+        return makeKeyValuePair(nameString(propertyID), StylePropertyMapReadOnly::reifyValueToVector(document, WTFMove(value), propertyID));
     });
 
     for (auto* map : { &nonInheritedCustomProperties, &inheritedCustomProperties }) {
         map->forEach([&](auto& it) {
-            values.append(makeKeyValuePair(it.key, StylePropertyMapReadOnly::reifyValueToVector(const_cast<CSSCustomPropertyValue*>(it.value.get()), std::nullopt, document)));
+            values.append(makeKeyValuePair(it.key, StylePropertyMapReadOnly::reifyValueToVector(document, const_cast<CSSCustomPropertyValue*>(it.value.get()), std::nullopt)));
             return IterationStatus::Continue;
         });
     }

--- a/Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp
@@ -67,7 +67,7 @@ auto DeclaredStylePropertyMap::entries(ScriptExecutionContext* context) const ->
 
     auto& document = downcast<Document>(*context);
     return map(styleRule->properties(), [&] (auto propertyReference) {
-        return StylePropertyMapEntry { propertyReference.cssName(), reifyValueToVector(RefPtr<CSSValue> { propertyReference.value() }, propertyReference.id(), document) };
+        return StylePropertyMapEntry { propertyReference.cssName(), reifyValueToVector(document, RefPtr<CSSValue> { propertyReference.value() }, propertyReference.id()) };
     });
 }
 

--- a/Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.cpp
@@ -71,7 +71,7 @@ auto HashMapStylePropertyMapReadOnly::entries(ScriptExecutionContext* context) c
 
     return WTF::map(m_map, [&](auto& entry) -> StylePropertyMapEntry {
         auto& [propertyName, cssValue] = entry;
-        return makeKeyValuePair(propertyName,  Vector<RefPtr<CSSStyleValue>> { reifyValue(cssValue.get(), cssPropertyID(propertyName), *document) });
+        return makeKeyValuePair(propertyName,  Vector<RefPtr<CSSStyleValue>> { reifyValue(*document, cssValue.get(), cssPropertyID(propertyName)) });
     });
 }
 

--- a/Source/WebCore/css/typedom/InlineStylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/InlineStylePropertyMap.cpp
@@ -83,7 +83,7 @@ auto InlineStylePropertyMap::entries(ScriptExecutionContext* context) const -> V
 
     auto& document = downcast<Document>(*context);
     return map(*inlineStyle, [&document] (auto property) {
-        return StylePropertyMapEntry(property.cssName(), reifyValueToVector(RefPtr<CSSValue> { property.value() }, property.id(), document));
+        return StylePropertyMapEntry(property.cssName(), reifyValueToVector(document, RefPtr<CSSValue> { property.value() }, property.id()));
     });
 }
 

--- a/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp
@@ -61,7 +61,7 @@ ExceptionOr<MainThreadStylePropertyMapReadOnly::CSSStyleValueOrUndefined> MainTh
         return { std::monostate { } };
 
     if (isCustomPropertyName(property)) {
-        if (auto value = reifyValue(customPropertyValue(property), std::nullopt, *document))
+        if (auto value = reifyValue(*document, customPropertyValue(property), std::nullopt))
             return { WTFMove(value) };
 
         return { std::monostate { } };
@@ -72,13 +72,13 @@ ExceptionOr<MainThreadStylePropertyMapReadOnly::CSSStyleValueOrUndefined> MainTh
         return Exception { ExceptionCode::TypeError, makeString("Invalid property "_s, property) };
 
     if (isShorthand(propertyID)) {
-        if (auto value = CSSStyleValueFactory::constructStyleValueForShorthandSerialization(shorthandPropertySerialization(propertyID), { *document }))
+        if (auto value = CSSStyleValueFactory::constructStyleValueForShorthandSerialization(*document, shorthandPropertySerialization(propertyID)))
             return { WTFMove(value) };
 
         return { std::monostate { } };
     }
 
-    if (auto value = reifyValue(propertyValue(propertyID), propertyID, *document))
+    if (auto value = reifyValue(*document, propertyValue(propertyID), propertyID))
         return { WTFMove(value) };
 
     return { std::monostate { } };
@@ -92,19 +92,19 @@ ExceptionOr<Vector<RefPtr<CSSStyleValue>>> MainThreadStylePropertyMapReadOnly::g
         return Vector<RefPtr<CSSStyleValue>> { };
 
     if (isCustomPropertyName(property))
-        return reifyValueToVector(customPropertyValue(property), std::nullopt, *document);
+        return reifyValueToVector(*document, customPropertyValue(property), std::nullopt);
 
     auto propertyID = cssPropertyID(property);
     if (!isExposed(propertyID, &document->settings()))
         return Exception { ExceptionCode::TypeError, makeString("Invalid property "_s, property) };
 
     if (isShorthand(propertyID)) {
-        if (RefPtr value = CSSStyleValueFactory::constructStyleValueForShorthandSerialization(shorthandPropertySerialization(propertyID), { *document }))
+        if (RefPtr value = CSSStyleValueFactory::constructStyleValueForShorthandSerialization(*document, shorthandPropertySerialization(propertyID)))
             return Vector<RefPtr<CSSStyleValue>> { WTFMove(value) };
         return Vector<RefPtr<CSSStyleValue>> { };
     }
 
-    return reifyValueToVector(propertyValue(propertyID), propertyID, *document);
+    return reifyValueToVector(*document, propertyValue(propertyID), propertyID);
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-has

--- a/Source/WebCore/css/typedom/StylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/StylePropertyMap.cpp
@@ -66,7 +66,7 @@ static RefPtr<CSSValue> cssValueFromStyleValues(CSSPropertyID propertyID, Vector
 ExceptionOr<void> StylePropertyMap::set(Document& document, const AtomString& property, FixedVector<std::variant<RefPtr<CSSStyleValue>, String>>&& values)
 {
     if (isCustomPropertyName(property)) {
-        auto styleValuesOrException = CSSStyleValueFactory::vectorFromStyleValuesOrStrings(property, WTFMove(values), { document });
+        auto styleValuesOrException = CSSStyleValueFactory::vectorFromStyleValuesOrStrings(document, property, WTFMove(values));
         if (styleValuesOrException.hasException())
             return styleValuesOrException.releaseException();
         auto styleValues = styleValuesOrException.releaseReturnValue();
@@ -100,7 +100,7 @@ ExceptionOr<void> StylePropertyMap::set(Document& document, const AtomString& pr
         return { };
     }
 
-    auto styleValuesOrException = CSSStyleValueFactory::vectorFromStyleValuesOrStrings(property, WTFMove(values), { document });
+    auto styleValuesOrException = CSSStyleValueFactory::vectorFromStyleValuesOrStrings(document, property, WTFMove(values));
     if (styleValuesOrException.hasException())
         return styleValuesOrException.releaseException();
     auto styleValues = styleValuesOrException.releaseReturnValue();
@@ -164,7 +164,7 @@ ExceptionOr<void> StylePropertyMap::append(Document& document, const AtomString&
     else if (currentValue)
         list.append(currentValue.releaseNonNull());
 
-    auto styleValuesOrException = CSSStyleValueFactory::vectorFromStyleValuesOrStrings(property, WTFMove(values), { document });
+    auto styleValuesOrException = CSSStyleValueFactory::vectorFromStyleValuesOrStrings(document, property, WTFMove(values));
     if (styleValuesOrException.hasException())
         return styleValuesOrException.releaseException();
 

--- a/Source/WebCore/css/typedom/StylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/StylePropertyMapReadOnly.cpp
@@ -44,15 +44,15 @@
 
 namespace WebCore {
 
-RefPtr<CSSStyleValue> StylePropertyMapReadOnly::reifyValue(RefPtr<CSSValue>&& value, std::optional<CSSPropertyID> propertyID, Document& document)
+RefPtr<CSSStyleValue> StylePropertyMapReadOnly::reifyValue(Document& document, RefPtr<CSSValue>&& value, std::optional<CSSPropertyID> propertyID)
 {
     if (!value)
         return nullptr;
-    auto result = CSSStyleValueFactory::reifyValue(value.releaseNonNull(), propertyID, &document);
+    auto result = CSSStyleValueFactory::reifyValue(document, value.releaseNonNull(), propertyID);
     return (result.hasException() ? nullptr : RefPtr<CSSStyleValue> { result.releaseReturnValue() });
 }
 
-Vector<RefPtr<CSSStyleValue>> StylePropertyMapReadOnly::reifyValueToVector(RefPtr<CSSValue>&& value, std::optional<CSSPropertyID> propertyID, Document& document)
+Vector<RefPtr<CSSStyleValue>> StylePropertyMapReadOnly::reifyValueToVector(Document& document, RefPtr<CSSValue>&& value, std::optional<CSSPropertyID> propertyID)
 {
     if (!value)
         return { };
@@ -75,10 +75,10 @@ Vector<RefPtr<CSSStyleValue>> StylePropertyMapReadOnly::reifyValueToVector(RefPt
 
     auto* valueList = dynamicDowncast<CSSValueList>(*value);
     if (!valueList || (propertyID && !CSSProperty::isListValuedProperty(*propertyID)))
-        return { StylePropertyMapReadOnly::reifyValue(WTFMove(value), propertyID, document) };
+        return { StylePropertyMapReadOnly::reifyValue(document, WTFMove(value), propertyID) };
 
     return WTF::map(*valueList, [&](auto& item) {
-        return StylePropertyMapReadOnly::reifyValue(Ref { const_cast<CSSValue&>(item) }, propertyID, document);
+        return StylePropertyMapReadOnly::reifyValue(document, Ref { const_cast<CSSValue&>(item) }, propertyID);
     });
 }
 

--- a/Source/WebCore/css/typedom/StylePropertyMapReadOnly.h
+++ b/Source/WebCore/css/typedom/StylePropertyMapReadOnly.h
@@ -69,8 +69,8 @@ public:
     virtual ExceptionOr<bool> has(ScriptExecutionContext&, const AtomString&) const = 0;
     virtual unsigned size() const = 0;
 
-    static RefPtr<CSSStyleValue> reifyValue(RefPtr<CSSValue>&&, std::optional<CSSPropertyID>, Document&);
-    static Vector<RefPtr<CSSStyleValue>> reifyValueToVector(RefPtr<CSSValue>&&, std::optional<CSSPropertyID>, Document&);
+    static RefPtr<CSSStyleValue> reifyValue(Document&, RefPtr<CSSValue>&&, std::optional<CSSPropertyID>);
+    static Vector<RefPtr<CSSStyleValue>> reifyValueToVector(Document&, RefPtr<CSSValue>&&, std::optional<CSSPropertyID>);
 
 protected:
     virtual Vector<StylePropertyMapEntry> entries(ScriptExecutionContext*) const = 0;

--- a/Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp
@@ -52,12 +52,12 @@ Ref<CSSTransformComponent> CSSMatrixComponent::create(Ref<DOMMatrixReadOnly>&& m
     return adoptRef(*new CSSMatrixComponent(WTFMove(matrix), is2D ? Is2D::Yes : Is2D::No));
 }
 
-ExceptionOr<Ref<CSSTransformComponent>> CSSMatrixComponent::create(Ref<const CSSFunctionValue> cssFunctionValue)
+ExceptionOr<Ref<CSSTransformComponent>> CSSMatrixComponent::create(Ref<const CSSFunctionValue> cssFunctionValue, Document& document)
 {
     auto makeMatrix = [&](NOESCAPE const Function<Ref<CSSTransformComponent>(Vector<double>&&)>& create, size_t expectedNumberOfComponents) -> ExceptionOr<Ref<CSSTransformComponent>> {
         Vector<double> components;
         for (auto& componentCSSValue : cssFunctionValue.get()) {
-            auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue, std::nullopt);
+            auto valueOrException = CSSStyleValueFactory::reifyValue(document, componentCSSValue, std::nullopt);
             if (valueOrException.hasException())
                 return valueOrException.releaseException();
             RefPtr unitValue = dynamicDowncast<CSSUnitValue>(valueOrException.releaseReturnValue());

--- a/Source/WebCore/css/typedom/transform/CSSMatrixComponent.h
+++ b/Source/WebCore/css/typedom/transform/CSSMatrixComponent.h
@@ -33,13 +33,14 @@ namespace WebCore {
 
 class CSSFunctionValue;
 class DOMMatrixReadOnly;
+class Document;
 template<typename> class ExceptionOr;
 
 class CSSMatrixComponent : public CSSTransformComponent {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSMatrixComponent);
 public:
     static Ref<CSSTransformComponent> create(Ref<DOMMatrixReadOnly>&&, CSSMatrixComponentOptions&& = { });
-    static ExceptionOr<Ref<CSSTransformComponent>> create(Ref<const CSSFunctionValue>);
+    static ExceptionOr<Ref<CSSTransformComponent>> create(Ref<const CSSFunctionValue>, Document&);
 
     DOMMatrix& matrix();
     void setMatrix(Ref<DOMMatrix>&&);

--- a/Source/WebCore/css/typedom/transform/CSSPerspective.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSPerspective.cpp
@@ -71,7 +71,7 @@ ExceptionOr<Ref<CSSPerspective>> CSSPerspective::create(CSSPerspectiveValue leng
     return adoptRef(*new CSSPerspective(checkedLength.releaseReturnValue()));
 }
 
-ExceptionOr<Ref<CSSPerspective>> CSSPerspective::create(Ref<const CSSFunctionValue> cssFunctionValue)
+ExceptionOr<Ref<CSSPerspective>> CSSPerspective::create(Ref<const CSSFunctionValue> cssFunctionValue, Document& document)
 {
     if (cssFunctionValue->name() != CSSValuePerspective) {
         ASSERT_NOT_REACHED();
@@ -83,7 +83,7 @@ ExceptionOr<Ref<CSSPerspective>> CSSPerspective::create(Ref<const CSSFunctionVal
         return Exception { ExceptionCode::TypeError, "Unexpected number of values."_s };
     }
 
-    auto keywordOrNumeric = CSSStyleValueFactory::reifyValue(*cssFunctionValue->item(0), std::nullopt);
+    auto keywordOrNumeric = CSSStyleValueFactory::reifyValue(document, *cssFunctionValue->item(0), std::nullopt);
     if (keywordOrNumeric.hasException())
         return keywordOrNumeric.releaseException();
     auto& keywordOrNumericValue = keywordOrNumeric.returnValue().get();

--- a/Source/WebCore/css/typedom/transform/CSSPerspective.h
+++ b/Source/WebCore/css/typedom/transform/CSSPerspective.h
@@ -34,12 +34,13 @@ namespace WebCore {
 template<typename> class ExceptionOr;
 class CSSFunctionValue;
 using CSSPerspectiveValue = std::variant<RefPtr<CSSNumericValue>, String, RefPtr<CSSKeywordValue>>;
+class Document;
 
 class CSSPerspective : public CSSTransformComponent {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSPerspective);
 public:
     static ExceptionOr<Ref<CSSPerspective>> create(CSSPerspectiveValue);
-    static ExceptionOr<Ref<CSSPerspective>> create(Ref<const CSSFunctionValue>);
+    static ExceptionOr<Ref<CSSPerspective>> create(Ref<const CSSFunctionValue>, Document&);
 
     virtual ~CSSPerspective();
 

--- a/Source/WebCore/css/typedom/transform/CSSRotate.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSRotate.cpp
@@ -72,12 +72,12 @@ ExceptionOr<Ref<CSSRotate>> CSSRotate::create(Ref<CSSNumericValue> angle)
         WTFMove(angle)));
 }
 
-ExceptionOr<Ref<CSSRotate>> CSSRotate::create(Ref<const CSSFunctionValue> cssFunctionValue)
+ExceptionOr<Ref<CSSRotate>> CSSRotate::create(Ref<const CSSFunctionValue> cssFunctionValue, Document& document)
 {
     auto makeRotate = [&](NOESCAPE const Function<ExceptionOr<Ref<CSSRotate>>(Vector<RefPtr<CSSNumericValue>>&&)>& create, size_t expectedNumberOfComponents) -> ExceptionOr<Ref<CSSRotate>> {
         Vector<RefPtr<CSSNumericValue>> components;
         for (auto& componentCSSValue : cssFunctionValue.get()) {
-            auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue, std::nullopt);
+            auto valueOrException = CSSStyleValueFactory::reifyValue(document, componentCSSValue, std::nullopt);
             if (valueOrException.hasException())
                 return valueOrException.releaseException();
             RefPtr numericValue = dynamicDowncast<CSSNumericValue>(valueOrException.releaseReturnValue());

--- a/Source/WebCore/css/typedom/transform/CSSRotate.h
+++ b/Source/WebCore/css/typedom/transform/CSSRotate.h
@@ -31,6 +31,7 @@
 namespace WebCore {
 
 class CSSFunctionValue;
+class Document;
 
 template<typename> class ExceptionOr;
 
@@ -39,7 +40,7 @@ class CSSRotate : public CSSTransformComponent {
 public:
     static ExceptionOr<Ref<CSSRotate>> create(CSSNumberish, CSSNumberish, CSSNumberish, Ref<CSSNumericValue>);
     static ExceptionOr<Ref<CSSRotate>> create(Ref<CSSNumericValue>);
-    static ExceptionOr<Ref<CSSRotate>> create(Ref<const CSSFunctionValue>);
+    static ExceptionOr<Ref<CSSRotate>> create(Ref<const CSSFunctionValue>, Document&);
 
     CSSNumberish x() { return { m_x.ptr() }; }
     CSSNumberish y() { return { m_y.ptr() }; }

--- a/Source/WebCore/css/typedom/transform/CSSScale.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSScale.cpp
@@ -63,12 +63,12 @@ ExceptionOr<Ref<CSSScale>> CSSScale::create(CSSNumberish x, CSSNumberish y, std:
     return adoptRef(*new CSSScale(z ? Is2D::No : Is2D::Yes, WTFMove(rectifiedX), WTFMove(rectifiedY), WTFMove(rectifiedZ)));
 }
 
-ExceptionOr<Ref<CSSScale>> CSSScale::create(Ref<const CSSFunctionValue> cssFunctionValue)
+ExceptionOr<Ref<CSSScale>> CSSScale::create(Ref<const CSSFunctionValue> cssFunctionValue, Document& document)
 {
     auto makeScale = [&](NOESCAPE const Function<ExceptionOr<Ref<CSSScale>>(Vector<RefPtr<CSSNumericValue>>&&)>& create, size_t minNumberOfComponents, std::optional<size_t> maxNumberOfComponents = std::nullopt) -> ExceptionOr<Ref<CSSScale>> {
         Vector<RefPtr<CSSNumericValue>> components;
         for (auto& componentCSSValue : cssFunctionValue.get()) {
-            auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue, std::nullopt);
+            auto valueOrException = CSSStyleValueFactory::reifyValue(document, componentCSSValue, std::nullopt);
             if (valueOrException.hasException())
                 return valueOrException.releaseException();
             RefPtr numericValue = dynamicDowncast<CSSNumericValue>(valueOrException.releaseReturnValue());

--- a/Source/WebCore/css/typedom/transform/CSSScale.h
+++ b/Source/WebCore/css/typedom/transform/CSSScale.h
@@ -31,6 +31,7 @@
 namespace WebCore {
 
 class CSSFunctionValue;
+class Document;
 
 template<typename> class ExceptionOr;
 
@@ -38,7 +39,7 @@ class CSSScale : public CSSTransformComponent {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSScale);
 public:
     static ExceptionOr<Ref<CSSScale>> create(CSSNumberish x, CSSNumberish y, std::optional<CSSNumberish>&& z);
-    static ExceptionOr<Ref<CSSScale>> create(Ref<const CSSFunctionValue>);
+    static ExceptionOr<Ref<CSSScale>> create(Ref<const CSSFunctionValue>, Document&);
 
     void serialize(StringBuilder&) const final;
     ExceptionOr<Ref<DOMMatrix>> toMatrix() final;

--- a/Source/WebCore/css/typedom/transform/CSSSkew.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSSkew.cpp
@@ -51,7 +51,7 @@ ExceptionOr<Ref<CSSSkew>> CSSSkew::create(Ref<CSSNumericValue> ax, Ref<CSSNumeri
     return adoptRef(*new CSSSkew(WTFMove(ax), WTFMove(ay)));
 }
 
-ExceptionOr<Ref<CSSSkew>> CSSSkew::create(Ref<const CSSFunctionValue> cssFunctionValue)
+ExceptionOr<Ref<CSSSkew>> CSSSkew::create(Ref<const CSSFunctionValue> cssFunctionValue, Document& document)
 {
     if (cssFunctionValue->name() != CSSValueSkew) {
         ASSERT_NOT_REACHED();
@@ -60,7 +60,7 @@ ExceptionOr<Ref<CSSSkew>> CSSSkew::create(Ref<const CSSFunctionValue> cssFunctio
 
     Vector<Ref<CSSNumericValue>> components;
     for (auto& componentCSSValue : cssFunctionValue.get()) {
-        auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue, std::nullopt);
+        auto valueOrException = CSSStyleValueFactory::reifyValue(document, componentCSSValue, std::nullopt);
         if (valueOrException.hasException())
             return valueOrException.releaseException();
         RefPtr numericValue = dynamicDowncast<CSSNumericValue>(valueOrException.releaseReturnValue());

--- a/Source/WebCore/css/typedom/transform/CSSSkew.h
+++ b/Source/WebCore/css/typedom/transform/CSSSkew.h
@@ -31,6 +31,7 @@
 namespace WebCore {
 
 class CSSFunctionValue;
+class Document;
 
 template<typename> class ExceptionOr;
 
@@ -38,7 +39,7 @@ class CSSSkew : public CSSTransformComponent {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSSkew);
 public:
     static ExceptionOr<Ref<CSSSkew>> create(Ref<CSSNumericValue>, Ref<CSSNumericValue>);
-    static ExceptionOr<Ref<CSSSkew>> create(Ref<const CSSFunctionValue>);
+    static ExceptionOr<Ref<CSSSkew>> create(Ref<const CSSFunctionValue>, Document&);
 
     const CSSNumericValue& ax() const { return m_ax.get(); }
     const CSSNumericValue& ay() const { return m_ay.get(); }

--- a/Source/WebCore/css/typedom/transform/CSSSkewX.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSSkewX.cpp
@@ -49,7 +49,7 @@ ExceptionOr<Ref<CSSSkewX>> CSSSkewX::create(Ref<CSSNumericValue> ax)
     return adoptRef(*new CSSSkewX(WTFMove(ax)));
 }
 
-ExceptionOr<Ref<CSSSkewX>> CSSSkewX::create(Ref<const CSSFunctionValue> cssFunctionValue)
+ExceptionOr<Ref<CSSSkewX>> CSSSkewX::create(Ref<const CSSFunctionValue> cssFunctionValue, Document& document)
 {
     if (cssFunctionValue->name() != CSSValueSkewX) {
         ASSERT_NOT_REACHED();
@@ -61,7 +61,7 @@ ExceptionOr<Ref<CSSSkewX>> CSSSkewX::create(Ref<const CSSFunctionValue> cssFunct
         return Exception { ExceptionCode::TypeError, "Unexpected number of values."_s };
     }
 
-    auto valueOrException = CSSStyleValueFactory::reifyValue(*cssFunctionValue->item(0), std::nullopt);
+    auto valueOrException = CSSStyleValueFactory::reifyValue(document, *cssFunctionValue->item(0), std::nullopt);
     if (valueOrException.hasException())
         return valueOrException.releaseException();
     RefPtr numericValue = dynamicDowncast<CSSNumericValue>(valueOrException.releaseReturnValue());

--- a/Source/WebCore/css/typedom/transform/CSSSkewX.h
+++ b/Source/WebCore/css/typedom/transform/CSSSkewX.h
@@ -31,6 +31,7 @@
 namespace WebCore {
 
 class CSSFunctionValue;
+class Document;
 
 template<typename> class ExceptionOr;
 
@@ -38,7 +39,7 @@ class CSSSkewX : public CSSTransformComponent {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSSkewX);
 public:
     static ExceptionOr<Ref<CSSSkewX>> create(Ref<CSSNumericValue>);
-    static ExceptionOr<Ref<CSSSkewX>> create(Ref<const CSSFunctionValue>);
+    static ExceptionOr<Ref<CSSSkewX>> create(Ref<const CSSFunctionValue>, Document&);
 
     const CSSNumericValue& ax() const { return m_ax.get(); }
     ExceptionOr<void> setAx(Ref<CSSNumericValue>);

--- a/Source/WebCore/css/typedom/transform/CSSSkewY.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSSkewY.cpp
@@ -49,7 +49,7 @@ ExceptionOr<Ref<CSSSkewY>> CSSSkewY::create(Ref<CSSNumericValue> ay)
     return adoptRef(*new CSSSkewY(WTFMove(ay)));
 }
 
-ExceptionOr<Ref<CSSSkewY>> CSSSkewY::create(Ref<const CSSFunctionValue> cssFunctionValue)
+ExceptionOr<Ref<CSSSkewY>> CSSSkewY::create(Ref<const CSSFunctionValue> cssFunctionValue, Document& document)
 {
     if (cssFunctionValue->name() != CSSValueSkewY) {
         ASSERT_NOT_REACHED();
@@ -61,7 +61,7 @@ ExceptionOr<Ref<CSSSkewY>> CSSSkewY::create(Ref<const CSSFunctionValue> cssFunct
         return Exception { ExceptionCode::TypeError, "Unexpected number of values."_s };
     }
 
-    auto valueOrException = CSSStyleValueFactory::reifyValue(*cssFunctionValue->item(0), std::nullopt);
+    auto valueOrException = CSSStyleValueFactory::reifyValue(document, *cssFunctionValue->item(0), std::nullopt);
     if (valueOrException.hasException())
         return valueOrException.releaseException();
     RefPtr numericValue = dynamicDowncast<CSSNumericValue>(valueOrException.releaseReturnValue());

--- a/Source/WebCore/css/typedom/transform/CSSSkewY.h
+++ b/Source/WebCore/css/typedom/transform/CSSSkewY.h
@@ -31,6 +31,7 @@
 namespace WebCore {
 
 class CSSFunctionValue;
+class Document;
 
 template<typename> class ExceptionOr;
 
@@ -38,7 +39,7 @@ class CSSSkewY : public CSSTransformComponent {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSSkewY);
 public:
     static ExceptionOr<Ref<CSSSkewY>> create(Ref<CSSNumericValue>);
-    static ExceptionOr<Ref<CSSSkewY>> create(Ref<const CSSFunctionValue>);
+    static ExceptionOr<Ref<CSSSkewY>> create(Ref<const CSSFunctionValue>, Document&);
 
     const CSSNumericValue& ay() const { return m_ay.get(); }
     ExceptionOr<void> setAy(Ref<CSSNumericValue>);

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
@@ -53,7 +53,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(CSSTransformValue);
 
-static ExceptionOr<Ref<CSSTransformComponent>> createTransformComponent(Ref<const CSSFunctionValue> functionValue)
+static ExceptionOr<Ref<CSSTransformComponent>> createTransformComponent(Ref<const CSSFunctionValue> functionValue, Document& document)
 {
     auto makeTransformComponent = [&](auto exceptionOrTransformComponent) -> ExceptionOr<Ref<CSSTransformComponent>> {
         if (exceptionOrTransformComponent.hasException())
@@ -67,43 +67,43 @@ static ExceptionOr<Ref<CSSTransformComponent>> createTransformComponent(Ref<cons
     case CSSValueTranslateZ:
     case CSSValueTranslate:
     case CSSValueTranslate3d:
-        return makeTransformComponent(CSSTranslate::create(WTFMove(functionValue)));
+        return makeTransformComponent(CSSTranslate::create(WTFMove(functionValue), document));
     case CSSValueScaleX:
     case CSSValueScaleY:
     case CSSValueScaleZ:
     case CSSValueScale:
     case CSSValueScale3d:
-        return makeTransformComponent(CSSScale::create(WTFMove(functionValue)));
+        return makeTransformComponent(CSSScale::create(WTFMove(functionValue), document));
     case CSSValueRotateX:
     case CSSValueRotateY:
     case CSSValueRotateZ:
     case CSSValueRotate:
     case CSSValueRotate3d:
-        return makeTransformComponent(CSSRotate::create(WTFMove(functionValue)));
+        return makeTransformComponent(CSSRotate::create(WTFMove(functionValue), document));
     case CSSValueSkewX:
-        return makeTransformComponent(CSSSkewX::create(WTFMove(functionValue)));
+        return makeTransformComponent(CSSSkewX::create(WTFMove(functionValue), document));
     case CSSValueSkewY:
-        return makeTransformComponent(CSSSkewY::create(WTFMove(functionValue)));
+        return makeTransformComponent(CSSSkewY::create(WTFMove(functionValue), document));
     case CSSValueSkew:
-        return makeTransformComponent(CSSSkew::create(WTFMove(functionValue)));
+        return makeTransformComponent(CSSSkew::create(WTFMove(functionValue), document));
     case CSSValuePerspective:
-        return makeTransformComponent(CSSPerspective::create(WTFMove(functionValue)));
+        return makeTransformComponent(CSSPerspective::create(WTFMove(functionValue), document));
     case CSSValueMatrix:
     case CSSValueMatrix3d:
-        return makeTransformComponent(CSSMatrixComponent::create(WTFMove(functionValue)));
+        return makeTransformComponent(CSSMatrixComponent::create(WTFMove(functionValue), document));
     default:
         return Exception { ExceptionCode::TypeError, "Unexpected function value type"_s };
     }
 }
 
-ExceptionOr<Ref<CSSTransformValue>> CSSTransformValue::create(Ref<const CSSTransformListValue> list)
+ExceptionOr<Ref<CSSTransformValue>> CSSTransformValue::create(Ref<const CSSTransformListValue> list, Document& document)
 {
     Vector<Ref<CSSTransformComponent>> components;
     for (auto& value : list.get()) {
         RefPtr functionValue = dynamicDowncast<CSSFunctionValue>(value);
         if (!functionValue)
             return Exception { ExceptionCode::TypeError, "Expected only function values in a transform list."_s };
-        auto component = createTransformComponent(functionValue.releaseNonNull());
+        auto component = createTransformComponent(functionValue.releaseNonNull(), document);
         if (component.hasException())
             return component.releaseException();
         components.append(component.releaseReturnValue());

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.h
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.h
@@ -34,12 +34,13 @@ namespace WebCore {
 class CSSTransformComponent;
 class CSSTransformListValue;
 class DOMMatrix;
+class Document;
 template<typename> class ExceptionOr;
 
 class CSSTransformValue final : public CSSStyleValue {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSTransformValue);
 public:
-    static ExceptionOr<Ref<CSSTransformValue>> create(Ref<const CSSTransformListValue>);
+    static ExceptionOr<Ref<CSSTransformValue>> create(Ref<const CSSTransformListValue>, Document&);
     static ExceptionOr<Ref<CSSTransformValue>> create(Vector<Ref<CSSTransformComponent>>&&);
 
     virtual ~CSSTransformValue();

--- a/Source/WebCore/css/typedom/transform/CSSTranslate.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSTranslate.cpp
@@ -58,12 +58,12 @@ ExceptionOr<Ref<CSSTranslate>> CSSTranslate::create(Ref<CSSNumericValue> x, Ref<
     return adoptRef(*new CSSTranslate(is2D, WTFMove(x), WTFMove(y), z.releaseNonNull()));
 }
 
-ExceptionOr<Ref<CSSTranslate>> CSSTranslate::create(Ref<const CSSFunctionValue> cssFunctionValue)
+ExceptionOr<Ref<CSSTranslate>> CSSTranslate::create(Ref<const CSSFunctionValue> cssFunctionValue, Document& document)
 {
     auto makeTranslate = [&](NOESCAPE const Function<ExceptionOr<Ref<CSSTranslate>>(Vector<Ref<CSSNumericValue>>&&)>& create, size_t minNumberOfComponents, std::optional<size_t> maxNumberOfComponents = std::nullopt) -> ExceptionOr<Ref<CSSTranslate>> {
         Vector<Ref<CSSNumericValue>> components;
         for (auto& componentCSSValue : cssFunctionValue.get()) {
-            auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue, std::nullopt);
+            auto valueOrException = CSSStyleValueFactory::reifyValue(document, componentCSSValue, std::nullopt);
             if (valueOrException.hasException())
                 return valueOrException.releaseException();
             RefPtr numericValue = dynamicDowncast<CSSNumericValue>(valueOrException.releaseReturnValue());

--- a/Source/WebCore/css/typedom/transform/CSSTranslate.h
+++ b/Source/WebCore/css/typedom/transform/CSSTranslate.h
@@ -31,6 +31,7 @@
 namespace WebCore {
 
 class CSSFunctionValue;
+class Document;
 
 template<typename> class ExceptionOr;
 
@@ -38,7 +39,7 @@ class CSSTranslate : public CSSTransformComponent {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSTranslate);
 public:
     static ExceptionOr<Ref<CSSTranslate>> create(Ref<CSSNumericValue> x, Ref<CSSNumericValue> y, RefPtr<CSSNumericValue> z);
-    static ExceptionOr<Ref<CSSTranslate>> create(Ref<const CSSFunctionValue>);
+    static ExceptionOr<Ref<CSSTranslate>> create(Ref<const CSSFunctionValue>, Document&);
 
     const CSSNumericValue& x() const { return m_x.get(); }
     const CSSNumericValue& y() const { return m_y.get(); }


### PR DESCRIPTION
#### 31aef00e876e84d75ac49e77591210c29a59ed27
<pre>
Pipe a non-null Document through CSS typedom reify
<a href="https://bugs.webkit.org/show_bug.cgi?id=291566">https://bugs.webkit.org/show_bug.cgi?id=291566</a>

Reviewed by Darin Adler.

Ensure the Document passed to CSSStyleValueFactory functions is always
non-null by always passing it as a reference and updating all call sites
to provide it as needed.

While this causes no functional change immediately, it will be needed
in the future and simplifies assumptions in the code.

* Source/WebCore/css/typedom/CSSStyleImageValue.cpp:
* Source/WebCore/css/typedom/CSSStyleImageValue.h:
* Source/WebCore/css/typedom/CSSStyleValue.cpp:
* Source/WebCore/css/typedom/CSSStyleValue.h:
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
* Source/WebCore/css/typedom/CSSStyleValueFactory.h:
* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp:
* Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp:
* Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.cpp:
* Source/WebCore/css/typedom/InlineStylePropertyMap.cpp:
* Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp:
* Source/WebCore/css/typedom/StylePropertyMap.cpp:
* Source/WebCore/css/typedom/StylePropertyMapReadOnly.cpp:
* Source/WebCore/css/typedom/StylePropertyMapReadOnly.h:
* Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp:
* Source/WebCore/css/typedom/transform/CSSMatrixComponent.h:
* Source/WebCore/css/typedom/transform/CSSPerspective.cpp:
* Source/WebCore/css/typedom/transform/CSSPerspective.h:
* Source/WebCore/css/typedom/transform/CSSRotate.cpp:
* Source/WebCore/css/typedom/transform/CSSRotate.h:
* Source/WebCore/css/typedom/transform/CSSScale.cpp:
* Source/WebCore/css/typedom/transform/CSSScale.h:
* Source/WebCore/css/typedom/transform/CSSSkew.cpp:
* Source/WebCore/css/typedom/transform/CSSSkew.h:
* Source/WebCore/css/typedom/transform/CSSSkewX.cpp:
* Source/WebCore/css/typedom/transform/CSSSkewX.h:
* Source/WebCore/css/typedom/transform/CSSSkewY.cpp:
* Source/WebCore/css/typedom/transform/CSSSkewY.h:
* Source/WebCore/css/typedom/transform/CSSTransformValue.cpp:
* Source/WebCore/css/typedom/transform/CSSTransformValue.h:
* Source/WebCore/css/typedom/transform/CSSTranslate.cpp:
* Source/WebCore/css/typedom/transform/CSSTranslate.h:

Canonical link: <a href="https://commits.webkit.org/293714@main">https://commits.webkit.org/293714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6d4aa1cf6efcdc16e33d00e9278f0518482fa12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19349 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104830 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50295 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101741 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27783 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75900 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32994 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102707 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14965 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90035 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56260 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14765 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8021 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49656 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8106 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107190 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26814 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19584 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84859 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27178 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86239 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84377 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21422 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29054 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6765 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20630 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26755 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31960 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26570 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29885 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28139 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->