### PR TITLE
[WTF] Speculatively make StringPrintStream defensive

### DIFF
--- a/Source/WTF/wtf/StringPrintStream.cpp
+++ b/Source/WTF/wtf/StringPrintStream.cpp
@@ -47,40 +47,32 @@ StringPrintStream::~StringPrintStream()
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
-void StringPrintStream::vprintf(const char* format, va_list argList)
+void StringPrintStream::vprintf(const char* format, va_list passedArgList)
 {
     ASSERT_WITH_SECURITY_IMPLICATION(m_length < m_buffer.size());
     ASSERT(!m_buffer[m_length]);
 
-    va_list firstPassArgList;
-    va_copy(firstPassArgList, argList);
+    while (true) {
+        va_list argList;
+        va_copy(argList, passedArgList);
 
-    int numberOfBytesNotIncludingTerminatorThatWouldHaveBeenWritten =
-        vsnprintf(m_buffer.subspan(m_length).data(), m_buffer.size() - m_length, format, firstPassArgList);
+        auto remaining = m_buffer.subspan(m_length);
+        int numberOfBytesNotIncludingTerminatorThatWouldHaveBeenWritten = vsnprintf(remaining.data(), remaining.size(), format, argList);
 
-    va_end(firstPassArgList);
+        va_end(argList);
 
-    int numberOfBytesThatWouldHaveBeenWritten =
-        numberOfBytesNotIncludingTerminatorThatWouldHaveBeenWritten + 1;
+        RELEASE_ASSERT(numberOfBytesNotIncludingTerminatorThatWouldHaveBeenWritten >= 0);
 
-    if (m_length + numberOfBytesThatWouldHaveBeenWritten <= m_buffer.size()) {
-        m_length += numberOfBytesNotIncludingTerminatorThatWouldHaveBeenWritten;
-        return; // This means that vsnprintf() succeeded.
+        size_t numberOfBytesThatWouldHaveBeenWritten = static_cast<size_t>(numberOfBytesNotIncludingTerminatorThatWouldHaveBeenWritten) + 1;
+
+        if (m_length + numberOfBytesThatWouldHaveBeenWritten <= m_buffer.size()) {
+            m_length += static_cast<size_t>(numberOfBytesNotIncludingTerminatorThatWouldHaveBeenWritten);
+            ASSERT(!m_buffer[m_length]);
+            return; // This means that vsnprintf() succeeded.
+        }
+
+        increaseSize(m_length + numberOfBytesThatWouldHaveBeenWritten);
     }
-
-    increaseSize(m_length + numberOfBytesThatWouldHaveBeenWritten);
-
-    int numberOfBytesNotIncludingTerminatorThatWereWritten =
-        vsnprintf(m_buffer.subspan(m_length).data(), m_buffer.size() - m_length, format, argList);
-
-    int numberOfBytesThatWereWritten = numberOfBytesNotIncludingTerminatorThatWereWritten + 1;
-
-    ASSERT_UNUSED(numberOfBytesThatWereWritten, m_length + numberOfBytesThatWereWritten <= m_buffer.size());
-
-    m_length += numberOfBytesNotIncludingTerminatorThatWereWritten;
-
-    ASSERT_WITH_SECURITY_IMPLICATION(m_length < m_buffer.size());
-    ASSERT(!m_buffer[m_length]);
 }
 
 CString StringPrintStream::toCString() const


### PR DESCRIPTION
#### f6b6c1d4d20db5d6836e0b4f97a14d2bb373b63e
<pre>
[WTF] Speculatively make StringPrintStream defensive
<a href="https://bugs.webkit.org/show_bug.cgi?id=291675">https://bugs.webkit.org/show_bug.cgi?id=291675</a>
<a href="https://rdar.apple.com/147532364">rdar://147532364</a>

Reviewed by Keith Miller.

We are observing super rare crash which seems like vsnprintf is
returning different numbers for preflight and actual calls. This is
super unlikely and not sure whether this is the actual issue, let&apos;s make
these calls a bit defensive.

1. Loop until we ensure that all contents get actually written.
2. Assert when negative number is returned from vsnprintf as an error.

* Source/WTF/wtf/StringPrintStream.cpp:
(WTF::StringPrintStream::vprintf):

Canonical link: <a href="https://commits.webkit.org/293796@main">https://commits.webkit.org/293796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12f3d5411c9219187fb5fa63f99d425345641daf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105084 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50537 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28040 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76099 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33181 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15197 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90273 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56458 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15002 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8260 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49906 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92614 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84927 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8348 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107444 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98563 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27069 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19785 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85051 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27432 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86473 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84575 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29249 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6973 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20897 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16259 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27006 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32234 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122189 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26817 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34110 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30133 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28376 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->