### PR TITLE
[WGSL] Validate that f16 can only be used if it's enabled

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_284652.html
+++ b/LayoutTests/fast/webgpu/regression/repro_284652.html
@@ -169,7 +169,7 @@ texture19 = device0.createTexture({
 {
 }
 shaderModule5 = device0.createShaderModule({
-  code : ` ;
+  code : ` enable f16;
              fn unconst_bool(v: bool) -> bool {
            return v;
            }

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/enable-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/enable-expected.txt
@@ -15,18 +15,5 @@ PASS :enable:case="unknown"
 PASS :enable:case="subgroups"
 PASS :enable:case="subgroups_f16_pass1"
 PASS :enable:case="subgroups_f16_pass2"
-FAIL :enable:case="in_comment_f16" assert_unreached:
-  - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-
-        /* enable f16; */
-        var<private> v: f16;
-
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/enable.spec.js:102:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
- Reached unreachable code
+PASS :enable:case="in_comment_f16"
 

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -1806,6 +1806,8 @@ Result<AST::Expression::Ref> Parser<Lexer>::parsePrimaryExpression()
         RETURN_ARENA_NODE(Float32Literal, lit.floatValue);
     }
     case TokenType::HalfLiteral: {
+        if (!m_shaderModule.enabledExtensions().contains(Extension::F16))
+            FAIL("f16 literal used without f16 extension enabled"_s);
         CONSUME_TYPE_NAMED(lit, HalfLiteral);
         RETURN_ARENA_NODE(Float16Literal, lit.floatValue);
     }

--- a/Source/WebGPU/WGSL/tests/f16-literal.wgsl
+++ b/Source/WebGPU/WGSL/tests/f16-literal.wgsl
@@ -1,0 +1,6 @@
+// RUN: %not %wgslc | %check
+
+fn main() -> f16 {
+    // CHECK-L: f16 literal used without f16 extension enabled
+    var x = 1h;
+}

--- a/Source/WebGPU/WGSL/tests/f16-types.wgsl
+++ b/Source/WebGPU/WGSL/tests/f16-types.wgsl
@@ -1,0 +1,20 @@
+// RUN: %not %wgslc | %check
+
+// CHECK-L: f16 type used without f16 extension enabled
+fn main() -> f16 {
+    var x: f16;
+
+    // CHECK-L: f16 type used without f16 extension enabled
+    x = vec2h().x;
+
+    // CHECK-L: f16 type used without f16 extension enabled
+    x = vec3h().x;
+
+    // CHECK-L: f16 type used without f16 extension enabled
+    x = vec4h().x;
+
+    // CHECK-L: f16 type used without f16 extension enabled
+    x = mat2x2h()[0].x;
+
+    return x;
+}

--- a/Source/WebGPU/WGSL/tests/function-call.wgsl
+++ b/Source/WebGPU/WGSL/tests/function-call.wgsl
@@ -1,5 +1,7 @@
 // RUN: %not %wgslc | %check
 
+enable f16;
+
 fn f1(x: f32) -> f32 {
     // CHECK-L: missing return at end of function
 }

--- a/Source/WebGPU/WGSL/tests/fuzz-127229681.wgsl
+++ b/Source/WebGPU/WGSL/tests/fuzz-127229681.wgsl
@@ -1,5 +1,7 @@
 // RUN: %wgslc
 
+enable f16;
+
 struct S {
   x: array<f32>,
 }

--- a/Source/WebGPU/WGSL/tests/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/overload.wgsl
@@ -1,5 +1,7 @@
 // RUN: %wgslc
 
+enable f16;
+
 // 8.6. Logical Expressions (https://gpuweb.github.io/gpuweb/wgsl/#logical-expr)
 
 // RUN: %metal-compile testLogicalNegation

--- a/Source/WebGPU/WGSL/tests/struct.wgsl
+++ b/Source/WebGPU/WGSL/tests/struct.wgsl
@@ -1,5 +1,7 @@
 // RUN: %metal-compile main
 
+enable f16;
+
 struct S {
     @size(16) x: f32,
     @align(16) y: i32,


### PR DESCRIPTION
#### f08815ba3bb00b493f18cd4bebbf2111bf963054
<pre>
[WGSL] Validate that f16 can only be used if it&apos;s enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=291645">https://bugs.webkit.org/show_bug.cgi?id=291645</a>
<a href="https://rdar.apple.com/148083643">rdar://148083643</a>

Reviewed by Mike Wyrzykowski.

While we parsed the `enable f16` directive, we never really validated that
it had to be enabled for f16 to be used. We validate in 3 locations, which
should be enough to prevent every usage of f16:
- when referencing a type by name we checked whether it&apos;s f16, vecN&lt;f16&gt; or
  matMxN&lt;f16&gt;. In theory just f16 should suffice, but it falls short due to
  the built-in type aliases
- when constructing a type we perform the same validations as above
- when parsing f16 literals.

* LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/enable-expected.txt:
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parsePrimaryExpression):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::lookupType):
(WGSL::TypeChecker::validateF16Usage):
* Source/WebGPU/WGSL/tests/f16-literal.wgsl: Added.
* Source/WebGPU/WGSL/tests/f16-types.wgsl: Added.
* Source/WebGPU/WGSL/tests/function-call.wgsl:
* Source/WebGPU/WGSL/tests/fuzz-127229681.wgsl:
* Source/WebGPU/WGSL/tests/overload.wgsl:
* Source/WebGPU/WGSL/tests/struct.wgsl:

Canonical link: <a href="https://commits.webkit.org/293957@main">https://commits.webkit.org/293957@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4016dbab1d5f2dd4bd6e95cf6c4a535774dfae39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105545 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50996 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28534 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76451 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33505 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15598 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90698 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56807 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15415 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8700 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50368 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85330 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8780 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107899 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27526 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20194 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85404 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27889 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84941 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21606 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29625 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7357 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21463 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27461 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32704 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27272 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30590 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28830 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->