### PR TITLE
CSS property value `unset` does not disable native appearance for widgets

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/native-appearance-disabled-for-value-unset-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/native-appearance-disabled-for-value-unset-expected.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Native appearance disabled when appearance-disabling property has author-specified value unset (reference)</title>
+    <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-disabling-properties">
+    <meta name="assert" content="Widgets with background and border set to `unset` should display the same as if they had background and border set to `initial`">
+    <style>
+      body * {
+        display: block;
+        background: initial;
+        border: initial;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Test passes if the following widgets display the same with their background and border set to 'unset' as they do with background and border set to 'initial'</h1>
+    <button>Button</button>
+    <meter value='10' min='0' max='100'></meter>
+    <progress></progress>
+    <select></select>
+    <textarea></textarea>
+    <input type=button>
+    <input type=checkbox>
+    <input type=checkbox switch>
+    <input type=color>
+    <input type=date>
+    <input type=datetime-local>
+    <input type=file>
+    <input type=month>
+    <input type=number>
+    <input type=radio>
+    <input type=range>
+    <input type=search>
+    <input type=submit>
+    <input type=text>
+    <input type=time>
+    <input type=week>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/native-appearance-disabled-for-value-unset.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/native-appearance-disabled-for-value-unset.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Native appearance disabled when appearance-disabling property has author-specified value unset</title>
+    <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-disabling-properties">
+    <link rel="match" href="reference/native-appearance-disabled-for-value-unset-ref.html">
+    <meta name="assert" content="Widgets with background and border set to `unset` should display the same as if they had background and border set to `initial`">
+    <style>
+      body * {
+        display: block;
+        background: unset;
+        border: unset;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Test passes if the following widgets display the same with their background and border set to 'unset' as they do with background and border set to 'initial'</h1>
+    <button>Button</button>
+    <meter value='10' min='0' max='100'></meter>
+    <progress></progress>
+    <select></select>
+    <textarea></textarea>
+    <input type=button>
+    <input type=checkbox>
+    <input type=checkbox switch>
+    <input type=color>
+    <input type=date>
+    <input type=datetime-local>
+    <input type=file>
+    <input type=month>
+    <input type=number>
+    <input type=radio>
+    <input type=range>
+    <input type=search>
+    <input type=submit>
+    <input type=text>
+    <input type=time>
+    <input type=week>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/reference/native-appearance-disabled-for-value-unset-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/reference/native-appearance-disabled-for-value-unset-ref.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Native appearance disabled when appearance-disabling property has author-specified value unset (reference)</title>
+    <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-disabling-properties">
+    <meta name="assert" content="Widgets with background and border set to `unset` should display the same as if they had background and border set to `initial`">
+    <style>
+      body * {
+        display: block;
+        background: initial;
+        border: initial;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Test passes if the following widgets display the same with their background and border set to 'unset' as they do with background and border set to 'initial'</h1>
+    <button>Button</button>
+    <meter value='10' min='0' max='100'></meter>
+    <progress></progress>
+    <select></select>
+    <textarea></textarea>
+    <input type=button>
+    <input type=checkbox>
+    <input type=checkbox switch>
+    <input type=color>
+    <input type=date>
+    <input type=datetime-local>
+    <input type=file>
+    <input type=month>
+    <input type=number>
+    <input type=radio>
+    <input type=range>
+    <input type=search>
+    <input type=submit>
+    <input type=text>
+    <input type=time>
+    <input type=week>
+  </body>
+</html>

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -328,8 +328,9 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
     bool isUnset = valueID == CSSValueUnset;
     bool isRevert = valueID == CSSValueRevert;
     bool isRevertLayer = valueID == CSSValueRevertLayer;
+    bool isRevertOrRevertLayer = isRevert || isRevertLayer;
 
-    if (isRevert || isRevertLayer) {
+    if (isRevertOrRevertLayer) {
         // In @keyframes, 'revert-layer' rolls back the cascaded value to the author level.
         // We can just not apply the property in order to keep the value from the base style.
         if (isRevertLayer && m_state.m_isBuildingKeyframeStyle)
@@ -359,8 +360,6 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
                 return;
             }
         }
-
-        isUnset = true;
     }
 
     auto isInheritedProperty = [&] {
@@ -373,7 +372,7 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
         return isInheritedProperty() ? ApplyValueType::Inherit : ApplyValueType::Initial;
     };
 
-    if (isUnset)
+    if (isUnset || isRevertOrRevertLayer)
         valueType = unsetValueType();
 
     if (!m_state.applyPropertyToRegularStyle() && !isValidVisitedLinkProperty(id)) {
@@ -408,18 +407,16 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
 
     BuilderGenerated::applyProperty(id, m_state, valueToApply.get(), valueType);
 
-    if (!isUnset) {
-        if (cascadeLevel == CascadeLevel::Author && m_state.element()->isDevolvableWidget() && CSSProperty::disablesNativeAppearance(id) && m_state.applyPropertyToRegularStyle())
-            style.setNativeAppearanceDisabled(true);
+    if (!isRevertOrRevertLayer && cascadeLevel == CascadeLevel::Author && m_state.element()->isDevolvableWidget() && CSSProperty::disablesNativeAppearance(id) && m_state.applyPropertyToRegularStyle())
+        style.setNativeAppearanceDisabled(true);
 
-        if (m_state.isCurrentPropertyInvalidAtComputedValueTime()) {
-            // https://drafts.csswg.org/css-variables-2/#invalid-variables
-            // A declaration can be invalid at computed-value time if...
-            // When this happens, the computed value is one of the following...
-            // Otherwise: Either the property’s inherited value or its initial value depending on whether the property
-            // is inherited or not, respectively, as if the property’s value had been specified as the unset keyword
-            BuilderGenerated::applyProperty(id, m_state, valueToApply.get(), unsetValueType());
-        }
+    if (!isUnset && !isRevertOrRevertLayer && m_state.isCurrentPropertyInvalidAtComputedValueTime()) {
+        // https://drafts.csswg.org/css-variables-2/#invalid-variables
+        // A declaration can be invalid at computed-value time if...
+        // When this happens, the computed value is one of the following...
+        // Otherwise: Either the property’s inherited value or its initial value depending on whether the property
+        // is inherited or not, respectively, as if the property’s value had been specified as the unset keyword
+        BuilderGenerated::applyProperty(id, m_state, valueToApply.get(), unsetValueType());
     }
 }
 


### PR DESCRIPTION
#### c789fa57f2154b8c65b7565b18b9c398a2b35513
<pre>
CSS property value `unset` does not disable native appearance for widgets
<a href="https://bugs.webkit.org/show_bug.cgi?id=291599">https://bugs.webkit.org/show_bug.cgi?id=291599</a>
<a href="https://rdar.apple.com/149311324">rdar://149311324</a>

Reviewed by Antti Koivisto and Abrar Rahman Protyasha.

The check for styles which should disable native appearance is no
longer skipped when the property value is unset. Added a WPT
test to ensure that widgets display the same when their background
and border have value &apos;unset&apos; as they do when their background and border
have value &apos;initial&apos;.

* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/native-appearance-disabled-for-value-unset-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/native-appearance-disabled-for-value-unset.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/reference/native-appearance-disabled-for-value-unset-ref.html: Added.
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyProperty):

Canonical link: <a href="https://commits.webkit.org/293767@main">https://commits.webkit.org/293767@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/103d64df4d22d52ef89a9ac532c9f0e4d538ea54

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104955 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50403 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101866 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19775 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27906 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75984 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33073 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15071 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90136 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56350 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14877 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8123 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49775 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84796 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8208 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107311 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26936 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19666 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84938 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27297 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86341 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84465 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21461 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29141 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6852 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20741 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26872 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32083 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26683 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30000 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28244 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->