### PR TITLE
DocumentFontLoader: Fix unsafe references to ref-counted argument

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -510,7 +510,6 @@ dom/DOMImplementation.cpp
 dom/DataTransfer.cpp
 dom/DataTransferItemList.cpp
 dom/Document.cpp
-dom/DocumentFontLoader.cpp
 dom/DocumentFragment.cpp
 dom/DocumentStorageAccess.cpp
 dom/Element.cpp

--- a/Source/WebCore/dom/DocumentFontLoader.cpp
+++ b/Source/WebCore/dom/DocumentFontLoader.cpp
@@ -73,7 +73,7 @@ CachedFont* DocumentFontLoader::cachedFont(URL&& url, bool isSVG, bool isInitiat
 
     CachedResourceRequest request(ResourceRequest(WTFMove(url)), options);
     request.setInitiatorType(cachedResourceRequestInitiatorTypes().css);
-    return m_document->protectedCachedResourceLoader()->requestFont(WTFMove(request), isSVG).value_or(nullptr).get();
+    return protectedDocument()->protectedCachedResourceLoader()->requestFont(WTFMove(request), isSVG).value_or(nullptr).get();
 }
 
 void DocumentFontLoader::beginLoadingFontSoon(CachedFont& font)
@@ -85,7 +85,7 @@ void DocumentFontLoader::beginLoadingFontSoon(CachedFont& font)
     // Increment the request count now, in order to prevent didFinishLoad from being dispatched
     // after this font has been requested but before it began loading. Balanced by
     // decrementRequestCount() in fontLoadingTimerFired() and in stopLoadingAndClearFonts().
-    m_document->protectedCachedResourceLoader()->incrementRequestCount(font);
+    protectedDocument()->protectedCachedResourceLoader()->incrementRequestCount(font);
 
     if (!m_isFontLoadingSuspended && !m_fontLoadingTimer.isActive())
         m_fontLoadingTimer.startOneShot(0_s);
@@ -99,7 +99,7 @@ void DocumentFontLoader::loadPendingFonts()
     Vector<CachedResourceHandle<CachedFont>> fontsToBeginLoading;
     fontsToBeginLoading.swap(m_fontsToBeginLoading);
 
-    Ref cachedResourceLoader = m_document->cachedResourceLoader();
+    Ref cachedResourceLoader = protectedDocument()->cachedResourceLoader();
     for (auto& fontHandle : fontsToBeginLoading) {
         fontHandle->beginLoadIfNeeded(cachedResourceLoader);
         // Balances incrementRequestCount() in beginLoadingFontSoon().
@@ -114,11 +114,12 @@ void DocumentFontLoader::fontLoadingTimerFired()
 
     // FIXME: Use SubresourceLoader instead.
     // Call FrameLoader::loadDone before FrameLoader::subresourceLoadDone to match the order in SubresourceLoader::notifyDone.
-    m_document->protectedCachedResourceLoader()->loadDone(LoadCompletionType::Finish);
+    Ref document = m_document.get();
+    document->protectedCachedResourceLoader()->loadDone(LoadCompletionType::Finish);
     // Ensure that if the request count reaches zero, the frame loader will know about it.
     // New font loads may be triggered by layout after the document load is complete but before we have dispatched
     // didFinishLoading for the frame. Make sure the delegate is always dispatched by checking explicitly.
-    if (RefPtr frame = m_document->frame())
+    if (RefPtr frame = document->frame())
         frame->protectedLoader()->checkLoadComplete();
 }
 
@@ -128,13 +129,14 @@ void DocumentFontLoader::stopLoadingAndClearFonts()
         return;
 
     m_fontLoadingTimer.stop();
-    Ref cachedResourceLoader = m_document->cachedResourceLoader();
+    Ref document = m_document.get();
+    Ref cachedResourceLoader = document->cachedResourceLoader();
     for (auto& fontHandle : m_fontsToBeginLoading) {
         // Balances incrementRequestCount() in beginLoadingFontSoon().
         cachedResourceLoader->decrementRequestCount(*fontHandle);
     }
     m_fontsToBeginLoading.clear();
-    if (RefPtr fontSelector = m_document->fontSelectorIfExists())
+    if (RefPtr fontSelector = document->fontSelectorIfExists())
         fontSelector->clearFonts();
 
     m_isFontLoadingSuspended = true;

--- a/Source/WebCore/dom/DocumentFontLoader.h
+++ b/Source/WebCore/dom/DocumentFontLoader.h
@@ -57,6 +57,7 @@ public:
 
 private:
     void fontLoadingTimerFired();
+    Ref<Document> protectedDocument() const { return m_document.get(); }
 
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     Timer m_fontLoadingTimer;


### PR DESCRIPTION
#### 320036a93a05d38b7ecaf6ecb9a6d411f25a8cea
<pre>
DocumentFontLoader: Fix unsafe references to ref-counted argument
<a href="https://bugs.webkit.org/show_bug.cgi?id=291580">https://bugs.webkit.org/show_bug.cgi?id=291580</a>
<a href="https://rdar.apple.com/149316394">rdar://149316394</a>

Reviewed by Chris Dumez.

* Source/WebCore/dom/DocumentFontLoader.cpp:
(WebCore::DocumentFontLoader::cachedFont):
(WebCore::DocumentFontLoader::beginLoadingFontSoon):
(WebCore::DocumentFontLoader::loadPendingFonts):
(WebCore::DocumentFontLoader::fontLoadingTimerFired):
(WebCore::DocumentFontLoader::stopLoadingAndClearFonts):
* Source/WebCore/dom/DocumentFontLoader.h:
(WebCore::DocumentFontLoader::protectedDocument const):

Canonical link: <a href="https://commits.webkit.org/293760@main">https://commits.webkit.org/293760@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b84321d07299c6921b6aa0e0c3494d0fe21ebbed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99760 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19406 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104885 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50348 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101801 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27842 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75940 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33037 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15017 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90077 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56303 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14824 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8064 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49710 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84752 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8149 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107246 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26872 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19625 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84898 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27235 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86282 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84421 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21457 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29091 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6805 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20686 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26811 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32026 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26624 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29940 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28190 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->