### PR TITLE
[WebDriver][BiDi] implement the browsingContext.handleUserPrompt command

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -954,6 +954,7 @@ set(WebKit_WEBDRIVER_BIDI_PROTOCOL_GENERATOR_INPUTS
     ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiBrowsingContext.json
     ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiLog.json
     ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiScript.json
+    ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiSession.json
 )
 
 add_custom_command(

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -506,6 +506,7 @@ $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiBrowser.json
 $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiBrowsingContext.json
 $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiLog.json
 $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiScript.json
+$(PROJECT_DIR)/UIProcess/Automation/protocol/BidiSession.json
 $(PROJECT_DIR)/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
 $(PROJECT_DIR)/UIProcess/Cocoa/UserMediaCaptureManagerProxy.messages.in
 $(PROJECT_DIR)/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -519,6 +519,7 @@ WEBDRIVER_BIDI_PROTOCOL_INPUT_FILES = \
     $(WebKit2)/UIProcess/Automation/protocol/BidiBrowsingContext.json \
     $(WebKit2)/UIProcess/Automation/protocol/BidiLog.json \
     $(WebKit2)/UIProcess/Automation/protocol/BidiScript.json \
+    $(WebKit2)/UIProcess/Automation/protocol/BidiSession.json \
 #
 
 WEBDRIVER_BIDI_PROTOCOL_OUTPUT_FILES = \

--- a/Source/WebKit/UIProcess/API/APIAutomationSessionClient.h
+++ b/Source/WebKit/UIProcess/API/APIAutomationSessionClient.h
@@ -84,7 +84,9 @@ public:
     virtual bool isShowingJavaScriptDialogOnPage(WebKit::WebAutomationSession&, WebKit::WebPageProxy&) { return false; }
     virtual void dismissCurrentJavaScriptDialogOnPage(WebKit::WebAutomationSession&, WebKit::WebPageProxy&) { }
     virtual void acceptCurrentJavaScriptDialogOnPage(WebKit::WebAutomationSession&, WebKit::WebPageProxy&) { }
-    virtual WTF::String messageOfCurrentJavaScriptDialogOnPage(WebKit::WebAutomationSession&, WebKit::WebPageProxy&) { return WTF::String(); }
+    virtual std::optional<WTF::String> messageOfCurrentJavaScriptDialogOnPage(WebKit::WebAutomationSession&, WebKit::WebPageProxy&) { return std::nullopt; }
+    virtual std::optional<WTF::String> defaultTextOfCurrentJavaScriptDialogOnPage(WebKit::WebAutomationSession&, WebKit::WebPageProxy&) { return std::nullopt; }
+    virtual std::optional<WTF::String> userInputOfCurrentJavaScriptDialogOnPage(WebKit::WebAutomationSession&, WebKit::WebPageProxy&) { return std::nullopt; }
     virtual void setUserInputForCurrentJavaScriptPromptOnPage(WebKit::WebAutomationSession&, WebKit::WebPageProxy&, const WTF::String&) { }
     virtual std::optional<JavaScriptDialogType> typeOfCurrentJavaScriptDialogOnPage(WebKit::WebAutomationSession&, WebKit::WebPageProxy&) { return std::nullopt; }
     virtual BrowsingContextPresentation currentPresentationOfPage(WebKit::WebAutomationSession&, WebKit::WebPageProxy&) { return BrowsingContextPresentation::Window; }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionDelegate.h
@@ -69,6 +69,8 @@ typedef NS_ENUM(NSInteger, _WKAutomationSessionWebExtensionResourceOptions) {
 - (void)_automationSession:(_WKAutomationSession *)automationSession dismissCurrentJavaScriptDialogForWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(10.13), ios(11.0));
 - (void)_automationSession:(_WKAutomationSession *)automationSession acceptCurrentJavaScriptDialogForWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(10.13), ios(11.0));
 - (nullable NSString *)_automationSession:(_WKAutomationSession *)automationSession messageOfCurrentJavaScriptDialogForWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(10.13), ios(11.0));
+- (nullable NSString *)_automationSession:(_WKAutomationSession *)automationSession userInputOfCurrentJavaScriptDialogForWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+- (nullable NSString *)_automationSession:(_WKAutomationSession *)automationSession defaultTextOfCurrentJavaScriptDialogForWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 - (void)_automationSession:(_WKAutomationSession *)automationSession setUserInput:(NSString *)value forCurrentJavaScriptDialogForWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(10.13), ios(11.0));
 - (_WKAutomationSessionJavaScriptDialogType)_automationSession:(_WKAutomationSession *)automationSession typeOfCurrentJavaScriptDialogForWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(10.14), ios(12.0));
 - (_WKAutomationSessionBrowsingContextPresentation)_automationSession:(_WKAutomationSession *)automationSession currentPresentationForWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(10.15), ios(13.0));

--- a/Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp
@@ -158,11 +158,11 @@ private:
         webkitWebViewAcceptCurrentScriptDialog(webView);
     }
 
-    String messageOfCurrentJavaScriptDialogOnPage(WebAutomationSession&, WebPageProxy& page) override
+    std::optional<String> messageOfCurrentJavaScriptDialogOnPage(WebAutomationSession&, WebPageProxy& page) override
     {
         auto* webView = webkitWebContextGetWebViewForPage(m_session->priv->webContext, &page);
         if (!webView)
-            return { };
+            return std::nullopt;
         return webkitWebViewGetCurrentScriptDialogMessage(webView);
     }
 

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -81,7 +81,6 @@ class OpenPanelParameters;
 namespace WebKit {
 
 class ViewSnapshot;
-class WebAutomationSessionClient;
 class WebFrameProxy;
 class WebOpenPanelResultListenerProxy;
 class WebPageProxy;
@@ -166,7 +165,7 @@ public:
     void wheelEventsFlushedForPage(const WebPageProxy&);
     void willClosePage(const WebPageProxy&);
     void handleRunOpenPanel(const WebPageProxy&, const WebFrameProxy&, const API::OpenPanelParameters&, WebOpenPanelResultListenerProxy&);
-    void willShowJavaScriptDialog(WebPageProxy&);
+    void willShowJavaScriptDialog(WebPageProxy&, const String& message, std::optional<String>&& defaultValue);
     void didEnterFullScreenForPage(const WebPageProxy&);
     void didExitFullScreenForPage(const WebPageProxy&);
 

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
@@ -38,6 +38,7 @@ namespace WebKit {
 
 class BidiBrowserAgent;
 class WebAutomationSession;
+class WebPageProxy;
 
 class WebDriverBidiProcessor final
     : public Inspector::FrontendChannel
@@ -61,6 +62,7 @@ public:
     void close(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, std::optional<bool>&& optionalPromptUnload, Inspector::CommandCallback<void>&&) override;
     void create(Inspector::Protocol::BidiBrowsingContext::CreateType, const Inspector::Protocol::BidiBrowsingContext::BrowsingContext& optionalReferenceContext, std::optional<bool>&& optionalBackground, const String& optionalUserContext, Inspector::CommandCallback<String>&&) override;
     void getTree(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext& optionalRoot, std::optional<double>&& optionalMaxDepth, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>>>&&) override;
+    void handleUserPrompt(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, std::optional<bool>&& optionalShouldAccept, const String& userText, Inspector::CommandCallback<void>&&) override;
     void navigate(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, const String& url, std::optional<Inspector::Protocol::BidiBrowsingContext::ReadinessState>&&, Inspector::CommandCallbackOf<String, Inspector::Protocol::BidiBrowsingContext::Navigation>&&) override;
     void reload(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, std::optional<bool>&& optionalIgnoreCache, std::optional<Inspector::Protocol::BidiBrowsingContext::ReadinessState>&& optionalWait, Inspector::CommandCallbackOf<String, String>&&) override;
 
@@ -70,7 +72,8 @@ public:
 
     // Event entry points called from the owning WebAutomationSession.
     void logEntryAdded(const String& level, const String& source, const String& message, double timestamp, const String& type, const String& method);
-
+    void userPromptOpenedOnPage(WebPageProxy&, const Inspector::Protocol::BidiBrowsingContext::UserPromptType&, const Inspector::Protocol::BidiSession::UserPromptHandlerType&, const String& message, std::optional<String>&& defaultValue);
+    void userPromptClosedOnPage(WebPageProxy&, const Inspector::Protocol::BidiBrowsingContext::UserPromptType&, bool accepted, std::optional<String>&& userText);
 private:
     Ref<Inspector::FrontendRouter> protectedFrontendRouter() const;
     Ref<Inspector::BackendDispatcher> protectedBackendDispatcher() const;
@@ -84,7 +87,7 @@ private:
     Ref<Inspector::BidiScriptBackendDispatcher> m_scriptDomainDispatcher;
 
     std::unique_ptr<BidiBrowserAgent> m_browserAgent;
-
+    std::unique_ptr<Inspector::BidiBrowsingContextFrontendDispatcher> m_browsingContextDomainNotifier;
     std::unique_ptr<Inspector::BidiLogFrontendDispatcher> m_logDomainNotifier;
 };
 

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json
@@ -46,6 +46,13 @@
             "spec": "https://w3c.github.io/webdriver-bidi/#type-browsingContext-ReadinessState",
             "type": "string",
             "enum": ["none", "interactive", "complete"]
+        },
+        {
+            "id": "UserPromptType",
+            "description": "Represents the possible user prompt types.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-browsingContext-UserPromptType",
+            "type": "string",
+            "enum": [ "alert", "beforeunload", "confirm", "prompt" ]
         }
     ],
     "commands": [
@@ -84,6 +91,18 @@
             ],
             "returns": [
                 { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "description": "The identifier of the browsing context to close. It is an error to pass a non-top level traversable." }
+            ]
+        },
+        {
+            "name": "handleUserPrompt",
+            "description": "Allows closing an open prompt.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-browsingContext-create",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/browsing_context/create",
+            "async": true,
+            "parameters": [
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "description": "The identifier of the browsing context in which to handle a user prompt.  It is an error to pass a non-top level traversable." },
+                { "name": "accept", "type": "boolean", "optional": true },
+                { "name": "userText", "type": "string", "optional": true }
             ]
         },
         {
@@ -130,6 +149,33 @@
             "returns": [
                 { "name": "url", "type": "string", "description": "The URL the browsing context navigated to." },
                 { "name": "navigation", "$ref": "BidiBrowsingContext.Navigation", "optional": true, "description": "The navigation ID, or null if not applicable." }
+            ]
+        }
+    ],
+    "events": [
+        {
+            "name": "userPromptClosed",
+            "description": "Event fired when a user prompt is dismissed in a navigable.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#event-browsingContext-userPromptClosed",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/browsing_context/user_prompt_closed",
+            "parameters": [
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "description": "The identifier of the navigable that triggered the user prompt." },
+                { "name": "type", "$ref": "BidiBrowsingContext.UserPromptType" },
+                { "name": "accepted", "type": "boolean" },
+                { "name": "userText", "type": "string", "optional": true }
+            ]
+        },
+        {
+            "name": "userPromptOpened",
+            "description": "Event fired when a user prompt is shown in a navigable.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#event-browsingContext-userPromptOpened",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/browsing_context/user_prompt_opened",
+            "parameters": [
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "description": "The identifier of the navigable that triggered the user prompt." },
+                { "name": "type", "$ref": "BidiBrowsingContext.UserPromptType" },
+                { "name": "handler", "$ref": "BidiSession.UserPromptHandlerType" },
+                { "name": "message", "type": "string" },
+                { "name": "defaultValue", "type": "string", "optional": true }
             ]
         }
     ]

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiSession.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiSession.json
@@ -1,0 +1,17 @@
+{
+    "domain": "BidiSession",
+    "exposedAs": "session",
+    "condition": "ENABLE(WEBDRIVER_BIDI)",
+    "description": "The session module contains commands and events for monitoring the status of the remote end.",
+    "spec": "https://w3c.github.io/webdriver-bidi/#module-session",
+    "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/session",
+    "types": [
+        {
+            "id": "UserPromptHandlerType",
+            "description": "A type that represents the behavior of the user prompt handler.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-script-Target",
+            "type": "string",
+            "enum": [ "accept", "dismiss", "ignore" ]
+        }
+    ]
+}

--- a/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.h
@@ -59,7 +59,9 @@ private:
     bool isShowingJavaScriptDialogOnPage(WebAutomationSession&, WebPageProxy&) override;
     void dismissCurrentJavaScriptDialogOnPage(WebAutomationSession&, WebPageProxy&) override;
     void acceptCurrentJavaScriptDialogOnPage(WebAutomationSession&, WebPageProxy&) override;
-    String messageOfCurrentJavaScriptDialogOnPage(WebAutomationSession&, WebPageProxy&) override;
+    std::optional<String> messageOfCurrentJavaScriptDialogOnPage(WebAutomationSession&, WebPageProxy&) override;
+    std::optional<String> defaultTextOfCurrentJavaScriptDialogOnPage(WebAutomationSession&, WebPageProxy&) override;
+    std::optional<String> userInputOfCurrentJavaScriptDialogOnPage(WebAutomationSession&, WebPageProxy&) override;
     void setUserInputForCurrentJavaScriptPromptOnPage(WebAutomationSession&, WebPageProxy&, const String&) override;
     std::optional<API::AutomationSessionClient::JavaScriptDialogType> typeOfCurrentJavaScriptDialogOnPage(WebAutomationSession&, WebPageProxy&) override;
     API::AutomationSessionClient::BrowsingContextPresentation currentPresentationOfPage(WebAutomationSession&, WebPageProxy&) override;
@@ -78,6 +80,8 @@ private:
         bool dismissCurrentJavaScriptDialogForWebView : 1;
         bool acceptCurrentJavaScriptDialogForWebView : 1;
         bool messageOfCurrentJavaScriptDialogForWebView : 1;
+        bool defaultTextOfCurrentJavaScriptDialogForWebView : 1;
+        bool userInputOfCurrentJavaScriptDialogForWebView : 1;
         bool setUserInputForCurrentJavaScriptPromptForWebView : 1;
         bool typeOfCurrentJavaScriptDialogForWebView : 1;
         bool currentPresentationForWebView : 1;

--- a/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm
@@ -53,6 +53,8 @@ AutomationSessionClient::AutomationSessionClient(id <_WKAutomationSessionDelegat
     m_delegateMethods.dismissCurrentJavaScriptDialogForWebView = [delegate respondsToSelector:@selector(_automationSession:dismissCurrentJavaScriptDialogForWebView:)];
     m_delegateMethods.acceptCurrentJavaScriptDialogForWebView = [delegate respondsToSelector:@selector(_automationSession:acceptCurrentJavaScriptDialogForWebView:)];
     m_delegateMethods.messageOfCurrentJavaScriptDialogForWebView = [delegate respondsToSelector:@selector(_automationSession:messageOfCurrentJavaScriptDialogForWebView:)];
+    m_delegateMethods.defaultTextOfCurrentJavaScriptDialogForWebView = [delegate respondsToSelector:@selector(_automationSession:defaultTextOfCurrentJavaScriptDialogForWebView:)];
+    m_delegateMethods.userInputOfCurrentJavaScriptDialogForWebView = [delegate respondsToSelector:@selector(_automationSession:userInputOfCurrentJavaScriptDialogForWebView:)];
     m_delegateMethods.setUserInputForCurrentJavaScriptPromptForWebView = [delegate respondsToSelector:@selector(_automationSession:setUserInput:forCurrentJavaScriptDialogForWebView:)];
     m_delegateMethods.typeOfCurrentJavaScriptDialogForWebView = [delegate respondsToSelector:@selector(_automationSession:typeOfCurrentJavaScriptDialogForWebView:)];
     m_delegateMethods.currentPresentationForWebView = [delegate respondsToSelector:@selector(_automationSession:currentPresentationForWebView:)];
@@ -182,12 +184,28 @@ void AutomationSessionClient::acceptCurrentJavaScriptDialogOnPage(WebAutomationS
         [m_delegate.get() _automationSession:wrapper(session) acceptCurrentJavaScriptDialogForWebView:webView.get()];
 }
 
-String AutomationSessionClient::messageOfCurrentJavaScriptDialogOnPage(WebAutomationSession& session, WebPageProxy& page)
+std::optional<String> AutomationSessionClient::messageOfCurrentJavaScriptDialogOnPage(WebAutomationSession& session, WebPageProxy& page)
 {
     if (auto webView = page.cocoaView(); webView && m_delegateMethods.messageOfCurrentJavaScriptDialogForWebView)
         return [m_delegate.get() _automationSession:wrapper(session) messageOfCurrentJavaScriptDialogForWebView:webView.get()];
 
-    return String();
+    return std::nullopt;
+}
+
+std::optional<String> AutomationSessionClient::defaultTextOfCurrentJavaScriptDialogOnPage(WebAutomationSession& session, WebPageProxy& page)
+{
+    if (auto webView = page.cocoaView(); webView && m_delegateMethods.defaultTextOfCurrentJavaScriptDialogForWebView)
+        return [m_delegate.get() _automationSession:wrapper(session) defaultTextOfCurrentJavaScriptDialogForWebView:webView.get()];
+
+    return std::nullopt;
+}
+
+std::optional<String> AutomationSessionClient::userInputOfCurrentJavaScriptDialogOnPage(WebAutomationSession& session, WebPageProxy& page)
+{
+    if (auto webView = page.cocoaView(); webView && m_delegateMethods.userInputOfCurrentJavaScriptDialogForWebView)
+        return [m_delegate.get() _automationSession:wrapper(session) userInputOfCurrentJavaScriptDialogForWebView:webView.get()];
+
+    return std::nullopt;
 }
 
 void AutomationSessionClient::setUserInputForCurrentJavaScriptPromptOnPage(WebAutomationSession& session, WebPageProxy& page, const String& value)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8679,7 +8679,7 @@ void WebPageProxy::runJavaScriptAlert(IPC::Connection& connection, FrameIdentifi
 
     if (m_controlledByAutomation) {
         if (RefPtr automationSession = configuration().processPool().automationSession())
-            automationSession->willShowJavaScriptDialog(*this);
+            automationSession->willShowJavaScriptDialog(*this, message, std::nullopt);
     }
 
     runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
@@ -8703,7 +8703,7 @@ void WebPageProxy::runJavaScriptConfirm(IPC::Connection& connection, FrameIdenti
 
     if (m_controlledByAutomation) {
         if (RefPtr automationSession = configuration().processPool().automationSession())
-            automationSession->willShowJavaScriptDialog(*this);
+            automationSession->willShowJavaScriptDialog(*this, message, std::nullopt);
     }
 
     runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply)](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {
@@ -8727,7 +8727,7 @@ void WebPageProxy::runJavaScriptPrompt(IPC::Connection& connection, FrameIdentif
 
     if (m_controlledByAutomation) {
         if (RefPtr automationSession = configuration().processPool().automationSession())
-            automationSession->willShowJavaScriptDialog(*this);
+            automationSession->willShowJavaScriptDialog(*this, message, defaultValue);
     }
 
     runModalJavaScriptDialog(WTFMove(frame), WTFMove(frameInfo), message, [reply = WTFMove(reply), defaultValue](WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&& frameInfo, const String& message, CompletionHandler<void()>&& completion) mutable {

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -7148,6 +7148,7 @@
 		9979659B25310A4800B31AE3 /* WebInspectorUIExtensionControllerMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebInspectorUIExtensionControllerMessageReceiver.cpp; sourceTree = "<group>"; };
 		997965A2253128C700B31AE3 /* _WKInspectorExtensionHost.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKInspectorExtensionHost.h; sourceTree = "<group>"; };
 		9979CA57237F49F00039EC05 /* _WKInspectorPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKInspectorPrivate.h; sourceTree = "<group>"; };
+		99965A552DA096EF0039DFF5 /* BidiSession.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = BidiSession.json; sourceTree = "<group>"; };
 		99996A9D25004BCB004F7559 /* _WKInspectorPrivateForTesting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKInspectorPrivateForTesting.h; sourceTree = "<group>"; };
 		99996A9E25004BCB004F7559 /* _WKInspectorTesting.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKInspectorTesting.mm; sourceTree = "<group>"; };
 		999B7ED82550E4A800F450A4 /* InspectorExtensionTypes.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = InspectorExtensionTypes.cpp; sourceTree = "<group>"; };
@@ -14077,6 +14078,7 @@
 				996D00412D7AA0CD0049C7D8 /* BidiBrowsingContext.json */,
 				996D00422D7AA0CD0049C7D8 /* BidiLog.json */,
 				996D00432D7AA0CD0049C7D8 /* BidiScript.json */,
+				99965A552DA096EF0039DFF5 /* BidiSession.json */,
 			);
 			path = protocol;
 			sourceTree = "<group>";


### PR DESCRIPTION
#### 46a863cf3b36aba43a25ccbaf642c5e72ecf3666
<pre>
[WebDriver][BiDi] implement the browsingContext.handleUserPrompt command
<a href="https://bugs.webkit.org/show_bug.cgi?id=288328">https://bugs.webkit.org/show_bug.cgi?id=288328</a>
<a href="https://rdar.apple.com/145987385">rdar://145987385</a>

Reviewed by Devin Rousso.

Add basic implementations for handleUserPrompt, userPromptOpened, and userPromptClosed.
Add _WKAutomationSessionDelegate methods which allow the client to report the user-entered
text and default/placeholder text for the current dialog.

There are a few related pieces of work which need to happen separately as followups:

* Implement support for `File and `Beforeunload` user prompt types in WebKit.
<a href="https://bugs.webkit.org/show_bug.cgi?id=291665">https://bugs.webkit.org/show_bug.cgi?id=291665</a>

* Pass `unhandledPromptBehavior` from driver to WebKit. WebDriver Classic defines
an `unhandledPromptBehavior` capability which allows for automatically accepting, dismissing,
or ignoring user prompts during testing. WebDriver BiDi calls this the `user prompt handler`
and includes its value in the `browsingContext.userPromptOpened` event.
<a href="https://bugs.webkit.org/show_bug.cgi?id=291666">https://bugs.webkit.org/show_bug.cgi?id=291666</a>

* Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json:
* Source/WebKit/UIProcess/Automation/protocol/BidiSession.json: Added.
The specification puts `UserPromptHandlerType` in the `session` domain since it is a
property of the session. Add a Session domain specification to keep the pattern going.

* Source/WebKit/UIProcess/API/APIAutomationSessionClient.h:
(API::AutomationSessionClient::defaultTextOfCurrentJavaScriptDialogOnPage): Added.
(API::AutomationSessionClient::userInputOfCurrentJavaScriptDialogOnPage): Added.
These are needed by `browsingContext.userPromptOpened` and `browsingContext.userPromptClosed`.

* Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionDelegate.h:
* Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.h:
* Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm:
(WebKit::AutomationSessionClient::AutomationSessionClient):
(WebKit::AutomationSessionClient::defaultTextOfCurrentJavaScriptDialogOnPage):
(WebKit::AutomationSessionClient::userInputOfCurrentJavaScriptDialogOnPage):
Add delegate methods and boilerplate to match new APIAutomationSessionClient methods.

* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::toProtocolUserPromptType): Added.
(WebKit::WebAutomationSession::willShowJavaScriptDialog):
Emit userPromptOpened after the run loop spins once and the dialog has definitely appeared.

(WebKit::WebAutomationSession::dismissCurrentJavaScriptDialog):
(WebKit::WebAutomationSession::acceptCurrentJavaScriptDialog):
Emit userPromptClosed after accepting or dismissing the user prompt.

* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
Drive-by, remove unnecessary forward declaration for a class that was renamed.

* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h:
* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp:
(WebKit::WebDriverBidiProcessor::WebDriverBidiProcessor):
Add frontend dispatcher object for `browsingContext` domain.

(WebKit::WebDriverBidiProcessor::handleUserPrompt):
Added. Accept or dismiss the user prompt.

(WebKit::WebDriverBidiProcessor::userPromptOpenedOnPage):
(WebKit::WebDriverBidiProcessor::userPromptClosedOnPage):
Added. These methods are pass through, the data is fetched from the client in WebAutomationSession.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
Add BidiSession.json.

Canonical link: <a href="https://commits.webkit.org/293978@main">https://commits.webkit.org/293978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63d558cf9330c6f524614a1bbeeadee8d58324cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105582 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51033 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76484 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33536 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90731 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56840 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15452 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50408 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85369 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8813 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107936 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27563 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20229 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85436 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27926 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84974 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21621 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29659 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7390 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21528 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27498 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32748 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27309 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30627 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28867 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->