### PR TITLE
AX: After ENABLE(AX_THREAD_TEXT_APIS), passing the indexForTextMarker(foo) to textMarkerForIndex doesn't return the same marker, making them logically inconsistent

### DIFF
--- a/LayoutTests/accessibility-isolated-tree/TestExpectations
+++ b/LayoutTests/accessibility-isolated-tree/TestExpectations
@@ -66,7 +66,6 @@ accessibility/mac/text-marker-word-nav.html [ Failure ]
 accessibility/mac/selected-visible-position-range.html [ Timeout ]
 accessibility/mac/text-marker-word-nav.html [ Timeout ]
 accessibility/mac/text-operation/text-operation-replace-across-multiple-fields.html [ Timeout ]
-accessibility/mac/textmarker-routines.html [ Timeout ]
 accessibility/textarea-insertion-point-line-number.html [ Failure ]
 
 accessibility/mac/doctype-node-in-text-marker-crash.html [ Crash ]

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -892,7 +892,7 @@ AXTextMarker AXTextMarker::nextMarkerFromOffset(unsigned offset) const
 
     auto marker = *this;
     while (offset) {
-        if (auto newMarker = marker.findMarker(AXDirection::Next))
+        if (auto newMarker = marker.findMarker(AXDirection::Next, CoalesceObjectBreaks::No))
             marker = WTFMove(newMarker);
         else
             break;


### PR DESCRIPTION
#### 158ad8435dde123aa74d956efebb8d2a0ab230cb
<pre>
AX: After ENABLE(AX_THREAD_TEXT_APIS), passing the indexForTextMarker(foo) to textMarkerForIndex doesn&apos;t return the same marker, making them logically inconsistent
<a href="https://bugs.webkit.org/show_bug.cgi?id=291631">https://bugs.webkit.org/show_bug.cgi?id=291631</a>
<a href="https://rdar.apple.com/149389130">rdar://149389130</a>

Reviewed by Joshua Hoffman.

Prior to this commit, imagining you have an `AXTextMarker` called |foo|, if you passed |foo| to a
NSAccessibilityIndexForTextMarkerAttribute request, and then immediately took that index and used it for a
NSAccessibilityTextMarkerForIndexAttribute request, you&apos;d get back a different marker.

This happened because AXTextMarker::nextMarkerFromOffset(unsigned) used the form of AXTextMarker::findMarker that
&quot;coalesces&quot; object breaks, meaning that when the traversal moves from the end of one text object to a new one, it
starts at offset 1 to avoid doubly-representing the same position (the end of one text and the start of another can be
considered the same position).

However, we do not want this behavior for the textmarker-for-index and index-for-textmarker APIs. Our implementation of
index-for-textmarker correctly does not coalesce object breaks, but our implementation of textmarker-for-index
(AXTextMarker::nextMarkerFromOffset(unsigned)) did, making them logically inconsistent. This commit fixes the issue
by making AXTextMarker::nextMarkerFromOffset(unsigned) not coalesce object breaks, matching the main-thread text marker
implementation and fixing accessibility/mac/textmarker-routines.html in ITM.

* LayoutTests/accessibility-isolated-tree/TestExpectations:
Remove failing expectation for accessibility/mac/textmarker-routines.html.
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::nextMarkerFromOffset const):

Canonical link: <a href="https://commits.webkit.org/293765@main">https://commits.webkit.org/293765@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/103fe268b02b57055229fa86701215ce51dcc614

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104977 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50430 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101892 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27932 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76014 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33101 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102858 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15095 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90172 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56370 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14900 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8153 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49801 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84834 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107337 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26962 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19701 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84965 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27324 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86371 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84484 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21460 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29160 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6887 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20777 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26898 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32109 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26709 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30026 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28270 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->