### PR TITLE
Ensure that the cell originating in spanning column respect min/max-width of 1px

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/colspan-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/colspan-001-expected.txt
@@ -1,16 +1,8 @@
 There should be five squares.
 
 
-FAIL td 1 assert_equals:
-<td colspan="2" style="background:blue;" data-expected-width="75" data-expected-height="75">
-      <div style="width:50px; height:75px;"></div>
-    </td>
-width expected 75 but got 100
-FAIL td 2 assert_equals:
-<td colspan="2" style="background:green;" data-expected-width="75" data-expected-height="75">
-      <div style="width:50px; height:75px;"></div>
-    </td>
-width expected 75 but got 50
+PASS td 1
+PASS td 2
 PASS td 3
 PASS td 4
 PASS td 5

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/colspan-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/colspan-002-expected.txt
@@ -1,16 +1,8 @@
 There should be five squares.
 
 
-FAIL td 1 assert_equals:
-<td colspan="3" style="background:blue;" data-expected-width="75" data-expected-height="75">
-      <div style="width:50px; height:75px;"></div>
-    </td>
-width expected 75 but got 100
-FAIL td 2 assert_equals:
-<td colspan="3" style="background:green;" data-expected-width="75" data-expected-height="75">
-      <div style="width:50px; height:75px;"></div>
-    </td>
-width expected 75 but got 50
+PASS td 1
+PASS td 2
 PASS td 3
 PASS td 4
 PASS td 5

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/colspan-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/colspan-003-expected.txt
@@ -1,16 +1,8 @@
 There should be five squares.
 
 
-FAIL td 1 assert_equals:
-<td colspan="10" style="background:blue;" data-expected-width="75" data-expected-height="75">
-      <div style="width:50px; height:75px;"></div>
-    </td>
-width expected 75 but got 100
-FAIL td 2 assert_equals:
-<td colspan="10" style="background:green;" data-expected-width="75" data-expected-height="75">
-      <div style="width:50px; height:75px;"></div>
-    </td>
-width expected 75 but got 50
+PASS td 1
+PASS td 2
 PASS td 3
 PASS td 4
 PASS td 5

--- a/LayoutTests/platform/glib/tables/mozilla/bugs/bug10633-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla/bugs/bug10633-expected.txt
@@ -6,76 +6,77 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,0) size 468x103
         RenderTableSection {TBODY} at (0,0) size 468x103
           RenderTableRow {TR} at (0,0) size 468x1
-            RenderTableCell {TD} at (0,0) size 18x0 [r=0 c=0 rs=1 cs=3]
-            RenderTableCell {TD} at (18,0) size 187x1 [r=0 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (0,0) size 19x0 [r=0 c=0 rs=1 cs=3]
+            RenderTableCell {TD} at (18,0) size 188x1 [r=0 c=3 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 187x1
-            RenderTableCell {TD} at (205,0) size 20x1 [r=0 c=4 rs=1 cs=1]
+            RenderTableCell {TD} at (205,0) size 21x1 [r=0 c=4 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 20x1
-            RenderTableCell {TD} at (225,0) size 18x1 [r=0 c=5 rs=1 cs=1]
+            RenderTableCell {TD} at (225,0) size 19x1 [r=0 c=5 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 18x1
-            RenderTableCell {TD} at (243,0) size 18x0 [r=0 c=6 rs=1 cs=3]
-            RenderTableCell {TD} at (261,0) size 187x1 [r=0 c=9 rs=1 cs=1]
+            RenderTableCell {TD} at (243,0) size 19x0 [r=0 c=6 rs=1 cs=3]
+            RenderTableCell {TD} at (261,0) size 188x1 [r=0 c=9 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 187x1
-            RenderTableCell {TD} at (448,0) size 20x1 [r=0 c=10 rs=1 cs=1]
+            RenderTableCell {TD} at (448,0) size 21x1 [r=0 c=10 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 20x1
           RenderTableRow {TR} at (0,1) size 468x22
-            RenderTableCell {TD} at (0,1) size 18x22 [r=1 c=0 rs=1 cs=3]
+            RenderTableCell {TD} at (0,1) size 19x22 [r=1 c=0 rs=1 cs=3]
               RenderImage {IMG} at (0,0) size 18x22
-            RenderTableCell {TD} at (18,3) size 187x18 [bgcolor=#FFCC00] [r=1 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (18,3) size 188x18 [bgcolor=#FFCC00] [r=1 c=3 rs=1 cs=1]
               RenderInline {A} at (33,2) size 121x17 [color=#0000EE]
                 RenderInline {B} at (33,2) size 121x17
                   RenderInline {FONT} at (33,2) size 121x17
                     RenderText {#text} at (33,2) size 121x17
                       text run at (33,0) width 121: "Detailed Search"
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (205,1) size 20x22 [r=1 c=4 rs=1 cs=1]
+            RenderTableCell {TD} at (205,1) size 21x22 [r=1 c=4 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 20x22
-            RenderTableCell {TD} at (225,3) size 18x18 [r=1 c=5 rs=1 cs=1]
+            RenderTableCell {TD} at (225,3) size 19x18 [r=1 c=5 rs=1 cs=1]
               RenderText {#text} at (0,2) size 4x17
                 text run at (0,0) width 4: " "
-            RenderTableCell {TD} at (243,1) size 18x22 [r=1 c=6 rs=1 cs=3]
+            RenderTableCell {TD} at (243,1) size 19x22 [r=1 c=6 rs=1 cs=3]
               RenderImage {IMG} at (0,0) size 18x22
-            RenderTableCell {TD} at (261,3) size 187x18 [bgcolor=#FFCC00] [r=1 c=9 rs=1 cs=1]
+            RenderTableCell {TD} at (261,3) size 188x18 [bgcolor=#FFCC00] [r=1 c=9 rs=1 cs=1]
               RenderInline {A} at (18,2) size 151x17 [color=#0000EE]
                 RenderInline {B} at (18,2) size 151x17
                   RenderInline {FONT} at (18,2) size 151x17
                     RenderText {#text} at (18,2) size 151x17
                       text run at (18,0) width 151: "Search By Distance"
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (448,1) size 20x22 [r=1 c=10 rs=1 cs=1]
+            RenderTableCell {TD} at (448,1) size 21x22 [r=1 c=10 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 20x22
           RenderTableRow {TR} at (0,23) size 468x80
-            RenderTableCell {TD} at (0,54) size 9x18 [r=2 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,54) size 7x18 [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (0,31) size 4x17
                 text run at (0,0) width 4: " "
-            RenderTableCell {TD} at (9,54) size 9x18 [bgcolor=#EBEBE4] [r=2 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (6,54) size 7x18 [bgcolor=#EBEBE4] [r=2 c=1 rs=1 cs=1]
               RenderText {#text} at (0,31) size 4x17
                 text run at (0,0) width 4: " "
-            RenderTableCell {TD} at (18,23) size 207x80 [bgcolor=#EBEBE4] [r=2 c=2 rs=1 cs=3]
-              RenderBlock {P} at (0,0) size 207x80
+            RenderTableCell {TD} at (12,23) size 214x80 [bgcolor=#EBEBE4] [r=2 c=2 rs=1 cs=3]
+              RenderBlock {P} at (0,0) size 213x80
                 RenderImage {IMG} at (0,0) size 1x5
                 RenderBR {BR} at (1,-9) size 0x17
-                RenderInline {FONT} at (0,5) size 181x60
-                  RenderText {#text} at (0,5) size 181x60
+                RenderInline {FONT} at (0,5) size 210x60
+                  RenderText {#text} at (0,5) size 210x60
                     text run at (0,5) width 123: "Search using almost "
                     text run at (123,5) width 21: "any"
                     text run at (0,20) width 181: "combination of business name,"
-                    text run at (0,35) width 173: "category, street address, city,"
-                    text run at (0,50) width 165: "state, ZIP, or phone number."
-                RenderInline {FONT} at (0,50) size 165x30
-                  RenderBR {BR} at (164,50) size 1x15
+                    text run at (0,35) width 177: "category, street address, city, "
+                    text run at (176,35) width 34: "state,"
+                    text run at (0,50) width 128: "ZIP, or phone number."
+                RenderInline {FONT} at (0,50) size 128x30
+                  RenderBR {BR} at (127,50) size 1x15
                   RenderText {#text} at (0,65) size 4x15
                     text run at (0,65) width 4: " "
-            RenderTableCell {TD} at (225,54) size 18x18 [r=2 c=5 rs=1 cs=1]
+            RenderTableCell {TD} at (225,54) size 19x18 [r=2 c=5 rs=1 cs=1]
               RenderText {#text} at (0,31) size 4x17
                 text run at (0,0) width 4: " "
-            RenderTableCell {TD} at (243,54) size 9x18 [r=2 c=6 rs=1 cs=1]
+            RenderTableCell {TD} at (243,54) size 8x18 [r=2 c=6 rs=1 cs=1]
               RenderText {#text} at (0,31) size 4x17
                 text run at (0,0) width 4: " "
-            RenderTableCell {TD} at (252,54) size 9x18 [bgcolor=#EBEBE4] [r=2 c=7 rs=1 cs=1]
+            RenderTableCell {TD} at (250,54) size 8x18 [bgcolor=#EBEBE4] [r=2 c=7 rs=1 cs=1]
               RenderText {#text} at (0,31) size 4x17
                 text run at (0,0) width 4: " "
-            RenderTableCell {TD} at (261,23) size 207x50 [bgcolor=#EBEBE4] [r=2 c=8 rs=1 cs=3]
+            RenderTableCell {TD} at (257,23) size 212x50 [bgcolor=#EBEBE4] [r=2 c=8 rs=1 cs=3]
               RenderInline {FONT} at (0,-7) size 207x57
                 RenderImage {IMG} at (0,0) size 1x5
                 RenderBR {BR} at (1,-7) size 0x15

--- a/LayoutTests/platform/glib/tables/mozilla/bugs/bug1302-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla/bugs/bug1302-expected.txt
@@ -9,8 +9,8 @@ layer at (0,0) size 785x904
             RenderText {#text} at (220,0) size 329x17
               text run at (220,0) width 329: "Tables I, II, III, IV (cellpadding=0 cellspacing=5)"
         RenderTable {TABLE} at (91,52) size 587x118 [bgcolor=#FFCC00] [border: (1px outset #000000)]
-          RenderTableSection {TBODY} at (1,1) size 584x116
-            RenderTableRow {TR} at (0,2) size 584x112
+          RenderTableSection {TBODY} at (1,1) size 585x116
+            RenderTableRow {TR} at (0,2) size 585x112
               RenderTableCell {TD} at (2,2) size 154x112 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderTable {TABLE} at (6,6) size 142x100 [bgcolor=#FFFFFF] [border: (1px outset #000000)]
                   RenderBlock {CAPTION} at (0,0) size 142x18
@@ -158,37 +158,37 @@ layer at (0,0) size 785x904
                       RenderTableCell {TD} at (93,55) size 22x20 [border: (1px inset #000000)] [r=2 c=4 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 20x17
                           text run at (1,1) width 20: "3,5"
-              RenderTableCell {TD} at (450,2) size 132x87 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
-                RenderTable {TABLE} at (6,6) size 120x75 [bgcolor=#FFFFFF] [border: (1px outset #000000)]
-                  RenderBlock {CAPTION} at (0,0) size 120x18
-                    RenderInline {NOBR} at (32,0) size 56x17
-                      RenderText {#text} at (32,0) size 56x17
-                        text run at (32,0) width 56: "Table IV"
-                  RenderTableSection {TBODY} at (1,19) size 118x55
-                    RenderTableRow {TR} at (0,5) size 118x20
+              RenderTableCell {TD} at (450,2) size 133x87 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
+                RenderTable {TABLE} at (6,6) size 121x75 [bgcolor=#FFFFFF] [border: (1px outset #000000)]
+                  RenderBlock {CAPTION} at (0,0) size 121x18
+                    RenderInline {NOBR} at (32,0) size 57x17
+                      RenderText {#text} at (32,0) size 57x17
+                        text run at (32,0) width 57: "Table IV"
+                  RenderTableSection {TBODY} at (1,19) size 119x55
+                    RenderTableRow {TR} at (0,5) size 119x20
                       RenderTableCell {TD} at (5,5) size 22x20 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 20x17
                           text run at (1,1) width 20: "1,1"
-                      RenderTableCell {TD} at (32,5) size 27x20 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=2]
+                      RenderTableCell {TD} at (32,5) size 28x20 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=2]
                         RenderText {#text} at (1,1) size 20x17
                           text run at (1,1) width 20: "1,2"
-                      RenderTableCell {TD} at (64,5) size 22x20 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
+                      RenderTableCell {TD} at (65,5) size 22x20 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 20x17
                           text run at (1,1) width 20: "1,4"
-                      RenderTableCell {TD} at (91,5) size 22x20 [border: (1px inset #000000)] [r=0 c=4 rs=1 cs=1]
+                      RenderTableCell {TD} at (92,5) size 22x20 [border: (1px inset #000000)] [r=0 c=4 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 20x17
                           text run at (1,1) width 20: "1,5"
-                    RenderTableRow {TR} at (0,30) size 118x20
+                    RenderTableRow {TR} at (0,30) size 119x20
                       RenderTableCell {TD} at (5,30) size 22x20 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 20x17
                           text run at (1,1) width 20: "2,1"
                       RenderTableCell {TD} at (32,30) size 22x20 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 20x17
                           text run at (1,1) width 20: "2,2"
-                      RenderTableCell {TD} at (59,30) size 27x20 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=2]
+                      RenderTableCell {TD} at (59,30) size 28x20 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=2]
                         RenderText {#text} at (1,1) size 20x17
                           text run at (1,1) width 20: "2,3"
-                      RenderTableCell {TD} at (91,30) size 22x20 [border: (1px inset #000000)] [r=1 c=4 rs=1 cs=1]
+                      RenderTableCell {TD} at (92,30) size 22x20 [border: (1px inset #000000)] [r=1 c=4 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 20x17
                           text run at (1,1) width 20: "2,5"
       RenderBlock (anonymous) at (0,170) size 769x18

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug10633-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug10633-expected.txt
@@ -6,53 +6,53 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,0) size 468x108
         RenderTableSection {TBODY} at (0,0) size 468x108
           RenderTableRow {TR} at (0,0) size 468x1
-            RenderTableCell {TD} at (0,0) size 18x0 [r=0 c=0 rs=1 cs=3]
-            RenderTableCell {TD} at (18,0) size 187x1 [r=0 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (0,0) size 19x0 [r=0 c=0 rs=1 cs=3]
+            RenderTableCell {TD} at (18,0) size 188x1 [r=0 c=3 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 187x1
-            RenderTableCell {TD} at (205,0) size 20x1 [r=0 c=4 rs=1 cs=1]
+            RenderTableCell {TD} at (205,0) size 21x1 [r=0 c=4 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 20x1
-            RenderTableCell {TD} at (225,0) size 18x1 [r=0 c=5 rs=1 cs=1]
+            RenderTableCell {TD} at (225,0) size 19x1 [r=0 c=5 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 18x1
-            RenderTableCell {TD} at (243,0) size 18x0 [r=0 c=6 rs=1 cs=3]
-            RenderTableCell {TD} at (261,0) size 187x1 [r=0 c=9 rs=1 cs=1]
+            RenderTableCell {TD} at (243,0) size 19x0 [r=0 c=6 rs=1 cs=3]
+            RenderTableCell {TD} at (261,0) size 188x1 [r=0 c=9 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 187x1
-            RenderTableCell {TD} at (448,0) size 20x1 [r=0 c=10 rs=1 cs=1]
+            RenderTableCell {TD} at (448,0) size 21x1 [r=0 c=10 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 20x1
           RenderTableRow {TR} at (0,1) size 468x22
-            RenderTableCell {TD} at (0,1) size 18x22 [r=1 c=0 rs=1 cs=3]
+            RenderTableCell {TD} at (0,1) size 19x22 [r=1 c=0 rs=1 cs=3]
               RenderImage {IMG} at (0,0) size 18x22
-            RenderTableCell {TD} at (18,2) size 187x20 [bgcolor=#FFCC00] [r=1 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (18,2) size 188x20 [bgcolor=#FFCC00] [r=1 c=3 rs=1 cs=1]
               RenderInline {A} at (33,1) size 121x19 [color=#0000EE]
                 RenderInline {B} at (33,1) size 121x19
                   RenderInline {FONT} at (33,1) size 121x19
                     RenderText {#text} at (33,1) size 121x19
                       text run at (33,0) width 121: "Detailed Search"
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (205,1) size 20x22 [r=1 c=4 rs=1 cs=1]
+            RenderTableCell {TD} at (205,1) size 21x22 [r=1 c=4 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 20x22
-            RenderTableCell {TD} at (225,2) size 18x20 [r=1 c=5 rs=1 cs=1]
+            RenderTableCell {TD} at (225,2) size 19x20 [r=1 c=5 rs=1 cs=1]
               RenderText {#text} at (0,1) size 4x19
                 text run at (0,0) width 4: " "
-            RenderTableCell {TD} at (243,1) size 18x22 [r=1 c=6 rs=1 cs=3]
+            RenderTableCell {TD} at (243,1) size 19x22 [r=1 c=6 rs=1 cs=3]
               RenderImage {IMG} at (0,0) size 18x22
-            RenderTableCell {TD} at (261,2) size 187x20 [bgcolor=#FFCC00] [r=1 c=9 rs=1 cs=1]
+            RenderTableCell {TD} at (261,2) size 188x20 [bgcolor=#FFCC00] [r=1 c=9 rs=1 cs=1]
               RenderInline {A} at (18,1) size 151x19 [color=#0000EE]
                 RenderInline {B} at (18,1) size 151x19
                   RenderInline {FONT} at (18,1) size 151x19
                     RenderText {#text} at (18,1) size 151x19
                       text run at (18,0) width 151: "Search By Distance"
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (448,1) size 20x22 [r=1 c=10 rs=1 cs=1]
+            RenderTableCell {TD} at (448,1) size 21x22 [r=1 c=10 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 20x22
           RenderTableRow {TR} at (0,23) size 468x85
-            RenderTableCell {TD} at (0,55) size 9x21 [r=2 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,55) size 7x21 [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (0,32) size 4x20
                 text run at (0,0) width 4: " "
-            RenderTableCell {TD} at (9,55) size 9x21 [bgcolor=#EBEBE4] [r=2 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (6,55) size 7x21 [bgcolor=#EBEBE4] [r=2 c=1 rs=1 cs=1]
               RenderText {#text} at (0,32) size 4x20
                 text run at (0,0) width 4: " "
-            RenderTableCell {TD} at (18,23) size 207x85 [bgcolor=#EBEBE4] [r=2 c=2 rs=1 cs=3]
-              RenderBlock {P} at (0,0) size 207x85
+            RenderTableCell {TD} at (12,23) size 214x85 [bgcolor=#EBEBE4] [r=2 c=2 rs=1 cs=3]
+              RenderBlock {P} at (0,0) size 213x85
                 RenderImage {IMG} at (0,0) size 1x5
                 RenderBR {BR} at (1,-10) size 0x19
                 RenderInline {FONT} at (0,5) size 204x63
@@ -67,16 +67,16 @@ layer at (0,0) size 800x600
                   RenderBR {BR} at (127,53) size 1x15
                   RenderText {#text} at (0,69) size 4x15
                     text run at (0,69) width 4: " "
-            RenderTableCell {TD} at (225,55) size 18x21 [r=2 c=5 rs=1 cs=1]
+            RenderTableCell {TD} at (225,55) size 19x21 [r=2 c=5 rs=1 cs=1]
               RenderText {#text} at (0,32) size 4x20
                 text run at (0,0) width 4: " "
-            RenderTableCell {TD} at (243,55) size 9x21 [r=2 c=6 rs=1 cs=1]
+            RenderTableCell {TD} at (243,55) size 8x21 [r=2 c=6 rs=1 cs=1]
               RenderText {#text} at (0,32) size 4x20
                 text run at (0,0) width 4: " "
-            RenderTableCell {TD} at (252,55) size 9x21 [bgcolor=#EBEBE4] [r=2 c=7 rs=1 cs=1]
+            RenderTableCell {TD} at (250,55) size 8x21 [bgcolor=#EBEBE4] [r=2 c=7 rs=1 cs=1]
               RenderText {#text} at (0,32) size 4x20
                 text run at (0,0) width 4: " "
-            RenderTableCell {TD} at (261,23) size 207x53 [bgcolor=#EBEBE4] [r=2 c=8 rs=1 cs=3]
+            RenderTableCell {TD} at (257,23) size 212x53 [bgcolor=#EBEBE4] [r=2 c=8 rs=1 cs=3]
               RenderInline {FONT} at (0,-7) size 205x59
                 RenderImage {IMG} at (0,0) size 1x5
                 RenderBR {BR} at (1,-7) size 0x15

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug1302-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug1302-expected.txt
@@ -8,9 +8,9 @@ layer at (0,0) size 800x972
           RenderInline {B} at (225,0) size 334x19
             RenderText {#text} at (225,0) size 334x19
               text run at (225,0) width 334: "Tables I, II, III, IV (cellpadding=0 cellspacing=5)"
-        RenderTable {TABLE} at (99,54) size 586x126 [bgcolor=#FFCC00] [border: (1px outset #000000)]
-          RenderTableSection {TBODY} at (1,1) size 584x124
-            RenderTableRow {TR} at (0,2) size 584x120
+        RenderTable {TABLE} at (98,54) size 588x126 [bgcolor=#FFCC00] [border: (1px outset #000000)]
+          RenderTableSection {TBODY} at (1,1) size 585x124
+            RenderTableRow {TR} at (0,2) size 585x120
               RenderTableCell {TD} at (2,2) size 154x120 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderTable {TABLE} at (6,6) size 142x108 [bgcolor=#FFFFFF] [border: (1px outset #000000)]
                   RenderBlock {CAPTION} at (0,0) size 142x20
@@ -158,37 +158,37 @@ layer at (0,0) size 800x972
                       RenderTableCell {TD} at (93,59) size 22x22 [border: (1px inset #000000)] [r=2 c=4 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 20x19
                           text run at (1,1) width 20: "3,5"
-              RenderTableCell {TD} at (450,2) size 132x93 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
-                RenderTable {TABLE} at (6,6) size 120x81 [bgcolor=#FFFFFF] [border: (1px outset #000000)]
-                  RenderBlock {CAPTION} at (0,0) size 120x20
-                    RenderInline {NOBR} at (31,0) size 58x19
-                      RenderText {#text} at (31,0) size 58x19
-                        text run at (31,0) width 58: "Table IV"
-                  RenderTableSection {TBODY} at (1,21) size 118x59
-                    RenderTableRow {TR} at (0,5) size 118x22
+              RenderTableCell {TD} at (450,2) size 133x93 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
+                RenderTable {TABLE} at (6,6) size 121x81 [bgcolor=#FFFFFF] [border: (1px outset #000000)]
+                  RenderBlock {CAPTION} at (0,0) size 121x20
+                    RenderInline {NOBR} at (32,0) size 57x19
+                      RenderText {#text} at (32,0) size 57x19
+                        text run at (32,0) width 57: "Table IV"
+                  RenderTableSection {TBODY} at (1,21) size 119x59
+                    RenderTableRow {TR} at (0,5) size 119x22
                       RenderTableCell {TD} at (5,5) size 22x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 20x19
                           text run at (1,1) width 20: "1,1"
-                      RenderTableCell {TD} at (32,5) size 27x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=2]
+                      RenderTableCell {TD} at (32,5) size 28x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=2]
                         RenderText {#text} at (1,1) size 20x19
                           text run at (1,1) width 20: "1,2"
-                      RenderTableCell {TD} at (64,5) size 22x22 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
+                      RenderTableCell {TD} at (65,5) size 22x22 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 20x19
                           text run at (1,1) width 20: "1,4"
-                      RenderTableCell {TD} at (91,5) size 22x22 [border: (1px inset #000000)] [r=0 c=4 rs=1 cs=1]
+                      RenderTableCell {TD} at (92,5) size 22x22 [border: (1px inset #000000)] [r=0 c=4 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 20x19
                           text run at (1,1) width 20: "1,5"
-                    RenderTableRow {TR} at (0,32) size 118x22
+                    RenderTableRow {TR} at (0,32) size 119x22
                       RenderTableCell {TD} at (5,32) size 22x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 20x19
                           text run at (1,1) width 20: "2,1"
                       RenderTableCell {TD} at (32,32) size 22x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 20x19
                           text run at (1,1) width 20: "2,2"
-                      RenderTableCell {TD} at (59,32) size 27x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=2]
+                      RenderTableCell {TD} at (59,32) size 28x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=2]
                         RenderText {#text} at (1,1) size 20x19
                           text run at (1,1) width 20: "2,3"
-                      RenderTableCell {TD} at (91,32) size 22x22 [border: (1px inset #000000)] [r=1 c=4 rs=1 cs=1]
+                      RenderTableCell {TD} at (92,32) size 22x22 [border: (1px inset #000000)] [r=1 c=4 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 20x19
                           text run at (1,1) width 20: "2,5"
       RenderBlock (anonymous) at (0,180) size 784x20

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug10633-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug10633-expected.txt
@@ -6,53 +6,53 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,0) size 468x103
         RenderTableSection {TBODY} at (0,0) size 468x103
           RenderTableRow {TR} at (0,0) size 468x1
-            RenderTableCell {TD} at (0,0) size 18x0 [r=0 c=0 rs=1 cs=3]
-            RenderTableCell {TD} at (18,0) size 187x1 [r=0 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (0,0) size 19x0 [r=0 c=0 rs=1 cs=3]
+            RenderTableCell {TD} at (18,0) size 188x1 [r=0 c=3 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 187x1
-            RenderTableCell {TD} at (205,0) size 20x1 [r=0 c=4 rs=1 cs=1]
+            RenderTableCell {TD} at (205,0) size 21x1 [r=0 c=4 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 20x1
-            RenderTableCell {TD} at (225,0) size 18x1 [r=0 c=5 rs=1 cs=1]
+            RenderTableCell {TD} at (225,0) size 19x1 [r=0 c=5 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 18x1
-            RenderTableCell {TD} at (243,0) size 18x0 [r=0 c=6 rs=1 cs=3]
-            RenderTableCell {TD} at (261,0) size 187x1 [r=0 c=9 rs=1 cs=1]
+            RenderTableCell {TD} at (243,0) size 19x0 [r=0 c=6 rs=1 cs=3]
+            RenderTableCell {TD} at (261,0) size 188x1 [r=0 c=9 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 187x1
-            RenderTableCell {TD} at (448,0) size 20x1 [r=0 c=10 rs=1 cs=1]
+            RenderTableCell {TD} at (448,0) size 21x1 [r=0 c=10 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 20x1
           RenderTableRow {TR} at (0,1) size 468x22
-            RenderTableCell {TD} at (0,1) size 18x22 [r=1 c=0 rs=1 cs=3]
+            RenderTableCell {TD} at (0,1) size 19x22 [r=1 c=0 rs=1 cs=3]
               RenderImage {IMG} at (0,0) size 18x22
-            RenderTableCell {TD} at (18,3) size 187x18 [bgcolor=#FFCC00] [r=1 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (18,3) size 188x18 [bgcolor=#FFCC00] [r=1 c=3 rs=1 cs=1]
               RenderInline {A} at (33,2) size 121x18 [color=#0000EE]
                 RenderInline {B} at (33,2) size 121x18
                   RenderInline {FONT} at (33,2) size 121x17
                     RenderText {#text} at (33,2) size 121x17
                       text run at (33,0) width 121: "Detailed Search"
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (205,1) size 20x22 [r=1 c=4 rs=1 cs=1]
+            RenderTableCell {TD} at (205,1) size 21x22 [r=1 c=4 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 20x22
-            RenderTableCell {TD} at (225,3) size 18x18 [r=1 c=5 rs=1 cs=1]
+            RenderTableCell {TD} at (225,3) size 19x18 [r=1 c=5 rs=1 cs=1]
               RenderText {#text} at (0,2) size 4x18
                 text run at (0,0) width 4: " "
-            RenderTableCell {TD} at (243,1) size 18x22 [r=1 c=6 rs=1 cs=3]
+            RenderTableCell {TD} at (243,1) size 19x22 [r=1 c=6 rs=1 cs=3]
               RenderImage {IMG} at (0,0) size 18x22
-            RenderTableCell {TD} at (261,3) size 187x18 [bgcolor=#FFCC00] [r=1 c=9 rs=1 cs=1]
+            RenderTableCell {TD} at (261,3) size 188x18 [bgcolor=#FFCC00] [r=1 c=9 rs=1 cs=1]
               RenderInline {A} at (18,2) size 151x18 [color=#0000EE]
                 RenderInline {B} at (18,2) size 151x18
                   RenderInline {FONT} at (18,2) size 151x17
                     RenderText {#text} at (18,2) size 151x17
                       text run at (18,0) width 151: "Search By Distance"
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (448,1) size 20x22 [r=1 c=10 rs=1 cs=1]
+            RenderTableCell {TD} at (448,1) size 21x22 [r=1 c=10 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 20x22
           RenderTableRow {TR} at (0,23) size 468x80
-            RenderTableCell {TD} at (0,54) size 9x18 [r=2 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,54) size 7x18 [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (0,31) size 4x18
                 text run at (0,0) width 4: " "
-            RenderTableCell {TD} at (9,54) size 9x18 [bgcolor=#EBEBE4] [r=2 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (6,54) size 7x18 [bgcolor=#EBEBE4] [r=2 c=1 rs=1 cs=1]
               RenderText {#text} at (0,31) size 4x18
                 text run at (0,0) width 4: " "
-            RenderTableCell {TD} at (18,23) size 207x80 [bgcolor=#EBEBE4] [r=2 c=2 rs=1 cs=3]
-              RenderBlock {P} at (0,0) size 207x80
+            RenderTableCell {TD} at (12,23) size 214x80 [bgcolor=#EBEBE4] [r=2 c=2 rs=1 cs=3]
+              RenderBlock {P} at (0,0) size 213x80
                 RenderImage {IMG} at (0,0) size 1x5
                 RenderBR {BR} at (1,-9) size 0x18
                 RenderInline {FONT} at (0,5) size 204x60
@@ -67,16 +67,16 @@ layer at (0,0) size 800x600
                   RenderBR {BR} at (127,50) size 1x15
                   RenderText {#text} at (0,65) size 4x15
                     text run at (0,65) width 4: " "
-            RenderTableCell {TD} at (225,54) size 18x18 [r=2 c=5 rs=1 cs=1]
+            RenderTableCell {TD} at (225,54) size 19x18 [r=2 c=5 rs=1 cs=1]
               RenderText {#text} at (0,31) size 4x18
                 text run at (0,0) width 4: " "
-            RenderTableCell {TD} at (243,54) size 9x18 [r=2 c=6 rs=1 cs=1]
+            RenderTableCell {TD} at (243,54) size 8x18 [r=2 c=6 rs=1 cs=1]
               RenderText {#text} at (0,31) size 4x18
                 text run at (0,0) width 4: " "
-            RenderTableCell {TD} at (252,54) size 9x18 [bgcolor=#EBEBE4] [r=2 c=7 rs=1 cs=1]
+            RenderTableCell {TD} at (250,54) size 8x18 [bgcolor=#EBEBE4] [r=2 c=7 rs=1 cs=1]
               RenderText {#text} at (0,31) size 4x18
                 text run at (0,0) width 4: " "
-            RenderTableCell {TD} at (261,23) size 207x50 [bgcolor=#EBEBE4] [r=2 c=8 rs=1 cs=3]
+            RenderTableCell {TD} at (257,23) size 212x50 [bgcolor=#EBEBE4] [r=2 c=8 rs=1 cs=3]
               RenderInline {FONT} at (0,-7) size 205x57
                 RenderImage {IMG} at (0,0) size 1x5
                 RenderBR {BR} at (1,-7) size 0x15

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug1302-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug1302-expected.txt
@@ -9,8 +9,8 @@ layer at (0,0) size 785x904
             RenderText {#text} at (217,0) size 335x18
               text run at (217,0) width 335: "Tables I, II, III, IV (cellpadding=0 cellspacing=5)"
         RenderTable {TABLE} at (91,52) size 587x118 [bgcolor=#FFCC00] [border: (1px outset #000000)]
-          RenderTableSection {TBODY} at (1,1) size 584x116
-            RenderTableRow {TR} at (0,2) size 584x112
+          RenderTableSection {TBODY} at (1,1) size 585x116
+            RenderTableRow {TR} at (0,2) size 585x112
               RenderTableCell {TD} at (2,2) size 154x112 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderTable {TABLE} at (6,6) size 142x100 [bgcolor=#FFFFFF] [border: (1px outset #000000)]
                   RenderBlock {CAPTION} at (0,0) size 142x18
@@ -158,37 +158,37 @@ layer at (0,0) size 785x904
                       RenderTableCell {TD} at (93,55) size 22x20 [border: (1px inset #000000)] [r=2 c=4 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 20x18
                           text run at (1,1) width 20: "3,5"
-              RenderTableCell {TD} at (450,2) size 132x87 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
-                RenderTable {TABLE} at (6,6) size 120x75 [bgcolor=#FFFFFF] [border: (1px outset #000000)]
-                  RenderBlock {CAPTION} at (0,0) size 120x18
-                    RenderInline {NOBR} at (31,0) size 58x18
-                      RenderText {#text} at (31,0) size 58x18
-                        text run at (31,0) width 58: "Table IV"
-                  RenderTableSection {TBODY} at (1,19) size 118x55
-                    RenderTableRow {TR} at (0,5) size 118x20
+              RenderTableCell {TD} at (450,2) size 133x87 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
+                RenderTable {TABLE} at (6,6) size 121x75 [bgcolor=#FFFFFF] [border: (1px outset #000000)]
+                  RenderBlock {CAPTION} at (0,0) size 121x18
+                    RenderInline {NOBR} at (32,0) size 57x18
+                      RenderText {#text} at (32,0) size 57x18
+                        text run at (32,0) width 57: "Table IV"
+                  RenderTableSection {TBODY} at (1,19) size 119x55
+                    RenderTableRow {TR} at (0,5) size 119x20
                       RenderTableCell {TD} at (5,5) size 22x20 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 20x18
                           text run at (1,1) width 20: "1,1"
-                      RenderTableCell {TD} at (32,5) size 27x20 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=2]
+                      RenderTableCell {TD} at (32,5) size 28x20 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=2]
                         RenderText {#text} at (1,1) size 20x18
                           text run at (1,1) width 20: "1,2"
-                      RenderTableCell {TD} at (64,5) size 22x20 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
+                      RenderTableCell {TD} at (65,5) size 22x20 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 20x18
                           text run at (1,1) width 20: "1,4"
-                      RenderTableCell {TD} at (91,5) size 22x20 [border: (1px inset #000000)] [r=0 c=4 rs=1 cs=1]
+                      RenderTableCell {TD} at (92,5) size 22x20 [border: (1px inset #000000)] [r=0 c=4 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 20x18
                           text run at (1,1) width 20: "1,5"
-                    RenderTableRow {TR} at (0,30) size 118x20
+                    RenderTableRow {TR} at (0,30) size 119x20
                       RenderTableCell {TD} at (5,30) size 22x20 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 20x18
                           text run at (1,1) width 20: "2,1"
                       RenderTableCell {TD} at (32,30) size 22x20 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 20x18
                           text run at (1,1) width 20: "2,2"
-                      RenderTableCell {TD} at (59,30) size 27x20 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=2]
+                      RenderTableCell {TD} at (59,30) size 28x20 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=2]
                         RenderText {#text} at (1,1) size 20x18
                           text run at (1,1) width 20: "2,3"
-                      RenderTableCell {TD} at (91,30) size 22x20 [border: (1px inset #000000)] [r=1 c=4 rs=1 cs=1]
+                      RenderTableCell {TD} at (92,30) size 22x20 [border: (1px inset #000000)] [r=1 c=4 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 20x18
                           text run at (1,1) width 20: "2,5"
       RenderBlock (anonymous) at (0,170) size 769x18

--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -124,6 +124,9 @@ void AutoTableLayout::recalcColumn(unsigned effCol)
                         break;
                     }
                 } else if (!effCol || section->primaryCellAt(i, effCol - 1) != cell) {
+                    // If a cell originates in this spanning column ensure we have a min/max width of at least 1px for it.
+                    columnLayout.minLogicalWidth = std::max(columnLayout.minLogicalWidth, cell->maxPreferredLogicalWidth() ? 1.f : 0.f);
+
                     // This spanning cell originates in this column. Insert the cell into spanning cells list.
                     insertSpanCell(cell);
                 }


### PR DESCRIPTION
#### 9c19b008c6622e71dfe649ff8a75a267a99125b7
<pre>
Ensure that the cell originating in spanning column respect min/max-width of 1px
<a href="https://bugs.webkit.org/show_bug.cgi?id=291662">https://bugs.webkit.org/show_bug.cgi?id=291662</a>

Reviewed by Antti Koivisto and Alan Baradlay.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Partial Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/4661416ff22985013680db8901b01ca79c026c87">https://chromium.googlesource.com/chromium/src.git/+/4661416ff22985013680db8901b01ca79c026c87</a>

This patch covers a case to ensure that the cell originating in the spanning
column have a min/max width of at least 1px for it.

* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::recalcColumn):

&gt; Progressions:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/colspan-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/colspan-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/colspan-003-expected.txt:

&gt; Rebaselines:
* LayoutTests/platform/glib/tables/mozilla/bugs/bug10633-expected.txt:
* LayoutTests/platform/glib/tables/mozilla/bugs/bug1302-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug10633-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug1302-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug10633-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug1302-expected.txt:

Canonical link: <a href="https://commits.webkit.org/293812@main">https://commits.webkit.org/293812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7809a1331f45d4d254551afa96e467f5ee5210f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105121 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50574 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102034 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19947 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/28096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/76122 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/33206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103000 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/15238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90311 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56481 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15043 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8301 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49943 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8386 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107481 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27106 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19818 "Unable to confirm if test failures are introduced by change, retrying build") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85077 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27469 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86511 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/84601 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21488 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29285 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/7011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/20942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27043 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32271 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26854 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30170 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28413 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->