### PR TITLE
Re-introduce container entity for standardizing model transform pivot

### DIFF
--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -157,6 +157,7 @@ private:
     RefPtr<WebCore::REModelLoader> m_loader;
     RefPtr<WebCore::REModel> m_model;
     RetainPtr<WKSRKEntity> m_modelRKEntity;
+    RetainPtr<WKSRKEntity> m_rkContainerEntity;
     REPtr<RESceneRef> m_scene;
     REPtr<REEntityRef> m_hostingEntity;
     REPtr<REEntityRef> m_containerEntity;

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -375,9 +375,9 @@ static RESRT computeSRT(CALayer *layer, simd_float3 originalBoundingBoxExtents, 
         srt.rotation = currentModelRotation;
 
         if (isPortal)
-            srt.translation = simd_make_float3(-boundingBoxCenter.x, -boundingBoxCenter.y, -boundingBoxCenter.z - boundingBoxExtents.z / 2.0f);
+            srt.translation = simd_make_float3(0.0, 0.0, -boundingBoxExtents.z / 2.0f);
         else
-            srt.translation = simd_make_float3(-boundingBoxCenter.x, -boundingBoxCenter.y, -boundingBoxCenter.z + boundingBoxExtents.z / 2.0f);
+            srt.translation = simd_make_float3(0.0, 0.0, boundingBoxExtents.z / 2.0f);
     } else {
         float boundingSphereDiameter = boundingRadius * 2.0f;
         float layerBoundingEdge = simd_reduce_min(boundsOfLayerInMeters);
@@ -390,9 +390,9 @@ static RESRT computeSRT(CALayer *layer, simd_float3 originalBoundingBoxExtents, 
         boundingBoxCenter = srt.scale * originalBoundingBoxCenter;
 
         if (isPortal)
-            srt.translation = simd_make_float3(-boundingBoxCenter.x, -boundingBoxCenter.y, -boundingBoxCenter.z - boundingSphereDiameter * minScale / 2.0f);
+            srt.translation = simd_make_float3(0.0, 0.0, -boundingSphereDiameter * minScale / 2.0f);
         else
-            srt.translation = simd_make_float3(-boundingBoxCenter.x, -boundingBoxCenter.y, -boundingBoxCenter.z + boundingSphereDiameter * minScale / 2.0f);
+            srt.translation = simd_make_float3(0.0, 0.0, boundingSphereDiameter * minScale / 2.0f);
     }
 
     return srt;
@@ -433,7 +433,7 @@ void ModelProcessModelPlayerProxy::updateTransform()
     if (!m_model || !m_layer)
         return;
 
-    [m_modelRKEntity setTransform:WKEntityTransform({ m_transformSRT.scale, m_transformSRT.rotation, m_transformSRT.translation })];
+    [m_rkContainerEntity setTransform:WKEntityTransform({ m_transformSRT.scale, m_transformSRT.rotation, m_transformSRT.translation })];
 }
 
 void ModelProcessModelPlayerProxy::updateOpacity()
@@ -491,6 +491,10 @@ void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& load
     m_hostingEntity = adoptRE(REEntityCreate());
     REEntitySetName(m_hostingEntity.get(), "WebKit:EntityWithRootComponent");
 
+    m_containerEntity = adoptRE(REEntityCreate());
+    REEntitySetName(m_containerEntity.get(), "WebKit:ModelContainerEntity");
+    m_rkContainerEntity = adoptNS([allocWKSRKEntityInstance() initWithCoreEntity:m_containerEntity.get()]);
+
     REPtr<REComponentRef> layerComponent = adoptRE(RECALayerServiceCreateRootComponent(webDefaultLayerService(), CALayerGetContext(m_layer.get()), m_hostingEntity.get(), nil));
     RESceneAddEntity(m_scene.get(), m_hostingEntity.get());
 
@@ -507,16 +511,21 @@ void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& load
     else
         REEntitySetName(m_model->rootEntity(), "WebKit:ModelRootEntity");
 
+    [m_rkContainerEntity setTransform:WKEntityTransform({ simd_make_float3(1.0f, 1.0f, 1.0f), simd_quaternion(0, simd_make_float3(1, 0, 0)), simd_make_float3(0.0f, 0.0f, -m_originalBoundingBoxExtents.z / 2.0f) })];
+    [m_modelRKEntity setTransform:WKEntityTransform({ simd_make_float3(1.0f, 1.0f, 1.0f), simd_quaternion(0, simd_make_float3(1, 0, 0)), simd_make_float3(-m_originalBoundingBoxCenter.x, -m_originalBoundingBoxCenter.y, 0.0f) })];
+
     if (canLoadWithRealityKit)
-        [m_model->rootRKEntity() setParentCoreEntity:clientComponentEntity preservingWorldTransform:NO];
+        [m_model->rootRKEntity() setParentCoreEntity:m_containerEntity.get() preservingWorldTransform:YES];
     else {
-        REEntitySetParent(m_model->rootEntity(), clientComponentEntity);
+        REEntitySetParent(m_model->rootEntity(), m_containerEntity.get());
     }
 
-    m_stageModeInteractionDriver = adoptNS([allocWKStageModeInteractionDriverInstance() initWithModel:m_modelRKEntity.get() container:clientComponentEntity delegate:m_objCAdapter.get()]);
+    REEntitySetParent(m_containerEntity.get(), clientComponentEntity);
 
-    REEntitySubtreeAddNetworkComponentRecursive([m_stageModeInteractionDriver interactionContainerRef]);
-    RENetworkMarkEntityMetadataDirty([m_stageModeInteractionDriver interactionContainerRef]);
+    m_stageModeInteractionDriver = adoptNS([allocWKStageModeInteractionDriverInstance() initWithModel:m_rkContainerEntity.get() container:clientComponentEntity delegate:m_objCAdapter.get()]);
+
+    REEntitySubtreeAddNetworkComponentRecursive(m_containerEntity.get());
+    RENetworkMarkEntityMetadataDirty(m_containerEntity.get());
 
     applyStageModeOperationToDriver();
 
@@ -806,8 +815,7 @@ void ModelProcessModelPlayerProxy::setStageMode(WebCore::StageModeOperation stag
 
     if (stagemodeOp != WebCore::StageModeOperation::None) {
         computeTransform(false);
-        [m_modelRKEntity recenterEntityAtTransform:WKEntityTransform({ m_transformSRT.scale, m_transformSRT.rotation, m_transformSRT.translation })];
-        updateTransformSRT();
+        updateTransform();
     }
 
     applyStageModeOperationToDriver();
@@ -815,7 +823,7 @@ void ModelProcessModelPlayerProxy::setStageMode(WebCore::StageModeOperation stag
 
 void ModelProcessModelPlayerProxy::updateTransformSRT()
 {
-    WKEntityTransform entityTransform = [m_modelRKEntity transform];
+    WKEntityTransform entityTransform = [m_rkContainerEntity transform];
     m_transformSRT = RESRT {
         .scale = entityTransform.scale,
         .rotation = entityTransform.rotation,

--- a/Source/WebKit/WebKitSwift/RealityKit/RKEntity.swift
+++ b/Source/WebKit/WebKitSwift/RealityKit/RKEntity.swift
@@ -96,7 +96,7 @@ public final class WKSRKEntity: NSObject {
     }
     
     @objc(interactionPivotPoint) public var interactionPivotPoint: simd_float3 {
-        entity.visualBounds(relativeTo: nil).center
+        entity.position(relativeTo: nil)
     }
 
     @objc(boundingBoxExtents) public var boundingBoxExtents: simd_float3 {
@@ -379,18 +379,6 @@ public final class WKSRKEntity: NSObject {
     
     @objc(interactionContainerDidRecenterFromTransform:) public func interactionContainerDidRecenter(_ transform: simd_float4x4) {
         entity.setTransformMatrix(transform, relativeTo: nil)
-    }
-    
-    @objc(recenterEntityAtTransform:) public func recenterEntity(at newTransform: WKEntityTransform) {
-        // Apply the scale and translation of the entity separately from the rotation
-        transform = WKEntityTransform(scale: newTransform.scale, rotation: .init(ix: 0, iy: 0, iz: 0, r: 1), translation: newTransform.translation)
-        
-        // The pivot for the orientation may be different from the center of the model's bounding box
-        // As a result, we offset the translation after the rotation has been applied to recenter it
-        let pivotPoint = interactionPivotPoint
-        transform = newTransform
-        let offset = pivotPoint - interactionPivotPoint
-        transform = WKEntityTransform(scale: newTransform.scale, rotation: newTransform.rotation, translation: newTransform.translation + offset)
     }
 }
 

--- a/Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h
+++ b/Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h
@@ -67,7 +67,6 @@ typedef struct {
 - (void)setUpAnimationWithAutoPlay:(BOOL)autoPlay;
 - (void)applyIBLData:(NSData *)data withCompletion:(void (^)(BOOL success))completion;
 - (void)interactionContainerDidRecenterFromTransform:(simd_float4x4)transform NS_SWIFT_NAME(interactionContainerDidRecenter(_:));
-- (void)recenterEntityAtTransform:(WKEntityTransform)transform NS_SWIFT_NAME(recenterEntity(at:));
 - (void)applyDefaultIBL NS_SWIFT_NAME(applyDefaultIBL());
 @end
 

--- a/Source/WebKit/WebKitSwift/StageMode/WKStageMode.h
+++ b/Source/WebKit/WebKitSwift/StageMode/WKStageMode.h
@@ -40,7 +40,6 @@ typedef NS_ENUM(NSInteger, WKStageModeOperation) {
 @end
 
 @interface WKStageModeInteractionDriver : NSObject
-@property (nonatomic, readonly) REEntityRef interactionContainerRef;
 @property (nonatomic, readonly) bool stageModeInteractionInProgress;
 
 - (instancetype)initWithModel:(WKSRKEntity *)model container:(REEntityRef)container delegate:(id<WKStageModeInteractionAware> _Nullable)delegate NS_SWIFT_NAME(init(with:container:delegate:));

--- a/Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift
+++ b/Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift
@@ -83,11 +83,6 @@ final public class WKStageModeInteractionDriver: NSObject {
     }
     
     // MARK: ObjC Exposed API
-    @objc(interactionContainerRef)
-    var interactionContainerRef: REEntityRef {
-        self.interactionContainer.__coreEntity.__as(REEntityRef.self)
-    }
-    
     @objc(stageModeInteractionInProgress)
     var stageModeInteractionInProgress: Bool {
         self.driverInitialized && self.stageModeOperation != .none


### PR DESCRIPTION
#### 2f993c069b6feb1b5b7933badbe3f75d2d2b2634
<pre>
Re-introduce container entity for standardizing model transform pivot
<a href="https://bugs.webkit.org/show_bug.cgi?id=291605">https://bugs.webkit.org/show_bug.cgi?id=291605</a>
<a href="https://rdar.apple.com/149343680">rdar://149343680</a>

Reviewed by NOBODY (OOPS!).

This PR reintroduces the container entity to the model element view hierarchy. This
was previously removed as part of a refactor to move parts of the model to the UI Process.
However, in an effort to standardize the pivot point for positioning, rotating, and scaling
the model, we are re-adding it back into the hierarchy such that it is positioned at
the initial bounding box center of the model. We make the container an RKEntity so that
we can apply transforms and reparent it while preserving world transforms. We also clean up
some unused APIs as a result of this change.

* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::updateTransform):
(WebKit::ModelProcessModelPlayerProxy::didFinishLoading):
(WebKit::ModelProcessModelPlayerProxy::setStageMode):
(WebKit::ModelProcessModelPlayerProxy::updateTransformSRT):
* Source/WebKit/WebKitSwift/RealityKit/RKEntity.swift:
(WKSRKEntity.interactionPivotPoint):
(WKSRKEntity.interactionContainerDidRecenter(_:)):
(WKSRKEntity.recenterEntity(at:)): Deleted.
* Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h:
* Source/WebKit/WebKitSwift/StageMode/WKStageMode.h:
* Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift:
(WKStageModeInteractionDriver.interactionContainerRef): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f993c069b6feb1b5b7933badbe3f75d2d2b2634

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19448 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104928 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50383 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27884 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75962 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33055 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90109 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56329 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49753 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8181 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107289 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26914 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19647 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84918 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27275 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86314 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84444 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29118 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6826 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/20720 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26850 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32062 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26661 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29978 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28223 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->