### PR TITLE
Web Inspector: Debugger: preserve the pause reason and data when stepping over `await`

### DIFF
--- a/LayoutTests/inspector/debugger/stepping/stepNext-await-expected.txt
+++ b/LayoutTests/inspector/debugger/stepping/stepNext-await-expected.txt
@@ -23,7 +23,7 @@ PAUSE AT <anonymous>:7:5
       9    }
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:8:5
       4    async function testStatements() {
       5        debugger;
@@ -34,7 +34,7 @@ PAUSE AT <anonymous>:8:5
      10
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:9:5
       5        debugger;
       6        let x = await 1;
@@ -67,7 +67,7 @@ PAUSE AT <anonymous>:14:5
      16        TestPage.dispatchEventToFrontend("done");
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:15:5
      11    async function testFunctions() {
      12        debugger;
@@ -78,7 +78,7 @@ PAUSE AT <anonymous>:15:5
      17    }
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:16:5
      12        debugger;
      13        let before = await 1;
@@ -89,7 +89,7 @@ PAUSE AT <anonymous>:16:5
      18
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:17:5
      13        let before = await 1;
      14        await a();
@@ -122,7 +122,7 @@ PAUSE AT <anonymous>:22:5
      24        TestPage.dispatchEventToFrontend("done");
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:23:5
      19    async function testEval() {
      20        debugger;
@@ -133,7 +133,7 @@ PAUSE AT <anonymous>:23:5
      25    }
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:24:5
      20        debugger;
      21        let before = await 1;
@@ -144,7 +144,7 @@ PAUSE AT <anonymous>:24:5
      26
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:25:5
      21        let before = await 1;
      22        await eval("1 + 1");
@@ -177,7 +177,7 @@ PAUSE AT <anonymous>:31:9
      33        TestPage.dispatchEventToFrontend("done");
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:33:5
      29            debugger;
      30            let inner = await 1;
@@ -188,7 +188,7 @@ PAUSE AT <anonymous>:33:5
      35
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:34:5
      30            let inner = await 1;
      31        })();
@@ -221,7 +221,7 @@ PAUSE AT <anonymous>:39:5
      41        await a(), await b(), await c();
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:40:9
      36    async function testCommas() {
      37        debugger;
@@ -232,7 +232,7 @@ PAUSE AT <anonymous>:40:9
      42        await true && (await a(), await b(), await c()) && await true;
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:41:9
      37        debugger;
      38        let x = await 1,
@@ -243,7 +243,7 @@ PAUSE AT <anonymous>:41:9
      43        TestPage.dispatchEventToFrontend("done");
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:42:5
      38        let x = await 1,
      39            y = await 2,
@@ -254,7 +254,7 @@ PAUSE AT <anonymous>:42:5
      44    }
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:42:16
      38        let x = await 1,
      39            y = await 2,
@@ -265,7 +265,7 @@ PAUSE AT <anonymous>:42:16
      44    }
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:42:27
      38        let x = await 1,
      39            y = await 2,
@@ -276,7 +276,7 @@ PAUSE AT <anonymous>:42:27
      44    }
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:43:5
      39            y = await 2,
      40            z = await 3;
@@ -287,7 +287,7 @@ PAUSE AT <anonymous>:43:5
      45
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:43:20
      39            y = await 2,
      40            z = await 3;
@@ -298,7 +298,7 @@ PAUSE AT <anonymous>:43:20
      45
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:43:31
      39            y = await 2,
      40            z = await 3;
@@ -309,7 +309,7 @@ PAUSE AT <anonymous>:43:31
      45
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:43:42
      39            y = await 2,
      40            z = await 3;
@@ -320,7 +320,7 @@ PAUSE AT <anonymous>:43:42
      45
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:44:5
      40            z = await 3;
      41        await a(), await b(), await c();
@@ -353,7 +353,7 @@ PAUSE AT <anonymous>:49:5
      51
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:49:24
      45
      46    async function testChainedExpressions() {
@@ -364,7 +364,7 @@ PAUSE AT <anonymous>:49:24
      51
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:49:37
      45
      46    async function testChainedExpressions() {
@@ -375,7 +375,7 @@ PAUSE AT <anonymous>:49:37
      51
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:50:5
      46    async function testChainedExpressions() {
      47        debugger;
@@ -408,7 +408,7 @@ PAUSE AT <anonymous>:55:5
      57        TestPage.dispatchEventToFrontend("done");
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:56:9
      52    async function testDeclarations() {
      53        debugger;
@@ -419,7 +419,7 @@ PAUSE AT <anonymous>:56:9
      58    }
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:57:9
      53        debugger;
      54        let x = await a(),
@@ -430,7 +430,7 @@ PAUSE AT <anonymous>:57:9
      59
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:58:5
      54        let x = await a(),
      55            y = await b(),
@@ -494,7 +494,7 @@ PAUSE AT <anonymous>:74:16
      76        TestPage.dispatchEventToFrontend("done");
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:75:9
      71    async function testFor() {
      72        debugger;
@@ -514,7 +514,7 @@ PAUSE AT <anonymous>:74:16
      76        TestPage.dispatchEventToFrontend("done");
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:75:9
      71    async function testFor() {
      72        debugger;
@@ -534,7 +534,7 @@ PAUSE AT <anonymous>:74:16
      76        TestPage.dispatchEventToFrontend("done");
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:77:5
      73        for await (let item of [a(), b()]) {
      74            c();
@@ -576,7 +576,7 @@ PAUSE AT <anonymous>:86:9
      88            if (state === 2)
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:87:13
      83            if (state === 1)
      84                await a(); // should not pause on this line

--- a/LayoutTests/inspector/debugger/stepping/stepOver-await-expected.txt
+++ b/LayoutTests/inspector/debugger/stepping/stepOver-await-expected.txt
@@ -23,7 +23,7 @@ PAUSE AT <anonymous>:7:5
       9    }
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:8:5
       4    async function testStatements() {
       5        debugger;
@@ -34,7 +34,7 @@ PAUSE AT <anonymous>:8:5
      10
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:9:5
       5        debugger;
       6        let x = await 1;
@@ -67,7 +67,7 @@ PAUSE AT <anonymous>:14:5
      16        TestPage.dispatchEventToFrontend("done");
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:15:5
      11    async function testFunctions() {
      12        debugger;
@@ -78,7 +78,7 @@ PAUSE AT <anonymous>:15:5
      17    }
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:16:5
      12        debugger;
      13        let before = await 1;
@@ -89,7 +89,7 @@ PAUSE AT <anonymous>:16:5
      18
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:17:5
      13        let before = await 1;
      14        await a();
@@ -122,7 +122,7 @@ PAUSE AT <anonymous>:22:5
      24        TestPage.dispatchEventToFrontend("done");
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:23:5
      19    async function testEval() {
      20        debugger;
@@ -133,7 +133,7 @@ PAUSE AT <anonymous>:23:5
      25    }
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:24:5
      20        debugger;
      21        let before = await 1;
@@ -144,7 +144,7 @@ PAUSE AT <anonymous>:24:5
      26
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:25:5
      21        let before = await 1;
      22        await eval("1 + 1");
@@ -177,7 +177,7 @@ PAUSE AT <anonymous>:31:9
      33        TestPage.dispatchEventToFrontend("done");
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:33:5
      29            debugger;
      30            let inner = await 1;
@@ -188,7 +188,7 @@ PAUSE AT <anonymous>:33:5
      35
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:34:5
      30            let inner = await 1;
      31        })();
@@ -221,7 +221,7 @@ PAUSE AT <anonymous>:39:5
      41        await a(), await b(), await c();
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:40:9
      36    async function testCommas() {
      37        debugger;
@@ -232,7 +232,7 @@ PAUSE AT <anonymous>:40:9
      42        await true && (await a(), await b(), await c()) && await true;
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:41:9
      37        debugger;
      38        let x = await 1,
@@ -243,7 +243,7 @@ PAUSE AT <anonymous>:41:9
      43        TestPage.dispatchEventToFrontend("done");
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:42:5
      38        let x = await 1,
      39            y = await 2,
@@ -254,7 +254,7 @@ PAUSE AT <anonymous>:42:5
      44    }
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:42:16
      38        let x = await 1,
      39            y = await 2,
@@ -265,7 +265,7 @@ PAUSE AT <anonymous>:42:16
      44    }
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:42:27
      38        let x = await 1,
      39            y = await 2,
@@ -276,7 +276,7 @@ PAUSE AT <anonymous>:42:27
      44    }
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:43:5
      39            y = await 2,
      40            z = await 3;
@@ -287,7 +287,7 @@ PAUSE AT <anonymous>:43:5
      45
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:43:20
      39            y = await 2,
      40            z = await 3;
@@ -298,7 +298,7 @@ PAUSE AT <anonymous>:43:20
      45
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:43:31
      39            y = await 2,
      40            z = await 3;
@@ -309,7 +309,7 @@ PAUSE AT <anonymous>:43:31
      45
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:43:42
      39            y = await 2,
      40            z = await 3;
@@ -320,7 +320,7 @@ PAUSE AT <anonymous>:43:42
      45
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:44:5
      40            z = await 3;
      41        await a(), await b(), await c();
@@ -353,7 +353,7 @@ PAUSE AT <anonymous>:49:5
      51
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:49:24
      45
      46    async function testChainedExpressions() {
@@ -364,7 +364,7 @@ PAUSE AT <anonymous>:49:24
      51
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:49:37
      45
      46    async function testChainedExpressions() {
@@ -375,7 +375,7 @@ PAUSE AT <anonymous>:49:37
      51
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:50:5
      46    async function testChainedExpressions() {
      47        debugger;
@@ -408,7 +408,7 @@ PAUSE AT <anonymous>:55:5
      57        TestPage.dispatchEventToFrontend("done");
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:56:9
      52    async function testDeclarations() {
      53        debugger;
@@ -419,7 +419,7 @@ PAUSE AT <anonymous>:56:9
      58    }
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:57:9
      53        debugger;
      54        let x = await a(),
@@ -430,7 +430,7 @@ PAUSE AT <anonymous>:57:9
      59
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:58:5
      54        let x = await a(),
      55            y = await b(),
@@ -485,7 +485,7 @@ PAUSE AT <anonymous>:74:16
      76        TestPage.dispatchEventToFrontend("done");
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:75:9
      71    async function testFor() {
      72        debugger;
@@ -505,7 +505,7 @@ PAUSE AT <anonymous>:74:16
      76        TestPage.dispatchEventToFrontend("done");
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:75:9
      71    async function testFor() {
      72        debugger;
@@ -525,7 +525,7 @@ PAUSE AT <anonymous>:74:16
      76        TestPage.dispatchEventToFrontend("done");
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:77:5
      73        for await (let item of [a(), b()]) {
      74            c();
@@ -567,7 +567,7 @@ PAUSE AT <anonymous>:86:9
      88            if (state === 2)
 
 RESUMED
-PAUSED (other)
+PAUSED (debugger-statement)
 PAUSE AT <anonymous>:87:13
      83            if (state === 1)
      84                await a(); // should not pause on this line

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
@@ -292,8 +292,8 @@ private:
     DebuggerFrontendDispatcher::Reason m_pauseReason;
     RefPtr<JSON::Object> m_pauseData;
 
-    DebuggerFrontendDispatcher::Reason m_preBlackboxPauseReason;
-    RefPtr<JSON::Object> m_preBlackboxPauseData;
+    DebuggerFrontendDispatcher::Reason m_lastPauseReason;
+    RefPtr<JSON::Object> m_lastPauseData;
 
     UncheckedKeyHashMap<AsyncCallIdentifier, RefPtr<AsyncStackTrace>> m_pendingAsyncCalls;
     Vector<AsyncCallIdentifier> m_currentAsyncCallIdentifierStack;


### PR DESCRIPTION
#### f3095ecef1bbcc787d22562981f86360ff1ff13e
<pre>
Web Inspector: Debugger: preserve the pause reason and data when stepping over `await`
<a href="https://bugs.webkit.org/show_bug.cgi?id=291670">https://bugs.webkit.org/show_bug.cgi?id=291670</a>

Reviewed by BJ Burg.

Currently the pause reason section of the navigation sidebar in the Sources Tab is empty when stepping over the `await` in code like
```js
(async function() {
    debugger;
    console.log(&quot;before&quot;);
    await (async function() { return 42; })();
    console.log(&quot;after&quot;);
})()
```
It should show &quot;Debugger Statement&quot; as the pause reason with the debugger breakpoint next to it so that the developer can see why the pause happened in the first place.

* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h:
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp:
(Inspector::InspectorDebuggerAgent::updatePauseReasonAndData):
(Inspector::InspectorDebuggerAgent::didPause):
Only override the cached last `DebuggerFrontendDispatcher::Reason` and pause data when the current `DebuggerFrontendDispatcher::Reason` is not invalid so as to preserve why Web Inspector paused even over an async boundary, which normally would clear that information.

* Source/JavaScriptCore/debugger/Debugger.h:
* Source/JavaScriptCore/debugger/Debugger.cpp:
(JSC::Debugger::~Debugger):
(JSC::Debugger::pauseIfNeeded):
(JSC::Debugger::willAwait):
(JSC::Debugger::didAwait):
(JSC::Debugger::resetAsyncPauseState):
(JSC::Debugger::AbandonPauseInAwaitTimer::AbandonPauseInAwaitTimer): Added.
(JSC::Debugger::AbandonPauseInAwaitTimer::doWork): Added.
Drive-by: only try to pause when stepping over an `await` so long as it&apos;s not been more than 1s as any longer could be confusing (e.g. &quot;why is Web Inspector suddenly pausing?&quot;).

* LayoutTests/inspector/debugger/stepping/stepNext-await-expected.txt:
* LayoutTests/inspector/debugger/stepping/stepOver-await-expected.txt:

Canonical link: <a href="https://commits.webkit.org/293844@main">https://commits.webkit.org/293844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6c6e4a6604c23521933454e1ab53eeba44d668d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19728 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105210 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50661 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28201 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/76182 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33252 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103087 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90385 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56543 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15118 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8381 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; Skipped layout-tests; 22 flakes") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50031 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92738 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85028 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8465 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107569 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98687 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27193 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19913 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85135 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27556 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86591 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84669 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21509 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29345 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7080 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21029 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27130 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32359 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122313 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26941 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34144 "Found 1 new JSC stress test failure: ChakraCore.yaml/ChakraCore/test/es6/ES6MathAPIs.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30257 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28500 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->