### PR TITLE
Badging.Origin is a constant failure with site isolation enabled

### DIFF
--- a/Source/WebCore/Modules/badge/BadgeClient.h
+++ b/Source/WebCore/Modules/badge/BadgeClient.h
@@ -29,14 +29,14 @@
 
 namespace WebCore {
 
-class Page;
+class Frame;
 class SecurityOriginData;
 
 class BadgeClient : public RefCounted<BadgeClient> {
 public:
     virtual ~BadgeClient() = default;
 
-    virtual void setAppBadge(Page*, const SecurityOriginData&, std::optional<uint64_t>) = 0;
+    virtual void setAppBadge(Frame*, const SecurityOriginData&, std::optional<uint64_t>) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/badge/EmptyBadgeClient.h
+++ b/Source/WebCore/Modules/badge/EmptyBadgeClient.h
@@ -36,7 +36,7 @@ public:
         return adoptRef(*new EmptyBadgeClient);
     }
 private:
-    void setAppBadge(Page*, const SecurityOriginData&, std::optional<uint64_t>) final { }
+    void setAppBadge(Frame*, const SecurityOriginData&, std::optional<uint64_t>) final { }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -426,7 +426,7 @@ void Navigator::setAppBadge(std::optional<unsigned long long> badge, Ref<Deferre
         return;
     }
 
-    page->badgeClient().setAppBadge(page.get(), SecurityOriginData::fromFrame(frame.get()), badge);
+    page->badgeClient().setAppBadge(frame.get(), SecurityOriginData::fromFrame(frame.get()), badge);
     promise->resolve();
 }
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -27,6 +27,7 @@
 #include "WebFrameProxy.h"
 
 #include "APINavigation.h"
+#include "APIUIClient.h"
 #include "BrowsingContextGroup.h"
 #include "Connection.h"
 #include "DrawingAreaMessages.h"
@@ -760,6 +761,12 @@ void WebFrameProxy::updateRemoteFrameSize(WebCore::IntSize size)
 {
     m_remoteFrameSize = size;
     send(Messages::WebFrame::UpdateFrameSize(size));
+}
+
+void WebFrameProxy::setAppBadge(const WebCore::SecurityOriginData& origin, std::optional<uint64_t> badge)
+{
+    if (RefPtr webPageProxy = m_page.get())
+        webPageProxy->uiClient().updateAppBadge(*webPageProxy, origin, badge);
 }
 
 std::optional<SharedPreferencesForWebProcess> WebFrameProxy::sharedPreferencesForWebProcess() const

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -54,6 +54,7 @@ class Decoder;
 }
 
 namespace WebCore {
+class SecurityOriginData;
 enum class SandboxFlag : uint16_t;
 using SandboxFlags = OptionSet<SandboxFlag>;
 enum class ResourceResponseSource : uint8_t;
@@ -218,6 +219,7 @@ public:
 
     WebCore::LayerHostingContextIdentifier layerHostingContextIdentifier() const { return m_layerHostingContextIdentifier; }
     void updateRemoteFrameSize(WebCore::IntSize);
+    void setAppBadge(const WebCore::SecurityOriginData&, std::optional<uint64_t> badge);
 
     WebCore::SandboxFlags effectiveSandboxFlags() const { return m_effectiveSandboxFlags; }
     void updateSandboxFlags(WebCore::SandboxFlags sandboxFlags) { m_effectiveSandboxFlags = sandboxFlags; }

--- a/Source/WebKit/UIProcess/WebFrameProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebFrameProxy.messages.in
@@ -27,4 +27,6 @@
 ]
 messages -> WebFrameProxy {
     [EnabledBy=SiteIsolationEnabled] UpdateRemoteFrameSize(WebCore::IntSize size)
+    [EnabledBy=AppBadgeEnabled] SetAppBadge(WebCore::SecurityOriginData origin, std::optional<uint64_t> badge)
+
 }

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -2913,17 +2913,10 @@ void WebProcessProxy::unwrapCryptoKey(WrappedCryptoKey&& wrappedKey, CompletionH
     });
 
 }
-void WebProcessProxy::setAppBadge(std::optional<WebPageProxyIdentifier> pageIdentifier, const SecurityOriginData& origin, std::optional<uint64_t> badge)
-{
-    if (!pageIdentifier) {
-        protectedWebsiteDataStore()->workerUpdatedAppBadge(origin, badge);
-        return;
-    }
 
-    // This page might have gone away since the WebContent process sent this message,
-    // and that's just fine.
-    if (RefPtr page = m_pageMap.get(*pageIdentifier))
-        page->uiClient().updateAppBadge(*page, origin, badge);
+void WebProcessProxy::setAppBadgeFromWorker(const SecurityOriginData& origin, std::optional<uint64_t> badge)
+{
+    protectedWebsiteDataStore()->workerUpdatedAppBadge(origin, badge);
 }
 
 const WeakHashSet<WebProcessProxy>* WebProcessProxy::serviceWorkerClientProcesses() const

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -506,7 +506,7 @@ public:
     void serializeAndWrapCryptoKey(WebCore::CryptoKeyData&&, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
     void unwrapCryptoKey(WebCore::WrappedCryptoKey&&, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
 
-    void setAppBadge(std::optional<WebPageProxyIdentifier>, const WebCore::SecurityOriginData&, std::optional<uint64_t> badge);
+    void setAppBadgeFromWorker(const WebCore::SecurityOriginData&, std::optional<uint64_t> badge);
 
     WebCore::CrossOriginMode crossOriginMode() const { return m_crossOriginMode; }
     LockdownMode lockdownMode() const { return m_lockdownMode; }

--- a/Source/WebKit/UIProcess/WebProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessProxy.messages.in
@@ -90,7 +90,7 @@ messages -> WebProcessProxy WantsDispatchMessage {
 #if ENABLE(NOTIFICATION_EVENT)
     [EnabledBy=NotificationEventEnabled] GetNotifications(URL registrationURL, String tag) -> (Vector<WebCore::NotificationData> result)
 #endif
-    [EnabledBy=AppBadgeEnabled] SetAppBadge(std::optional<WebKit::WebPageProxyIdentifier> pageIdentifier, WebCore::SecurityOriginData origin, std::optional<uint64_t> badge)
+    [EnabledBy=AppBadgeEnabled] SetAppBadgeFromWorker(WebCore::SecurityOriginData origin, std::optional<uint64_t> badge)
 
     SerializeAndWrapCryptoKey(struct WebCore::CryptoKeyData key) -> (std::optional<Vector<uint8_t>> wrappedKey) Synchronous
     UnwrapCryptoKey(struct WebCore::WrappedCryptoKey wrappedKey) -> (std::optional<Vector<uint8_t>> key) Synchronous

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebBadgeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebBadgeClient.cpp
@@ -33,13 +33,9 @@
 namespace WebKit {
 using namespace WebCore;
 
-void WebBadgeClient::setAppBadge(WebCore::Page* page, const WebCore::SecurityOriginData& origin, std::optional<uint64_t> badge)
+void WebBadgeClient::setAppBadge(WebCore::Frame* frame, const WebCore::SecurityOriginData& origin, std::optional<uint64_t> badge)
 {
-    std::optional<WebPageProxyIdentifier> pageIdentifier;
-    if (page)
-        pageIdentifier = WebPage::fromCorePage(*page)->webPageProxyIdentifier();
-
-    WebProcess::singleton().setAppBadge(pageIdentifier, origin, badge);
+    WebProcess::singleton().setAppBadge(frame, origin, badge);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebBadgeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebBadgeClient.h
@@ -38,7 +38,7 @@ public:
     }
 
 private:
-    void setAppBadge(WebCore::Page*, const WebCore::SecurityOriginData&, std::optional<uint64_t>) final;
+    void setAppBadge(WebCore::Frame*, const WebCore::SecurityOriginData&, std::optional<uint64_t>) final;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1498,4 +1498,9 @@ uint64_t WebFrame::messageSenderDestinationID() const
     return m_frameID.toUInt64();
 }
 
+void WebFrame::setAppBadge(const WebCore::SecurityOriginData& origin, std::optional<uint64_t> badge)
+{
+    send(Messages::WebFrameProxy::SetAppBadge(origin, badge));
+}
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -254,6 +254,8 @@ public:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
     static void sendCancelReply(IPC::Connection&, IPC::Decoder&);
 
+    void setAppBadge(const WebCore::SecurityOriginData&, std::optional<uint64_t> badge);
+
 private:
     WebFrame(WebPage&, WebCore::FrameIdentifier);
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -2274,7 +2274,7 @@ bool WebProcess::areAllPagesThrottleable() const
     });
 }
 
-void WebProcess::setAppBadge(std::optional<WebPageProxyIdentifier> pageIdentifier, const WebCore::SecurityOriginData& origin, std::optional<uint64_t> badge)
+void WebProcess::setAppBadge(WebCore::Frame* frame, const WebCore::SecurityOriginData& origin, std::optional<uint64_t> badge)
 {
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
     if (DeprecatedGlobalSettings::builtInNotificationsEnabled()) {
@@ -2284,7 +2284,12 @@ void WebProcess::setAppBadge(std::optional<WebPageProxyIdentifier> pageIdentifie
     }
 #endif
 
-    protectedParentProcessConnection()->send(Messages::WebProcessProxy::SetAppBadge(pageIdentifier, origin, badge), 0);
+    RefPtr protectedFrame = frame;
+    if (frame) {
+        if (auto webFrame = WebFrame::fromCoreFrame(*frame))
+            webFrame->setAppBadge(origin, badge);
+    } else
+        protectedParentProcessConnection()->send(Messages::WebProcessProxy::SetAppBadgeFromWorker(origin, badge), 0);
 }
 
 #if HAVE(DISPLAY_LINK)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -102,6 +102,7 @@ enum class UserInterfaceIdiom : uint8_t;
 
 namespace WebCore {
 class CPUMonitor;
+class Frame;
 class PageGroup;
 class SecurityOriginData;
 class Site;
@@ -466,7 +467,7 @@ public:
     void deleteWebsiteDataForOrigin(OptionSet<WebsiteDataType>, const WebCore::ClientOrigin&, CompletionHandler<void()>&&);
     void reloadExecutionContextsForOrigin(const WebCore::ClientOrigin&, std::optional<WebCore::FrameIdentifier> triggeringFrame, CompletionHandler<void()>&&);
 
-    void setAppBadge(std::optional<WebPageProxyIdentifier>, const WebCore::SecurityOriginData&, std::optional<uint64_t>);
+    void setAppBadge(WebCore::Frame*, const WebCore::SecurityOriginData&, std::optional<uint64_t> badge);
 
     void deferNonVisibleProcessEarlyMemoryCleanupTimer();
 


### PR DESCRIPTION
#### 65d1d0d960767c264ec37158bc640acb5edc4fc9
<pre>
Badging.Origin is a constant failure with site isolation enabled
<a href="https://rdar.apple.com/149354580">rdar://149354580</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291610">https://bugs.webkit.org/show_bug.cgi?id=291610</a>

Reviewed by Alex Christensen.

This was a classic case of an isolated frame web content process being confused about
which web page identifier was the right one to use.

And fixing it was a chance to rearchitect the message to target frames instead of pages,
as frame identifiers are now global and not confused across processes.

The patch is mostly client and IPC plumbing changes to support this.

* Source/WebCore/Modules/badge/BadgeClient.h:
* Source/WebCore/Modules/badge/EmptyBadgeClient.h:
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::setAppBadge):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::setAppBadge):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebFrameProxy.messages.in:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::unwrapCryptoKey):
(WebKit::WebProcessProxy::setAppBadgeFromWorker):
(WebKit::WebProcessProxy::setAppBadge): Deleted.
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebBadgeClient.cpp:
(WebKit::WebBadgeClient::setAppBadge):
* Source/WebKit/WebProcess/WebCoreSupport/WebBadgeClient.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::setAppBadge):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::setAppBadge):
* Source/WebKit/WebProcess/WebProcess.h:

Canonical link: <a href="https://commits.webkit.org/293759@main">https://commits.webkit.org/293759@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e1d5ee84478748e89bb07fcdbc9574b66c8984c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99849 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9777 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104975 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50428 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101890 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19799 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27930 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76004 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33100 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102856 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15102 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90174 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56369 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14906 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8160 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49799 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84832 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107335 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26960 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19699 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84967 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27322 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86373 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84487 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21451 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29161 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6889 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20775 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26896 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32117 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26707 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30024 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28268 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->