### PR TITLE
[Safer CPP] Address UnretainedLambdaCapturesChecker warnings in PDFAnnotationTypeHelpers.mm

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UnretainedLambdaCapturesCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedLambdaCapturesCheckerExpectations
@@ -9,6 +9,5 @@ UIProcess/mac/WKFullScreenWindowController.mm
 UIProcess/mac/WKImmediateActionController.mm
 UIProcess/mac/WKPrintingView.mm
 UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
-WebProcess/Plugins/PDF/PDFAnnotationTypeHelpers.mm
 WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
 WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFAnnotationTypeHelpers.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFAnnotationTypeHelpers.mm
@@ -84,8 +84,8 @@ bool annotationCheckerInternal(PDFAnnotation *annotation, Type type, AnnotationT
 template <typename Type>
 bool annotationCheckerInternal(PDFAnnotation *annotation, std::initializer_list<Type>&& types, AnnotationToTypeConverter<Type> converter)
 {
-    auto checker = [annotation, converter = WTFMove(converter)](auto&& type) {
-        return annotationCheckerInternal(annotation, std::forward<decltype(type)>(type), WTFMove(converter));
+    auto checker = [annotation = RetainPtr { annotation }, converter = WTFMove(converter)](auto&& type) {
+        return annotationCheckerInternal(annotation.get(), std::forward<decltype(type)>(type), WTFMove(converter));
     };
     ASSERT(std::ranges::count_if(types, checker) <= 1);
     return std::ranges::any_of(WTFMove(types), WTFMove(checker));


### PR DESCRIPTION
#### 07ef022d64f027c0dcd2caf433980dd8b094d488
<pre>
[Safer CPP] Address UnretainedLambdaCapturesChecker warnings in PDFAnnotationTypeHelpers.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=291592">https://bugs.webkit.org/show_bug.cgi?id=291592</a>
<a href="https://rdar.apple.com/149332108">rdar://149332108</a>

Reviewed by Chris Dumez.

This patch addresses the following warnings:

```
/Volumes/Data/worker/macOS-Safer-CPP-Checks-EWS/build/Source/WebKit/WebProcess/Plugins/PDF/PDFAnnotationTypeHelpers.mm:87:21: warning: Captured raw-pointer &apos;annotation&apos; to unretained type is unsafe [alpha.webkit.UnretainedLambdaCapturesChecker]
   87 |     auto checker = [annotation, converter = WTFMove(converter)](auto&amp;&amp; type) {
      |                     ^
```

... by retaining `annotation` during capture instantiation.

* Source/WebKit/SaferCPPExpectations/UnretainedLambdaCapturesCheckerExpectations:
* Source/WebKit/WebProcess/Plugins/PDF/PDFAnnotationTypeHelpers.mm:
(WebKit::PDFAnnotationTypeHelpers::annotationCheckerInternal):

Canonical link: <a href="https://commits.webkit.org/293745@main">https://commits.webkit.org/293745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49e521da45942e1278785c94fa9ee0f561d7c5a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9715 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104921 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50378 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27877 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75956 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33052 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102803 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15040 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90104 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56322 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14847 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49746 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84770 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8176 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107282 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26907 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19643 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84912 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86309 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84438 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21441 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29119 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6824 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20715 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26845 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32056 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26656 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29973 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28218 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->