### PR TITLE
NetworkStorageManager.GetAllDatabaseNamesAndVersions crashes with invalid requestIdentifier

### DIFF
--- a/LayoutTests/ipc/getAllDatabaseNamesAndVersions-no-resource-identifier-expected.txt
+++ b/LayoutTests/ipc/getAllDatabaseNamesAndVersions-no-resource-identifier-expected.txt
@@ -1,0 +1,3 @@
+This test passes if webkit does not crash
+
+PASS

--- a/LayoutTests/ipc/getAllDatabaseNamesAndVersions-no-resource-identifier.html
+++ b/LayoutTests/ipc/getAllDatabaseNamesAndVersions-no-resource-identifier.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<script>
+  window.testRunner?.waitUntilDone();
+    window.testRunner?.dumpAsText();
+
+    function test() {
+        var pass = document.getElementById('pass');
+        if (window.IPC) {
+            import('./coreipc.js').then(({
+                CoreIPC
+            }) => {
+                CoreIPC.Networking.NetworkStorageManager.GetAllDatabaseNamesAndVersions(0, {
+                    requestIdentifier: {
+                        m_idbConnectionIdentifier: {},
+                        m_resourceNumber: {
+                            optionalValue: 1234
+                        }
+                    },
+                    origin: {
+                        topOrigin: {
+                            data: {
+                                variantType: 'WebCore::SecurityOriginData::Tuple',
+                                variant: {
+                                    protocol: '',
+                                    host: '',
+                                    port: {}
+                                }
+                            }
+                        },
+                        clientOrigin: {
+                            data: {
+                                variantType: 'WebCore::SecurityOriginData::Tuple',
+                                variant: {
+                                    protocol: '',
+                                    host: '',
+                                    port: {}
+                                }
+                            }
+                        }
+                    }
+                });
+                pass.innerText = "PASS";
+                window.testRunner?.notifyDone();
+            });
+        } else {
+            pass.innerText = "PASS";
+            window.testRunner?.notifyDone();
+        }
+    }
+</script>
+<body onload="test()">
+  <p>This test passes if webkit does not crash</p>
+  <div id="pass"></div>
+</body>

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1935,6 +1935,7 @@ void NetworkStorageManager::iterateCursor(const WebCore::IDBRequestData& request
 
 void NetworkStorageManager::getAllDatabaseNamesAndVersions(IPC::Connection& connection, const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::ClientOrigin& origin)
 {
+    MESSAGE_CHECK(requestIdentifier.connectionIdentifier(), connection);
     Ref connectionToClient = m_idbStorageRegistry->ensureConnectionToClient(connection.uniqueID(), *requestIdentifier.connectionIdentifier());
     auto result = checkedOriginStorageManager(origin)->idbStorageManager(*m_idbStorageRegistry).getAllDatabaseNamesAndVersions();
     connectionToClient->didGetAllDatabaseNamesAndVersions(requestIdentifier, WTFMove(result));


### PR DESCRIPTION
#### 5644d5bcff23fefeab1ff294b8917ed9afc40ef0
<pre>
NetworkStorageManager.GetAllDatabaseNamesAndVersions crashes with invalid requestIdentifier
<a href="https://rdar.apple.com/149291737">rdar://149291737</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291649">https://bugs.webkit.org/show_bug.cgi?id=291649</a>

Reviewed by Sihui Liu.

This fixes the bug by checking if the requestIdentifier is valid

* LayoutTests/ipc/getAllDatabaseNamesAndVersions-no-resource-identifier-expected.txt: Added.
* LayoutTests/ipc/getAllDatabaseNamesAndVersions-no-resource-identifier.html: Added.
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::getAllDatabaseNamesAndVersions):

Canonical link: <a href="https://commits.webkit.org/293790@main">https://commits.webkit.org/293790@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33574f55c07edcb0c5846e389c05033e220b0ec1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105040 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50494 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76058 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33142 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102920 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56416 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14956 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8211 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49863 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107401 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27026 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19745 "Found 1 new test failure: ipc/invalid-mediarecorder-identifier.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85008 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27388 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86426 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84531 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29209 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6932 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/20845 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16255 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26963 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32200 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26774 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30090 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28333 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->