### PR TITLE
ASAN_ILL | WebCore::CSSAnimation::syncStyleOriginatedTimeline

### DIFF
--- a/LayoutTests/animations/cssAnimToWebAnimSwitchCrash-expected.txt
+++ b/LayoutTests/animations/cssAnimToWebAnimSwitchCrash-expected.txt
@@ -1,0 +1,2 @@
+AAAAAAAAAAAAAAAA
+Test Passes if there is no crash

--- a/LayoutTests/animations/cssAnimToWebAnimSwitchCrash.html
+++ b/LayoutTests/animations/cssAnimToWebAnimSwitchCrash.html
@@ -1,0 +1,26 @@
+<style>
+    *:nth-child(odd) { auto;-webkit-animation-direction: alternate }
+    * { currentColor;-webkit-animation: keyframes4 1s }
+    @keyframes keyframes4 {
+</style>
+
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+    function main() {
+        try { v17 = x2.getAnimations(); } catch { }
+        try { v82 = v17[33 % v17.length]; } catch { }
+        try { v92 = new KeyframeEffect(x31,{ "text-shadow": ["0.92em 1em", ], },200); } catch { }
+        try { v82.effect = v92; } catch { }
+        try { x11.outerHTML = "AAAAAAAAAAAAAAAA"; } catch { }
+    }
+</script>
+
+<body onload="main()">
+    <svg id="x11" match-source">
+        <animateTransform id="x31" additive="replace">
+        </animateTransform>
+    </svg>
+    <picture id="x2" contextmenu="x9">
+    <p>Test Passes if there is no crash</p>
+</body>

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -69,7 +69,8 @@ void CSSAnimation::syncPropertiesWithBackingAnimation()
     // When multiple animation-* properties are set simultaneously, animation-timeline
     // is updated first, so e.g. a change to animation-play-state applies to the
     // simultaneously-applied timeline specified in animation-timeline.
-    syncStyleOriginatedTimeline();
+    if (owningElement())
+        syncStyleOriginatedTimeline();
 
     Ref animation = backingAnimation();
     RefPtr animationEffect = effect();
@@ -158,7 +159,6 @@ void CSSAnimation::syncStyleOriginatedTimeline()
     suspendEffectInvalidation();
 
     ASSERT(owningElement());
-    Ref target = owningElement()->element;
     Ref document = owningElement()->element.document();
     auto& timeline = backingAnimation().timeline();
     WTF::switchOn(timeline,


### PR DESCRIPTION
#### 58b0332588b9e7d6f78aacc7dfc0b18d91d342da
<pre>
ASAN_ILL | WebCore::CSSAnimation::syncStyleOriginatedTimeline
<a href="https://bugs.webkit.org/show_bug.cgi?id=291601">https://bugs.webkit.org/show_bug.cgi?id=291601</a>
<a href="https://rdar.apple.com/147939911">rdar://147939911</a>

Reviewed by NOBODY (OOPS!).

The issue was caused by change in animation mode from CSS to Web based in the
included http test script. The web based annimation does not make use of
owning element and delets the same. This causes failure when syncStyleOriginatedTimeline
function is called. The fix is to have a check for owningElement before calling the above
function.

The syncStyleOriginatedTimeline had a unused variable target and that was also
cleaned up

* LayoutTests/animations/cssAnimToWebAnimSwitchCrash-expected.txt: Added.
* LayoutTests/animations/cssAnimToWebAnimSwitchCrash.html: Added.
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::syncPropertiesWithBackingAnimation):
(WebCore::CSSAnimation::syncStyleOriginatedTimeline):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58b0332588b9e7d6f78aacc7dfc0b18d91d342da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99814 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19459 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104939 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50393 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101855 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19764 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27895 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75970 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33064 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102821 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15056 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90122 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56337 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14862 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8109 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49764 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84782 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107300 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26925 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19657 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84926 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27286 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86327 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84453 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29128 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6838 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/20731 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26861 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32072 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26672 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29989 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28234 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->