### PR TITLE
@font-face `font-family` descriptor should not allow a list of values

### DIFF
--- a/LayoutTests/fast/text/font-face-empty-string-expected.txt
+++ b/LayoutTests/fast/text/font-face-empty-string-expected.txt
@@ -15,7 +15,8 @@ PASS fontface.unicodeRange = '' threw exception SyntaxError: The string did not 
 PASS fontface = new FontFace('WebFont', 'url(\'asdf\')', {featureSettings: ''}) did not throw exception.
 PASS fontface.featureSettings is "normal"
 PASS fontface.featureSettings = '' threw exception SyntaxError: The string did not match the expected pattern..
-PASS fontface.family = '' did not throw exception.
+PASS fontface.family = '' threw exception SyntaxError: The string did not match the expected pattern..
+PASS fontface.family = '""' did not throw exception.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/text/font-face-empty-string.html
+++ b/LayoutTests/fast/text/font-face-empty-string.html
@@ -21,7 +21,8 @@ shouldNotThrow("fontface = new FontFace('WebFont', 'url(\\\'asdf\\\')', {feature
 shouldBeEqualToString("fontface.featureSettings", "normal");
 shouldThrow("fontface.featureSettings = ''");
 
-shouldNotThrow("fontface.family = ''");
+shouldThrow("fontface.family = ''");
+shouldNotThrow("fontface.family = '\"\"'");
 </script>
 <script src="../../resources/js-test-post.js"></script>
 </body>

--- a/LayoutTests/fast/text/font-face-family-expected.txt
+++ b/LayoutTests/fast/text/font-face-family-expected.txt
@@ -3,9 +3,11 @@ PASS new FontFace('4a', 'url(garbage.otf)') is non-null.
 PASS new FontFace('4"a', 'url(garbage.otf)') is non-null.
 PASS new FontFace('4\'a', 'url(garbage.otf)') is non-null.
 PASS new FontFace('4\'a"b', 'url(garbage.otf)') is non-null.
-PASS (new FontFace('a b', 'url(garbage.otf)')).family is "a b"
-PASS (new FontFace('a b, c', 'url(garbage.otf)')).family is "a b, c"
-PASS (new FontFace('ab,c', 'url(garbage.otf)')).family is "ab,c"
+PASS (new FontFace('ab', 'url(garbage.otf)')).family is "ab"
+PASS (new FontFace('"ab"', 'url(garbage.otf)')).family is "ab"
+PASS (new FontFace('a b', 'url(garbage.otf)')).family is "\"a b\""
+PASS (new FontFace('a b, c', 'url(garbage.otf)')).family is "normal"
+PASS (new FontFace('ab,c', 'url(garbage.otf)')).family is "normal"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/text/font-face-family.html
+++ b/LayoutTests/fast/text/font-face-family.html
@@ -10,9 +10,11 @@ shouldBeNonNull("new FontFace('4a', 'url(garbage.otf)')");
 shouldBeNonNull("new FontFace('4\"a', 'url(garbage.otf)')");
 shouldBeNonNull("new FontFace('4\\'a', 'url(garbage.otf)')");
 shouldBeNonNull("new FontFace('4\\'a\"b', 'url(garbage.otf)')");
-shouldBeEqualToString("(new FontFace('a b', 'url(garbage.otf)')).family", "a b");
-shouldBeEqualToString("(new FontFace('a b, c', 'url(garbage.otf)')).family", "a b, c");
-shouldBeEqualToString("(new FontFace('ab,c', 'url(garbage.otf)')).family", "ab,c");
+shouldBeEqualToString("(new FontFace('ab', 'url(garbage.otf)')).family", "ab");
+shouldBeEqualToString("(new FontFace('\"ab\"', 'url(garbage.otf)')).family", "ab");
+shouldBeEqualToString("(new FontFace('a b', 'url(garbage.otf)')).family", "\"a b\"");
+shouldBeEqualToString("(new FontFace('a b, c', 'url(garbage.otf)')).family", "normal");
+shouldBeEqualToString("(new FontFace('ab,c', 'url(garbage.otf)')).family", "normal");
 </script>
 <script src="../../resources/js-test-post.js"></script>
 </body>

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -145,12 +145,9 @@ StyleRuleFontFace* CSSFontFace::cssConnection() const
     );
 }
 
-// FIXME: Don't use a list here and rename to setFamily. https://bugs.webkit.org/show_bug.cgi?id=196381
-void CSSFontFace::setFamilies(CSSValueList& family)
+void CSSFontFace::setFamily(CSSValue& family)
 {
-    ASSERT(family.length());
-
-    RefPtr oldFamily = std::exchange(m_families, &family);
+    RefPtr oldFamily = std::exchange(m_family, &family);
     mutableProperties().setProperty(CSSPropertyFontFamily, family);
 
     iterateClients(m_clients, [&](CSSFontFaceClient& client) {
@@ -352,16 +349,7 @@ void CSSFontFace::setDisplay(CSSValue& loadingBehaviorValue)
 
 String CSSFontFace::family() const
 {
-    // Code to extract the name of the first family is needed because we incorrectly use a list of families.
-    // FIXME: Consider switching to getPropertyValue after https://bugs.webkit.org/show_bug.cgi?id=196381 is fixed.
-    auto family = properties().getPropertyCSSValue(CSSPropertyFontFamily);
-    auto familyList = dynamicDowncast<CSSValueList>(family.get());
-    if (!familyList)
-        return { };
-    auto firstFamily = dynamicDowncast<CSSPrimitiveValue>(familyList->item(0));
-    if (!firstFamily || !firstFamily->isFontFamily())
-        return { };
-    return firstFamily->stringValue();
+    return properties().getPropertyValue(CSSPropertyFontFamily);
 }
 
 String CSSFontFace::style() const
@@ -399,9 +387,9 @@ String CSSFontFace::display() const
     return properties().getPropertyValue(CSSPropertyFontDisplay);
 }
 
-RefPtr<CSSValueList> CSSFontFace::families() const
+RefPtr<CSSValue> CSSFontFace::familyCSSValue() const
 {
-    return m_families;
+    return m_family;
 }
 
 bool CSSFontFace::rangesMatchCodePoint(char32_t character) const

--- a/Source/WebCore/css/CSSFontFace.h
+++ b/Source/WebCore/css/CSSFontFace.h
@@ -75,7 +75,7 @@ public:
     static Ref<CSSFontFace> create(CSSFontSelector&, StyleRuleFontFace* cssConnection = nullptr, FontFace* wrapper = nullptr, bool isLocalFallback = false);
     virtual ~CSSFontFace();
 
-    void setFamilies(CSSValueList&);
+    void setFamily(CSSValue&);
     void setStyle(CSSValue&);
     void setWeight(CSSValue&);
     void setWidth(CSSValue&);
@@ -104,10 +104,16 @@ public:
     //             Success    Failure
     enum class Status : uint8_t { Pending, Loading, TimedOut, Success, Failure };
 
-    struct UnicodeRange;
+    struct UnicodeRange {
+        char32_t from;
+        char32_t to;
 
-    RefPtr<CSSValueList> families() const;
+        bool operator==(const UnicodeRange&) const = default;
+    };
+
     std::span<const UnicodeRange> ranges() const { ASSERT(m_status != Status::Failure); return m_ranges.span(); }
+
+    RefPtr<CSSValue> familyCSSValue() const;
 
     void setFontSelectionCapabilities(FontSelectionCapabilities capabilities) { m_fontSelectionCapabilities = capabilities; }
     FontSelectionCapabilities fontSelectionCapabilities() const { ASSERT(m_status != Status::Failure); return m_fontSelectionCapabilities.computeFontSelectionCapabilities(); }
@@ -134,12 +140,6 @@ public:
     RefPtr<Font> font(const FontDescription&, bool syntheticBold, bool syntheticItalic, ExternalResourceDownloadPolicy, const FontPaletteValues&, RefPtr<FontFeatureValues>);
 
     static void appendSources(CSSFontFace&, CSSValueList&, ScriptExecutionContext*, bool isInitiatingElementInUserAgentShadowTree);
-
-    struct UnicodeRange {
-        char32_t from;
-        char32_t to;
-        friend bool operator==(const UnicodeRange&, const UnicodeRange&) = default;
-    };
 
     bool rangesMatchCodePoint(char32_t) const;
 
@@ -182,7 +182,7 @@ private:
     Document* document();
 
     const Variant<Ref<MutableStyleProperties>, Ref<StyleRuleFontFace>> m_propertiesOrCSSConnection;
-    RefPtr<CSSValueList> m_families;
+    RefPtr<CSSValue> m_family;
     Vector<UnicodeRange> m_ranges;
 
     FontFeatureSettings m_featureSettings;
@@ -211,7 +211,7 @@ public:
     virtual ~CSSFontFaceClient() = default;
     virtual void fontLoaded(CSSFontFace&) { }
     virtual void fontStateChanged(CSSFontFace&, CSSFontFace::Status /*oldState*/, CSSFontFace::Status /*newState*/) { }
-    virtual void fontPropertyChanged(CSSFontFace&, CSSValueList* /*oldFamilies*/ = nullptr) { }
+    virtual void fontPropertyChanged(CSSFontFace&, CSSValue* /*oldFamily*/ = nullptr) { }
     virtual void updateStyleIfNeeded(CSSFontFace&) { }
 };
 

--- a/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -128,10 +128,9 @@ void CSSFontFaceSet::ensureLocalFontFacesForFamilyRegistered(const AtomString& f
     Vector<Ref<CSSFontFace>> faces;
     for (auto item : capabilities) {
         auto face = CSSFontFace::create(owningFontSelector, nullptr, nullptr, true);
-        
-        // FIXME: Don't use a list here. https://bugs.webkit.org/show_bug.cgi?id=196381
+
         auto& pool = owningFontSelector->protectedScriptExecutionContext()->cssValuePool();
-        face->setFamilies(CSSValueList::createCommaSeparated(pool.createFontFamilyValue(familyName)).get());
+        face->setFamily(pool.createFontFamilyValue(familyName));
         face->setFontSelectionCapabilities(item);
         face->adoptSource(makeUnique<CSSFontFaceSource>(face.get(), familyName));
         ASSERT(!face->computeFailureState());
@@ -169,30 +168,28 @@ String CSSFontFaceSet::familyNameFromPrimitive(const CSSPrimitiveValue& value)
 
 void CSSFontFaceSet::addToFacesLookupTable(CSSFontFace& face)
 {
-    auto families = face.families();
-    if (!families) {
+    auto family = face.familyCSSValue();
+    if (!family) {
         // If the font has failed, there's no point in actually adding it to m_facesLookupTable,
         // because no font requests can actually use it for anything. So, let's just ... not add it.
         return;
     }
 
-    for (auto& item : *families) {
-        auto familyName = AtomString { CSSFontFaceSet::familyNameFromPrimitive(downcast<CSSPrimitiveValue>(item)) };
-        if (familyName.isNull())
-            continue;
+    auto familyName = AtomString { CSSFontFaceSet::familyNameFromPrimitive(downcast<CSSPrimitiveValue>(*family)) };
+    if (familyName.isNull())
+        return;
 
-        auto addResult = m_facesLookupTable.add(familyName, Vector<Ref<CSSFontFace>>());
-        auto& familyFontFaces = addResult.iterator->value;
-        if (addResult.isNewEntry) {
-            // m_locallyInstalledFontFaces grows without bound, eventually encorporating every font installed on the system.
-            // This is by design.
-            if (m_owningFontSelector)
-                ensureLocalFontFacesForFamilyRegistered(familyName);
-            familyFontFaces = { };
-        }
-
-        familyFontFaces.append(face);
+    auto addResult = m_facesLookupTable.add(familyName, Vector<Ref<CSSFontFace>>());
+    auto& familyFontFaces = addResult.iterator->value;
+    if (addResult.isNewEntry) {
+        // m_locallyInstalledFontFaces grows without bound, eventually incorporating every font installed on the system.
+        // This is by design.
+        if (m_owningFontSelector)
+            ensureLocalFontFacesForFamilyRegistered(familyName);
+        familyFontFaces = { };
     }
+
+    familyFontFaces.append(face);
 }
 
 void CSSFontFaceSet::add(CSSFontFace& face)
@@ -222,32 +219,30 @@ void CSSFontFaceSet::add(CSSFontFace& face)
     }
 }
 
-void CSSFontFaceSet::removeFromFacesLookupTable(const CSSFontFace& face, const CSSValueList& familiesToSearchFor)
+void CSSFontFaceSet::removeFromFacesLookupTable(const CSSFontFace& face, const CSSValue& familyToSearchFor)
 {
-    for (auto& item : familiesToSearchFor) {
-        String familyName = CSSFontFaceSet::familyNameFromPrimitive(downcast<CSSPrimitiveValue>(item));
-        if (familyName.isNull())
-            continue;
+    auto familyName = CSSFontFaceSet::familyNameFromPrimitive(downcast<CSSPrimitiveValue>(familyToSearchFor));
+    if (familyName.isNull())
+        return;
 
-        auto iterator = m_facesLookupTable.find(familyName);
-        if (iterator == m_facesLookupTable.end()) {
-            // The font may have failed even before addToFacesLookupTable() was called on it,
-            // which means we never added it (because there's no point in adding a failed font).
-            // So, if it was never added, removing it is free! Woohoo!
-            return;
-        }
-        bool found = false;
-        for (size_t i = 0; i < iterator->value.size(); ++i) {
-            if (iterator->value[i].ptr() == &face) {
-                found = true;
-                iterator->value.remove(i);
-                break;
-            }
-        }
-        ASSERT_UNUSED(found, found);
-        if (!iterator->value.size())
-            m_facesLookupTable.remove(iterator);
+    auto iterator = m_facesLookupTable.find(familyName);
+    if (iterator == m_facesLookupTable.end()) {
+        // The font may have failed even before addToFacesLookupTable() was called on it,
+        // which means we never added it (because there's no point in adding a failed font).
+        // So, if it was never added, removing it is free! Woohoo!
+        return;
     }
+    bool found = false;
+    for (size_t i = 0; i < iterator->value.size(); ++i) {
+        if (iterator->value[i].ptr() == &face) {
+            found = true;
+            iterator->value.remove(i);
+            break;
+        }
+    }
+    ASSERT_UNUSED(found, found);
+    if (!iterator->value.size())
+        m_facesLookupTable.remove(iterator);
 }
 
 void CSSFontFaceSet::remove(const CSSFontFace& face)
@@ -256,12 +251,12 @@ void CSSFontFaceSet::remove(const CSSFontFace& face)
 
     m_cache.clear();
 
-    m_fontModifiedObservers.forEach([] (auto& observer) {
+    m_fontModifiedObservers.forEach([](auto& observer) {
         observer();
     });
     
-    if (auto families = face.families())
-        removeFromFacesLookupTable(face, *families);
+    if (auto family = face.familyCSSValue())
+        removeFromFacesLookupTable(face, *family);
 
     if (face.cssConnection()) {
         ASSERT(m_constituentCSSConnections.get(face.cssConnection()) == &face);
@@ -404,27 +399,25 @@ static CodePointsMap codePointsFromString(StringView stringView)
     return result;
 }
 
-ExceptionOr<Vector<std::reference_wrapper<CSSFontFace>>> CSSFontFaceSet::matchingFacesExcludingPreinstalledFonts(const String& fontShorthand, const String& string)
+ExceptionOr<Vector<std::reference_wrapper<CSSFontFace>>> CSSFontFaceSet::matchingFacesExcludingPreinstalledFonts(ScriptExecutionContext& context, const String& fontShorthand, const String& string)
 {
-    auto font = CSSPropertyParserHelpers::parseUnresolvedFont(fontShorthand, HTMLStandardMode);
+    auto font = CSSPropertyParserHelpers::parseUnresolvedFont(fontShorthand, context);
     if (!font)
         return Exception { ExceptionCode::SyntaxError };
 
     UncheckedKeyHashSet<AtomString> uniqueFamilies;
     Vector<AtomString> familyOrder;
     for (auto& familyRaw : font->family) {
-        AtomString familyAtom;
-        WTF::switchOn(familyRaw, [&] (CSSValueID familyKeyword) {
-            if (familyKeyword != CSSValueWebkitBody)
-                familyAtom = familyNamesData->at(CSSPropertyParserHelpers::genericFontFamilyIndex(familyKeyword));
-            else {
-                ASSERT(m_owningFontSelector && m_owningFontSelector->scriptExecutionContext());
-                Ref owningFontSelector = *m_owningFontSelector;
-                familyAtom = AtomString { owningFontSelector->protectedScriptExecutionContext()->settingsValues().fontGenericFamilies.standardFontFamily() };
+        auto familyAtom = WTF::switchOn(familyRaw,
+            [&](CSSValueID familyKeyword) -> AtomString {
+                if (familyKeyword == CSSValueWebkitBody)
+                    return AtomString { context.settingsValues().fontGenericFamilies.standardFontFamily() };
+                return familyNamesData->at(CSSPropertyParserHelpers::genericFontFamilyIndex(familyKeyword));
+            },
+            [&](const AtomString& familyString) -> AtomString  {
+                return familyString;
             }
-        }, [&] (const AtomString& familyString) {
-            familyAtom = familyString;
-        });
+        );
 
         if (!familyAtom.isNull() && uniqueFamilies.add(familyAtom).isNewEntry)
             familyOrder.append(familyAtom);
@@ -457,9 +450,9 @@ ExceptionOr<Vector<std::reference_wrapper<CSSFontFace>>> CSSFontFaceSet::matchin
     });
 }
 
-ExceptionOr<bool> CSSFontFaceSet::check(const String& font, const String& text)
+ExceptionOr<bool> CSSFontFaceSet::check(ScriptExecutionContext& context, const String& font, const String& text)
 {
-    auto matchingFaces = this->matchingFacesExcludingPreinstalledFonts(font, text);
+    auto matchingFaces = this->matchingFacesExcludingPreinstalledFonts(context, font, text);
     if (matchingFaces.hasException())
         return matchingFaces.releaseException();
 
@@ -564,16 +557,16 @@ void CSSFontFaceSet::fontStateChanged(CSSFontFace& face, CSSFontFace::Status old
     }
 }
 
-void CSSFontFaceSet::fontPropertyChanged(CSSFontFace& face, CSSValueList* oldFamilies)
+void CSSFontFaceSet::fontPropertyChanged(CSSFontFace& face, CSSValue* oldFamily)
 {
     m_cache.clear();
 
-    if (oldFamilies) {
-        removeFromFacesLookupTable(face, *oldFamilies);
+    if (oldFamily) {
+        removeFromFacesLookupTable(face, *oldFamily);
         addToFacesLookupTable(face);
     }
 
-    m_fontModifiedObservers.forEach([] (auto& observer) {
+    m_fontModifiedObservers.forEach([](auto& observer) {
         observer();
     });
 }

--- a/Source/WebCore/css/CSSFontFaceSet.h
+++ b/Source/WebCore/css/CSSFontFaceSet.h
@@ -86,7 +86,7 @@ public:
 
     CSSFontFace* lookUpByCSSConnection(StyleRuleFontFace&);
 
-    ExceptionOr<bool> check(const String& font, const String& text);
+    ExceptionOr<bool> check(ScriptExecutionContext&, const String& font, const String& text);
 
     CSSSegmentedFontFace* fontFace(FontSelectionRequest, const AtomString& family);
 
@@ -97,7 +97,7 @@ public:
 
     size_t facesPartitionIndex() const { return m_facesPartitionIndex; }
 
-    ExceptionOr<Vector<std::reference_wrapper<CSSFontFace>>> matchingFacesExcludingPreinstalledFonts(const String& font, const String& text);
+    ExceptionOr<Vector<std::reference_wrapper<CSSFontFace>>> matchingFacesExcludingPreinstalledFonts(ScriptExecutionContext&, const String& font, const String& text);
 
     // FIXME: Should this be implemented?
     void updateStyleIfNeeded(CSSFontFace&) final { }
@@ -105,14 +105,14 @@ public:
 private:
     CSSFontFaceSet(CSSFontSelector*);
 
-    void removeFromFacesLookupTable(const CSSFontFace&, const CSSValueList& familiesToSearchFor);
+    void removeFromFacesLookupTable(const CSSFontFace&, const CSSValue& familyToSearchFor);
     void addToFacesLookupTable(CSSFontFace&);
 
     void incrementActiveCount();
     void decrementActiveCount();
 
     void fontStateChanged(CSSFontFace&, CSSFontFace::Status oldState, CSSFontFace::Status newState) final;
-    void fontPropertyChanged(CSSFontFace&, CSSValueList* oldFamilies = nullptr) final;
+    void fontPropertyChanged(CSSFontFace&, CSSValue* oldFamily = nullptr) final;
 
     void ensureLocalFontFacesForFamilyRegistered(const AtomString&);
 

--- a/Source/WebCore/css/CSSFontSelector.cpp
+++ b/Source/WebCore/css/CSSFontSelector.cpp
@@ -177,8 +177,8 @@ void CSSFontSelector::addFontFaceRule(StyleRuleFontFace& fontFaceRule, bool isIn
         return;
     }
 
-    const StyleProperties& style = fontFaceRule.properties();
-    RefPtr familyList = dynamicDowncast<CSSValueList>(style.getPropertyCSSValue(CSSPropertyFontFamily));
+    auto& style = fontFaceRule.properties();
+    RefPtr fontFamily = style.getPropertyCSSValue(CSSPropertyFontFamily);
     RefPtr fontStyle = style.getPropertyCSSValue(CSSPropertyFontStyle);
     RefPtr fontWeight = style.getPropertyCSSValue(CSSPropertyFontWeight);
     RefPtr fontWidth = style.getPropertyCSSValue(CSSPropertyFontWidth);
@@ -188,10 +188,7 @@ void CSSFontSelector::addFontFaceRule(StyleRuleFontFace& fontFaceRule, bool isIn
     RefPtr featureSettings = style.getPropertyCSSValue(CSSPropertyFontFeatureSettings);
     RefPtr display = style.getPropertyCSSValue(CSSPropertyFontDisplay);
     RefPtr sizeAdjust = style.getPropertyCSSValue(CSSPropertySizeAdjust);
-    if (!familyList || !srcList || (unicodeRange && !rangeList))
-        return;
-
-    if (!familyList->length())
+    if (!fontFamily || !srcList || (unicodeRange && !rangeList))
         return;
 
     if (!srcList->length())
@@ -200,7 +197,7 @@ void CSSFontSelector::addFontFaceRule(StyleRuleFontFace& fontFaceRule, bool isIn
     SetForScope creatingFont(m_creatingFont, true);
     auto fontFace = CSSFontFace::create(*this, &fontFaceRule);
 
-    fontFace->setFamilies(*familyList);
+    fontFace->setFamily(*fontFamily);
     if (fontStyle)
         fontFace->setStyle(*fontStyle);
     if (fontWeight)

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -12217,9 +12217,8 @@
         "@font-face": {
             "font-family": {
                 "codegen-properties": {
-                    "parser-function": "consumeFontFaceFontFamily",
-                    "parser-grammar-unused": "<family-name>",
-                    "parser-grammar-unused-reason": "Needs support for primitive <family-name>."
+                    "parser-grammar": "<family-name>",
+                    "parser-exported": true
                 },
                 "specification": {
                     "category": "css-fonts-4",

--- a/Source/WebCore/css/FontFace.cpp
+++ b/Source/WebCore/css/FontFace.cpp
@@ -181,11 +181,11 @@ FontFace::~FontFace()
 
 ExceptionOr<void> FontFace::setFamily(ScriptExecutionContext& context, const String& family)
 {
-    if (family.isNull())
-        return Exception { ExceptionCode::SyntaxError };
-    // FIXME: Don't use a list here. https://bugs.webkit.org/show_bug.cgi?id=196381
-    m_backing->setFamilies(CSSValueList::createCommaSeparated(context.cssValuePool().createFontFamilyValue(AtomString { family })));
-    return { };
+    if (auto value = CSSPropertyParserHelpers::parseFontFaceFontFamily(family, context)) {
+        m_backing->setFamily(*value);
+        return { };
+    }
+    return Exception { ExceptionCode::SyntaxError };
 }
 
 ExceptionOr<void> FontFace::setStyle(ScriptExecutionContext& context, const String& style)

--- a/Source/WebCore/css/FontFaceSet.cpp
+++ b/Source/WebCore/css/FontFaceSet.cpp
@@ -148,10 +148,10 @@ void FontFaceSet::clear()
     }
 }
 
-void FontFaceSet::load(const String& font, const String& text, LoadPromise&& promise)
+void FontFaceSet::load(ScriptExecutionContext& context, const String& font, const String& text, LoadPromise&& promise)
 {
     m_backing->updateStyleIfNeeded();
-    auto matchingFacesResult = m_backing->matchingFacesExcludingPreinstalledFonts(font, text);
+    auto matchingFacesResult = m_backing->matchingFacesExcludingPreinstalledFonts(context, font, text);
     if (matchingFacesResult.hasException()) {
         promise.reject(matchingFacesResult.releaseException());
         return;
@@ -214,12 +214,12 @@ void FontFaceSet::load(const String& font, const String& text, LoadPromise&& pro
         pendingPromise->promise->resolve(pendingPromise->faces);
 }
 
-ExceptionOr<bool> FontFaceSet::check(const String& family, const String& text)
+ExceptionOr<bool> FontFaceSet::check(ScriptExecutionContext& context, const String& family, const String& text)
 {
     m_backing->updateStyleIfNeeded();
-    return m_backing->check(family, text);
+    return m_backing->check(context, family, text);
 }
-    
+
 auto FontFaceSet::status() const -> LoadStatus
 {
     m_backing->updateStyleIfNeeded();

--- a/Source/WebCore/css/FontFaceSet.h
+++ b/Source/WebCore/css/FontFaceSet.h
@@ -55,8 +55,8 @@ public:
     void clear();
 
     using LoadPromise = DOMPromiseDeferred<IDLSequence<IDLInterface<FontFace>>>;
-    void load(const String& font, const String& text, LoadPromise&&);
-    ExceptionOr<bool> check(const String& font, const String& text);
+    void load(ScriptExecutionContext&, const String& font, const String& text, LoadPromise&&);
+    ExceptionOr<bool> check(ScriptExecutionContext&, const String& font, const String& text);
 
     enum class LoadStatus { Loading, Loaded };
     LoadStatus status() const;

--- a/Source/WebCore/css/FontFaceSet.idl
+++ b/Source/WebCore/css/FontFaceSet.idl
@@ -54,11 +54,11 @@ enum FontFaceSetLoadStatus {
 
     // check and start loads if appropriate
     // and fulfill promise when all loads complete
-    Promise<sequence<FontFace>> load(DOMString font, optional DOMString text = " ");
+    [CallWith=CurrentScriptExecutionContext] Promise<sequence<FontFace>> load(DOMString font, optional DOMString text = " ");
 
     // return whether all fonts in the fontlist are loaded
     // (does not initiate load if not available)
-    boolean check(DOMString font, optional DOMString text = " ");
+    [CallWith=CurrentScriptExecutionContext] boolean check(DOMString font, optional DOMString text = " ");
 
     // async notification that font loading and layout operations are done
     readonly attribute Promise<FontFaceSet> ready;

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -653,7 +653,7 @@ static std::optional<Random::SharingFixed> consumeOptionalRandomSharingFixed(CSS
 
     // Use a non-property parsing state for the fixed number value to disconnect it from the current parse.
     // FIXME: Add a mechanism to pass along the depth count when doing this so that we can limit stack usage.
-    auto numberParsingState = CSS::PropertyParserState { .context = state.propertyParserState.context };
+    auto numberParsingState = CSS::PropertyParserState { .context = state.propertyParserState.context, .pool = state.propertyParserState.pool };
     auto number = CSSPropertyParserHelpers::MetaConsumer<CSS::Number<CSS::ClosedUnitRange>>::consume(tokens, numberParsingState);
     if (!number)
         return { };

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp
@@ -869,9 +869,9 @@ RefPtr<CSSValue> consumeColor(CSSParserTokenRange& range, CSS::PropertyParserSta
         if (auto keyword = color->keyword())
             return CSSPrimitiveValue::create(keyword->valueID);
         if (auto hex = color->hex())
-            return CSSValuePool::singleton().createColorValue(Color { hex->value });
+            return propertyParserState.pool.createColorValue(Color { hex->value });
         if (auto resolved = color->resolved())
-            return CSSValuePool::singleton().createColorValue(WTFMove(resolved->value));
+            return propertyParserState.pool.createColorValue(WTFMove(resolved->value));
 
         return CSSColorValue::create(WTFMove(*color));
     }
@@ -892,7 +892,7 @@ Color consumeColorRaw(CSSParserTokenRange& range, CSS::PropertyParserState& prop
 
 // MARK: - Raw parsing entry points
 
-Color parseColorRawSlow(const String& string, const CSSParserContext& context, const CSSColorParsingOptions& options, CSS::PlatformColorResolutionState& eagerResolutionState)
+Color parseColorRawSlow(const String& string, const CSSParserContext& context, ScriptExecutionContext& scriptExecutionContext, const CSSColorParsingOptions& options, CSS::PlatformColorResolutionState& eagerResolutionState)
 {
     CSSTokenizer tokenizer(string);
     CSSParserTokenRange range(tokenizer.tokenRange());
@@ -900,7 +900,7 @@ Color parseColorRawSlow(const String& string, const CSSParserContext& context, c
     // Handle leading whitespace.
     range.consumeWhitespace();
 
-    auto state = CSS::PropertyParserState { .context = context };
+    auto state = CSS::PropertyParserState { .context = context, .pool = scriptExecutionContext.cssValuePool() };
     auto result = consumeUnresolvedColor(range, state, options);
 
     // Handle trailing whitespace.

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.h
@@ -35,6 +35,7 @@ namespace WebCore {
 class Color;
 class CSSParserTokenRange;
 class CSSValue;
+class ScriptExecutionContext;
 struct CSSParserContext;
 enum CSSValueID : uint16_t;
 
@@ -65,10 +66,10 @@ RefPtr<CSSValue> consumeColor(CSSParserTokenRange&, CSS::PropertyParserState&, c
 WebCore::Color consumeColorRaw(CSSParserTokenRange&, CSS::PropertyParserState&, const CSSColorParsingOptions&, CSS::PlatformColorResolutionState&);
 
 // MARK: <color> parsing (raw)
-WEBCORE_EXPORT WebCore::Color parseColorRawSlow(const String&, const CSSParserContext&, const CSSColorParsingOptions&, CSS::PlatformColorResolutionState&);
+WEBCORE_EXPORT WebCore::Color parseColorRawSlow(const String&, const CSSParserContext&, ScriptExecutionContext&, const CSSColorParsingOptions&, CSS::PlatformColorResolutionState&);
 
 // NOTE: Callers must include CSSPropertyParserConsumer+ColorInlines.h to use this.
-template<typename F> WebCore::Color parseColorRaw(const String&, const CSSParserContext&, NOESCAPE const F& lazySlowPathOptionsFunctor);
+template<typename F> WebCore::Color parseColorRaw(const String&, const CSSParserContext&, ScriptExecutionContext&, NOESCAPE const F& lazySlowPathOptionsFunctor);
 
 // FIXME: All callers are not getting the right Settings, keyword resolution and calc resolution
 // when using this function and should switch to parseColorRaw().

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorInlines.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorInlines.h
@@ -33,7 +33,7 @@ namespace CSSPropertyParserHelpers {
 
 // MARK: <color> parsing (raw)
 
-template<typename F> WebCore::Color parseColorRaw(const String& string, const CSSParserContext& context, NOESCAPE const F& lazySlowPathOptionsFunctor)
+template<typename F> WebCore::Color parseColorRaw(const String& string, const CSSParserContext& context, ScriptExecutionContext& scriptExecutionContext, NOESCAPE const F& lazySlowPathOptionsFunctor)
 {
     if (auto color = CSSParserFastPaths::parseSimpleColor(string, context))
         return *color;
@@ -47,7 +47,7 @@ template<typename F> WebCore::Color parseColorRaw(const String& string, const CS
     if (eagerResolutionDelegate)
         eagerResolutionState.delegate = &eagerResolutionDelegate.value();
 
-    return parseColorRawSlow(string, context, options, eagerResolutionState);
+    return parseColorRawSlow(string, context, scriptExecutionContext, options, eagerResolutionState);
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
@@ -288,12 +288,12 @@ static std::optional<CSSValueID> consumeGenericFamilyUnresolved(CSSParserTokenRa
     return consumeIdentRaw<CSSValueSerif, CSSValueSansSerif, CSSValueCursive, CSSValueFantasy, CSSValueMonospace, CSSValueWebkitBody, CSSValueWebkitPictograph, CSSValueSystemUi>(range);
 }
 
-static RefPtr<CSSValue> consumeGenericFamily(CSSParserTokenRange& range)
+static RefPtr<CSSValue> consumeGenericFamily(CSSParserTokenRange& range, CSS::PropertyParserState& state)
 {
     if (auto familyName = consumeGenericFamilyUnresolved(range)) {
         // FIXME: Remove special case for system-ui.
         if (*familyName == CSSValueSystemUi)
-            return CSSValuePool::singleton().createFontFamilyValue(nameString(*familyName));
+            return state.pool.createFontFamilyValue(nameString(*familyName));
         return CSSPrimitiveValue::create(*familyName);
     }
     return nullptr;
@@ -318,14 +318,14 @@ static std::optional<UnresolvedFontFamily> consumeFontFamilyUnresolved(CSSParser
     return list;
 }
 
-RefPtr<CSSValue> consumeFamilyName(CSSParserTokenRange& range, CSS::PropertyParserState&)
+RefPtr<CSSValue> consumeFamilyName(CSSParserTokenRange& range, CSS::PropertyParserState& state)
 {
     // https://drafts.csswg.org/css-fonts-4/#family-name-syntax
 
     auto familyName = consumeFamilyNameUnresolved(range);
     if (familyName.isNull())
         return nullptr;
-    return CSSValuePool::singleton().createFontFamilyValue(familyName);
+    return state.pool.createFontFamilyValue(familyName);
 }
 
 RefPtr<CSSValue> consumeFontFamily(CSSParserTokenRange& range, CSS::PropertyParserState& state)
@@ -334,7 +334,7 @@ RefPtr<CSSValue> consumeFontFamily(CSSParserTokenRange& range, CSS::PropertyPars
     // https://drafts.csswg.org/css-fonts-4/#font-family-prop
 
     return consumeListSeparatedBy<',', OneOrMore>(range, [&](auto& range) -> RefPtr<CSSValue> {
-        if (auto parsedValue = consumeGenericFamily(range))
+        if (auto parsedValue = consumeGenericFamily(range, state))
             return parsedValue;
         return consumeFamilyName(range, state);
     });
@@ -458,14 +458,15 @@ static std::optional<UnresolvedFont> consumeUnresolvedFont(CSSParserTokenRange& 
     };
 }
 
-std::optional<UnresolvedFont> parseUnresolvedFont(const String& string, const CSSParserContext& parserContext)
+std::optional<UnresolvedFont> parseUnresolvedFont(const String& string, ScriptExecutionContext& context, std::optional<CSSParserMode> parserModeOverride)
 {
+    auto parserContext = CSSParserContext(parserModeOverride ? *parserModeOverride : parserMode(context));
     auto tokenizer = CSSTokenizer(string);
     auto range = tokenizer.tokenRange();
 
     range.consumeWhitespace();
 
-    auto state = CSS::PropertyParserState { .context = parserContext };
+    auto state = CSS::PropertyParserState { .context = parserContext, .pool = context.cssValuePool() };
     return consumeUnresolvedFont(range, state);
 }
 
@@ -492,21 +493,27 @@ RefPtr<CSSValue> consumeFontSizeAdjust(CSSParserTokenRange& range, CSS::Property
 // MARK: - @font-face
 
 // MARK: @font-face 'font-family'
-RefPtr<CSSValue> consumeFontFaceFontFamily(CSSParserTokenRange& range, CSS::PropertyParserState& state)
+
+RefPtr<CSSValue> parseFontFaceFontFamily(const String& string, ScriptExecutionContext& context)
 {
     // <'font-family'> = <family-name>
     // https://drafts.csswg.org/css-fonts-4/#descdef-font-face-font-family
 
-    auto name = consumeFamilyName(range, state);
-    if (!name || !range.atEnd())
+    CSSParserContext parserContext(parserMode(context));
+    CSSParser parser(parserContext, string);
+    CSSParserTokenRange range = parser.tokenizer()->tokenRange();
+
+    range.consumeWhitespace();
+
+    if (range.atEnd())
         return nullptr;
 
-    // FIXME-NEWPARSER: https://bugs.webkit.org/show_bug.cgi?id=196381 For compatibility with the old parser, we have to make
-    // a list here, even though the list always contains only a single family name.
-    // Once the old parser is gone, we can delete this function, make the caller
-    // use consumeFamilyName instead, and then patch the @font-face code to
-    // not expect a list with a single name in it.
-    return CSSValueList::createCommaSeparated(name.releaseNonNull());
+    auto state = CSS::PropertyParserState { .context = parserContext, .pool = context.cssValuePool() };
+    auto parsedValue = CSSPropertyParsing::consumeFontFaceFontFamily(range, state);
+    if (!parsedValue || !range.atEnd())
+        return nullptr;
+
+    return parsedValue;
 }
 
 // MARK: @font-face 'src'
@@ -665,7 +672,7 @@ RefPtr<CSSValueList> parseFontFaceSrc(const String& string, ScriptExecutionConte
     if (range.atEnd())
         return nullptr;
 
-    auto state = CSS::PropertyParserState { .context = parserContext };
+    auto state = CSS::PropertyParserState { .context = parserContext, .pool = context.cssValuePool() };
     auto parsedValue = consumeFontFaceSrc(range, state);
     if (!parsedValue || !range.atEnd())
         return nullptr;
@@ -689,7 +696,7 @@ RefPtr<CSSValue> parseFontFaceSizeAdjust(const String& string, ScriptExecutionCo
     if (range.atEnd())
         return nullptr;
 
-    auto state = CSS::PropertyParserState { .context = parserContext };
+    auto state = CSS::PropertyParserState { .context = parserContext, .pool = context.cssValuePool() };
     auto parsedValue = CSSPropertyParsing::consumeFontFaceSizeAdjust(range, state);
     if (!parsedValue || !range.atEnd())
         return nullptr;
@@ -761,7 +768,7 @@ RefPtr<CSSValue> parseFontFaceFontStyle(const String& string, ScriptExecutionCon
     if (range.atEnd())
         return nullptr;
 
-    auto state = CSS::PropertyParserState { .context = parserContext };
+    auto state = CSS::PropertyParserState { .context = parserContext, .pool = context.cssValuePool() };
     auto parsedValue = consumeFontFaceFontStyle(range, state);
     if (!parsedValue || !range.atEnd())
         return nullptr;
@@ -894,7 +901,7 @@ RefPtr<CSSValue> parseFontFaceFeatureSettings(const String& string, ScriptExecut
     if (range.atEnd())
         return nullptr;
 
-    auto state = CSS::PropertyParserState { .context = parserContext };
+    auto state = CSS::PropertyParserState { .context = parserContext, .pool = context.cssValuePool() };
     auto parsedValue = CSSPropertyParsing::consumeFontFeatureSettings(range, state);
     if (!parsedValue || !range.atEnd())
         return nullptr;
@@ -940,7 +947,7 @@ RefPtr<CSSValue> parseFontFaceFontWidth(const String& string, ScriptExecutionCon
     if (range.atEnd())
         return nullptr;
 
-    auto state = CSS::PropertyParserState { .context = parserContext };
+    auto state = CSS::PropertyParserState { .context = parserContext, .pool = context.cssValuePool() };
     auto parsedValue = CSSPropertyParsing::consumeFontFaceFontWidth(range, state);
     if (!parsedValue || !range.atEnd())
         return nullptr;
@@ -964,7 +971,7 @@ RefPtr<CSSValue> parseFontFaceFontWeight(const String& string, ScriptExecutionCo
     if (range.atEnd())
         return nullptr;
 
-    auto state = CSS::PropertyParserState { .context = parserContext };
+    auto state = CSS::PropertyParserState { .context = parserContext, .pool = context.cssValuePool() };
     auto parsedValue = CSSPropertyParsing::consumeFontFaceFontWeight(range, state);
     if (!parsedValue || !range.atEnd())
         return nullptr;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h
@@ -99,7 +99,7 @@ struct UnresolvedFont {
 
 // MARK: 'font' (shorthand)
 // https://drafts.csswg.org/css-fonts-4/#font-prop
-std::optional<UnresolvedFont> parseUnresolvedFont(const String&, const CSSParserContext&);
+std::optional<UnresolvedFont> parseUnresolvedFont(const String&, ScriptExecutionContext&, std::optional<CSSParserMode> parserModeOverride = std::nullopt);
 
 // MARK: 'font-style'
 // https://drafts.csswg.org/css-fonts-4/#font-style-prop
@@ -124,7 +124,7 @@ RefPtr<CSSValue> consumeFontSizeAdjust(CSSParserTokenRange&, CSS::PropertyParser
 
 // MARK: @font-face 'font-family'
 // https://drafts.csswg.org/css-fonts-4/#font-family-desc
-RefPtr<CSSValue> consumeFontFaceFontFamily(CSSParserTokenRange&, CSS::PropertyParserState&);
+RefPtr<CSSValue> parseFontFaceFontFamily(const String&, ScriptExecutionContext&);
 
 // MARK: @font-face 'src'
 // https://drafts.csswg.org/css-fonts-4/#src-desc

--- a/Source/WebCore/css/parser/CSSPropertyParserState.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserState.h
@@ -26,6 +26,7 @@
 
 #include "CSSProperty.h"
 #include "CSSPropertyNames.h"
+#include "CSSValuePool.h"
 #include "StyleRuleType.h"
 
 namespace WebCore {
@@ -36,6 +37,7 @@ namespace CSS {
 
 struct PropertyParserState {
     const CSSParserContext& context;
+    CSSValuePool& pool { CSSValuePool::singleton() };
 
     StyleRuleType currentRule { StyleRuleType::Style };
     CSSPropertyID currentProperty { CSSPropertyInvalid };

--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -107,9 +107,10 @@ static std::optional<Color> parseColorValue(StringView string, HTMLInputElement&
     if (context.colorSpace().isNull())
         return parseSimpleColorValue(string);
 
-    auto parserContext = context.protectedDocument()->cssParserContext();
+    auto document = context.protectedDocument();
+    auto parserContext = document->cssParserContext();
     parserContext.mode = HTMLStandardMode;
-    auto color = CSSPropertyParserHelpers::parseColorRaw(string.toString(), parserContext, [] {
+    auto color = CSSPropertyParserHelpers::parseColorRaw(string.toString(), parserContext, document, [] {
         return colorParsingParameters();
     });
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -184,9 +184,11 @@ void CanvasRenderingContext2D::setFontWithoutUpdatingStyle(const String& newFont
     if (newFont == state().unparsedFont && state().font.realized())
         return;
 
+    auto& document = canvas().document();
+
     // According to http://lists.w3.org/Archives/Public/public-html/2009Jul/0947.html,
     // the "inherit" and "initial" values must be ignored. CSSPropertyParserHelpers::parseUnresolvedFont() ignores these.
-    auto unresolvedFont = CSSPropertyParserHelpers::parseUnresolvedFont(newFont, strictToCSSParserMode(!usesCSSCompatibilityParseMode()));
+    auto unresolvedFont = CSSPropertyParserHelpers::parseUnresolvedFont(newFont, document, strictToCSSParserMode(!usesCSSCompatibilityParseMode()));
     if (!unresolvedFont)
         return;
 
@@ -202,7 +204,6 @@ void CanvasRenderingContext2D::setFontWithoutUpdatingStyle(const String& newFont
 
     // Map the <canvas> font into the text style. If the font uses keywords like larger/smaller, these will work
     // relative to the canvas.
-    Document& document = canvas().document();
     auto fontCascade = Style::resolveForUnresolvedFont(*unresolvedFont, WTFMove(fontDescription), document);
     if (!fontCascade)
         return;

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -3177,9 +3177,7 @@ void CanvasRenderingContext2DBase::setLetterSpacing(const String& letterSpacing)
     tokenRange.consumeWhitespace();
 
     auto parserContext = CSSParserContext { HTMLStandardMode };
-    auto parserState = CSS::PropertyParserState {
-        .context = parserContext,
-    };
+    auto parserState = CSS::PropertyParserState { .context = parserContext, .pool = canvasBase().scriptExecutionContext()->cssValuePool() };
 
     auto parsedValue = CSSPropertyParserHelpers::MetaConsumer<CSS::Length<>>::consume(tokenRange, parserState);
     if (!parsedValue)
@@ -3207,9 +3205,7 @@ void CanvasRenderingContext2DBase::setWordSpacing(const String& wordSpacing)
     tokenRange.consumeWhitespace();
 
     auto parserContext = CSSParserContext { HTMLStandardMode };
-    auto parserState = CSS::PropertyParserState {
-        .context = parserContext,
-    };
+    auto parserState = CSS::PropertyParserState { .context = parserContext, .pool = canvasBase().scriptExecutionContext()->cssValuePool() };
 
     auto parsedValue = CSSPropertyParserHelpers::MetaConsumer<CSS::Length<>>::consume(tokenRange, parserState);
     if (!parsedValue)

--- a/Source/WebCore/html/canvas/CanvasStyle.cpp
+++ b/Source/WebCore/html/canvas/CanvasStyle.cpp
@@ -71,7 +71,7 @@ Color CanvasStyleColorResolutionDelegate::currentColor() const
         return Color::black;
 
     auto colorString = m_canvasElement->inlineStyle()->getPropertyValue(CSSPropertyColor);
-    auto color = CSSPropertyParserHelpers::parseColorRaw(WTFMove(colorString), m_canvasElement->cssParserContext(), [] {
+    auto color = CSSPropertyParserHelpers::parseColorRaw(WTFMove(colorString), m_canvasElement->cssParserContext(), m_canvasElement->document(), [] {
         return LazySlowPathColorParsingParameters { { }, { }, std::nullopt };
     });
     if (!color.isValid())
@@ -118,7 +118,7 @@ static LazySlowPathColorParsingParameters colorParsingParameters(CanvasBase& can
 
 Color parseColor(const String& colorString, CanvasBase& canvasBase)
 {
-    return CSSPropertyParserHelpers::parseColorRaw(colorString, canvasBase.cssParserContext(), [&] {
+    return CSSPropertyParserHelpers::parseColorRaw(colorString, canvasBase.cssParserContext(), *canvasBase.scriptExecutionContext(), [&] {
         return colorParsingParameters(canvasBase);
     });
 }
@@ -128,7 +128,7 @@ Color parseColor(const String& colorString, ScriptExecutionContext& scriptExecut
     // FIXME: Add constructor for CSSParserContext that takes a ScriptExecutionContext to allow preferences to be
     //        checked correctly.
 
-    return CSSPropertyParserHelpers::parseColorRaw(colorString, CSSParserContext(HTMLStandardMode), [&] {
+    return CSSPropertyParserHelpers::parseColorRaw(colorString, CSSParserContext(HTMLStandardMode), scriptExecutionContext, [&] {
         return elementlessColorParsingParameters(&scriptExecutionContext);
     });
 }

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
@@ -101,7 +101,7 @@ void OffscreenCanvasRenderingContext2D::setFont(const String& newFont)
 
     // According to http://lists.w3.org/Archives/Public/public-html/2009Jul/0947.html,
     // the "inherit" and "initial" values must be ignored. CSSPropertyParserHelpers::parseFont() ignores these.
-    auto unresolvedFont = CSSPropertyParserHelpers::parseUnresolvedFont(newFont, strictToCSSParserMode(!usesCSSCompatibilityParseMode()));
+    auto unresolvedFont = CSSPropertyParserHelpers::parseUnresolvedFont(newFont, context, strictToCSSParserMode(!usesCSSCompatibilityParseMode()));
     if (!unresolvedFont)
         return;
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2300,7 +2300,7 @@ ExceptionOr<void> Internals::setUnderPageBackgroundColorOverride(const String& c
     if (!document || !document->page())
         return Exception { ExceptionCode::InvalidAccessError };
 
-    auto color = CSSPropertyParserHelpers::parseColorRaw(colorValue, document->cssParserContext(), [] {
+    auto color = CSSPropertyParserHelpers::parseColorRaw(colorValue, document->cssParserContext(), *document, [] {
         return LazySlowPathColorParsingParameters { { }, { }, std::nullopt };
     });
     if (!color.isValid())


### PR DESCRIPTION
#### 10a58951bcbd6b83478fd5798c22eaf8ec5e62dc
<pre>
@font-face `font-family` descriptor should not allow a list of values
<a href="https://bugs.webkit.org/show_bug.cgi?id=196381">https://bugs.webkit.org/show_bug.cgi?id=196381</a>
<a href="https://rdar.apple.com/142009630">rdar://142009630</a>

Reviewed by Darin Adler.

Updates @font-face&apos;s `font-family` descriptor consistently use a since CSSValue
rather than a CSSValueList with a single element as its representation.

Also requires piping a CSSValuePool in CSS::PropertyParserState so that worker
uses of parsing functions don&apos;t use the main thread only default pool.

* LayoutTests/fast/text/font-face-empty-string-expected.txt:
* LayoutTests/fast/text/font-face-empty-string.html:
* LayoutTests/fast/text/font-face-family-expected.txt:
* LayoutTests/fast/text/font-face-family.html:
    - Update tests/results to match the Font Loading spec which
      states that the normal grammar should be used for font-family.

* Source/WebCore/css/CSSFontFace.cpp:
* Source/WebCore/css/CSSFontFace.h:
* Source/WebCore/css/CSSFontFaceSet.cpp:
* Source/WebCore/css/CSSFontFaceSet.h:
* Source/WebCore/css/CSSFontSelector.cpp:
* Source/WebCore/css/FontFace.cpp:
    - Switch to use single &quot;family&quot; rather than &quot;families&quot;.

* Source/WebCore/css/CSSProperties.json:
    - Switch to using a generated parser.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h:
(WebCore::CSSPropertyParserHelpers::parseFontFaceFontFamily):
(WebCore::CSSPropertyParserHelpers::consumeFontFaceFontFamily): Deleted.
    - Remove hand rolled consume function, but adds &quot;parse&quot; version
      to match other font-face descriptors for use by the FontFace class.

* Source/WebCore/svg/SVGFontFaceElement.cpp:
(WebCore::SVGFontFaceElement::attributeChanged):
    - Set a rule type on the CSSParserContext to make setProperty() call
      the right parsing function.

* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp:
* Source/WebCore/css/parser/CSSPropertyParserState.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp:
    - Update to pass the appropriate CSSValuePool to the parser.

Canonical link: <a href="https://commits.webkit.org/293891@main">https://commits.webkit.org/293891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b515e993d781f16a1da6ae4277642f9d9f99e728

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105326 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50778 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28318 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76276 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33336 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103203 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15404 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90498 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56637 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15222 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8496 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50147 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85128 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8579 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107685 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27309 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20007 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85229 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27672 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86705 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84768 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21544 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29446 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7181 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21164 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27246 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32479 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27057 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30373 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28616 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->