### PR TITLE
New Test (292698@main): [ Sequoia wk1 ] accessibility/text-marker/text-marker-debug-description.html is a consistent failure

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -3100,4 +3100,3 @@ webkit.org/b/291207 fullscreen/full-screen-document-background-color.html [ Pass
 
 webkit.org/b/291577 fast/hidpi/filters-reference.html [ ImageOnlyFailure ]
 
-webkit.org/b/291603 accessibility/text-marker/text-marker-debug-description.html [ Pass Failure ]

--- a/Tools/DumpRenderTree/AccessibilityUIElement.cpp
+++ b/Tools/DumpRenderTree/AccessibilityUIElement.cpp
@@ -1157,6 +1157,26 @@ static JSValueRef setSelectedTextMarkerRangeCallback(JSContextRef context, JSObj
     return JSValueMakeBoolean(context, false);
 }
 
+static JSValueRef textMarkerDebugDescriptionCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+{
+    AccessibilityTextMarker* marker = nullptr;
+    if (argumentCount == 1)
+        marker = toTextMarker(JSValueToObject(context, arguments[0], exception));
+
+    auto description = toAXElement(thisObject)->textMarkerDebugDescription(marker);
+    return JSValueMakeString(context, description.get());
+}
+
+static JSValueRef textMarkerRangeDebugDescriptionCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+{
+    AccessibilityTextMarkerRange* markerRange = nullptr;
+    if (argumentCount == 1)
+        markerRange = toTextMarkerRange(JSValueToObject(context, arguments[0], exception));
+
+    auto description = toAXElement(thisObject)->textMarkerRangeDebugDescription(markerRange);
+    return JSValueMakeString(context, description.get());
+}
+
 // Static Value Getters
 
 static JSValueRef getARIADropEffectsCallback(JSContextRef context, JSObjectRef thisObject, JSStringRef propertyName, JSValueRef* exception)
@@ -1918,7 +1938,21 @@ AccessibilityTextMarkerRange AccessibilityUIElement::textMarkerRangeMatchesTextN
 }
 #endif
 
-#endif
+#endif // !SUPPORTS_AX_TEXTMARKERS
+
+#if PLATFORM(IOS_FAMILY) || !SUPPORTS_AX_TEXTMARKERS
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::textMarkerDebugDescription(AccessibilityTextMarker*)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::textMarkerRangeDebugDescription(AccessibilityTextMarkerRange*)
+{
+    return nullptr;
+}
+
+#endif // PLATFORM(IOS_FAMILY) || !SUPPORTS_AX_TEXTMARKERS
 
 // Destruction
 
@@ -2138,6 +2172,8 @@ JSClassRef AccessibilityUIElement::getJSClass()
         { "sentenceTextMarkerRangeForTextMarker", sentenceTextMarkerRangeForTextMarkerCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "previousSentenceStartTextMarkerForTextMarker", previousSentenceStartTextMarkerForTextMarkerCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "nextSentenceEndTextMarkerForTextMarker", nextSentenceEndTextMarkerForTextMarkerCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
+        { "textMarkerDebugDescription", textMarkerDebugDescriptionCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
+        { "textMarkerRangeDebugDescription", textMarkerRangeDebugDescriptionCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "setSelectedChild", setSelectedChildCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "setSelectedChildAtIndex", setSelectedChildAtIndexCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "removeSelectionAtIndex", removeSelectionAtIndexCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },

--- a/Tools/DumpRenderTree/AccessibilityUIElement.h
+++ b/Tools/DumpRenderTree/AccessibilityUIElement.h
@@ -311,6 +311,8 @@ public:
     bool isTextMarkerValid(AccessibilityTextMarker*);
     bool isTextMarkerNull(AccessibilityTextMarker*);
     AccessibilityTextMarker textMarkerForIndex(int);
+    JSRetainPtr<JSStringRef> textMarkerDebugDescription(AccessibilityTextMarker*);
+    JSRetainPtr<JSStringRef> textMarkerRangeDebugDescription(AccessibilityTextMarkerRange*);
 
     void scrollToMakeVisible();
     void scrollToMakeVisibleWithSubFocus(int x, int y, int width, int height);

--- a/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
@@ -2154,6 +2154,32 @@ AccessibilityTextMarker AccessibilityUIElement::nextSentenceEndTextMarkerForText
     return nullptr;
 }
 
+JSRetainPtr<JSStringRef> AccessibilityUIElement::textMarkerDebugDescription(AccessibilityTextMarker* marker)
+{
+    if (!marker)
+        return nullptr;
+
+    BEGIN_AX_OBJC_EXCEPTIONS
+    RetainPtr description = [m_element accessibilityAttributeValue:@"AXTextMarkerDebugDescription" forParameter:marker->platformTextMarker()];
+    return [description createJSStringRef];
+    END_AX_OBJC_EXCEPTIONS
+
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::textMarkerRangeDebugDescription(AccessibilityTextMarkerRange* range)
+{
+    if (!range)
+        return nullptr;
+
+    BEGIN_AX_OBJC_EXCEPTIONS
+    RetainPtr description = [m_element accessibilityAttributeValue:@"AXTextMarkerRangeDebugDescription" forParameter:range->platformTextMarkerRange()];
+    return [description createJSStringRef];
+    END_AX_OBJC_EXCEPTIONS
+
+    return nullptr;
+}
+
 #endif // SUPPORTS_AX_TEXTMARKERS && PLATFORM(MAC)
 
 JSRetainPtr<JSStringRef> AccessibilityUIElement::supportedActions()


### PR DESCRIPTION
#### 91145ee4eea6f56e141dba911417c8182c7115f3
<pre>
New Test (292698@main): [ Sequoia wk1 ] accessibility/text-marker/text-marker-debug-description.html is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=291603">https://bugs.webkit.org/show_bug.cgi?id=291603</a>
<a href="https://rdar.apple.com/149343437">rdar://149343437</a>

Reviewed by Tyler Wilcock.

Was missig the DumpRenderTree implementation of the new AccessibilityUIElement methods.

* LayoutTests/platform/mac-wk1/TestExpectations:
* Tools/DumpRenderTree/AccessibilityUIElement.cpp:
(textMarkerDebugDescriptionCallback):
(textMarkerRangeDebugDescriptionCallback):
(AccessibilityUIElement::textMarkerDebugDescription):
(AccessibilityUIElement::textMarkerRangeDebugDescription):
(AccessibilityUIElement::getJSClass):
* Tools/DumpRenderTree/AccessibilityUIElement.h:
* Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm:
(AccessibilityUIElement::textMarkerDebugDescription):
(AccessibilityUIElement::textMarkerRangeDebugDescription):

Canonical link: <a href="https://commits.webkit.org/293792@main">https://commits.webkit.org/293792@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85b2ce4313a7d076980ddd4832cad3cf0cd02fba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99934 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105061 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50515 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101975 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28018 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76078 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33164 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90252 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56436 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14980 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8239 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49884 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84903 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8326 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107422 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27047 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19767 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85032 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27410 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86452 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84556 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21477 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29229 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6952 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20866 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26984 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26795 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30111 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28354 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->