### PR TITLE
[Script Telemetry] Refactor some script telemetry checks

### DIFF
--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -958,6 +958,9 @@ bool ScriptExecutionContext::requiresScriptExecutionTelemetry(ScriptTelemetryCat
     if (!vm->topCallFrame)
         return false;
 
+    if (!shouldEnableScriptTelemetry(category, advancedPrivacyProtections()))
+        return false;
+
     auto [taintedness, taintedURL] = JSC::sourceTaintedOriginFromStack(*vm, vm->topCallFrame);
     switch (taintedness) {
     case JSC::SourceTaintedOrigin::Untainted:

--- a/Source/WebCore/page/ScriptTelemetryCategory.cpp
+++ b/Source/WebCore/page/ScriptTelemetryCategory.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "ScriptTelemetryCategory.h"
 
+#include "AdvancedPrivacyProtections.h"
+
 #if !(USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/ScriptTelemetryCategoryAdditions.cpp>))
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
@@ -45,20 +47,12 @@ ASCIILiteral description(ScriptTelemetryCategory category)
         return "Canvas"_s;
     case ScriptTelemetryCategory::Cookies:
         return "Cookies"_s;
-    case ScriptTelemetryCategory::Gamepads:
-        return "Gamepads"_s;
     case ScriptTelemetryCategory::HardwareConcurrency:
         return "HardwareConcurrency"_s;
     case ScriptTelemetryCategory::LocalStorage:
         return "LocalStorage"_s;
-    case ScriptTelemetryCategory::MediaDevices:
-        return "MediaDevices"_s;
-    case ScriptTelemetryCategory::Notifications:
-        return "Notifications"_s;
     case ScriptTelemetryCategory::Payments:
         return "Payments"_s;
-    case ScriptTelemetryCategory::Permissions:
-        return "Permissions"_s;
     case ScriptTelemetryCategory::QueryParameters:
         return "QueryParameters"_s;
     case ScriptTelemetryCategory::Referrer:
@@ -72,6 +66,14 @@ ASCIILiteral description(ScriptTelemetryCategory category)
     }
     ASSERT_NOT_REACHED();
     return { };
+}
+
+bool shouldEnableScriptTelemetry(ScriptTelemetryCategory category, OptionSet<AdvancedPrivacyProtections> protections)
+{
+    if (protections.contains(AdvancedPrivacyProtections::BaselineProtections))
+        return true;
+
+    return category != ScriptTelemetryCategory::FormControls;
 }
 
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/ScriptTelemetryCategoryAdditions.cpp>)

--- a/Source/WebCore/page/ScriptTelemetryCategory.h
+++ b/Source/WebCore/page/ScriptTelemetryCategory.h
@@ -26,23 +26,22 @@
 #pragma once
 
 #include <wtf/HashTraits.h>
+#include <wtf/OptionSet.h>
 #include <wtf/text/ASCIILiteral.h>
 
 namespace WebCore {
+
+enum class AdvancedPrivacyProtections : uint16_t;
 
 enum class ScriptTelemetryCategory : uint8_t {
     Unspecified = 0,
     Audio,
     Canvas,
     Cookies,
-    Gamepads,
     HardwareConcurrency,
     LocalStorage,
-    MediaDevices,
-    Notifications,
     Payments,
     QueryParameters,
-    Permissions,
     Referrer,
     ScreenOrViewport,
     Speech,
@@ -51,6 +50,8 @@ enum class ScriptTelemetryCategory : uint8_t {
 
 String makeLogMessage(const URL&, ScriptTelemetryCategory);
 ASCIILiteral description(ScriptTelemetryCategory);
+
+bool shouldEnableScriptTelemetry(ScriptTelemetryCategory, OptionSet<AdvancedPrivacyProtections>);
 
 } // namespace WebCore
 


### PR DESCRIPTION
#### 80d1fc8191a20585eb4656e6ec2417ff120cddb1
<pre>
[Script Telemetry] Refactor some script telemetry checks
<a href="https://bugs.webkit.org/show_bug.cgi?id=291669">https://bugs.webkit.org/show_bug.cgi?id=291669</a>
<a href="https://rdar.apple.com/149391869">rdar://149391869</a>

Reviewed by Tim Horton and Abrar Rahman Protyasha.

Refactor several script telemetry checks:
-   Remove a coupld of unused flags.
-   Limit `ScriptTelemetryCategory::FormControls` to only when advanced privacy protections are
    enabled.

* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::requiresScriptExecutionTelemetry):
* Source/WebCore/page/ScriptTelemetryCategory.cpp:
(WebCore::description):
(WebCore::shouldEnableScriptTelemetry):
* Source/WebCore/page/ScriptTelemetryCategory.h:

Canonical link: <a href="https://commits.webkit.org/293795@main">https://commits.webkit.org/293795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/218bcd5f925524d2e62481a163bc13a4bed52a09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105076 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50530 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28033 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76093 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33176 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90266 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56452 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14994 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8253 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49899 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84918 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8340 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107437 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27062 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19779 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85045 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27425 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86466 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84569 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21479 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29243 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6966 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20887 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26999 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32227 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26810 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30126 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28369 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->