### PR TITLE
Drop WTF::String's `operator NSString *()`

### DIFF
--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -250,9 +250,6 @@ public:
     // Given Cocoa idioms, this is a more useful default. Clients that need to preserve the
     // null string can check isNull explicitly.
     RetainPtr<NSString> createNSString() const;
-
-    // FIXME: Port call sites to createNSString() and remove this.
-    operator NSString *() const;
 #endif
 
 #if OS(WINDOWS)
@@ -504,13 +501,6 @@ inline Expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8Conver
 }
 
 #if USE(FOUNDATION) && defined(__OBJC__)
-
-inline String::operator NSString *() const
-{
-    if (!m_impl)
-        return @"";
-    SUPPRESS_UNCOUNTED_ARG return *m_impl;
-}
 
 inline RetainPtr<NSString> String::createNSString() const
 {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -4102,7 +4102,7 @@ void MediaPlayerPrivateAVFoundationObjC::updateSpatialTrackingLabel()
 
     if (!m_spatialTrackingLabel.isNull()) {
         INFO_LOG(LOGIDENTIFIER, "Explicitly set STSLabel: ", m_spatialTrackingLabel);
-        [m_avPlayer _setSTSLabel:m_spatialTrackingLabel];
+        [m_avPlayer _setSTSLabel:m_spatialTrackingLabel.createNSString().get()];
         return;
     }
 
@@ -4117,7 +4117,7 @@ void MediaPlayerPrivateAVFoundationObjC::updateSpatialTrackingLabel()
     if (!m_defaultSpatialTrackingLabel.isNull()) {
         // If a default spatial tracking label was explicitly set, use it.
         INFO_LOG(LOGIDENTIFIER, "Default STSLabel: ", m_defaultSpatialTrackingLabel);
-        [m_avPlayer _setSTSLabel:m_defaultSpatialTrackingLabel];
+        [m_avPlayer _setSTSLabel:m_defaultSpatialTrackingLabel.createNSString().get()];
         return;
     }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1825,7 +1825,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::updateSpatialTrackingLabel()
 
     if (!m_spatialTrackingLabel.isNull()) {
         INFO_LOG(LOGIDENTIFIER, "Explicitly set STSLabel: ", m_spatialTrackingLabel);
-        renderer.STSLabel = m_spatialTrackingLabel;
+        renderer.STSLabel = m_spatialTrackingLabel.createNSString().get();
         return;
     }
 
@@ -1847,16 +1847,16 @@ void MediaPlayerPrivateMediaSourceAVFObjC::updateSpatialTrackingLabel()
     // the session's spatial tracking label if not, and set the label directly on each audio
     // renderer.
     AVAudioSession *session = [PAL::getAVAudioSessionClass() sharedInstance];
-    String defaultLabel;
+    RetainPtr<NSString> defaultLabel;
     if (!m_defaultSpatialTrackingLabel.isNull()) {
         INFO_LOG(LOGIDENTIFIER, "Default STSLabel: ", m_defaultSpatialTrackingLabel);
-        defaultLabel = m_defaultSpatialTrackingLabel;
+        defaultLabel = m_defaultSpatialTrackingLabel.createNSString();
     } else {
         INFO_LOG(LOGIDENTIFIER, "AVAudioSession label: ", session.spatialTrackingLabel);
         defaultLabel = session.spatialTrackingLabel;
     }
     for (const auto &key : m_sampleBufferAudioRendererMap.keys())
-        [(__bridge AVSampleBufferAudioRenderer *)key.get() setSTSLabel:defaultLabel];
+        [(__bridge AVSampleBufferAudioRenderer *)key.get() setSTSLabel:defaultLabel.get()];
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1822,7 +1822,7 @@ void MediaPlayerPrivateWebM::updateSpatialTrackingLabel()
 
     if (!m_spatialTrackingLabel.isNull()) {
         INFO_LOG(LOGIDENTIFIER, "Explicitly set STSLabel: ", m_spatialTrackingLabel);
-        renderer.STSLabel = m_spatialTrackingLabel;
+        renderer.STSLabel = m_spatialTrackingLabel.createNSString().get();
         return;
     }
 
@@ -1843,16 +1843,16 @@ void MediaPlayerPrivateWebM::updateSpatialTrackingLabel()
     // the session's spatial tracking label if not, and set the label directly on each audio
     // renderer.
     AVAudioSession *session = [PAL::getAVAudioSessionClass() sharedInstance];
-    String defaultLabel;
+    RetainPtr<NSString> defaultLabel;
     if (!m_defaultSpatialTrackingLabel.isNull()) {
         INFO_LOG(LOGIDENTIFIER, "Default STSLabel: ", m_defaultSpatialTrackingLabel);
-        defaultLabel = m_defaultSpatialTrackingLabel;
+        defaultLabel = m_defaultSpatialTrackingLabel.createNSString();
     } else {
         INFO_LOG(LOGIDENTIFIER, "AVAudioSession label: ", session.spatialTrackingLabel);
         defaultLabel = session.spatialTrackingLabel;
     }
     for (auto& renderer : m_audioRenderers)
-        [(__bridge AVSampleBufferAudioRenderer *)renderer.second.get() setSTSLabel:defaultLabel];
+        [(__bridge AVSampleBufferAudioRenderer *)renderer.second.get() setSTSLabel:defaultLabel.get()];
 }
 #endif
 

--- a/Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm
@@ -61,7 +61,7 @@ bool GPUConnectionToWebProcess::setCaptureAttributionString()
 
     RetainPtr visibleName = applicationVisibleNameFromOrigin(m_captureOrigin->data());
     if (!visibleName)
-        visibleName = gpuProcess().applicationVisibleName();
+        visibleName = gpuProcess().applicationVisibleName().createNSString();
 
     if ([PAL::getSTDynamicActivityAttributionPublisherClass() respondsToSelector:@selector(setCurrentAttributionWebsiteString:auditToken:)])
         [PAL::getSTDynamicActivityAttributionPublisherClass() setCurrentAttributionWebsiteString:visibleName.get() auditToken:auditToken.value()];

--- a/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
@@ -188,7 +188,7 @@ void GPUProcess::createMemoryAttributionIDForTask(WebCore::ProcessIdentity proce
 void GPUProcess::unregisterMemoryAttributionID(const String& attributionID, CompletionHandler<void()>&& completionHandler)
 {
     Ref<WKSharedSimulationConnectionHelper> sharedSimulationConnectionHelper = adoptRef(*new WKSharedSimulationConnectionHelper);
-    sharedSimulationConnectionHelper->unregisterMemoryAttributionID(attributionID, [sharedSimulationConnectionHelper, completionHandler = WTFMove(completionHandler)] (RetainPtr<id> appService) mutable {
+    sharedSimulationConnectionHelper->unregisterMemoryAttributionID(attributionID.createNSString().get(), [sharedSimulationConnectionHelper, completionHandler = WTFMove(completionHandler)] (RetainPtr<id> appService) mutable {
         if (appService)
             RELEASE_LOG(ModelElement, "GPUProcess: Memory attribution ID unregistration succeeded");
         else

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -189,10 +189,10 @@ static ResourceError toResourceError(String payload, Model& model)
 
 void RKModelLoaderUSD::load()
 {
-    NSString *attributionID = nil;
+    RetainPtr<NSString> attributionID;
     if (m_attributionTaskID.has_value())
-        attributionID = m_attributionTaskID.value();
-    [getWKSRKEntityClass() loadFromData:m_model->data()->createNSData().get() withAttributionTaskID:attributionID completionHandler:makeBlockPtr([weakThis = WeakPtr { *this }] (WKSRKEntity *entity) mutable {
+        attributionID = m_attributionTaskID.value().createNSString();
+    [getWKSRKEntityClass() loadFromData:m_model->data()->createNSData().get() withAttributionTaskID:attributionID.get() completionHandler:makeBlockPtr([weakThis = WeakPtr { *this }] (WKSRKEntity *entity) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -2477,7 +2477,7 @@ void NetworkSessionCocoa::removeNetworkWebsiteData(std::optional<WallTime> modif
     NSDictionary *options = @{
         (id)getkSymptomAnalyticsServiceDomainTrackingClearHistoryKey(): @{
             (id)getkSymptomAnalyticsServiceDomainTrackingClearHistoryBundleIDs(): @{
-                bundleID : contextArray.get(),
+                bundleID.createNSString().get() : contextArray.get(),
             },
             (id)getkSymptomAnalyticsServiceDomainTrackingClearHistoryStartDate(): startDate,
             (id)getkSymptomAnalyticsServiceDomainTrackingClearHistoryEndDate(): [NSDate distantFuture]

--- a/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm
+++ b/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm
@@ -107,8 +107,8 @@ std::variant<MediaPlaybackTargetContextCocoa, MediaPlaybackTargetContextMock> Me
     return MediaPlaybackTargetContextCocoa(dynamic_objc_cast<AVOutputContext>(m_context.toID()));
 #else
     auto propertyList = [NSMutableDictionary dictionaryWithCapacity:2];
-    propertyList[@"AVOutputContextSerializationKeyContextID"] = m_contextID;
-    propertyList[@"AVOutputContextSerializationKeyContextType"] = m_contextType;
+    propertyList[@"AVOutputContextSerializationKeyContextID"] = m_contextID.createNSString().get();
+    propertyList[@"AVOutputContextSerializationKeyContextType"] = m_contextType.createNSString().get();
     auto unarchiver = adoptNS([[WKKeyedCoder alloc] initWithDictionary:propertyList]);
     auto outputContext = adoptNS([[PAL::getAVOutputContextClass() alloc] initWithCoder:unarchiver.get()]);
     // std::variant construction in older clang gives either an error, a vtable linkage error unless we construct it this way.

--- a/Source/WebKit/Platform/ios/PaymentAuthorizationController.mm
+++ b/Source/WebKit/Platform/ios/PaymentAuthorizationController.mm
@@ -130,7 +130,7 @@
 - (NSString *)presentationSceneBundleIdentifierForPaymentAuthorizationController:(PKPaymentAuthorizationController *)controller
 {
     if (!_presenter)
-        return applicationBundleIdentifier();
+        return applicationBundleIdentifier().createNSString().autorelease();
     return nsStringNilIfEmpty(_presenter->bundleIdentifier());
 }
 #endif

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
@@ -308,7 +308,7 @@ void PlaybackSessionInterfaceLMK::audioMediaSelectionOptionsChanged(const Vector
 {
     RetainPtr audioTracks = adoptNS([[NSMutableArray alloc] initWithCapacity:options.size()]);
     for (auto& option : options) {
-        RetainPtr audioTrack = adoptNS([allocWKSLinearMediaTrackInstance() initWithLocalizedDisplayName:option.displayName]);
+        RetainPtr audioTrack = adoptNS([allocWKSLinearMediaTrackInstance() initWithLocalizedDisplayName:option.displayName.createNSString().get()]);
         [audioTracks addObject:audioTrack.get()];
     }
 
@@ -320,7 +320,7 @@ void PlaybackSessionInterfaceLMK::legibleMediaSelectionOptionsChanged(const Vect
 {
     RetainPtr legibleTracks = adoptNS([[NSMutableArray alloc] initWithCapacity:options.size()]);
     for (auto& option : options) {
-        RetainPtr legibleTrack = adoptNS([allocWKSLinearMediaTrackInstance() initWithLocalizedDisplayName:option.displayName]);
+        RetainPtr legibleTrack = adoptNS([allocWKSLinearMediaTrackInstance() initWithLocalizedDisplayName:option.displayName.createNSString().get()]);
         [legibleTracks addObject:legibleTrack.get()];
     }
 
@@ -427,7 +427,7 @@ static RetainPtr<NSData> artworkData(const WebCore::NowPlayingMetadata& metadata
 
 void PlaybackSessionInterfaceLMK::nowPlayingMetadataChanged(const WebCore::NowPlayingMetadata& metadata)
 {
-    RetainPtr contentMetadata = adoptNS([allocWKSLinearMediaContentMetadataInstance() initWithTitle:metadata.title subtitle:metadata.artist]);
+    RetainPtr contentMetadata = adoptNS([allocWKSLinearMediaContentMetadataInstance() initWithTitle:metadata.title.createNSString().get() subtitle:metadata.artist.createNSString().get()]);
     [m_player setContentMetadata:contentMetadata.get()];
     [m_player setArtwork:artworkData(metadata).get()];
 }

--- a/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
@@ -260,7 +260,7 @@ void AuxiliaryProcess::handleAXPreferenceChange(const String& domain, const Stri
         // these methods need to be called directly.
         if (CFEqual(key.createCFString().get(), kAXSReduceMotionPreference) && [value isKindOfClass:[NSNumber class]])
             _AXSSetReduceMotionEnabled([(NSNumber *)value boolValue]);
-        else if (CFEqual(key.createCFString().get(), increaseContrastPreferenceKey()) && [value isKindOfClass:[NSNumber class]])
+        else if (key == increaseContrastPreferenceKey() && [value isKindOfClass:[NSNumber class]])
             _AXSSetDarkenSystemColors([(NSNumber *)value boolValue]);
 #endif
     }

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -4984,7 +4984,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
             return;
         }
 
-        UIAction *dimmingAction = [UIAction actionWithTitle:WEB_UI_STRING("Auto Dimming", "Menu item label to toggle automatic scene dimming in fullscreen (visionOS only)") image:[UIImage _systemImageNamed:@"circle.lefthalf.dotted.inset.half.filled"] identifier:nil handler:[weakSelf] (UIAction *) {
+        UIAction *dimmingAction = [UIAction actionWithTitle:WEB_UI_STRING("Auto Dimming", "Menu item label to toggle automatic scene dimming in fullscreen (visionOS only)").createNSString().get() image:[UIImage _systemImageNamed:@"circle.lefthalf.dotted.inset.half.filled"] identifier:nil handler:[weakSelf] (UIAction *) {
             auto strongSelf = weakSelf.get();
             if (!strongSelf)
                 return;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -256,7 +256,7 @@ static void dumpUIView(TextStream& ts, UIView *view)
         auto rects = [(WKBaseScrollView *)view overlayRegionsForTesting];
         auto overlaysAsStrings = adoptNS([[NSMutableArray alloc] initWithCapacity:rects.size()]);
         for (auto rect : rects)
-            [overlaysAsStrings addObject:rectToString(CGRect(rect))];
+            [overlaysAsStrings addObject:rectToString(CGRect(rect)).createNSString().get()];
 
         [overlaysAsStrings sortUsingSelector:@selector(localizedCaseInsensitiveCompare:)];
         for (NSString *overlayAsString in overlaysAsStrings.get())

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -2144,14 +2144,14 @@ void UIDelegate::UIClient::requestPermissionOnXRSessionFeatures(WebPageProxy&, c
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), requestPermissionSelector);
     if (!usingOldDelegateMethod) {
-        [delegate _webView:uiDelegate->m_webView.get().get() requestPermissionForXRSessionOrigin:securityOriginData.toString() mode:toWKXRSessionMode(mode) grantedFeatures:toWKXRSessionFeatureFlags(granted) consentRequiredFeatures:toWKXRSessionFeatureFlags(consentRequired) consentOptionalFeatures:toWKXRSessionFeatureFlags(consentOptional) requiredFeaturesRequested:toWKXRSessionFeatureFlags(requiredFeaturesRequested) optionalFeaturesRequested:toWKXRSessionFeatureFlags(optionalFeaturesRequested) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (_WKXRSessionFeatureFlags userGrantedFeatures) mutable {
+        [delegate _webView:uiDelegate->m_webView.get().get() requestPermissionForXRSessionOrigin:securityOriginData.toString().createNSString().get() mode:toWKXRSessionMode(mode) grantedFeatures:toWKXRSessionFeatureFlags(granted) consentRequiredFeatures:toWKXRSessionFeatureFlags(consentRequired) consentOptionalFeatures:toWKXRSessionFeatureFlags(consentOptional) requiredFeaturesRequested:toWKXRSessionFeatureFlags(requiredFeaturesRequested) optionalFeaturesRequested:toWKXRSessionFeatureFlags(optionalFeaturesRequested) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (_WKXRSessionFeatureFlags userGrantedFeatures) mutable {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();
             completionHandler(toPlatformXRFeatures(userGrantedFeatures));
         }).get()];
     } else {
-        [delegate _webView:uiDelegate->m_webView.get().get() requestPermissionForXRSessionOrigin:securityOriginData.toString() mode:toWKXRSessionMode(mode) grantedFeatures:toWKXRSessionFeatureFlags(granted) consentRequiredFeatures:toWKXRSessionFeatureFlags(consentRequired) consentOptionalFeatures:toWKXRSessionFeatureFlags(consentOptional) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (_WKXRSessionFeatureFlags userGrantedFeatures) mutable {
+        [delegate _webView:uiDelegate->m_webView.get().get() requestPermissionForXRSessionOrigin:securityOriginData.toString().createNSString().get() mode:toWKXRSessionMode(mode) grantedFeatures:toWKXRSessionFeatureFlags(granted) consentRequiredFeatures:toWKXRSessionFeatureFlags(consentRequired) consentOptionalFeatures:toWKXRSessionFeatureFlags(consentOptional) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (_WKXRSessionFeatureFlags userGrantedFeatures) mutable {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -381,7 +381,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     // Propagate the view's visibility state to the WebContent process so that it is marked as "Foreground Running" when necessary.
 #if HAVE(NON_HOSTING_VISIBILITY_PROPAGATION_VIEW)
     auto environmentIdentifier = _page->legacyMainFrameProcess().environmentIdentifier();
-    _visibilityPropagationViewForWebProcess = adoptNS([[_UINonHostingVisibilityPropagationView alloc] initWithFrame:CGRectZero pid:processID environmentIdentifier:environmentIdentifier]);
+    _visibilityPropagationViewForWebProcess = adoptNS([[_UINonHostingVisibilityPropagationView alloc] initWithFrame:CGRectZero pid:processID environmentIdentifier:environmentIdentifier.createNSString().get()]);
 #else
     _visibilityPropagationViewForWebProcess = adoptNS([[_UILayerHostView alloc] initWithFrame:CGRectZero pid:processID contextID:contextID]);
 #endif

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -8870,7 +8870,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     auto context = adoptNS([[PUICTextInputContext alloc] init]);
     [self _updateTextInputTraits:context.get()];
-    [context setInitialText:_focusedElementInformation.value];
+    [context setInitialText:_focusedElementInformation.value.createNSString().get()];
 #if HAVE(QUICKBOARD_CONTROLLER)
     [context setAcceptsEmoji:YES];
     [context setShouldPresentModernTextInputUI:YES];
@@ -9105,9 +9105,9 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
     case WebKit::InputType::Color:
         return nil;
     case WebKit::InputType::Search:
-        return WebCore::formControlSearchButtonTitle();
+        return WebCore::formControlSearchButtonTitle().createNSString().autorelease();
     default:
-        return WebCore::formControlGoButtonTitle();
+        return WebCore::formControlGoButtonTitle().createNSString().autorelease();
     }
 }
 
@@ -9162,7 +9162,7 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
         return @"";
     }
 
-    return options[index].text;
+    return options[index].text.createNSString().autorelease();
 }
 
 - (void)selectMenu:(WKSelectMenuListViewController *)selectMenu didCheckItemAtIndex:(NSUInteger)index checked:(BOOL)checked
@@ -11918,7 +11918,7 @@ static WebKit::DocumentEditingContextRequest toWebRequest(id request)
 
 - (NSString *)initialValueForViewController:(PUICQuickboardViewController *)controller
 {
-    return _focusedElementInformation.value;
+    return _focusedElementInformation.value.createNSString().autorelease();
 }
 
 - (BOOL)shouldDisplayInputContextViewForListViewController:(PUICQuickboardViewController *)controller

--- a/Source/WebKit/UIProcess/ios/WKModelView.mm
+++ b/Source/WebKit/UIProcess/ios/WKModelView.mm
@@ -128,7 +128,7 @@ SOFT_LINK_CLASS(AssetViewer, ASVInlinePreview);
     _preview = adoptNS([allocASVInlinePreviewInstance() initWithFrame:bounds]);
     [self.layer addSublayer:[_preview layer]];
 
-    auto url = adoptNS([[NSURL alloc] initFileURLWithPath:_filePath]);
+    RetainPtr url = adoptNS([[NSURL alloc] initFileURLWithPath:_filePath.createNSString().get()]);
 
     [_preview setupRemoteConnectionWithCompletionHandler:^(NSError *contextError) {
         if (contextError) {

--- a/Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm
@@ -272,13 +272,13 @@ const CGFloat toolbarBottomMarginSmall = 2;
     [_contentView accessoryView].items = @[ resetButton.get(), UIBarButtonItem.flexibleSpaceItem, doneButton.get() ];
 #else
     RetainPtr resetButton = [UIButton buttonWithType:UIButtonTypePlain];
-    [resetButton setTitle:WEB_UI_STRING_KEY("Reset", "Reset Button Date/Time Context Menu", "Reset button in date input context menu") forState:UIControlStateNormal];
+    [resetButton setTitle:WEB_UI_STRING_KEY("Reset", "Reset Button Date/Time Context Menu", "Reset button in date input context menu").createNSString().get() forState:UIControlStateNormal];
     [resetButton setTitleColor:UIColor.labelColor forState:UIControlStateNormal];
     [resetButton addTarget:self action:@selector(resetDatePicker) forControlEvents:UIControlEventPrimaryActionTriggered];
     [resetButton setTranslatesAutoresizingMaskIntoConstraints:NO];
 
     RetainPtr doneButton = [UIButton buttonWithType:UIButtonTypePlain];
-    [doneButton setTitle:WebCore::formControlDoneButtonTitle() forState:UIControlStateNormal];
+    [doneButton setTitle:WebCore::formControlDoneButtonTitle().createNSString().get() forState:UIControlStateNormal];
     [doneButton setTitleColor:UIColor.labelColor forState:UIControlStateNormal];
     [doneButton addTarget:self action:@selector(dismissDatePicker) forControlEvents:UIControlEventPrimaryActionTriggered];
     [doneButton setTranslatesAutoresizingMaskIntoConstraints:NO];

--- a/Source/WebKit/UIProcess/ios/forms/WKDatePickerViewController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDatePickerViewController.mm
@@ -268,15 +268,15 @@ struct EraAndYear {
 
     _monthPicker = adoptNS([[WKDatePickerWheel alloc] initWithController:self style:PUICPickerViewStyleList]);
     [self _configurePickerView:_monthPicker.get()];
-    _monthLabel = [self _createAndConfigureGranularityLabelWithText:WebCore::datePickerMonthLabelTitle()];
+    _monthLabel = [self _createAndConfigureGranularityLabelWithText:WebCore::datePickerMonthLabelTitle().createNSString().get()];
 
     _dayPicker = adoptNS([[WKDatePickerWheel alloc] initWithController:self style:PUICPickerViewStyleList]);
     [self _configurePickerView:_dayPicker.get()];
-    _dayLabel = [self _createAndConfigureGranularityLabelWithText:WebCore::datePickerDayLabelTitle()];
+    _dayLabel = [self _createAndConfigureGranularityLabelWithText:WebCore::datePickerDayLabelTitle().createNSString().get()];
 
     _yearAndEraPicker = adoptNS([[WKDatePickerWheel alloc] initWithController:self style:PUICPickerViewStyleList]);
     [self _configurePickerView:_yearAndEraPicker.get()];
-    _yearLabel = [self _createAndConfigureGranularityLabelWithText:WebCore::datePickerYearLabelTitle()];
+    _yearLabel = [self _createAndConfigureGranularityLabelWithText:WebCore::datePickerYearLabelTitle().createNSString().get()];
 
     [self _updateSelectedPickerViewIndices];
 
@@ -285,7 +285,7 @@ struct EraAndYear {
     _focusedPicker = _dayPicker;
 
     _setButton = [UIButton buttonWithType:UIButtonTypeSystem];
-    [_setButton setTitle:WebCore::datePickerSetButtonTitle() forState:UIControlStateNormal];
+    [_setButton setTitle:WebCore::datePickerSetButtonTitle().createNSString().get() forState:UIControlStateNormal];
     [_setButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
     [_setButton setBackgroundColor:[UIColor systemGreenColor]];
     [_setButton _setContinuousCornerRadius:datePickerSetButtonHeight() / 2];

--- a/Source/WebKit/UIProcess/ios/forms/WKFocusedFormControlView.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFocusedFormControlView.mm
@@ -106,7 +106,7 @@ static UIBezierPath *pathWithRoundedRectInFrame(CGRect rect, CGFloat borderRadiu
 
     _dismissButton = [UIButton buttonWithType:UIButtonTypeSystem];
     [_dismissButton addTarget:self action:@selector(didDismiss) forControlEvents:UIControlEventTouchUpInside];
-    [_dismissButton setTitle:WebCore::formControlHideButtonTitle() forState:UIControlStateNormal];
+    [_dismissButton setTitle:WebCore::formControlHideButtonTitle().createNSString().get() forState:UIControlStateNormal];
     [_dismissButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
 
     _tapGestureRecognizer = adoptNS([[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap)]);

--- a/Source/WebKit/UIProcess/ios/forms/WKNumberPadView.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKNumberPadView.mm
@@ -116,7 +116,7 @@ static UIColor *buttonTitleColorForKey(WKNumberPadKey key)
     return key == WKNumberPadKeyAccept ? [UIColor systemBlueColor] : [UIColor whiteColor];
 }
 
-static NSString *buttonTitleForKey(WKNumberPadKey key)
+static RetainPtr<NSString> buttonTitleForKey(WKNumberPadKey key)
 {
     switch (key) {
     case WKNumberPadKeyDash:
@@ -134,11 +134,11 @@ static NSString *buttonTitleForKey(WKNumberPadKey key)
     case WKNumberPadKeyToggleMode:
         return @"…";
     case WKNumberPadKeyAccept:
-        return WebCore::numberPadOKButtonTitle();
+        return WebCore::numberPadOKButtonTitle().createNSString();
     case WKNumberPadKeyNone:
         return nil;
     default:
-        return String::number(key);
+        return String::number(key).createNSString();
     }
 }
 
@@ -238,12 +238,12 @@ static NSString *buttonTitleForKey(WKNumberPadKey key)
 
 - (NSString *)defaultTitle
 {
-    return buttonTitleForKey(self.defaultKey);
+    return buttonTitleForKey(self.defaultKey).autorelease();
 }
 
 - (NSString *)alternateTitle
 {
-    return buttonTitleForKey(self.alternateKey);
+    return buttonTitleForKey(self.alternateKey).autorelease();
 }
 
 - (WKNumberPadKey)currentKey
@@ -319,7 +319,7 @@ static NSString *buttonTitleForKey(WKNumberPadKey key)
         BOOL enabled = self.alternateKey != WKNumberPadKeyNone;
         [self setEnabled:enabled];
         // This matches behavior on iOS, wherein switching to symbol keys disables any keys that don't support alternatives, but leaves their titles unchanged.
-        [self setTitle:buttonTitleForKey(enabled ? self.alternateKey : self.defaultKey) forState:UIControlStateNormal];
+        [self setTitle:buttonTitleForKey(enabled ? self.alternateKey : self.defaultKey).get() forState:UIControlStateNormal];
         [self setTitleColor:buttonTitleColorForKey(enabled ? self.alternateKey : self.defaultKey) forState:UIControlStateNormal];
     } else {
         [self setEnabled:self.defaultKey != WKNumberPadKeyNone];

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -471,7 +471,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     descriptor = [descriptor fontDescriptorByAddingAttributes:@{
         UIFontWeightTrait : [NSNumber numberWithDouble:UIFontWeightMedium]
     }];
-    RetainPtr buttonTitle = adoptNS([[NSMutableAttributedString alloc] initWithString:label attributes:@{
+    RetainPtr buttonTitle = adoptNS([[NSMutableAttributedString alloc] initWithString:label.createNSString().get() attributes:@{
         NSFontAttributeName : [UIFont fontWithDescriptor:descriptor.get() size:0]
     }]);
     fullscreenButtonConfiguration.attributedTitle = buttonTitle.get();


### PR DESCRIPTION
#### 178decda22a3337804306aa98478c797ba329862
<pre>
Drop WTF::String&apos;s `operator NSString *()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=291575">https://bugs.webkit.org/show_bug.cgi?id=291575</a>

Reviewed by Geoffrey Garen and Darin Adler.

Drop WTF::String&apos;s `operator NSString *()` now that all call sites use
createNSString() instead. createNSString() has the benefit of making it
clearer we&apos;re allocating a new object and it returns a RetainPtr
instead of an autoreleased object.

* Source/WTF/wtf/text/WTFString.h:
(WTF::String::operator NSString * const): Deleted.

Canonical link: <a href="https://commits.webkit.org/293779@main">https://commits.webkit.org/293779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b91ade67ee330d230fcafa25ce1d0920f14f547f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99921 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105048 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50502 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101962 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28005 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/76071 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33152 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15162 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90236 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56429 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/14966 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8222 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49871 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92579 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84890 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8310 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107409 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98528 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27034 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19753 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85015 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27396 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86436 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84539 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21467 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29218 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/6938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20853 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26971 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32194 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122154 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26782 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34103 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30098 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28341 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->