### PR TITLE
[GTK][WPE] Propagate the damage from accelerated 2D canvas

### DIFF
--- a/LayoutTests/platform/glib/damage/accelerated-canvas-2d-fillRect-with-border-changes-expected.html
+++ b/LayoutTests/platform/glib/damage/accelerated-canvas-2d-fillRect-with-border-changes-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <link rel="stylesheet" href="./common.css">
+    <style>
+      body {
+          overflow: hidden;
+      }
+      div {
+          border: 50px solid blue;
+          width: 2000px;
+          height: 2000px;
+      }
+    </style>
+  </head>
+  <body>
+    <div></div>
+  </body>
+</html>
+

--- a/LayoutTests/platform/glib/damage/accelerated-canvas-2d-fillRect-with-border-changes.html
+++ b/LayoutTests/platform/glib/damage/accelerated-canvas-2d-fillRect-with-border-changes.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <link rel="stylesheet" href="./common.css">
+    <style>
+      body {
+          overflow: hidden;
+      }
+      canvas {
+          border: 50px solid #000;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas width="2000" height="2000" />
+    <script>
+      var canvas = document.getElementsByTagName("canvas")[0];
+      var ctx = canvas.getContext("2d");
+
+      requestAnimationFrame(() => {
+          ctx.fillStyle = "red";
+          ctx.fillRect(0, 0, 5, 5);
+          canvas.style.borderColor = 'red';
+
+          requestAnimationFrame(() => {
+              ctx.fillStyle = "white";
+              ctx.fillRect(0, 0, 5, 5);
+              canvas.style.borderColor = 'blue';
+          });
+      });
+    </script>
+  </body>
+</html>

--- a/LayoutTests/platform/glib/damage/accelerated-canvas-2d-fillRect.html
+++ b/LayoutTests/platform/glib/damage/accelerated-canvas-2d-fillRect.html
@@ -24,6 +24,8 @@
           },
           () => {
               var damage = latestFrameDamage();
+              // In case of accelerated canvas, the layer with contents is being created in a lazy fashion,
+              // and therefore during the rendering of the first canvas frame, the whole layer is damaged.
               assertRectsEq(damage.rects, [[0, 0, Math.min(window.innerWidth, 2000), Math.min(window.innerHeight, 2000)]]);
           },
           () => {
@@ -32,7 +34,15 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertRectsEq(damage.rects, [[0, 0, Math.min(window.innerWidth, 2000), Math.min(window.innerHeight, 2000)]]);
+              assertRectsEq(damage.rects, [[4, 4, 7, 7]]);
+          },
+          () => {
+              ctx.fillStyle = "green";
+              ctx.fillRect(10, 10, 5, 5);
+          },
+          () => {
+              var damage = latestFrameDamage();
+              assertRectsEq(damage.rects, [[9, 9, 7, 7]]);
           },
       ], 0);
     </script>

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -185,6 +185,8 @@ private:
 
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
 
+    std::optional<FloatRect> computeDirtyRectangleIfNeeded(const std::optional<FloatRect>&) const;
+
     bool m_ignoreReset { false };
     mutable bool m_didClearImageBuffer { false };
 #if ENABLE(WEBGL)

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2373,10 +2373,13 @@ void CanvasRenderingContext2DBase::didDraw(std::optional<FloatRect> rect, Option
         dirtyRect.unite(shadowRect);
     }
 
+#if !USE(COORDINATED_GRAPHICS)
     // FIXME: This does not apply the clip because we have no way of reading the clip out of the GraphicsContext.
     if (m_dirtyRect.contains(dirtyRect))
         canvasBase().didDraw(std::nullopt, shouldApplyPostProcessing);
-    else {
+    else
+#endif
+    {
         // Inflate dirty rect to cover antialiasing on image buffers.
         if (context->shouldAntialias())
             dirtyRect.inflate(1);

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -511,6 +511,7 @@ public:
     virtual void setNeedsDisplayInRect(const FloatRect&, ShouldClipToLayer = ClipToLayer) = 0;
 
     virtual void setContentsNeedsDisplay() { };
+    virtual void setContentsNeedsDisplayInRect(const FloatRect&) { setContentsNeedsDisplay(); }
 
     // The tile phase is relative to the GraphicsLayer bounds.
     virtual void setContentsTilePhase(const FloatSize& p) { m_contentsTilePhase = p; }

--- a/Source/WebCore/platform/graphics/GraphicsLayerContentsDisplayDelegate.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerContentsDisplayDelegate.h
@@ -39,6 +39,7 @@ class PlatformCALayer;
 #elif USE(COORDINATED_GRAPHICS)
 class CoordinatedPlatformLayer;
 class CoordinatedPlatformLayerBuffer;
+class Damage;
 #endif
 
 // Platform specific interface for attaching contents to GraphicsLayer.
@@ -55,7 +56,7 @@ public:
     virtual GraphicsLayer::CompositingCoordinatesOrientation orientation() const;
 #elif USE(COORDINATED_GRAPHICS)
     virtual void setDisplayBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&&) = 0;
-    virtual bool display(CoordinatedPlatformLayer&) = 0;
+    virtual bool display(CoordinatedPlatformLayer&, std::optional<Damage>&&) = 0;
 #else
     virtual PlatformLayer* platformLayer() const = 0;
 #endif

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -490,7 +490,7 @@ void TextureMapperLayer::collectDamageSelf(TextureMapperPaintOptions& options, D
         return;
     }
 
-    if (m_contentsLayer) {
+    if (m_contentsLayer && (!m_damageInLayerCoordinateSpace || m_damageInLayerCoordinateSpace->isEmpty())) {
         // Layers with content layer are fully damaged for now.
         // FIXME: Remove that special case.
         damageWholeLayer();

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -144,7 +144,7 @@ public:
     void setContentsClippingRect(const FloatRoundedRect&);
     void setContentsScale(float);
     enum class RequireComposition : bool { No, Yes };
-    void setContentsBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&&, RequireComposition = RequireComposition::Yes);
+    void setContentsBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&&, std::optional<Damage>&& = std::nullopt, RequireComposition = RequireComposition::Yes);
 #if ENABLE(VIDEO) && USE(GSTREAMER)
     void replaceCurrentContentsBufferWithCopy();
 #endif
@@ -196,6 +196,10 @@ private:
 
     bool needsBackingStore() const;
     void purgeBackingStores();
+
+#if ENABLE(DAMAGE_TRACKING)
+    void addDamage(Damage&&);
+#endif
 
     enum class Change : uint32_t {
         Position                     = 1 << 0,

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferProxy.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferProxy.cpp
@@ -93,7 +93,7 @@ void CoordinatedPlatformLayerBufferProxy::setDisplayBuffer(std::unique_ptr<Coord
 
     {
         Locker layerLocker { m_layer->lock() };
-        m_layer->setContentsBuffer(WTFMove(buffer), CoordinatedPlatformLayer::RequireComposition::No);
+        m_layer->setContentsBuffer(WTFMove(buffer), std::nullopt, CoordinatedPlatformLayer::RequireComposition::No);
     }
     m_layer->requestComposition();
 }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerAsyncContentsDisplayDelegateCoordinated.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerAsyncContentsDisplayDelegateCoordinated.h
@@ -46,7 +46,7 @@ private:
     explicit GraphicsLayerAsyncContentsDisplayDelegateCoordinated(GraphicsLayer&);
 
     void setDisplayBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&&) override { RELEASE_ASSERT_NOT_REACHED(); }
-    bool display(CoordinatedPlatformLayer&) override { RELEASE_ASSERT_NOT_REACHED(); }
+    bool display(CoordinatedPlatformLayer&, std::optional<Damage>&&) override { RELEASE_ASSERT_NOT_REACHED(); }
 
     bool tryCopyToLayer(ImageBuffer&, bool opaque) override;
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerContentsDisplayDelegateCoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerContentsDisplayDelegateCoordinated.cpp
@@ -41,12 +41,12 @@ void GraphicsLayerContentsDisplayDelegateCoordinated::setDisplayBuffer(std::uniq
     m_displayBuffer = WTFMove(displayBuffer);
 }
 
-bool GraphicsLayerContentsDisplayDelegateCoordinated::display(CoordinatedPlatformLayer& layer)
+bool GraphicsLayerContentsDisplayDelegateCoordinated::display(CoordinatedPlatformLayer& layer, std::optional<Damage>&& dirtyRegion)
 {
     if (!m_displayBuffer)
         return false;
 
-    layer.setContentsBuffer(WTFMove(m_displayBuffer));
+    layer.setContentsBuffer(WTFMove(m_displayBuffer), WTFMove(dirtyRegion));
     return true;
 }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerContentsDisplayDelegateCoordinated.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerContentsDisplayDelegateCoordinated.h
@@ -40,7 +40,7 @@ public:
 
 private:
     void setDisplayBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&&) final;
-    bool display(CoordinatedPlatformLayer&) final;
+    bool display(CoordinatedPlatformLayer&, std::optional<Damage>&&) final;
 
 protected:
     GraphicsLayerContentsDisplayDelegateCoordinated();

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
@@ -78,6 +78,7 @@ private:
     void setContentsTilePhase(const FloatSize&) override;
     void setContentsClippingRect(const FloatRoundedRect&) override;
     void setContentsNeedsDisplay() override;
+    void setContentsNeedsDisplayInRect(const FloatRect&) override;
     void setContentsToPlatformLayer(PlatformLayer*, ContentsLayerPurpose) override;
     void setContentsDisplayDelegate(RefPtr<GraphicsLayerContentsDisplayDelegate>&&, ContentsLayerPurpose) override;
     RefPtr<GraphicsLayerAsyncContentsDisplayDelegate> createAsyncContentsDisplayDelegate(GraphicsLayerAsyncContentsDisplayDelegate*) override;
@@ -199,6 +200,7 @@ private:
     bool m_hasDescendantsWithRunningTransformAnimations { false };
     FloatSize m_pixelAlignmentOffset;
     std::optional<Damage> m_dirtyRegion;
+    std::optional<Damage> m_contentsDirtyRegion;
     FloatRect m_visibleRect;
     struct {
         GraphicsLayerTransform current;

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -168,12 +168,12 @@ void RenderBoxModelObject::setSelectionState(HighlightState state)
         containingBlock->setSelectionState(state);
 }
 
-void RenderBoxModelObject::contentChanged(ContentChangeType changeType)
+void RenderBoxModelObject::contentChanged(ContentChangeType changeType, const std::optional<FloatRect>& dirtyRect)
 {
     if (!hasLayer())
         return;
 
-    layer()->contentChanged(changeType);
+    layer()->contentChanged(changeType, dirtyRect);
 }
 
 bool RenderBoxModelObject::hasAcceleratedCompositing() const

--- a/Source/WebCore/rendering/RenderBoxModelObject.h
+++ b/Source/WebCore/rendering/RenderBoxModelObject.h
@@ -199,7 +199,7 @@ public:
 
     bool canHaveBoxInfoInFragment() const { return !isFloating() && !isBlockLevelReplacedOrAtomicInline() && !isInline() && !isRenderTableCell() && isRenderBlock() && !isRenderSVGBlock(); }
 
-    void contentChanged(ContentChangeType);
+    void contentChanged(ContentChangeType, const std::optional<FloatRect>& = std::nullopt);
     bool hasAcceleratedCompositing() const;
 
     RenderBoxModelObject* continuation() const;

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1012,7 +1012,7 @@ RenderLayerCompositor& RenderLayer::compositor() const
     return renderer().view().compositor();
 }
 
-void RenderLayer::contentChanged(ContentChangeType changeType)
+void RenderLayer::contentChanged(ContentChangeType changeType, const std::optional<FloatRect>& dirtyRect)
 {
     if (changeType == ContentChangeType::Canvas || changeType == ContentChangeType::Video || changeType == ContentChangeType::FullScreen || changeType == ContentChangeType::Model || changeType == ContentChangeType::HDRImage) {
         setNeedsPostLayoutCompositingUpdate();
@@ -1020,7 +1020,7 @@ void RenderLayer::contentChanged(ContentChangeType changeType)
     }
 
     if (auto* backing = this->backing())
-        backing->contentChanged(changeType);
+        backing->contentChanged(changeType, dirtyRect);
 }
 
 bool RenderLayer::canRender3DTransforms() const

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -520,7 +520,8 @@ public:
 
     // Notification from the renderer that its content changed (e.g. current frame of image changed).
     // Allows updates of layer content without repainting.
-    void contentChanged(ContentChangeType);
+    // Also, allows specifying the changed rectangle to limit the painting when patform supports it.
+    void contentChanged(ContentChangeType, const std::optional<FloatRect>& = std::nullopt);
 
     bool canRender3DTransforms() const;
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3441,7 +3441,7 @@ bool RenderLayerBacking::rendererHasHDRContent() const
 }
 #endif
 
-void RenderLayerBacking::contentChanged(ContentChangeType changeType)
+void RenderLayerBacking::contentChanged(ContentChangeType changeType, const std::optional<FloatRect>& dirtyRect)
 {
     PaintedContentsInfo contentsInfo(*this);
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
@@ -3482,9 +3482,14 @@ void RenderLayerBacking::contentChanged(ContentChangeType changeType)
         if (changeType == ContentChangeType::Canvas)
             compositor().scheduleCompositingLayerUpdate();
 
-        m_graphicsLayer->setContentsNeedsDisplay();
+        if (dirtyRect)
+            m_graphicsLayer->setContentsNeedsDisplayInRect(*dirtyRect);
+        else
+            m_graphicsLayer->setContentsNeedsDisplay();
         return;
     }
+#else
+    UNUSED_PARAM(dirtyRect);
 #endif
 }
 

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -174,7 +174,7 @@ public:
     void setContentsNeedDisplayInRect(const LayoutRect&, GraphicsLayer::ShouldClipToLayer = GraphicsLayer::ClipToLayer);
 
     // Notification from the renderer that its content changed.
-    void contentChanged(ContentChangeType);
+    void contentChanged(ContentChangeType, const std::optional<FloatRect>&);
 
     // Interface to start, finish, suspend and resume animations
     bool startAnimation(double timeOffset, const Animation&, const BlendingKeyframes&);


### PR DESCRIPTION
#### fdfdd4c0e355483c04b7c4e3b4ccae00c23bfcf7
<pre>
[GTK][WPE] Propagate the damage from accelerated 2D canvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=291678">https://bugs.webkit.org/show_bug.cgi?id=291678</a>

Reviewed by Nikolas Zimmermann.

This change enables propagating damage from accelerated 2D canvas up
to the platform and to the WPE/GTK WebKit&apos;s compositor so that it can
optimize some of its drawing operations.

Co-authored-by: Carlos Garcia Campos &lt;cgarcia@igalia.com&gt;
Canonical link: <a href="https://commits.webkit.org/298552@main">https://commits.webkit.org/298552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/955baa95ba394762625a26bd77df3de151cdf315

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121785 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66270 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117626 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43983 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87917 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118685 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103858 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68318 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27924 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21973 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65456 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98171 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22094 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124935 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42632 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31969 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96674 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42999 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100047 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96460 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24563 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41720 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19578 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38557 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42523 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48095 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41996 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45327 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43704 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->