### PR TITLE
Add a WKFrameInfo accessor on _WKFocusedElementInfo

### DIFF
--- a/Source/WebKit/Shared/FocusedElementInformation.h
+++ b/Source/WebKit/Shared/FocusedElementInformation.h
@@ -27,6 +27,7 @@
 
 #include "ArgumentCoders.h"
 #include "ColorControlSupportsAlpha.h"
+#include "FrameInfoData.h"
 #include "IdentifierTypes.h"
 #include <WebCore/AutocapitalizeTypes.h>
 #include <WebCore/Autofill.h>
@@ -140,7 +141,7 @@ struct FocusedElementInformation {
     FocusedElementInformationIdentifier identifier;
     Markable<WebCore::ScrollingNodeID> containerScrollingNodeID;
 
-    Markable<WebCore::FrameIdentifier> frameID;
+    std::optional<FrameInfoData> frame;
 };
 #endif
 

--- a/Source/WebKit/Shared/FocusedElementInformation.serialization.in
+++ b/Source/WebKit/Shared/FocusedElementInformation.serialization.in
@@ -108,7 +108,7 @@ enum class WebKit::InputType : uint8_t {
 
     WebKit::FocusedElementInformationIdentifier identifier;
     Markable<WebCore::ScrollingNodeID> containerScrollingNodeID;
-    Markable<WebCore::FrameIdentifier> frameID;
+    std::optional<WebKit::FrameInfoData> frame;
 }
 #endif
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKFocusedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKFocusedElementInfo.h
@@ -55,6 +55,8 @@ typedef NS_ENUM(NSInteger, WKInputType) {
     WKInputTypeDrawing,
 };
 
+@class WKFrameInfo;
+
 /**
  * The _WKFocusedElementInfo provides basic information about an element that
  * has been focused (either programmatically or through user interaction) but
@@ -73,6 +75,9 @@ typedef NS_ENUM(NSInteger, WKInputType) {
 
 /* The text of a label element associated with the input. */
 @property (nonatomic, readonly, copy) NSString *label;
+
+/* The frame containing the element */
+@property (nonatomic, readonly, copy) WKFrameInfo *frame WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 /**
  * Whether the element was focused due to user interaction. NO indicates that

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4068,7 +4068,8 @@ std::optional<FocusedElementInformation> WebPage::focusedElementInformation()
 
     FocusedElementInformation information;
 
-    information.frameID = focusedOrMainFrame->frameID();
+    if (RefPtr webFrame = WebProcess::singleton().webFrame(focusedOrMainFrame->frameID()))
+        information.frame = webFrame->info();
 
     information.lastInteractionLocation = m_lastInteractionLocation;
     if (auto elementContext = contextForElement(*focusedElement))

--- a/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
@@ -757,7 +757,10 @@ TEST(KeyboardInputTests, TestWebViewAdditionalContextForStrongPasswordAssistance
         return expected;
     }];
 
-    [inputDelegate setFocusRequiresStrongPasswordAssistanceHandler:[&] (WKWebView *, id<_WKFocusedElementInfo>, void(^completionHandler)(BOOL)) {
+    bool verifiedFrame { false };
+    [inputDelegate setFocusRequiresStrongPasswordAssistanceHandler:[&] (WKWebView *, id<_WKFocusedElementInfo> info, void(^completionHandler)(BOOL)) {
+        EXPECT_NOT_NULL(info.frame);
+        verifiedFrame = true;
         completionHandler(YES);
     }];
 
@@ -769,6 +772,7 @@ TEST(KeyboardInputTests, TestWebViewAdditionalContextForStrongPasswordAssistance
     NSDictionary *actual = [[webView textInputContentView] _autofillContext];
     EXPECT_TRUE([[actual allValues] containsObject:expected]);
     EXPECT_TRUE([actual[@"_automaticPasswordKeyboard"] boolValue]);
+    EXPECT_TRUE(verifiedFrame);
 }
 
 TEST(KeyboardInputTests, TestWebViewAdditionalContextForNonAutofillCredentialType)


### PR DESCRIPTION
#### fb0335ccf55ee6ad2eca421438ba4b6b9d11156f
<pre>
Add a WKFrameInfo accessor on _WKFocusedElementInfo
<a href="https://bugs.webkit.org/show_bug.cgi?id=291608">https://bugs.webkit.org/show_bug.cgi?id=291608</a>
<a href="https://rdar.apple.com/149350466">rdar://149350466</a>

Reviewed by Brady Eidson.

* Source/WebKit/Shared/FocusedElementInformation.h:
* Source/WebKit/Shared/FocusedElementInformation.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKFocusedElementInfo.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKFocusedElementInfo initWithFocusedElementInformation:isUserInitiated:webView:userObject:]):
(-[WKFocusedElementInfo frame]):
(-[WKContentView _elementDidFocus:userIsInteracting:blurPreviousNode:activityStateChanges:userObject:]):
(-[WKContentView _autofillContext]):
(-[WKFocusedElementInfo initWithFocusedElementInformation:isUserInitiated:userObject:]): Deleted.
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::focusedElementInformation):
* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:
(TestWebKitAPI::TEST(KeyboardInputTests, TestWebViewAdditionalContextForStrongPasswordAssistance)):

Canonical link: <a href="https://commits.webkit.org/293962@main">https://commits.webkit.org/293962@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f119ada23a26937060c921c1d46b04877d31d96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104952 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50405 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101868 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27908 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75983 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33074 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90135 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56349 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14876 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8122 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49777 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84795 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107313 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19668 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84937 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27299 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86340 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84464 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29140 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6851 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20743 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16342 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26874 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32085 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26685 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30002 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28246 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->