### PR TITLE
REGRESSION (288265@main): [ macOS wk1 debug ] inspector/console/console-oom.html is a consistent timeout

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -3100,6 +3100,4 @@ webkit.org/b/291207 fullscreen/full-screen-document-background-color.html [ Pass
 
 webkit.org/b/291577 fast/hidpi/filters-reference.html [ ImageOnlyFailure ]
 
-webkit.org/b/291598 [ Debug ] inspector/console/console-oom.html [ Pass Timeout ]
-
 webkit.org/b/291603 accessibility/text-marker/text-marker-debug-description.html [ Pass Failure ]

--- a/Source/WTF/wtf/UnalignedAccess.h
+++ b/Source/WTF/wtf/UnalignedAccess.h
@@ -36,7 +36,9 @@ inline Type unalignedLoad(const void* pointer)
 {
     static_assert(std::is_trivially_copyable<Type>::value);
     Type result { };
-    memcpySpan(asMutableByteSpan(result), unsafeMakeSpan(static_cast<const uint8_t*>(pointer), sizeof(Type)));
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    memcpy(&result, pointer, sizeof(Type));
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return result;
 }
 
@@ -44,7 +46,9 @@ template<typename Type>
 inline void unalignedStore(void* pointer, Type value)
 {
     static_assert(std::is_trivially_copyable<Type>::value);
-    memcpySpan(unsafeMakeSpan(static_cast<uint8_t*>(pointer), sizeof(Type)), asByteSpan(value));
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    memcpy(pointer, &value, sizeof(Type));
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 } // namespace WTF


### PR DESCRIPTION
#### 2c0038e9d995133c2b0830f4a2f5ec8e33fda355
<pre>
REGRESSION (288265@main): [ macOS wk1 debug ] inspector/console/console-oom.html is a consistent timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=291598">https://bugs.webkit.org/show_bug.cgi?id=291598</a>
<a href="https://rdar.apple.com/149340500">rdar://149340500</a>

Reviewed by Ryosuke Niwa.

The changes to UnalignedAccess.h made in 288265@main made the test runtime go from
30-50s to ~175s in debug builds (no ovbious regression on release builds but the
runtime is much shorter there 2-3s).

Given that these functions in UnalignedAccess.h currently take a raw `void*` pointer
and no size, using memcpySpan() instead of memcpy() doesn&apos;t actually improve safety
here. I am therefore reverting the changes I made to UnalignedAccess.h.

It appears a lot of the CPY cycles were spent under `unsafeMakeSpan()`.

* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WTF/wtf/UnalignedAccess.h:
(WTF::unalignedLoad):
(WTF::unalignedStore):

Canonical link: <a href="https://commits.webkit.org/293754@main">https://commits.webkit.org/293754@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1aafc195f5dacaf06551d6e61f8d1b1c7a317a71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99816 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9737 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104941 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50395 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27897 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75978 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33066 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102823 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90126 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56345 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14866 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8113 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49766 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92473 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84786 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8198 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107302 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98422 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26927 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19659 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84936 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27288 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86331 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84463 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21453 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29130 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6842 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20733 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26863 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32074 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122048 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26674 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34078 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29991 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28236 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->