### PR TITLE
Google Meet is sometimes encoding black frames from a getDisplayMedia track

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2915,6 +2915,7 @@ fast/mediastream/getDisplayMedia-max-constraints3.html [ Skip ]
 fast/mediastream/getDisplayMedia-max-constraints5.html [ Skip ]
 webkit.org/b/263466 fast/mediastream/getDisplayMedia-max-constraints4.html [ Failure ]
 webrtc/getDisplayMedia-pc.html [ Skip ]
+webrtc/getDisplayMedia-odd-size.html [ Skip ]
 
 fast/mediastream/getDisplayMedia-size.html [ Skip ]
 

--- a/LayoutTests/webrtc/getDisplayMedia-odd-size-expected.txt
+++ b/LayoutTests/webrtc/getDisplayMedia-odd-size-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS Setting up streaming of getDisplayMedia with VP8
+PASS Testing odd width
+PASS  Testing odd height
+

--- a/LayoutTests/webrtc/getDisplayMedia-odd-size.html
+++ b/LayoutTests/webrtc/getDisplayMedia-odd-size.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+        <script src="../fast/mediastream/resources/getDisplayMedia-utils.js"></script>
+    </head>
+    <body>
+        <video id="video" autoplay=""></video>
+        <canvas id="canvas" width="1280" height="720"></canvas>
+        <script src ="routines.js"></script>
+        <script>
+video = document.getElementById("video");
+canvas = document.getElementById("canvas");
+
+function grabFrameData()
+{
+    canvas.getContext('2d').drawImage(video, 0, 0, video.videoWidth, video.videoHeight);
+    return canvas.getContext('2d').getImageData(0, 0, video.videoWidth, video.videoHeight);
+}
+
+async function waitFor(duration)
+{
+    return new Promise((resolve) => setTimeout(resolve, duration));
+}
+
+function testImage()
+{
+    const data = grabFrameData().data;
+    assert_greater_than(data[0], 100, "test1");
+    assert_greater_than(data[1], 100, "test1");
+    assert_greater_than(data[2], 100, "test1");
+}
+
+var localStream;
+var pc1, pc2;
+promise_test(async (test) => {
+    localStream = await callGetDisplayMedia({ video: { width:639 } });
+    const stream = await new Promise((resolve, reject) => {
+        createConnections((firstConnection) => {
+            pc1 = firstConnection;
+            firstConnection.addTrack(localStream.getVideoTracks()[0], localStream);
+            firstConnection.getTransceivers()[0].setCodecPreferences([{mimeType: "video/VP8", clockRate: 90000}]);
+        }, (secondConnection) => {
+            pc2 = secondConnection;
+            secondConnection.ontrack = (trackEvent) => {
+                resolve(trackEvent.streams[0]);
+            };
+        });
+        setTimeout(() => reject("Test timed out"), 5000);
+    });
+
+    video.srcObject = stream;
+    let promise = new Promise(resolve => video.requestVideoFrameCallback(resolve));
+    await video.play();
+    await promise;
+}, "Setting up streaming of getDisplayMedia with VP8");
+
+promise_test(async (test) => {
+    assert_equals(video.videoWidth, 639);
+    testImage();
+}, "Testing odd width");
+
+promise_test(async (test) => {
+    await localStream.getVideoTracks()[0].applyConstraints({ height:479 });
+
+    while (!(video.videoHeight % 2))
+        await waitFor(50);
+    testImage();
+}, " Testing odd height");
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
+++ b/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
@@ -209,10 +209,7 @@ RetainPtr<CVPixelBufferRef> SharedVideoFrameInfo::createPixelBufferFromMemory(st
 
     data = copyToCVPixelBufferPlane(rawPixelBuffer, 0, data, m_height, m_bytesPerRow);
     if (CVPixelBufferGetPlaneCount(rawPixelBuffer) >= 2) {
-        if (CVPixelBufferGetWidthOfPlane(rawPixelBuffer, 1) != m_widthPlaneB || CVPixelBufferGetHeightOfPlane(rawPixelBuffer, 1) != m_heightPlaneB)
-            return nullptr;
-        data = copyToCVPixelBufferPlane(rawPixelBuffer, 1, data, m_heightPlaneB, m_bytesPerRowPlaneB);
-
+        data = copyToCVPixelBufferPlane(rawPixelBuffer, 1, data, std::min<size_t>(m_heightPlaneB, CVPixelBufferGetHeightOfPlane(rawPixelBuffer, 1)), m_bytesPerRowPlaneB);
         if (CVPixelBufferGetPlaneCount(rawPixelBuffer) == 3)
             copyToCVPixelBufferPlane(rawPixelBuffer, 2, data, m_height, m_bytesPerRowPlaneAlpha);
     }


### PR DESCRIPTION
#### 4dd862e5ce1c10d77f72be94260164c5f13aafbd
<pre>
Google Meet is sometimes encoding black frames from a getDisplayMedia track
<a href="https://rdar.apple.com/149383110">rdar://149383110</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291626">https://bugs.webkit.org/show_bug.cgi?id=291626</a>

Reviewed by Chris Dumez.

There is sometimes a mismatch in the width/height of plane B of a memory pixel buffer in web process and an IO surface pixel buffer in GPU process.
This happens in particular for getDisplayMedia frames when the width or height is odd.
In that case, planeB rounding may be different.

We would previously fail the creation of the memory pixel buffer in web process, which would trigger black frame encoding when SW VP8 is used.

The added test covers odd sizes for getDisplayMedia tracks but it does not reproduce the specific configuration of ScreenCaptureKit pixel buffers.
Manually tested.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/webrtc/getDisplayMedia-odd-size-expected.txt: Added.
* LayoutTests/webrtc/getDisplayMedia-odd-size.html: Added.
* Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm:
(WebCore::SharedVideoFrameInfo::createPixelBufferFromMemory):

Canonical link: <a href="https://commits.webkit.org/293784@main">https://commits.webkit.org/293784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1604ecda9b519170d8aea919d22554594d68e76f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9811 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105007 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50461 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101921 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27963 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76034 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33125 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102887 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15129 "Found 1 new test failure: fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90199 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56392 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8184 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49830 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8273 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107368 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26993 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19725 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84987 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27355 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84509 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21472 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29188 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6912 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20811 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26930 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32146 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26741 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30057 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28300 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->