### PR TITLE
[libpas] limit how long the scavenger holds onto commit-locks

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_page_sharing_pool.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_sharing_pool.c
@@ -39,6 +39,11 @@
 #include "pas_scavenger.h"
 #include "pas_utility_heap_config.h"
 
+/* Limit the amount of VA space that is madvised before the scavanger thread gives up the commit locks
+   to give other threads a chance to acquire the locks, while still providing for opportunities to
+   amortize madvise syscalls. */
+static const size_t scavenge_log_bytes_limit = 1024 * 1024ull;
+
 pas_page_sharing_pool pas_physical_page_sharing_pool = {
     .first_delta = PAS_VERSIONED_FIELD_INITIALIZER,
     .delta = PAS_SEGMENTED_VECTOR_INITIALIZER,
@@ -748,6 +753,7 @@ pas_physical_page_sharing_pool_scavenge(uint64_t max_epoch)
     pas_page_sharing_pool_take_result take_result;
     pas_physical_memory_transaction transaction;
     size_t total_bytes;
+    bool try_again;
     
     if (verbose)
         pas_log("Doing scavenge up to %llu\n", (unsigned long long)max_epoch);
@@ -756,6 +762,7 @@ pas_physical_page_sharing_pool_scavenge(uint64_t max_epoch)
     
     pas_physical_memory_transaction_construct(&transaction);
     do {
+        try_again = false;
         pas_deferred_decommit_log decommit_log;
         
         if (verbose)
@@ -774,6 +781,10 @@ pas_physical_page_sharing_pool_scavenge(uint64_t max_epoch)
             if (verbose) {
                 pas_log("Take result = %s\n",
                         pas_page_sharing_pool_take_result_get_string(take_result));
+            }
+            if (take_result == pas_page_sharing_pool_take_success && decommit_log.total >= scavenge_log_bytes_limit) {
+                try_again = true;
+                break;
             }
         } while (take_result == pas_page_sharing_pool_take_success);
 
@@ -803,7 +814,7 @@ pas_physical_page_sharing_pool_scavenge(uint64_t max_epoch)
         
         pas_deferred_decommit_log_decommit_all(&decommit_log);
         pas_deferred_decommit_log_destruct(&decommit_log, pas_lock_is_not_held);
-    } while (!pas_physical_memory_transaction_end(&transaction));
+    } while (!pas_physical_memory_transaction_end(&transaction) || try_again);
 
     PAS_ASSERT(take_result != pas_page_sharing_pool_take_locks_unavailable);
     PAS_ASSERT(take_result != pas_page_sharing_pool_take_success);


### PR DESCRIPTION
#### 6988dffd045c3dae50b91cd72f39251c7a6d5e42
<pre>
[libpas] limit how long the scavenger holds onto commit-locks
<a href="https://bugs.webkit.org/show_bug.cgi?id=291689">https://bugs.webkit.org/show_bug.cgi?id=291689</a>
<a href="https://rdar.apple.com/149488668">rdar://149488668</a>

Reviewed by Keith Miller and Yusuke Suzuki.

Both Jetstream2 and Speedometer3 traces show that the scavenger thread
sometimes holds commit locks for multiple milliseconds at a time
and that the main thread and compiler threads sometimes get blocked
for good chunks of that time.

To avoid the scavenger blocking the other threads for too long,
limit the size of the VA range that the scavanger will madvise while
holding commit locks. The limit is chosen such that there are still
opportunities to amortize madvise syscalls while the lock won&apos;t
be held while madvising excessively long regions (which often occurs
as multiple madvise calls anyway).

Verified in traces that this eliminates the ~1 of milliseconds blocking
times due to the scavanger in these workloads.

* Source/bmalloc/libpas/src/libpas/pas_page_sharing_pool.c:
(pas_physical_page_sharing_pool_scavenge):

Canonical link: <a href="https://commits.webkit.org/293855@main">https://commits.webkit.org/293855@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78684652d5dbb67313c3313805e0e10069515428

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99992 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19640 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105120 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50573 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28131 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76124 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33207 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102999 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15237 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90310 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56483 "Found 2 new API test failures: /TestWebKit:WebKit.UserMediaBasic, /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15042 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8300 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49942 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92650 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84968 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8385 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107480 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98599 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27105 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19863 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85078 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27468 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86510 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84602 "Found 6 new API test failures: /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, /TestWebKit:WebKit.OnDeviceChangeCrash, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mouse-target, /TestWebKit:WebKit.UserMediaBasic, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/custom-container-destroyed, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/default (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29282 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7010 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20941 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16291 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27042 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122225 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26853 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34123 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30169 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28412 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->