### PR TITLE
[merge-back] WebKit: User session corruption and format string vulnerability on global localization variables

### DIFF
--- a/Source/WTF/wtf/cocoa/VectorCocoa.h
+++ b/Source/WTF/wtf/cocoa/VectorCocoa.h
@@ -91,6 +91,9 @@ template<typename CollectionType, typename MapFunctionType> RetainPtr<NSMutableA
 
 template<typename VectorElementType> Vector<VectorElementType> makeVector(NSArray *array)
 {
+    if (!array)
+        return { };
+
     Vector<VectorElementType> vector;
     vector.reserveInitialCapacity(array.count);
     for (id element in array) {
@@ -104,6 +107,9 @@ template<typename VectorElementType> Vector<VectorElementType> makeVector(NSArra
 
 template<typename MapFunctionType> Vector<typename std::invoke_result_t<MapFunctionType, id>::value_type> makeVector(NSArray *array, NOESCAPE MapFunctionType&& function)
 {
+    if (!array)
+        return { };
+
     Vector<typename std::invoke_result_t<MapFunctionType, id>::value_type> vector;
     vector.reserveInitialCapacity(array.count);
     for (id element in array) {

--- a/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm
@@ -49,15 +49,11 @@ static std::unique_ptr<HashSet<String>>& internalClassNamesExemptFromSecureCodin
         if (isInAuxiliaryProcess())
             return;
 
-        RetainPtr<id> object = [[NSUserDefaults standardUserDefaults] objectForKey:@"WebKitCrashOnSecureCodingWithExemptClassesKey"];
-        if (!object)
+        RetainPtr<NSArray> array = [[NSUserDefaults standardUserDefaults] arrayForKey:@"WebKitCrashOnSecureCodingWithExemptClassesKey"];
+        if (!array)
             return;
 
         exemptClassNames.get() = WTF::makeUnique<HashSet<String>>();
-
-        RetainPtr array = dynamic_objc_cast<NSArray>(object.get());
-        if (!array)
-            return;
 
         for (id value in array.get()) {
             if (RetainPtr string = dynamic_objc_cast<NSString>(value))

--- a/Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
@@ -72,7 +72,7 @@ RefPtr<WebCore::SharedBuffer> AuxiliaryProcessProxy::fetchAudioComponentServerRe
 
 Vector<String> AuxiliaryProcessProxy::platformOverrideLanguages() const
 {
-    static const NeverDestroyed<Vector<String>> overrideLanguages = makeVector<String>([[NSUserDefaults standardUserDefaults] valueForKey:@"AppleLanguages"]);
+    static const NeverDestroyed<Vector<String>> overrideLanguages = makeVector<String>([[NSUserDefaults standardUserDefaults] stringArrayForKey:@"AppleLanguages"]);
     return overrideLanguages;
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm
@@ -47,10 +47,7 @@ bool WebPreferences::platformGetStringUserValueForKey(const String& key, String&
     if (!m_identifier)
         return false;
 
-    RetainPtr object = [[NSUserDefaults standardUserDefaults] objectForKey:makeKey(m_identifier, m_keyPrefix, key).get()];
-    if (!object)
-        return false;
-    RetainPtr string = dynamic_objc_cast<NSString>(object.get());
+    RetainPtr string = [[NSUserDefaults standardUserDefaults] stringForKey:makeKey(m_identifier, m_keyPrefix, key).get()];
     if (!string)
         return false;
 


### PR DESCRIPTION
#### 0d55629e64b25250884ea7a4f31bfe8381cd3d31
<pre>
[merge-back] WebKit: User session corruption and format string vulnerability on global localization variables
<a href="https://bugs.webkit.org/show_bug.cgi?id=291581">https://bugs.webkit.org/show_bug.cgi?id=291581</a>
<a href="https://rdar.apple.com/148058226">rdar://148058226</a>

Reviewed by Per Arne Vollan.

Merge-back 289651.162@safari-7621-branch.

* Source/WTF/wtf/cocoa/VectorCocoa.h:
(WTF::makeVector):
* Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm:
(WebKit::SecureCoding::internalClassNamesExemptFromSecureCodingCrash):
* Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm:
(WebKit::AuxiliaryProcessProxy::platformOverrideLanguages const):
* Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm:
(WebKit::WebPreferences::platformGetStringUserValueForKey):

Canonical link: <a href="https://commits.webkit.org/293731@main">https://commits.webkit.org/293731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1b48d8a80d63642b7a933cb9913614b3d970ed6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99733 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19381 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104862 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50327 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19685 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27816 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75921 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33017 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102740 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15002 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90060 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56281 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14805 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8047 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49687 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92410 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8132 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107222 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98349 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26847 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19609 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84880 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27211 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86265 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84399 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21433 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29078 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6788 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20666 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26788 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31996 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121967 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26601 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34056 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29917 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28170 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->