### PR TITLE
Drop AtomString's `operator NSString *()`

### DIFF
--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -114,9 +114,6 @@ public:
 #if USE(FOUNDATION) && defined(__OBJC__)
     AtomString(NSString *);
     RetainPtr<NSString> createNSString() const { return m_string.createNSString(); }
-
-    // FIXME: remove this operator and port call sites to createNSString().
-    operator NSString *() const { return m_string.createNSString().autorelease(); }
 #endif
 
 #if OS(WINDOWS)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -820,12 +820,12 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     m_requestLicenseCallback = WTFMove(callback);
 
     if (m_group) {
-        auto* options = @{ ContentKeyReportGroupKey: m_group.get(), InitializationDataTypeKey: (NSString*)initDataType };
+        auto* options = @{ ContentKeyReportGroupKey: m_group.get(), InitializationDataTypeKey: initDataType.createNSString().get() };
         [m_group processContentKeyRequestWithIdentifier:identifier.get() initializationData:initializationData.get() options:options];
         return;
     }
 
-    auto* options = @{ InitializationDataTypeKey: (NSString*)initDataType };
+    auto* options = @{ InitializationDataTypeKey: initDataType.createNSString().get() };
     [m_session processContentKeyRequestWithIdentifier:identifier.get() initializationData:initializationData.get() options:options];
 }
 

--- a/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
+++ b/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
@@ -40,6 +40,7 @@
 #import <wtf/Language.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/TZoneMallocInlines.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/AtomStringHash.h>
 #import "LocalizedDateCache.h"
@@ -70,7 +71,7 @@ static RetainPtr<NSDateFormatter> createDateTimeFormatter(NSLocale* locale, NSCa
 }
 
 LocaleCocoa::LocaleCocoa(const AtomString& locale)
-    : m_locale(adoptNS([[NSLocale alloc] initWithLocaleIdentifier:locale]))
+    : m_locale(adoptNS([[NSLocale alloc] initWithLocaleIdentifier:locale.createNSString().get()]))
     , m_gregorianCalendar(adoptNS([[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian]))
     , m_didInitializeNumberData(false)
 {
@@ -292,7 +293,7 @@ RetainPtr<CFStringRef> LocaleCocoa::canonicalLanguageIdentifierFromString(const 
     if (cache.m_key == string)
         return cache.m_value;
     auto result = cache.m_map.ensure(string, [&] {
-        return (__bridge CFStringRef)[NSLocale canonicalLanguageIdentifierFromString:string];
+        return bridge_cast([NSLocale canonicalLanguageIdentifierFromString:string.createNSString().get()]);
     }).iterator->value;
     cache.m_key = string;
     cache.m_value = result;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -15724,7 +15724,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         }
     );
 
-    [range setFrameIdentifier:webRange.frameIdentifier];
+    [range setFrameIdentifier:webRange.frameIdentifier.createNSString().get()];
     [range setOrder:webRange.order];
     return range.autorelease();
 }

--- a/Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm
@@ -238,7 +238,7 @@ void WebDateTimePickerMac::didChooseDate(StringView date)
 
     RetainPtr currentDateValueString = _params.currentValue.createNSString();
 
-    RetainPtr<NSString> format = [self dateFormatStringForType:_params.type];
+    RetainPtr<NSString> format = [self dateFormatStringForType:_params.type.createNSString().get()];
     [_dateFormatter setDateFormat:format.get()];
 
     if (![currentDateValueString length])

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMElement.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMElement.mm
@@ -38,7 +38,7 @@
 
 - (NSString *)getAttribute:(NSString *)attribute
 {
-    return downcast<WebCore::Element>(*_impl).getAttribute(attribute);
+    return downcast<WebCore::Element>(*_impl).getAttribute(attribute).createNSString().autorelease();
 }
 
 - (void)setAttribute:(NSString *)name value:(NSString *)value

--- a/Source/WebKitLegacy/mac/DOM/DOM.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOM.mm
@@ -394,7 +394,7 @@ id <DOMEventTarget> kit(EventTarget* target)
     auto* link = [self _linkElement];
     if (!link)
         return nil;
-    return link->getAttribute(HTMLNames::targetAttr);
+    return link->getAttribute(HTMLNames::targetAttr).createNSString().autorelease();
 }
 
 - (CGRect)hrefFrame

--- a/Source/WebKitLegacy/mac/DOM/DOMCustomXPathNSResolver.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMCustomXPathNSResolver.mm
@@ -42,7 +42,7 @@ AtomString DOMCustomXPathNSResolver::lookupNamespaceURI(const AtomString& prefix
     NSString *namespaceURI = nil;
     
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    namespaceURI = [m_customResolver lookupNamespaceURI:prefix];
+    namespaceURI = [m_customResolver lookupNamespaceURI:prefix.createNSString().get()];
     END_BLOCK_OBJC_EXCEPTIONS
     
     return namespaceURI;

--- a/Source/WebKitLegacy/mac/DOM/DOMEvent.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMEvent.mm
@@ -55,7 +55,7 @@
 - (NSString *)type
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->type();
+    return IMPL->type().createNSString().autorelease();
 }
 
 - (id <DOMEventTarget>)target

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLAnchorElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLAnchorElement.mm
@@ -45,7 +45,7 @@
 - (NSString *)charset
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::charsetAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::charsetAttr).createNSString().autorelease();
 }
 
 - (void)setCharset:(NSString *)newCharset
@@ -57,7 +57,7 @@
 - (NSString *)coords
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::coordsAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::coordsAttr).createNSString().autorelease();
 }
 
 - (void)setCoords:(NSString *)newCoords
@@ -69,7 +69,7 @@
 - (NSString *)download
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::downloadAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::downloadAttr).createNSString().autorelease();
 }
 
 - (void)setDownload:(NSString *)newDownload
@@ -81,7 +81,7 @@
 - (NSString *)hreflang
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::hreflangAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::hreflangAttr).createNSString().autorelease();
 }
 
 - (void)setHreflang:(NSString *)newHreflang
@@ -93,7 +93,7 @@
 - (NSString *)name
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getNameAttribute();
+    return IMPL->getNameAttribute().createNSString().autorelease();
 }
 
 - (void)setName:(NSString *)newName
@@ -105,7 +105,7 @@
 - (NSString *)ping
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::pingAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::pingAttr).createNSString().autorelease();
 }
 
 - (void)setPing:(NSString *)newPing
@@ -117,7 +117,7 @@
 - (NSString *)rel
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::relAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::relAttr).createNSString().autorelease();
 }
 
 - (void)setRel:(NSString *)newRel
@@ -129,7 +129,7 @@
 - (NSString *)rev
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::revAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::revAttr).createNSString().autorelease();
 }
 
 - (void)setRev:(NSString *)newRev
@@ -141,7 +141,7 @@
 - (NSString *)shape
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::shapeAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::shapeAttr).createNSString().autorelease();
 }
 
 - (void)setShape:(NSString *)newShape
@@ -153,7 +153,7 @@
 - (NSString *)target
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::targetAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::targetAttr).createNSString().autorelease();
 }
 
 - (void)setTarget:(NSString *)newTarget
@@ -165,7 +165,7 @@
 - (NSString *)type
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::typeAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::typeAttr).createNSString().autorelease();
 }
 
 - (void)setType:(NSString *)newType
@@ -177,7 +177,7 @@
 - (NSString *)accessKey
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::accesskeyAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::accesskeyAttr).createNSString().autorelease();
 }
 
 - (void)setAccessKey:(NSString *)newAccessKey

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLAreaElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLAreaElement.mm
@@ -46,7 +46,7 @@
 - (NSString *)alt
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::altAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::altAttr).createNSString().autorelease();
 }
 
 - (void)setAlt:(NSString *)newAlt
@@ -58,7 +58,7 @@
 - (NSString *)coords
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::coordsAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::coordsAttr).createNSString().autorelease();
 }
 
 - (void)setCoords:(NSString *)newCoords
@@ -82,7 +82,7 @@
 - (NSString *)ping
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::pingAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::pingAttr).createNSString().autorelease();
 }
 
 - (void)setPing:(NSString *)newPing
@@ -94,7 +94,7 @@
 - (NSString *)rel
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::relAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::relAttr).createNSString().autorelease();
 }
 
 - (void)setRel:(NSString *)newRel
@@ -106,7 +106,7 @@
 - (NSString *)shape
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::shapeAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::shapeAttr).createNSString().autorelease();
 }
 
 - (void)setShape:(NSString *)newShape
@@ -118,7 +118,7 @@
 - (NSString *)target
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::targetAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::targetAttr).createNSString().autorelease();
 }
 
 - (void)setTarget:(NSString *)newTarget
@@ -130,7 +130,7 @@
 - (NSString *)accessKey
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::accesskeyAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::accesskeyAttr).createNSString().autorelease();
 }
 
 - (void)setAccessKey:(NSString *)newAccessKey

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLBRElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLBRElement.mm
@@ -42,7 +42,7 @@
 - (NSString *)clear
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::clearAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::clearAttr).createNSString().autorelease();
 }
 
 - (void)setClear:(NSString *)newClear

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLBaseElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLBaseElement.mm
@@ -54,7 +54,7 @@
 - (NSString *)target
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::targetAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::targetAttr).createNSString().autorelease();
 }
 
 - (void)setTarget:(NSString *)newTarget

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLBaseFontElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLBaseFontElement.mm
@@ -42,7 +42,7 @@
 - (NSString *)color
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::colorAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::colorAttr).createNSString().autorelease();
 }
 
 - (void)setColor:(NSString *)newColor
@@ -54,7 +54,7 @@
 - (NSString *)face
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::faceAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::faceAttr).createNSString().autorelease();
 }
 
 - (void)setFace:(NSString *)newFace
@@ -66,7 +66,7 @@
 - (NSString *)size
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::sizeAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::sizeAttr).createNSString().autorelease();
 }
 
 - (void)setSize:(NSString *)newSize

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLBodyElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLBodyElement.mm
@@ -42,7 +42,7 @@
 - (NSString *)aLink
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::alinkAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::alinkAttr).createNSString().autorelease();
 }
 
 - (void)setALink:(NSString *)newALink
@@ -54,7 +54,7 @@
 - (NSString *)background
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::backgroundAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::backgroundAttr).createNSString().autorelease();
 }
 
 - (void)setBackground:(NSString *)newBackground
@@ -66,7 +66,7 @@
 - (NSString *)bgColor
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::bgcolorAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::bgcolorAttr).createNSString().autorelease();
 }
 
 - (void)setBgColor:(NSString *)newBgColor
@@ -78,7 +78,7 @@
 - (NSString *)link
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::linkAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::linkAttr).createNSString().autorelease();
 }
 
 - (void)setLink:(NSString *)newLink
@@ -90,7 +90,7 @@
 - (NSString *)text
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::textAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::textAttr).createNSString().autorelease();
 }
 
 - (void)setText:(NSString *)newText
@@ -102,7 +102,7 @@
 - (NSString *)vLink
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::vlinkAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::vlinkAttr).createNSString().autorelease();
 }
 
 - (void)setVLink:(NSString *)newVLink

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLButtonElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLButtonElement.mm
@@ -77,7 +77,7 @@
 - (NSString *)type
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->type();
+    return IMPL->type().createNSString().autorelease();
 }
 
 - (void)setType:(NSString *)newType
@@ -89,7 +89,7 @@
 - (NSString *)name
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getNameAttribute();
+    return IMPL->getNameAttribute().createNSString().autorelease();
 }
 
 - (void)setName:(NSString *)newName
@@ -101,7 +101,7 @@
 - (NSString *)value
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::valueAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::valueAttr).createNSString().autorelease();
 }
 
 - (void)setValue:(NSString *)newValue
@@ -119,7 +119,7 @@
 - (NSString *)accessKey
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::accesskeyAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::accesskeyAttr).createNSString().autorelease();
 }
 
 - (void)setAccessKey:(NSString *)newAccessKey

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLDivElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLDivElement.mm
@@ -42,7 +42,7 @@
 - (NSString *)align
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr).createNSString().autorelease();
 }
 
 - (void)setAlign:(NSString *)newAlign

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLDocument.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLDocument.mm
@@ -71,7 +71,7 @@
 - (NSString *)dir
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->dir();
+    return IMPL->dir().createNSString().autorelease();
 }
 
 - (void)setDir:(NSString *)newDir

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLElement.mm
@@ -48,7 +48,7 @@
 - (NSString *)title
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::titleAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::titleAttr).createNSString().autorelease();
 }
 
 - (void)setTitle:(NSString *)newTitle
@@ -60,7 +60,7 @@
 - (NSString *)lang
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::langAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::langAttr).createNSString().autorelease();
 }
 
 - (void)setLang:(NSString *)newLang
@@ -84,7 +84,7 @@
 - (NSString *)dir
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->dir();
+    return IMPL->dir().createNSString().autorelease();
 }
 
 - (void)setDir:(NSString *)newDir
@@ -120,7 +120,7 @@
 - (NSString *)webkitdropzone
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::webkitdropzoneAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::webkitdropzoneAttr).createNSString().autorelease();
 }
 
 - (void)setWebkitdropzone:(NSString *)newWebkitdropzone
@@ -144,7 +144,7 @@
 - (NSString *)accessKey
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::accesskeyAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::accesskeyAttr).createNSString().autorelease();
 }
 
 - (void)setAccessKey:(NSString *)newAccessKey
@@ -210,7 +210,7 @@
 - (NSString *)idName
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getIdAttribute();
+    return IMPL->getIdAttribute().createNSString().autorelease();
 }
 
 - (void)setIdName:(NSString *)newIdName
@@ -278,7 +278,7 @@
 - (NSString *)autocapitalize
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->autocapitalize();
+    return IMPL->autocapitalize().createNSString().autorelease();
 }
 
 - (void)setAutocapitalize:(NSString *)newAutocapitalize

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLEmbedElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLEmbedElement.mm
@@ -42,7 +42,7 @@
 - (NSString *)align
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr).createNSString().autorelease();
 }
 
 - (void)setAlign:(NSString *)newAlign
@@ -66,7 +66,7 @@
 - (NSString *)name
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getNameAttribute();
+    return IMPL->getNameAttribute().createNSString().autorelease();
 }
 
 - (void)setName:(NSString *)newName
@@ -90,7 +90,7 @@
 - (NSString *)type
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::typeAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::typeAttr).createNSString().autorelease();
 }
 
 - (void)setType:(NSString *)newType

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLFontElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLFontElement.mm
@@ -42,7 +42,7 @@
 - (NSString *)color
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::colorAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::colorAttr).createNSString().autorelease();
 }
 
 - (void)setColor:(NSString *)newColor
@@ -54,7 +54,7 @@
 - (NSString *)face
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::faceAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::faceAttr).createNSString().autorelease();
 }
 
 - (void)setFace:(NSString *)newFace
@@ -66,7 +66,7 @@
 - (NSString *)size
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::sizeAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::sizeAttr).createNSString().autorelease();
 }
 
 - (void)setSize:(NSString *)newSize

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLFormElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLFormElement.mm
@@ -45,7 +45,7 @@
 - (NSString *)acceptCharset
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::accept_charsetAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::accept_charsetAttr).createNSString().autorelease();
 }
 
 - (void)setAcceptCharset:(NSString *)newAcceptCharset
@@ -69,7 +69,7 @@
 - (NSString *)autocomplete
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->autocomplete();
+    return IMPL->autocomplete().createNSString().autorelease();
 }
 
 - (void)setAutocomplete:(NSString *)newAutocomplete
@@ -117,7 +117,7 @@
 - (NSString *)name
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getNameAttribute();
+    return IMPL->getNameAttribute().createNSString().autorelease();
 }
 
 - (void)setName:(NSString *)newName
@@ -141,7 +141,7 @@
 - (NSString *)target
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::targetAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::targetAttr).createNSString().autorelease();
 }
 
 - (void)setTarget:(NSString *)newTarget

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLFrameElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLFrameElement.mm
@@ -47,7 +47,7 @@
 - (NSString *)frameBorder
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::frameborderAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::frameborderAttr).createNSString().autorelease();
 }
 
 - (void)setFrameBorder:(NSString *)newFrameBorder
@@ -59,7 +59,7 @@
 - (NSString *)longDesc
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::longdescAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::longdescAttr).createNSString().autorelease();
 }
 
 - (void)setLongDesc:(NSString *)newLongDesc
@@ -71,7 +71,7 @@
 - (NSString *)marginHeight
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::marginheightAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::marginheightAttr).createNSString().autorelease();
 }
 
 - (void)setMarginHeight:(NSString *)newMarginHeight
@@ -83,7 +83,7 @@
 - (NSString *)marginWidth
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::marginwidthAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::marginwidthAttr).createNSString().autorelease();
 }
 
 - (void)setMarginWidth:(NSString *)newMarginWidth
@@ -95,7 +95,7 @@
 - (NSString *)name
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getNameAttribute();
+    return IMPL->getNameAttribute().createNSString().autorelease();
 }
 
 - (void)setName:(NSString *)newName
@@ -119,7 +119,7 @@
 - (NSString *)scrolling
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::scrollingAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::scrollingAttr).createNSString().autorelease();
 }
 
 - (void)setScrolling:(NSString *)newScrolling

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLFrameSetElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLFrameSetElement.mm
@@ -42,7 +42,7 @@
 - (NSString *)cols
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::colsAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::colsAttr).createNSString().autorelease();
 }
 
 - (void)setCols:(NSString *)newCols
@@ -54,7 +54,7 @@
 - (NSString *)rows
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::rowsAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::rowsAttr).createNSString().autorelease();
 }
 
 - (void)setRows:(NSString *)newRows

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLHRElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLHRElement.mm
@@ -43,7 +43,7 @@
 - (NSString *)align
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr).createNSString().autorelease();
 }
 
 - (void)setAlign:(NSString *)newAlign
@@ -67,7 +67,7 @@
 - (NSString *)size
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::sizeAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::sizeAttr).createNSString().autorelease();
 }
 
 - (void)setSize:(NSString *)newSize
@@ -79,7 +79,7 @@
 - (NSString *)width
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::widthAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::widthAttr).createNSString().autorelease();
 }
 
 - (void)setWidth:(NSString *)newWidth

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLHeadingElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLHeadingElement.mm
@@ -42,7 +42,7 @@
 - (NSString *)align
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr).createNSString().autorelease();
 }
 
 - (void)setAlign:(NSString *)newAlign

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLHtmlElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLHtmlElement.mm
@@ -42,7 +42,7 @@
 - (NSString *)version
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::versionAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::versionAttr).createNSString().autorelease();
 }
 
 - (void)setVersion:(NSString *)newVersion

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLIFrameElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLIFrameElement.mm
@@ -46,7 +46,7 @@
 - (NSString *)align
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr).createNSString().autorelease();
 }
 
 - (void)setAlign:(NSString *)newAlign
@@ -58,7 +58,7 @@
 - (NSString *)frameBorder
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::frameborderAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::frameborderAttr).createNSString().autorelease();
 }
 
 - (void)setFrameBorder:(NSString *)newFrameBorder
@@ -70,7 +70,7 @@
 - (NSString *)height
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::heightAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::heightAttr).createNSString().autorelease();
 }
 
 - (void)setHeight:(NSString *)newHeight
@@ -82,7 +82,7 @@
 - (NSString *)longDesc
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::longdescAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::longdescAttr).createNSString().autorelease();
 }
 
 - (void)setLongDesc:(NSString *)newLongDesc
@@ -94,7 +94,7 @@
 - (NSString *)marginHeight
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::marginheightAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::marginheightAttr).createNSString().autorelease();
 }
 
 - (void)setMarginHeight:(NSString *)newMarginHeight
@@ -106,7 +106,7 @@
 - (NSString *)marginWidth
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::marginwidthAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::marginwidthAttr).createNSString().autorelease();
 }
 
 - (void)setMarginWidth:(NSString *)newMarginWidth
@@ -118,7 +118,7 @@
 - (NSString *)name
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getNameAttribute();
+    return IMPL->getNameAttribute().createNSString().autorelease();
 }
 
 - (void)setName:(NSString *)newName
@@ -130,7 +130,7 @@
 - (NSString *)sandbox
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::sandboxAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::sandboxAttr).createNSString().autorelease();
 }
 
 - (void)setSandbox:(NSString *)newSandbox
@@ -142,7 +142,7 @@
 - (NSString *)scrolling
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::scrollingAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::scrollingAttr).createNSString().autorelease();
 }
 
 - (void)setScrolling:(NSString *)newScrolling
@@ -178,7 +178,7 @@
 - (NSString *)width
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::widthAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::widthAttr).createNSString().autorelease();
 }
 
 - (void)setWidth:(NSString *)newWidth

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLImageElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLImageElement.mm
@@ -45,7 +45,7 @@
 - (NSString *)name
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getNameAttribute();
+    return IMPL->getNameAttribute().createNSString().autorelease();
 }
 
 - (void)setName:(NSString *)newName
@@ -57,7 +57,7 @@
 - (NSString *)align
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr).createNSString().autorelease();
 }
 
 - (void)setAlign:(NSString *)newAlign
@@ -69,7 +69,7 @@
 - (NSString *)alt
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::altAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::altAttr).createNSString().autorelease();
 }
 
 - (void)setAlt:(NSString *)newAlt
@@ -165,7 +165,7 @@
 - (NSString *)srcset
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::srcsetAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::srcsetAttr).createNSString().autorelease();
 }
 
 - (void)setSrcset:(NSString *)newSrcset
@@ -177,7 +177,7 @@
 - (NSString *)sizes
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::sizesAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::sizesAttr).createNSString().autorelease();
 }
 
 - (void)setSizes:(NSString *)newSizes
@@ -195,7 +195,7 @@
 - (NSString *)useMap
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::usemapAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::usemapAttr).createNSString().autorelease();
 }
 
 - (void)setUseMap:(NSString *)newUseMap

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLInputElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLInputElement.mm
@@ -75,7 +75,7 @@
 - (NSString *)accept
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::acceptAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::acceptAttr).createNSString().autorelease();
 }
 
 - (void)setAccept:(NSString *)newAccept
@@ -87,7 +87,7 @@
 - (NSString *)alt
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::altAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::altAttr).createNSString().autorelease();
 }
 
 - (void)setAlt:(NSString *)newAlt
@@ -147,7 +147,7 @@
 - (NSString *)dirName
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::dirnameAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::dirnameAttr).createNSString().autorelease();
 }
 
 - (void)setDirName:(NSString *)newDirName
@@ -239,7 +239,7 @@
 - (NSString *)formTarget
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::formtargetAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::formtargetAttr).createNSString().autorelease();
 }
 
 - (void)setFormTarget:(NSString *)newFormTarget
@@ -281,7 +281,7 @@
 - (NSString *)max
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::maxAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::maxAttr).createNSString().autorelease();
 }
 
 - (void)setMax:(NSString *)newMax
@@ -305,7 +305,7 @@
 - (NSString *)min
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::minAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::minAttr).createNSString().autorelease();
 }
 
 - (void)setMin:(NSString *)newMin
@@ -329,7 +329,7 @@
 - (NSString *)name
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getNameAttribute();
+    return IMPL->getNameAttribute().createNSString().autorelease();
 }
 
 - (void)setName:(NSString *)newName
@@ -341,7 +341,7 @@
 - (NSString *)pattern
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::patternAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::patternAttr).createNSString().autorelease();
 }
 
 - (void)setPattern:(NSString *)newPattern
@@ -353,7 +353,7 @@
 - (NSString *)placeholder
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::placeholderAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::placeholderAttr).createNSString().autorelease();
 }
 
 - (void)setPlaceholder:(NSString *)newPlaceholder
@@ -413,7 +413,7 @@
 - (NSString *)step
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::stepAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::stepAttr).createNSString().autorelease();
 }
 
 - (void)setStep:(NSString *)newStep
@@ -425,7 +425,7 @@
 - (NSString *)type
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->type();
+    return IMPL->type().createNSString().autorelease();
 }
 
 - (void)setType:(NSString *)newType
@@ -437,7 +437,7 @@
 - (NSString *)defaultValue
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->defaultValue();
+    return IMPL->defaultValue().createNSString().autorelease();
 }
 
 - (void)setDefaultValue:(NSString *)newDefaultValue
@@ -539,7 +539,7 @@
 - (NSString *)selectionDirection
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->selectionDirection();
+    return IMPL->selectionDirection().createNSString().autorelease();
 }
 
 - (void)setSelectionDirection:(NSString *)newSelectionDirection
@@ -551,7 +551,7 @@
 - (NSString *)align
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr).createNSString().autorelease();
 }
 
 - (void)setAlign:(NSString *)newAlign
@@ -563,7 +563,7 @@
 - (NSString *)useMap
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::usemapAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::usemapAttr).createNSString().autorelease();
 }
 
 - (void)setUseMap:(NSString *)newUseMap
@@ -584,7 +584,7 @@
 - (NSString *)accessKey
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::accesskeyAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::accesskeyAttr).createNSString().autorelease();
 }
 
 - (void)setAccessKey:(NSString *)newAccessKey

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLLIElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLLIElement.mm
@@ -42,7 +42,7 @@
 - (NSString *)type
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::typeAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::typeAttr).createNSString().autorelease();
 }
 
 - (void)setType:(NSString *)newType

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLLabelElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLLabelElement.mm
@@ -52,7 +52,7 @@
 - (NSString *)htmlFor
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::forAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::forAttr).createNSString().autorelease();
 }
 
 - (void)setHtmlFor:(NSString *)newHtmlFor
@@ -70,7 +70,7 @@
 - (NSString *)accessKey
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::accesskeyAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::accesskeyAttr).createNSString().autorelease();
 }
 
 - (void)setAccessKey:(NSString *)newAccessKey

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLLegendElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLLegendElement.mm
@@ -50,7 +50,7 @@
 - (NSString *)align
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr).createNSString().autorelease();
 }
 
 - (void)setAlign:(NSString *)newAlign
@@ -62,7 +62,7 @@
 - (NSString *)accessKey
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::accesskeyAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::accesskeyAttr).createNSString().autorelease();
 }
 
 - (void)setAccessKey:(NSString *)newAccessKey

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLLinkElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLLinkElement.mm
@@ -60,7 +60,7 @@
 - (NSString *)charset
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::charsetAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::charsetAttr).createNSString().autorelease();
 }
 
 - (void)setCharset:(NSString *)newCharset
@@ -84,7 +84,7 @@
 - (NSString *)hreflang
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::hreflangAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::hreflangAttr).createNSString().autorelease();
 }
 
 - (void)setHreflang:(NSString *)newHreflang
@@ -96,7 +96,7 @@
 - (NSString *)media
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::mediaAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::mediaAttr).createNSString().autorelease();
 }
 
 - (void)setMedia:(NSString *)newMedia
@@ -108,7 +108,7 @@
 - (NSString *)rel
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::relAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::relAttr).createNSString().autorelease();
 }
 
 - (void)setRel:(NSString *)newRel
@@ -120,7 +120,7 @@
 - (NSString *)rev
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::revAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::revAttr).createNSString().autorelease();
 }
 
 - (void)setRev:(NSString *)newRev
@@ -132,7 +132,7 @@
 - (NSString *)target
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::targetAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::targetAttr).createNSString().autorelease();
 }
 
 - (void)setTarget:(NSString *)newTarget
@@ -144,7 +144,7 @@
 - (NSString *)type
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::typeAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::typeAttr).createNSString().autorelease();
 }
 
 - (void)setType:(NSString *)newType
@@ -156,7 +156,7 @@
 - (NSString *)as
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::asAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::asAttr).createNSString().autorelease();
 }
 
 - (void)setAs:(NSString *)newAs

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLMapElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLMapElement.mm
@@ -50,7 +50,7 @@
 - (NSString *)name
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getNameAttribute();
+    return IMPL->getNameAttribute().createNSString().autorelease();
 }
 
 - (void)setName:(NSString *)newName

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLMarqueeElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLMarqueeElement.mm
@@ -43,7 +43,7 @@
 - (NSString *)behavior
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::behaviorAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::behaviorAttr).createNSString().autorelease();
 }
 
 - (void)setBehavior:(NSString *)newBehavior
@@ -55,7 +55,7 @@
 - (NSString *)bgColor
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::bgcolorAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::bgcolorAttr).createNSString().autorelease();
 }
 
 - (void)setBgColor:(NSString *)newBgColor
@@ -67,7 +67,7 @@
 - (NSString *)direction
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::directionAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::directionAttr).createNSString().autorelease();
 }
 
 - (void)setDirection:(NSString *)newDirection
@@ -79,7 +79,7 @@
 - (NSString *)height
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::heightAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::heightAttr).createNSString().autorelease();
 }
 
 - (void)setHeight:(NSString *)newHeight
@@ -163,7 +163,7 @@
 - (NSString *)width
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::widthAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::widthAttr).createNSString().autorelease();
 }
 
 - (void)setWidth:(NSString *)newWidth

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLMediaElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLMediaElement.mm
@@ -291,7 +291,7 @@
 - (NSString *)mediaGroup
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::mediagroupAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::mediagroupAttr).createNSString().autorelease();
 }
 
 - (void)setMediaGroup:(NSString *)newMediaGroup

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLMetaElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLMetaElement.mm
@@ -42,7 +42,7 @@
 - (NSString *)content
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::contentAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::contentAttr).createNSString().autorelease();
 }
 
 - (void)setContent:(NSString *)newContent
@@ -54,7 +54,7 @@
 - (NSString *)httpEquiv
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::http_equivAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::http_equivAttr).createNSString().autorelease();
 }
 
 - (void)setHttpEquiv:(NSString *)newHttpEquiv
@@ -66,7 +66,7 @@
 - (NSString *)name
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getNameAttribute();
+    return IMPL->getNameAttribute().createNSString().autorelease();
 }
 
 - (void)setName:(NSString *)newName
@@ -78,7 +78,7 @@
 - (NSString *)scheme
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::schemeAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::schemeAttr).createNSString().autorelease();
 }
 
 - (void)setScheme:(NSString *)newScheme

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLModElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLModElement.mm
@@ -54,7 +54,7 @@
 - (NSString *)dateTime
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::datetimeAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::datetimeAttr).createNSString().autorelease();
 }
 
 - (void)setDateTime:(NSString *)newDateTime

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLOListElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLOListElement.mm
@@ -79,7 +79,7 @@
 - (NSString *)type
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::typeAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::typeAttr).createNSString().autorelease();
 }
 
 - (void)setType:(NSString *)newType

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLObjectElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLObjectElement.mm
@@ -55,7 +55,7 @@
 - (NSString *)code
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::codeAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::codeAttr).createNSString().autorelease();
 }
 
 - (void)setCode:(NSString *)newCode
@@ -67,7 +67,7 @@
 - (NSString *)align
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr).createNSString().autorelease();
 }
 
 - (void)setAlign:(NSString *)newAlign
@@ -79,7 +79,7 @@
 - (NSString *)archive
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::archiveAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::archiveAttr).createNSString().autorelease();
 }
 
 - (void)setArchive:(NSString *)newArchive
@@ -91,7 +91,7 @@
 - (NSString *)border
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::borderAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::borderAttr).createNSString().autorelease();
 }
 
 - (void)setBorder:(NSString *)newBorder
@@ -103,7 +103,7 @@
 - (NSString *)codeBase
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::codebaseAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::codebaseAttr).createNSString().autorelease();
 }
 
 - (void)setCodeBase:(NSString *)newCodeBase
@@ -115,7 +115,7 @@
 - (NSString *)codeType
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::codetypeAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::codetypeAttr).createNSString().autorelease();
 }
 
 - (void)setCodeType:(NSString *)newCodeType
@@ -151,7 +151,7 @@
 - (NSString *)height
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::heightAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::heightAttr).createNSString().autorelease();
 }
 
 - (void)setHeight:(NSString *)newHeight
@@ -175,7 +175,7 @@
 - (NSString *)name
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getNameAttribute();
+    return IMPL->getNameAttribute().createNSString().autorelease();
 }
 
 - (void)setName:(NSString *)newName
@@ -187,7 +187,7 @@
 - (NSString *)standby
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::standbyAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::standbyAttr).createNSString().autorelease();
 }
 
 - (void)setStandby:(NSString *)newStandby
@@ -199,7 +199,7 @@
 - (NSString *)type
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::typeAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::typeAttr).createNSString().autorelease();
 }
 
 - (void)setType:(NSString *)newType
@@ -211,7 +211,7 @@
 - (NSString *)useMap
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::usemapAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::usemapAttr).createNSString().autorelease();
 }
 
 - (void)setUseMap:(NSString *)newUseMap
@@ -235,7 +235,7 @@
 - (NSString *)width
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::widthAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::widthAttr).createNSString().autorelease();
 }
 
 - (void)setWidth:(NSString *)newWidth

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLOptGroupElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLOptGroupElement.mm
@@ -55,7 +55,7 @@
 - (NSString *)label
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::labelAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::labelAttr).createNSString().autorelease();
 }
 
 - (void)setLabel:(NSString *)newLabel

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLParagraphElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLParagraphElement.mm
@@ -42,7 +42,7 @@
 - (NSString *)align
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr).createNSString().autorelease();
 }
 
 - (void)setAlign:(NSString *)newAlign

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLParamElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLParamElement.mm
@@ -42,7 +42,7 @@
 - (NSString *)name
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getNameAttribute();
+    return IMPL->getNameAttribute().createNSString().autorelease();
 }
 
 - (void)setName:(NSString *)newName
@@ -54,7 +54,7 @@
 - (NSString *)type
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::typeAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::typeAttr).createNSString().autorelease();
 }
 
 - (void)setType:(NSString *)newType
@@ -66,7 +66,7 @@
 - (NSString *)value
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::valueAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::valueAttr).createNSString().autorelease();
 }
 
 - (void)setValue:(NSString *)newValue
@@ -78,7 +78,7 @@
 - (NSString *)valueType
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::valuetypeAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::valuetypeAttr).createNSString().autorelease();
 }
 
 - (void)setValueType:(NSString *)newValueType

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLScriptElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLScriptElement.mm
@@ -55,7 +55,7 @@
 - (NSString *)htmlFor
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::forAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::forAttr).createNSString().autorelease();
 }
 
 - (void)setHtmlFor:(NSString *)newHtmlFor
@@ -67,7 +67,7 @@
 - (NSString *)event
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::eventAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::eventAttr).createNSString().autorelease();
 }
 
 - (void)setEvent:(NSString *)newEvent
@@ -79,7 +79,7 @@
 - (NSString *)charset
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::charsetAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::charsetAttr).createNSString().autorelease();
 }
 
 - (void)setCharset:(NSString *)newCharset
@@ -127,7 +127,7 @@
 - (NSString *)type
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::typeAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::typeAttr).createNSString().autorelease();
 }
 
 - (void)setType:(NSString *)newType
@@ -151,7 +151,7 @@
 - (NSString *)nonce
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::nonceAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::nonceAttr).createNSString().autorelease();
 }
 
 - (void)setNonce:(NSString *)newNonce

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLSelectElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLSelectElement.mm
@@ -97,7 +97,7 @@
 - (NSString *)name
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getNameAttribute();
+    return IMPL->getNameAttribute().createNSString().autorelease();
 }
 
 - (void)setName:(NSString *)newName
@@ -121,7 +121,7 @@
 - (NSString *)type
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->type();
+    return IMPL->type().createNSString().autorelease();
 }
 
 - (DOMHTMLOptionsCollection *)options

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLStyleElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLStyleElement.mm
@@ -56,7 +56,7 @@
 - (NSString *)media
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::mediaAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::mediaAttr).createNSString().autorelease();
 }
 
 - (void)setMedia:(NSString *)newMedia
@@ -68,7 +68,7 @@
 - (NSString *)type
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::typeAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::typeAttr).createNSString().autorelease();
 }
 
 - (void)setType:(NSString *)newType
@@ -86,7 +86,7 @@
 - (NSString *)nonce
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::nonceAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::nonceAttr).createNSString().autorelease();
 }
 
 - (void)setNonce:(NSString *)newNonce

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLTableCaptionElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLTableCaptionElement.mm
@@ -42,7 +42,7 @@
 - (NSString *)align
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr).createNSString().autorelease();
 }
 
 - (void)setAlign:(NSString *)newAlign

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLTableCellElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLTableCellElement.mm
@@ -49,7 +49,7 @@
 - (NSString *)align
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr).createNSString().autorelease();
 }
 
 - (void)setAlign:(NSString *)newAlign
@@ -61,7 +61,7 @@
 - (NSString *)axis
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::axisAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::axisAttr).createNSString().autorelease();
 }
 
 - (void)setAxis:(NSString *)newAxis
@@ -73,7 +73,7 @@
 - (NSString *)bgColor
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::bgcolorAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::bgcolorAttr).createNSString().autorelease();
 }
 
 - (void)setBgColor:(NSString *)newBgColor
@@ -85,7 +85,7 @@
 - (NSString *)ch
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::charAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::charAttr).createNSString().autorelease();
 }
 
 - (void)setCh:(NSString *)newCh
@@ -97,7 +97,7 @@
 - (NSString *)chOff
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::charoffAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::charoffAttr).createNSString().autorelease();
 }
 
 - (void)setChOff:(NSString *)newChOff
@@ -133,7 +133,7 @@
 - (NSString *)headers
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::headersAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::headersAttr).createNSString().autorelease();
 }
 
 - (void)setHeaders:(NSString *)newHeaders
@@ -145,7 +145,7 @@
 - (NSString *)height
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::heightAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::heightAttr).createNSString().autorelease();
 }
 
 - (void)setHeight:(NSString *)newHeight
@@ -169,7 +169,7 @@
 - (NSString *)vAlign
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::valignAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::valignAttr).createNSString().autorelease();
 }
 
 - (void)setVAlign:(NSString *)newVAlign
@@ -181,7 +181,7 @@
 - (NSString *)width
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::widthAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::widthAttr).createNSString().autorelease();
 }
 
 - (void)setWidth:(NSString *)newWidth
@@ -193,7 +193,7 @@
 - (NSString *)abbr
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::abbrAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::abbrAttr).createNSString().autorelease();
 }
 
 - (void)setAbbr:(NSString *)newAbbr
@@ -205,7 +205,7 @@
 - (NSString *)scope
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->scope();
+    return IMPL->scope().createNSString().autorelease();
 }
 
 - (void)setScope:(NSString *)newScope

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLTableColElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLTableColElement.mm
@@ -42,7 +42,7 @@
 - (NSString *)align
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr).createNSString().autorelease();
 }
 
 - (void)setAlign:(NSString *)newAlign
@@ -54,7 +54,7 @@
 - (NSString *)ch
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::charAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::charAttr).createNSString().autorelease();
 }
 
 - (void)setCh:(NSString *)newCh
@@ -66,7 +66,7 @@
 - (NSString *)chOff
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::charoffAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::charoffAttr).createNSString().autorelease();
 }
 
 - (void)setChOff:(NSString *)newChOff
@@ -90,7 +90,7 @@
 - (NSString *)vAlign
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::valignAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::valignAttr).createNSString().autorelease();
 }
 
 - (void)setVAlign:(NSString *)newVAlign
@@ -102,7 +102,7 @@
 - (NSString *)width
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::widthAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::widthAttr).createNSString().autorelease();
 }
 
 - (void)setWidth:(NSString *)newWidth

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLTableElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLTableElement.mm
@@ -98,7 +98,7 @@
 - (NSString *)align
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr).createNSString().autorelease();
 }
 
 - (void)setAlign:(NSString *)newAlign
@@ -110,7 +110,7 @@
 - (NSString *)bgColor
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::bgcolorAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::bgcolorAttr).createNSString().autorelease();
 }
 
 - (void)setBgColor:(NSString *)newBgColor
@@ -122,7 +122,7 @@
 - (NSString *)border
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::borderAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::borderAttr).createNSString().autorelease();
 }
 
 - (void)setBorder:(NSString *)newBorder
@@ -134,7 +134,7 @@
 - (NSString *)cellPadding
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::cellpaddingAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::cellpaddingAttr).createNSString().autorelease();
 }
 
 - (void)setCellPadding:(NSString *)newCellPadding
@@ -146,7 +146,7 @@
 - (NSString *)cellSpacing
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::cellspacingAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::cellspacingAttr).createNSString().autorelease();
 }
 
 - (void)setCellSpacing:(NSString *)newCellSpacing
@@ -158,7 +158,7 @@
 - (NSString *)frameBorders
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::frameAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::frameAttr).createNSString().autorelease();
 }
 
 - (void)setFrameBorders:(NSString *)newFrameBorders
@@ -170,7 +170,7 @@
 - (NSString *)rules
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::rulesAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::rulesAttr).createNSString().autorelease();
 }
 
 - (void)setRules:(NSString *)newRules
@@ -182,7 +182,7 @@
 - (NSString *)summary
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::summaryAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::summaryAttr).createNSString().autorelease();
 }
 
 - (void)setSummary:(NSString *)newSummary
@@ -194,7 +194,7 @@
 - (NSString *)width
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::widthAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::widthAttr).createNSString().autorelease();
 }
 
 - (void)setWidth:(NSString *)newWidth

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLTableRowElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLTableRowElement.mm
@@ -64,7 +64,7 @@
 - (NSString *)align
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr).createNSString().autorelease();
 }
 
 - (void)setAlign:(NSString *)newAlign
@@ -76,7 +76,7 @@
 - (NSString *)bgColor
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::bgcolorAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::bgcolorAttr).createNSString().autorelease();
 }
 
 - (void)setBgColor:(NSString *)newBgColor
@@ -88,7 +88,7 @@
 - (NSString *)ch
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::charAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::charAttr).createNSString().autorelease();
 }
 
 - (void)setCh:(NSString *)newCh
@@ -100,7 +100,7 @@
 - (NSString *)chOff
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::charoffAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::charoffAttr).createNSString().autorelease();
 }
 
 - (void)setChOff:(NSString *)newChOff
@@ -112,7 +112,7 @@
 - (NSString *)vAlign
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::valignAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::valignAttr).createNSString().autorelease();
 }
 
 - (void)setVAlign:(NSString *)newVAlign

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLTableSectionElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLTableSectionElement.mm
@@ -46,7 +46,7 @@
 - (NSString *)align
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::alignAttr).createNSString().autorelease();
 }
 
 - (void)setAlign:(NSString *)newAlign
@@ -58,7 +58,7 @@
 - (NSString *)ch
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::charAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::charAttr).createNSString().autorelease();
 }
 
 - (void)setCh:(NSString *)newCh
@@ -70,7 +70,7 @@
 - (NSString *)chOff
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::charoffAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::charoffAttr).createNSString().autorelease();
 }
 
 - (void)setChOff:(NSString *)newChOff
@@ -82,7 +82,7 @@
 - (NSString *)vAlign
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::valignAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::valignAttr).createNSString().autorelease();
 }
 
 - (void)setVAlign:(NSString *)newVAlign

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLTextAreaElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLTextAreaElement.mm
@@ -69,7 +69,7 @@ DOMHTMLTextAreaElement *kit(WebCore::HTMLTextAreaElement* value)
 - (NSString *)dirName
 {
     WebCore::JSMainThreadNullState state;
-    return unwrap(*self).getAttribute(WebCore::HTMLNames::dirnameAttr);
+    return unwrap(*self).getAttribute(WebCore::HTMLNames::dirnameAttr).createNSString().autorelease();
 }
 
 - (void)setDirName:(NSString *)newDirName
@@ -111,7 +111,7 @@ DOMHTMLTextAreaElement *kit(WebCore::HTMLTextAreaElement* value)
 - (NSString *)name
 {
     WebCore::JSMainThreadNullState state;
-    return unwrap(*self).getNameAttribute();
+    return unwrap(*self).getNameAttribute().createNSString().autorelease();
 }
 
 - (void)setName:(NSString *)newName
@@ -123,7 +123,7 @@ DOMHTMLTextAreaElement *kit(WebCore::HTMLTextAreaElement* value)
 - (NSString *)placeholder
 {
     WebCore::JSMainThreadNullState state;
-    return unwrap(*self).getAttribute(WebCore::HTMLNames::placeholderAttr);
+    return unwrap(*self).getAttribute(WebCore::HTMLNames::placeholderAttr).createNSString().autorelease();
 }
 
 - (void)setPlaceholder:(NSString *)newPlaceholder
@@ -183,7 +183,7 @@ DOMHTMLTextAreaElement *kit(WebCore::HTMLTextAreaElement* value)
 - (NSString *)wrap
 {
     WebCore::JSMainThreadNullState state;
-    return unwrap(*self).getAttribute(WebCore::HTMLNames::wrapAttr);
+    return unwrap(*self).getAttribute(WebCore::HTMLNames::wrapAttr).createNSString().autorelease();
 }
 
 - (void)setWrap:(NSString *)newWrap
@@ -195,7 +195,7 @@ DOMHTMLTextAreaElement *kit(WebCore::HTMLTextAreaElement* value)
 - (NSString *)type
 {
     WebCore::JSMainThreadNullState state;
-    return unwrap(*self).type();
+    return unwrap(*self).type().createNSString().autorelease();
 }
 
 - (NSString *)defaultValue
@@ -267,7 +267,7 @@ DOMHTMLTextAreaElement *kit(WebCore::HTMLTextAreaElement* value)
 - (NSString *)selectionDirection
 {
     WebCore::JSMainThreadNullState state;
-    return unwrap(*self).selectionDirection();
+    return unwrap(*self).selectionDirection().createNSString().autorelease();
 }
 
 - (void)setSelectionDirection:(NSString *)newSelectionDirection
@@ -279,7 +279,7 @@ DOMHTMLTextAreaElement *kit(WebCore::HTMLTextAreaElement* value)
 - (NSString *)accessKey
 {
     WebCore::JSMainThreadNullState state;
-    return unwrap(*self).getAttribute(WebCore::HTMLNames::accesskeyAttr);
+    return unwrap(*self).getAttribute(WebCore::HTMLNames::accesskeyAttr).createNSString().autorelease();
 }
 
 - (void)setAccessKey:(NSString *)newAccessKey

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLUListElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLUListElement.mm
@@ -55,7 +55,7 @@
 - (NSString *)type
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::typeAttr);
+    return IMPL->getAttribute(WebCore::HTMLNames::typeAttr).createNSString().autorelease();
 }
 
 - (void)setType:(NSString *)newType

--- a/Source/WebKitLegacy/mac/DOM/DOMKeyboardEvent.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMKeyboardEvent.mm
@@ -44,7 +44,7 @@
 - (NSString *)keyIdentifier
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->keyIdentifier();
+    return IMPL->keyIdentifier().createNSString().autorelease();
 }
 
 - (unsigned)location

--- a/Source/WebKitLegacy/mac/DOM/DOMNode.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMNode.mm
@@ -152,13 +152,13 @@ DOMNode *kit(Node* value)
 - (NSString *)namespaceURI
 {
     JSMainThreadNullState state;
-    return unwrap(*self).namespaceURI();
+    return unwrap(*self).namespaceURI().createNSString().autorelease();
 }
 
 - (NSString *)prefix
 {
     JSMainThreadNullState state;
-    return unwrap(*self).prefix();
+    return unwrap(*self).prefix().createNSString().autorelease();
 }
 
 - (void)setPrefix:(NSString *)newPrefix
@@ -170,7 +170,7 @@ DOMNode *kit(Node* value)
 - (NSString *)localName
 {
     JSMainThreadNullState state;
-    return unwrap(*self).localName();
+    return unwrap(*self).localName().createNSString().autorelease();
 }
 
 - (DOMNamedNodeMap *)attributes
@@ -297,13 +297,13 @@ DOMNode *kit(Node* value)
 - (NSString *)lookupPrefix:(NSString *)inNamespaceURI
 {
     JSMainThreadNullState state;
-    return unwrap(*self).lookupPrefix(inNamespaceURI);
+    return unwrap(*self).lookupPrefix(inNamespaceURI).createNSString().autorelease();
 }
 
 - (NSString *)lookupNamespaceURI:(NSString *)inPrefix
 {
     JSMainThreadNullState state;
-    return unwrap(*self).lookupNamespaceURI(inPrefix);
+    return unwrap(*self).lookupNamespaceURI(inPrefix).createNSString().autorelease();
 }
 
 - (BOOL)isDefaultNamespace:(NSString *)inNamespaceURI

--- a/Source/WebKitLegacy/mac/DOM/DOMTokenList.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMTokenList.mm
@@ -59,7 +59,7 @@
 - (NSString *)value
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->value();
+    return IMPL->value().createNSString().autorelease();
 }
 
 - (void)setValue:(NSString *)newValue
@@ -71,7 +71,7 @@
 - (NSString *)item:(unsigned)index
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->item(index);
+    return IMPL->item(index).createNSString().autorelease();
 }
 
 - (BOOL)contains:(NSString *)token

--- a/Source/WebKitLegacy/mac/DOM/DOMXPath.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMXPath.mm
@@ -47,7 +47,7 @@
 
 - (NSString *)lookupNamespaceURI:(NSString *)prefix
 {
-    return IMPL->lookupNamespaceURI(prefix);
+    return IMPL->lookupNamespaceURI(prefix).createNSString().autorelease();
 }
 
 @end

--- a/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
@@ -230,8 +230,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     HistoryItem* coreItem = core(_private);
     NSMutableString *result = [NSMutableString stringWithFormat:@"%@ %@", [super description], coreItem->urlString().createNSString().get()];
     if (!coreItem->target().isEmpty()) {
-        NSString *target = coreItem->target();
-        [result appendFormat:@" in \"%@\"", target];
+        RetainPtr target = coreItem->target().createNSString();
+        [result appendFormat:@" in \"%@\"", target.get()];
     }
     if (coreItem->isTargetItem())
         [result appendString:@" *target*"];

--- a/Source/WebKitLegacy/mac/Plugins/WebBasePluginPackage.mm
+++ b/Source/WebKitLegacy/mac/Plugins/WebBasePluginPackage.mm
@@ -236,7 +236,7 @@ static constexpr auto QuickTimeCocoaPluginIdentifier = "com.apple.quicktime.webp
     
     for (auto& entry : pluginInfo.mimes) {
         if (entry.extensions.contains(extension))
-            return entry.type;
+            return entry.type.createNSString().autorelease();
     }
 
     return nil;

--- a/Source/WebKitLegacy/mac/Plugins/WebPluginDatabase.mm
+++ b/Source/WebKitLegacy/mac/Plugins/WebPluginDatabase.mm
@@ -291,7 +291,7 @@ static RetainPtr<NSArray>& additionalWebPlugInPaths()
         while ((plugin = [pluginEnumerator nextObject])) {
             const auto& pluginInfo = [plugin pluginInfo];
             for (size_t i = 0; i < pluginInfo.mimes.size(); ++i)
-                [MIMETypes addObject:pluginInfo.mimes[i].type];
+                [MIMETypes addObject:pluginInfo.mimes[i].type.createNSString().get()];
         }
 
         // Register plug-in views and representations.
@@ -418,12 +418,12 @@ static RetainPtr<NSArray>& additionalWebPlugInPaths()
     // Unregister plug-in's MIME type registrations
     const auto& pluginInfo = [plugin pluginInfo];
     for (size_t i = 0; i < pluginInfo.mimes.size(); ++i) {
-        NSString *MIMEType = pluginInfo.mimes[i].type;
+        RetainPtr MIMEType = pluginInfo.mimes[i].type.createNSString();
 
-        if ([registeredMIMETypes containsObject:MIMEType]) {
+        if ([registeredMIMETypes containsObject:MIMEType.get()]) {
             if (self == sharedDatabase())
-                [WebView _unregisterPluginMIMEType:MIMEType];
-            [registeredMIMETypes removeObject:MIMEType];
+                [WebView _unregisterPluginMIMEType:MIMEType.get()];
+            [registeredMIMETypes removeObject:MIMEType.get()];
         }
     }
 

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -2379,7 +2379,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     auto coreFrame = _private->coreFrame;
     if (!coreFrame)
         return nil;
-    return coreFrame->tree().uniqueName();
+    return coreFrame->tree().uniqueName().createNSString().autorelease();
 }
 
 - (WebFrameView *)frameView


### PR DESCRIPTION
#### a8821c1d98c95725c59cdc9464a10c2048513d41
<pre>
Drop AtomString&apos;s `operator NSString *()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=291612">https://bugs.webkit.org/show_bug.cgi?id=291612</a>

Reviewed by Geoffrey Garen.

Drop AtomString&apos;s `operator NSString *()`. Use createNSString() instead which makes it
clearer we&apos;re allocating a new object and which returns a RetainPtr instead of an
autoreleased object.

* Source/WTF/wtf/text/AtomString.h:
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(HTMLConverter::_addAttachmentForElement):
(HTMLConverter::_fillInBlock):
(HTMLConverter::_processHeadElement):
(HTMLConverter::_addLinkForElement):
(HTMLConverter::_addTableForElement):
(HTMLConverter::_processElement):
(HTMLConverter::_exitElement):
(preferredFilenameForElement):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::requestLicense):
* Source/WebCore/platform/text/cocoa/LocaleCocoa.mm:
(WebCore::LocaleCocoa::LocaleCocoa):
(WebCore::LocaleCocoa::canonicalLanguageIdentifierFromString):
* Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm:
(-[WKDateTimePicker updatePicker:]):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMElement.mm:
(-[WKDOMElement getAttribute:]):
* Source/WebKitLegacy/mac/DOM/DOMCustomXPathNSResolver.mm:
(DOMCustomXPathNSResolver::lookupNamespaceURI):
* Source/WebKitLegacy/mac/DOM/DOMEvent.mm:
(-[DOMEvent type]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLAnchorElement.mm:
(-[DOMHTMLAnchorElement charset]):
(-[DOMHTMLAnchorElement coords]):
(-[DOMHTMLAnchorElement download]):
(-[DOMHTMLAnchorElement hreflang]):
(-[DOMHTMLAnchorElement name]):
(-[DOMHTMLAnchorElement ping]):
(-[DOMHTMLAnchorElement rel]):
(-[DOMHTMLAnchorElement rev]):
(-[DOMHTMLAnchorElement shape]):
(-[DOMHTMLAnchorElement target]):
(-[DOMHTMLAnchorElement type]):
(-[DOMHTMLAnchorElement accessKey]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLAreaElement.mm:
(-[DOMHTMLAreaElement alt]):
(-[DOMHTMLAreaElement coords]):
(-[DOMHTMLAreaElement ping]):
(-[DOMHTMLAreaElement rel]):
(-[DOMHTMLAreaElement shape]):
(-[DOMHTMLAreaElement target]):
(-[DOMHTMLAreaElement accessKey]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLBRElement.mm:
(-[DOMHTMLBRElement clear]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLBaseElement.mm:
(-[DOMHTMLBaseElement target]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLBaseFontElement.mm:
(-[DOMHTMLBaseFontElement color]):
(-[DOMHTMLBaseFontElement face]):
(-[DOMHTMLBaseFontElement size]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLBodyElement.mm:
(-[DOMHTMLBodyElement aLink]):
(-[DOMHTMLBodyElement background]):
(-[DOMHTMLBodyElement bgColor]):
(-[DOMHTMLBodyElement link]):
(-[DOMHTMLBodyElement text]):
(-[DOMHTMLBodyElement vLink]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLButtonElement.mm:
(-[DOMHTMLButtonElement type]):
(-[DOMHTMLButtonElement name]):
(-[DOMHTMLButtonElement value]):
(-[DOMHTMLButtonElement accessKey]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLDivElement.mm:
(-[DOMHTMLDivElement align]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLDocument.mm:
(-[DOMHTMLDocument dir]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLElement.mm:
(-[DOMHTMLElement title]):
(-[DOMHTMLElement lang]):
(-[DOMHTMLElement dir]):
(-[DOMHTMLElement webkitdropzone]):
(-[DOMHTMLElement accessKey]):
(-[DOMHTMLElement idName]):
(-[DOMHTMLElement autocapitalize]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLEmbedElement.mm:
(-[DOMHTMLEmbedElement align]):
(-[DOMHTMLEmbedElement name]):
(-[DOMHTMLEmbedElement type]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLFontElement.mm:
(-[DOMHTMLFontElement color]):
(-[DOMHTMLFontElement face]):
(-[DOMHTMLFontElement size]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLFormElement.mm:
(-[DOMHTMLFormElement acceptCharset]):
(-[DOMHTMLFormElement autocomplete]):
(-[DOMHTMLFormElement name]):
(-[DOMHTMLFormElement target]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLFrameElement.mm:
(-[DOMHTMLFrameElement frameBorder]):
(-[DOMHTMLFrameElement longDesc]):
(-[DOMHTMLFrameElement marginHeight]):
(-[DOMHTMLFrameElement marginWidth]):
(-[DOMHTMLFrameElement name]):
(-[DOMHTMLFrameElement scrolling]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLFrameSetElement.mm:
(-[DOMHTMLFrameSetElement cols]):
(-[DOMHTMLFrameSetElement rows]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLHRElement.mm:
(-[DOMHTMLHRElement align]):
(-[DOMHTMLHRElement size]):
(-[DOMHTMLHRElement width]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLHeadingElement.mm:
(-[DOMHTMLHeadingElement align]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLHtmlElement.mm:
(-[DOMHTMLHtmlElement version]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLIFrameElement.mm:
(-[DOMHTMLIFrameElement align]):
(-[DOMHTMLIFrameElement frameBorder]):
(-[DOMHTMLIFrameElement height]):
(-[DOMHTMLIFrameElement longDesc]):
(-[DOMHTMLIFrameElement marginHeight]):
(-[DOMHTMLIFrameElement marginWidth]):
(-[DOMHTMLIFrameElement name]):
(-[DOMHTMLIFrameElement sandbox]):
(-[DOMHTMLIFrameElement scrolling]):
(-[DOMHTMLIFrameElement width]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLImageElement.mm:
(-[DOMHTMLImageElement name]):
(-[DOMHTMLImageElement align]):
(-[DOMHTMLImageElement alt]):
(-[DOMHTMLImageElement srcset]):
(-[DOMHTMLImageElement sizes]):
(-[DOMHTMLImageElement useMap]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLInputElement.mm:
(-[DOMHTMLInputElement accept]):
(-[DOMHTMLInputElement alt]):
(-[DOMHTMLInputElement dirName]):
(-[DOMHTMLInputElement formTarget]):
(-[DOMHTMLInputElement max]):
(-[DOMHTMLInputElement min]):
(-[DOMHTMLInputElement name]):
(-[DOMHTMLInputElement pattern]):
(-[DOMHTMLInputElement placeholder]):
(-[DOMHTMLInputElement step]):
(-[DOMHTMLInputElement type]):
(-[DOMHTMLInputElement defaultValue]):
(-[DOMHTMLInputElement selectionDirection]):
(-[DOMHTMLInputElement align]):
(-[DOMHTMLInputElement useMap]):
(-[DOMHTMLInputElement accessKey]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLLIElement.mm:
(-[DOMHTMLLIElement type]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLLabelElement.mm:
(-[DOMHTMLLabelElement htmlFor]):
(-[DOMHTMLLabelElement accessKey]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLLegendElement.mm:
(-[DOMHTMLLegendElement align]):
(-[DOMHTMLLegendElement accessKey]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLLinkElement.mm:
(-[DOMHTMLLinkElement charset]):
(-[DOMHTMLLinkElement hreflang]):
(-[DOMHTMLLinkElement media]):
(-[DOMHTMLLinkElement rel]):
(-[DOMHTMLLinkElement rev]):
(-[DOMHTMLLinkElement target]):
(-[DOMHTMLLinkElement type]):
(-[DOMHTMLLinkElement as]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLMapElement.mm:
(-[DOMHTMLMapElement name]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLMarqueeElement.mm:
(-[DOMHTMLMarqueeElement behavior]):
(-[DOMHTMLMarqueeElement bgColor]):
(-[DOMHTMLMarqueeElement direction]):
(-[DOMHTMLMarqueeElement height]):
(-[DOMHTMLMarqueeElement width]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLMediaElement.mm:
(-[DOMHTMLMediaElement mediaGroup]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLMetaElement.mm:
(-[DOMHTMLMetaElement content]):
(-[DOMHTMLMetaElement httpEquiv]):
(-[DOMHTMLMetaElement name]):
(-[DOMHTMLMetaElement scheme]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLModElement.mm:
(-[DOMHTMLModElement dateTime]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLOListElement.mm:
(-[DOMHTMLOListElement type]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLObjectElement.mm:
(-[DOMHTMLObjectElement code]):
(-[DOMHTMLObjectElement align]):
(-[DOMHTMLObjectElement archive]):
(-[DOMHTMLObjectElement border]):
(-[DOMHTMLObjectElement codeBase]):
(-[DOMHTMLObjectElement codeType]):
(-[DOMHTMLObjectElement height]):
(-[DOMHTMLObjectElement name]):
(-[DOMHTMLObjectElement standby]):
(-[DOMHTMLObjectElement type]):
(-[DOMHTMLObjectElement useMap]):
(-[DOMHTMLObjectElement width]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLOptGroupElement.mm:
(-[DOMHTMLOptGroupElement label]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLParagraphElement.mm:
(-[DOMHTMLParagraphElement align]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLParamElement.mm:
(-[DOMHTMLParamElement name]):
(-[DOMHTMLParamElement type]):
(-[DOMHTMLParamElement value]):
(-[DOMHTMLParamElement valueType]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLScriptElement.mm:
(-[DOMHTMLScriptElement htmlFor]):
(-[DOMHTMLScriptElement event]):
(-[DOMHTMLScriptElement charset]):
(-[DOMHTMLScriptElement type]):
(-[DOMHTMLScriptElement nonce]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLSelectElement.mm:
(-[DOMHTMLSelectElement name]):
(-[DOMHTMLSelectElement type]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLStyleElement.mm:
(-[DOMHTMLStyleElement media]):
(-[DOMHTMLStyleElement type]):
(-[DOMHTMLStyleElement nonce]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLTableCaptionElement.mm:
(-[DOMHTMLTableCaptionElement align]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLTableCellElement.mm:
(-[DOMHTMLTableCellElement align]):
(-[DOMHTMLTableCellElement axis]):
(-[DOMHTMLTableCellElement bgColor]):
(-[DOMHTMLTableCellElement ch]):
(-[DOMHTMLTableCellElement chOff]):
(-[DOMHTMLTableCellElement headers]):
(-[DOMHTMLTableCellElement height]):
(-[DOMHTMLTableCellElement vAlign]):
(-[DOMHTMLTableCellElement width]):
(-[DOMHTMLTableCellElement abbr]):
(-[DOMHTMLTableCellElement scope]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLTableColElement.mm:
(-[DOMHTMLTableColElement align]):
(-[DOMHTMLTableColElement ch]):
(-[DOMHTMLTableColElement chOff]):
(-[DOMHTMLTableColElement vAlign]):
(-[DOMHTMLTableColElement width]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLTableElement.mm:
(-[DOMHTMLTableElement align]):
(-[DOMHTMLTableElement bgColor]):
(-[DOMHTMLTableElement border]):
(-[DOMHTMLTableElement cellPadding]):
(-[DOMHTMLTableElement cellSpacing]):
(-[DOMHTMLTableElement frameBorders]):
(-[DOMHTMLTableElement rules]):
(-[DOMHTMLTableElement summary]):
(-[DOMHTMLTableElement width]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLTableRowElement.mm:
(-[DOMHTMLTableRowElement align]):
(-[DOMHTMLTableRowElement bgColor]):
(-[DOMHTMLTableRowElement ch]):
(-[DOMHTMLTableRowElement chOff]):
(-[DOMHTMLTableRowElement vAlign]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLTableSectionElement.mm:
(-[DOMHTMLTableSectionElement align]):
(-[DOMHTMLTableSectionElement ch]):
(-[DOMHTMLTableSectionElement chOff]):
(-[DOMHTMLTableSectionElement vAlign]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLTextAreaElement.mm:
(-[DOMHTMLTextAreaElement dirName]):
(-[DOMHTMLTextAreaElement name]):
(-[DOMHTMLTextAreaElement placeholder]):
(-[DOMHTMLTextAreaElement wrap]):
(-[DOMHTMLTextAreaElement type]):
(-[DOMHTMLTextAreaElement selectionDirection]):
(-[DOMHTMLTextAreaElement accessKey]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLUListElement.mm:
(-[DOMHTMLUListElement type]):
* Source/WebKitLegacy/mac/DOM/DOMKeyboardEvent.mm:
(-[DOMKeyboardEvent keyIdentifier]):
* Source/WebKitLegacy/mac/DOM/DOMNode.mm:
(-[DOMNode namespaceURI]):
(-[DOMNode prefix]):
(-[DOMNode localName]):
(-[DOMNode lookupPrefix:]):
(-[DOMNode lookupNamespaceURI:]):
* Source/WebKitLegacy/mac/DOM/DOMTokenList.mm:
(-[DOMTokenList value]):
(-[DOMTokenList item:]):
* Source/WebKitLegacy/mac/DOM/DOMXPath.mm:
(-[DOMNativeXPathNSResolver lookupNamespaceURI:]):
* Source/WebKitLegacy/mac/History/WebHistoryItem.mm:
(-[WebHistoryItem description]):
* Source/WebKitLegacy/mac/Plugins/WebBasePluginPackage.mm:
(-[WebBasePluginPackage MIMETypeForExtension:]):
* Source/WebKitLegacy/mac/Plugins/WebPluginDatabase.mm:
(-[WebPluginDatabase refresh]):
(-[WebPluginDatabase _removePlugin:]):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame name]):

Canonical link: <a href="https://commits.webkit.org/293773@main">https://commits.webkit.org/293773@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6b3e1c36c82041f90fefd3140ca365aa8ac223e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99826 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19471 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104951 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50404 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101867 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75990 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33075 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102833 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90141 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56355 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14878 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8128 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49776 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92482 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84797 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8213 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107312 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98432 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26937 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19669 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84939 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86346 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84466 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21464 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29142 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6857 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20742 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26873 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32084 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122058 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26684 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34079 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30001 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28245 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->