### PR TITLE
WebKit serialization tends to use copying when it should be moving

### DIFF
--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
@@ -125,7 +125,7 @@ ExceptionOr<bool> NavigatorBeacon::sendBeacon(Document& document, const String& 
         return true;
     }
 
-    ResourceRequest request(parsedUrl);
+    ResourceRequest request(WTFMove(parsedUrl));
     request.setHTTPMethod("POST"_s);
     request.setRequester(ResourceRequestRequester::Beacon);
     if (RefPtr documentLoader = document.loader())

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -254,7 +254,7 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
                 imageURL = document->completeURL(attr);
             m_pendingURL = attr;
         }
-        ResourceRequest resourceRequest(imageURL);
+        ResourceRequest resourceRequest(WTFMove(imageURL));
         resourceRequest.setInspectorInitiatorNodeIdentifier(InspectorInstrumentation::identifierForNode(element));
 
         auto request = createPotentialAccessControlRequest(WTFMove(resourceRequest), WTFMove(options), document, crossOriginAttribute);
@@ -292,7 +292,7 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
         if (imageElement && imageElement->isMultiRepresentationHEIC()) {
             auto fallbackURL = imageElement->src();
             if (!fallbackURL.isNull()) {
-                ResourceRequest resourceRequest(fallbackURL);
+                ResourceRequest resourceRequest(WTFMove(fallbackURL));
                 resourceRequest.setInspectorInitiatorNodeIdentifier(InspectorInstrumentation::identifierForNode(*imageElement));
 
                 auto request = createPotentialAccessControlRequest(WTFMove(resourceRequest), WTFMove(options), document, crossOriginAttribute);

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -352,12 +352,12 @@ std::unique_ptr<LinkPreloadResourceClient> LinkLoader::preloadIfNeeded(const Lin
         if (params.relAttribute.isLinkModulePreload) {
             options.mode = FetchOptions::Mode::Cors;
             options.credentials = equalLettersIgnoringASCIICase(params.crossOrigin, "use-credentials"_s) ? FetchOptions::Credentials::Include : FetchOptions::Credentials::SameOrigin;
-            CachedResourceRequest cachedRequest { ResourceRequest { url }, WTFMove(options) };
+            CachedResourceRequest cachedRequest { ResourceRequest { WTFMove(url) }, WTFMove(options) };
             cachedRequest.setOrigin(document.securityOrigin());
             updateRequestForAccessControl(cachedRequest.resourceRequest(), document.securityOrigin(), options.storedCredentialsPolicy);
             return cachedRequest;
         }
-        return createPotentialAccessControlRequest(url, WTFMove(options), document, params.crossOrigin);
+        return createPotentialAccessControlRequest(WTFMove(url), WTFMove(options), document, params.crossOrigin);
     }();
     linkRequest.setPriority(DefaultResourceLoadPriority::forResourceType(type.value()));
     linkRequest.setInitiatorType("link"_s);

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -291,7 +291,7 @@ bool DragController::performDragOperation(DragData&& dragData)
         return false;
 
     client().willPerformDragDestinationAction(DragDestinationAction::Load, dragData);
-    ResourceRequest resourceRequest { urlString };
+    ResourceRequest resourceRequest { WTFMove(urlString) };
     resourceRequest.setIsAppInitiated(false);
     FrameLoadRequest frameLoadRequest { *localMainFrame, resourceRequest };
     frameLoadRequest.setShouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy);

--- a/Source/WebCore/platform/network/ResourceRequestBase.cpp
+++ b/Source/WebCore/platform/network/ResourceRequestBase.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003, 2006 Apple Inc.  All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc.  All rights reserved.
  * Copyright (C) 2009, 2012 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -126,6 +126,16 @@ const URL& ResourceRequestBase::url() const
     updateResourceRequest(); 
     
     return m_requestData.m_url;
+}
+
+void ResourceRequestBase::setURL(URL&& url, bool didFilterLinkDecoration)
+{
+    updateResourceRequest();
+
+    m_requestData.m_url = WTFMove(url);
+    m_requestData.m_didFilterLinkDecoration = didFilterLinkDecoration;
+
+    m_platformRequestUpdated = false;
 }
 
 void ResourceRequestBase::setURL(const URL& url, bool didFilterLinkDecoration)

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003, 2006 Apple Inc.  All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc.  All rights reserved.
  * Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
  * Copyright (C) 2009, 2012 Google Inc. All rights reserved.
  *
@@ -67,7 +67,29 @@ public:
 
     struct RequestData {
         RequestData() { }
-        
+
+        RequestData(URL&& url, URL&& firstPartyForCookies, double timeoutInterval, String&& httpMethod, HTTPHeaderMap&& httpHeaderFields, Vector<String>&& responseContentDispositionEncodingFallbackArray, const ResourceRequestCachePolicy& cachePolicy, const SameSiteDisposition& sameSiteDisposition, const ResourceLoadPriority& priority, const ResourceRequestRequester& requester, bool allowCookies, bool isTopSite, bool isAppInitiated = true, bool privacyProxyFailClosedForUnreachableNonMainHosts = false, bool useAdvancedPrivacyProtections = false, bool didFilterLinkDecoration = false, bool isPrivateTokenUsageByThirdPartyAllowed = false, bool wasSchemeOptimisticallyUpgraded = false)
+            : m_url(WTFMove(url))
+            , m_firstPartyForCookies(WTFMove(firstPartyForCookies))
+            , m_timeoutInterval(timeoutInterval)
+            , m_httpMethod(WTFMove(httpMethod))
+            , m_httpHeaderFields(WTFMove(httpHeaderFields))
+            , m_responseContentDispositionEncodingFallbackArray(WTFMove(responseContentDispositionEncodingFallbackArray))
+            , m_cachePolicy(cachePolicy)
+            , m_sameSiteDisposition(sameSiteDisposition)
+            , m_priority(priority)
+            , m_requester(requester)
+            , m_isTopSite(isTopSite)
+            , m_allowCookies(allowCookies)
+            , m_isAppInitiated(isAppInitiated)
+            , m_privacyProxyFailClosedForUnreachableNonMainHosts(privacyProxyFailClosedForUnreachableNonMainHosts)
+            , m_useAdvancedPrivacyProtections(useAdvancedPrivacyProtections)
+            , m_didFilterLinkDecoration(didFilterLinkDecoration)
+            , m_isPrivateTokenUsageByThirdPartyAllowed(isPrivateTokenUsageByThirdPartyAllowed)
+            , m_wasSchemeOptimisticallyUpgraded(wasSchemeOptimisticallyUpgraded)
+        {
+        }
+
         RequestData(const URL& url, const URL& firstPartyForCookies, double timeoutInterval, const String& httpMethod, const HTTPHeaderMap& httpHeaderFields, const Vector<String>& responseContentDispositionEncodingFallbackArray, const ResourceRequestCachePolicy& cachePolicy, const SameSiteDisposition& sameSiteDisposition, const ResourceLoadPriority& priority, const ResourceRequestRequester& requester, bool allowCookies, bool isTopSite, bool isAppInitiated = true, bool privacyProxyFailClosedForUnreachableNonMainHosts = false, bool useAdvancedPrivacyProtections = false, bool didFilterLinkDecoration = false, bool isPrivateTokenUsageByThirdPartyAllowed = false, bool wasSchemeOptimisticallyUpgraded = false)
             : m_url(url)
             , m_firstPartyForCookies(firstPartyForCookies)
@@ -90,6 +112,12 @@ public:
         {
         }
         
+        RequestData(URL&& url, ResourceRequestCachePolicy cachePolicy)
+            : m_url(WTFMove(url))
+            , m_cachePolicy(cachePolicy)
+        {
+        }
+
         RequestData(const URL& url, ResourceRequestCachePolicy cachePolicy)
             : m_url(url)
             , m_cachePolicy(cachePolicy)
@@ -133,6 +161,7 @@ public:
     WEBCORE_EXPORT bool isEmpty() const;
     
     WEBCORE_EXPORT const URL& url() const;
+    WEBCORE_EXPORT void setURL(URL&&, bool didFilterLinkDecoration = false);
     WEBCORE_EXPORT void setURL(const URL&, bool didFilterLinkDecoration = false);
 
     void redirectAsGETIfNeeded(const ResourceRequestBase &, const ResourceResponse&);
@@ -296,6 +325,17 @@ protected:
         , m_platformRequestBodyUpdated(true)
         , m_hiddenFromInspector(false)
     {
+    }
+
+    ResourceRequestBase(URL&& url, ResourceRequestCachePolicy policy)
+        : m_requestData({ WTFMove(url), policy })
+        , m_resourceRequestUpdated(true)
+        , m_platformRequestUpdated(false)
+        , m_resourceRequestBodyUpdated(true)
+        , m_platformRequestBodyUpdated(false)
+        , m_hiddenFromInspector(false)
+    {
+        m_requestData.m_allowCookies = true;
     }
 
     ResourceRequestBase(const URL& url, ResourceRequestCachePolicy policy)

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006, 2008, 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2009 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -87,6 +87,7 @@ public:
     WEBCORE_EXPORT bool isSuccessful() const;
 
     WEBCORE_EXPORT const URL& url() const;
+    WEBCORE_EXPORT void setURL(URL&&);
     WEBCORE_EXPORT void setURL(const URL&);
 
     WEBCORE_EXPORT const String& mimeType() const;
@@ -220,7 +221,7 @@ public:
 
     WEBCORE_EXPORT static ResourceResponse dataURLResponse(const URL&, const DataURLDecoder::Result&);
     
-    WEBCORE_EXPORT ResourceResponseBase(std::optional<ResourceResponseData>);
+    WEBCORE_EXPORT ResourceResponseBase(std::optional<ResourceResponseData>&&);
     
     WEBCORE_EXPORT std::optional<ResourceResponseData> getResponseData() const;
 
@@ -232,6 +233,7 @@ protected:
     };
 
     WEBCORE_EXPORT ResourceResponseBase();
+    WEBCORE_EXPORT ResourceResponseBase(URL&&, String&& mimeType, long long expectedLength, const String& textEncodingName);
     WEBCORE_EXPORT ResourceResponseBase(const URL&, const String& mimeType, long long expectedLength, const String& textEncodingName);
 
     WEBCORE_EXPORT void lazyInit(InitLevel) const;

--- a/Source/WebCore/platform/network/cf/ResourceRequest.h
+++ b/Source/WebCore/platform/network/cf/ResourceRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003-2023 Apple Inc.  All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc.  All rights reserved.
  * Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -54,14 +54,30 @@ using ResourceRequestData = Variant<ResourceRequestBase::RequestData, ResourceRe
 class ResourceRequest : public ResourceRequestBase {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ResourceRequest, WEBCORE_EXPORT);
 public:
-    explicit ResourceRequest(const String& url) 
+    explicit ResourceRequest(String&& url)
+        : ResourceRequestBase(URL({ }, WTFMove(url)), ResourceRequestCachePolicy::UseProtocolCachePolicy)
+    {
+    }
+
+    explicit ResourceRequest(const String& url)
         : ResourceRequestBase(URL({ }, url), ResourceRequestCachePolicy::UseProtocolCachePolicy)
     {
     }
 
-    ResourceRequest(const URL& url) 
+    ResourceRequest(URL&& url)
+        : ResourceRequestBase(WTFMove(url), ResourceRequestCachePolicy::UseProtocolCachePolicy)
+    {
+    }
+
+    ResourceRequest(const URL& url)
         : ResourceRequestBase(url, ResourceRequestCachePolicy::UseProtocolCachePolicy)
     {
+    }
+
+    ResourceRequest(URL&& url, const String& referrer, ResourceRequestCachePolicy policy = ResourceRequestCachePolicy::UseProtocolCachePolicy)
+        : ResourceRequestBase(WTFMove(url), policy)
+    {
+        setHTTPReferrer(referrer);
     }
 
     ResourceRequest(const URL& url, const String& referrer, ResourceRequestCachePolicy policy = ResourceRequestCachePolicy::UseProtocolCachePolicy)
@@ -89,7 +105,7 @@ public:
 
     ResourceRequest(ResourceRequestPlatformData&&, const String& cachePartition, bool hiddenFromInspector);
 
-    WEBCORE_EXPORT static ResourceRequest fromResourceRequestData(ResourceRequestData, const String& cachePartition, bool hiddenFromInspector);
+    WEBCORE_EXPORT static ResourceRequest fromResourceRequestData(ResourceRequestData&&, String&& cachePartition, bool hiddenFromInspector);
 
     WEBCORE_EXPORT void updateFromDelegatePreservingOldProperties(const ResourceRequest&);
     

--- a/Source/WebCore/platform/network/cf/ResourceResponse.h
+++ b/Source/WebCore/platform/network/cf/ResourceResponse.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006 Apple Inc.  All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -52,6 +52,12 @@ public:
     {
         m_initLevel = Uninitialized;
         m_isNull = !nsResponse;
+    }
+
+    ResourceResponse(URL&& url, String&& mimeType, long long expectedLength, String&& textEncodingName)
+        : ResourceResponseBase(WTFMove(url), WTFMove(mimeType), expectedLength, WTFMove(textEncodingName))
+    {
+        m_initLevel = AllFields;
     }
 
     ResourceResponse(const URL& url, const String& mimeType, long long expectedLength, const String& textEncodingName)

--- a/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
@@ -88,11 +88,11 @@ ResourceRequestData ResourceRequest::getRequestDataToSerialize() const
     return m_requestData;
 }
 
-ResourceRequest ResourceRequest::fromResourceRequestData(ResourceRequestData requestData, const String& cachePartition, bool hiddenFromInspector)
+ResourceRequest ResourceRequest::fromResourceRequestData(ResourceRequestData&& requestData, String&& cachePartition, bool hiddenFromInspector)
 {
     if (std::holds_alternative<RequestData>(requestData))
-        return ResourceRequest(WTFMove(std::get<RequestData>(requestData)), cachePartition, hiddenFromInspector);
-    return ResourceRequest(WTFMove(std::get<ResourceRequestPlatformData>(requestData)), cachePartition, hiddenFromInspector);
+        return ResourceRequest(WTFMove(std::get<RequestData>(requestData)), WTFMove(cachePartition), hiddenFromInspector);
+    return ResourceRequest(WTFMove(std::get<ResourceRequestPlatformData>(requestData)), WTFMove(cachePartition), hiddenFromInspector);
 }
 
 NSURLRequest *ResourceRequest::nsURLRequest(HTTPBodyUpdatePolicy bodyPolicy) const

--- a/Source/WebCore/platform/network/curl/ResourceRequest.h
+++ b/Source/WebCore/platform/network/curl/ResourceRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003, 2006 Apple Inc.  All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc.  All rights reserved.
  * Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
  * Copyright (C) 2019 Sony Interactive Entertainment Inc.
  *
@@ -33,14 +33,30 @@ namespace WebCore {
 
 class ResourceRequest : public ResourceRequestBase {
 public:
-    ResourceRequest(const String& url)
+    explicit ResourceRequest(String&& url)
+        : ResourceRequestBase(URL({ }, WTFMove(url)), ResourceRequestCachePolicy::UseProtocolCachePolicy)
+    {
+    }
+
+    explicit ResourceRequest(const String& url)
         : ResourceRequestBase(URL({ }, url), ResourceRequestCachePolicy::UseProtocolCachePolicy)
+    {
+    }
+
+    ResourceRequest(URL&& url)
+        : ResourceRequestBase(WTFMove(url), ResourceRequestCachePolicy::UseProtocolCachePolicy)
     {
     }
 
     ResourceRequest(const URL& url)
         : ResourceRequestBase(url, ResourceRequestCachePolicy::UseProtocolCachePolicy)
     {
+    }
+
+    ResourceRequest(URL&& url, const String& referrer, ResourceRequestCachePolicy policy = ResourceRequestCachePolicy::UseProtocolCachePolicy)
+        : ResourceRequestBase(WTFMove(url), policy)
+    {
+        setHTTPReferrer(referrer);
     }
 
     ResourceRequest(const URL& url, const String& referrer, ResourceRequestCachePolicy policy = ResourceRequestCachePolicy::UseProtocolCachePolicy)

--- a/Source/WebCore/platform/network/curl/ResourceResponse.h
+++ b/Source/WebCore/platform/network/curl/ResourceResponse.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006 Apple Inc.  All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc.  All rights reserved.
  * Copyright (C) 2018 Sony Interactive Entertainment Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,6 +36,11 @@ class ResourceResponse : public ResourceResponseBase {
 public:
     ResourceResponse()
         : ResourceResponseBase()
+    {
+    }
+
+    ResourceResponse(URL&& url, String&& mimeType, long long expectedLength, String&& textEncodingName)
+        : ResourceResponseBase(WTFMove(url), WTFMove(mimeType), expectedLength, WTFMove(textEncodingName))
     {
     }
 

--- a/Source/WebCore/platform/network/soup/ResourceRequest.h
+++ b/Source/WebCore/platform/network/soup/ResourceRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003, 2006 Apple Inc.  All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc.  All rights reserved.
  * Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -44,14 +44,30 @@ using ResourceRequestData = std::variant<ResourceRequestBase::RequestData, Resou
 
 class ResourceRequest : public ResourceRequestBase {
 public:
+    explicit ResourceRequest(String&& url)
+        : ResourceRequestBase(URL({ }, WTFMove(url)), ResourceRequestCachePolicy::UseProtocolCachePolicy)
+    {
+    }
+
     explicit ResourceRequest(const String& url)
         : ResourceRequestBase(URL({ }, url), ResourceRequestCachePolicy::UseProtocolCachePolicy)
+    {
+    }
+
+    ResourceRequest(URL&& url)
+        : ResourceRequestBase(WTFMove(url), ResourceRequestCachePolicy::UseProtocolCachePolicy)
     {
     }
 
     ResourceRequest(const URL& url)
         : ResourceRequestBase(url, ResourceRequestCachePolicy::UseProtocolCachePolicy)
     {
+    }
+
+    ResourceRequest(URL&& url, const String& referrer, ResourceRequestCachePolicy policy = ResourceRequestCachePolicy::UseProtocolCachePolicy)
+        : ResourceRequestBase(WTFMove(url), policy)
+    {
+        setHTTPReferrer(referrer);
     }
 
     ResourceRequest(const URL& url, const String& referrer, ResourceRequestCachePolicy policy = ResourceRequestCachePolicy::UseProtocolCachePolicy)
@@ -95,7 +111,7 @@ public:
     // We only need to encode platform data if acceptEncoding or redirectCount are not the default.
     bool encodingRequiresPlatformData() const { return !m_acceptEncoding || m_redirectCount; }
 
-    WEBCORE_EXPORT static ResourceRequest fromResourceRequestData(ResourceRequestData);
+    WEBCORE_EXPORT static ResourceRequest fromResourceRequestData(ResourceRequestData&&);
     WEBCORE_EXPORT ResourceRequestData getRequestDataToSerialize() const;
 
 private:

--- a/Source/WebCore/platform/network/soup/ResourceRequestSoup.cpp
+++ b/Source/WebCore/platform/network/soup/ResourceRequestSoup.cpp
@@ -238,7 +238,7 @@ void ResourceRequest::updateFromDelegatePreservingOldProperties(const ResourceRe
         setInspectorInitiatorNodeIdentifier(*oldInspectorInitiatorNodeIdentifier);
 }
 
-ResourceRequest ResourceRequest::fromResourceRequestData(ResourceRequestData requestData)
+ResourceRequest ResourceRequest::fromResourceRequestData(ResourceRequestData&& requestData)
 {
     if (std::holds_alternative<ResourceRequestBase::RequestData>(requestData))
         return ResourceRequest(WTFMove(std::get<ResourceRequestBase::RequestData>(requestData)));

--- a/Source/WebCore/platform/network/soup/ResourceResponse.h
+++ b/Source/WebCore/platform/network/soup/ResourceResponse.h
@@ -37,6 +37,11 @@ class ResourceResponse : public ResourceResponseBase {
 public:
     ResourceResponse() = default;
 
+    ResourceResponse(URL&& url, String&& mimeType, long long expectedLength, String&& textEncodingName)
+        : ResourceResponseBase(WTFMove(url), WTFMove(mimeType), expectedLength, WTFMove(textEncodingName))
+    {
+    }
+
     ResourceResponse(const URL& url, const String& mimeType, long long expectedLength, const String& textEncodingName)
         : ResourceResponseBase(url, mimeType, expectedLength, textEncodingName)
     {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2225,7 +2225,7 @@ void WebPage::loadData(LoadParameters&& loadParameters)
     if (loadParameters.isServiceWorkerLoad && corePage())
         corePage()->markAsServiceWorkerPage();
 
-    ResourceResponse response(URL(), loadParameters.MIMEType, sharedBuffer->size(), loadParameters.encodingName);
+    ResourceResponse response(URL(), WTFMove(loadParameters.MIMEType), sharedBuffer->size(), WTFMove(loadParameters.encodingName));
     loadDataImpl(loadParameters.navigationID, loadParameters.shouldTreatAsContinuingLoad, WTFMove(loadParameters.websitePolicies), sharedBuffer.releaseNonNull(), ResourceRequest(baseURL), WTFMove(response), URL(), loadParameters.userData, loadParameters.isNavigatingToAppBoundDomain, loadParameters.sessionHistoryVisibility, loadParameters.shouldOpenExternalURLsPolicy);
 }
 
@@ -2243,7 +2243,7 @@ void WebPage::loadAlternateHTML(LoadParameters&& loadParameters)
     }
     m_mainFrame->coreLocalFrame()->loader().setProvisionalLoadErrorBeingHandledURL(provisionalLoadErrorURL);
 
-    ResourceResponse response(URL(), loadParameters.MIMEType, sharedBuffer->size(), loadParameters.encodingName);
+    ResourceResponse response(URL(), WTFMove(loadParameters.MIMEType), sharedBuffer->size(), WTFMove(loadParameters.encodingName));
     loadDataImpl(loadParameters.navigationID, loadParameters.shouldTreatAsContinuingLoad, WTFMove(loadParameters.websitePolicies), sharedBuffer.releaseNonNull(), ResourceRequest(baseURL), WTFMove(response), unreachableURL, loadParameters.userData, loadParameters.isNavigatingToAppBoundDomain, WebCore::SubstituteData::SessionHistoryVisibility::Hidden);
     m_mainFrame->coreLocalFrame()->loader().setProvisionalLoadErrorBeingHandledURL({ });
 }


### PR DESCRIPTION
#### a83c1665d5a6a45ac4bdcb55eaadb38c0b6a3b75
<pre>
WebKit serialization tends to use copying when it should be moving
<a href="https://bugs.webkit.org/show_bug.cgi?id=291589">https://bugs.webkit.org/show_bug.cgi?id=291589</a>
<a href="https://rdar.apple.com/149327994">rdar://149327994</a>

Reviewed by Pascoe.

ResourceRequestBase, RequestData, and ResourceResponse Data are serialized through IPC using
move operations, but because these classes only offer copy-based constructors they are passing
through the copy code path instead of moving the memory. In the case of strings, URLs, Vectors
of Strings, Maps of Strings this is more costly than necessary.

This patch adds the relevant constructors and adopts them in more places.

* Source/WebCore/Modules/beacon/NavigatorBeacon.cpp:
(WebCore::NavigatorBeacon::sendBeacon): Use move operation.
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::updateFromElement): Ditto.
* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::LinkLoader::preloadIfNeeded): Ditto.
* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::performDragOperation): Ditto.
* Source/WebCore/platform/network/ResourceRequestBase.cpp:
(WebCore::ResourceRequestBase::setURL): Added.
* Source/WebCore/platform/network/ResourceRequestBase.h:
(WebCore::ResourceRequestBase::RequestData::RequestData): Added.
(WebCore::ResourceRequestBase::ResourceRequestBase): Added.
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::ResourceResponseBase::ResourceResponseBase): Added.
(WebCore::ResourceResponseBase::setURL): Added.
* Source/WebCore/platform/network/ResourceResponseBase.h:
* Source/WebCore/platform/network/cf/ResourceRequest.h:
(WebCore::ResourceRequest::ResourceRequest): Add move constructor.
* Source/WebCore/platform/network/cf/ResourceResponse.h:
(WebCore::ResourceResponse::ResourceResponse): Ditto.
* Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm:
(WebCore::ResourceRequest::fromResourceRequestData): Implemented move operations.
* Source/WebCore/platform/network/curl/ResourceRequest.h:
(WebCore::ResourceRequest::ResourceRequest): Add move constructor.
* Source/WebCore/platform/network/curl/ResourceResponse.h:
(WebCore::ResourceResponse::ResourceResponse): Ditto.
* Source/WebCore/platform/network/soup/ResourceRequest.h:
(WebCore::ResourceRequest::ResourceRequest): Ditto.
* Source/WebCore/platform/network/soup/ResourceRequestSoup.cpp:
(WebCore::ResourceRequest::fromResourceRequestData): Implemented move operations.
* Source/WebCore/platform/network/soup/ResourceResponse.h:
(WebCore::ResourceResponse::ResourceResponse): Add move constructor.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::loadData): Use Move operators.
(WebKit::WebPage::loadAlternateHTML): Ditto.

Canonical link: <a href="https://commits.webkit.org/293818@main">https://commits.webkit.org/293818@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/894098d05c20341b3eea0cb3971474cdcba6b870

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99783 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104908 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50367 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101824 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19733 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75958 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33049 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102790 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15030 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90094 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56324 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14838 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8081 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49733 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84763 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8166 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107269 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26894 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19636 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84909 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27257 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86299 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84434 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21494 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29107 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6816 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20703 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26833 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32043 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26644 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29961 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28208 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->