### PR TITLE
Add PlatformDynamicRangeLimit::ValueType to abstract the value&storage type

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.cpp
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 
-float PlatformDynamicRangeLimit::normalizedAverage(float standardPercent, float constrainedHighPercent, float noLimitPercent)
+PlatformDynamicRangeLimit::ValueType PlatformDynamicRangeLimit::normalizedAverage(float standardPercent, float constrainedHighPercent, float noLimitPercent)
 {
     if (!std::isfinite(standardPercent) || standardPercent < 0 || standardPercent > 100 || !std::isfinite(constrainedHighPercent) || constrainedHighPercent < 0 || constrainedHighPercent > 100 || !std::isfinite(noLimitPercent) || noLimitPercent < 0 || noLimitPercent > 100) {
         ASSERT(std::isfinite(standardPercent));

--- a/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h
+++ b/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h
@@ -40,6 +40,8 @@ struct DynamicRangeLimit;
 
 class PlatformDynamicRangeLimit {
 public:
+    using ValueType = float;
+
     static constexpr PlatformDynamicRangeLimit standard() { return PlatformDynamicRangeLimit(standardValue); }
     static constexpr PlatformDynamicRangeLimit constrainedHigh() { return PlatformDynamicRangeLimit(constrainedHighValue); }
     static constexpr PlatformDynamicRangeLimit noLimit() { return PlatformDynamicRangeLimit(noLimitValue); }
@@ -53,7 +55,7 @@ public:
     // `dynamic-range-limit` mapped to PlatformDynamicRangeLimit.value():
     // ["standard", "constrainedHigh"] -> [standard().value(), constrainedHigh().value()],
     // ["constrainedHigh", "noLimit"] -> [constrainedHigh().value(), noLimit().value()]
-    constexpr float value() const { return m_value; }
+    constexpr ValueType value() const { return m_value; }
 
     constexpr auto operator<=>(const PlatformDynamicRangeLimit&) const = default;
 
@@ -61,18 +63,18 @@ private:
     friend struct IPC::ArgumentCoder<WebCore::PlatformDynamicRangeLimit, void>;
     friend Style::DynamicRangeLimit;
 
-    constexpr PlatformDynamicRangeLimit(float value) : m_value(std::clamp(value, 0.0f, 1.0f)) { }
+    constexpr PlatformDynamicRangeLimit(ValueType value) : m_value(std::clamp(value, 0.0f, 1.0f)) { }
 
     PlatformDynamicRangeLimit(float standardPercent, float constrainedHighPercent, float noLimitPercent)
         : m_value(normalizedAverage(standardPercent, constrainedHighPercent, noLimitPercent)) { }
 
-    static float normalizedAverage(float standardPercent, float constrainedHighPercent, float noLimitPercent);
+    static ValueType normalizedAverage(float standardPercent, float constrainedHighPercent, float noLimitPercent);
 
-    static constexpr float standardValue = 0;
-    static constexpr float constrainedHighValue = 0.5;
-    static constexpr float noLimitValue = 1;
+    static constexpr ValueType standardValue = 0;
+    static constexpr ValueType constrainedHighValue = 0.5;
+    static constexpr ValueType noLimitValue = 1;
 
-    float m_value { constrainedHighValue };
+    ValueType m_value { constrainedHighValue };
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, PlatformDynamicRangeLimit);

--- a/Tools/TestWebKitAPI/Tests/WebCore/PlatformDynamicRangeLimitTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PlatformDynamicRangeLimitTests.cpp
@@ -33,6 +33,8 @@
 namespace TestWebKitAPI {
 
 // Tests rely on these assumptions:
+static_assert(std::is_same_v<WebCore::PlatformDynamicRangeLimit::ValueType, float>);
+static_assert(std::is_same_v<decltype(WebCore::PlatformDynamicRangeLimit::standard().value()), float>);
 static_assert(WebCore::PlatformDynamicRangeLimit::standard().value() == 0.0f);
 static_assert(WebCore::PlatformDynamicRangeLimit::constrainedHigh().value() == 0.5f);
 static_assert(WebCore::PlatformDynamicRangeLimit::noLimit().value() == 1.0f);


### PR DESCRIPTION
#### f77e0a06eb5e5bd38008a3aa4bf7976762f4f2be
<pre>
Add PlatformDynamicRangeLimit::ValueType to abstract the value&amp;storage type
<a href="https://bugs.webkit.org/show_bug.cgi?id=291621">https://bugs.webkit.org/show_bug.cgi?id=291621</a>
<a href="https://rdar.apple.com/149364934">rdar://149364934</a>

Reviewed by Mike Wyrzykowski.

Use PlatformDynamicRangeLimit::ValueType instead of naked float.
This will make future changes simpler and clearer.

Exception: The private 3-float constructor still takes floats, because
that won&apos;t change even if/when ValueType changes.

* Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.cpp:
(WebCore::PlatformDynamicRangeLimit::normalizedAverage):
* Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h:
(WebCore::PlatformDynamicRangeLimit::value const):
(WebCore::PlatformDynamicRangeLimit::PlatformDynamicRangeLimit):
* Tools/TestWebKitAPI/Tests/WebCore/PlatformDynamicRangeLimitTests.cpp:

Canonical link: <a href="https://commits.webkit.org/293945@main">https://commits.webkit.org/293945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f73053bd2532e3262b20094c94df15dfe7e95d64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104963 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50415 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101878 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27918 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75994 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33083 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102844 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56359 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14886 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8138 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49787 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84805 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107323 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26948 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19676 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84948 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27310 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86356 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84474 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21593 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29149 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6867 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20757 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26884 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32095 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26695 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30012 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28256 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->