### PR TITLE
[JSC] Tighten Temporal test expectations

### DIFF
--- a/JSTests/stress/temporal-instant.js
+++ b/JSTests/stress/temporal-instant.js
@@ -304,6 +304,8 @@ shouldThrow(() => Temporal.Instant.from('1976-11-18T15:23:30.1234Z[-foo=bar]'), 
 shouldThrow(() => Temporal.Instant.from('1976-11-18T15:23:30Z[1foo=bar]'), RangeError);
 // no zero-length annotation key
 shouldThrow(() => Temporal.Instant.from('1976-11-18T15:23:30.123456789Z[======]'), RangeError);
+// no zero-length annotation value
+shouldThrow(() => Temporal.Instant.from('1976-11-18T15:23:30.123456789Z[!x-ff=]'), RangeError);
 // non-ASCII minusSign is invalid
 shouldThrow(() => Temporal.Instant.from('1976-11-18T15:23:30.12\u221202:00'), RangeError);
 shouldThrow(() => Temporal.Instant.from('\u2212009999-11-18T15:23:30.12Z'), RangeError);

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -249,6 +249,7 @@ skip:
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-object.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-time-designator-required-for-disambiguation.js
+    - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-time-zone-annotation.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-unknown-annotation.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/basic.js
     - test/built-ins/Temporal/PlainDate/prototype/toString/calendarname-always.js
@@ -270,7 +271,6 @@ skip:
     - test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-leap-second.js
     - test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-number.js
     - test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-wrong-type.js
-    - test/built-ins/Temporal/PlainDateTime/compare/argument-string-time-zone-annotation.js
     - test/built-ins/Temporal/PlainDateTime/compare/calendar-temporal-object.js
     - test/built-ins/Temporal/PlainDateTime/constructor-full.js
     - test/built-ins/Temporal/PlainDateTime/from/argument-plaindate.js
@@ -291,6 +291,7 @@ skip:
     - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-number.js
     - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-wrong-type.js
     - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-calendar-annotation.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-time-zone-annotation.js
     - test/built-ins/Temporal/PlainDateTime/prototype/equals/calendar-temporal-object.js
     - test/built-ins/Temporal/PlainDateTime/prototype/round/smallestunit-plurals-accepted.js
     - test/built-ins/Temporal/PlainDateTime/prototype/round/smallestunit-string-shorthand.js
@@ -304,6 +305,7 @@ skip:
     - test/built-ins/Temporal/PlainDateTime/prototype/with/calendar-temporal-object-throws.js
     - test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-time-designator-required-for-disambiguation.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-time-zone-annotation.js
     - test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-unknown-annotation.js
     - test/built-ins/Temporal/PlainTime/compare/argument-string-time-designator-required-for-disambiguation.js
     - test/built-ins/Temporal/PlainTime/from/argument-string-time-designator-required-for-disambiguation.js
@@ -338,24 +340,11 @@ skip:
     - test/intl402/Temporal/Instant/prototype/toString/timezone-string-datetime.js
 
     # Depends on annotations in datetime strings
-    - test/built-ins/Temporal/Instant/compare/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/Instant/from/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/Instant/prototype/equals/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/Instant/prototype/since/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/Instant/prototype/until/argument-string-time-zone-annotation.js
     - test/built-ins/Temporal/PlainDate/compare/argument-string-time-zone-annotation.js
     - test/built-ins/Temporal/PlainDate/from/argument-string-time-zone-annotation.js
     - test/built-ins/Temporal/PlainDate/prototype/equals/argument-string-time-zone-annotation.js
     - test/built-ins/Temporal/PlainDate/prototype/since/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-time-zone-annotation.js
     - test/built-ins/Temporal/PlainDate/prototype/until/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/PlainTime/compare/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/PlainTime/from/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/PlainTime/prototype/since/argument-string-time-zone-annotation.js
-    - test/built-ins/Temporal/PlainTime/prototype/until/argument-string-time-zone-annotation.js
 
     # Depends on Temporal.ZonedDateTime
     - test/built-ins/Temporal/Duration/compare/relativeto-zoneddatetime-negative-epochnanoseconds.js

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -245,8 +245,8 @@ test/built-ins/Temporal/Duration/prototype/total/precision-exact-mathematical-va
   default: 'Test262Error: seconds=0, milliseconds=950 Expected SameValue(«0.9500000000000001», «0.95») to be true'
   strict mode: 'Test262Error: seconds=0, milliseconds=950 Expected SameValue(«0.9500000000000001», «0.95») to be true'
 test/built-ins/Temporal/Duration/prototype/total/relativeto-plaindatetime.js:
-  default: 'RangeError: Cannot total a duration of years, months, or weeks without a relativeTo option'
-  strict mode: 'RangeError: Cannot total a duration of years, months, or weeks without a relativeTo option'
+  default: 'Error: FIXME: years, months, or weeks totalling with relativeTo not implemented yet'
+  strict mode: 'Error: FIXME: years, months, or weeks totalling with relativeTo not implemented yet'
 test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-invalid-offset-string.js:
   default: 'Test262Error: "0" is not a valid offset string Expected a TypeError but got a RangeError'
   strict mode: 'Test262Error: "0" is not a valid offset string Expected a TypeError but got a RangeError'
@@ -254,8 +254,8 @@ test/built-ins/Temporal/Duration/prototype/total/relativeto-string-limits.js:
   default: 'Test262Error: "+275760-09-13T00:00Z[UTC]" is outside the representable range for a relativeTo parameter after conversion to DateTime Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: "+275760-09-13T00:00Z[UTC]" is outside the representable range for a relativeTo parameter after conversion to DateTime Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/Duration/prototype/total/throws-if-date-time-invalid-with-plaindate-relative.js:
-  default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
+  default: 'Test262Error: Expected a RangeError but got a Error'
+  strict mode: 'Test262Error: Expected a RangeError but got a Error'
 test/built-ins/Temporal/Duration/prototype/total/throws-if-date-time-invalid-with-zoneddatetime-relative.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(864n * 10n**19n - 1n, \"UTC\")')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(864n * 10n**19n - 1n, \"UTC\")')"

--- a/Source/JavaScriptCore/runtime/TemporalDuration.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.cpp
@@ -510,7 +510,7 @@ ISO8601::Duration TemporalDuration::round(JSGlobalObject* globalObject, JSValue 
         throwRangeError(globalObject, scope, "Cannot round a duration of years, months, or weeks without a relativeTo option"_s);
         return { };
     }
-    if (largestUnit <= TemporalUnit::Week) {
+    if (largestUnit <= TemporalUnit::Week || smallestUnit <= TemporalUnit::Week) {
         throwVMError(globalObject, scope, "FIXME: years, months, or weeks rounding with relativeTo not implemented yet"_s);
         return { };
     }
@@ -548,6 +548,10 @@ double TemporalDuration::total(JSGlobalObject* globalObject, JSValue optionsValu
     // FIXME: Implement relativeTo parameter after PlainDateTime / ZonedDateTime.
     if (unit > TemporalUnit::Year && (years() || months() || weeks() || (days() && unit < TemporalUnit::Day))) {
         throwRangeError(globalObject, scope, "Cannot total a duration of years, months, or weeks without a relativeTo option"_s);
+        return { };
+    }
+    if (unit <= TemporalUnit::Week) {
+        throwVMError(globalObject, scope, "FIXME: years, months, or weeks totalling with relativeTo not implemented yet"_s);
         return { };
     }
 


### PR DESCRIPTION
#### 2a82bda90bd6bc624ae3c17ef0fe83d7b6c4f8ce
<pre>
[JSC] Tighten Temporal test expectations
<a href="https://bugs.webkit.org/show_bug.cgi?id=223166">https://bugs.webkit.org/show_bug.cgi?id=223166</a>

Reviewed by Yusuke Suzuki and Sosuke Suzuki.

Some improvements to the tests for Temporal.

* JSTests/stress/temporal-instant.js: Add an extra test for zero-length
  annotation values.
* JSTests/test262/config.yaml: Remove most
  argument-string-time-zone-annotation.js from the skip list. In some
  cases, these tests already pass. In other cases they fail but because
  of something else that&apos;s not implemented, so recategorize them under
  another heading.
* JSTests/test262/expectations.yaml: Adjust the expectations for two
  tests. Previously, these tests would hit a debug assertion in
  TemporalDuration::round(ISO8601::Duration&amp;, double, TemporalUnit,
  RoundingMode) Since we are throwing an error to avoid hitting the
  assertion, reflect the thrown error in the expectation.
* Source/JavaScriptCore/runtime/TemporalDuration.cpp: Properly throw an
  error on not-implemented behaviour so that the debug assertion isn&apos;t
  hit.
(JSC::TemporalDuration::round const):
(JSC::TemporalDuration::total const):

Canonical link: <a href="https://commits.webkit.org/293829@main">https://commits.webkit.org/293829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c201db2b28b3bfd3aedf4e0601aee43d5101b14

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99808 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9727 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104933 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50387 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27889 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75966 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33056 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15052 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90116 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56333 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14857 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8103 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49758 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92466 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84779 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107294 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98414 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19653 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84920 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27280 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86321 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84446 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21501 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29125 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6833 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/20725 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26855 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32066 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122040 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26666 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34073 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29983 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28228 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->