### PR TITLE
[JSC] Handle multiple Temporal calendar annotations

### DIFF
--- a/JSTests/stress/temporal-instant.js
+++ b/JSTests/stress/temporal-instant.js
@@ -291,6 +291,10 @@ shouldBe(`${Temporal.Instant.from('1976-11-18T15:23:30.123456789Z[_foo=bar]')}`,
 shouldBe(`${Temporal.Instant.from('1976-11-18T15:23:30.123456789Z[foo-0_5=bar]')}`, '1976-11-18T15:23:30.123456789Z');
 // critical annotations work
 shouldBe(`${Temporal.Instant.from('1976-11-18T15:23:30.123456789Z[!u-ca=hebrew]')}`, '1976-11-18T15:23:30.123456789Z');
+// multiple annotations work
+shouldBe(`${Temporal.Instant.from('1976-11-18T15:23:30.123456789Z[u-ca=hebrew][u-ca=discord]')}`, '1976-11-18T15:23:30.123456789Z');
+// can't have multiple annotations if one is critical
+shouldThrow(() => Temporal.Instant.from('1976-11-18T15:23:30.123456789Z[!u-ca=hebrew][u-ca=discord]'), RangeError);
 // can't have an unknown critical annotation
 shouldThrow(() => Temporal.Instant.from('1976-11-18T15:23:30.123456789Z[!foo=bar]'), RangeError);
 // no junk at end of string

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -214,6 +214,7 @@ skip:
     - test/built-ins/Temporal/PlainDate/compare/argument-propertybag-calendar-leap-second.js
     - test/built-ins/Temporal/PlainDate/compare/argument-propertybag-calendar-number.js
     - test/built-ins/Temporal/PlainDate/compare/argument-propertybag-calendar-wrong-type.js
+    - test/built-ins/Temporal/PlainDate/compare/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainDate/compare/argument-string-invalid.js
     - test/built-ins/Temporal/PlainDate/compare/calendar-temporal-object.js
     - test/built-ins/Temporal/PlainDate/from/argument-plaindate.js
@@ -223,13 +224,16 @@ skip:
     - test/built-ins/Temporal/PlainDate/from/argument-propertybag-calendar-number.js
     - test/built-ins/Temporal/PlainDate/from/argument-propertybag-calendar-wrong-type.js
     - test/built-ins/Temporal/PlainDate/from/argument-propertybag-calendar.js
+    - test/built-ins/Temporal/PlainDate/from/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainDate/from/argument-string-invalid.js
+    - test/built-ins/Temporal/PlainDate/from/argument-string-unknown-annotation.js
     - test/built-ins/Temporal/PlainDate/from/calendar-temporal-object.js
     - test/built-ins/Temporal/PlainDate/prototype/add/balance-smaller-units.js
     - test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-case-insensitive.js
     - test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-leap-second.js
     - test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-number.js
     - test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-wrong-type.js
+    - test/built-ins/Temporal/PlainDate/prototype/equals/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainDate/prototype/equals/argument-string-invalid.js
     - test/built-ins/Temporal/PlainDate/prototype/equals/argument-string.js
     - test/built-ins/Temporal/PlainDate/prototype/equals/calendar-temporal-object.js
@@ -237,12 +241,15 @@ skip:
     - test/built-ins/Temporal/PlainDate/prototype/since/argument-propertybag-calendar-leap-second.js
     - test/built-ins/Temporal/PlainDate/prototype/since/argument-propertybag-calendar-number.js
     - test/built-ins/Temporal/PlainDate/prototype/since/argument-propertybag-calendar-wrong-type.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainDate/prototype/since/argument-string-invalid.js
     - test/built-ins/Temporal/PlainDate/prototype/since/calendar-temporal-object.js
     - test/built-ins/Temporal/PlainDate/prototype/since/order-of-operations.js
     - test/built-ins/Temporal/PlainDate/prototype/subtract/balance-smaller-units.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-object.js
+    - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-time-designator-required-for-disambiguation.js
+    - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-unknown-annotation.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/basic.js
     - test/built-ins/Temporal/PlainDate/prototype/toString/calendarname-always.js
     - test/built-ins/Temporal/PlainDate/prototype/toString/calendarname-auto.js
@@ -254,6 +261,7 @@ skip:
     - test/built-ins/Temporal/PlainDate/prototype/until/argument-propertybag-calendar-leap-second.js
     - test/built-ins/Temporal/PlainDate/prototype/until/argument-propertybag-calendar-number.js
     - test/built-ins/Temporal/PlainDate/prototype/until/argument-propertybag-calendar-wrong-type.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainDate/prototype/until/argument-string-invalid.js
     - test/built-ins/Temporal/PlainDate/prototype/until/calendar-temporal-object.js
     - test/built-ins/Temporal/PlainDate/prototype/until/order-of-operations.js
@@ -262,9 +270,7 @@ skip:
     - test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-leap-second.js
     - test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-number.js
     - test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-wrong-type.js
-    - test/built-ins/Temporal/PlainDateTime/compare/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainDateTime/compare/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/PlainDateTime/compare/argument-string-unknown-annotation.js
     - test/built-ins/Temporal/PlainDateTime/compare/calendar-temporal-object.js
     - test/built-ins/Temporal/PlainDateTime/constructor-full.js
     - test/built-ins/Temporal/PlainDateTime/from/argument-plaindate.js
@@ -284,6 +290,7 @@ skip:
     - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-leap-second.js
     - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-number.js
     - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-wrong-type.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainDateTime/prototype/equals/calendar-temporal-object.js
     - test/built-ins/Temporal/PlainDateTime/prototype/round/smallestunit-plurals-accepted.js
     - test/built-ins/Temporal/PlainDateTime/prototype/round/smallestunit-string-shorthand.js
@@ -295,7 +302,9 @@ skip:
     - test/built-ins/Temporal/PlainDateTime/prototype/toString/calendarname-undefined.js
     - test/built-ins/Temporal/PlainDateTime/prototype/toString/calendarname-wrong-type.js
     - test/built-ins/Temporal/PlainDateTime/prototype/with/calendar-temporal-object-throws.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-time-designator-required-for-disambiguation.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-unknown-annotation.js
     - test/built-ins/Temporal/PlainTime/compare/argument-string-time-designator-required-for-disambiguation.js
     - test/built-ins/Temporal/PlainTime/from/argument-string-time-designator-required-for-disambiguation.js
     - test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-time-designator-required-for-disambiguation.js
@@ -329,60 +338,24 @@ skip:
     - test/intl402/Temporal/Instant/prototype/toString/timezone-string-datetime.js
 
     # Depends on annotations in datetime strings
-    - test/built-ins/Temporal/Instant/compare/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/Instant/compare/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/Instant/compare/argument-string-unknown-annotation.js
-    - test/built-ins/Temporal/Instant/from/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/Instant/from/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/Instant/from/argument-string-unknown-annotation.js
-    - test/built-ins/Temporal/Instant/prototype/equals/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/Instant/prototype/equals/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/Instant/prototype/equals/argument-string-unknown-annotation.js
-    - test/built-ins/Temporal/Instant/prototype/since/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/Instant/prototype/since/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/Instant/prototype/since/argument-string-unknown-annotation.js
-    - test/built-ins/Temporal/Instant/prototype/until/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/Instant/prototype/until/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/Instant/prototype/until/argument-string-unknown-annotation.js
-    - test/built-ins/Temporal/PlainDate/compare/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainDate/compare/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/PlainDate/compare/argument-string-unknown-annotation.js
-    - test/built-ins/Temporal/PlainDate/from/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainDate/from/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/PlainDate/from/argument-string-unknown-annotation.js
-    - test/built-ins/Temporal/PlainDate/prototype/equals/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainDate/prototype/equals/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/PlainDate/prototype/equals/argument-string-unknown-annotation.js
-    - test/built-ins/Temporal/PlainDate/prototype/since/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainDate/prototype/since/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/PlainDate/prototype/since/argument-string-unknown-annotation.js
-    - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-unknown-annotation.js
-    - test/built-ins/Temporal/PlainDate/prototype/until/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainDate/prototype/until/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/PlainDate/prototype/until/argument-string-unknown-annotation.js
-    - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-unknown-annotation.js
-    - test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-unknown-annotation.js
-    - test/built-ins/Temporal/PlainTime/compare/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainTime/compare/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/PlainTime/compare/argument-string-unknown-annotation.js
-    - test/built-ins/Temporal/PlainTime/from/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainTime/from/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/PlainTime/from/argument-string-unknown-annotation.js
-    - test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-unknown-annotation.js
-    - test/built-ins/Temporal/PlainTime/prototype/since/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainTime/prototype/since/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/PlainTime/prototype/since/argument-string-unknown-annotation.js
-    - test/built-ins/Temporal/PlainTime/prototype/until/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainTime/prototype/until/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/PlainTime/prototype/until/argument-string-unknown-annotation.js
 
     # Depends on Temporal.ZonedDateTime
     - test/built-ins/Temporal/Duration/compare/relativeto-zoneddatetime-negative-epochnanoseconds.js


### PR DESCRIPTION
#### 09fe0b34ffb6b1f0b547f7f6e4b9e3f4f0da54ba
<pre>
[JSC] Handle multiple Temporal calendar annotations
<a href="https://bugs.webkit.org/show_bug.cgi?id=223166">https://bugs.webkit.org/show_bug.cgi?id=223166</a>

Reviewed by Justin Michaud.

This is part of a normative change to the Temporal proposal:
<a href="https://github.com/tc39/proposal-temporal/pull/2397">https://github.com/tc39/proposal-temporal/pull/2397</a>
This change allows parsing multiple annotations in Temporal strings. If
there are multiple `u-ca` calendar annotations, the first one is used.
But if there are multiple calendars and any have the `!` flag, the
string is rejected because that&apos;s inconsistent.

This makes a lot of test262 tests newly pass and they can be removed
from the skip list. Some other tests under the same heading still fail
because PlainDate and PlainDateTime don&apos;t yet support calendars, so
recategorize them under the &quot;Depends on calendar support&quot; heading.

* JSTests/stress/temporal-instant.js:
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::parseOneCalendar):
(JSC::ISO8601::parseCalendar):
(JSC::ISO8601::parseCalendarTime):
(JSC::ISO8601::parseCalendarDateTime):

Canonical link: <a href="https://commits.webkit.org/293742@main">https://commits.webkit.org/293742@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b486223802c1ce5422d6318df4003450bf4bf309

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99790 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9709 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104915 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50373 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27871 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75954 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33048 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90096 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56320 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14843 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8083 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49740 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92452 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107276 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98398 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26901 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84911 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84436 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21440 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29109 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/6818 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/20709 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26839 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/32051 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122022 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26650 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34067 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29967 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28214 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->