### PR TITLE
[JSC] Iterator helpers incorrectly close iterators on early errors

### DIFF
--- a/JSTests/stress/iterator-helper-close-timing.js
+++ b/JSTests/stress/iterator-helper-close-timing.js
@@ -1,0 +1,43 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+function createIterator() {
+    return {
+        next() { return { done: true } },
+        return() { this.closed = true }
+    };
+}
+
+{
+    let iter = createIterator();
+    shouldBe(iter.closed, undefined);
+    shouldThrow(() => {
+        Iterator.prototype.drop.call(iter, NaN);
+    }, `RangeError: Iterator.prototype.drop argument must not be NaN.`);
+    shouldBe(iter.closed, true);
+}
+{
+    let iter = createIterator();
+    shouldBe(iter.closed, undefined);
+    shouldThrow(() => {
+        Iterator.prototype.take.call(iter, NaN);
+    }, `RangeError: Iterator.prototype.take argument must not be NaN.`);
+    shouldBe(iter.closed, true);
+}

--- a/Source/JavaScriptCore/builtins/JSIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/JSIteratorPrototype.js
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.map
+// https://tc39.es/ecma262/#sec-iterator.prototype.map
 function map(mapper)
 {
     "use strict";
@@ -33,8 +33,11 @@ function map(mapper)
         @throwTypeError("Iterator.prototype.map requires that |this| be an Object.");
 
     if (!@isCallable(mapper)) {
-        @iteratorGenericClose(this);
-        @throwTypeError("Iterator.prototype.map callback must be a function.");
+        try {
+            @iteratorGenericClose(this);
+        } finally {
+            @throwTypeError("Iterator.prototype.map callback must be a function.");
+        }
     }
 
     var iterated = this;
@@ -57,7 +60,7 @@ function map(mapper)
     return @iteratorHelperCreate(generator, iterated);
 }
 
-// https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.filter
+// https://tc39.es/ecma262/#sec-iterator.prototype.filter
 function filter(predicate)
 {
     "use strict";
@@ -66,8 +69,11 @@ function filter(predicate)
         @throwTypeError("Iterator.prototype.filter requires that |this| be an Object.");
 
     if (!@isCallable(predicate)) {
-        @iteratorGenericClose(this);
-        @throwTypeError("Iterator.prototype.filter callback must be a function.");
+        try {
+            @iteratorGenericClose(this);
+        } finally {
+            @throwTypeError("Iterator.prototype.filter callback must be a function.");
+        }
     }
 
     var iterated = this;
@@ -90,7 +96,7 @@ function filter(predicate)
     return @iteratorHelperCreate(generator, iterated);
 }
 
-// https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.take
+// https://tc39.es/ecma262/#sec-iterator.prototype.take
 function take(limit)
 {
     "use strict";
@@ -101,14 +107,20 @@ function take(limit)
     var numLimit;
     @ifAbruptCloseIterator(this, numLimit = @toNumber(limit));
     if (numLimit !== numLimit) {
-        @iteratorGenericClose(this);
-        @throwRangeError("Iterator.prototype.take argument must not be NaN.");
+        try {
+            @iteratorGenericClose(this);
+        } finally {
+            @throwRangeError("Iterator.prototype.take argument must not be NaN.");
+        }
     }
 
     var intLimit = @toIntegerOrInfinity(numLimit);
     if (intLimit < 0) {
-        @iteratorGenericClose(this);
-        @throwRangeError("Iterator.prototype.take argument must be non-negative.");
+        try {
+            @iteratorGenericClose(this);
+        } finally {
+            @throwRangeError("Iterator.prototype.take argument must be non-negative.");
+        }
     }
 
     var iterated = this;
@@ -139,7 +151,7 @@ function take(limit)
     return @iteratorHelperCreate(generator, iterated);
 }
 
-// https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.drop
+// https://tc39.es/ecma262/#sec-iterator.prototype.drop
 function drop(limit)
 {
     "use strict";
@@ -150,14 +162,20 @@ function drop(limit)
     var numLimit;
     @ifAbruptCloseIterator(this, (numLimit = @toNumber(limit)));
     if (numLimit !== numLimit) {
-        @iteratorGenericClose(this);
-        @throwRangeError("Iterator.prototype.drop argument must not be NaN.");
+        try {
+            @iteratorGenericClose(this);
+        } finally {
+            @throwRangeError("Iterator.prototype.drop argument must not be NaN.");
+        }
     }
 
     var intLimit = @toIntegerOrInfinity(numLimit);
     if (intLimit < 0) {
-        @iteratorGenericClose(this);
-        @throwRangeError("Iterator.prototype.drop argument must be non-negative.");
+        try {
+            @iteratorGenericClose(this);
+        } finally {
+            @throwRangeError("Iterator.prototype.drop argument must be non-negative.");
+        }
     }
 
     var iterated = this;
@@ -185,7 +203,7 @@ function drop(limit)
     return @iteratorHelperCreate(generator, iterated);
 }
 
-// https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.flatmap
+// https://tc39.es/ecma262/#sec-iterator.prototype.flatmap
 function flatMap(mapper)
 {
     "use strict";
@@ -194,8 +212,11 @@ function flatMap(mapper)
         @throwTypeError("Iterator.prototype.flatMap requires that |this| be an Object.");
 
     if (!@isCallable(mapper)) {
-        @iteratorGenericClose(this);
-        @throwTypeError("Iterator.prototype.flatMap callback must be a function.");
+        try {
+            @iteratorGenericClose(this);
+        } finally {
+            @throwTypeError("Iterator.prototype.flatMap callback must be a function.");
+        }
     }
 
     var iterated = this;
@@ -220,7 +241,7 @@ function flatMap(mapper)
     return @iteratorHelperCreate(generator, iterated);
 }
 
-// https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.some
+// https://tc39.es/ecma262/#sec-iterator.prototype.some
 function some(predicate)
 {
     "use strict";
@@ -229,8 +250,11 @@ function some(predicate)
         @throwTypeError("Iterator.prototype.some requires that |this| be an Object.");
 
     if (!@isCallable(predicate)) {
-        @iteratorGenericClose(this);
-        @throwTypeError("Iterator.prototype.some callback must be a function.");
+        try {
+            @iteratorGenericClose(this);
+        } finally {
+            @throwTypeError("Iterator.prototype.some callback must be a function.");
+        }
     }
 
     var iterated = this;
@@ -244,7 +268,7 @@ function some(predicate)
     return false;
 }
 
-// https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.every
+// https://tc39.es/ecma262/#sec-iterator.prototype.every
 function every(predicate)
 {
     "use strict";
@@ -253,8 +277,11 @@ function every(predicate)
         @throwTypeError("Iterator.prototype.every requires that |this| be an Object.");
 
     if (!@isCallable(predicate)) {
-        @iteratorGenericClose(this);
-        @throwTypeError("Iterator.prototype.every callback must be a function.");
+        try {
+            @iteratorGenericClose(this);
+        } finally {
+            @throwTypeError("Iterator.prototype.every callback must be a function.");
+        }
     }
 
     var iterated = this;
@@ -268,7 +295,7 @@ function every(predicate)
     return true;
 }
 
-// https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.find
+// https://tc39.es/ecma262/#sec-iterator.prototype.find
 function find(predicate)
 {
     "use strict";
@@ -277,8 +304,11 @@ function find(predicate)
         @throwTypeError("Iterator.prototype.find requires that |this| be an Object.");
 
     if (!@isCallable(predicate)) {
-        @iteratorGenericClose(this);
-        @throwTypeError("Iterator.prototype.find callback must be a function.");
+        try {
+            @iteratorGenericClose(this);
+        } finally {
+            @throwTypeError("Iterator.prototype.find callback must be a function.");
+        }
     }
 
     var iterated = this;
@@ -292,7 +322,7 @@ function find(predicate)
     return @undefined;
 }
 
-// https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.reduce
+// https://tc39.es/ecma262/#sec-iterator.prototype.reduce
 function reduce(reducer /*, initialValue */)
 {
     "use strict";
@@ -301,8 +331,11 @@ function reduce(reducer /*, initialValue */)
         @throwTypeError("Iterator.prototype.reduce requires that |this| be an Object.");
 
     if (!@isCallable(reducer)) {
-        @iteratorGenericClose(this);
-        @throwTypeError("Iterator.prototype.reduce reducer argument must be a function.");
+        try {
+            @iteratorGenericClose(this);
+        } finally {
+            @throwTypeError("Iterator.prototype.reduce reducer argument must be a function.");
+        }
     }
 
     var iterated = this;

--- a/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
@@ -163,8 +163,11 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncForEach, (JSGlobalObject* globalObject
 
     JSValue callbackArg = callFrame->argument(0);
     if (!callbackArg.isCallable()) {
-        iteratorClose(globalObject, thisValue);
-        RETURN_IF_EXCEPTION(scope, { });
+        {
+            auto catchScope = DECLARE_CATCH_SCOPE(vm);
+            iteratorClose(globalObject, thisValue);
+            catchScope.clearException();
+        }
         return throwVMTypeError(globalObject, scope, "Iterator.prototype.forEach requires the callback argument to be callable."_s);
     }
 


### PR DESCRIPTION
#### d6f3d9c7c304a8d5768e4a5ff4f1ce27e2dbfa47
<pre>
[JSC] Iterator helpers incorrectly close iterators on early errors
<a href="https://bugs.webkit.org/show_bug.cgi?id=291195">https://bugs.webkit.org/show_bug.cgi?id=291195</a>
<a href="https://rdar.apple.com/148774612">rdar://148774612</a>

Reviewed by Keith Miller and Sosuke Suzuki.

NaN / Integer checks should be done without iterator closing.
We also fix iterator helpers&apos; closing timing for the other methods as
well.

* JSTests/stress/iterator-helper-close-timing.js: Added.
(shouldBe):
(shouldThrow):
* Source/JavaScriptCore/builtins/JSIteratorPrototype.js:

Canonical link: <a href="https://commits.webkit.org/293842@main">https://commits.webkit.org/293842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc43c36667ed91a3bf4e88e4f0521fbc77133682

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9926 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105114 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50567 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19939 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28136 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76120 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33202 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102993 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15224 "Found 1 new test failure: media/video-aspect-ratio.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90299 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56479 "Found 2 new API test failures: /TestWebKit:WebKit.UserMediaBasic, /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15029 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-contain/contain-size-021.html imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-fixed-ancestor-iframe.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8289 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49936 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92644 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84954 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8374 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107474 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98593 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19869 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85073 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27462 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86499 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84597 "Found 6 new API test failures: /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, /TestWebKit:WebKit.OnDeviceChangeCrash, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mouse-target, /TestWebKit:WebKit.UserMediaBasic, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/custom-container-destroyed, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/default (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29275 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6999 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20935 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16285 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27036 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32264 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122219 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26847 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34122 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30163 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28406 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->