### PR TITLE
[JSC] Add inferredNameWithHash() helper for unified CodeBlock name and hash logging

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -120,6 +120,11 @@ CString CodeBlock::inferredName() const
     }
 }
 
+String CodeBlock::inferredNameWithHash() const
+{
+    return makeString(inferredName(), "#"_s, hashAsStringIfPossible());
+}
+
 bool CodeBlock::hasHash() const
 {
     return !!m_hash;
@@ -164,7 +169,7 @@ CString CodeBlock::hashAsStringIfPossible() const
 
 void CodeBlock::dumpAssumingJITType(PrintStream& out, JITType jitType) const
 {
-    out.print(inferredName(), "#", hashAsStringIfPossible());
+    out.print(inferredNameWithHash());
     out.print(":[", RawPointer(this), "->");
     if (!!m_alternative)
         out.print(RawPointer(alternative()), "->");
@@ -201,7 +206,7 @@ void CodeBlock::dump(PrintStream& out) const
 
 void CodeBlock::dumpSimpleName(PrintStream& out) const
 {
-    out.print(inferredName(), "#", hashAsStringIfPossible());
+    out.print(inferredNameWithHash());
 }
 
 void CodeBlock::dumpSource()

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -200,6 +200,7 @@ public:
     UnlinkedCodeBlock* unlinkedCodeBlock() const { return m_unlinkedCode.get(); }
 
     CString inferredName() const;
+    String inferredNameWithHash() const;
     CodeBlockHash hash() const;
     bool hasHash() const;
     bool isSafeToComputeHash() const;

--- a/Source/JavaScriptCore/interpreter/CallFrame.cpp
+++ b/Source/JavaScriptCore/interpreter/CallFrame.cpp
@@ -302,7 +302,7 @@ void CallFrame::dump(PrintStream& out) const
     }
 
     if (CodeBlock* codeBlock = this->codeBlock()) {
-        out.print(codeBlock->inferredName(), "#", codeBlock->hashAsStringIfPossible(), " [", codeBlock->jitType(), " ", bytecodeIndex(), "]");
+        out.print(codeBlock->inferredNameWithHash(), " [", codeBlock->jitType(), " ", bytecodeIndex(), "]");
 
         out.print("(");
         thisValue().dumpForBacktrace(out);

--- a/Source/JavaScriptCore/runtime/NarrowingNumberPredictionFuzzerAgent.cpp
+++ b/Source/JavaScriptCore/runtime/NarrowingNumberPredictionFuzzerAgent.cpp
@@ -63,7 +63,7 @@ SpeculatedType NarrowingNumberPredictionFuzzerAgent::getPrediction(CodeBlock* co
     }
 
     if (Options::dumpFuzzerAgentPredictions())
-        dataLogLn("NarrowingNumberPredictionFuzzerAgent::getPrediction name:(", codeBlock->inferredName(), "#", codeBlock->hashAsStringIfPossible(), "),bytecodeIndex:(", codeOrigin.bytecodeIndex(), "),original:(", SpeculationDump(original), "),generated:(", SpeculationDump(generated), ")");
+        dataLogLn("NarrowingNumberPredictionFuzzerAgent::getPrediction name:(", codeBlock->inferredNameWithHash(), "),bytecodeIndex:(", codeOrigin.bytecodeIndex(), "),original:(", SpeculationDump(original), "),generated:(", SpeculationDump(generated), ")");
 
     return generated;
 }

--- a/Source/JavaScriptCore/runtime/RandomizingFuzzerAgent.cpp
+++ b/Source/JavaScriptCore/runtime/RandomizingFuzzerAgent.cpp
@@ -46,7 +46,7 @@ SpeculatedType RandomizingFuzzerAgent::getPrediction(CodeBlock* codeBlock, const
     uint32_t low = m_random.getUint32();
     SpeculatedType generated = static_cast<SpeculatedType>((static_cast<uint64_t>(high) << 32) | low) & SpecFullTop;
     if (Options::dumpFuzzerAgentPredictions())
-        dataLogLn("getPrediction name:(", codeBlock->inferredName(), "#", codeBlock->hashAsStringIfPossible(), "),bytecodeIndex:(", codeOrigin.bytecodeIndex(), "),original:(", SpeculationDump(original), "),generated:(", SpeculationDump(generated), ")");
+        dataLogLn("getPrediction name:(", codeBlock->inferredNameWithHash(), "),bytecodeIndex:(", codeOrigin.bytecodeIndex(), "),original:(", SpeculationDump(original), "),generated:(", SpeculationDump(generated), ")");
     return generated;
 }
 

--- a/Source/JavaScriptCore/runtime/WideningNumberPredictionFuzzerAgent.cpp
+++ b/Source/JavaScriptCore/runtime/WideningNumberPredictionFuzzerAgent.cpp
@@ -66,7 +66,7 @@ SpeculatedType WideningNumberPredictionFuzzerAgent::getPrediction(CodeBlock* cod
     }
 
     if (Options::dumpFuzzerAgentPredictions())
-        dataLogLn("WideningNumberPredictionFuzzerAgent::getPrediction name:(", codeBlock->inferredName(), "#", codeBlock->hashAsStringIfPossible(), "),bytecodeIndex:(", codeOrigin.bytecodeIndex(), "),original:(", SpeculationDump(original), "),generated:(", SpeculationDump(generated), ")");
+        dataLogLn("WideningNumberPredictionFuzzerAgent::getPrediction name:(", codeBlock->inferredNameWithHash(), "),bytecodeIndex:(", codeOrigin.bytecodeIndex(), "),original:(", SpeculationDump(original), "),generated:(", SpeculationDump(generated), ")");
 
     return generated;
 }


### PR DESCRIPTION
#### 9f88bc3bc9055736404869b952a86527d4241ea6
<pre>
[JSC] Add inferredNameWithHash() helper for unified CodeBlock name and hash logging
<a href="https://bugs.webkit.org/show_bug.cgi?id=291650">https://bugs.webkit.org/show_bug.cgi?id=291650</a>
<a href="https://rdar.apple.com/149422510">rdar://149422510</a>

Reviewed by Yusuke Suzuki.

This patch adds a new helper method CodeBlock::inferredNameWithHash() that
combines a CodeBlock&apos;s inferred name and hash into a single formatted String.
This improves consistency and readability in logging, debugging, and profiling.

Changes include:
1. Added CodeBlock::inferredNameWithHash() and replaced repeated
   `inferredName() + &quot;#&quot; + hashAsStringIfPossible()` patterns.
2. Also adds `loopBodySize` to `LoopData`` for additional insight during loop
   unrolling diagnostics.
3. Moved `m_unrolledLoopHeaders.add(header);` under `unrollLoop()`.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::inferredNameWithHash const):
(JSC::CodeBlock::dumpAssumingJITType const):
(JSC::CodeBlock::dumpSimpleName const):
* Source/JavaScriptCore/bytecode/CodeBlock.h:
* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
(JSC::DFG::LoopUnrollingPhase::tryUnroll):
(JSC::DFG::LoopUnrollingPhase::isLoopBodyUnrollable):
(JSC::DFG::LoopUnrollingPhase::unrollLoop):
(JSC::DFG::LoopUnrollingPhase::LoopData::dump const):
* Source/JavaScriptCore/interpreter/CallFrame.cpp:
(JSC::CallFrame::dump const):
* Source/JavaScriptCore/runtime/NarrowingNumberPredictionFuzzerAgent.cpp:
(JSC::NarrowingNumberPredictionFuzzerAgent::getPrediction):
* Source/JavaScriptCore/runtime/RandomizingFuzzerAgent.cpp:
(JSC::RandomizingFuzzerAgent::getPrediction):
* Source/JavaScriptCore/runtime/WideningNumberPredictionFuzzerAgent.cpp:
(JSC::WideningNumberPredictionFuzzerAgent::getPrediction):

Canonical link: <a href="https://commits.webkit.org/293801@main">https://commits.webkit.org/293801@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/749ef3ed8561fe0f6e2f7379263ec0b5c3afe3b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105034 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50488 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19860 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27990 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76063 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33143 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15153 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90224 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56450 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14957 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8209 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49857 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92565 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84883 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8298 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107395 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98514 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19742 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85007 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27382 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86424 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84530 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29207 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6930 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20839 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16262 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26957 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32182 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122140 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26768 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34100 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30084 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28327 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->