### PR TITLE
AX: Remove output of default-value and irrelevant fields in AXTextMarker::debugDescription to make the result less noisy

### DIFF
--- a/LayoutTests/accessibility/text-marker/text-marker-debug-description-expected.txt
+++ b/LayoutTests/accessibility/text-marker/text-marker-debug-description-expected.txt
@@ -1,19 +1,13 @@
 This tests the AXTextMarker and AXTextMarkerRange DebugDescription APIs.
 
 text:
-text: 'some text', start: {role StaticText, anchor 0, affinity 1, offset 0, charStart 0, charOffset 0, origin Unknown}, end: {role StaticText, anchor 0, affinity 1, offset 9, charStart 0, charOffset 9, origin Unknown}
-
-role StaticText, anchor 0, affinity 1, offset 0, charStart 0, charOffset 0, origin Unknown
-
-role StaticText, anchor 0, affinity 1, offset 9, charStart 0, charOffset 9, origin Unknown
-
+PASS: containsExpectedFields(axElement.textMarkerRangeDebugDescription(range)) === true
+PASS: containsExpectedFields(axElement.textMarkerDebugDescription(start)) === true
+PASS: containsExpectedFields(axElement.textMarkerDebugDescription(end)) === true
 link:
-text: 'Click on the hypertext.', start: {role StaticText, anchor 0, affinity 1, offset 0, charStart 0, charOffset 0, origin Unknown}, end: {role StaticText, anchor 0, affinity 1, offset 23, charStart 0, charOffset 23, origin Unknown}
-
-role StaticText, anchor 0, affinity 1, offset 0, charStart 0, charOffset 0, origin Unknown
-
-role StaticText, anchor 0, affinity 1, offset 23, charStart 0, charOffset 23, origin Unknown
-
+PASS: containsExpectedFields(axElement.textMarkerRangeDebugDescription(range)) === true
+PASS: containsExpectedFields(axElement.textMarkerDebugDescription(start)) === true
+PASS: containsExpectedFields(axElement.textMarkerDebugDescription(end)) === true
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/text-marker/text-marker-debug-description.html
+++ b/LayoutTests/accessibility/text-marker/text-marker-debug-description.html
@@ -12,22 +12,40 @@
 </div>
 
 <script>
+function containsExpectedFields(string) {
+    // Match key-value pairs using regex.
+    const fieldPattern = /(\w+)\s+([^,}]+)/g;
+    let match;
+    const fields = {};
+
+    // Parse all key-value pairs into an object.
+    while ((match = fieldPattern.exec(string)) !== null) {
+        const key = match[1];
+        const value = match[2].trim();
+        fields[key] = value;
+    }
+
+    const hasValidID = fields.hasOwnProperty("ID") && !isNaN(fields.ID) && Number(fields.ID) !== 0;
+    const hasValidOffset = fields.hasOwnProperty("offset") && !isNaN(fields.offset);
+    return hasValidID && hasValidOffset && fields.role == "StaticText";
+}
+
 if (window.accessibilityController) {
     let output = "This tests the AXTextMarker and AXTextMarkerRange DebugDescription APIs.\n\n";
 
+    var axElement, range, start, end;
     let ids = ["text", "link"];
     ids.forEach((id) => {
         output += `${id}:\n`;
-        let axElement = accessibilityController.accessibleElementById(id);
-        let range = axElement.textMarkerRangeForElement(axElement);
-        output += `${axElement.textMarkerRangeDebugDescription(range)}\n\n`;
+        axElement = accessibilityController.accessibleElementById(id);
+        range = axElement.textMarkerRangeForElement(axElement);
+        output += expect("containsExpectedFields(axElement.textMarkerRangeDebugDescription(range))", "true");
 
-        let start = axElement.startTextMarkerForTextMarkerRange(range);
-        let end = axElement.endTextMarkerForTextMarkerRange(range);
-        output += `${axElement.textMarkerDebugDescription(start)}\n\n`;
-        output += `${axElement.textMarkerDebugDescription(end)}\n\n`;
+        start = axElement.startTextMarkerForTextMarkerRange(range);
+        end = axElement.endTextMarkerForTextMarkerRange(range);
+        output += expect("containsExpectedFields(axElement.textMarkerDebugDescription(start))", "true");
+        output += expect("containsExpectedFields(axElement.textMarkerDebugDescription(end))", "true");
     });
-
     document.getElementById("content").style.visibility = "hidden";
     debug(output);
 }


### PR DESCRIPTION
#### 30d20c6874b2ca52d3f090e79f3542f504aea981
<pre>
AX: Remove output of default-value and irrelevant fields in AXTextMarker::debugDescription to make the result less noisy
<a href="https://bugs.webkit.org/show_bug.cgi?id=291685">https://bugs.webkit.org/show_bug.cgi?id=291685</a>
<a href="https://rdar.apple.com/149479318">rdar://149479318</a>

Reviewed by Andres Gonzalez.

The output of AXTextMarker::debugDescription is hard to understand because it includes tons of irrelevant information:
  - We log affinity regardless of its value, even though 99% of the time it is downstream. Furthermore, affinity is
    logged as 0 (downstream) or 1 (upstream), which is not helpful. With this commit, affinity is now only printed
    if it is upstream, and the text will be &quot;upstream&quot; rather than 1.

  - We logged the treeID() of the text marker. This has never been useful information for me personally. This commit
    removes it. This allows us to shorten &quot;objectID&quot; to &quot;ID&quot; since the disambiguation of ID type is no longer needed.

  - We always logged the text marker origin, even it it was unknown. If it&apos;s unknown, we should just print nothing.

  - |anchor|, |charStart|, and |charOffset| are completely unused for text markers used off the main-thread. Only
    log them when on the main-thread.

This commit also endcaps the description with curly braces. I&apos;ve found this very helpful, since text markers are often
logged as part of other strings. The curly braces make it clear when this structured information begins and ends, rather
than it being a continuation of the preceeding plain-text.

&quot;start marker was {ID 12, offset 3, ...} and end marker was {ID 12, offset 4, ...}&quot;

vs.

&quot;start marker was ID 12, offset 3, ... and end marker was ID 12, offset 4, ...&quot;

This commit also improves the developer experience when fixing tests. Because object IDs can differ between runs of
layout tests, we avoided including them in the AXTextMarker::debugDescription in test mode. But this information is
useful when fixing layout tests. In this commit, we again unconditionally log object IDs, and change
text-marker-debug-description.html to expect the presence of specific key-values (some object ID, some offset,
and some role) rather than outputting the raw string value.

Example output before this commit (main-thread and non-main-thread):

treeID 1, objectID 68, role StaticText, anchor 0, affinity 1, offset 0, charStart 0, charOffset 0, origin Unknown

After this commit, main-thread:

{ID 68, role StaticText, anchor 0, offset 0, charStart 0, charOffset 0}

After this commit, off-main-thread:

{ID 68, role StaticText, offset 0}

* LayoutTests/accessibility/text-marker/text-marker-debug-description-expected.txt:
* LayoutTests/accessibility/text-marker/text-marker-debug-description.html:
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::debugDescription const):

Canonical link: <a href="https://commits.webkit.org/293813@main">https://commits.webkit.org/293813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e157b839c52b57a2351b6ce232af6e99ad8a3cfd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105105 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50558 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19930 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28061 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76114 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33195 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102984 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15219 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90293 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56473 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15024 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8283 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49927 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84949 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107465 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27090 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19807 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85067 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27453 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86493 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84591 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21491 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29270 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6993 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20925 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27027 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32255 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26838 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30154 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28397 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->