### PR TITLE
[SaferCPP] Address issues for CSSPrimitiveValue

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -17,7 +17,6 @@ accessibility/AXSearchManager.h
 bindings/js/JSEventTargetCustom.h
 bindings/js/JSLazyEventListener.cpp
 css/CSSFontSelector.h
-css/CSSPrimitiveValueMappings.h
 css/CSSRuleList.h
 css/CSSStyleProperties.h
 css/CSSValueList.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -426,8 +426,6 @@ css/CSSOffsetRotateValue.cpp
 css/CSSOffsetRotateValue.h
 css/CSSPageRule.cpp
 css/CSSPendingSubstitutionValue.cpp
-css/CSSPrimitiveValue.cpp
-css/CSSPrimitiveValueMappings.h
 css/CSSProperty.h
 css/CSSPropertyRule.cpp
 css/CSSReflectValue.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -213,7 +213,6 @@ css/CSSImageSetValue.cpp
 css/CSSImageValue.cpp
 css/CSSKeyframeRule.cpp
 css/CSSLayerBlockRule.cpp
-css/CSSPrimitiveValue.cpp
 css/CSSRule.cpp
 css/CSSStyleProperties.cpp
 css/CSSStyleRule.cpp

--- a/Source/WebCore/css/CSSGridLineValue.cpp
+++ b/Source/WebCore/css/CSSGridLineValue.cpp
@@ -63,22 +63,17 @@ Ref<CSSGridLineValue> CSSGridLineValue::create(RefPtr<CSSPrimitiveValue>&& spanV
 
 bool CSSGridLineValue::equals(const CSSGridLineValue& other) const
 {
-    if (m_spanValue) {
-        if (!other.m_spanValue || !m_spanValue->equals(*other.m_spanValue))
+    auto equals = [](CSSPrimitiveValue* value, CSSPrimitiveValue* otherValue) {
+        if ((!value && otherValue) || (value && !otherValue))
             return false;
-    } else if (other.m_spanValue)
-        return false;
+        return (!value && !otherValue) || value->equals(*otherValue);
+    };
 
-    if (m_numericValue) {
-        if (!other.m_numericValue || !m_numericValue->equals(*other.m_numericValue))
-            return false;
-    } else if (other.m_numericValue)
+    if (!equals(protectedSpanValue().get(), other.protectedSpanValue().get()))
         return false;
-
-    if (m_gridLineName) {
-        if (!other.m_gridLineName || !m_gridLineName->equals(*other.m_gridLineName))
-            return false;
-    } else if (other.m_gridLineName)
+    if (!equals(protectedNumericValue().get(), other.protectedNumericValue().get()))
+        return false;
+    if (!equals(protectedGridLineName().get(), other.protectedGridLineName().get()))
         return false;
 
     return true;

--- a/Source/WebCore/css/CSSGridLineValue.h
+++ b/Source/WebCore/css/CSSGridLineValue.h
@@ -38,8 +38,11 @@ public:
     bool equals(const CSSGridLineValue& other) const;
 
     CSSPrimitiveValue* spanValue() const { return m_spanValue.get(); }
+    RefPtr<CSSPrimitiveValue> protectedSpanValue() const { return m_spanValue.get(); }
     CSSPrimitiveValue* numericValue() const { return m_numericValue.get(); }
+    RefPtr<CSSPrimitiveValue> protectedNumericValue() const { return m_numericValue.get(); }
     CSSPrimitiveValue* gridLineName() const { return m_gridLineName.get(); }
+    RefPtr<CSSPrimitiveValue> protectedGridLineName() const { return m_gridLineName.get(); }
 
 private:
     explicit CSSGridLineValue(RefPtr<CSSPrimitiveValue>&&, RefPtr<CSSPrimitiveValue>&&, RefPtr<CSSPrimitiveValue>&&);

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "CSSAttrValue.h"
+#include "CSSCalcValue.h"
 #include "CSSPrimitiveNumericUnits.h"
 #include "CSSPropertyNames.h"
 #include "CSSValue.h"
@@ -34,7 +35,6 @@
 
 namespace WebCore {
 
-class CSSCalcValue;
 class CSSToLengthConversionData;
 class FontCascade;
 class RenderStyle;
@@ -199,7 +199,9 @@ public:
 
     WEBCORE_EXPORT String stringValue() const;
     const CSSCalcValue* cssCalcValue() const { return isCalculated() ? m_value.calc : nullptr; }
+    RefPtr<const CSSCalcValue> protectedCssCalcValue() const { return cssCalcValue(); }
     const CSSAttrValue* cssAttrValue() const { return isAttr() ? m_value.attr : nullptr; }
+    RefPtr<const CSSAttrValue> protectedCssAttrValue() const { return cssAttrValue(); }
 
     String customCSSText(const CSS::SerializationContext&) const;
 

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -97,39 +97,39 @@ public:
 
     operator unsigned short() const
     {
-        return numericValue().resolveAsNumber<unsigned short>(m_builderState.cssToLengthConversionData());
+        return protectedNumericValue()->resolveAsNumber<unsigned short>(m_builderState.cssToLengthConversionData());
     }
 
     operator int() const
     {
-        return numericValue().resolveAsNumber<int>(m_builderState.cssToLengthConversionData());
+        return protectedNumericValue()->resolveAsNumber<int>(m_builderState.cssToLengthConversionData());
     }
 
     operator unsigned() const
     {
-        return numericValue().resolveAsNumber<unsigned>(m_builderState.cssToLengthConversionData());
+        return protectedNumericValue()->resolveAsNumber<unsigned>(m_builderState.cssToLengthConversionData());
     }
 
     operator float() const
     {
-        return numericValue().resolveAsNumber<float>(m_builderState.cssToLengthConversionData());
+        return protectedNumericValue()->resolveAsNumber<float>(m_builderState.cssToLengthConversionData());
     }
 
     operator double() const
     {
-        return numericValue().resolveAsNumber<double>(m_builderState.cssToLengthConversionData());
+        return protectedNumericValue()->resolveAsNumber<double>(m_builderState.cssToLengthConversionData());
     }
 
 private:
-    const CSSPrimitiveValue& numericValue() const
+    Ref<const CSSPrimitiveValue> protectedNumericValue() const
     {
-        auto& value = downcast<CSSPrimitiveValue>(m_value);
-        ASSERT(value.isNumberOrInteger());
+        Ref value = downcast<const CSSPrimitiveValue>(m_value);
+        ASSERT(value->isNumberOrInteger());
         return value;
     }
 
     const Style::BuilderState& m_builderState;
-    const CSSValue& m_value;
+    Ref<const CSSValue> m_value;
 };
 
 inline TypeDeducingCSSValueMapper fromCSSValueDeducingType(const Style::BuilderState& builderState, const CSSValue& value)
@@ -2182,7 +2182,7 @@ template<int supported> Length CSSPrimitiveValue::convertToLength(const CSSToLen
     if ((supported & AutoConversion) && valueID() == CSSValueAuto)
         return Length(LengthType::Auto);
     if ((supported & CalculatedConversion) && isCalculated())
-        return Length(cssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { }));
+        return Length(protectedCssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { }));
     return Length(LengthType::Undefined);
 }
 

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -187,11 +187,6 @@ CSSUnitType CSSCalcValue::primitiveType() const
     return CSSUnitType::CSS_NUMBER;
 }
 
-bool CSSCalcValue::requiresConversionData() const
-{
-    return m_tree.requiresConversionData;
-}
-
 void CSSCalcValue::collectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const
 {
     CSSCalc::collectComputedStyleDependencies(m_tree, dependencies);

--- a/Source/WebCore/css/calc/CSSCalcValue.h
+++ b/Source/WebCore/css/calc/CSSCalcValue.h
@@ -84,7 +84,7 @@ public:
     CSSUnitType primitiveType() const;
 
     // Returns whether the CSSCalc::Tree requires `CSSToLengthConversionData` to fully resolve.
-    bool requiresConversionData() const;
+    bool requiresConversionData() const { return m_tree.requiresConversionData; };
 
     double doubleValue(const CSSToLengthConversionData&) const;
     double doubleValue(const CSSToLengthConversionData&, const CSSCalcSymbolTable&) const;

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -1380,7 +1380,7 @@ inline ScrollbarGutter BuilderConverter::convertScrollbarGutter(BuilderState&, c
 
 inline ScrollbarWidth BuilderConverter::convertScrollbarWidth(BuilderState& builderState, const CSSValue& value)
 {
-    ScrollbarWidth scrollbarWidth = fromCSSValueDeducingType(builderState, value);
+    auto scrollbarWidth = fromCSSValue<ScrollbarWidth>(value);
     if (scrollbarWidth == ScrollbarWidth::Thin && builderState.document().quirks().needsScrollbarWidthThinDisabledQuirk())
         return ScrollbarWidth::Auto;
 


### PR DESCRIPTION
#### fe955121b3698d51e59c3e71ed0de1aec4c25eac
<pre>
[SaferCPP] Address issues for CSSPrimitiveValue
<a href="https://rdar.apple.com/149405072">rdar://149405072</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291643">https://bugs.webkit.org/show_bug.cgi?id=291643</a>

Reviewed by Tim Nguyen.

Fix outstanding issues in CSSPrimitiveValue files.
Updated callers of CSSPrimitiveValue::equals() in CSSGridLineValue.cpp.

* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/css/CSSGridLineValue.cpp:
(WebCore::CSSGridLineValue::equals const):
* Source/WebCore/css/CSSGridLineValue.h:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::primitiveType const):
(WebCore::CSSPrimitiveValue::create):
(WebCore::CSSPrimitiveValue::resolveAsLengthDouble const):
(WebCore::CSSPrimitiveValue::doubleValue const):
(WebCore::CSSPrimitiveValue::doubleValueDeprecated const):
(WebCore::CSSPrimitiveValue::doubleValueDividingBy100IfPercentage const):
(WebCore::CSSPrimitiveValue::doubleValueDividingBy100IfPercentageDeprecated const):
(WebCore::CSSPrimitiveValue::stringValue const):
(WebCore::CSSPrimitiveValue::serializeInternal const):
(WebCore::CSSPrimitiveValue::equals const):
(WebCore::CSSPrimitiveValue::collectComputedStyleDependencies const):
(WebCore::CSSPrimitiveValue::customVisitChildren const):
* Source/WebCore/css/CSSPrimitiveValue.h:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::TypeDeducingCSSValueMapper::operator unsigned short const):
(WebCore::TypeDeducingCSSValueMapper::operator int const):
(WebCore::TypeDeducingCSSValueMapper::operator unsigned const):
(WebCore::TypeDeducingCSSValueMapper::operator float const):
(WebCore::TypeDeducingCSSValueMapper::operator double const):
(WebCore::TypeDeducingCSSValueMapper::protectedNumericValue const):
(WebCore::CSSPrimitiveValue::convertToLength const):
(WebCore::TypeDeducingCSSValueMapper::numericValue const): Deleted.
* Source/WebCore/css/calc/CSSCalcValue.cpp:
(WebCore::CSSCalcValue::requiresConversionData const): Deleted.
* Source/WebCore/css/calc/CSSCalcValue.h:

Canonical link: <a href="https://commits.webkit.org/293925@main">https://commits.webkit.org/293925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa4614ff793b1333c37f309e5c00fd7381d89788

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105359 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50812 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20183 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76308 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33366 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15435 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90531 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56668 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15255 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8530 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50180 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92887 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85162 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8612 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107718 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98836 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27342 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20038 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85260 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86738 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84799 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21571 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29478 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7214 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/21213 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27279 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32512 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27090 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30406 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28649 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->