### PR TITLE
REGRESSION(289593@main): Images are still restricted even after opting out pages from Lockdown Mode

### DIFF
--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -79,8 +79,8 @@
 		5CF869ED29D266AE0045F0D2 /* NSKeyedUnarchiverSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CF869EC29D266AE0045F0D2 /* NSKeyedUnarchiverSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		6D45AA352D026F760002871B /* ScreenTimeSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D45AA312D026F6F0002871B /* ScreenTimeSoftLink.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		6D45AA372D026F8F0002871B /* ScreenTimeSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6D45AA362D026F8C0002871B /* ScreenTimeSoftLink.mm */; };
-		7A46A8112A3265C8007BDD04 /* LockdownModeSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A46A80F2A3265C8007BDD04 /* LockdownModeSoftLink.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		7A46A8122A3265E2007BDD04 /* LockdownModeSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7A46A80E2A3265C7007BDD04 /* LockdownModeSoftLink.mm */; };
+		7A46A8112A3265C8007BDD04 /* LockdownModeCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A46A80F2A3265C8007BDD04 /* LockdownModeCocoa.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7A46A8122A3265E2007BDD04 /* LockdownModeCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7A46A80E2A3265C7007BDD04 /* LockdownModeCocoa.mm */; };
 		7AA1E2CE29EF5921002D4455 /* DataDetectorsUISoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AA1E2CD29EF5921002D4455 /* DataDetectorsUISoftLink.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7AA1E2D029EF5947002D4455 /* DataDetectorsUISoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7AA1E2CF29EF5946002D4455 /* DataDetectorsUISoftLink.mm */; };
 		7B47F2A328587B9700E793C8 /* CoreGraphicsSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B47F2A128587B9700E793C8 /* CoreGraphicsSoftLink.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -667,8 +667,8 @@
 		72C9483A2959517C006ECB96 /* NSSearchFieldCellSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSSearchFieldCellSPI.h; sourceTree = "<group>"; };
 		7A36D0F8223AD9AB00B0522E /* CommonCryptoSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CommonCryptoSPI.h; sourceTree = "<group>"; };
 		7A3A6A7F20CADB4600317AAE /* NSImageSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSImageSPI.h; sourceTree = "<group>"; };
-		7A46A80E2A3265C7007BDD04 /* LockdownModeSoftLink.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = LockdownModeSoftLink.mm; sourceTree = "<group>"; };
-		7A46A80F2A3265C8007BDD04 /* LockdownModeSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LockdownModeSoftLink.h; sourceTree = "<group>"; };
+		7A46A80E2A3265C7007BDD04 /* LockdownModeCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = LockdownModeCocoa.mm; sourceTree = "<group>"; };
+		7A46A80F2A3265C8007BDD04 /* LockdownModeCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LockdownModeCocoa.h; sourceTree = "<group>"; };
 		7AA1E2CD29EF5921002D4455 /* DataDetectorsUISoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DataDetectorsUISoftLink.h; sourceTree = "<group>"; };
 		7AA1E2CF29EF5946002D4455 /* DataDetectorsUISoftLink.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DataDetectorsUISoftLink.mm; sourceTree = "<group>"; };
 		7B47F2A128587B9700E793C8 /* CoreGraphicsSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreGraphicsSoftLink.h; sourceTree = "<group>"; };
@@ -1143,8 +1143,8 @@
 				1C022EFC22CFE8E0006DF01B /* Gunzip.cpp */,
 				F47471EC2ACA17AF00E0D4AB /* LinkPresentationSoftLink.h */,
 				F47471ED2ACA17AF00E0D4AB /* LinkPresentationSoftLink.mm */,
-				7A46A80F2A3265C8007BDD04 /* LockdownModeSoftLink.h */,
-				7A46A80E2A3265C7007BDD04 /* LockdownModeSoftLink.mm */,
+				7A46A80F2A3265C8007BDD04 /* LockdownModeCocoa.h */,
+				7A46A80E2A3265C7007BDD04 /* LockdownModeCocoa.mm */,
 				CDACB35E23873E480018D7CE /* MediaToolboxSoftLink.cpp */,
 				CDACB35F23873E480018D7CE /* MediaToolboxSoftLink.h */,
 				F47221F5276FC32300B984C7 /* NaturalLanguageSoftLink.h */,
@@ -1484,7 +1484,7 @@
 				DD20DDED27BC90D70093D175 /* LaunchServicesSPI.h in Headers */,
 				F47471EE2ACA17AF00E0D4AB /* LinkPresentationSoftLink.h in Headers */,
 				F410F1552ACA2EBA00A79859 /* LinkPresentationSPI.h in Headers */,
-				7A46A8112A3265C8007BDD04 /* LockdownModeSoftLink.h in Headers */,
+				7A46A8112A3265C8007BDD04 /* LockdownModeCocoa.h in Headers */,
 				DD20DE6227BC90D80093D175 /* Logging.h in Headers */,
 				DD20DDC627BC90D70093D175 /* LookupSoftLink.h in Headers */,
 				DD20DE2127BC90D80093D175 /* LookupSPI.h in Headers */,
@@ -1772,7 +1772,7 @@
 				A30D41221F0DD0EA00B71954 /* KillRing.cpp in Sources */,
 				A30D41251F0DD12D00B71954 /* KillRingMac.mm in Sources */,
 				F47471EF2ACA17AF00E0D4AB /* LinkPresentationSoftLink.mm in Sources */,
-				7A46A8122A3265E2007BDD04 /* LockdownModeSoftLink.mm in Sources */,
+				7A46A8122A3265E2007BDD04 /* LockdownModeCocoa.mm in Sources */,
 				1C4876D81F8D7F4E00CCEEBD /* Logging.cpp in Sources */,
 				44E1A8B021FA54EB00C3048E /* LookupSoftLink.mm in Sources */,
 				5C7C787423AC3E770065F47E /* ManagedConfigurationSoftLink.mm in Sources */,

--- a/Source/WebCore/PAL/pal/cocoa/LockdownModeCocoa.h
+++ b/Source/WebCore/PAL/pal/cocoa/LockdownModeCocoa.h
@@ -29,7 +29,9 @@
 
 namespace PAL {
 
-PAL_EXPORT BOOL isLockdownModeEnabled();
+PAL_EXPORT bool isLockdownModeEnabled();
+PAL_EXPORT bool isLockdownModeEnabledForCurrentProcess();
+PAL_EXPORT void setLockdownModeEnabledForCurrentProcess(bool);
 
 }
 

--- a/Source/WebCore/PAL/pal/cocoa/LockdownModeCocoa.mm
+++ b/Source/WebCore/PAL/pal/cocoa/LockdownModeCocoa.mm
@@ -24,12 +24,13 @@
  */
 
 #import "config.h"
-#import "LockdownModeSoftLink.h"
+#import "LockdownModeCocoa.h"
 
 #if HAVE(LOCKDOWN_MODE_FRAMEWORK)
 
 #import <LockdownMode/LockdownMode.h>
 #import <sys/sysctl.h>
+#import <wtf/NeverDestroyed.h>
 #import <wtf/SoftLinking.h>
 
 OBJC_CLASS LockdownModeManager;
@@ -39,7 +40,7 @@ SOFT_LINK_CLASS_OPTIONAL(LockdownMode, LockdownModeManager)
 
 namespace PAL {
 
-BOOL isLockdownModeEnabled()
+bool isLockdownModeEnabled()
 {
     if (LockdownModeLibrary())
         return [(LockdownModeManager *)[getLockdownModeManagerClass() shared] enabled];
@@ -53,6 +54,22 @@ BOOL isLockdownModeEnabled()
     return false;
 }
 
+static std::optional<bool>& isLockdownModeEnabledForCurrentProcessCached()
+{
+    static NeverDestroyed<std::optional<bool>> cachedIsLockdownModeEnabledForCurrentProcess;
+    return cachedIsLockdownModeEnabledForCurrentProcess;
 }
+
+bool isLockdownModeEnabledForCurrentProcess()
+{
+    return isLockdownModeEnabledForCurrentProcessCached().value_or(isLockdownModeEnabled());
+}
+
+void setLockdownModeEnabledForCurrentProcess(bool isLockdownModeEnabled)
+{
+    isLockdownModeEnabledForCurrentProcessCached() = isLockdownModeEnabled;
+}
+
+} // namespace PAL
 
 #endif

--- a/Source/WebCore/platform/graphics/cg/UTIRegistry.mm
+++ b/Source/WebCore/platform/graphics/cg/UTIRegistry.mm
@@ -42,19 +42,11 @@
 #import <MobileCoreServices/MobileCoreServices.h>
 #endif
 
-#import <pal/cocoa/LockdownModeSoftLink.h>
+#if HAVE(LOCKDOWN_MODE_FRAMEWORK)
+#import <pal/cocoa/LockdownModeCocoa.h>
+#endif
 
 namespace WebCore {
-
-#if HAVE(LOCKDOWN_MODE_FRAMEWORK)
-static bool isLockdownModeEnabled()
-{
-    static std::optional<bool> isLockdownModeEnabled;
-    if (!isLockdownModeEnabled)
-        isLockdownModeEnabled = PAL::isLockdownModeEnabled();
-    return *isLockdownModeEnabled;
-}
-#endif
 
 template<std::size_t size>
 static MemoryCompactLookupOnlyRobinHoodHashSet<String> filterSupportedImageTypes(const std::array<ASCIILiteral, size>& imageTypes)
@@ -138,7 +130,7 @@ static const MemoryCompactLookupOnlyRobinHoodHashSet<String>& lockdownSupportedI
 const MemoryCompactLookupOnlyRobinHoodHashSet<String>& supportedImageTypes()
 {
 #if HAVE(LOCKDOWN_MODE_FRAMEWORK)
-    if (isLockdownModeEnabled())
+    if (PAL::isLockdownModeEnabledForCurrentProcess())
         return lockdownSupportedImageTypes();
 #endif
     return defaultSupportedImageTypes();
@@ -153,7 +145,7 @@ MemoryCompactRobinHoodHashSet<String>& additionalSupportedImageTypes()
 void setAdditionalSupportedImageTypes(const Vector<String>& imageTypes)
 {
 #if HAVE(LOCKDOWN_MODE_FRAMEWORK)
-    if (isLockdownModeEnabled())
+    if (PAL::isLockdownModeEnabledForCurrentProcess())
         return;
 #endif
     MIMETypeRegistry::additionalSupportedImageMIMETypes().clear();
@@ -230,7 +222,7 @@ static Vector<String> allowableLockdownSupportedImageTypes()
 static Vector<String> allowableSupportedImageTypes()
 {
 #if HAVE(LOCKDOWN_MODE_FRAMEWORK)
-    if (isLockdownModeEnabled())
+    if (PAL::isLockdownModeEnabledForCurrentProcess())
         return allowableLockdownSupportedImageTypes();
 #endif
     return allowableDefaultSupportedImageTypes();

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferences.mm
@@ -30,7 +30,7 @@
 #import <wtf/RetainPtr.h>
 
 #if HAVE(LOCKDOWN_MODE_FRAMEWORK)
-#import <pal/cocoa/LockdownModeSoftLink.h>
+#import <pal/cocoa/LockdownModeCocoa.h>
 #endif
 
 constexpr auto CaptivePortalConfigurationIgnoreFileName = @"com.apple.WebKit.cpmconfig_ignore";

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -244,6 +244,10 @@
 #include "LaunchServicesDatabaseManager.h"
 #endif
 
+#if HAVE(LOCKDOWN_MODE_FRAMEWORK)
+#import <pal/cocoa/LockdownModeCocoa.h>
+#endif
+
 #if PLATFORM(MAC)
 #import <wtf/spi/darwin/SandboxSPI.h>
 #endif
@@ -641,6 +645,10 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
 
     ScriptExecutionContext::setCrossOriginMode(parameters.crossOriginMode);
     DeprecatedGlobalSettings::setArePDFImagesEnabled(!isLockdownModeEnabled());
+
+#if HAVE(LOCKDOWN_MODE_FRAMEWORK)
+    PAL::setLockdownModeEnabledForCurrentProcess(isLockdownModeEnabled());
+#endif
 
 #if ENABLE(SERVICE_CONTROLS)
     setEnabledServices(parameters.hasImageServices, parameters.hasSelectionServices, parameters.hasRichContentServices);


### PR DESCRIPTION
#### 69431ee5773488ddff588de2776df095f0ba6ed5
<pre>
REGRESSION(289593@main): Images are still restricted even after opting out pages from Lockdown Mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=291614#">https://bugs.webkit.org/show_bug.cgi?id=291614#</a>
<a href="https://rdar.apple.com/147500578">rdar://147500578</a>

Reviewed by Tim Horton.

In 289593@main we made UTIRegistry call PAL::isLockdownModeEnabled() to detect
whether the Lockdown Mode is enabled. But this function ends up calling the system
LockdownModeLibrary. This does not take into consideration the opted out pages.
So this causes the restricted images to be always restricted in Lockdown Mode.

The fix is to used WebProcess::isLockdownModeEnabled() instead because this will
return false when opting out the page. To propagate this to WebCore a getter and
a setter for isLockdownModeEnabledForCurrentProcess will be added in PAL.

UTIRegistry will call PAL::isLockdownModeEnabledForCurrentProcess() instead.

* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/cocoa/LockdownModeCocoa.h: Renamed from Source/WebCore/PAL/pal/cocoa/LockdownModeSoftLink.h.
* Source/WebCore/PAL/pal/cocoa/LockdownModeCocoa.mm: Renamed from Source/WebCore/PAL/pal/cocoa/LockdownModeSoftLink.mm.
(PAL::isLockdownModeEnabled):
(PAL::isLockdownModeEnabledForCurrentProcessCached):
(PAL::isLockdownModeEnabledForCurrentProcess):
(PAL::setLockdownModeEnabledForCurrentProcess):
* Source/WebCore/platform/graphics/cg/UTIRegistry.mm:
(WebCore::supportedImageTypes):
(WebCore::setAdditionalSupportedImageTypes):
(WebCore::allowableSupportedImageTypes):
(WebCore::isLockdownModeEnabled): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferences.mm:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::initializeWebProcess):

Canonical link: <a href="https://commits.webkit.org/293755@main">https://commits.webkit.org/293755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9296cf6895b5c52e071663d7c4edd3a2b12b42e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99831 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104957 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50409 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101872 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19781 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27912 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75988 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33077 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102838 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15076 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90143 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56353 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14881 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8130 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49781 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84800 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8215 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107317 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19672 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84942 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27304 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86348 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84468 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21454 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29144 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6859 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20746 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26878 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32089 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26689 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30006 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28250 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->