### PR TITLE
GPUP: Drawing paths spends time in copying path data

### DIFF
--- a/Source/WebCore/platform/graphics/Path.h
+++ b/Source/WebCore/platform/graphics/Path.h
@@ -47,6 +47,7 @@ public:
     Path() = default;
     WEBCORE_EXPORT Path(PathSegment&&);
     WEBCORE_EXPORT Path(Vector<PathSegment>&&);
+    WEBCORE_EXPORT Path(std::span<const PathSegment>);
     explicit Path(const Vector<FloatPoint>& points);
     Path(Ref<PathImpl>&&);
 
@@ -99,10 +100,10 @@ public:
     WEBCORE_EXPORT bool isEmpty() const;
     bool definitelySingleLine() const;
     WEBCORE_EXPORT PlatformPathPtr platformPath() const;
+    WEBCORE_EXPORT PlatformPathPtr platformPathIfExists() const;
 
     const PathSegment* singleSegmentIfExists() const { return asSingle(); }
-    WEBCORE_EXPORT const Vector<PathSegment>* segmentsIfExists() const;
-    WEBCORE_EXPORT Vector<PathSegment> segments() const;
+    WEBCORE_EXPORT std::span<const PathSegment> segments() const;
 
     float length() const;
     bool isClosed() const;

--- a/Source/WebCore/platform/graphics/cg/PathCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/PathCG.cpp
@@ -581,16 +581,13 @@ static inline void addToCGContextPath(CGContextRef context, PathSegment anySegme
 
 void addToCGContextPath(CGContextRef context, const Path& path)
 {
-    if (auto* singleSegment = path.singleSegmentIfExists(); LIKELY(singleSegment)) {
-        addToCGContextPath(context, *singleSegment);
+    if (auto* platformPath = path.platformPathIfExists()) {
+        CGContextAddPath(context, platformPath);
         return;
     }
-    if (auto* segments = path.segmentsIfExists(); LIKELY(segments)) {
-        for (auto& segment : *segments)
-            addToCGContextPath(context, segment);
-        return;
-    }
-    CGContextAddPath(context, path.platformPath());
+
+    for (auto& segment : path.segments())
+        addToCGContextPath(context, segment);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -112,8 +112,7 @@ static std::optional<FloatRect> guardRectForRegionBounds(const InteractionRegion
 
     bool isSmallRect = false;
     bool isComplexShape =  region.clipPath
-        && region.clipPath->segmentsIfExists()
-        && region.clipPath->segmentsIfExists()->size() > complexSegmentsCount;
+        && region.clipPath->segments().size() > complexSegmentsCount;
 
     auto guardRect = region.rectInLayerCoordinates;
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2026,7 +2026,7 @@ header: <WebCore/RectEdges.h>
 }
 
 [AdditionalEncoder=StreamConnectionEncoder] class WebCore::Path {
-    Vector<WebCore::PathSegment> segments();
+    std::span<const WebCore::PathSegment> segments();
 }
 
 #if ENABLE(META_VIEWPORT)


### PR DESCRIPTION
#### 63b37855fc3948f0eb24803617ea9fae57bf501e
<pre>
GPUP: Drawing paths spends time in copying path data
<a href="https://bugs.webkit.org/show_bug.cgi?id=291630">https://bugs.webkit.org/show_bug.cgi?id=291630</a>
<a href="https://rdar.apple.com/149387451">rdar://149387451</a>

Reviewed by Simon Fraser.

WebCore::Path would have two PathImpl implementations:
  - PathStream where storage is Vector&lt;PathSegment&gt;
  - PathCG, PathCairo, PathSkia where storage is platform path.

Path IPC works on list of PathSegments. This would mean that
since the platform implementation variant could not guarantee a list of
PathSegments storage in place, Vector&lt;PathSegment&gt; would be created for
sending the segments, even for PathStream. This would be slower than
neccesary.

Fix by migrating platform path back to PathStream when the segments are
needed. This way the IPC serialization can always refer to
std::span&lt;PathSegments&gt;, which does not copy redundantly on send side.
Note that the migration is rare. Holding path data with platform path
only happens in WCP if Path::addPath(), Path::transform() or
Path::strokeBoundingRect has been called.

Later commits will work on moving PathStream to Path, simplifying the
implementation further.

* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::Path):
(WebCore::Path::platformPathIfExists const):
(WebCore::Path::segments const):
(WebCore::Path::segmentsIfExists const): Deleted.
* Source/WebCore/platform/graphics/Path.h:
* Source/WebCore/platform/graphics/cg/PathCG.cpp:
(WebCore::addToCGContextPath):
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::guardRectForRegionBounds):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/294018@main">https://commits.webkit.org/294018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a576d00cd9dcb801ed49aeff9b641c526ad4db5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105003 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50457 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101917 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27959 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76031 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33123 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102883 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15128 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90198 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56389 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14933 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8183 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49826 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84859 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107364 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26989 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19723 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84984 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27351 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86398 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84506 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21648 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29186 "Found 1 new test failure: interaction-region/icon-masking.html (failure)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6911 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20807 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26926 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32142 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26737 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30053 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28296 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->