### PR TITLE
[WTF] Introduce StatisticsManager for recording per-key numeric statistics with histogram support

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -935,6 +935,8 @@
 		FEC26BF3289DBBD300639A59 /* FunctionPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = FEC26BF2289DBBD300639A59 /* FunctionPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FEDACD3D1630F83F00C69634 /* StackStats.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FEDACD3B1630F83F00C69634 /* StackStats.cpp */; };
 		FEEA4DF9216D7BE400AC0602 /* StackPointer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FEEA4DF8216D7BE400AC0602 /* StackPointer.cpp */; };
+		FF3997412DB044E600A58E88 /* StatisticsManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF3997402DB044E600A58E88 /* StatisticsManager.cpp */; };
+		FF3997422DB044E600A58E88 /* StatisticsManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FF39973F2DB044E600A58E88 /* StatisticsManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF41AC672A79C9BA00AC0FA5 /* WYHash.h in Headers */ = {isa = PBXBuildFile; fileRef = FF41AC662A79C9B900AC0FA5 /* WYHash.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF895F11282AB96400E7BAE8 /* CompactRefPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = FF895F10282AB96400E7BAE8 /* CompactRefPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF8CB4012A88C0D3004AF498 /* SuperFastHash.h in Headers */ = {isa = PBXBuildFile; fileRef = FF8CB4002A88C0D3004AF498 /* SuperFastHash.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2000,6 +2002,8 @@
 		FEEA4DF8216D7BE400AC0602 /* StackPointer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StackPointer.cpp; sourceTree = "<group>"; };
 		FEF295BF20B49DCB00CF283A /* UTF8ConversionError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UTF8ConversionError.h; sourceTree = "<group>"; };
 		FF0A436588954F3CB07DBECA /* StdList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StdList.h; sourceTree = "<group>"; };
+		FF39973F2DB044E600A58E88 /* StatisticsManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StatisticsManager.h; sourceTree = "<group>"; };
+		FF3997402DB044E600A58E88 /* StatisticsManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StatisticsManager.cpp; sourceTree = "<group>"; };
 		FF41AC662A79C9B900AC0FA5 /* WYHash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WYHash.h; sourceTree = "<group>"; };
 		FF895F10282AB96400E7BAE8 /* CompactRefPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CompactRefPtr.h; sourceTree = "<group>"; };
 		FF8CB4002A88C0D3004AF498 /* SuperFastHash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SuperFastHash.h; sourceTree = "<group>"; };
@@ -2604,6 +2608,8 @@
 				FEDACD3C1630F83F00C69634 /* StackStats.h */,
 				313EDEC9778E49C9BEA91CFC /* StackTrace.cpp */,
 				EF7D6CD59D8642A8A0DA86AD /* StackTrace.h */,
+				FF3997402DB044E600A58E88 /* StatisticsManager.cpp */,
+				FF39973F2DB044E600A58E88 /* StatisticsManager.h */,
 				7C595FFC252A96E000E42168 /* StdFilesystem.h */,
 				FE97F6A8245CE5DD00C63FC6 /* StdIntExtras.h */,
 				A8A47311151A825B004123FF /* StdLibExtras.h */,
@@ -2873,9 +2879,9 @@
 		DD3DC9FF27A4E176007E5B61 /* Scripts */ = {
 			isa = PBXGroup;
 			children = (
-				DD725EC92D8A442900E72544 /* audit-spi-if-needed.sh */,
 				DD9C67FB2D70243000D4BEC7 /* generate-platform-args */,
 				DD3DCA0027A4E176007E5B61 /* Preferences */,
+				DD725EC92D8A442900E72544 /* audit-spi-if-needed.sh */,
 				DD28DF2329D368BD00BBB459 /* generate-tapi-filelist.py */,
 				DD3DCA0527A4E176007E5B61 /* generate-unified-source-bundles.rb */,
 				DD3DCA0627A4E176007E5B61 /* GeneratePreferences.rb */,
@@ -3303,7 +3309,6 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DD725ECA2D8A443E00E72544 /* audit-spi-if-needed.sh in Headers */,
 				FE6997E129D241630078B9C6 /* AbortWithReasonSPI.h in Headers */,
 				144EB7462CBC94B100926E1B /* AbstractRefCounted.h in Headers */,
 				1404B3E52CBC954D00A7471C /* AbstractRefCountedAndCanMakeWeakPtr.h in Headers */,
@@ -3326,6 +3331,7 @@
 				DDF307E327C086DF006A526F /* AtomStringHash.h in Headers */,
 				DDF307CA27C086DF006A526F /* AtomStringImpl.h in Headers */,
 				DDF307DB27C086DF006A526F /* AtomStringTable.h in Headers */,
+				DD725ECA2D8A443E00E72544 /* audit-spi-if-needed.sh in Headers */,
 				DD3DC8DA27A4BF8E007E5B61 /* AutodrainedPool.h in Headers */,
 				DD3DC97E27A4BF8E007E5B61 /* AutomaticThread.h in Headers */,
 				DD3DC89327A4BF8E007E5B61 /* BackwardsGraph.h in Headers */,
@@ -3718,6 +3724,7 @@
 				DD3DC8A127A4BF8E007E5B61 /* StackShotProfiler.h in Headers */,
 				DD3DC97A27A4BF8E007E5B61 /* StackStats.h in Headers */,
 				DD3DC99C27A4BF8E007E5B61 /* StackTrace.h in Headers */,
+				FF3997422DB044E600A58E88 /* StatisticsManager.h in Headers */,
 				DD3DC94827A4BF8E007E5B61 /* StdFilesystem.h in Headers */,
 				DD3DC86527A4BF8E007E5B61 /* StdIntExtras.h in Headers */,
 				DD3DC98127A4BF8E007E5B61 /* StdLibExtras.h in Headers */,
@@ -4382,6 +4389,7 @@
 				FEEA4DF9216D7BE400AC0602 /* StackPointer.cpp in Sources */,
 				FEDACD3D1630F83F00C69634 /* StackStats.cpp in Sources */,
 				3337DB9CE743410FAF076E17 /* StackTrace.cpp in Sources */,
+				FF3997412DB044E600A58E88 /* StatisticsManager.cpp in Sources */,
 				0F95B63720CB5EFD00479635 /* StringBuffer.cpp in Sources */,
 				A8A4743C151A825B004123FF /* StringBuilder.cpp in Sources */,
 				E38D6E271F5522E300A75CC4 /* StringBuilderJSON.cpp in Sources */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -308,6 +308,7 @@ set(WTF_PUBLIC_HEADERS
     StackShotProfiler.h
     StackStats.h
     StackTrace.h
+    StatisticsManager.h
     StdFilesystem.h
     StdIntExtras.h
     StdLibExtras.h
@@ -597,6 +598,7 @@ set(WTF_SOURCES
     StackPointer.cpp
     StackStats.cpp
     StackTrace.cpp
+    StatisticsManager.cpp
     StringPrintStream.cpp
     SuspendableWorkQueue.cpp
     ThreadGroup.cpp

--- a/Source/WTF/wtf/StatisticsManager.cpp
+++ b/Source/WTF/wtf/StatisticsManager.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#include "config.h"
+#include "StatisticsManager.h"
+
+#include <wtf/DataLog.h>
+#include <wtf/text/StringHash.h>
+#include <wtf/text/WTFString.h>
+
+namespace WTF {
+
+StatisticsManager& StatisticsManager::singleton()
+{
+    static std::once_flag onceFlag;
+    static StatisticsManager* instance = nullptr;
+    std::call_once(onceFlag, [] {
+        instance = new StatisticsManager();
+    });
+    return *instance;
+}
+
+void StatisticsManager::addDataPoint(ASCIILiteral id, double value)
+{
+    Locker locker { m_lock };
+    m_data.add(id, Vector<double>()).iterator->value.append(value);
+}
+
+static void dumpHistogram(const AbstractLocker&, const Vector<double>& values, double min, double max, size_t binCount = 10)
+{
+    if (values.isEmpty() || min == max)
+        return;
+
+    Vector<size_t> bins(binCount, 0);
+    double binSize = (max - min) / binCount;
+
+    for (double value : values) {
+        size_t index = std::min(binCount - 1, static_cast<size_t>((value - min) / binSize));
+        ++bins[index];
+    }
+
+    for (size_t i = 0; i < binCount; ++i) {
+        double start = min + i * binSize;
+        double end = start + binSize;
+        dataLogF("  [%.2f - %.2f): %zu\n", start, end, bins[i]);
+    }
+}
+
+void StatisticsManager::dumpStatistics()
+{
+    Locker locker { m_lock };
+
+    for (const auto& entry : m_data) {
+        const String& id = entry.key;
+        const Vector<double>& values = entry.value;
+        size_t count = values.size();
+        if (!count)
+            continue;
+
+        double sum = 0;
+        double sumOfSquares = 0;
+        double min = std::numeric_limits<double>::infinity();
+        double max = -min;
+
+        for (double value : values) {
+            sum += value;
+            sumOfSquares += value * value;
+            min = std::min(min, value);
+            max = std::max(max, value);
+        }
+
+        double mean = sum / count;
+        double variance = (sumOfSquares / count) - (mean * mean);
+        double stddev = std::sqrt(variance);
+
+        CString utf8ID = id.utf8();
+        dataLogF(
+            "Statistics for %s:\n"
+            "  Count    : %zu\n"
+            "  Min      : %.6f\n"
+            "  Max      : %.6f\n"
+            "  Mean     : %.6f\n"
+            "  Variance : %.6f\n"
+            "  Std Dev  : %.6f\n"
+            "  Histogram:\n",
+            utf8ID.data(), count, min, max, mean, variance, stddev);
+
+        dumpHistogram(locker, values, min, max);
+        dataLogF("\n");
+    }
+}
+
+void StatisticsManager::clear()
+{
+    Locker locker { m_lock };
+    m_data.clear();
+}
+
+} // namespace WTF

--- a/Source/WTF/wtf/StatisticsManager.h
+++ b/Source/WTF/wtf/StatisticsManager.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+#include <wtf/HashMap.h>
+#include <wtf/Vector.h>
+
+namespace WTF {
+
+class StatisticsManager {
+public:
+    WTF_EXPORT_PRIVATE static StatisticsManager& singleton();
+
+    WTF_EXPORT_PRIVATE void addDataPoint(ASCIILiteral id, double value);
+    WTF_EXPORT_PRIVATE void dumpStatistics();
+    WTF_EXPORT_PRIVATE void clear();
+
+private:
+    StatisticsManager() = default;
+    ~StatisticsManager() = default;
+
+    mutable Lock m_lock;
+    UncheckedKeyHashMap<ASCIILiteral, Vector<double>> m_data WTF_GUARDED_BY_LOCK(m_lock);
+};
+
+} // namespace WTF
+
+using WTF::StatisticsManager;


### PR DESCRIPTION
#### 222d2e04c1d686c2294db4a68733d64da28825b3
<pre>
[WTF] Introduce StatisticsManager for recording per-key numeric statistics with histogram support
<a href="https://bugs.webkit.org/show_bug.cgi?id=291647">https://bugs.webkit.org/show_bug.cgi?id=291647</a>
<a href="https://rdar.apple.com/149416894">rdar://149416894</a>

Reviewed by Keith Miller.

This patch introduces `WTF::StatisticsManager`, a thread-safe singleton for
recording statistical metrics (e.g. count, min, max, mean, variance, standard
deviation) for arbitrary string identifiers.

Each identifier (e.g. &quot;unrolled-loop-loopBodySize&quot;) accumulates the
full data history (Vector&lt;double&gt;) in time. And count, sum, sum-of-squares,
min, max, and histogram with 10 bins, computed on-demand during dumpStatistics().

This supports runtime use cases such as performance profiling, optimization
validation, and internal monitoring.

Example usage:

    StatisticsManager::singleton().addDataPoint(&quot;fully-unrolled-loop-loopBodySize&quot;, loopSize);
    ...
    StatisticsManager::singleton().addDataPoint(&quot;partially-unrolled-loop-loopBodySize&quot;, loopSize);

    ...
    StatisticsManager::singleton().dumpStatistics();
    StatisticsManager::singleton().clear(); // optional

Output format:

Statistics for fully-unrolled-loop-loopBodySize:
    Count    : 34
    Min      : 22.000000
    Max      : 189.000000
    Mean     : 49.794118
    Variance : 1487.045848
    Std Dev  : 38.562233
    Histogram:
    [22.00 - 38.70): 21
    [38.70 - 55.40): 6
    [55.40 - 72.10): 2
    [72.10 - 88.80): 1
    [88.80 - 105.50): 0
    [105.50 - 122.20): 1
    [122.20 - 138.90): 1
    [138.90 - 155.60): 1
    [155.60 - 172.30): 0
    [172.30 - 189.00): 1

Statistics for partially-unrolled-loop-loopBodySize:
    ...

Future extensions may include percentile estimation, histogram range controls,
or scoped/statistical macros for easier instrumentation.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/StatisticsManager.cpp: Added.
(WTF::StatisticsManager::singleton):
(WTF::StatisticsManager::StatBucket::add):
(WTF::StatisticsManager::StatBucket::mean const):
(WTF::StatisticsManager::StatBucket::variance const):
(WTF::StatisticsManager::StatBucket::stdDev const):
(WTF::StatisticsManager::StatBucket::prepareHistogram):
(WTF::StatisticsManager::StatBucket::addToHistogram):
(WTF::StatisticsManager::StatBucket::dumpHistogram):
(WTF::StatisticsManager::addDataPoint):
(WTF::StatisticsManager::dumpStatistics):
(WTF::StatisticsManager::clear):
* Source/WTF/wtf/StatisticsManager.h: Added.

Canonical link: <a href="https://commits.webkit.org/293856@main">https://commits.webkit.org/293856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/584f191896f3fb50aa495feff045ead207f7a9eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100121 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10066 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105251 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50702 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28242 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/76216 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33283 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103128 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90425 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56577 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15156 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8423 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50072 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92779 "Built successfully and passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8506 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107610 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98728 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27234 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85171 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27597 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86632 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84706 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21519 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29383 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21089 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27171 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32403 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122354 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26982 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34151 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30298 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28541 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->