### PR TITLE
In <model> 1 spatial centimeter should be equal to 1 css centimeter

### DIFF
--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -412,6 +412,26 @@ static CGFloat effectivePointsPerMeter(CALayer *caLayer)
     return defaultPointsPerMeter;
 }
 
+static RESRT modelStandardizedTransformSRT(RESRT originalSRT)
+{
+    constexpr float defaultScaleFactor = 0.32f;
+
+    originalSRT.scale *= defaultScaleFactor;
+    originalSRT.translation *= defaultScaleFactor;
+
+    return originalSRT;
+}
+
+static RESRT modelLocalizedTransformSRT(RESRT originalSRT)
+{
+    constexpr float defaultScaleFactor = 0.32f;
+
+    originalSRT.scale /= defaultScaleFactor;
+    originalSRT.translation /= defaultScaleFactor;
+
+    return originalSRT;
+}
+
 void ModelProcessModelPlayerProxy::computeTransform(bool setDefaultRotation)
 {
     if (!m_model || !m_layer)
@@ -423,7 +443,8 @@ void ModelProcessModelPlayerProxy::computeTransform(bool setDefaultRotation)
     RESRT newSRT = computeSRT(m_layer.get(), m_originalBoundingBoxExtents, m_originalBoundingBoxCenter, boundingRadius, m_hasPortal, effectivePointsPerMeter(m_layer.get()), m_stageModeOperation, currentModelRotation);
     m_transformSRT = newSRT;
 
-    simd_float4x4 matrix = RESRTMatrix(m_transformSRT);
+    newSRT = modelStandardizedTransformSRT(newSRT);
+    simd_float4x4 matrix = RESRTMatrix(newSRT);
     WebCore::TransformationMatrix transform = WebCore::TransformationMatrix(matrix);
     send(Messages::ModelProcessModelPlayer::DidUpdateEntityTransform(transform));
 }
@@ -583,7 +604,8 @@ std::optional<WebCore::LayerHostingContextIdentifier> ModelProcessModelPlayerPro
 
 void ModelProcessModelPlayerProxy::setEntityTransform(WebCore::TransformationMatrix transform)
 {
-    m_transformSRT = REMakeSRTFromMatrix(transform);
+    RESRT newSRT = REMakeSRTFromMatrix(transform);
+    m_transformSRT = modelLocalizedTransformSRT(newSRT);
     updateTransform();
 }
 
@@ -816,13 +838,15 @@ void ModelProcessModelPlayerProxy::setStageMode(WebCore::StageModeOperation stag
 void ModelProcessModelPlayerProxy::updateTransformSRT()
 {
     WKEntityTransform entityTransform = [m_modelRKEntity transform];
-    m_transformSRT = RESRT {
+    RESRT newSRT = RESRT {
         .scale = entityTransform.scale,
         .rotation = entityTransform.rotation,
         .translation = entityTransform.translation
     };
+    m_transformSRT = newSRT;
 
-    simd_float4x4 matrix = RESRTMatrix(m_transformSRT);
+    newSRT = modelStandardizedTransformSRT(newSRT);
+    simd_float4x4 matrix = RESRTMatrix(newSRT);
     WebCore::TransformationMatrix transform = WebCore::TransformationMatrix(matrix);
     send(Messages::ModelProcessModelPlayer::DidUpdateEntityTransform(transform));
 }


### PR DESCRIPTION
#### a5aeac22c5f32b374e1b2668bc31c2f755c8e5d2
<pre>
In &lt;model&gt; 1 spatial centimeter should be equal to 1 css centimeter
<a href="https://bugs.webkit.org/show_bug.cgi?id=291654">https://bugs.webkit.org/show_bug.cgi?id=291654</a>
<a href="https://rdar.apple.com/148281742">rdar://148281742</a>

Reviewed by NOBODY (OOPS!).

This PR adds two static functions to convert the entityTransform coordinate space such that
the scale and position are standardized in a way where 1 spatial cm = 1 css cm. This means
that a 1cm cube should have a scale factor of 1.0 when it is placed in a portal with width
and height of 1 css cm.

* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::modelStandardizedTransformSRT):
(WebKit::modelLocalizedTransformSRT):
(WebKit::ModelProcessModelPlayerProxy::computeTransform):
(WebKit::ModelProcessModelPlayerProxy::setEntityTransform):
(WebKit::ModelProcessModelPlayerProxy::updateTransformSRT):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5aeac22c5f32b374e1b2668bc31c2f755c8e5d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99924 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105051 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50505 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28008 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76068 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33149 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102931 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15165 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90243 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56426 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14973 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49874 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84893 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107412 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27037 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19756 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85018 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27399 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86443 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84541 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29217 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6945 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/20856 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26974 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32202 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26785 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30101 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28344 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->