### PR TITLE
SVGTextMetrics: Remove remained Font dead code

### DIFF
--- a/Source/WebCore/rendering/svg/SVGTextMetrics.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextMetrics.cpp
@@ -34,11 +34,7 @@ SVGTextMetrics::SVGTextMetrics(const RenderSVGInlineText& textRenderer, const Te
 
     // Calculate width/height using the scaled font, divide this result by the scalingFactor afterwards.
     m_width = scaledFont.width(run) / scalingFactor;
-    m_glyph.name = emptyString();
     m_height = scaledFont.metricsOfPrimaryFont().height() / scalingFactor;
-
-    m_glyph.unicodeString = run.text().toString();
-    m_glyph.isValid = true;
 
     m_length = static_cast<unsigned>(run.length());
 }

--- a/Source/WebCore/rendering/svg/SVGTextMetrics.h
+++ b/Source/WebCore/rendering/svg/SVGTextMetrics.h
@@ -45,7 +45,7 @@ public:
     static SVGTextMetrics measureCharacterRange(const RenderSVGInlineText&, unsigned position, unsigned length);
     static TextRun constructTextRun(const RenderSVGInlineText&, unsigned position = 0, unsigned length = std::numeric_limits<unsigned>::max());
 
-    bool isEmpty() const { return !m_width && !m_height && !m_glyph.isValid && m_length == 1; }
+    bool isEmpty() const { return !m_width && !m_height && m_length == 1; }
 
     float width() const { return m_width; }
     void setWidth(float width) { m_width = width; }
@@ -53,27 +53,12 @@ public:
     float height() const { return m_height; }
     unsigned length() const { return m_length; }
 
-    struct Glyph {
-        Glyph()
-            : isValid(false)
-        {
-        }
-
-        bool isValid;
-        String name;
-        String unicodeString;
-    };
-
-    // Only useful when measuring individual characters, to lookup ligatures.
-    const Glyph& glyph() const { return m_glyph; }
-
 private:
     SVGTextMetrics(const RenderSVGInlineText&, const TextRun&);
 
     float m_width { 0 };
     float m_height { 0 };
     unsigned m_length { 0 };
-    Glyph m_glyph;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 4ae27215b1ca684339ae2a8c636bf2ba557c9941
<pre>
SVGTextMetrics: Remove remained Font dead code
<a href="https://bugs.webkit.org/show_bug.cgi?id=291693">https://bugs.webkit.org/show_bug.cgi?id=291693</a>
<a href="https://rdar.apple.com/149490330">rdar://149490330</a>

Reviewed by Said Abou-Hallawa.

We no longer handle individual m_glyph data here.
This is no longer needed since <a href="https://commits.webkit.org/173514@main">https://commits.webkit.org/173514@main</a>

We are removing the remaining bits of it here.

* Source/WebCore/rendering/svg/SVGTextMetrics.cpp:
(WebCore::SVGTextMetrics::SVGTextMetrics):
* Source/WebCore/rendering/svg/SVGTextMetrics.h:
(WebCore::SVGTextMetrics::isEmpty const):
(WebCore::SVGTextMetrics::Glyph::Glyph): Deleted.
(WebCore::SVGTextMetrics::glyph const): Deleted.

Canonical link: <a href="https://commits.webkit.org/293820@main">https://commits.webkit.org/293820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79e6eecf85e95e853bb965d273811958c911a532

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105125 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50578 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102038 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28133 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76129 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33212 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103004 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15231 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56488 "Found 2 new API test failures: /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /TestWebKit:WebKit.OnDeviceChangeCrash (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15036 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8303 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49947 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84962 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107485 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27110 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19867 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85083 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27473 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86513 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84608 "Found 5 new API test failures: /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies, /TestWebKit:WebKit.OnDeviceChangeCrash, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mouse-target, /TestWebKit:WebKit.UserMediaBasic, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/default (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21495 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29283 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20946 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27047 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32275 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26858 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30174 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28417 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->