### PR TITLE
[iOS] Propagate platform layer IDs of composited layers that intersect with the selection range to the UI process through EditorState

### DIFF
--- a/LayoutTests/editing/editable-region/iframe-expected.txt
+++ b/LayoutTests/editing/editable-region/iframe-expected.txt
@@ -45,6 +45,7 @@
                               (children 1
                                 (GraphicsLayer
                                   (anchor 0.00 0.00)
+                                  (bounds 310.00 670.00)
                                 )
                               )
                             )

--- a/LayoutTests/editing/editable-region/iframe-without-editable-region-expected.txt
+++ b/LayoutTests/editing/editable-region/iframe-without-editable-region-expected.txt
@@ -35,6 +35,7 @@
                               (children 1
                                 (GraphicsLayer
                                   (anchor 0.00 0.00)
+                                  (bounds 310.00 670.00)
                                 )
                               )
                             )

--- a/LayoutTests/fast/scrolling/mac/event-region-subframe-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/event-region-subframe-expected.txt
@@ -35,6 +35,7 @@
                               (children 1
                                 (GraphicsLayer
                                   (anchor 0.00 0.00)
+                                  (bounds 485.00 1016.00)
                                 )
                               )
                             )

--- a/LayoutTests/fast/scrolling/mac/event-region-subscroller-frame-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/event-region-subscroller-frame-expected.txt
@@ -56,6 +56,7 @@ After adding scrollable content to frame:
                               (children 1
                                 (GraphicsLayer
                                   (anchor 0.00 0.00)
+                                  (bounds 85.00 216.00)
                                 )
                               )
                             )

--- a/LayoutTests/platform/ios/compositing/tiling/tiled-drawing-async-frame-scrolling-expected.txt
+++ b/LayoutTests/platform/ios/compositing/tiling/tiled-drawing-async-frame-scrolling-expected.txt
@@ -80,10 +80,11 @@
                               (children 1
                                 (GraphicsLayer
                                   (anchor 0.00 0.00)
-                                  (backingStoreAttached 0)
-                                  (visible rect 0.00, 0.00 0.00 x 0.00)
+                                  (bounds 400.00 300.00)
+                                  (backingStoreAttached 1)
+                                  (visible rect 0.00, 0.00 300.00 x 150.00)
                                   (coverage rect 0.00, 0.00 300.00 x 150.00)
-                                  (intersects coverage rect 0)
+                                  (intersects coverage rect 1)
                                   (contentsScale 2.00)
                                 )
                               )
@@ -157,10 +158,11 @@
                               (children 1
                                 (GraphicsLayer
                                   (anchor 0.00 0.00)
-                                  (backingStoreAttached 0)
-                                  (visible rect 0.00, 0.00 0.00 x 0.00)
+                                  (bounds 400.00 300.00)
+                                  (backingStoreAttached 1)
+                                  (visible rect 0.00, 0.00 300.00 x 150.00)
                                   (coverage rect 0.00, 0.00 300.00 x 150.00)
-                                  (intersects coverage rect 0)
+                                  (intersects coverage rect 1)
                                   (contentsScale 2.00)
                                 )
                               )
@@ -234,10 +236,11 @@
                               (children 1
                                 (GraphicsLayer
                                   (anchor 0.00 0.00)
-                                  (backingStoreAttached 0)
-                                  (visible rect 0.00, 0.00 0.00 x 0.00)
+                                  (bounds 400.00 300.00)
+                                  (backingStoreAttached 1)
+                                  (visible rect 0.00, 0.00 300.00 x 150.00)
                                   (coverage rect 0.00, 0.00 300.00 x 150.00)
-                                  (intersects coverage rect 0)
+                                  (intersects coverage rect 1)
                                   (contentsScale 2.00)
                                 )
                               )

--- a/LayoutTests/platform/mac-wk2/compositing/tiling/tiled-drawing-async-frame-scrolling-expected.txt
+++ b/LayoutTests/platform/mac-wk2/compositing/tiling/tiled-drawing-async-frame-scrolling-expected.txt
@@ -80,10 +80,11 @@
                               (children 1
                                 (GraphicsLayer
                                   (anchor 0.00 0.00)
-                                  (backingStoreAttached 0)
-                                  (visible rect 0.00, 0.00 0.00 x 0.00)
+                                  (bounds 400.00 300.00)
+                                  (backingStoreAttached 1)
+                                  (visible rect 0.00, 0.00 285.00 x 135.00)
                                   (coverage rect 0.00, 0.00 285.00 x 135.00)
-                                  (intersects coverage rect 0)
+                                  (intersects coverage rect 1)
                                   (contentsScale 1.00)
                                 )
                               )
@@ -187,10 +188,11 @@
                               (children 1
                                 (GraphicsLayer
                                   (anchor 0.00 0.00)
-                                  (backingStoreAttached 0)
-                                  (visible rect 0.00, 0.00 0.00 x 0.00)
+                                  (bounds 400.00 300.00)
+                                  (backingStoreAttached 1)
+                                  (visible rect 0.00, 0.00 285.00 x 135.00)
                                   (coverage rect 0.00, 0.00 285.00 x 135.00)
-                                  (intersects coverage rect 0)
+                                  (intersects coverage rect 1)
                                   (contentsScale 1.00)
                                 )
                               )
@@ -312,10 +314,11 @@
                                   (children 1
                                     (GraphicsLayer
                                       (anchor 0.00 0.00)
-                                      (backingStoreAttached 0)
-                                      (visible rect 0.00, 0.00 0.00 x 0.00)
+                                      (bounds 400.00 300.00)
+                                      (backingStoreAttached 1)
+                                      (visible rect 0.00, 0.00 285.00 x 135.00)
                                       (coverage rect 0.00, 0.00 285.00 x 135.00)
-                                      (intersects coverage rect 0)
+                                      (intersects coverage rect 1)
                                       (contentsScale 1.00)
                                     )
                                   )

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2561,7 +2561,7 @@ FloatRect FrameSelection::selectionBounds(ClipToVisibleContent clipToVisibleCont
         return LayoutRect();
     
 #if PLATFORM(IOS_FAMILY)
-    auto selectionGeometries = RenderObject::collectSelectionGeometries(m_selection.range().value());
+    auto selectionGeometries = RenderObject::collectSelectionGeometries(m_selection.range().value()).geometries;
     IntRect visibleSelectionRect;
     for (auto geometry : selectionGeometries)
         visibleSelectionRect.unite(geometry.rect());

--- a/Source/WebCore/page/TextIndicator.cpp
+++ b/Source/WebCore/page/TextIndicator.cpp
@@ -320,7 +320,7 @@ static bool initializeIndicator(TextIndicatorData& data, LocalFrame& frame, cons
         data.options.add(TextIndicatorOption::PaintAllContent);
 #if PLATFORM(IOS_FAMILY)
     else if (data.options.contains(TextIndicatorOption::UseSelectionRectForSizing)) {
-        textRects = RenderObject::collectSelectionGeometries(range).map([&](auto& geometry) -> FloatRect {
+        textRects = RenderObject::collectSelectionGeometries(range).geometries.map([&](auto& geometry) -> FloatRect {
             return geometry.rect();
         });
     }

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1593,6 +1593,8 @@ void RenderLayerBacking::updateGeometry(const RenderLayer* compositedAncestor)
 
     m_graphicsLayer->setPosition(primaryLayerPosition);
     m_graphicsLayer->setSize(primaryGraphicsLayerRect.size());
+    if (hasTiledBackingFlatteningLayer())
+        m_childContainmentLayer->setSize(primaryGraphicsLayerRect.size());
 
     // Compute renderer offset from primary graphics layer. Note that primaryGraphicsLayerRect is in parentGraphicsLayer's coordinate system which is not necessarily
     // the same as the ancestor graphics layer.

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -33,6 +33,7 @@
 #include "LayoutRect.h"
 #include "LocalFrame.h"
 #include "Page.h"
+#include "PlatformLayerIdentifier.h"
 #include "RenderObjectEnums.h"
 #include "RenderStyle.h"
 #include "ScrollAlignment.h"
@@ -833,7 +834,11 @@ public:
 #if PLATFORM(IOS_FAMILY)
     virtual void collectSelectionGeometries(Vector<SelectionGeometry>&, unsigned startOffset = 0, unsigned endOffset = std::numeric_limits<unsigned>::max());
     virtual void absoluteQuadsForSelection(Vector<FloatQuad>& quads) const { absoluteQuads(quads); }
-    WEBCORE_EXPORT static Vector<SelectionGeometry> collectSelectionGeometries(const SimpleRange&);
+    struct SelectionGeometries {
+        Vector<SelectionGeometry> geometries;
+        Vector<PlatformLayerIdentifier> intersectingLayerIDs;
+    };
+    WEBCORE_EXPORT static SelectionGeometries collectSelectionGeometries(const SimpleRange&);
     WEBCORE_EXPORT static Vector<SelectionGeometry> collectSelectionGeometriesWithoutUnionInteriorLines(const SimpleRange&);
 #endif
 
@@ -1163,12 +1168,13 @@ private:
     void setLayerNeedsFullRepaintForPositionedMovementLayout();
 
 #if PLATFORM(IOS_FAMILY)
-    struct SelectionGeometries {
+    struct SelectionGeometriesInternal {
         Vector<SelectionGeometry> geometries;
         int maxLineNumber { 0 };
         bool hasBidirectionalText { false };
+        Vector<PlatformLayerIdentifier> intersectingLayerIDs;
     };
-    WEBCORE_EXPORT static SelectionGeometries collectSelectionGeometriesInternal(const SimpleRange&);
+    WEBCORE_EXPORT static SelectionGeometriesInternal collectSelectionGeometriesInternal(const SimpleRange&);
 #endif
 
     Node* generatingPseudoHostElement() const;

--- a/Source/WebKit/Shared/EditorState.h
+++ b/Source/WebKit/Shared/EditorState.h
@@ -158,6 +158,7 @@ struct EditorState {
         WebCore::IntRect markedTextCaretRectAtStart;
         WebCore::IntRect markedTextCaretRectAtEnd;
         std::optional<WebCore::PlatformLayerIdentifier> enclosingLayerID;
+        Vector<WebCore::PlatformLayerIdentifier> intersectingLayerIDs;
         std::optional<WebCore::ScrollingNodeID> enclosingScrollingNodeID;
         std::optional<WebCore::ScrollingNodeID> scrollingNodeIDAtStart;
         std::optional<WebCore::ScrollingNodeID> scrollingNodeIDAtEnd;

--- a/Source/WebKit/Shared/EditorState.serialization.in
+++ b/Source/WebKit/Shared/EditorState.serialization.in
@@ -128,6 +128,7 @@ using WebCore::ScrollOffset = WebCore::IntPoint;
     WebCore::IntRect markedTextCaretRectAtStart;
     WebCore::IntRect markedTextCaretRectAtEnd;
     std::optional<WebCore::PlatformLayerIdentifier> enclosingLayerID;
+    Vector<WebCore::PlatformLayerIdentifier> intersectingLayerIDs;
     std::optional<WebCore::ScrollingNodeID> enclosingScrollingNodeID;
     std::optional<WebCore::ScrollingNodeID> scrollingNodeIDAtStart;
     std::optional<WebCore::ScrollingNodeID> scrollingNodeIDAtEnd;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -993,6 +993,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 - (void)_updateDoubleTapGestureRecognizerEnablement;
 
 @property (nonatomic, readonly) BOOL shouldUseAsyncInteractions;
+@property (nonatomic, readonly) NSArray<UIView *> *allViewsIntersectingSelectionRange;
 
 #if ENABLE(MODEL_PROCESS)
 - (void)_willInvalidateDraggedModelWithContainerView:(UIView *)containerView;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -340,7 +340,7 @@ void WebPage::getPlatformEditorState(LocalFrame& frame, EditorState& result) con
 
     if (frame.editor().hasComposition()) {
         if (auto compositionRange = frame.editor().compositionRange()) {
-            visualData.markedTextRects = RenderObject::collectSelectionGeometries(*compositionRange);
+            visualData.markedTextRects = RenderObject::collectSelectionGeometries(*compositionRange).geometries;
             convertContentToRootView(view, visualData.markedTextRects);
 
             postLayoutData.markedText = plainTextForContext(*compositionRange);
@@ -373,8 +373,8 @@ void WebPage::getPlatformEditorState(LocalFrame& frame, EditorState& result) con
         selectedRange = selection.toNormalizedRange();
         String selectedText;
         if (selectedRange) {
-            visualData.selectionGeometries = RenderObject::collectSelectionGeometries(*selectedRange);
-            convertContentToRootView(view, visualData.selectionGeometries);
+            auto [selectionGeometries, intersectingLayerIDs] = RenderObject::collectSelectionGeometries(*selectedRange);
+            convertContentToRootView(view, selectionGeometries);
             selectedText = plainTextForDisplay(*selectedRange);
             postLayoutData.selectedTextLength = selectedText.length();
             const int maxSelectedTextLength = 200;
@@ -401,6 +401,9 @@ void WebPage::getPlatformEditorState(LocalFrame& frame, EditorState& result) con
 
             if (auto imageElement = findSelectedEditableImageElement())
                 postLayoutData.selectedEditableImage = contextForElement(*imageElement);
+
+            visualData.selectionGeometries = WTFMove(selectionGeometries);
+            visualData.intersectingLayerIDs = WTFMove(intersectingLayerIDs);
         }
         // FIXME: We should disallow replace when the string contains only CJ characters.
         postLayoutData.isReplaceAllowed = result.isContentEditable && !result.isInPasswordField && !selectedText.containsOnly<isASCIIWhitespace>();
@@ -3067,7 +3070,7 @@ void WebPage::requestAutocorrectionData(const String& textForAutocorrection, Com
 
     Vector<SelectionGeometry> selectionGeometries;
     if (textForRange == textForAutocorrection)
-        selectionGeometries = RenderObject::collectSelectionGeometries(*range);
+        selectionGeometries = RenderObject::collectSelectionGeometries(*range).geometries;
 
     auto rootViewSelectionRects = selectionGeometries.map([&](const auto& selectionGeometry) -> FloatRect {
         return frame->view()->contentsToRootView(selectionGeometry.rect());

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebFrameIOS.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebFrameIOS.mm
@@ -206,7 +206,7 @@ using namespace WebCore;
 
 - (NSArray *)selectionRectsForCoreRange:(const SimpleRange&)range
 {
-    return createNSArray(RenderObject::collectSelectionGeometries(range), [] (auto&& geometry) {
+    return createNSArray(RenderObject::collectSelectionGeometries(range).geometries, [](auto&& geometry) {
         auto webRect = [WebSelectionRect selectionRect];
         webRect.rect = geometry.rect();
         webRect.writingDirection = geometry.direction() == TextDirection::LTR ? WKWritingDirectionLeftToRight : WKWritingDirectionRightToLeft;

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -93,7 +93,13 @@ SOFT_LINK_CLASS(UIKit, UIPhysicalKeyboardEvent)
             return frontmostView.get();
     }
 
-    return [self.layer.presentationLayer containsPoint:point] ? self : nil;
+    if (![self.layer.presentationLayer containsPoint:point])
+        return nil;
+
+    if ([self.layer.name isEqualToString:@"Page TiledBacking containment"])
+        return nil;
+
+    return self;
 }
 
 @end


### PR DESCRIPTION
#### 3ad783f63512f9ff92397ad353fe41c1aea693b4
<pre>
[iOS] Propagate platform layer IDs of composited layers that intersect with the selection range to the UI process through EditorState
<a href="https://bugs.webkit.org/show_bug.cgi?id=291663">https://bugs.webkit.org/show_bug.cgi?id=291663</a>
Work towards <a href="https://rdar.apple.com/149242162">rdar://149242162</a>

Reviewed by Abrar Rahman Protyasha.

This is the first half of the fix for <a href="https://rdar.apple.com/149242162">rdar://149242162</a>, which involves plumbing graphics layer IDs
for composited layers that intersect with nodes in the selected range. This information will
eventually be used by text interaction logic in the UI process, to insert (or move) managed text
selection/interaction views into the right place in the compositing view hierarchy, such that the
selection is rendered over all layers which may contain selected content.

See below for more details.

* LayoutTests/editing/editable-region/iframe-expected.txt:
* LayoutTests/editing/editable-region/iframe-without-editable-region-expected.txt:
* LayoutTests/fast/scrolling/mac/event-region-subframe-expected.txt:
* LayoutTests/fast/scrolling/mac/event-region-subscroller-frame-expected.txt:
* LayoutTests/platform/ios/compositing/tiling/tiled-drawing-async-frame-scrolling-expected.txt:
* LayoutTests/platform/mac-wk2/compositing/tiling/tiled-drawing-async-frame-scrolling-expected.txt:

Rebaseline several layout tests.

* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::selectionBounds):
* Source/WebCore/page/TextIndicator.cpp:
(WebCore::initializeIndicator):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateGeometry):

In preparation for the next patch, we also enlarge the size of the `Page TiledBacking containment`
layer to match the size of the primary `m_graphicsLayer`, for frame layers with tiled backing. This
is necessary to ensure that selection hit-testing (e.g. when moving selection handles) behaves well
with UIKit&apos;s text interaction logic, which fails if the layer is empty.

* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::primaryLayerID):
(WebCore::RenderObject::collectSelectionGeometriesInternal):

Rename the existing `SelectionGeometries` struct to `SelectionGeometriesInternal`.

(WebCore::RenderObject::collectSelectionGeometries):

Reintroduce the `SelectionGeometries` struct as a vector of selection geometries and a vector of
intersecting layer IDs, and make the public method return this struct.

* Source/WebCore/rendering/RenderObject.h:
* Source/WebKit/Shared/EditorState.h:
* Source/WebKit/Shared/EditorState.serialization.in:

Send the list of intersecting layer IDs over to the UI process via `EditorState`.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _selectionContainerViewInternal]):
(-[WKContentView _viewForLayerID:]):
(-[WKContentView allViewsIntersectingSelectionRange]):

Add a helper method (to be used in the next patch) that returns an array of all native compositing
views, wherein selected content is rendered. We&apos;ll adjust UI-side logic to slot selection views
*after* the last view in this list.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::getPlatformEditorState const):
(WebKit::WebPage::requestAutocorrectionData):
* Source/WebKitLegacy/ios/WebCoreSupport/WebFrameIOS.mm:
(-[WebFrame selectionRectsForCoreRange:]):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(-[UIView _wtr_frontmostViewAtPoint:]):

Adjust this testing helper to ignore the `Page TiledBacking Containment` layer when finding the
frontmost view under the point. Needed to keep `selection-clipped-by-fixed-position-container.html`
passing.

Canonical link: <a href="https://commits.webkit.org/293826@main">https://commits.webkit.org/293826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4189c8cd106a2214be63e1a38d57cc363498ea1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99984 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105112 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50565 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76119 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33201 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102991 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15222 "Found 1 new test failure: media/video-aspect-ratio.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90300 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56478 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15027 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8290 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49934 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84952 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8375 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107472 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19811 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85079 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27460 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86500 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84603 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21497 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29274 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7000 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20933 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27034 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32262 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26845 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30161 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28404 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->