### PR TITLE
[JSC] Move Loop Unrolling After CPSRethreading to Preserve Variable Availability

### DIFF
--- a/JSTests/stress/loop-unrolling-liveness-2.js
+++ b/JSTests/stress/loop-unrolling-liveness-2.js
@@ -1,0 +1,12 @@
+
+//@ runDefault("--validateOptions=true", "--thresholdForJITSoon=10", "--thresholdForJITAfterWarmUp=10", "--thresholdForOptimizeAfterWarmUp=100", "--thresholdForOptimizeAfterLongWarmUp=100", "--thresholdForOptimizeSoon=100", "--thresholdForFTLOptimizeAfterWarmUp=1000", "--thresholdForFTLOptimizeSoon=1000", "--validateBCE=true", "--useConcurrentJIT=0")
+for (let v3 = 0; v3 < 1000; v3++) {
+    const v4 = `
+        class C6 {
+        }
+        for (let v7 = 0; v7 < 5; v7++) {
+            C6 ? -6 : C6;
+        }
+    `;
+    eval(v4);
+}

--- a/Source/JavaScriptCore/dfg/DFGBasicBlock.h
+++ b/Source/JavaScriptCore/dfg/DFGBasicBlock.h
@@ -163,6 +163,8 @@ public:
     {
         return terminal()->successors();
     }
+
+    bool isJumpPad() { return m_nodes.size() == 1 && m_nodes[0]->isJump(); }
     
     void removePredecessor(BasicBlock* block);
     void replacePredecessor(BasicBlock* from, BasicBlock* to);

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.cpp
@@ -156,6 +156,7 @@ Node* CloneHelper::cloneNodeImpl(BasicBlock* into, Node* node)
 
 BasicBlock* CloneHelper::blockClone(BasicBlock* block)
 {
+    ASSERT(block);
     auto iter = m_blockClones.find(block);
     if (iter != m_blockClones.end())
         return iter->value;

--- a/Source/JavaScriptCore/dfg/DFGCriticalEdgeBreakingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCriticalEdgeBreakingPhase.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,6 +46,7 @@ public:
     
     bool run()
     {
+        Vector<BasicBlock*> newJumpPads;
         for (BlockIndex blockIndex = 0; blockIndex < m_graph.numBlocks(); ++blockIndex) {
             BasicBlock* block = m_graph.block(blockIndex);
             if (!block)
@@ -76,16 +77,58 @@ public:
                     pad->predecessors.append(block);
                     (*successor)->replacePredecessor(block, pad);
                     successorPads.set(*successor, pad);
+                    newJumpPads.append(pad);
                 } else
                     pad = iter->value;
 
                 *successor = pad;
             }
         }
-        
-        return m_insertionSet.execute();
+
+        bool changed = m_insertionSet.execute();
+        if (changed && m_graph.m_shouldFixAvailability)
+            performFixJumpPadAvailability(newJumpPads);
+        return changed;
     }
 
+    // This finalizes variable availability and Phi placement for newly inserted jump pads.
+    // It is necessary after loop unrolling and critical edge breaking to ensure SSA and OSR correctness.
+    void performFixJumpPadAvailability(Vector<BasicBlock*>& pads)
+    {
+        for (BasicBlock* pad : pads) {
+            ASSERT(pad->isJumpPad());
+            BasicBlock* successor = pad->successor(0);
+            for (unsigned i = successor->variablesAtHead.size(); i--;) {
+                Node* node = successor->variablesAtHead[i];
+                if (!node)
+                    continue;
+
+                VariableAccessData* variable = node->variableAccessData();
+                Node* phi = m_graph.addNode(Phi, node->origin, OpInfo(variable));
+                pad->phis.append(phi);
+                switch (variable->operand().kind()) {
+                case OperandKind::Argument: {
+                    size_t index = variable->operand().toArgument();
+                    pad->variablesAtHead.atFor<OperandKind::Argument>(index) = phi;
+                    pad->variablesAtTail.atFor<OperandKind::Argument>(index) = phi;
+                    break;
+                }
+                case OperandKind::Local: {
+                    size_t index = variable->operand().toLocal();
+                    pad->variablesAtHead.atFor<OperandKind::Local>(index) = phi;
+                    pad->variablesAtTail.atFor<OperandKind::Local>(index) = phi;
+                    break;
+                }
+                case OperandKind::Tmp: {
+                    size_t index = variable->operand().value();
+                    pad->variablesAtHead.atFor<OperandKind::Tmp>(index) = phi;
+                    pad->variablesAtTail.atFor<OperandKind::Tmp>(index) = phi;
+                    break;
+                }
+                }
+            }
+        }
+    }
 private:
     BlockInsertionSet m_insertionSet;
 };

--- a/Source/JavaScriptCore/dfg/DFGCriticalEdgeBreakingPhase.h
+++ b/Source/JavaScriptCore/dfg/DFGCriticalEdgeBreakingPhase.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,7 +32,7 @@ namespace JSC { namespace DFG {
 class Graph;
 
 // Inserts dummy basic blocks to break critical edges. An edge A->B is
-// critical if A has multiple successors and B has multiple predessors.
+// critical if A has multiple successors and B has multiple predecessors.
 
 bool performCriticalEdgeBreaking(Graph&);
 

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -1339,6 +1339,7 @@ public:
     bool m_hasExceptionHandlers { false };
     bool m_isInSSAConversion { false };
     bool m_isValidating { false };
+    bool m_shouldFixAvailability { false };
     std::optional<uint32_t> m_maxLocalsForCatchOSREntry;
     std::unique_ptr<FlowIndexing> m_indexingCache;
     std::unique_ptr<FlowMap<AbstractValue>> m_abstractValuesCache;

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -363,15 +363,16 @@ Plan::CompilationPath Plan::compileInThreadImpl()
             m_finalizer = makeUnique<FailedFinalizer>(*this);
             return FailPath;
         }
-
-        if (Options::useLoopUnrolling())
-            RUN_PHASE(performLoopUnrolling);
-        
         RUN_PHASE(performCleanUp); // Reduce the graph size a bit.
         RUN_PHASE(performCriticalEdgeBreaking);
         if (Options::createPreHeaders())
             RUN_PHASE(performLoopPreHeaderCreation);
         RUN_PHASE(performCPSRethreading);
+        if (Options::useLoopUnrolling()) {
+            SetForScope fixAvailabilityScope(dfg.m_shouldFixAvailability, true);
+            RUN_PHASE(performLoopUnrolling);
+            RUN_PHASE(performCriticalEdgeBreaking);
+        }
         RUN_PHASE(performSSAConversion);
         RUN_PHASE(performSSALowering);
         

--- a/Source/JavaScriptCore/dfg/DFGSSAConversionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSSAConversionPhase.cpp
@@ -52,7 +52,9 @@ public:
     
     bool run()
     {
-        RELEASE_ASSERT(m_graph.m_form == ThreadedCPS);
+        // SSA computes its own Phi nodes using variablesAtHead from CPS-form basic blocks.
+        // As long as those are correctly computed and preserved, this is safe.
+        RELEASE_ASSERT(m_graph.m_form == ThreadedCPS || m_graph.m_form == LoadStore);
         RELEASE_ASSERT(!m_graph.m_isInSSAConversion);
         m_graph.m_isInSSAConversion = true;
         


### PR DESCRIPTION
#### 8c21b3a3b7cdb94cb0a4424dc158fa710a099093
<pre>
[JSC] Move Loop Unrolling After CPSRethreading to Preserve Variable Availability
<a href="https://rdar.apple.com/149343163">rdar://149343163</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291602">https://bugs.webkit.org/show_bug.cgi?id=291602</a>

Reviewed by Yusuke Suzuki.

In the DFG, loop unrolling was previously performed before CPSRethreading.
While this worked for many optimization cases, it introduced incorrect variable
availability for OSR exit. This is because CPSRethreading is responsible for
recomputing variablesAtHead and variablesAtTail, which are used to determine
which variables are live at the entry and exit of a block.

Performing loop unrolling before CPSRethreading meant that cloned blocks from
the original loop could obscure or disrupt availability information, leading
to missing variables during OSR exit.

This patch moves loop unrolling after CPSRethreading and introduces `m_shouldFixAvailability`
to selectively patch jump pad availability after critical edge breaking,
ensuring correctness in all subsequent compiler phases.

Reviewed by Yusuke Suzuki.

* JSTests/stress/loop-unrolling-liveness-2.js: Added.
(v3.const.v4):
* Source/JavaScriptCore/dfg/DFGBasicBlock.h:
(JSC::DFG::BasicBlock::isJumpPad):
* Source/JavaScriptCore/dfg/DFGCloneHelper.cpp:
(JSC::DFG::CloneHelper::blockClone):
* Source/JavaScriptCore/dfg/DFGCriticalEdgeBreakingPhase.cpp:
(JSC::DFG::CriticalEdgeBreakingPhase::run):
(JSC::DFG::CriticalEdgeBreakingPhase::performFixJumpPadAvailability):
* Source/JavaScriptCore/dfg/DFGCriticalEdgeBreakingPhase.h:
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
(JSC::DFG::LoopUnrollingPhase::LoopData::loopTarget const):
(JSC::DFG::LoopUnrollingPhase::LoopData::exitTarget const):
(JSC::DFG::LoopUnrollingPhase::run):
(JSC::DFG::LoopUnrollingPhase::loopAnalysisPredecessors):
(JSC::DFG::LoopUnrollingPhase::loopAnalysisSuccessor):
(JSC::DFG::LoopUnrollingPhase::locatePreHeader):
(JSC::DFG::LoopUnrollingPhase::locateTail):
(JSC::DFG::LoopUnrollingPhase::unrollLoop):
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::compileInThreadImpl):
* Source/JavaScriptCore/dfg/DFGSSAConversionPhase.cpp:
(JSC::DFG::SSAConversionPhase::run):

Canonical link: <a href="https://commits.webkit.org/293914@main">https://commits.webkit.org/293914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4be18a3cee6275f6fbba80de2725c929b8fd29b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100273 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105403 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50856 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28396 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76346 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33404 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15478 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90573 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56703 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15299 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8572 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50224 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92931 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85209 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107762 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98880 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27386 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20081 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85315 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27749 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86780 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84837 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29521 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7256 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21279 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16316 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27323 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32556 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122506 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27134 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34186 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30450 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28693 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->