### PR TITLE
Make PlatformMediaSessionClient a CheckedPtr

### DIFF
--- a/Source/WTF/wtf/Logger.cpp
+++ b/Source/WTF/wtf/Logger.cpp
@@ -68,4 +68,16 @@ Vector<std::reference_wrapper<Logger::MessageHandlerObserver>>& Logger::messageH
     return observers;
 }
 
+const Logger& emptyLogger()
+{
+    static NeverDestroyed<Ref<Logger>> emptyLogger = [&] {
+        // Passing the wrapper as the "owner" of the logger ensures
+        // no caller will every be able to enable this logger.
+        auto logger = Logger::create(&emptyLogger);
+        logger->setEnabled(&emptyLogger, false);
+        return logger;
+    }();
+    return emptyLogger->get();
+}
+
 } // namespace WTF

--- a/Source/WTF/wtf/Logger.h
+++ b/Source/WTF/wtf/Logger.h
@@ -422,6 +422,8 @@ private:
     const void* m_owner;
 };
 
+WTF_EXPORT_PRIVATE const Logger& emptyLogger();
+
 template<> struct LogArgument<Logger::LogSiteIdentifier> {
     static String toString(const Logger::LogSiteIdentifier& value) { return value.toString(); }
 };
@@ -444,3 +446,4 @@ template<> struct LogArgument<id> {
 
 using WTF::Logger;
 using WTF::JSONLogValue;
+using WTF::emptyLogger;

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -301,8 +301,8 @@ GPUExternalTexture* GPUDevice::externalTextureForDescriptor(const GPUExternalTex
 #endif
         if (!videoElement->get())
             return nullptr;
-        HTMLVideoElement& v = *videoElement->get();
-        if (m_previouslyImportedExternalTexture.first.get() == &v)
+        Ref v = *videoElement->get();
+        if (m_previouslyImportedExternalTexture.first.get() == v.ptr())
             return m_previouslyImportedExternalTexture.second.get();
 
         auto it = m_videoElementToExternalTextureMap.find(v);
@@ -334,11 +334,12 @@ private:
 
     CallbackResult<void> invoke(double, const VideoFrameMetadata&) override
     {
-        if (!m_videoElement)
+        RefPtr videoElement = m_videoElement.get();
+        if (!videoElement)
             return { };
         if (!m_gpuDevice)
             return { };
-        auto texture = m_gpuDevice->takeExternalTextureForVideoElement(*m_videoElement);
+        auto texture = m_gpuDevice->takeExternalTextureForVideoElement(*videoElement);
         if (!texture)
             return { };
         if (texture.get() == m_externalTexture.ptr())

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.cpp
@@ -153,15 +153,15 @@ void WebKitMediaKeys::setMediaElement(HTMLMediaElement* element)
 
 RefPtr<MediaPlayer> WebKitMediaKeys::cdmMediaPlayer(const LegacyCDM*) const
 {
-    if (!m_mediaElement)
-        return nullptr;
-    return m_mediaElement->player();
+    if (RefPtr mediaElement = m_mediaElement.get())
+        return mediaElement->player();
+    return nullptr;
 }
 
 void WebKitMediaKeys::keyAdded()
 {
-    if (m_mediaElement)
-        m_mediaElement->keyAdded();
+    if (RefPtr mediaElement = m_mediaElement.get())
+        mediaElement->keyAdded();
 }
 
 RefPtr<ArrayBuffer> WebKitMediaKeys::cachedKeyForKeyId(const String& keyId) const

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -145,10 +145,11 @@ const AtomString& MediaControlsHost::mediaControlsContainerClassName() const
 
 Vector<RefPtr<TextTrack>> MediaControlsHost::sortedTrackListForMenu(TextTrackList& trackList)
 {
-    if (!m_mediaElement)
+    RefPtr mediaElement = protectedElement();
+    if (!mediaElement)
         return { };
 
-    Page* page = m_mediaElement->document().page();
+    Page* page = mediaElement->document().page();
     if (!page)
         return { };
 
@@ -157,10 +158,11 @@ Vector<RefPtr<TextTrack>> MediaControlsHost::sortedTrackListForMenu(TextTrackLis
 
 Vector<RefPtr<AudioTrack>> MediaControlsHost::sortedTrackListForMenu(AudioTrackList& trackList)
 {
-    if (!m_mediaElement)
+    RefPtr mediaElement = protectedElement();
+    if (!mediaElement)
         return { };
 
-    Page* page = m_mediaElement->document().page();
+    Page* page = mediaElement->document().page();
     if (!page)
         return { };
 
@@ -169,10 +171,11 @@ Vector<RefPtr<AudioTrack>> MediaControlsHost::sortedTrackListForMenu(AudioTrackL
 
 String MediaControlsHost::displayNameForTrack(const std::optional<TextOrAudioTrack>& track)
 {
-    if (!m_mediaElement || !track)
+    RefPtr mediaElement = protectedElement();
+    if (!mediaElement || !track)
         return emptyString();
 
-    Page* page = m_mediaElement->document().page();
+    Page* page = mediaElement->document().page();
     if (!page)
         return emptyString();
 
@@ -193,10 +196,11 @@ TextTrack& MediaControlsHost::captionMenuAutomaticItem()
 
 AtomString MediaControlsHost::captionDisplayMode() const
 {
-    if (!m_mediaElement)
+    RefPtr mediaElement = protectedElement();
+    if (!mediaElement)
         return emptyAtom();
 
-    Page* page = m_mediaElement->document().page();
+    Page* page = mediaElement->document().page();
     if (!page)
         return emptyAtom();
 
@@ -217,14 +221,16 @@ AtomString MediaControlsHost::captionDisplayMode() const
 
 void MediaControlsHost::setSelectedTextTrack(TextTrack* track)
 {
-    if (m_mediaElement)
-        m_mediaElement->setSelectedTextTrack(track);
+    RefPtr mediaElement = protectedElement();
+    if (mediaElement)
+        mediaElement->setSelectedTextTrack(track);
 }
 
 Element* MediaControlsHost::textTrackContainer()
 {
-    if (!m_textTrackContainer && m_mediaElement)
-        m_textTrackContainer = MediaControlTextTrackContainerElement::create(m_mediaElement->document(), *m_mediaElement);
+    RefPtr mediaElement = protectedElement();
+    if (!m_textTrackContainer && mediaElement)
+        m_textTrackContainer = MediaControlTextTrackContainerElement::create(mediaElement->document(), *mediaElement);
 
     return m_textTrackContainer.get();
 }
@@ -274,46 +280,54 @@ void MediaControlsHost::updateCaptionDisplaySizes(ForceUpdate force)
     
 bool MediaControlsHost::allowsInlineMediaPlayback() const
 {
-    return m_mediaElement && !m_mediaElement->mediaSession().requiresFullscreenForVideoPlayback();
+    RefPtr mediaElement = protectedElement();
+    return mediaElement && !mediaElement->mediaSession().requiresFullscreenForVideoPlayback();
 }
 
 bool MediaControlsHost::supportsFullscreen() const
 {
-    return m_mediaElement && m_mediaElement->supportsFullscreen(HTMLMediaElementEnums::VideoFullscreenModeStandard);
+    RefPtr mediaElement = protectedElement();
+    return mediaElement && mediaElement->supportsFullscreen(HTMLMediaElementEnums::VideoFullscreenModeStandard);
 }
 
 bool MediaControlsHost::isVideoLayerInline() const
 {
-    return m_mediaElement && m_mediaElement->isVideoLayerInline();
+    RefPtr mediaElement = protectedElement();
+    return mediaElement && mediaElement->isVideoLayerInline();
 }
 
 bool MediaControlsHost::isInMediaDocument() const
 {
-    return m_mediaElement && m_mediaElement->document().isMediaDocument();
+    RefPtr mediaElement = protectedElement();
+    return mediaElement && mediaElement->document().isMediaDocument();
 }
 
 bool MediaControlsHost::userGestureRequired() const
 {
-    return m_mediaElement && !m_mediaElement->mediaSession().playbackStateChangePermitted(MediaPlaybackState::Playing);
+    RefPtr mediaElement = protectedElement();
+    return mediaElement && !mediaElement->mediaSession().playbackStateChangePermitted(MediaPlaybackState::Playing);
 }
 
 bool MediaControlsHost::shouldForceControlsDisplay() const
 {
-    return m_mediaElement && m_mediaElement->shouldForceControlsDisplay();
+    RefPtr mediaElement = protectedElement();
+    return mediaElement && mediaElement->shouldForceControlsDisplay();
 }
 
 bool MediaControlsHost::supportsSeeking() const
 {
-    return m_mediaElement && m_mediaElement->supportsSeeking();
+    RefPtr mediaElement = protectedElement();
+    return mediaElement && mediaElement->supportsSeeking();
 }
 
 bool MediaControlsHost::inWindowFullscreen() const
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    if (!m_mediaElement)
+    RefPtr mediaElement = protectedElement();
+    if (!mediaElement)
         return false;
 
-    if (RefPtr videoElement = dynamicDowncast<HTMLVideoElement>(*m_mediaElement))
+    if (RefPtr videoElement = dynamicDowncast<HTMLVideoElement>(*mediaElement))
         return videoElement->webkitPresentationMode() == HTMLVideoElement::VideoPresentationMode::InWindow;
 #endif
     return false;
@@ -328,18 +342,19 @@ bool MediaControlsHost::supportsRewind() const
 
 bool MediaControlsHost::needsChromeMediaControlsPseudoElement() const
 {
-    if (m_mediaElement)
-        return m_mediaElement->document().quirks().needsChromeMediaControlsPseudoElement();
+    if (RefPtr mediaElement = protectedElement())
+        return mediaElement->document().quirks().needsChromeMediaControlsPseudoElement();
     return false;
 }
 
 String MediaControlsHost::externalDeviceDisplayName() const
 {
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
-    if (!m_mediaElement)
+    RefPtr mediaElement = protectedElement();
+    if (!mediaElement)
         return emptyString();
 
-    RefPtr player = m_mediaElement->player();
+    RefPtr player = mediaElement->player();
     if (!player) {
         LOG(Media, "MediaControlsHost::externalDeviceDisplayName - returning \"\" because player is NULL");
         return emptyString();
@@ -358,10 +373,11 @@ auto MediaControlsHost::externalDeviceType() const -> DeviceType
 #if !ENABLE(WIRELESS_PLAYBACK_TARGET)
     return DeviceType::None;
 #else
-    if (!m_mediaElement)
+    RefPtr mediaElement = protectedElement();
+    if (!mediaElement)
         return DeviceType::None;
 
-    RefPtr player = m_mediaElement->player();
+    RefPtr player = mediaElement->player();
     if (!player) {
         LOG(Media, "MediaControlsHost::externalDeviceType - returning \"none\" because player is NULL");
         return DeviceType::None;
@@ -383,13 +399,14 @@ auto MediaControlsHost::externalDeviceType() const -> DeviceType
 
 bool MediaControlsHost::controlsDependOnPageScaleFactor() const
 {
-    return m_mediaElement && m_mediaElement->mediaControlsDependOnPageScaleFactor();
+    RefPtr mediaElement = protectedElement();
+    return mediaElement && mediaElement->mediaControlsDependOnPageScaleFactor();
 }
 
 void MediaControlsHost::setControlsDependOnPageScaleFactor(bool value)
 {
-    if (m_mediaElement)
-        m_mediaElement->setMediaControlsDependOnPageScaleFactor(value);
+    if (RefPtr mediaElement = protectedElement())
+        mediaElement->setMediaControlsDependOnPageScaleFactor(value);
 }
 
 String MediaControlsHost::generateUUID()
@@ -399,7 +416,7 @@ String MediaControlsHost::generateUUID()
 
 Vector<String> MediaControlsHost::shadowRootStyleSheets() const
 {
-    if (RefPtr mediaElement = m_mediaElement.get())
+    if (RefPtr mediaElement = protectedElement())
         return RenderTheme::singleton().mediaControlsStyleSheets(*mediaElement);
     return { };
 }
@@ -514,12 +531,11 @@ bool MediaControlsHost::showMediaControlsContextMenu(HTMLElement& target, String
     if (m_showMediaControlsContextMenuCallback)
         return false;
 
-    if (!m_mediaElement)
+    RefPtr mediaElement = protectedElement();
+    if (!mediaElement)
         return false;
 
-    auto& mediaElement = *m_mediaElement;
-
-    auto* page = mediaElement.document().page();
+    auto* page = mediaElement->document().page();
     if (!page)
         return false;
 
@@ -601,13 +617,13 @@ bool MediaControlsHost::showMediaControlsContextMenu(HTMLElement& target, String
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     if (optionsJSONObject->getBoolean("includePictureInPicture"_s).value_or(false)) {
         ASSERT(is<HTMLVideoElement>(mediaElement));
-        ASSERT(downcast<HTMLVideoElement>(mediaElement).webkitSupportsPresentationMode(HTMLVideoElement::VideoPresentationMode::PictureInPicture));
+        ASSERT(downcast<HTMLVideoElement>(mediaElement)->webkitSupportsPresentationMode(HTMLVideoElement::VideoPresentationMode::PictureInPicture));
         items.append(createMenuItem(PictureInPictureTag::IncludePictureInPicture, WEB_UI_STRING_KEY("Picture in Picture", "Picture in Picture (Media Controls Menu)", "Picture in Picture media controls context menu title"), false, "pip.enter"_s));
     }
 #endif // ENABLE(VIDEO_PRESENTATION_MODE)
 
     if (optionsJSONObject->getBoolean("includeLanguages"_s).value_or(false)) {
-        if (RefPtr audioTracks = mediaElement.audioTracks(); audioTracks && audioTracks->length() > 1) {
+        if (RefPtr audioTracks = mediaElement->audioTracks(); audioTracks && audioTracks->length() > 1) {
             auto& captionPreferences = page->group().ensureCaptionPreferences();
             auto languageMenuItems = captionPreferences.sortedTrackListForMenu(audioTracks.get()).map([&](auto& audioTrack) {
                 return createMenuItem(audioTrack, captionPreferences.displayNameForTrack(audioTrack.get()), audioTrack->enabled());
@@ -619,7 +635,7 @@ bool MediaControlsHost::showMediaControlsContextMenu(HTMLElement& target, String
     }
 
     if (optionsJSONObject->getBoolean("includeSubtitles"_s).value_or(false)) {
-        if (RefPtr textTracks = mediaElement.textTracks(); textTracks && textTracks->length()) {
+        if (RefPtr textTracks = mediaElement->textTracks(); textTracks && textTracks->length()) {
             auto& captionPreferences = page->group().ensureCaptionPreferences();
             auto sortedTextTracks = captionPreferences.sortedTrackListForMenu(textTracks.get(), { TextTrack::Kind::Subtitles, TextTrack::Kind::Captions, TextTrack::Kind::Descriptions });
             bool allTracksDisabled = notFound == sortedTextTracks.findIf([] (const auto& textTrack) {
@@ -643,7 +659,7 @@ bool MediaControlsHost::showMediaControlsContextMenu(HTMLElement& target, String
     }
 
     if (optionsJSONObject->getBoolean("includeChapters"_s).value_or(false)) {
-        if (RefPtr textTracks = mediaElement.textTracks(); textTracks && textTracks->length()) {
+        if (RefPtr textTracks = mediaElement->textTracks(); textTracks && textTracks->length()) {
             auto& captionPreferences = page->group().ensureCaptionPreferences();
 
             for (auto& textTrack : captionPreferences.sortedTrackListForMenu(textTracks.get(), { TextTrack::Kind::Chapters })) {
@@ -667,7 +683,7 @@ bool MediaControlsHost::showMediaControlsContextMenu(HTMLElement& target, String
     }
 
     if (optionsJSONObject->getBoolean("includePlaybackRates"_s).value_or(false)) {
-        auto playbackRate = mediaElement.playbackRate();
+        auto playbackRate = mediaElement->playbackRate();
 
         items.append(createSubmenu(WEB_UI_STRING_KEY("Playback Speed", "Playback Speed (Media Controls Menu)", "Playback Speed media controls context menu title"), "speedometer"_s, {
             createMenuItem(PlaybackSpeed::x0_5, WEB_UI_STRING_KEY("0.5×", "0.5× (Media Controls Menu Playback Speed)", "0.5× media controls context menu playback speed label"), playbackRate == 0.5),
@@ -699,7 +715,7 @@ bool MediaControlsHost::showMediaControlsContextMenu(HTMLElement& target, String
 
     if (page->settings().showMediaStatsContextMenuItemEnabled() && page->settings().developerExtrasEnabled() && optionsJSONObject->getBoolean("includeShowMediaStats"_s).value_or(false)) {
         items.append(createSeparator());
-        items.append(createMenuItem(ShowMediaStatsTag::IncludeShowMediaStats, contextMenuItemTagShowMediaStats(), mediaElement.showingStats(), "chart.bar.xaxis"_s));
+        items.append(createMenuItem(ShowMediaStatsTag::IncludeShowMediaStats, contextMenuItemTagShowMediaStats(), mediaElement->showingStats(), "chart.bar.xaxis"_s));
     }
 
     if (items.isEmpty())
@@ -722,18 +738,18 @@ bool MediaControlsHost::showMediaControlsContextMenu(HTMLElement& target, String
         if (selectedItemID == invalidMenuItemIdentifier)
             return;
 
-        if (!protectedThis->m_mediaElement)
+        RefPtr mediaElement = protectedThis->protectedElement();
+        if (!mediaElement)
             return;
-        auto& mediaElement = *protectedThis->m_mediaElement;
 
-        UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, &mediaElement.document());
+        UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, &mediaElement->document());
 
         auto selectedItem = idMap.get(selectedItemID);
         WTF::switchOn(selectedItem,
 #if ENABLE(VIDEO_PRESENTATION_MODE)
             [&] (PictureInPictureTag) {
                 // Media controls are not shown when in PiP so we can assume that we're not in PiP.
-                downcast<HTMLVideoElement>(mediaElement).webkitSetPresentationMode(HTMLVideoElement::VideoPresentationMode::PictureInPicture);
+                downcast<HTMLVideoElement>(mediaElement)->webkitSetPresentationMode(HTMLVideoElement::VideoPresentationMode::PictureInPicture);
             },
 #endif // ENABLE(VIDEO_PRESENTATION_MODE)
             [&] (RefPtr<AudioTrack>& selectedAudioTrack) {
@@ -748,43 +764,43 @@ bool MediaControlsHost::showMediaControlsContextMenu(HTMLElement& target, String
                     if (auto* textTrack = std::get_if<RefPtr<TextTrack>>(&track))
                         (*textTrack)->setMode(TextTrack::Mode::Disabled);
                 }
-                mediaElement.setSelectedTextTrack(selectedTextTrack.get());
+                mediaElement->setSelectedTextTrack(selectedTextTrack.get());
             },
             [&] (RefPtr<VTTCue>& cue) {
-                mediaElement.setCurrentTime(cue->startMediaTime());
+                mediaElement->setCurrentTime(cue->startMediaTime());
             },
             [&] (PlaybackSpeed playbackSpeed) {
                 switch (playbackSpeed) {
                 case PlaybackSpeed::x0_5:
-                    mediaElement.setDefaultPlaybackRate(0.5);
-                    mediaElement.setPlaybackRate(0.5);
+                    mediaElement->setDefaultPlaybackRate(0.5);
+                    mediaElement->setPlaybackRate(0.5);
                     return;
 
                 case PlaybackSpeed::x1_0:
-                    mediaElement.setDefaultPlaybackRate(1.0);
-                    mediaElement.setPlaybackRate(1.0);
+                    mediaElement->setDefaultPlaybackRate(1.0);
+                    mediaElement->setPlaybackRate(1.0);
                     return;
 
                 case PlaybackSpeed::x1_25:
-                    mediaElement.setDefaultPlaybackRate(1.25);
-                    mediaElement.setPlaybackRate(1.25);
+                    mediaElement->setDefaultPlaybackRate(1.25);
+                    mediaElement->setPlaybackRate(1.25);
                     return;
 
                 case PlaybackSpeed::x1_5:
-                    mediaElement.setDefaultPlaybackRate(1.5);
-                    mediaElement.setPlaybackRate(1.5);
+                    mediaElement->setDefaultPlaybackRate(1.5);
+                    mediaElement->setPlaybackRate(1.5);
                     return;
 
                 case PlaybackSpeed::x2_0:
-                    mediaElement.setDefaultPlaybackRate(2.0);
-                    mediaElement.setPlaybackRate(2.0);
+                    mediaElement->setDefaultPlaybackRate(2.0);
+                    mediaElement->setPlaybackRate(2.0);
                     return;
                 }
 
                 ASSERT_NOT_REACHED();
             },
             [&] (ShowMediaStatsTag) {
-                mediaElement.setShowingStats(!mediaElement.showingStats());
+                mediaElement->setShowingStats(!mediaElement->showingStats());
             }
         );
 
@@ -808,8 +824,8 @@ bool MediaControlsHost::showMediaControlsContextMenu(HTMLElement& target, String
 
 auto MediaControlsHost::sourceType() const -> std::optional<SourceType>
 {
-    if (m_mediaElement)
-        return m_mediaElement->sourceType();
+    if (RefPtr mediaElement = protectedElement())
+        return mediaElement->sourceType();
     return std::nullopt;
 }
 
@@ -827,7 +843,7 @@ void MediaControlsHost::savePreviouslySelectedTextTrackIfNecessary()
     if (m_previouslySelectedTextTrack)
         return;
 
-    auto mediaElement = RefPtr { m_mediaElement.get() };
+    RefPtr mediaElement = protectedElement();
     if (!mediaElement)
         return;
 
@@ -868,7 +884,7 @@ void MediaControlsHost::restorePreviouslySelectedTextTrackIfNecessary()
     if (!m_previouslySelectedTextTrack)
         return;
 
-    auto mediaElement = RefPtr { m_mediaElement.get() };
+    RefPtr mediaElement = protectedElement();
     if (!mediaElement)
         return;
 
@@ -889,7 +905,7 @@ void MediaControlsHost::restorePreviouslySelectedTextTrackIfNecessary()
 #if ENABLE(MEDIA_SESSION)
 RefPtr<MediaSession> MediaControlsHost::mediaSession() const
 {
-    RefPtr mediaElement = m_mediaElement.get();
+    RefPtr mediaElement = protectedElement();
     if (!mediaElement)
         return { };
 
@@ -911,11 +927,11 @@ void MediaControlsHost::ensureMediaSessionObserver()
 
 void MediaControlsHost::metadataChanged(const RefPtr<MediaMetadata>&)
 {
-    RefPtr mediaElement = m_mediaElement.get();
+    RefPtr mediaElement = protectedElement();
     if (!mediaElement)
         return;
 
-    RefPtr shadowRoot = m_mediaElement->userAgentShadowRoot();
+    RefPtr shadowRoot = mediaElement->userAgentShadowRoot();
     if (!shadowRoot)
         return;
 

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
@@ -133,6 +133,8 @@ private:
     void savePreviouslySelectedTextTrackIfNecessary();
     void restorePreviouslySelectedTextTrackIfNecessary();
 
+    RefPtr<HTMLMediaElement> protectedElement() const { return m_mediaElement.ptr(); }
+
 #if ENABLE(MEDIA_SESSION)
     RefPtr<MediaSession> mediaSession() const;
 
@@ -140,7 +142,7 @@ private:
     void metadataChanged(const RefPtr<MediaMetadata>&) final;
 #endif
 
-    WeakPtr<HTMLMediaElement> m_mediaElement;
+    WeakRef<HTMLMediaElement> m_mediaElement;
     RefPtr<MediaControlTextTrackContainerElement> m_textTrackContainer;
     RefPtr<TextTrack> m_previouslySelectedTextTrack;
 

--- a/Source/WebCore/Modules/pictureinpicture/DocumentPictureInPicture.cpp
+++ b/Source/WebCore/Modules/pictureinpicture/DocumentPictureInPicture.cpp
@@ -48,7 +48,7 @@ bool DocumentPictureInPicture::pictureInPictureEnabled(Document&)
 
 void DocumentPictureInPicture::exitPictureInPicture(Document& document, Ref<DeferredPromise>&& promise)
 {
-    auto element = document.pictureInPictureElement();
+    RefPtr element = document.pictureInPictureElement();
 
     if (!element) {
         promise->reject(ExceptionCode::InvalidStateError);

--- a/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp
+++ b/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp
@@ -53,13 +53,14 @@ HTMLVideoElementPictureInPicture::HTMLVideoElementPictureInPicture(HTMLVideoElem
 #endif
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    m_videoElement->setPictureInPictureObserver(this);
+    videoElement.setPictureInPictureObserver(this);
 }
 
 HTMLVideoElementPictureInPicture::~HTMLVideoElementPictureInPicture()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    m_videoElement->setPictureInPictureObserver(nullptr);
+    if (RefPtr videoElement = m_videoElement.ptr())
+        videoElement->setPictureInPictureObserver(nullptr);
 }
 
 HTMLVideoElementPictureInPicture* HTMLVideoElementPictureInPicture::from(HTMLVideoElement& videoElement)
@@ -142,25 +143,30 @@ void HTMLVideoElementPictureInPicture::setDisablePictureInPicture(HTMLVideoEleme
 void HTMLVideoElementPictureInPicture::exitPictureInPicture(Ref<DeferredPromise>&& promise)
 {
     INFO_LOG(LOGIDENTIFIER);
-    if (m_enterPictureInPicturePromise || m_exitPictureInPicturePromise) {
+    RefPtr videoElement = m_videoElement.ptr();
+    if (m_enterPictureInPicturePromise || m_exitPictureInPicturePromise || !videoElement) {
         promise->reject(ExceptionCode::NotAllowedError);
         return;
     }
 
     m_exitPictureInPicturePromise = WTFMove(promise);
-    m_videoElement->webkitSetPresentationMode(HTMLVideoElement::VideoPresentationMode::Inline);
+    videoElement->webkitSetPresentationMode(HTMLVideoElement::VideoPresentationMode::Inline);
 }
 
 void HTMLVideoElementPictureInPicture::didEnterPictureInPicture(const IntSize& windowSize)
 {
+    RefPtr videoElement = m_videoElement.ptr();
+    if (!videoElement)
+        return;
+
     INFO_LOG(LOGIDENTIFIER);
-    m_videoElement->document().setPictureInPictureElement(m_videoElement.ptr());
+    videoElement->document().setPictureInPictureElement(videoElement.get());
     m_pictureInPictureWindow->setSize(windowSize);
 
     PictureInPictureEvent::Init initializer;
     initializer.bubbles = true;
     initializer.pictureInPictureWindow = m_pictureInPictureWindow;
-    m_videoElement->scheduleEvent(PictureInPictureEvent::create(eventNames().enterpictureinpictureEvent, WTFMove(initializer)));
+    videoElement->scheduleEvent(PictureInPictureEvent::create(eventNames().enterpictureinpictureEvent, WTFMove(initializer)));
 
     if (m_enterPictureInPicturePromise) {
         m_enterPictureInPicturePromise->resolve<IDLInterface<PictureInPictureWindow>>(*m_pictureInPictureWindow);
@@ -170,14 +176,18 @@ void HTMLVideoElementPictureInPicture::didEnterPictureInPicture(const IntSize& w
 
 void HTMLVideoElementPictureInPicture::didExitPictureInPicture()
 {
+    RefPtr videoElement = m_videoElement.ptr();
+    if (!videoElement)
+        return;
+
     INFO_LOG(LOGIDENTIFIER);
     m_pictureInPictureWindow->close();
-    m_videoElement->document().setPictureInPictureElement(nullptr);
+    videoElement->document().setPictureInPictureElement(nullptr);
 
     PictureInPictureEvent::Init initializer;
     initializer.bubbles = true;
     initializer.pictureInPictureWindow = m_pictureInPictureWindow;
-    m_videoElement->scheduleEvent(PictureInPictureEvent::create(eventNames().leavepictureinpictureEvent, WTFMove(initializer)));
+    videoElement->scheduleEvent(PictureInPictureEvent::create(eventNames().leavepictureinpictureEvent, WTFMove(initializer)));
 
     if (m_exitPictureInPicturePromise) {
         m_exitPictureInPicturePromise->resolve();

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp
@@ -294,8 +294,8 @@ void RemotePlayback::shouldPlayToRemoteTargetChanged(bool shouldPlayToRemoteTarg
     else
         disconnect();
 
-    if (m_mediaElement)
-        m_mediaElement->remoteHasAvailabilityCallbacksChanged();
+    if (RefPtr mediaElement = m_mediaElement.get())
+        mediaElement->remoteHasAvailabilityCallbacksChanged();
 }
 
 void RemotePlayback::setState(State state)
@@ -386,8 +386,8 @@ void RemotePlayback::playbackTargetPickerWasDismissed()
     for (auto& promise : std::exchange(m_promptPromises, { }))
         promise->reject(ExceptionCode::NotAllowedError);
 
-    if (m_mediaElement)
-        m_mediaElement->remoteHasAvailabilityCallbacksChanged();
+    if (RefPtr mediaElement = m_mediaElement.get())
+        mediaElement->remoteHasAvailabilityCallbacksChanged();
 }
 
 void RemotePlayback::isPlayingToRemoteTargetChanged(bool isPlayingToTarget)

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -162,6 +162,8 @@ void AudioContext::constructCommon()
 
 AudioContext::~AudioContext()
 {
+    m_mediaSession->invalidateClient();
+
     if (RefPtr document = this->document())
         document->removeAudioProducer(*this);
 }

--- a/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp
@@ -50,14 +50,15 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(MediaElementAudioSourceNode);
 
 ExceptionOr<Ref<MediaElementAudioSourceNode>> MediaElementAudioSourceNode::create(BaseAudioContext& context, MediaElementAudioSourceOptions&& options)
 {
-    RELEASE_ASSERT(options.mediaElement);
+    RefPtr mediaElement = WTFMove(options.mediaElement);
+    RELEASE_ASSERT(mediaElement);
 
-    if (options.mediaElement->audioSourceNode())
+    if (!mediaElement || mediaElement->audioSourceNode())
         return Exception { ExceptionCode::InvalidStateError, "Media element is already associated with an audio source node"_s };
 
-    auto node = adoptRef(*new MediaElementAudioSourceNode(context, *options.mediaElement));
+    auto node = adoptRef(*new MediaElementAudioSourceNode(context, *mediaElement));
 
-    options.mediaElement->setAudioSourceNode(node.ptr());
+    mediaElement->setAudioSourceNode(node.ptr());
 
     // context keeps reference until node is disconnected.
     context.sourceNodeWillBeginPlayback(node);

--- a/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h
@@ -71,7 +71,7 @@ private:
 
     bool wouldTaintOrigin();
 
-    Ref<HTMLMediaElement> m_mediaElement;
+    const Ref<HTMLMediaElement> m_mediaElement;
     Lock m_processLock;
 
     unsigned m_sourceNumberOfChannels WTF_GUARDED_BY_LOCK(m_processLock) { 0 };

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -62,7 +62,6 @@ editing/Editor.h
 editing/TextIterator.cpp
 editing/VisibleUnits.cpp
 html/HTMLMediaElement.cpp
-html/MediaElementSession.h
 html/canvas/PlaceholderRenderingContext.cpp
 html/parser/HTMLConstructionSite.cpp
 html/parser/HTMLDocumentParser.cpp

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -35,7 +35,6 @@ dom/QualifiedName.h
 dom/TreeScope.h
 editing/cocoa/HTMLConverter.mm
 html/FormListedElement.cpp
-html/MediaElementSession.h
 html/parser/HTMLTreeBuilder.h
 html/track/TrackBase.h
 html/track/WebVTTParser.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1108,7 +1108,6 @@ rendering/RenderLayerScrollableArea.cpp
 rendering/RenderListBox.cpp
 rendering/RenderListItem.cpp
 rendering/RenderListMarker.cpp
-rendering/RenderMedia.cpp
 rendering/RenderMenuList.cpp
 rendering/RenderMeter.cpp
 rendering/RenderMultiColumnFlow.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -44,7 +44,6 @@ Modules/model-element/HTMLModelElement.cpp
 Modules/notifications/Notification.cpp
 Modules/paymentrequest/PaymentRequest.cpp
 Modules/permissions/Permissions.cpp
-Modules/pictureinpicture/DocumentPictureInPicture.cpp
 Modules/speech/SpeechRecognition.cpp
 Modules/speech/SpeechSynthesis.cpp
 Modules/storage/WorkerStorageConnection.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2390,6 +2390,7 @@ platform/audio/IIRFilter.cpp
 platform/audio/MultiChannelResampler.cpp
 platform/audio/Panner.cpp
 platform/audio/PlatformMediaSession.cpp
+platform/audio/PlatformMediaSessionInterface.cpp
 platform/audio/PlatformMediaSessionManager.cpp
 platform/audio/PlatformRawAudioData.cpp
 platform/audio/PushPullFIFO.cpp

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -724,6 +724,12 @@ public:
 
     void audioSessionCategoryChanged(AudioSessionCategory, AudioSessionMode, RouteSharingPolicy);
 
+    // CheckedPtr interface
+    uint32_t checkedPtrCount() const { return CanMakeCheckedPtr<Node>::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const { return CanMakeCheckedPtr<Node>::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const { CanMakeCheckedPtr<Node>::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const { CanMakeCheckedPtr<Node>::decrementCheckedPtrCount(); }
+
 protected:
     HTMLMediaElement(const QualifiedName&, Document&, bool createdByParser);
     virtual ~HTMLMediaElement();

--- a/Source/WebCore/html/MediaController.cpp
+++ b/Source/WebCore/html/MediaController.cpp
@@ -66,6 +66,42 @@ MediaController::MediaController(ScriptExecutionContext& context)
 
 MediaController::~MediaController() = default;
 
+void MediaController::forEachElement(Function<void(Ref<HTMLMediaElement>&&)>&& func) const
+{
+    for (auto& element : m_mediaElements) {
+        if (RefPtr protectedElement = element.get())
+            func(protectedElement.releaseNonNull());
+    }
+}
+
+bool MediaController::anyElement(Function<bool(Ref<HTMLMediaElement>&&)>&& func) const
+{
+    for (auto& element : m_mediaElements) {
+        RefPtr protectedElement = element.get();
+        if (!protectedElement)
+            continue;
+
+        if (func(protectedElement.releaseNonNull()))
+            return true;
+    }
+    return false;
+}
+
+bool MediaController::everyElement(Function<bool(Ref<HTMLMediaElement>&&)>&& func) const
+{
+    bool isNonEmpty = false;
+    for (auto& element : m_mediaElements) {
+        RefPtr protectedElement = element.get();
+        if (!protectedElement)
+            continue;
+
+        isNonEmpty = true;
+        if (!func(protectedElement.releaseNonNull()))
+            return false;
+    }
+    return isNonEmpty;
+}
+
 void MediaController::addMediaElement(HTMLMediaElement& element)
 {
     ASSERT(!m_mediaElements.contains(&element));
@@ -85,12 +121,13 @@ Ref<TimeRanges> MediaController::buffered() const
     if (m_mediaElements.isEmpty())
         return TimeRanges::create();
 
-    // The buffered attribute must return a new static normalized TimeRanges object that represents 
+    // The buffered attribute must return a new static normalized TimeRanges object that represents
     // the intersection of the ranges of the media resources of the mediagroup elements that the
     // user agent has buffered, at the time the attribute is evaluated.
-    Ref<TimeRanges> bufferedRanges = m_mediaElements.first()->buffered();
-    for (size_t index = 1; index < m_mediaElements.size(); ++index)
-        bufferedRanges->intersectWith(m_mediaElements[index]->buffered());
+    Ref<TimeRanges> bufferedRanges = TimeRanges::create(-std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity());
+    forEachElement([&] (auto element) {
+        bufferedRanges->intersectWith(element->buffered());
+    });
     return bufferedRanges;
 }
 
@@ -102,23 +139,22 @@ Ref<TimeRanges> MediaController::seekable() const
     // The seekable attribute must return a new static normalized TimeRanges object that represents
     // the intersection of the ranges of the media resources of the mediagroup elements that the
     // user agent is able to seek to, at the time the attribute is evaluated.
-    Ref<TimeRanges> seekableRanges = m_mediaElements.first()->seekable();
-    for (size_t index = 1; index < m_mediaElements.size(); ++index)
-        seekableRanges->intersectWith(m_mediaElements[index]->seekable());
+    Ref<TimeRanges> seekableRanges = TimeRanges::create(-std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity());
+    forEachElement([&] (auto element) {
+        seekableRanges->intersectWith(element->seekable());
+    });
     return seekableRanges;
 }
 
 Ref<TimeRanges> MediaController::played()
 {
-    if (m_mediaElements.isEmpty())
-        return TimeRanges::create();
-
-    // The played attribute must return a new static normalized TimeRanges object that represents 
+    // The played attribute must return a new static normalized TimeRanges object that represents
     // the union of the ranges of the media resources of the mediagroup elements that the
     // user agent has so far rendered, at the time the attribute is evaluated.
-    Ref<TimeRanges> playedRanges = m_mediaElements.first()->played();
-    for (size_t index = 1; index < m_mediaElements.size(); ++index)
-        playedRanges->unionWith(m_mediaElements[index]->played());
+    Ref<TimeRanges> playedRanges = TimeRanges::create();
+    forEachElement([&] (auto element) {
+        playedRanges->unionWith(element->played());
+    });
     return playedRanges;
 }
 
@@ -127,12 +163,12 @@ double MediaController::duration() const
     // FIXME: Investigate caching the maximum duration and only updating the cached value
     // when the mediagroup elements' durations change.
     double maxDuration = 0;
-    for (auto& mediaElement : m_mediaElements) {
+    forEachElement([&] (auto mediaElement) {
         double duration = mediaElement->duration();
         if (std::isnan(duration))
-            continue;
+            return;
         maxDuration = std::max(maxDuration, duration);
-    }
+    });
     return maxDuration;
 }
 
@@ -166,8 +202,9 @@ void MediaController::setCurrentTime(double time)
     m_clock->setCurrentTime(time);
     
     // Seek each mediagroup element to the new playback position relative to the media element timeline.
-    for (auto& mediaElement : m_mediaElements)
+    forEachElement([&] (auto mediaElement) {
         mediaElement->seek(MediaTime::createWithDouble(time));
+    });
 
     scheduleTimeupdateEvent();
     m_resetCurrentTimeInNextPlay = false;
@@ -190,8 +227,9 @@ void MediaController::play()
 {
     // When the play() method is invoked, the user agent must invoke the play method of each
     // mediagroup element in turn,
-    for (auto& mediaElement : m_mediaElements)
+    forEachElement([&] (auto mediaElement) {
         mediaElement->play();
+    });
 
     // and then invoke the unpause method of the MediaController.
     unpause();
@@ -238,8 +276,9 @@ void MediaController::setPlaybackRate(double rate)
     // playback rate to the new value,
     m_clock->setPlayRate(rate);
 
-    for (auto& mediaElement : m_mediaElements)
+    forEachElement([&] (auto mediaElement) {
         mediaElement->updatePlaybackRate();
+    });
 
     // then queue a task to fire a simple event named ratechange at the MediaController.
     scheduleEvent(eventNames().ratechangeEvent);
@@ -262,8 +301,9 @@ ExceptionOr<void> MediaController::setVolume(double level)
     // and queue a task to fire a simple event named volumechange at the MediaController.
     scheduleEvent(eventNames().volumechangeEvent);
 
-    for (auto& mediaElement : m_mediaElements)
+    forEachElement([&] (auto mediaElement) {
         mediaElement->updateVolume();
+    });
 
     return { };
 }
@@ -280,8 +320,9 @@ void MediaController::setMuted(bool flag)
     // and queue a task to fire a simple event named volumechange at the MediaController.
     scheduleEvent(eventNames().volumechangeEvent);
 
-    for (auto& mediaElement : m_mediaElements)
+    forEachElement([&] (auto mediaElement) {
         mediaElement->updateVolume();
+    });
 }
 
 static const AtomString& playbackStateWaiting()
@@ -344,21 +385,18 @@ static AtomString eventNameForReadyState(MediaControllerInterface::ReadyState st
 
 void MediaController::updateReadyState()
 {
-    ReadyState oldReadyState = m_readyState;
-    ReadyState newReadyState;
-    
-    if (m_mediaElements.isEmpty()) {
-        // If the MediaController has no mediagroup elements, let new readiness state be 0.
-        newReadyState = HAVE_NOTHING;
-    } else {
-        // Otherwise, let it have the lowest value of the readyState IDL attributes of all of its
-        // mediagroup elements.
-        newReadyState = m_mediaElements.first()->readyState();
-        for (size_t index = 1; index < m_mediaElements.size(); ++index)
-            newReadyState = std::min(newReadyState, m_mediaElements[index]->readyState());
-    }
+    auto readyStates = m_mediaElements.map([] (auto& checkedElement) -> std::optional<ReadyState> {
+        if (RefPtr mediaElement = checkedElement.get())
+            return mediaElement->readyState();
+        return std::nullopt;
+    });
 
-    if (newReadyState == oldReadyState) 
+    // If the MediaController has no mediagroup elements, let new readiness state be 0.
+    // Otherwise, let it have the lowest value of the readyState IDL attributes of all of its
+    // mediagroup elements.
+    ReadyState oldReadyState = m_readyState;
+    ReadyState newReadyState = std::ranges::min(readyStates).value_or(HAVE_NOTHING);
+    if (newReadyState == oldReadyState)
         return;
 
     // If the MediaController's most recently reported readiness state is greater than new readiness 
@@ -468,8 +506,9 @@ void MediaController::updatePlaybackState()
 
 void MediaController::updateMediaElements()
 {
-    for (auto& mediaElement : m_mediaElements)
+    forEachElement([&] (auto mediaElement) {
         mediaElement->updatePlayState();
+    });
 }
 
 void MediaController::bringElementUpToSpeed(HTMLMediaElement& element)
@@ -492,23 +531,18 @@ bool MediaController::isBlocked() const
     if (m_mediaElements.isEmpty())
         return false;
     
-    bool allPaused = true;
-    for (auto& element : m_mediaElements) {
+    return anyElement([&] (auto element) {
         //  or if any of its mediagroup elements are blocked media elements,
         if (element->isBlocked())
             return true;
         
         // or if any of its mediagroup elements whose autoplaying flag is true still have their
         // paused attribute set to true,
-        if (element->isAutoplaying() && element->paused())
-            return true;
-        
-        if (!element->paused())
-            allPaused = false;
-    }
-    
-    // or if all of its mediagroup elements have their paused attribute set to true.
-    return allPaused;
+        return element->isAutoplaying() && element->paused();
+    }) || everyElement([&] (auto element) {
+        // or if all of its mediagroup elements have their paused attribute set to true.
+        return element->paused();
+    });
 }
 
 bool MediaController::hasEnded() const
@@ -519,15 +553,9 @@ bool MediaController::hasEnded() const
 
     // [and] all of the MediaController's mediagroup elements have ended playback ... let new
     // playback state be ended.
-    if (m_mediaElements.isEmpty())
-        return false;
-    
-    bool allHaveEnded = true;
-    for (auto& mediaElement : m_mediaElements) {
-        if (!mediaElement->ended())
-            allHaveEnded = false;
-    }
-    return allHaveEnded;
+    return everyElement([] (auto mediaElement) {
+        return mediaElement->ended();
+    });
 }
 
 void MediaController::scheduleEvent(const AtomString& eventName)
@@ -553,73 +581,70 @@ void MediaController::clearPositionTimerFired()
 
 bool MediaController::hasAudio() const
 {
-    for (auto& mediaElement : m_mediaElements) {
-        if (mediaElement->hasAudio())
-            return true;
-    }
-    return false;
+    return anyElement([] (auto mediaElement) {
+        return mediaElement->hasAudio();
+    });
 }
 
 bool MediaController::hasVideo() const
 {
-    for (auto& mediaElement : m_mediaElements) {
-        if (mediaElement->hasVideo())
-            return true;
-    }
-    return false;
+    return anyElement([] (auto mediaElement) {
+        return mediaElement->hasVideo();
+    });
 }
 
 bool MediaController::hasClosedCaptions() const
 {
-    for (auto& mediaElement : m_mediaElements) {
-        if (mediaElement->hasClosedCaptions())
-            return true;
-    }
-    return false;
+    return anyElement([] (auto mediaElement) {
+        return mediaElement->hasClosedCaptions();
+    });
 }
 
 void MediaController::setClosedCaptionsVisible(bool visible)
 {
     m_closedCaptionsVisible = visible;
-    for (auto& mediaElement : m_mediaElements)
+    forEachElement([visible] (auto mediaElement) {
         mediaElement->setClosedCaptionsVisible(visible);
+    });
 }
 
 bool MediaController::supportsScanning() const
 {
-    for (auto& mediaElement : m_mediaElements) {
-        if (!mediaElement->supportsScanning())
-            return false;
-    }
-    return true;
+    return everyElement([] (auto mediaElement) {
+        return mediaElement->supportsScanning();
+    });
 }
 
 void MediaController::beginScrubbing()
 {
-    for (auto& mediaElement : m_mediaElements)
+    forEachElement([] (auto mediaElement) {
         mediaElement->beginScrubbing();
+    });
     if (m_playbackState == PLAYING)
         m_clock->stop();
 }
 
 void MediaController::endScrubbing()
 {
-    for (auto& mediaElement : m_mediaElements)
+    forEachElement([] (auto mediaElement) {
         mediaElement->endScrubbing();
+    });
     if (m_playbackState == PLAYING)
         m_clock->start();
 }
 
 void MediaController::beginScanning(ScanDirection direction)
 {
-    for (auto& mediaElement : m_mediaElements)
+    forEachElement([direction] (auto mediaElement) {
         mediaElement->beginScanning(direction);
+    });
 }
 
 void MediaController::endScanning()
 {
-    for (auto& mediaElement : m_mediaElements)
+    forEachElement([] (auto mediaElement) {
         mediaElement->endScanning();
+    });
 }
 
 bool MediaController::canPlay() const
@@ -627,35 +652,30 @@ bool MediaController::canPlay() const
     if (m_paused)
         return true;
 
-    for (auto& mediaElement : m_mediaElements) {
-        if (!mediaElement->canPlay())
-            return false;
-    }
-    return true;
+    return everyElement([] (auto mediaElement) {
+        return mediaElement->canPlay();
+    });
 }
 
 bool MediaController::isLiveStream() const
 {
-    for (auto& mediaElement : m_mediaElements) {
-        if (!mediaElement->isLiveStream())
-            return false;
-    }
-    return true;
+    return everyElement([] (auto mediaElement) {
+        return mediaElement->isLiveStream();
+    });
 }
 
 bool MediaController::hasCurrentSrc() const
 {
-    for (auto& mediaElement : m_mediaElements) {
-        if (!mediaElement->hasCurrentSrc())
-            return false;
-    }
-    return true;
+    return everyElement([] (auto mediaElement) {
+        return mediaElement->hasCurrentSrc();
+    });
 }
 
 void MediaController::returnToRealtime()
 {
-    for (auto& mediaElement : m_mediaElements)
+    return forEachElement([] (auto mediaElement) {
         mediaElement->returnToRealtime();
+    });
 }
 
 // The spec says to fire periodic timeupdate events (those sent while playing) every

--- a/Source/WebCore/html/MediaController.h
+++ b/Source/WebCore/html/MediaController.h
@@ -130,12 +130,16 @@ private:
 
     ReadyState readyState() const final { return m_readyState; }
 
+    void forEachElement(Function<void(Ref<HTMLMediaElement>&&)>&&) const;
+    bool anyElement(Function<bool(Ref<HTMLMediaElement>&&)>&&) const;
+    bool everyElement(Function<bool(Ref<HTMLMediaElement>&&)>&&) const;
+
     enum PlaybackState { WAITING, PLAYING, ENDED };
 
     friend class HTMLMediaElement;
     friend class MediaControllerEventListener;
 
-    Vector<HTMLMediaElement*> m_mediaElements;
+    Vector<CheckedPtr<HTMLMediaElement>> m_mediaElements;
     bool m_paused;
     double m_defaultPlaybackRate;
     double m_volume;

--- a/Source/WebCore/html/MediaElementSession.h
+++ b/Source/WebCore/html/MediaElementSession.h
@@ -160,7 +160,8 @@ public:
     WEBCORE_EXPORT void removeBehaviorRestriction(BehaviorRestrictions);
     bool hasBehaviorRestriction(BehaviorRestrictions restriction) const { return restriction & m_restrictions; }
 
-    HTMLMediaElement& element() const { return m_element; }
+    WeakPtr<HTMLMediaElement> element() const { return m_element; }
+    RefPtr<HTMLMediaElement> protectedElement() const;
 
     bool wantsToObserveViewportVisibilityForMediaControls() const;
     bool wantsToObserveViewportVisibilityForAutoplay() const;
@@ -228,7 +229,7 @@ private:
 
     void addMediaUsageManagerSessionIfNecessary();
 
-    HTMLMediaElement& m_element;
+    WeakPtr<HTMLMediaElement> m_element;
     BehaviorRestrictions m_restrictions;
 
     std::optional<MediaUsageInfo> m_mediaUsageInfo;

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
@@ -88,6 +88,8 @@ private:
     void show();
     bool isShowing() const;
 
+    RefPtr<HTMLMediaElement> protectedMediaElement() const;
+
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final;
     uint64_t logIdentifier() const final;

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -632,8 +632,8 @@ static bool hasAudibleMedia(const Element& element)
     if (RefPtr media = dynamicDowncast<HTMLMediaElement>(element))
         return media->isAudible();
 
-    for (auto& media : descendantsOfType<HTMLMediaElement>(element)) {
-        if (media.isAudible())
+    for (Ref media : descendantsOfType<HTMLMediaElement>(element)) {
+        if (media->isAudible())
             return true;
     }
 

--- a/Source/WebCore/platform/audio/PlatformMediaSessionInterface.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionInterface.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PlatformMediaSessionInterface.h"
+
+#include <wtf/NeverDestroyed.h>
+
+namespace WebCore {
+
+class EmptyPlatformMediaSessionClient final : public PlatformMediaSessionClient {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    PlatformMediaSessionMediaType mediaType() const final { return PlatformMediaSessionMediaType::None; }
+    PlatformMediaSessionMediaType presentationType() const final { return PlatformMediaSessionMediaType::None; }
+    void mayResumePlayback(bool) final { }
+    void suspendPlayback() final { }
+    bool canReceiveRemoteControlCommands() const final { return false; }
+    void didReceiveRemoteControlCommand(PlatformMediaSessionRemoteControlCommandType, const PlatformMediaSessionRemoteCommandArgument&) final { }
+    bool supportsSeeking() const final { return false; }
+    bool shouldOverrideBackgroundPlaybackRestriction(PlatformMediaSessionInterruptionType) const final { return false; }
+    std::optional<MediaSessionGroupIdentifier> mediaSessionGroupIdentifier() const final { return std::nullopt; }
+    void isActiveNowPlayingSessionChanged() final { }
+    std::optional<ProcessID> mediaSessionPresentingApplicationPID() const final { return std::nullopt; }
+
+#if !RELEASE_LOG_DISABLED
+    virtual const Logger& logger() const { return emptyLogger(); }
+    virtual uint64_t logIdentifier() const { return 0; }
+#endif
+};
+
+PlatformMediaSessionClient& emptyPlatformMediaSessionClient()
+{
+    static NeverDestroyed<EmptyPlatformMediaSessionClient> client { };
+    return client;
+}
+
+}

--- a/Source/WebCore/platform/audio/PlatformMediaSessionInterface.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionInterface.h
@@ -129,8 +129,10 @@ struct PlatformMediaSessionRemoteCommandArgument {
     std::optional<bool> fastSeek;
 };
 
-class PlatformMediaSessionClient {
+class PlatformMediaSessionClient : public CanMakeCheckedPtr<PlatformMediaSessionClient> {
     WTF_MAKE_NONCOPYABLE(PlatformMediaSessionClient);
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlatformMediaSessionClient);
 public:
     PlatformMediaSessionClient() = default;
 
@@ -189,6 +191,8 @@ public:
 protected:
     virtual ~PlatformMediaSessionClient() = default;
 };
+
+PlatformMediaSessionClient& emptyPlatformMediaSessionClient();
 
 class AudioCaptureSource : public CanMakeWeakPtr<AudioCaptureSource> {
 public:
@@ -309,6 +313,7 @@ public:
     virtual String description() const = 0;
 #endif
 
+    void invalidateClient() { m_client = emptyPlatformMediaSessionClient(); }
     PlatformMediaSessionClient& client() const { return m_client; }
 
 #if !RELEASE_LOG_DISABLED
@@ -327,7 +332,7 @@ protected:
     }
 
 private:
-    PlatformMediaSessionClient& m_client;
+    CheckedRef<PlatformMediaSessionClient> m_client;
     MediaSessionIdentifier m_mediaSessionIdentifier;
     bool m_hasPlayedAudiblySinceLastInterruption { false };
 };

--- a/Source/WebCore/platform/audio/cocoa/AudioOutputUnitAdaptor.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioOutputUnitAdaptor.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEB_AUDIO)
 
+#include "Logging.h"
 #include <pal/cf/AudioToolboxSoftLink.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -44,6 +44,7 @@
 #include <pal/spi/cg/CoreGraphicsSPI.h>
 #include <wtf/FlipBytes.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/cf/TypeCastsCF.h>
 
 #include "MediaAccessibilitySoftLink.h"
 #if ENABLE(QUICKLOOK_FULLSCREEN)

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -445,7 +445,7 @@ URL HitTestResult::absolutePDFURL() const
 URL HitTestResult::absoluteMediaURL() const
 {
 #if ENABLE(VIDEO)
-    if (auto* element = mediaElement()) {
+    if (RefPtr element = mediaElement()) {
         auto sourceURL = element->currentSrc();
         if (RefPtr page = element->document().page())
             return page->applyLinkDecorationFiltering(sourceURL, LinkDecorationFilteringTrigger::Unspecified);
@@ -458,11 +458,10 @@ URL HitTestResult::absoluteMediaURL() const
 bool HitTestResult::mediaSupportsFullscreen() const
 {
 #if ENABLE(VIDEO)
-    HTMLMediaElement* mediaElt(mediaElement());
-    return is<HTMLVideoElement>(mediaElt) && mediaElt->supportsFullscreen(HTMLMediaElementEnums::VideoFullscreenModeStandard);
-#else
-    return false;
+    if (RefPtr element = mediaElement())
+        return is<HTMLVideoElement>(*element) && element->supportsFullscreen(HTMLMediaElementEnums::VideoFullscreenModeStandard);
 #endif
+    return false;
 }
 
 #if ENABLE(VIDEO)
@@ -490,7 +489,7 @@ bool HitTestResult::hasMediaElement() const
 void HitTestResult::toggleMediaControlsDisplay() const
 {
 #if ENABLE(VIDEO)
-    if (HTMLMediaElement* mediaElt = mediaElement())
+    if (RefPtr mediaElt = mediaElement())
         mediaElt->setControls(!mediaElt->controls());
 #endif
 }
@@ -498,7 +497,7 @@ void HitTestResult::toggleMediaControlsDisplay() const
 void HitTestResult::toggleMediaLoopPlayback() const
 {
 #if ENABLE(VIDEO)
-    if (HTMLMediaElement* mediaElt = mediaElement())
+    if (RefPtr mediaElt = mediaElement())
         mediaElt->setLoop(!mediaElt->loop());
 #endif
 }
@@ -506,7 +505,7 @@ void HitTestResult::toggleMediaLoopPlayback() const
 void HitTestResult::toggleShowMediaStats() const
 {
 #if ENABLE(VIDEO)
-    if (HTMLMediaElement* mediaElt = mediaElement())
+    if (RefPtr mediaElt = mediaElement())
         mediaElt->setShowingStats(!mediaElt->showingStats());
 #endif
 }
@@ -514,7 +513,7 @@ void HitTestResult::toggleShowMediaStats() const
 bool HitTestResult::mediaIsInFullscreen() const
 {
 #if ENABLE(VIDEO)
-    if (HTMLMediaElement* mediaElement = this->mediaElement())
+    if (RefPtr mediaElement = this->mediaElement())
         return mediaElement->isVideo() && mediaElement->isStandardFullscreen();
 #endif
     return false;
@@ -523,7 +522,7 @@ bool HitTestResult::mediaIsInFullscreen() const
 void HitTestResult::toggleMediaFullscreenState() const
 {
 #if ENABLE(VIDEO)
-    if (HTMLMediaElement* mediaElement = this->mediaElement()) {
+    if (RefPtr mediaElement = this->mediaElement()) {
         if (mediaElement->isVideo() && mediaElement->supportsFullscreen(HTMLMediaElementEnums::VideoFullscreenModeStandard)) {
             UserGestureIndicator indicator(IsProcessingUserGesture::Yes, &mediaElement->document());
             mediaElement->toggleStandardFullscreenState();
@@ -548,11 +547,10 @@ void HitTestResult::enterFullscreenForVideo() const
 bool HitTestResult::mediaIsInVideoViewer() const
 {
 #if PLATFORM(MAC) && ENABLE(VIDEO) && ENABLE(VIDEO_PRESENTATION_MODE)
-    HTMLMediaElement* mediaElt(mediaElement());
-    return is<HTMLVideoElement>(mediaElt) && mediaElt->fullscreenMode() == HTMLMediaElementEnums::VideoFullscreenModeInWindow;
-#else
-    return false;
+    if (RefPtr mediaElt = mediaElement())
+        return is<HTMLVideoElement>(mediaElt) && mediaElt->fullscreenMode() == HTMLMediaElementEnums::VideoFullscreenModeInWindow;
 #endif
+    return false;
 }
 
 void HitTestResult::toggleVideoViewer() const
@@ -573,7 +571,7 @@ void HitTestResult::toggleVideoViewer() const
 bool HitTestResult::mediaControlsEnabled() const
 {
 #if ENABLE(VIDEO)
-    if (HTMLMediaElement* mediaElement = this->mediaElement())
+    if (RefPtr mediaElement = this->mediaElement())
         return mediaElement->controls();
 #endif
     return false;
@@ -582,7 +580,7 @@ bool HitTestResult::mediaControlsEnabled() const
 bool HitTestResult::mediaLoopEnabled() const
 {
 #if ENABLE(VIDEO)
-    if (HTMLMediaElement* mediaElt = mediaElement())
+    if (RefPtr mediaElt = mediaElement())
         return mediaElt->loop();
 #endif
     return false;
@@ -591,7 +589,7 @@ bool HitTestResult::mediaLoopEnabled() const
 bool HitTestResult::mediaStatsShowing() const
 {
 #if ENABLE(VIDEO)
-    if (HTMLMediaElement* mediaElt = mediaElement())
+    if (RefPtr mediaElt = mediaElement())
         return mediaElt->showingStats();
 #endif
     return false;
@@ -600,7 +598,7 @@ bool HitTestResult::mediaStatsShowing() const
 bool HitTestResult::mediaPlaying() const
 {
 #if ENABLE(VIDEO)
-    if (HTMLMediaElement* mediaElt = mediaElement())
+    if (RefPtr mediaElt = mediaElement())
         return !mediaElt->paused();
 #endif
     return false;
@@ -609,7 +607,7 @@ bool HitTestResult::mediaPlaying() const
 void HitTestResult::toggleMediaPlayState() const
 {
 #if ENABLE(VIDEO)
-    if (HTMLMediaElement* mediaElt = mediaElement())
+    if (RefPtr mediaElt = mediaElement())
         mediaElt->togglePlayState();
 #endif
 }
@@ -617,7 +615,7 @@ void HitTestResult::toggleMediaPlayState() const
 bool HitTestResult::mediaHasAudio() const
 {
 #if ENABLE(VIDEO)
-    if (HTMLMediaElement* mediaElt = mediaElement())
+    if (RefPtr mediaElt = mediaElement())
         return mediaElt->hasAudio();
 #endif
     return false;
@@ -626,7 +624,7 @@ bool HitTestResult::mediaHasAudio() const
 bool HitTestResult::mediaIsVideo() const
 {
 #if ENABLE(VIDEO)
-    if (HTMLMediaElement* mediaElt = mediaElement())
+    if (RefPtr mediaElt = mediaElement())
         return is<HTMLVideoElement>(*mediaElt);
 #endif
     return false;
@@ -635,7 +633,7 @@ bool HitTestResult::mediaIsVideo() const
 bool HitTestResult::mediaMuted() const
 {
 #if ENABLE(VIDEO)
-    if (HTMLMediaElement* mediaElt = mediaElement())
+    if (RefPtr mediaElt = mediaElement())
         return mediaElt->muted();
 #endif
     return false;
@@ -644,7 +642,7 @@ bool HitTestResult::mediaMuted() const
 void HitTestResult::toggleMediaMuteState() const
 {
 #if ENABLE(VIDEO)
-    if (HTMLMediaElement* mediaElt = mediaElement())
+    if (RefPtr mediaElt = mediaElement())
         mediaElt->setMuted(!mediaElt->muted());
 #endif
 }
@@ -652,7 +650,7 @@ void HitTestResult::toggleMediaMuteState() const
 bool HitTestResult::isDownloadableMedia() const
 {
 #if ENABLE(VIDEO)
-    if (HTMLMediaElement* mediaElt = mediaElement())
+    if (RefPtr mediaElt = mediaElement())
         return mediaElt->canSaveMediaData();
 #endif
 
@@ -871,29 +869,27 @@ String HitTestResult::linkSuggestedFilename() const
 bool HitTestResult::mediaSupportsEnhancedFullscreen() const
 {
 #if PLATFORM(MAC) && ENABLE(VIDEO) && ENABLE(VIDEO_PRESENTATION_MODE)
-    HTMLMediaElement* mediaElt(mediaElement());
-    return is<HTMLVideoElement>(mediaElt) && mediaElt->supportsFullscreen(HTMLMediaElementEnums::VideoFullscreenModePictureInPicture);
-#else
-    return false;
+    if (RefPtr mediaElt = mediaElement())
+        return is<HTMLVideoElement>(mediaElt) && mediaElt->supportsFullscreen(HTMLMediaElementEnums::VideoFullscreenModePictureInPicture);
 #endif
+    return false;
 }
 
 bool HitTestResult::mediaIsInEnhancedFullscreen() const
 {
 #if PLATFORM(MAC) && ENABLE(VIDEO) && ENABLE(VIDEO_PRESENTATION_MODE)
-    HTMLMediaElement* mediaElt(mediaElement());
-    return is<HTMLVideoElement>(mediaElt) && mediaElt->fullscreenMode() == HTMLMediaElementEnums::VideoFullscreenModePictureInPicture;
-#else
-    return false;
+    if (RefPtr mediaElt = mediaElement())
+        return is<HTMLVideoElement>(mediaElt) && mediaElt->fullscreenMode() == HTMLMediaElementEnums::VideoFullscreenModePictureInPicture;
 #endif
+    return false;
 }
 
 void HitTestResult::toggleEnhancedFullscreenForVideo() const
 {
 #if PLATFORM(MAC) && ENABLE(VIDEO) && ENABLE(VIDEO_PRESENTATION_MODE)
-    auto* mediaElement(this->mediaElement());
-    auto* videoElement = dynamicDowncast<HTMLVideoElement>(*mediaElement);
-    if (!videoElement || !mediaElement->supportsFullscreen(HTMLMediaElementEnums::VideoFullscreenModePictureInPicture))
+    RefPtr mediaElement(this->mediaElement());
+    RefPtr videoElement = dynamicDowncast<HTMLVideoElement>(mediaElement);
+    if (!mediaElement || !videoElement || !mediaElement->supportsFullscreen(HTMLMediaElementEnums::VideoFullscreenModePictureInPicture))
         return;
 
     UserGestureIndicator indicator(IsProcessingUserGesture::Yes, &mediaElement->document());

--- a/Source/WebCore/rendering/RenderMedia.cpp
+++ b/Source/WebCore/rendering/RenderMedia.cpp
@@ -56,17 +56,17 @@ void RenderMedia::layout()
     LayoutSize oldSize = size();
     RenderImage::layout();
     if (oldSize != size())
-        mediaElement().layoutSizeChanged();
+        protectedMediaElement()->layoutSizeChanged();
 }
 
 void RenderMedia::styleDidChange(StyleDifference difference, const RenderStyle* oldStyle)
 {
     RenderImage::styleDidChange(difference, oldStyle);
     if (!oldStyle || style().usedVisibility() != oldStyle->usedVisibility())
-        mediaElement().visibilityDidChange();
+        protectedMediaElement()->visibilityDidChange();
 
     if (!oldStyle || style().dynamicRangeLimit() != oldStyle->dynamicRangeLimit())
-        mediaElement().dynamicRangeLimitDidChange(style().dynamicRangeLimit().toPlatformDynamicRangeLimit());
+        protectedMediaElement()->dynamicRangeLimitDidChange(style().dynamicRangeLimit().toPlatformDynamicRangeLimit());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderMedia.h
+++ b/Source/WebCore/rendering/RenderMedia.h
@@ -40,6 +40,7 @@ public:
     virtual ~RenderMedia();
 
     HTMLMediaElement& mediaElement() const { return downcast<HTMLMediaElement>(nodeForNonAnonymous()); }
+    Ref<HTMLMediaElement> protectedMediaElement() const { return mediaElement(); }
 
     bool shouldDisplayBrokenImageIcon() const final { return false; }
 

--- a/Source/WebCore/rendering/RenderVideo.cpp
+++ b/Source/WebCore/rendering/RenderVideo.cpp
@@ -66,7 +66,7 @@ void RenderVideo::willBeDestroyed()
 {
     visibleInViewportStateChanged();
 
-    if (RefPtr player = videoElement().player())
+    if (RefPtr player = protectedVideoElement()->player())
         player->renderVideoWillBeDestroyed();
 
     RenderMedia::willBeDestroyed();
@@ -74,7 +74,7 @@ void RenderVideo::willBeDestroyed()
 
 void RenderVideo::visibleInViewportStateChanged()
 {
-    videoElement().isVisibleInViewportChanged();
+    protectedVideoElement()->isVisibleInViewportChanged();
 }
 
 IntSize RenderVideo::defaultSize()
@@ -88,7 +88,7 @@ IntSize RenderVideo::defaultSize()
 
 void RenderVideo::intrinsicSizeChanged()
 {
-    if (videoElement().shouldDisplayPosterImage())
+    if (protectedVideoElement()->shouldDisplayPosterImage())
         RenderMedia::intrinsicSizeChanged();
     if (updateIntrinsicSize())
         invalidateLineLayout();
@@ -102,7 +102,7 @@ bool RenderVideo::updateIntrinsicSize()
         return false;
 
     // Treat the media player's natural size as visually non-empty.
-    if (videoElement().readyState() >= HTMLMediaElementEnums::HAVE_METADATA)
+    if (protectedVideoElement()->readyState() >= HTMLMediaElementEnums::HAVE_METADATA)
         incrementVisuallyNonEmptyPixelCountIfNeeded(roundedIntSize(size));
 
     if (size == intrinsicSize())
@@ -125,8 +125,9 @@ LayoutSize RenderVideo::calculateIntrinsicSizeInternal()
     // The intrinsic height of a video element's playback area is the intrinsic height 
     // of the video resource, if that is available; otherwise it is the intrinsic 
     // height of the poster frame, if that is available; otherwise it is 150 CSS pixels.
-    RefPtr player = videoElement().player();
-    if (player && videoElement().readyState() >= HTMLVideoElement::HAVE_METADATA) {
+    Ref videoElement = protectedVideoElement();
+    RefPtr player = videoElement->player();
+    if (player && videoElement->readyState() >= HTMLVideoElement::HAVE_METADATA) {
         LayoutSize size(player->naturalSize());
         if (!size.isEmpty())
             return size;
@@ -139,7 +140,7 @@ LayoutSize RenderVideo::calculateIntrinsicSizeInternal()
     // size since they also have audio-only files. By setting the intrinsic
     // size to 300x1 the video will resize itself in these cases, and audio will
     // have the correct height (it needs to be > 0 for controls to render properly).
-    if (videoElement().document().isMediaDocument())
+    if (videoElement->document().isMediaDocument())
         return LayoutSize(defaultSize().width(), 1);
 
     return defaultSize();
@@ -169,7 +170,7 @@ void RenderVideo::imageChanged(WrappedImagePtr newImage, const IntRect* rect)
     // Cache the image intrinsic size so we can continue to use it to draw the image correctly
     // even if we know the video intrinsic size but aren't able to draw video frames yet
     // (we don't want to scale the poster to the video size without keeping aspect ratio).
-    if (videoElement().shouldDisplayPosterImage())
+    if (protectedVideoElement()->shouldDisplayPosterImage())
         m_cachedImageSize = intrinsicSize();
 
     // The intrinsic size is now that of the image, but in case we already had the
@@ -180,13 +181,14 @@ void RenderVideo::imageChanged(WrappedImagePtr newImage, const IntRect* rect)
 
 IntRect RenderVideo::videoBox() const
 {
-    RefPtr mediaPlayer = videoElement().player();
+    Ref videoElement = protectedVideoElement();
+    RefPtr mediaPlayer = videoElement->player();
     if (mediaPlayer && mediaPlayer->shouldIgnoreIntrinsicSize())
         return snappedIntRect(contentBoxRect());
 
     LayoutSize intrinsicSize = this->intrinsicSize();
 
-    if (videoElement().shouldDisplayPosterImage())
+    if (videoElement->shouldDisplayPosterImage())
         intrinsicSize = m_cachedImageSize;
 
     return snappedIntRect(replacedContentRect(intrinsicSize));
@@ -205,7 +207,7 @@ IntRect RenderVideo::videoBoxInRootView() const
 
 bool RenderVideo::shouldDisplayVideo() const
 {
-    return !videoElement().shouldDisplayPosterImage();
+    return !protectedVideoElement()->shouldDisplayPosterImage();
 }
 
 bool RenderVideo::failedToLoadPosterImage() const
@@ -217,8 +219,9 @@ void RenderVideo::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOf
 {
     ASSERT(!isSkippedContentRoot(*this));
 
-    RefPtr mediaPlayer = videoElement().player();
-    bool displayingPoster = videoElement().shouldDisplayPosterImage();
+    Ref videoElement = protectedVideoElement();
+    RefPtr mediaPlayer = videoElement->player();
+    bool displayingPoster = videoElement->shouldDisplayPosterImage();
 
     if (!displayingPoster && !mediaPlayer) {
         if (paintInfo.phase == PaintPhase::Foreground)
@@ -261,19 +264,19 @@ void RenderVideo::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOf
 
     // Painting contents during fullscreen playback causes stutters on iOS when the device is rotated.
     // https://bugs.webkit.org/show_bug.cgi?id=142097
-    if (videoElement().supportsAcceleratedRendering() && videoElement().isFullscreen())
+    if (videoElement->supportsAcceleratedRendering() && videoElement->isFullscreen())
         return;
 
     // Avoid unnecessary paints by skipping software painting if
     // the renderer is accelerated, and the paint operation does
     // not flatten compositing layers and is not snapshotting.
     if (hasAcceleratedCompositing()
-        && videoElement().supportsAcceleratedRendering()
+        && videoElement->supportsAcceleratedRendering()
         && !paintInfo.paintBehavior.contains(PaintBehavior::FlattenCompositingLayers)
         && !paintInfo.paintBehavior.contains(PaintBehavior::Snapshotting))
         return;
 
-    videoElement().paint(context, rect);
+    videoElement->paint(context, rect);
 }
 
 void RenderVideo::layout()
@@ -296,6 +299,11 @@ HTMLVideoElement& RenderVideo::videoElement() const
     return downcast<HTMLVideoElement>(RenderMedia::mediaElement());
 }
 
+Ref<HTMLVideoElement> RenderVideo::protectedVideoElement() const
+{
+    return videoElement();
+}
+
 void RenderVideo::updateFromElement()
 {
     RenderMedia::updateFromElement();
@@ -311,14 +319,15 @@ bool RenderVideo::updatePlayer()
     auto intrinsicSizeChanged = updateIntrinsicSize();
     ASSERT(!intrinsicSizeChanged || !view().frameView().layoutContext().isInRenderTreeLayout());
 
-    RefPtr mediaPlayer = videoElement().player();
+    Ref videoElement = protectedVideoElement();
+    RefPtr mediaPlayer = videoElement->player();
     if (!mediaPlayer)
         return intrinsicSizeChanged;
 
-    if (videoElement().inActiveDocument())
+    if (videoElement->inActiveDocument())
         contentChanged(ContentChangeType::Video);
 
-    videoElement().updateMediaPlayer(videoBox().size(), style().objectFit() != ObjectFit::Fill);
+    videoElement->updateMediaPlayer(videoBox().size(), style().objectFit() != ObjectFit::Fill);
     return intrinsicSizeChanged;
 }
 
@@ -334,29 +343,30 @@ LayoutUnit RenderVideo::minimumReplacedHeight() const
 
 bool RenderVideo::supportsAcceleratedRendering() const
 {
-    return videoElement().supportsAcceleratedRendering();
+    return protectedVideoElement()->supportsAcceleratedRendering();
 }
 
 void RenderVideo::acceleratedRenderingStateChanged()
 {
-    videoElement().acceleratedRenderingStateChanged();
+    protectedVideoElement()->acceleratedRenderingStateChanged();
 }
 
 bool RenderVideo::requiresImmediateCompositing() const
 {
-    RefPtr player = videoElement().player();
+    RefPtr player = protectedVideoElement()->player();
     return player && player->requiresImmediateCompositing();
 }
 
 bool RenderVideo::foregroundIsKnownToBeOpaqueInRect(const LayoutRect& localRect, unsigned maxDepthToTest) const
 {
-    if (videoElement().shouldDisplayPosterImage())
+    Ref videoElement = protectedVideoElement();
+    if (videoElement->shouldDisplayPosterImage())
         return RenderImage::foregroundIsKnownToBeOpaqueInRect(localRect, maxDepthToTest);
 
     if (!videoBox().contains(enclosingIntRect(localRect)))
         return false;
 
-    if (RefPtr player = videoElement().player())
+    if (RefPtr player = videoElement->player())
         return player->hasAvailableVideoFrame();
 
     return false;
@@ -364,7 +374,9 @@ bool RenderVideo::foregroundIsKnownToBeOpaqueInRect(const LayoutRect& localRect,
 
 bool RenderVideo::hasVideoMetadata() const
 {
-    return videoElement().player() && videoElement().player()->readyState() >= MediaPlayerEnums::ReadyState::HaveMetadata;
+    if (RefPtr player = protectedVideoElement()->player())
+        return player->readyState() >= MediaPlayerEnums::ReadyState::HaveMetadata;
+    return false;
 }
 
 bool RenderVideo::hasPosterFrameSize() const
@@ -374,7 +386,7 @@ bool RenderVideo::hasPosterFrameSize() const
     // so that contain: inline-size could affect the intrinsic size, which should be 0 x block-size.
     if (shouldApplyInlineSizeContainment())
         isEmpty = isHorizontalWritingMode() ? !m_cachedImageSize.height() : !m_cachedImageSize.width();
-    return videoElement().shouldDisplayPosterImage() && !isEmpty && !imageResource().errorOccurred();
+    return protectedVideoElement()->shouldDisplayPosterImage() && !isEmpty && !imageResource().errorOccurred();
 }
 
 bool RenderVideo::hasDefaultObjectSize() const

--- a/Source/WebCore/rendering/RenderVideo.h
+++ b/Source/WebCore/rendering/RenderVideo.h
@@ -40,6 +40,7 @@ public:
     virtual ~RenderVideo();
 
     WEBCORE_EXPORT HTMLVideoElement& videoElement() const;
+    Ref<HTMLVideoElement> protectedVideoElement() const;
 
     IntRect videoBox() const;
     WEBCORE_EXPORT IntRect videoBoxInRootView() const;

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -267,7 +267,7 @@ void WebFullScreenManager::enterFullScreenForElement(Element& element, HTMLMedia
         return;
     }
 
-    if (auto* currentPlaybackControlsElement = m_page->playbackSessionManager().currentPlaybackControlsElement())
+    if (RefPtr currentPlaybackControlsElement = m_page->playbackSessionManager().currentPlaybackControlsElement())
         currentPlaybackControlsElement->prepareForVideoFullscreenStandby();
 #endif
 
@@ -420,8 +420,8 @@ void WebFullScreenManager::didEnterFullScreen(CompletionHandler<bool(bool)>&& co
 #endif
 
 #if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))
-    auto* currentPlaybackControlsElement = m_page->playbackSessionManager().currentPlaybackControlsElement();
-    setPIPStandbyElement(dynamicDowncast<WebCore::HTMLVideoElement>(currentPlaybackControlsElement));
+    RefPtr currentPlaybackControlsElement = m_page->playbackSessionManager().currentPlaybackControlsElement();
+    setPIPStandbyElement(dynamicDowncast<WebCore::HTMLVideoElement>(currentPlaybackControlsElement.get()));
 #endif
 
 #if ENABLE(VIDEO)
@@ -442,8 +442,8 @@ void WebFullScreenManager::updateMainVideoElement()
 
         RefPtr<WebCore::HTMLVideoElement> mainVideo;
         WebCore::FloatRect mainVideoBounds;
-        for (auto& video : WebCore::descendantsOfType<WebCore::HTMLVideoElement>(*m_element)) {
-            auto rendererAndBounds = video.boundingAbsoluteRectWithoutLayout();
+        for (Ref video : WebCore::descendantsOfType<WebCore::HTMLVideoElement>(*m_element)) {
+            auto rendererAndBounds = video->boundingAbsoluteRectWithoutLayout();
             if (!rendererAndBounds)
                 continue;
 
@@ -455,7 +455,7 @@ void WebFullScreenManager::updateMainVideoElement()
                 continue;
 
             mainVideoBounds = bounds;
-            mainVideo = &video;
+            mainVideo = video.ptr();
         }
         return mainVideo;
     }());

--- a/Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -94,7 +94,6 @@ mac/DOM/DOMHTMLTableSectionElement.mm
 mac/DOM/DOMHTMLTextAreaElement.mm
 mac/DOM/DOMHTMLTitleElement.mm
 mac/DOM/DOMHTMLUListElement.mm
-mac/DOM/DOMHTMLVideoElement.mm
 mac/DOM/DOMImplementation.mm
 mac/DOM/DOMKeyboardEvent.mm
 mac/DOM/DOMMediaList.mm

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLMediaElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLMediaElement.mm
@@ -44,7 +44,7 @@
 #import <wtf/GetPtr.h>
 #import <wtf/URL.h>
 
-#define IMPL static_cast<WebCore::HTMLMediaElement*>(reinterpret_cast<WebCore::Node*>(_internal))
+#define IMPL RefPtr { static_cast<WebCore::HTMLMediaElement*>(reinterpret_cast<WebCore::Node*>(_internal)) }
 
 @implementation DOMHTMLMediaElement
 

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLVideoElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLVideoElement.mm
@@ -39,7 +39,7 @@
 #import <wtf/GetPtr.h>
 #import <wtf/URL.h>
 
-#define IMPL static_cast<WebCore::HTMLVideoElement*>(reinterpret_cast<WebCore::Node*>(_internal))
+#define IMPL RefPtr { static_cast<WebCore::HTMLVideoElement*>(reinterpret_cast<WebCore::Node*>(_internal)) }
 
 @implementation DOMHTMLVideoElement
 


### PR DESCRIPTION
#### e5e34e38459892dbee6c0941c00d15500eed6ce0
<pre>
Make PlatformMediaSessionClient a CheckedPtr
<a href="https://rdar.apple.com/149224332">rdar://149224332</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291585">https://bugs.webkit.org/show_bug.cgi?id=291585</a>

Reviewed by Andy Estes.

Make PlatformMediaSessionClient a CheckedPtr and add an explicit invalidate() client
call to PlatformMediaSessionInterface.

Add a new empty PlatformMediaSessionClient subclass for use when the main client is
invalidated that uses a (also new) empty Logger. This keeps clients from having to
test that the Logger is non-null through LOG_IF_POSSIBLE macros.

SaferCpp Bot Fixes:
- Now that HTMLMediaElement is _explicitly_ capable of being a CheckedPtr (previously
  it was only implicitly CheckedPtr via Node), fix a number of SaferCpp warnings about
  raw or WeakPtr use of HTMLMediaElement.

* Source/WTF/wtf/Logger.cpp:
(WTF::emptyLogger):
* Source/WTF/wtf/Logger.h:
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::~AudioContext):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::~HTMLMediaElement):
* Source/WebCore/html/HTMLMediaElement.h:
(WebCore::HTMLMediaElement::checkedPtrCount const):
(WebCore::HTMLMediaElement::checkedPtrCountWithoutThreadCheck const):
(WebCore::HTMLMediaElement::incrementCheckedPtrCount const):
(WebCore::HTMLMediaElement::decrementCheckedPtrCount const):
* Source/WebCore/platform/audio/PlatformMediaSessionInterface.cpp: Added.
(WebCore::emptyPlatformMediaSessionClient):
* Source/WebCore/platform/audio/PlatformMediaSessionInterface.h:
(WebCore::PlatformMediaSessionInterface::invalidateClient):

Canonical link: <a href="https://commits.webkit.org/293979@main">https://commits.webkit.org/293979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b81e04164a09ee88496f661f8387e5ae2901638

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105580 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51031 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102484 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28569 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76483 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33535 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15635 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90732 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56839 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15451 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8735 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50406 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/93107 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85368 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107934 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/99051 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27561 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20227 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85443 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27924 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86932 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84981 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21619 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29658 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7391 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21526 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27496 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32746 "Found 32 new failures in platform/audio/PlatformMediaSessionInterface.h, platform/audio/PlatformMediaSession.cpp and found 2 fixed files: mac/DOM/DOMHTMLVideoElement.mm, mac/DOM/DOMHTMLMediaElement.mm") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122677 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27307 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34220 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30625 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28865 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->