### PR TITLE
Use WTF aliases for std::variant auxiliaries

### DIFF
--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -4509,9 +4509,9 @@ static Vector<WatchpointSet*, 3> collectAdditionalWatchpoints(VM& vm, AccessCase
 static Variant<StructureTransitionStructureStubClearingWatchpoint, AdaptiveValueStructureStubClearingWatchpoint>& addWatchpoint(PolymorphicAccessJITStubRoutine::Watchpoints& watchpoints, const ObjectPropertyCondition& key, WatchpointSet& watchpointSet)
 {
     if (!key || key.condition().kind() != PropertyCondition::Equivalence)
-        return *watchpoints.add(std::in_place_type<StructureTransitionStructureStubClearingWatchpoint>, key, watchpointSet);
+        return *watchpoints.add(WTF::InPlaceType<StructureTransitionStructureStubClearingWatchpoint>, key, watchpointSet);
     ASSERT(key.condition().kind() == PropertyCondition::Equivalence);
-    return *watchpoints.add(std::in_place_type<AdaptiveValueStructureStubClearingWatchpoint>, key, watchpointSet);
+    return *watchpoints.add(WTF::InPlaceType<AdaptiveValueStructureStubClearingWatchpoint>, key, watchpointSet);
 }
 
 static void ensureReferenceAndInstallWatchpoint(VM& vm, PolymorphicAccessJITStubRoutine::Watchpoints& watchpoints, WatchpointSet& watchpointSet, const ObjectPropertyCondition& key)

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -10579,7 +10579,7 @@ void SpeculativeJIT::compileCallDOM(Node* node)
     auto appendCell = [&](Edge& edge) {
         SpeculateCellOperand operand(this, edge);
         regs.append(operand.gpr());
-        operands.append(OperandVariant(std::in_place_type<SpeculateCellOperand>, WTFMove(operand)));
+        operands.append(OperandVariant(WTF::InPlaceType<SpeculateCellOperand>, WTFMove(operand)));
     };
 
     auto appendString = [&](Edge& edge) {
@@ -10587,19 +10587,19 @@ void SpeculativeJIT::compileCallDOM(Node* node)
         GPRReg gpr = operand.gpr();
         regs.append(gpr);
         speculateString(edge, gpr);
-        operands.append(OperandVariant(std::in_place_type<SpeculateCellOperand>, WTFMove(operand)));
+        operands.append(OperandVariant(WTF::InPlaceType<SpeculateCellOperand>, WTFMove(operand)));
     };
 
     auto appendInt32 = [&](Edge& edge) {
         SpeculateInt32Operand operand(this, edge);
         regs.append(operand.gpr());
-        operands.append(OperandVariant(std::in_place_type<SpeculateInt32Operand>, WTFMove(operand)));
+        operands.append(OperandVariant(WTF::InPlaceType<SpeculateInt32Operand>, WTFMove(operand)));
     };
 
     auto appendBoolean = [&](Edge& edge) {
         SpeculateBooleanOperand operand(this, edge);
         regs.append(operand.gpr());
-        operands.append(OperandVariant(std::in_place_type<SpeculateBooleanOperand>, WTFMove(operand)));
+        operands.append(OperandVariant(WTF::InPlaceType<SpeculateBooleanOperand>, WTFMove(operand)));
     };
 
     unsigned index = 0;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -852,7 +852,7 @@ void SpeculativeJIT::emitCall(Node* node)
     LinkableConstant callLinkInfoConstant;
     if (!isDirect) {
         std::tie(callLinkInfo, callLinkInfoConstant) = addCallLinkInfo(m_currentNode->origin.semantic);
-        std::visit([&](auto* callLinkInfo) {
+        WTF::visit([&](auto* callLinkInfo) {
             callLinkInfo->setUpCall(callType);
         }, callLinkInfo);
     }
@@ -4811,7 +4811,7 @@ void SpeculativeJIT::compileHasPrivate(Node* node, AccessType type)
         codeBlock(), stubInfo, JITType::DFGJIT, codeOrigin, callSite, type, usedRegisters,
         JSValueRegs::payloadOnly(baseGPR), JSValueRegs::payloadOnly(propertyOrBrandGPR), resultRegs, InvalidGPRReg, InvalidGPRReg);
 
-    std::visit([&](auto* stubInfo) {
+    WTF::visit([&](auto* stubInfo) {
         stubInfo->propertyIsSymbol = true;
     }, stubInfo);
 
@@ -4914,7 +4914,7 @@ void SpeculativeJIT::compilePutByVal(Node* node)
             codeBlock(), stubInfo, JITType::DFGJIT, codeOrigin, callSite, isDirect ? (ecmaMode.isStrict() ? AccessType::PutByValDirectStrict : AccessType::PutByValDirectSloppy) : (ecmaMode.isStrict() ? AccessType::PutByValStrict : AccessType::PutByValSloppy), usedRegisters,
             baseRegs, propertyRegs, valueRegs, InvalidGPRReg, InvalidGPRReg);
 
-        std::visit([&](auto* stubInfo) {
+        WTF::visit([&](auto* stubInfo) {
             if (m_state.forNode(child2).isType(SpecString))
                 stubInfo->propertyIsString = true;
             else if (m_state.forNode(child2).isType(SpecInt32Only))
@@ -5069,7 +5069,7 @@ void SpeculativeJIT::compileGetPrivateNameByVal(Node* node, JSValueRegs baseRegs
         codeBlock(), stubInfo, JITType::DFGJIT, codeOrigin, callSite, AccessType::GetPrivateName, usedRegisters,
         baseRegs, propertyRegs, resultRegs, InvalidGPRReg, InvalidGPRReg);
 
-    std::visit([&](auto* stubInfo) {
+    WTF::visit([&](auto* stubInfo) {
         stubInfo->propertyIsSymbol = true;
     }, stubInfo);
 
@@ -5173,7 +5173,7 @@ void SpeculativeJIT::compilePutPrivateName(Node* node)
         codeBlock(), stubInfo, JITType::DFGJIT, codeOrigin, callSite, node->privateFieldPutKind().isDefine() ? AccessType::DefinePrivateNameByVal : AccessType::SetPrivateNameByVal, usedRegisters,
         JSValueRegs::payloadOnly(baseGPR), JSValueRegs::payloadOnly(propertyGPR), valueRegs, InvalidGPRReg, InvalidGPRReg);
 
-    std::visit([&](auto* stubInfo) {
+    WTF::visit([&](auto* stubInfo) {
         stubInfo->propertyIsSymbol = true;
     }, stubInfo);
 
@@ -5232,7 +5232,7 @@ void SpeculativeJIT::compileCheckPrivateBrand(Node* node)
         codeBlock(), stubInfo, JITType::DFGJIT, codeOrigin, callSite, AccessType::CheckPrivateBrand, usedRegisters,
         baseRegs, JSValueRegs::payloadOnly(brandGPR), InvalidGPRReg);
 
-    std::visit([&](auto* stubInfo) {
+    WTF::visit([&](auto* stubInfo) {
         stubInfo->propertyIsSymbol = true;
     }, stubInfo);
 
@@ -5269,7 +5269,7 @@ void SpeculativeJIT::compileSetPrivateBrand(Node* node)
         codeBlock(), stubInfo, JITType::DFGJIT, codeOrigin, callSite, AccessType::SetPrivateBrand, usedRegisters,
         JSValueRegs::payloadOnly(baseGPR), JSValueRegs::payloadOnly(brandGPR), InvalidGPRReg);
 
-    std::visit([&](auto* stubInfo) {
+    WTF::visit([&](auto* stubInfo) {
         stubInfo->propertyIsSymbol = true;
     }, stubInfo);
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -952,7 +952,7 @@ void SpeculativeJIT::emitCall(Node* node)
     };
     
     if (!isDirect) {
-        std::visit([&](auto* callLinkInfo) {
+        WTF::visit([&](auto* callLinkInfo) {
             callLinkInfo->setUpCall(callType);
         }, callLinkInfo);
     }
@@ -2713,7 +2713,7 @@ void SpeculativeJIT::compileGetByVal(Node* node, const ScopedLambda<std::tuple<J
         if (!m_state.forNode(m_graph.varArgChild(node, 0)).isType(SpecCell))
             slowCases.append(branchIfNotCell(BaselineJITRegisters::GetByVal::baseJSR));
 
-        std::visit([&](auto* stubInfo) {
+        WTF::visit([&](auto* stubInfo) {
             if (m_state.forNode(m_graph.varArgChild(node, 1)).isType(SpecString))
                 stubInfo->propertyIsString = true;
             else if (m_state.forNode(m_graph.varArgChild(node, 1)).isType(SpecInt32Only))
@@ -5873,7 +5873,7 @@ void SpeculativeJIT::compile(Node* node)
                 BaselineJITRegisters::InByVal::baseJSR, BaselineJITRegisters::InByVal::propertyJSR, resultRegs, BaselineJITRegisters::InByVal::profileGPR, BaselineJITRegisters::InByVal::stubInfoGPR);
             JumpList slowCases;
 
-            std::visit([&](auto* stubInfo) {
+            WTF::visit([&](auto* stubInfo) {
                 stubInfo->propertyIsInt32 = true;
             }, stubInfo);
 
@@ -6934,7 +6934,7 @@ void SpeculativeJIT::compileGetByValWithThis(Node* node)
     if (!m_state.forNode(node->child1()).isType(SpecCell))
         slowCases.append(branchIfNotCell(BaselineJITRegisters::GetByValWithThis::baseJSR));
 
-    std::visit([&](auto* stubInfo) {
+    WTF::visit([&](auto* stubInfo) {
         if (m_state.forNode(node->child3()).isType(SpecString))
             stubInfo->propertyIsString = true;
         else if (m_state.forNode(node->child3()).isType(SpecInt32Only))
@@ -7253,7 +7253,7 @@ void SpeculativeJIT::compileHasPrivate(Node* node, AccessType type)
         BaselineJITRegisters::InByVal::baseJSR, BaselineJITRegisters::InByVal::propertyJSR, resultRegs, BaselineJITRegisters::InByVal::profileGPR, BaselineJITRegisters::InByVal::stubInfoGPR);
     JumpList slowCases;
 
-    std::visit([&](auto* stubInfo) {
+    WTF::visit([&](auto* stubInfo) {
         stubInfo->propertyIsSymbol = true;
     }, stubInfo);
 
@@ -7372,7 +7372,7 @@ void SpeculativeJIT::compilePutByVal(Node* node)
             BaselineJITRegisters::PutByVal::baseJSR, BaselineJITRegisters::PutByVal::propertyJSR, BaselineJITRegisters::PutByVal::valueJSR, BaselineJITRegisters::PutByVal::profileGPR, BaselineJITRegisters::PutByVal::stubInfoGPR);
         JumpList slowCases;
 
-        std::visit([&](auto* stubInfo) {
+        WTF::visit([&](auto* stubInfo) {
             if (m_state.forNode(child2).isType(SpecString))
                 stubInfo->propertyIsString = true;
             else if (m_state.forNode(child2).isType(SpecInt32Only))
@@ -7533,7 +7533,7 @@ void SpeculativeJIT::compileGetPrivateNameByVal(Node* node, JSValueRegs baseRegs
     if (!m_state.forNode(m_graph.child(node, 0)).isType(SpecCell))
         slowCases.append(branchIfNotCell(BaselineJITRegisters::GetByVal::baseJSR));
 
-    std::visit([&](auto* stubInfo) {
+    WTF::visit([&](auto* stubInfo) {
         stubInfo->propertyIsSymbol = true;
     }, stubInfo);
 
@@ -7648,7 +7648,7 @@ void SpeculativeJIT::compilePutPrivateName(Node* node)
         BaselineJITRegisters::PutByVal::baseJSR, BaselineJITRegisters::PutByVal::propertyJSR, BaselineJITRegisters::PutByVal::valueJSR, BaselineJITRegisters::PutByVal::profileGPR, BaselineJITRegisters::PutByVal::stubInfoGPR);
     JumpList slowCases;
 
-    std::visit([&](auto* stubInfo) {
+    WTF::visit([&](auto* stubInfo) {
         stubInfo->propertyIsSymbol = true;
     }, stubInfo);
 
@@ -7698,7 +7698,7 @@ void SpeculativeJIT::compileCheckPrivateBrand(Node* node)
     if (needsTypeCheck(node->child1(), SpecCell))
         slowCases.append(branchIfNotCell(BaselineJITRegisters::PrivateBrand::baseJSR));
 
-    std::visit([&](auto* stubInfo) {
+    WTF::visit([&](auto* stubInfo) {
         stubInfo->propertyIsSymbol = true;
     }, stubInfo);
 
@@ -7746,7 +7746,7 @@ void SpeculativeJIT::compileSetPrivateBrand(Node* node)
         BaselineJITRegisters::PrivateBrand::baseJSR, BaselineJITRegisters::PrivateBrand::propertyJSR, BaselineJITRegisters::PrivateBrand::stubInfoGPR);
     JumpList slowCases;
 
-    std::visit([&](auto* stubInfo) {
+    WTF::visit([&](auto* stubInfo) {
         stubInfo->propertyIsSymbol = true;
     }, stubInfo);
 
@@ -8261,7 +8261,7 @@ void SpeculativeJIT::compileEnumeratorPutByVal(Node* node)
                 BaselineJITRegisters::PutByVal::baseJSR, BaselineJITRegisters::PutByVal::propertyJSR, BaselineJITRegisters::PutByVal::valueJSR, BaselineJITRegisters::PutByVal::profileGPR, BaselineJITRegisters::PutByVal::stubInfoGPR);
             JumpList slowCases;
 
-            std::visit([&](auto* stubInfo) {
+            WTF::visit([&](auto* stubInfo) {
                 if (m_state.forNode(m_graph.varArgChild(node, 1)).isType(SpecString))
                     stubInfo->propertyIsString = true;
                 else if (m_state.forNode(m_graph.varArgChild(node, 1)).isType(SpecInt32Only))

--- a/Source/JavaScriptCore/jit/JITInlineCacheGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITInlineCacheGenerator.cpp
@@ -43,7 +43,7 @@ namespace JSC {
 JITInlineCacheGenerator::JITInlineCacheGenerator(CodeBlock*, CompileTimeStructureStubInfo stubInfo, JITType, CodeOrigin, AccessType accessType)
     : m_accessType(accessType)
 {
-    std::visit(WTF::makeVisitor(
+    WTF::visit(WTF::makeVisitor(
         [&](StructureStubInfo* stubInfo) {
             m_stubInfo = stubInfo;
         },
@@ -120,7 +120,7 @@ JITGetByIdGenerator::JITGetByIdGenerator(
     , m_cacheType(cacheType)
 {
     RELEASE_ASSERT(base.payloadGPR() != value.tagGPR());
-    std::visit([&](auto* stubInfo) {
+    WTF::visit([&](auto* stubInfo) {
         setUpStubInfo(*stubInfo, codeBlock, accessType, cacheType, codeOrigin, callSite, usedRegisters, propertyName, base, value, stubInfoGPR);
     }, stubInfo);
 }
@@ -201,7 +201,7 @@ JITGetByIdWithThisGenerator::JITGetByIdWithThisGenerator(
     : JITByIdGenerator(codeBlock, stubInfo, jitType, codeOrigin, AccessType::GetByIdWithThis, base, value)
 {
     RELEASE_ASSERT(thisRegs.payloadGPR() != thisRegs.tagGPR());
-    std::visit([&](auto* stubInfo) {
+    WTF::visit([&](auto* stubInfo) {
         setUpStubInfo(*stubInfo, codeBlock, AccessType::GetByIdWithThis, CacheType::GetByIdSelf, codeOrigin, callSite, usedRegisters, propertyName, value, base, thisRegs, stubInfoGPR);
     }, stubInfo);
 }
@@ -233,7 +233,7 @@ JITPutByIdGenerator::JITPutByIdGenerator(
     AccessType accessType)
         : JITByIdGenerator(codeBlock, stubInfo, jitType, codeOrigin, accessType, base, value)
 {
-    std::visit([&](auto* stubInfo) {
+    WTF::visit([&](auto* stubInfo) {
         setUpStubInfo(*stubInfo, codeBlock, accessType, CacheType::PutByIdReplace, codeOrigin, callSite, usedRegisters, propertyName, base, value, stubInfoGPR, scratch);
     }, stubInfo);
 }
@@ -280,7 +280,7 @@ void JITPutByIdGenerator::generateFastPath(CCallHelpers& jit)
 JITDelByValGenerator::JITDelByValGenerator(CodeBlock* codeBlock, CompileTimeStructureStubInfo stubInfo, JITType jitType, CodeOrigin codeOrigin, CallSiteIndex callSiteIndex, AccessType accessType, const RegisterSetBuilder& usedRegisters, JSValueRegs base, JSValueRegs property, JSValueRegs result, GPRReg stubInfoGPR)
     : Base(codeBlock, stubInfo, jitType, codeOrigin, accessType)
 {
-    std::visit([&](auto* stubInfo) {
+    WTF::visit([&](auto* stubInfo) {
         setUpStubInfo(*stubInfo, codeBlock, accessType, CacheType::Unset, codeOrigin, callSiteIndex, usedRegisters, base, property, result, stubInfoGPR);
     }, stubInfo);
 }
@@ -310,7 +310,7 @@ void JITDelByValGenerator::finalize(LinkBuffer& fastPath, LinkBuffer& slowPath)
 JITDelByIdGenerator::JITDelByIdGenerator(CodeBlock* codeBlock, CompileTimeStructureStubInfo stubInfo, JITType jitType, CodeOrigin codeOrigin, CallSiteIndex callSiteIndex, AccessType accessType, const RegisterSetBuilder& usedRegisters, CacheableIdentifier propertyName, JSValueRegs base, JSValueRegs result, GPRReg stubInfoGPR)
     : Base(codeBlock, stubInfo, jitType, codeOrigin, accessType)
 {
-    std::visit([&](auto* stubInfo) {
+    WTF::visit([&](auto* stubInfo) {
         setUpStubInfo(*stubInfo, codeBlock, accessType, CacheType::Unset, codeOrigin, callSiteIndex, usedRegisters, propertyName, base, result, stubInfoGPR);
     }, stubInfo);
 }
@@ -340,7 +340,7 @@ void JITDelByIdGenerator::finalize(LinkBuffer& fastPath, LinkBuffer& slowPath)
 JITInByValGenerator::JITInByValGenerator(CodeBlock* codeBlock, CompileTimeStructureStubInfo stubInfo, JITType jitType, CodeOrigin codeOrigin, CallSiteIndex callSiteIndex, AccessType accessType, const RegisterSetBuilder& usedRegisters, JSValueRegs base, JSValueRegs property, JSValueRegs result, GPRReg arrayProfileGPR, GPRReg stubInfoGPR)
     : Base(codeBlock, stubInfo, jitType, codeOrigin, accessType)
 {
-    std::visit([&](auto* stubInfo) {
+    WTF::visit([&](auto* stubInfo) {
         setUpStubInfo(*stubInfo, codeBlock, accessType, CacheType::Unset, codeOrigin, callSiteIndex, usedRegisters, base, property, result, arrayProfileGPR, stubInfoGPR);
     }, stubInfo);
 }
@@ -375,7 +375,7 @@ JITInByIdGenerator::JITInByIdGenerator(
     : JITByIdGenerator(codeBlock, stubInfo, jitType, codeOrigin, AccessType::InById, base, value)
 {
     RELEASE_ASSERT(base.payloadGPR() != value.tagGPR());
-    std::visit([&](auto* stubInfo) {
+    WTF::visit([&](auto* stubInfo) {
         setUpStubInfo(*stubInfo, codeBlock, AccessType::InById, CacheType::InByIdSelf, codeOrigin, callSite, usedRegisters, propertyName, base, value, stubInfoGPR);
     }, stubInfo);
 }
@@ -422,7 +422,7 @@ JITInstanceOfGenerator::JITInstanceOfGenerator(
     bool prototypeIsKnownObject)
     : JITInlineCacheGenerator(codeBlock, stubInfo, jitType, codeOrigin, AccessType::InstanceOf)
 {
-    std::visit([&](auto* stubInfo) {
+    WTF::visit([&](auto* stubInfo) {
         setUpStubInfo(*stubInfo, codeBlock, AccessType::InstanceOf, CacheType::Unset, codeOrigin, callSiteIndex, usedRegisters, result, value, prototype, stubInfoGPR, prototypeIsKnownObject);
     }, stubInfo);
 }
@@ -454,7 +454,7 @@ JITGetByValGenerator::JITGetByValGenerator(CodeBlock* codeBlock, CompileTimeStru
     , m_base(base)
     , m_result(result)
 {
-    std::visit([&](auto* stubInfo) {
+    WTF::visit([&](auto* stubInfo) {
         setUpStubInfo(*stubInfo, codeBlock, accessType, CacheType::Unset, codeOrigin, callSiteIndex, usedRegisters, base, property, result, arrayProfileGPR, stubInfoGPR);
     }, stubInfo);
 }
@@ -492,7 +492,7 @@ JITGetByValWithThisGenerator::JITGetByValWithThisGenerator(CodeBlock* codeBlock,
     , m_base(base)
     , m_result(result)
 {
-    std::visit([&](auto* stubInfo) {
+    WTF::visit([&](auto* stubInfo) {
         setUpStubInfo(*stubInfo, codeBlock, accessType, CacheType::Unset, codeOrigin, callSiteIndex, usedRegisters, base, property, thisRegs, result, arrayProfileGPR, stubInfoGPR);
     }, stubInfo);
 }
@@ -532,7 +532,7 @@ JITPutByValGenerator::JITPutByValGenerator(CodeBlock* codeBlock, CompileTimeStru
     , m_base(base)
     , m_value(value)
 {
-    std::visit([&](auto* stubInfo) {
+    WTF::visit([&](auto* stubInfo) {
         setUpStubInfo(*stubInfo, codeBlock, accessType, CacheType::Unset, codeOrigin, callSiteIndex, usedRegisters, base, property, value, arrayProfileGPR, stubInfoGPR);
     }, stubInfo);
 }
@@ -563,7 +563,7 @@ JITPrivateBrandAccessGenerator::JITPrivateBrandAccessGenerator(CodeBlock* codeBl
     : Base(codeBlock, stubInfo, jitType, codeOrigin, accessType)
 {
     ASSERT(accessType == AccessType::CheckPrivateBrand || accessType == AccessType::SetPrivateBrand);
-    std::visit([&](auto* stubInfo) {
+    WTF::visit([&](auto* stubInfo) {
         setUpStubInfo(*stubInfo, codeBlock, accessType, CacheType::Unset, codeOrigin, callSiteIndex, usedRegisters, base, brand, stubInfoGPR);
     }, stubInfo);
 }

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -2089,7 +2089,7 @@ JSC_DEFINE_HOST_FUNCTION(functionWriteFile, (JSGlobalObject* globalObject, CallF
     if (!handle)
         return throwVMError(globalObject, scope, "Could not open file."_s);
 
-    auto size = std::visit(WTF::makeVisitor([&](const String& string) {
+    auto size = WTF::visit(WTF::makeVisitor([&](const String& string) {
         CString utf8 = string.utf8();
         return handle.write(byteCast<uint8_t>(utf8.span()));
     }, [&] (const std::span<const uint8_t>& data) {

--- a/Source/JavaScriptCore/runtime/TemporalTimeZone.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalTimeZone.cpp
@@ -35,14 +35,14 @@ const ClassInfo TemporalTimeZone::s_info = { "Object"_s, &Base::s_info, nullptr,
 
 TemporalTimeZone* TemporalTimeZone::createFromID(VM& vm, Structure* structure, TimeZoneID identifier)
 {
-    TemporalTimeZone* format = new (NotNull, allocateCell<TemporalTimeZone>(vm)) TemporalTimeZone(vm, structure, TimeZone { std::in_place_index_t<0>(), identifier });
+    TemporalTimeZone* format = new (NotNull, allocateCell<TemporalTimeZone>(vm)) TemporalTimeZone(vm, structure, TimeZone { WTF::InPlaceIndexT<0>(), identifier });
     format->finishCreation(vm);
     return format;
 }
 
 TemporalTimeZone* TemporalTimeZone::createFromUTCOffset(VM& vm, Structure* structure, int64_t utcOffset)
 {
-    TemporalTimeZone* format = new (NotNull, allocateCell<TemporalTimeZone>(vm)) TemporalTimeZone(vm, structure, TimeZone { std::in_place_index_t<1>(), utcOffset });
+    TemporalTimeZone* format = new (NotNull, allocateCell<TemporalTimeZone>(vm)) TemporalTimeZone(vm, structure, TimeZone { WTF::InPlaceIndexT<1>(), utcOffset });
     format->finishCreation(vm);
     return format;
 }

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -350,7 +350,7 @@ RefPtr<TypeDefinition> TypeDefinition::tryCreateFunctionSignature(FunctionArgCou
     void* memory = nullptr;
     if (!result.getValue(memory))
         return nullptr;
-    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(std::in_place_type<FunctionSignature>, argumentCount, returnCount);
+    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(WTF::InPlaceType<FunctionSignature>, argumentCount, returnCount);
     return adoptRef(signature);
 }
 
@@ -361,7 +361,7 @@ RefPtr<TypeDefinition> TypeDefinition::tryCreateStructType(StructFieldCount fiel
     void* memory = nullptr;
     if (!result.getValue(memory))
         return nullptr;
-    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(std::in_place_type<StructType>, fieldCount, fields);
+    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(WTF::InPlaceType<StructType>, fieldCount, fields);
     return adoptRef(signature);
 }
 
@@ -372,7 +372,7 @@ RefPtr<TypeDefinition> TypeDefinition::tryCreateArrayType()
     void* memory = nullptr;
     if (!result.getValue(memory))
         return nullptr;
-    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(std::in_place_type<ArrayType>);
+    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(WTF::InPlaceType<ArrayType>);
     return adoptRef(signature);
 }
 
@@ -383,7 +383,7 @@ RefPtr<TypeDefinition> TypeDefinition::tryCreateRecursionGroup(RecursionGroupCou
     void* memory = nullptr;
     if (!result.getValue(memory))
         return nullptr;
-    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(std::in_place_type<RecursionGroup>, typeCount);
+    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(WTF::InPlaceType<RecursionGroup>, typeCount);
     return adoptRef(signature);
 }
 
@@ -394,7 +394,7 @@ RefPtr<TypeDefinition> TypeDefinition::tryCreateProjection()
     void* memory = nullptr;
     if (!result.getValue(memory))
         return nullptr;
-    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(std::in_place_type<Projection>);
+    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(WTF::InPlaceType<Projection>);
     return adoptRef(signature);
 }
 
@@ -405,7 +405,7 @@ RefPtr<TypeDefinition> TypeDefinition::tryCreateSubtype(SupertypeCount count, bo
     void* memory = nullptr;
     if (!result.getValue(memory))
         return nullptr;
-    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(std::in_place_type<Subtype>, count, isFinal);
+    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(WTF::InPlaceType<Subtype>, count, isFinal);
     return adoptRef(signature);
 }
 

--- a/Source/WTF/wtf/CompactVariant.h
+++ b/Source/WTF/wtf/CompactVariant.h
@@ -50,16 +50,16 @@ public:
         m_data = Operations::template encode<typename VariantBestMatch<StdVariant, U>::type>(std::forward<U>(value));
     }
 
-    template<typename T, typename... Args> explicit constexpr CompactVariant(std::in_place_type_t<T>, Args&&... args)
+    template<typename T, typename... Args> explicit constexpr CompactVariant(WTF::InPlaceTypeT<T>, Args&&... args)
         requires std::constructible_from<StdVariant, T>
     {
         m_data = Operations::template encodeFromArguments<T>(std::forward<Args>(args)...);
     }
 
-    template<size_t I, typename... Args> explicit constexpr CompactVariant(std::in_place_index_t<I>, Args&&... args)
-        requires std::constructible_from<StdVariant, std::variant_alternative_t<I, StdVariant>>
+    template<size_t I, typename... Args> explicit constexpr CompactVariant(WTF::InPlaceIndexT<I>, Args&&... args)
+        requires std::constructible_from<StdVariant, WTF::VariantAlternativeT<I, StdVariant>>
     {
-        m_data = Operations::template encodeFromArguments<std::variant_alternative_t<I, StdVariant>>(std::forward<Args>(args)...);
+        m_data = Operations::template encodeFromArguments<WTF::VariantAlternativeT<I, StdVariant>>(std::forward<Args>(args)...);
     }
 
     CompactVariant(const CompactVariant& other)
@@ -132,7 +132,7 @@ public:
     template<size_t I, typename... Args> void emplace(Args&&... args)
     {
         Operations::destruct(m_data);
-        m_data = Operations::template encodeFromArguments<std::variant_alternative_t<I, StdVariant>>(std::forward<Args>(args)...);
+        m_data = Operations::template encodeFromArguments<WTF::VariantAlternativeT<I, StdVariant>>(std::forward<Args>(args)...);
     }
 
     constexpr Index index() const
@@ -147,13 +147,13 @@ public:
 
     template<typename T> constexpr bool holdsAlternative() const
     {
-        static_assert(alternativeIndexV<T, StdVariant> <= std::variant_size_v<StdVariant>);
+        static_assert(alternativeIndexV<T, StdVariant> <= WTF::VariantSizeV<StdVariant>);
         return index() == alternativeIndexV<T, StdVariant>;
     }
 
     template<size_t I> constexpr bool holdsAlternative() const
     {
-        static_assert(I <= std::variant_size_v<StdVariant>);
+        static_assert(I <= WTF::VariantSizeV<StdVariant>);
         return index() == I;
     }
 

--- a/Source/WTF/wtf/CrossThreadCopier.h
+++ b/Source/WTF/wtf/CrossThreadCopier.h
@@ -324,13 +324,13 @@ template<typename... Types> struct CrossThreadCopierBase<false, false, Variant<T
     static constexpr bool IsNeeded = (CrossThreadCopier<std::remove_cvref_t<Types>>::IsNeeded || ...);
     static Variant<Types...> copy(const Type& source)
     {
-        return std::visit([] (auto& type) -> Variant<Types...> {
+        return WTF::visit([] (auto& type) -> Variant<Types...> {
             return CrossThreadCopier<std::remove_cvref_t<decltype(type)>>::copy(type);
         }, source);
     }
     static Variant<Types...> copy(Type&& source)
     {
-        return std::visit([] (auto&& type) -> Variant<Types...> {
+        return WTF::visit([] (auto&& type) -> Variant<Types...> {
             return CrossThreadCopier<std::remove_cvref_t<decltype(type)>>::copy(std::forward<decltype(type)>(type));
         }, WTFMove(source));
     }

--- a/Source/WTF/wtf/Expected.h
+++ b/Source/WTF/wtf/Expected.h
@@ -244,10 +244,10 @@ struct base {
     typedef unexpected<E> unexpected_type;
     Variant<value_type, error_type> s;
     constexpr base() { }
-    constexpr base(value_tag_t, const value_type& val) : s(std::in_place_index_t<0>(), val) { }
-    constexpr base(value_tag_t, value_type&& val) : s(std::in_place_index_t<0>(), std::forward<value_type>(val)) { }
-    constexpr base(error_tag_t, const error_type& err) : s(std::in_place_index_t<1>(), err) { }
-    constexpr base(error_tag_t, error_type&& err) : s(std::in_place_index_t<1>(), std::forward<error_type>(err)) { }
+    constexpr base(value_tag_t, const value_type& val) : s(WTF::InPlaceIndexT<0>(), val) { }
+    constexpr base(value_tag_t, value_type&& val) : s(WTF::InPlaceIndexT<0>(), std::forward<value_type>(val)) { }
+    constexpr base(error_tag_t, const error_type& err) : s(WTF::InPlaceIndexT<1>(), err) { }
+    constexpr base(error_tag_t, error_type&& err) : s(WTF::InPlaceIndexT<1>(), std::forward<error_type>(err)) { }
     constexpr base(const base& o)
         : s(o.s) { }
     constexpr base(base&& o)

--- a/Source/WTF/wtf/GenericHashKey.h
+++ b/Source/WTF/wtf/GenericHashKey.h
@@ -40,13 +40,13 @@ class GenericHashKey final {
 
 public:
     constexpr GenericHashKey(Key&& key)
-        : m_value(std::in_place_type_t<Key>(), WTFMove(key))
+        : m_value(InPlaceTypeT<Key>(), WTFMove(key))
     {
     }
 
     template<typename K>
     constexpr GenericHashKey(K&& key)
-        : m_value(std::in_place_type_t<Key>(), std::forward<K>(key))
+        : m_value(InPlaceTypeT<Key>(), std::forward<K>(key))
     {
     }
 

--- a/Source/WTF/wtf/Hasher.h
+++ b/Source/WTF/wtf/Hasher.h
@@ -197,7 +197,7 @@ template<typename T> void add(Hasher& hasher, const std::optional<T>& optional)
 template<typename... Types> void add(Hasher& hasher, const Variant<Types...>& variant)
 {
     add(hasher, variant.index());
-    std::visit([&hasher] (auto& value) {
+    WTF::visit([&hasher] (auto& value) {
         add(hasher, value);
     }, variant);
 }

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -597,13 +597,13 @@ template<typename T> concept HasSwitchOn = requires(T t) {
 #ifdef _LIBCPP_VERSION
 
 // Single-variant switch-based visit function adapted from https://www.reddit.com/r/cpp/comments/kst2pu/comment/giilcxv/.
-// Works around bad code generation for std::visit with one Variant by some standard library / compilers that
+// Works around bad code generation for WTF::visit with one Variant by some standard library / compilers that
 // lead to excessive binary size growth. Currently only needed by libc++. See https://webkit.org/b/279498.
 
 
 template<size_t Minimum = 0, class F, class V> ALWAYS_INLINE decltype(auto) visitOneVariant(NOESCAPE F&& f, V&& v)
 {
-    constexpr auto Maximum = std::variant_size_v<std::remove_cvref_t<V>>;
+    constexpr auto Maximum = VariantSizeV<std::remove_cvref_t<V>>;
 
 #define WTF_INDEX_VISIT_CASE(Min, Max, N) f(std::get<Min + N>(std::forward<V>(v)))
 #define WTF_INDEX_VISIT_NEXT(Min, Max)    visitOneVariant<Min>(std::forward<F>(f), std::forward<V>(v))
@@ -621,9 +621,9 @@ template<class V, class... F> requires (!HasSwitchOn<V>) ALWAYS_INLINE auto swit
 
 #else
 
-template<class V, class... F> requires (!HasSwitchOn<V>) ALWAYS_INLINE auto switchOn(V&& v, F&&... f) -> decltype(std::visit(makeVisitor(std::forward<F>(f)...), asVariant(std::forward<V>(v))))
+template<class V, class... F> requires (!HasSwitchOn<V>) ALWAYS_INLINE auto switchOn(V&& v, F&&... f) -> decltype(WTF::visit(makeVisitor(std::forward<F>(f)...), asVariant(std::forward<V>(v))))
 {
-    return std::visit(makeVisitor(std::forward<F>(f)...), asVariant(std::forward<V>(v)));
+    return WTF::visit(makeVisitor(std::forward<F>(f)...), asVariant(std::forward<V>(v)));
 }
 
 #endif
@@ -781,12 +781,12 @@ template<typename TypeList> using VariantOrSingle = std::conditional_t<
 //   };
 
 template<typename T> struct IsStdInPlaceTypeImpl : std::false_type {};
-template<typename T> struct IsStdInPlaceTypeImpl<std::in_place_type_t<T>> : std::true_type {};
+template<typename T> struct IsStdInPlaceTypeImpl<WTF::InPlaceTypeT<T>> : std::true_type { };
 template<typename T> using IsStdInPlaceType = IsStdInPlaceTypeImpl<std::remove_cvref_t<T>>;
 template<typename T> constexpr bool IsStdInPlaceTypeV = IsStdInPlaceType<T>::value;
 
 template<typename T> struct IsStdInPlaceIndexImpl : std::false_type { };
-template<size_t I>   struct IsStdInPlaceIndexImpl<std::in_place_index_t<I>> : std::true_type { };
+template<size_t I>   struct IsStdInPlaceIndexImpl<WTF::InPlaceIndexT<I>> : std::true_type { };
 template<typename T> using IsStdInPlaceIndex = IsStdInPlaceIndexImpl<std::remove_cvref_t<T>>;
 template<typename T> constexpr bool IsStdInPlaceIndexV = IsStdInPlaceIndex<T>::value;
 

--- a/Source/WTF/wtf/Variant.h
+++ b/Source/WTF/wtf/Variant.h
@@ -25,9 +25,28 @@
 
 #pragma once
 
+#include <utility>
 #include <variant>
 
 namespace WTF {
-template<class... Ts> using Variant = std::variant<Ts...>;
+template<typename... Ts> using Variant = std::variant<Ts...>;
+template<typename T> constexpr std::in_place_type_t<T> InPlaceType { };
+template<typename T> using InPlaceTypeT = std::in_place_type_t<T>;
+template<size_t I> constexpr std::in_place_index_t<I> InPlaceIndex { };
+template<size_t I> using InPlaceIndexT = std::in_place_index_t<I>;
+template <size_t I, class T> struct VariantAlternative;
+template<size_t I, typename... Types> struct VariantAlternative<I, Variant<Types...>> : std::variant_alternative<I, Variant<Types...>> { };
+template<size_t I, typename T> using VariantAlternativeT = typename VariantAlternative<I, T>::type;
+template<typename T> struct VariantSize;
+template<typename... Types> struct VariantSize<Variant<Types...>> : std::integral_constant<std::size_t, sizeof...(Types)> { };
+template<typename T> struct VariantSize<const T> : VariantSize<T> { };
+template<typename T> constexpr size_t VariantSizeV = VariantSize<T>::value;
+
+template<typename Visitor, typename... Variants> constexpr auto visit(Visitor&& v, Variants&&... values)
+    -> decltype(std::visit<Visitor, Variants...>(std::forward<Visitor>(v), std::forward<Variants>(values)...))
+{
+    return std::visit<Visitor, Variants...>(std::forward<Visitor>(v), std::forward<Variants>(values)...);
+}
+
 }
 using WTF::Variant;

--- a/Source/WTF/wtf/VariantExtras.h
+++ b/Source/WTF/wtf/VariantExtras.h
@@ -93,10 +93,10 @@ template<typename Arg, typename... Ts> struct VariantBestMatch<Variant<Ts...>, A
 
 template<typename V, typename F> constexpr decltype(auto) typeForIndex(size_t index, NOESCAPE F&& f)
 {
-    return visitAtIndex<0, std::variant_size_v<std::remove_cvref_t<V>>>(
+    return visitAtIndex<0, VariantSizeV<std::remove_cvref_t<V>>>(
         index,
         [&]<size_t I>() ALWAYS_INLINE_LAMBDA {
-           return f.template operator()<std::variant_alternative_t<I, std::remove_cvref_t<V>>>();
+            return f.template operator()<VariantAlternativeT<I, std::remove_cvref_t<V>>>();
         }
     );
 }

--- a/Source/WTF/wtf/VariantListOperations.h
+++ b/Source/WTF/wtf/VariantListOperations.h
@@ -361,7 +361,7 @@ template<typename V> struct VariantListProxy {
 
     template<size_t I> bool holds_alternative() const
     {
-        static_assert(I <= std::variant_size_v<Variant>);
+        static_assert(I <= VariantSizeV<Variant>);
         return Operations::readIndex(buffer) == I;
     }
 

--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.cpp
@@ -95,7 +95,7 @@ void GPUBuffer::mapAsync(GPUMapModeFlags mode, std::optional<GPUSize64> offset, 
 static auto makeArrayBuffer(Variant<std::span<const uint8_t>, size_t> source, size_t offset, auto& cachedArrayBuffers, auto& device, auto& buffer)
 {
     RefPtr<ArrayBuffer> arrayBuffer;
-    std::visit(WTF::makeVisitor([&](std::span<const uint8_t> source) {
+    WTF::visit(WTF::makeVisitor([&](std::span<const uint8_t> source) {
         arrayBuffer = ArrayBuffer::create(source);
     }, [&](size_t numberOfElements) {
         arrayBuffer = ArrayBuffer::create(numberOfElements, 1);

--- a/Source/WebCore/Modules/identity/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredential.cpp
@@ -74,13 +74,13 @@ static ExceptionOr<DigitalCredentialRequestTypes> jsToCredentialRequest(const Do
         auto result = convertDictionary<MobileDocumentRequest>(*globalObject, request.data.get());
         if (result.hasException(scope))
             return Exception { ExceptionCode::ExistingExceptionError };
-        return DigitalCredentialRequestTypes { std::in_place_type<MobileDocumentRequest>, result.releaseReturnValue() };
+        return DigitalCredentialRequestTypes { WTF::InPlaceType<MobileDocumentRequest>, result.releaseReturnValue() };
     }
     case IdentityCredentialProtocol::Openid4vp: {
         auto result = convertDictionary<OpenID4VPRequest>(*globalObject, request.data.get());
         if (result.hasException(scope))
             return Exception { ExceptionCode::ExistingExceptionError };
-        return DigitalCredentialRequestTypes { std::in_place_type<OpenID4VPRequest>, result.releaseReturnValue() };
+        return DigitalCredentialRequestTypes { WTF::InPlaceType<OpenID4VPRequest>, result.releaseReturnValue() };
     }
     default:
         ASSERT_NOT_REACHED();
@@ -146,7 +146,7 @@ void DigitalCredential::discoverFromExternalSource(const Document& document, Cre
         }
 
         DigitalCredentialRequestTypes credentialVariant = resultOrException.releaseReturnValue();
-        std::visit(
+        WTF::visit(
             [&](auto& credential) { requestData.requests.append(credential); },
             credentialVariant);
     }

--- a/Source/WebCore/Modules/indexeddb/IDBKeyPath.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyPath.cpp
@@ -204,7 +204,7 @@ bool isIDBKeyPathValid(const IDBKeyPath& keyPath)
         }
         return true;
     });
-    return std::visit(visitor, keyPath);
+    return WTF::visit(visitor, keyPath);
 }
 
 #if !LOG_DISABLED
@@ -225,7 +225,7 @@ String loggingString(const IDBKeyPath& path)
         return builder.toString();
     });
 
-    return std::visit(visitor, path);
+    return WTF::visit(visitor, path);
 }
 #endif
 

--- a/Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp
@@ -55,7 +55,7 @@ RefPtr<SharedBuffer> serializeIDBKeyPath(const std::optional<IDBKeyPath>& keyPat
                 encoder.encodeString("string"_s, string);
             });
         });
-        std::visit(visitor, keyPath.value());
+        WTF::visit(visitor, keyPath.value());
     } else
         encoder->encodeEnum("type"_s, KeyPathType::Null);
 

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -176,7 +176,7 @@ String MediaControlsHost::displayNameForTrack(const std::optional<TextOrAudioTra
     if (!page)
         return emptyString();
 
-    return std::visit([page] (auto& track) {
+    return WTF::visit([page] (auto& track) {
         return page->group().ensureCaptionPreferences().displayNameForTrack(track.get());
     }, track.value());
 }

--- a/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.cpp
@@ -37,14 +37,14 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(PaymentMethodChangeEvent);
 PaymentMethodChangeEvent::PaymentMethodChangeEvent(const AtomString& type, Init&& eventInit)
     : PaymentRequestUpdateEvent { EventInterfaceType::PaymentMethodChangeEvent, type, eventInit }
     , m_methodName { WTFMove(eventInit.methodName) }
-    , m_methodDetails { std::in_place_type_t<JSValueInWrappedObject>(), eventInit.methodDetails.get() }
+    , m_methodDetails { WTF::InPlaceTypeT<JSValueInWrappedObject>(), eventInit.methodDetails.get() }
 {
 }
 
 PaymentMethodChangeEvent::PaymentMethodChangeEvent(const AtomString& type, const String& methodName, MethodDetailsFunction&& methodDetailsFunction)
     : PaymentRequestUpdateEvent { EventInterfaceType::PaymentMethodChangeEvent, type }
     , m_methodName { methodName }
-    , m_methodDetails { std::in_place_type_t<MethodDetailsFunction>(), WTFMove(methodDetailsFunction) }
+    , m_methodDetails { WTF::InPlaceTypeT<MethodDetailsFunction>(), WTFMove(methodDetailsFunction) }
 {
 }
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
@@ -67,7 +67,7 @@ static AudioDecoder::Config createAudioDecoderConfig(const WebCodecsAudioDecoder
 {
     Vector<uint8_t> description;
     if (config.description) {
-        auto data = std::visit([](auto& buffer) {
+        auto data = WTF::visit([](auto& buffer) {
             return buffer ? buffer->span() : std::span<const uint8_t> { };
         }, *config.description);
         if (!data.empty())
@@ -89,7 +89,7 @@ static bool isValidDecoderConfig(const WebCodecsAudioDecoderConfig& config)
         return false;
 
     // 2. If description is [detached], return false.
-    if (config.description && std::visit([](auto& view) { return view->isDetached(); }, *config.description))
+    if (config.description && WTF::visit([](auto& view) { return view->isDetached(); }, *config.description))
         return false;
 
     // FIXME: Not yet per spec https://github.com/w3c/webcodecs/issues/878

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -108,7 +108,7 @@ static bool isValidDecoderConfig(const WebCodecsVideoDecoderConfig& config)
         return false;
 
     // 6. If description is [detached], return false.
-    if (config.description && std::visit([](auto& view) { return view->isDetached(); }, *config.description))
+    if (config.description && WTF::visit([](auto& view) { return view->isDetached(); }, *config.description))
         return false;
 
     // 7. Return true.
@@ -119,7 +119,7 @@ static VideoDecoder::Config createVideoDecoderConfig(const WebCodecsVideoDecoder
 {
     Vector<uint8_t> description;
     if (config.description) {
-        auto data = std::visit([](auto& buffer) {
+        auto data = WTF::visit([](auto& buffer) {
             return buffer ? buffer->span() : std::span<const uint8_t> { };
         }, *config.description);
         if (!data.empty())

--- a/Source/WebCore/bindings/js/BufferSource.h
+++ b/Source/WebCore/bindings/js/BufferSource.h
@@ -58,20 +58,20 @@ public:
 
     size_t length() const
     {
-        return std::visit([](auto& buffer) {
+        return WTF::visit([](auto& buffer) {
             return buffer ? buffer->byteLength() : 0;
         }, m_variant);
     }
 
     std::span<const uint8_t> span() const
     {
-        return std::visit([](auto& buffer) {
+        return WTF::visit([](auto& buffer) {
             return buffer ? buffer->span() : std::span<const uint8_t> { };
         }, m_variant);
     }
     std::span<uint8_t> mutableSpan()
     {
-        return std::visit([](auto& buffer) {
+        return WTF::visit([](auto& buffer) {
             return buffer ? buffer->mutableSpan() : std::span<uint8_t> { };
         }, m_variant);
     }

--- a/Source/WebCore/bindings/js/IDBBindingUtilities.cpp
+++ b/Source/WebCore/bindings/js/IDBBindingUtilities.cpp
@@ -471,7 +471,7 @@ static IndexKey::Data createKeyPathArray(JSGlobalObject& lexicalGlobalObject, JS
         return keys;
     });
 
-    return std::visit(visitor, info.keyPath());
+    return WTF::visit(visitor, info.keyPath());
 }
 
 void generateIndexKeyForValue(JSGlobalObject& lexicalGlobalObject, const IDBIndexInfo& info, JSValue value, IndexKey& outKey, const std::optional<IDBKeyPath>& objectStoreKeyPath, const IDBKeyData& objectStoreKey)

--- a/Source/WebCore/bindings/js/JSDOMConvertUnion.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertUnion.h
@@ -374,7 +374,7 @@ template<typename... T> struct JSConverter<IDLUnion<T...>> {
     static constexpr bool needsState = true;
     static constexpr bool needsGlobalObject = true;
 
-    using Sequence = brigand::make_sequence<brigand::ptrdiff_t<0>, std::variant_size<ImplementationType>::value>;
+    using Sequence = brigand::make_sequence<brigand::ptrdiff_t<0>, WTF::VariantSizeV<ImplementationType>>;
 
     static JSC::JSValue convert(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, const ImplementationType& variant)
     {

--- a/Source/WebCore/contentextensions/ContentExtensionActions.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionActions.cpp
@@ -168,7 +168,7 @@ void ModifyHeadersAction::applyToRequest(ResourceRequest& request, UncheckedKeyH
 
 void ModifyHeadersAction::ModifyHeaderInfo::applyToRequest(ResourceRequest& request, UncheckedKeyHashMap<String, ModifyHeadersAction::ModifyHeadersOperationType>& headerNameToFirstOperationApplied)
 {
-    std::visit(WTF::makeVisitor([&] (const AppendOperation& operation) {
+    WTF::visit(WTF::makeVisitor([&] (const AppendOperation& operation) {
         ModifyHeadersOperationType previouslyAppliedHeaderOperation = headerNameToFirstOperationApplied.get(operation.header);
         if (previouslyAppliedHeaderOperation == ModifyHeadersAction::ModifyHeadersOperationType::Remove)
             return;
@@ -242,7 +242,7 @@ void ModifyHeadersAction::ModifyHeaderInfo::serialize(Vector<uint8_t>& vector) c
     auto beginIndex = vector.size();
     append(vector, 0);
     vector.append(operation.index());
-    std::visit(WTF::makeVisitor([&] (const RemoveOperation& operation) {
+    WTF::visit(WTF::makeVisitor([&] (const RemoveOperation& operation) {
         append(vector, operation.header.utf8());
     }, [&] (const auto& operation) {
         auto valueUTF8 = operation.value.utf8();
@@ -332,7 +332,7 @@ void RedirectAction::serialize(Vector<uint8_t>& vector) const
     auto beginIndex = vector.size();
     append(vector, 0);
     vector.append(action.index());
-    std::visit(WTF::makeVisitor([&](const ExtensionPathAction& action) {
+    WTF::visit(WTF::makeVisitor([&](const ExtensionPathAction& action) {
         append(vector, action.extensionPath.utf8());
     }, [&](const RegexSubstitutionAction& action) {
         action.serialize(vector);
@@ -371,7 +371,7 @@ size_t RedirectAction::serializedLength(std::span<const uint8_t> span)
 
 void RedirectAction::applyToRequest(ResourceRequest& request, const URL& extensionBaseURL)
 {
-    std::visit(WTF::makeVisitor([&](const ExtensionPathAction& action) {
+    WTF::visit(WTF::makeVisitor([&](const ExtensionPathAction& action) {
         auto url = extensionBaseURL;
         url.setPath(action.extensionPath);
         request.setURL(WTFMove(url));
@@ -593,7 +593,7 @@ void RedirectAction::URLTransformAction::serialize(Vector<uint8_t>& vector) cons
     }
     if (hasQuery) {
         vector.append(queryTransform.index());
-        std::visit(WTF::makeVisitor([&](const String&) {
+        WTF::visit(WTF::makeVisitor([&](const String&) {
             append(vector, queryStringUTF8.length());
             append(vector, queryStringUTF8);
         }, [&](const QueryTransform& transform) {
@@ -723,7 +723,7 @@ void RedirectAction::URLTransformAction::applyToURL(URL& url) const
         url.setPath(path);
     if (!!port)
         url.setPort(*port);
-    std::visit(WTF::makeVisitor([&] (const String& query) {
+    WTF::visit(WTF::makeVisitor([&] (const String& query) {
         if (!query.isNull())
             url.setQuery(query.isEmpty() ? StringView() : StringView(query));
     }, [&] (const URLTransformAction::QueryTransform& transform) {

--- a/Source/WebCore/contentextensions/ContentExtensionCompiler.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionCompiler.cpp
@@ -106,7 +106,7 @@ static Vector<unsigned> serializeActions(const Vector<ContentExtensionRule>& rul
             actionLocations.append(actions.size());
 
             actions.append(actionData.index());
-            std::visit(WTF::makeVisitor([&](const auto& member) {
+            WTF::visit(WTF::makeVisitor([&](const auto& member) {
                 member.serialize(actions);
             }), actionData);
             continue;
@@ -140,7 +140,7 @@ static Vector<unsigned> serializeActions(const Vector<ContentExtensionRule>& rul
             }).iterator->value;
         };
 
-        auto actionLocation = std::visit(WTF::makeVisitor([&] (const CSSDisplayNoneSelectorAction& actionData) {
+        auto actionLocation = WTF::visit(WTF::makeVisitor([&] (const CSSDisplayNoneSelectorAction& actionData) {
             const auto addResult = cssDisplayNoneActionsMap.add(rule.trigger(), PendingDisplayNoneActions());
             auto& pendingStringActions = addResult.iterator->value;
             if (!pendingStringActions.combinedSelectors.isEmpty())

--- a/Source/WebCore/contentextensions/ContentExtensionRule.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionRule.cpp
@@ -41,7 +41,7 @@ ContentExtensionRule::ContentExtensionRule(Trigger&& trigger, Action&& action)
 
 template<size_t index, typename... Types>
 struct VariantDeserializerHelper {
-    using VariantType = typename std::variant_alternative<index, Variant<Types...>>::type;
+    using VariantType = typename WTF::VariantAlternativeT<index, Variant<Types...>>;
     static Variant<Types...> deserialize(std::span<const uint8_t> span, size_t i)
     {
         if (i == index)
@@ -58,7 +58,7 @@ struct VariantDeserializerHelper {
 
 template<typename... Types>
 struct VariantDeserializerHelper<0, Types...> {
-    using VariantType = typename std::variant_alternative<0, Variant<Types...>>::type;
+    using VariantType = typename WTF::VariantAlternativeT<0, Variant<Types...>>;
     static Variant<Types...> deserialize(std::span<const uint8_t> span, size_t i)
     {
         ASSERT_UNUSED(i, !i);

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
@@ -264,7 +264,7 @@ ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForLoad(
         const String& contentRuleListIdentifier = actionsFromContentRuleList.contentRuleListIdentifier;
         ContentRuleListResults::Result result;
         for (const auto& action : actionsFromContentRuleList.actions) {
-            std::visit(WTF::makeVisitor([&](const BlockLoadAction&) {
+            WTF::visit(WTF::makeVisitor([&](const BlockLoadAction&) {
                 results.summary.blockedLoad = true;
                 result.blockedLoad = true;
             }, [&](const BlockCookiesAction&) {
@@ -349,7 +349,7 @@ ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForPingL
     makeSecureIfNecessary(results, url);
     for (const auto& actionsFromContentRuleList : actions) {
         for (const auto& action : actionsFromContentRuleList.actions) {
-            std::visit(WTF::makeVisitor([&](const BlockLoadAction&) {
+            WTF::visit(WTF::makeVisitor([&](const BlockLoadAction&) {
                 results.summary.blockedLoad = true;
             }, [&](const BlockCookiesAction&) {
                 results.summary.blockedCookies = true;
@@ -380,7 +380,7 @@ bool ContentExtensionsBackend::processContentRuleListsForResourceMonitoring(cons
     bool matched = false;
     for (const auto& actionsFromContentRuleList : actions) {
         for (const auto& action : actionsFromContentRuleList.actions) {
-            std::visit(WTF::makeVisitor([&](const BlockLoadAction&) {
+            WTF::visit(WTF::makeVisitor([&](const BlockLoadAction&) {
                 matched = true;
             }, [&](const BlockCookiesAction&) {
             }, [&](const CSSDisplayNoneSelectorAction&) {

--- a/Source/WebCore/css/CSSCustomPropertyValue.h
+++ b/Source/WebCore/css/CSSCustomPropertyValue.h
@@ -68,14 +68,14 @@ public:
 
     static Ref<CSSCustomPropertyValue> createUnresolved(const AtomString& name, Ref<CSSVariableReferenceValue>&& value)
     {
-        return adoptRef(*new CSSCustomPropertyValue(name, VariantValue { std::in_place_type<Ref<CSSVariableReferenceValue>>, WTFMove(value) }));
+        return adoptRef(*new CSSCustomPropertyValue(name, VariantValue { WTF::InPlaceType<Ref<CSSVariableReferenceValue>>, WTFMove(value) }));
     }
 
     static Ref<CSSCustomPropertyValue> createWithID(const AtomString& name, CSSValueID);
 
     static Ref<CSSCustomPropertyValue> createSyntaxAll(const AtomString& name, Ref<CSSVariableData>&& value)
     {
-        return adoptRef(*new CSSCustomPropertyValue(name, VariantValue { std::in_place_type<Ref<CSSVariableData>>, WTFMove(value) }));
+        return adoptRef(*new CSSCustomPropertyValue(name, VariantValue { WTF::InPlaceType<Ref<CSSVariableData>>, WTFMove(value) }));
     }
 
     static Ref<CSSCustomPropertyValue> createForSyntaxValue(const AtomString& name, SyntaxValue&& syntaxValue)

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -1305,7 +1305,7 @@ static Ref<CSSValue> valueForGridTrackList(GridTrackSizingDirection direction, R
     });
 
     for (auto& entry : computedTracks)
-        std::visit(trackEntryVisitor, entry);
+        WTF::visit(trackEntryVisitor, entry);
 
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }

--- a/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
@@ -124,7 +124,7 @@ CSSUnparsedValue::~CSSUnparsedValue() = default;
 void CSSUnparsedValue::serialize(StringBuilder& builder, OptionSet<SerializationArguments> arguments) const
 {
     for (auto& segment : m_segments) {
-        std::visit(WTF::makeVisitor([&] (const String& value) {
+        WTF::visit(WTF::makeVisitor([&] (const String& value) {
             builder.append(value);
         }, [&] (const RefPtr<CSSOMVariableReferenceValue>& value) {
             value->serialize(builder, arguments);

--- a/Source/WebCore/dom/CustomElementDefaultARIA.cpp
+++ b/Source/WebCore/dom/CustomElementDefaultARIA.cpp
@@ -56,7 +56,7 @@ const AtomString& CustomElementDefaultARIA::valueForAttribute(const Element& thi
     if (it == m_map.end())
         return nullAtom();
 
-    return std::visit(WTF::makeVisitor([&](const AtomString& stringValue) -> const AtomString& {
+    return WTF::visit(WTF::makeVisitor([&](const AtomString& stringValue) -> const AtomString& {
         return stringValue;
     }, [&](const WeakPtr<Element, WeakPtrImplWithEventTargetData>& weakElementValue) -> const AtomString& {
         RefPtr elementValue = weakElementValue.get();
@@ -90,7 +90,7 @@ RefPtr<Element> CustomElementDefaultARIA::elementForAttribute(const Element& thi
         return nullptr;
 
     RefPtr<Element> result;
-    std::visit(WTF::makeVisitor([&](const AtomString& stringValue) {
+    WTF::visit(WTF::makeVisitor([&](const AtomString& stringValue) {
         if (thisElement.isInTreeScope())
             result = thisElement.treeScope().elementByIdResolvingReferenceTarget(stringValue);
     }, [&](const WeakPtr<Element, WeakPtrImplWithEventTargetData>& weakElementValue) {
@@ -114,7 +114,7 @@ Vector<Ref<Element>> CustomElementDefaultARIA::elementsForAttribute(const Elemen
     auto it = m_map.find(name);
     if (it == m_map.end())
         return result;
-    std::visit(WTF::makeVisitor([&](const AtomString& stringValue) {
+    WTF::visit(WTF::makeVisitor([&](const AtomString& stringValue) {
         if (thisElement.isInTreeScope()) {
             SpaceSplitString idList { stringValue, SpaceSplitString::ShouldFoldCase::No };
             result = WTF::compactMap(idList, [&](auto& id) {

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -132,7 +132,7 @@ void EventTarget::addEventListenerForBindings(const AtomString& eventType, RefPt
         SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE addEventListener(eventType, listener.releaseNonNull(), capture);
     });
 
-    std::visit(visitor, variant);
+    WTF::visit(visitor, variant);
 }
 
 void EventTarget::removeEventListenerForBindings(const AtomString& eventType, RefPtr<EventListener>&& listener, EventListenerOptionsOrBoolean&& variant)
@@ -148,7 +148,7 @@ void EventTarget::removeEventListenerForBindings(const AtomString& eventType, Re
         SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE removeEventListener(eventType, *listener, capture);
     });
 
-    std::visit(visitor, variant);
+    WTF::visit(visitor, variant);
 }
 
 bool EventTarget::removeEventListener(const AtomString& eventType, EventListener& listener, const EventListenerOptions& options)

--- a/Source/WebCore/dom/TrustedType.cpp
+++ b/Source/WebCore/dom/TrustedType.cpp
@@ -181,7 +181,7 @@ ExceptionOr<String> trustedTypeCompliantString(TrustedType expectedType, ScriptE
         return WTFMove(std::get<Exception>(convertedInput));
 
     if (!std::holds_alternative<std::monostate>(convertedInput)) {
-        stringValue = std::visit(TrustedTypeVisitor { }, convertedInput);
+        stringValue = WTF::visit(TrustedTypeVisitor { }, convertedInput);
         if (stringValue.isNull())
             convertedInput = std::monostate();
     }
@@ -302,7 +302,7 @@ ExceptionOr<String> requireTrustedTypesForPreNavigationCheckPasses(ScriptExecuti
         return String(urlString);
     }
 
-    auto stringifiedConvertedScriptSource = std::visit(TrustedTypeVisitor { }, convertedScriptSource);
+    auto stringifiedConvertedScriptSource = WTF::visit(TrustedTypeVisitor { }, convertedScriptSource);
 
     auto newURL = URL(makeString("javascript:"_s, stringifiedConvertedScriptSource));
     return String(newURL.isValid()

--- a/Source/WebCore/html/Allowlist.h
+++ b/Source/WebCore/html/Allowlist.h
@@ -57,7 +57,7 @@ public:
     // This is simplified version of https://w3c.github.io/webappsec-permissions-policy/#matches.
     bool matches(const SecurityOriginData& origin) const
     {
-        return std::visit(WTF::makeVisitor([&origin](const HashSet<SecurityOriginData>& origins) -> bool {
+        return WTF::visit(WTF::makeVisitor([&origin](const HashSet<SecurityOriginData>& origins) -> bool {
             return origins.contains(origin);
         }, [&] (const auto&) {
             return true;

--- a/Source/WebCore/html/URLSearchParams.cpp
+++ b/Source/WebCore/html/URLSearchParams.cpp
@@ -58,7 +58,7 @@ ExceptionOr<Ref<URLSearchParams>> URLSearchParams::create(Variant<Vector<Vector<
     }, [&](const String& string) -> ExceptionOr<Ref<URLSearchParams>> {
         return adoptRef(*new URLSearchParams(string, nullptr));
     });
-    return std::visit(visitor, variant);
+    return WTF::visit(visitor, variant);
 }
 
 String URLSearchParams::get(const String& name) const

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2566,7 +2566,7 @@ RefPtr<ImageData> CanvasRenderingContext2DBase::makeImageDataIfContentsCached(co
         return ImageData::create(sourceRect.size(), colorSpace);
     if (std::holds_alternative<CachedContentsUnknown>(m_cachedContents))
         return nullptr;
-    static_assert(std::variant_size_v<decltype(m_cachedContents)> == 3); // Written this way to avoid dangling references during visit.
+    static_assert(WTF::VariantSizeV<decltype(m_cachedContents)> == 3); // Written this way to avoid dangling references during visit.
     // Always consume the cached image data.
     Ref pixelBuffer = WTFMove(std::get<CachedContentsImageData>(m_cachedContents).imageData);
     m_cachedContents.emplace<CachedContentsUnknown>();

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -1165,7 +1165,7 @@ void WebGLRenderingContextBase::bufferData(GCGLenum target, std::optional<Buffer
     if (!buffer)
         return;
 
-    std::visit([context = m_context, target, usage](auto& data) {
+    WTF::visit([context = m_context, target, usage](auto& data) {
         context->bufferData(target, data->span(), usage);
     }, data.value());
 }
@@ -1182,7 +1182,7 @@ void WebGLRenderingContextBase::bufferSubData(GCGLenum target, long long offset,
         return;
     }
 
-    std::visit([context = m_context, target, offset](auto& data) {
+    WTF::visit([context = m_context, target, offset](auto& data) {
         context->bufferSubData(target, static_cast<GCGLintptr>(offset), data->span());
     }, data);
 }
@@ -3147,7 +3147,7 @@ ExceptionOr<void> WebGLRenderingContextBase::texImageSourceHelper(TexImageFuncti
     if (isContextLost())
         return { };
 
-    return std::visit([this, protectedThis = Ref { *this }, functionID, target, level, internalformat, border, format, type, xoffset, yoffset, zoffset, inputSourceImageRect, depth, unpackImageHeight](auto&& source) {
+    return WTF::visit([this, protectedThis = Ref { *this }, functionID, target, level, internalformat, border, format, type, xoffset, yoffset, zoffset, inputSourceImageRect, depth, unpackImageHeight](auto&& source) {
         return texImageSource(functionID, target, level, internalformat, border, format, type, xoffset, yoffset, zoffset, inputSourceImageRect, depth, unpackImageHeight, *source);
     }, source);
 }

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -159,7 +159,7 @@ void VTTCueBox::applyCSSPropertiesWithRegion()
         return;
 
     // the 'left' property must be set to left
-    std::visit(WTF::makeVisitor([this, protectedThis = Ref { *this }] (double left) {
+    WTF::visit(WTF::makeVisitor([this, protectedThis = Ref { *this }] (double left) {
         setInlineStyleProperty(CSSPropertyLeft, left, CSSUnitType::CSS_PERCENTAGE);
     }, [this, protectedThis = Ref { *this }] (auto) {
         setInlineStyleProperty(CSSPropertyLeft, CSSValueAuto);
@@ -210,14 +210,14 @@ void VTTCueBox::applyCSSProperties()
     setInlineStyleProperty(CSSPropertyWritingMode, cue->getCSSWritingMode());
 
     // the 'top' property must be set to top
-    std::visit(WTF::makeVisitor([this, protectedThis = Ref { *this }] (double top) {
+    WTF::visit(WTF::makeVisitor([this, protectedThis = Ref { *this }] (double top) {
         setInlineStyleProperty(CSSPropertyTop, top, CSSUnitType::CSS_CQH);
     }, [this, protectedThis = Ref { *this }] (auto) {
         setInlineStyleProperty(CSSPropertyTop, CSSValueAuto);
     }), cue->top());
 
     // the 'left' property must be set to left
-    std::visit(WTF::makeVisitor([this, protectedThis = Ref { *this }] (double left) {
+    WTF::visit(WTF::makeVisitor([this, protectedThis = Ref { *this }] (double left) {
         setInlineStyleProperty(CSSPropertyLeft, left, CSSUnitType::CSS_CQW);
     }, [this, protectedThis = Ref { *this }] (auto) {
         setInlineStyleProperty(CSSPropertyLeft, CSSValueAuto);
@@ -230,14 +230,14 @@ void VTTCueBox::applyCSSProperties()
     // is not a true viewport, but it is a container, so they serve the same purpose.
 
     // the 'width' property must be set to width
-    std::visit(WTF::makeVisitor([this, protectedThis = Ref { *this }] (double width) {
+    WTF::visit(WTF::makeVisitor([this, protectedThis = Ref { *this }] (double width) {
         setInlineStyleProperty(CSSPropertyWidth, width, CSSUnitType::CSS_CQW);
     }, [this, protectedThis = Ref { *this }] (auto) {
         setInlineStyleProperty(CSSPropertyWidth, CSSValueAuto);
     }), cue->width());
 
     // the 'height' property must be set to height
-    std::visit(WTF::makeVisitor([this, protectedThis = Ref { *this }] (double height) {
+    WTF::visit(WTF::makeVisitor([this, protectedThis = Ref { *this }] (double height) {
         setInlineStyleProperty(CSSPropertyHeight, height, CSSUnitType::CSS_CQH);
     }, [this, protectedThis = Ref { *this }] (auto) {
         setInlineStyleProperty(CSSPropertyHeight, CSSValueAuto);

--- a/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
@@ -165,7 +165,7 @@ static Ref<Inspector::Protocol::IndexedDB::KeyPath> keyPathFromIDBKeyPath(const 
         keyPath->setArray(WTFMove(array));
         return keyPath;
     });
-    return std::visit(visitor, idbKeyPath.value());
+    return WTF::visit(visitor, idbKeyPath.value());
 }
 
 static RefPtr<IDBTransaction> transactionForDatabase(IDBDatabase* idbDatabase, const String& objectStoreName, IDBTransactionMode mode = IDBTransactionMode::Readonly)

--- a/Source/WebCore/platform/FixedContainerEdges.h
+++ b/Source/WebCore/platform/FixedContainerEdges.h
@@ -42,7 +42,7 @@ struct FixedContainerEdges {
 
     bool hasFixedEdge(BoxSide side) const
     {
-        return std::visit(WTF::makeVisitor([&](PredominantColorType type) {
+        return WTF::visit(WTF::makeVisitor([&](PredominantColorType type) {
             return type != PredominantColorType::None;
         }, [&](const Color&) {
             return true;
@@ -51,7 +51,7 @@ struct FixedContainerEdges {
 
     Color predominantColor(BoxSide side) const
     {
-        return std::visit(WTF::makeVisitor([&](PredominantColorType) -> Color {
+        return WTF::visit(WTF::makeVisitor([&](PredominantColorType) -> Color {
             return { };
         }, [&](const Color& color) {
             return color;

--- a/Source/WebCore/platform/Length.cpp
+++ b/Source/WebCore/platform/Length.cpp
@@ -237,7 +237,7 @@ void Length::deref() const
 
 LengthType Length::typeFromIndex(const IPCData& data)
 {
-    static_assert(std::variant_size_v<IPCData> == 13);
+    static_assert(WTF::VariantSizeV<IPCData> == 13);
     switch (data.index()) {
     case WTF::alternativeIndexV<AutoData, IPCData>:
         return LengthType::Auto;

--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -638,7 +638,7 @@ std::span<const uint8_t> DataSegment::span() const
         [](const FileSystem::MappedFileData& data) { return data.span(); },
         [](const Provider& provider) { return provider.span(); }
     );
-    return std::visit(visitor, m_immutableData);
+    return WTF::visit(visitor, m_immutableData);
 }
 
 bool DataSegment::containsMappedFileData() const

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -179,7 +179,7 @@ static FontRanges realizeNextFallback(const FontCascadeDescription& description,
             return { fontFamilySpecification.fontRanges(description), IsGenericFontFamily::Yes };
         });
         const auto& currentFamily = description.effectiveFamilyAt(index++);
-        auto ranges = std::visit(visitor, currentFamily);
+        auto ranges = WTF::visit(visitor, currentFamily);
         if (!ranges.isNull())
             return ranges;
     }

--- a/Source/WebCore/platform/network/DNS.cpp
+++ b/Source/WebCore/platform/network/DNS.cpp
@@ -88,7 +88,7 @@ bool isIPAddressDisallowed(const URL& url)
 
 bool IPAddress::containsOnlyZeros() const
 {
-    return std::visit(WTF::makeVisitor([] (const WTF::HashTableEmptyValueType&) {
+    return WTF::visit(WTF::makeVisitor([] (const WTF::HashTableEmptyValueType&) {
         ASSERT_NOT_REACHED();
         return false;
     }, [] (const in_addr& address) {

--- a/Source/WebCore/rendering/style/ShapeValue.cpp
+++ b/Source/WebCore/rendering/style/ShapeValue.cpp
@@ -46,7 +46,7 @@ bool ShapeValue::isImageValid() const
 
 bool ShapeValue::operator==(const ShapeValue& other) const
 {
-    return std::visit(WTF::makeVisitor(
+    return WTF::visit(WTF::makeVisitor(
         []<typename T>(const T& a, const T& b) {
             return a == b;
         },
@@ -58,7 +58,7 @@ bool ShapeValue::operator==(const ShapeValue& other) const
 
 bool ShapeValue::canBlend(const ShapeValue& other) const
 {
-    return std::visit(WTF::makeVisitor(
+    return WTF::visit(WTF::makeVisitor(
         [](const ShapeAndBox& a, const ShapeAndBox& b) {
             return Style::canBlend(a.shape, b.shape) && a.box == b.box;
         },
@@ -70,7 +70,7 @@ bool ShapeValue::canBlend(const ShapeValue& other) const
 
 Ref<ShapeValue> ShapeValue::blend(const ShapeValue& other, const BlendingContext& context) const
 {
-    return std::visit(WTF::makeVisitor(
+    return WTF::visit(WTF::makeVisitor(
         [&](const ShapeAndBox& a, const ShapeAndBox& b) -> Ref<ShapeValue> {
             return ShapeValue::create(Style::blend(a.shape, b.shape, context), a.box);
         },

--- a/Source/WebCore/rendering/style/StyleGridData.cpp
+++ b/Source/WebCore/rendering/style/StyleGridData.cpp
@@ -205,7 +205,7 @@ void StyleGridData::computeCachedTrackData(const GridTrackList& list, Vector<Gri
     });
 
     for (const auto& entry : list.list)
-        std::visit(visitor, entry);
+        WTF::visit(visitor, entry);
 
     // The parser should have rejected any <track-list> without any <track-size> as
     // this is not conformant to the syntax.
@@ -220,7 +220,7 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, const RepeatEntry& entry)
         ts << names;
     });
 
-    std::visit(visitor, entry);
+    WTF::visit(visitor, entry);
     return ts;
 }
 
@@ -240,7 +240,7 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, const GridTrackEntry& entry)
         ts << "masonry"_s;
     });
 
-    std::visit(visitor, entry);
+    WTF::visit(visitor, entry);
     return ts;
 }
 

--- a/Source/WebCore/style/StyleInterpolationFunctions.h
+++ b/Source/WebCore/style/StyleInterpolationFunctions.h
@@ -600,7 +600,7 @@ inline bool canInterpolate(const GridTrackList& from, const GridTrackList& to)
     );
 
     for (i = 0; i < from.list.size(); i++) {
-        if (!std::visit(visitor, from.list[i]))
+        if (!WTF::visit(visitor, from.list[i]))
             return false;
     }
 
@@ -655,7 +655,7 @@ inline RepeatTrackList blendFunc(const RepeatTrackList& from, const RepeatTrackL
     );
 
     for (i = 0; i < from.size(); i++)
-        std::visit(visitor, from[i]);
+        WTF::visit(visitor, from[i]);
 
     return result;
 }
@@ -700,7 +700,7 @@ inline GridTrackList blendFunc(const GridTrackList& from, const GridTrackList& t
 
 
     for (i = 0; i < from.list.size(); i++)
-        std::visit(visitor, from.list[i]);
+        WTF::visit(visitor, from.list[i]);
 
     return result;
 }

--- a/Source/WebCore/style/values/StyleValueTypes.h
+++ b/Source/WebCore/style/values/StyleValueTypes.h
@@ -519,7 +519,7 @@ template<CSSValueID C> struct Blending<Constant<C>> {
 template<typename... StyleTypes> struct Blending<Variant<StyleTypes...>> {
     auto canBlend(const Variant<StyleTypes...>& a, const Variant<StyleTypes...>& b) -> bool
     {
-        return std::visit(WTF::makeVisitor(
+        return WTF::visit(WTF::makeVisitor(
             []<typename T>(const T& a, const T& b) -> bool {
                 return WebCore::Style::canBlend(a, b);
             },
@@ -530,7 +530,7 @@ template<typename... StyleTypes> struct Blending<Variant<StyleTypes...>> {
     }
     auto canBlend(const Variant<StyleTypes...>& a, const Variant<StyleTypes...>& b, const RenderStyle& aStyle, const RenderStyle& bStyle) -> bool
     {
-        return std::visit(WTF::makeVisitor(
+        return WTF::visit(WTF::makeVisitor(
             [&]<typename T>(const T& a, const T& b) -> bool {
                 return WebCore::Style::canBlend(a, b, aStyle, bStyle);
             },
@@ -541,7 +541,7 @@ template<typename... StyleTypes> struct Blending<Variant<StyleTypes...>> {
     }
     auto blend(const Variant<StyleTypes...>& a, const Variant<StyleTypes...>& b, const BlendingContext& context) -> Variant<StyleTypes...>
     {
-        return std::visit(WTF::makeVisitor(
+        return WTF::visit(WTF::makeVisitor(
             [&]<typename T>(const T& a, const T& b) -> Variant<StyleTypes...> {
                 return WebCore::Style::blend(a, b, context);
             },
@@ -552,7 +552,7 @@ template<typename... StyleTypes> struct Blending<Variant<StyleTypes...>> {
     }
     auto blend(const Variant<StyleTypes...>& a, const Variant<StyleTypes...>& b, const RenderStyle& aStyle, const RenderStyle& bStyle, const BlendingContext& context) -> Variant<StyleTypes...>
     {
-        return std::visit(WTF::makeVisitor(
+        return WTF::visit(WTF::makeVisitor(
             [&]<typename T>(const T& a, const T& b) -> Variant<StyleTypes...> {
                 return WebCore::Style::blend(a, b, aStyle, bStyle, context);
             },

--- a/Source/WebCore/style/values/images/StyleGradient.cpp
+++ b/Source/WebCore/style/values/images/StyleGradient.cpp
@@ -893,7 +893,7 @@ template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(c
             );
         },
         [&](const SpaceSeparatedTuple<Horizontal, Vertical>& pair) -> std::pair<FloatPoint, FloatPoint> {
-            return std::visit(WTF::makeVisitor(
+            return WTF::visit(WTF::makeVisitor(
                 [&](CSS::Keyword::Left, CSS::Keyword::Top) -> std::pair<FloatPoint, FloatPoint> {
                     return { { 0, 0 }, { size.width(), size.height() } };
                 },

--- a/Source/WebCore/style/values/shapes/StyleBasicShape.cpp
+++ b/Source/WebCore/style/values/shapes/StyleBasicShape.cpp
@@ -47,7 +47,7 @@ auto ToStyle<CSS::BasicShape>::operator()(const CSS::BasicShape& value, const Bu
 
 auto Blending<BasicShape>::canBlend(const BasicShape& a, const BasicShape& b) -> bool
 {
-    return std::visit(WTF::makeVisitor(
+    return WTF::visit(WTF::makeVisitor(
         []<typename T>(const T& a, const T& b) {
             return WebCore::Style::canBlend(a, b);
         },
@@ -65,7 +65,7 @@ auto Blending<BasicShape>::canBlend(const BasicShape& a, const BasicShape& b) ->
 
 auto Blending<BasicShape>::blend(const BasicShape& a, const BasicShape& b, const BlendingContext& context) -> BasicShape
 {
-    return std::visit(WTF::makeVisitor(
+    return WTF::visit(WTF::makeVisitor(
         [&]<typename T>(const T& a, const T& b) -> BasicShape {
             return { WebCore::Style::blend(a, b, context) };
         },

--- a/Source/WebCore/style/values/shapes/StyleCircleFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleCircleFunction.cpp
@@ -112,7 +112,7 @@ WebCore::Path PathComputation<Circle>::operator()(const Circle& value, const Flo
 auto Blending<Circle>::canBlend(const Circle& a, const Circle& b) -> bool
 {
     auto canBlendRadius = [](const auto& radiusA, const auto& radiusB) {
-        return std::visit(WTF::makeVisitor(
+        return WTF::visit(WTF::makeVisitor(
             [](const Circle::Length&, const Circle::Length&) {
                 return true;
             },
@@ -130,7 +130,7 @@ auto Blending<Circle>::canBlend(const Circle& a, const Circle& b) -> bool
 auto Blending<Circle>::blend(const Circle& a, const Circle& b, const BlendingContext& context) -> Circle
 {
     auto blendRadius = [](const auto& radiusA, const auto& radiusB, const BlendingContext& context) -> Circle::RadialSize {
-        return std::visit(WTF::makeVisitor(
+        return WTF::visit(WTF::makeVisitor(
             [&](const Circle::Length& lengthA, const Circle::Length& lengthB) -> Circle::RadialSize {
                 return WebCore::Style::blend(lengthA, lengthB, context);
             },

--- a/Source/WebCore/style/values/shapes/StyleEllipseFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleEllipseFunction.cpp
@@ -120,7 +120,7 @@ WebCore::Path PathComputation<Ellipse>::operator()(const Ellipse& value, const F
 auto Blending<Ellipse>::canBlend(const Ellipse& a, const Ellipse& b) -> bool
 {
     auto canBlendRadius = [](const auto& radiusA, const auto& radiusB) {
-        return std::visit(WTF::makeVisitor(
+        return WTF::visit(WTF::makeVisitor(
             [](const Ellipse::Length&, const Ellipse::Length&) {
                 return true;
             },
@@ -139,7 +139,7 @@ auto Blending<Ellipse>::canBlend(const Ellipse& a, const Ellipse& b) -> bool
 auto Blending<Ellipse>::blend(const Ellipse& a, const Ellipse& b, const BlendingContext& context) -> Ellipse
 {
     auto blendRadius = [](const auto& radiusA, const auto& radiusB, const BlendingContext& context) -> Ellipse::RadialSize {
-        return std::visit(WTF::makeVisitor(
+        return WTF::visit(WTF::makeVisitor(
             [&](const Ellipse::Length& lengthA, const Ellipse::Length& lengthB) -> Ellipse::RadialSize {
                 return WebCore::Style::blend(lengthA, lengthB, context);
             },

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -82,7 +82,7 @@ Variant<SuccessfulCheck, FailedCheck> staticCheck(const String& wgsl, const std:
     RUN_PASS(mangleNames, shaderModule);
 
     Vector<Warning> warnings { };
-    return Variant<SuccessfulCheck, FailedCheck>(std::in_place_type<SuccessfulCheck>, WTFMove(warnings), WTFMove(shaderModule));
+    return Variant<SuccessfulCheck, FailedCheck>(WTF::InPlaceType<SuccessfulCheck>, WTFMove(warnings), WTFMove(shaderModule));
 }
 
 SuccessfulCheck::SuccessfulCheck(SuccessfulCheck&&) = default;

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -793,10 +793,10 @@ template<typename... Types> struct ArgumentCoder<Variant<Types...>> {
         constexpr size_t index = sizeof...(Indices);
         if constexpr (index < sizeof...(Types)) {
             if (index == i) {
-                auto optional = decoder.template decode<typename std::variant_alternative_t<index, Variant<Types...>>>();
+                auto optional = decoder.template decode<typename WTF::VariantAlternativeT<index, Variant<Types...>>>();
                 if (!optional)
                     return std::nullopt;
-                return std::make_optional<Variant<Types...>>(std::in_place_index<index>, WTFMove(*optional));
+                return std::make_optional<Variant<Types...>>(WTF::InPlaceIndex<index>, WTFMove(*optional));
             }
             return decode(decoder, std::make_index_sequence<index + 1> { }, i);
         } else

--- a/Source/WebKit/Platform/IPC/MessageReceiveQueueMap.cpp
+++ b/Source/WebKit/Platform/IPC/MessageReceiveQueueMap.cpp
@@ -74,15 +74,15 @@ MessageReceiveQueue* MessageReceiveQueueMap::get(const Decoder& message) const
     {
         auto it = m_anyIDQueues.find(receiverName);
         if (it != m_anyIDQueues.end())
-            return std::visit(queueExtractor, it->value);
+            return WTF::visit(queueExtractor, it->value);
     }
     {
         auto it = m_queues.find(std::make_pair(receiverName, message.destinationID()));
         if (it != m_queues.end())
-            return std::visit(queueExtractor, it->value);
+            return WTF::visit(queueExtractor, it->value);
     }
     if (m_anyReceiverQueue)
-        return std::visit(queueExtractor, *m_anyReceiverQueue);
+        return WTF::visit(queueExtractor, *m_anyReceiverQueue);
     return nullptr;
 }
 

--- a/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm
+++ b/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm
@@ -112,7 +112,7 @@ Variant<MediaPlaybackTargetContextCocoa, MediaPlaybackTargetContextMock> MediaPl
     auto unarchiver = adoptNS([[WKKeyedCoder alloc] initWithDictionary:propertyList]);
     auto outputContext = adoptNS([[PAL::getAVOutputContextClass() alloc] initWithCoder:unarchiver.get()]);
     // Variant construction in older clang gives either an error, a vtable linkage error unless we construct it this way.
-    Variant<MediaPlaybackTargetContextCocoa, MediaPlaybackTargetContextMock> variant { std::in_place_type<MediaPlaybackTargetContextCocoa>, WTFMove(outputContext) };
+    Variant<MediaPlaybackTargetContextCocoa, MediaPlaybackTargetContextMock> variant { WTF::InPlaceType<MediaPlaybackTargetContextCocoa>, WTFMove(outputContext) };
     return variant;
 #endif
 }

--- a/Source/WebKit/Shared/Cocoa/CoreIPCContacts.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCContacts.mm
@@ -153,7 +153,7 @@ bool CoreIPCCNContact::isValidCNContactType(NSInteger proposedType)
 static RetainPtr<NSArray> nsArrayFromVectorOfLabeledValues(const Vector<CoreIPCContactLabeledValue>& labeledValues)
 {
     return createNSArray(labeledValues, [] (auto& labeledValue) -> RetainPtr<id> {
-        auto theValue = std::visit([] (auto& actualValue) -> RetainPtr<id> {
+        auto theValue = WTF::visit([] (auto& actualValue) -> RetainPtr<id> {
             return actualValue.toID();
         }, labeledValue.value);
 

--- a/Source/WebKit/UIProcess/WebProcessActivityState.cpp
+++ b/Source/WebKit/UIProcess/WebProcessActivityState.cpp
@@ -88,7 +88,7 @@ void WebProcessActivityState::takeMutedCaptureAssertion()
     Ref isMutedCaptureAssertion = ProcessAssertion::create(protectedProcess(), "WebKit Muted Media Capture"_s, ProcessAssertionType::Background);
     m_isMutedCaptureAssertion = isMutedCaptureAssertion.copyRef();
 
-    auto page = std::visit([](auto&& weakPageRef) -> Variant<WeakPtr<WebPageProxy>, WeakPtr<RemotePageProxy>> {
+    auto page = WTF::visit([](auto&& weakPageRef) -> Variant<WeakPtr<WebPageProxy>, WeakPtr<RemotePageProxy>> {
         return weakPageRef.get();
     }, m_page);
 
@@ -99,7 +99,7 @@ void WebProcessActivityState::takeMutedCaptureAssertion()
                 page->processActivityState().m_isMutedCaptureAssertion = nullptr;
             }
         };
-        std::visit(invalidateCaptureAssertion, weakPage);
+        WTF::visit(invalidateCaptureAssertion, weakPage);
     });
 }
 
@@ -184,7 +184,7 @@ bool WebProcessActivityState::hasValidOpeningAppLinkActivity() const
 
 void WebProcessActivityState::updateWebProcessSuspensionDelay()
 {
-    Seconds timeout = std::visit(WTF::makeVisitor([&](const WeakRef<WebPageProxy>& page) {
+    Seconds timeout = WTF::visit(WTF::makeVisitor([&](const WeakRef<WebPageProxy>& page) {
         return webProcessSuspensionDelay(Ref { page.get() }.ptr());
     }, [&] (const WeakRef<RemotePageProxy>& page) {
         return webProcessSuspensionDelay(page->protectedPage().get());
@@ -236,7 +236,7 @@ void WebProcessActivityState::viewDidLeaveWindow()
 
 WebProcessProxy& WebProcessActivityState::process() const
 {
-    return std::visit([](auto& page) -> WebProcessProxy& {
+    return WTF::visit([](auto& page) -> WebProcessProxy& {
         using T = std::decay_t<decltype(page)>;
         if constexpr (std::is_same_v<T, WeakRef<WebPageProxy>>)
             return page->legacyMainFrameProcess();

--- a/Tools/TestWebKitAPI/Tests/WTF/CompactVariant.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CompactVariant.cpp
@@ -109,7 +109,7 @@ TEST(WTF_CompactVariant, SmartPointers)
         RefLogger testRefLogger("testRefLogger");
         Ref<RefLogger> ref(testRefLogger);
 
-        CompactVariant<Ref<RefLogger>, std::unique_ptr<double>> variant { std::in_place_type<Ref<RefLogger>>, WTFMove(ref) };
+        CompactVariant<Ref<RefLogger>, std::unique_ptr<double>> variant { WTF::InPlaceType<Ref<RefLogger>>, WTFMove(ref) };
 
         EXPECT_TRUE(WTF::holdsAlternative<Ref<RefLogger>>(variant));
         EXPECT_FALSE(WTF::holdsAlternative<std::unique_ptr<double>>(variant));
@@ -357,7 +357,7 @@ TEST(WTF_CompactVariant, ArgumentConstruct)
 TEST(WTF_CompactVariant, ArgumentConstructInPlaceType)
 {
     {
-        CompactVariant<float, LifecycleLogger> variant { std::in_place_type<LifecycleLogger>, "compact" };
+        CompactVariant<float, LifecycleLogger> variant { WTF::InPlaceType<LifecycleLogger>, "compact" };
 
         ASSERT_STREQ("construct(compact) ", takeLogStr().c_str());
     }
@@ -367,7 +367,7 @@ TEST(WTF_CompactVariant, ArgumentConstructInPlaceType)
 TEST(WTF_CompactVariant, ArgumentConstructInPlaceIndex)
 {
     {
-        CompactVariant<float, LifecycleLogger> variant { std::in_place_index<1>, "compact" };
+        CompactVariant<float, LifecycleLogger> variant { WTF::InPlaceIndex<1>, "compact" };
 
         ASSERT_STREQ("construct(compact) ", takeLogStr().c_str());
     }
@@ -421,7 +421,7 @@ TEST(WTF_CompactVariant, ArgumentCopyAssignment)
 TEST(WTF_CompactVariant, CopyConstruct)
 {
     {
-        CompactVariant<float, LifecycleLogger> variant { std::in_place_type<LifecycleLogger>, "compact" };
+        CompactVariant<float, LifecycleLogger> variant { WTF::InPlaceType<LifecycleLogger>, "compact" };
 
         CompactVariant<float, LifecycleLogger> other { variant };
 
@@ -433,7 +433,7 @@ TEST(WTF_CompactVariant, CopyConstruct)
 TEST(WTF_CompactVariant, CopyAssignment)
 {
     {
-        CompactVariant<float, LifecycleLogger> variant { std::in_place_type<LifecycleLogger>, "compact" };
+        CompactVariant<float, LifecycleLogger> variant { WTF::InPlaceType<LifecycleLogger>, "compact" };
 
         CompactVariant<float, LifecycleLogger> other = variant;
 
@@ -445,7 +445,7 @@ TEST(WTF_CompactVariant, CopyAssignment)
 TEST(WTF_CompactVariant, MoveConstruct)
 {
     {
-        CompactVariant<float, LifecycleLogger> variant { std::in_place_type<LifecycleLogger>, "compact" };
+        CompactVariant<float, LifecycleLogger> variant { WTF::InPlaceType<LifecycleLogger>, "compact" };
 
         CompactVariant<float, LifecycleLogger> other { WTFMove(variant) };
 
@@ -457,7 +457,7 @@ TEST(WTF_CompactVariant, MoveConstruct)
 TEST(WTF_CompactVariant, MoveAssignment)
 {
     {
-        CompactVariant<float, LifecycleLogger> variant { std::in_place_type<LifecycleLogger>, "compact" };
+        CompactVariant<float, LifecycleLogger> variant { WTF::InPlaceType<LifecycleLogger>, "compact" };
 
         CompactVariant<float, LifecycleLogger> other = WTFMove(variant);
 
@@ -469,7 +469,7 @@ TEST(WTF_CompactVariant, MoveAssignment)
 TEST(WTF_CompactVariant, ConstructThenReassign)
 {
     {
-        CompactVariant<float, LifecycleLogger> variant { std::in_place_type<LifecycleLogger>, "compact" };
+        CompactVariant<float, LifecycleLogger> variant { WTF::InPlaceType<LifecycleLogger>, "compact" };
 
         variant = 1.0f;
 
@@ -544,7 +544,7 @@ TEST(WTF_CompactVariant, SwitchOn)
 {
     // `switchOn` should not cause any lifecycle events.
     {
-        CompactVariant<float, LifecycleLogger> variant { std::in_place_type<LifecycleLogger>, "compact" };
+        CompactVariant<float, LifecycleLogger> variant { WTF::InPlaceType<LifecycleLogger>, "compact" };
 
         WTF::switchOn(variant,
             [&](const float&) { },

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PrivateClickMeasurement.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PrivateClickMeasurement.mm
@@ -66,7 +66,7 @@ void addValuesToTable(WebCore::SQLiteDatabase& database, ASCIILiteral query, std
         }, [&] (double real) {
             return statement->bindDouble(i + 1, real);
         });
-        auto result = std::visit(visitor, values[i]);
+        auto result = WTF::visit(visitor, values[i]);
         EXPECT_EQ(result, SQLITE_OK);
     }
     EXPECT_EQ(statement->step(), SQLITE_DONE);


### PR DESCRIPTION
#### d3aa971a4c8dd8675e2d8d9f9caedad56599da44
<pre>
Use WTF aliases for std::variant auxiliaries
<a href="https://bugs.webkit.org/show_bug.cgi?id=291694">https://bugs.webkit.org/show_bug.cgi?id=291694</a>

Reviewed by Keith Miller and Simon Fraser.

This is step 3 of the process begun in 293592@main.
293804@main was step 2.

* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::addWatchpoint):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::emitCall):
(JSC::DFG::SpeculativeJIT::compileHasPrivate):
(JSC::DFG::SpeculativeJIT::compilePutByVal):
(JSC::DFG::SpeculativeJIT::compileGetPrivateNameByVal):
(JSC::DFG::SpeculativeJIT::compilePutPrivateName):
(JSC::DFG::SpeculativeJIT::compileCheckPrivateBrand):
(JSC::DFG::SpeculativeJIT::compileSetPrivateBrand):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::emitCall):
(JSC::DFG::SpeculativeJIT::compileGetByVal):
(JSC::DFG::SpeculativeJIT::compile):
(JSC::DFG::SpeculativeJIT::compileGetByValWithThis):
(JSC::DFG::SpeculativeJIT::compileHasPrivate):
(JSC::DFG::SpeculativeJIT::compilePutByVal):
(JSC::DFG::SpeculativeJIT::compileGetPrivateNameByVal):
(JSC::DFG::SpeculativeJIT::compilePutPrivateName):
(JSC::DFG::SpeculativeJIT::compileCheckPrivateBrand):
(JSC::DFG::SpeculativeJIT::compileSetPrivateBrand):
(JSC::DFG::SpeculativeJIT::compileEnumeratorPutByVal):
* Source/JavaScriptCore/jit/JITInlineCacheGenerator.cpp:
(JSC::JITInlineCacheGenerator::JITInlineCacheGenerator):
(JSC::JITGetByIdGenerator::JITGetByIdGenerator):
(JSC::JITGetByIdWithThisGenerator::JITGetByIdWithThisGenerator):
(JSC::JITPutByIdGenerator::JITPutByIdGenerator):
(JSC::JITDelByValGenerator::JITDelByValGenerator):
(JSC::JITDelByIdGenerator::JITDelByIdGenerator):
(JSC::JITInByValGenerator::JITInByValGenerator):
(JSC::JITInByIdGenerator::JITInByIdGenerator):
(JSC::JITInstanceOfGenerator::JITInstanceOfGenerator):
(JSC::JITGetByValGenerator::JITGetByValGenerator):
(JSC::JITGetByValWithThisGenerator::JITGetByValWithThisGenerator):
(JSC::JITPutByValGenerator::JITPutByValGenerator):
(JSC::JITPrivateBrandAccessGenerator::JITPrivateBrandAccessGenerator):
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalTimeZone.cpp:
(JSC::TemporalTimeZone::createFromID):
(JSC::TemporalTimeZone::createFromUTCOffset):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::TypeDefinition::tryCreateFunctionSignature):
(JSC::Wasm::TypeDefinition::tryCreateStructType):
(JSC::Wasm::TypeDefinition::tryCreateArrayType):
(JSC::Wasm::TypeDefinition::tryCreateRecursionGroup):
(JSC::Wasm::TypeDefinition::tryCreateProjection):
(JSC::Wasm::TypeDefinition::tryCreateSubtype):
* Source/WTF/wtf/CompactVariant.h:
(WTF::CompactVariant::emplace):
(WTF::CompactVariant::holdsAlternative const):
* Source/WTF/wtf/CrossThreadCopier.h:
* Source/WTF/wtf/Expected.h:
(std::experimental::fundamentals_v3::__expected_detail::base::base):
* Source/WTF/wtf/GenericHashKey.h:
* Source/WTF/wtf/Hasher.h:
(WTF::add):
* Source/WTF/wtf/StdLibExtras.h:
(WTF::visitOneVariant):
(WTF::switchOn):
* Source/WTF/wtf/Variant.h:
(WTF::visit):
* Source/WTF/wtf/VariantExtras.h:
(WTF::typeForIndex):
* Source/WTF/wtf/VariantListOperations.h:
(WTF::VariantListProxy::holds_alternative const):
* Source/WebCore/Modules/WebGPU/GPUBuffer.cpp:
(WebCore::makeArrayBuffer):
* Source/WebCore/Modules/identity/DigitalCredential.cpp:
(WebCore::jsToCredentialRequest):
(WebCore::DigitalCredential::discoverFromExternalSource):
* Source/WebCore/Modules/indexeddb/IDBKeyPath.cpp:
(WebCore::isIDBKeyPathValid):
(WebCore::loggingString):
* Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp:
(WebCore::serializeIDBKeyPath):
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::displayNameForTrack):
* Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.cpp:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
(WebCore::createAudioDecoderConfig):
(WebCore::isValidDecoderConfig):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::isValidDecoderConfig):
(WebCore::createVideoDecoderConfig):
* Source/WebCore/bindings/js/BufferSource.h:
(WebCore::BufferSource::length const):
(WebCore::BufferSource::span const):
(WebCore::BufferSource::mutableSpan):
* Source/WebCore/bindings/js/IDBBindingUtilities.cpp:
(WebCore::createKeyPathArray):
* Source/WebCore/bindings/js/JSDOMConvertUnion.h:
* Source/WebCore/contentextensions/ContentExtensionActions.cpp:
(WebCore::ContentExtensions::ModifyHeadersAction::ModifyHeaderInfo::applyToRequest):
(WebCore::ContentExtensions::ModifyHeadersAction::ModifyHeaderInfo::serialize const):
(WebCore::ContentExtensions::RedirectAction::serialize const):
(WebCore::ContentExtensions::RedirectAction::applyToRequest):
(WebCore::ContentExtensions::RedirectAction::URLTransformAction::serialize const):
(WebCore::ContentExtensions::RedirectAction::URLTransformAction::applyToURL const):
* Source/WebCore/contentextensions/ContentExtensionCompiler.cpp:
(WebCore::ContentExtensions::serializeActions):
* Source/WebCore/contentextensions/ContentExtensionRule.cpp:
* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForLoad):
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForPingLoad):
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForResourceMonitoring):
* Source/WebCore/css/CSSCustomPropertyValue.h:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::valueForGridTrackList):
* Source/WebCore/css/typedom/CSSUnparsedValue.cpp:
(WebCore::CSSUnparsedValue::serialize const):
* Source/WebCore/dom/CustomElementDefaultARIA.cpp:
(WebCore::CustomElementDefaultARIA::valueForAttribute const):
(WebCore::CustomElementDefaultARIA::elementForAttribute const):
(WebCore::CustomElementDefaultARIA::elementsForAttribute const):
* Source/WebCore/dom/EventTarget.cpp:
(WebCore::EventTarget::addEventListenerForBindings):
(WebCore::EventTarget::removeEventListenerForBindings):
* Source/WebCore/dom/TrustedType.cpp:
(WebCore::trustedTypeCompliantString):
(WebCore::requireTrustedTypesForPreNavigationCheckPasses):
* Source/WebCore/html/Allowlist.h:
(WebCore::Allowlist::matches const):
* Source/WebCore/html/URLSearchParams.cpp:
(WebCore::URLSearchParams::create):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::makeImageDataIfContentsCached const):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::bufferData):
(WebCore::WebGLRenderingContextBase::bufferSubData):
(WebCore::WebGLRenderingContextBase::texImageSourceHelper):
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCueBox::applyCSSPropertiesWithRegion):
(WebCore::VTTCueBox::applyCSSProperties):
* Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp:
* Source/WebCore/platform/FixedContainerEdges.h:
(WebCore::FixedContainerEdges::hasFixedEdge const):
(WebCore::FixedContainerEdges::predominantColor const):
* Source/WebCore/platform/Length.cpp:
(WebCore::Length::typeFromIndex):
* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::DataSegment::span const):
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::realizeNextFallback):
* Source/WebCore/platform/network/DNS.cpp:
(WebCore::IPAddress::containsOnlyZeros const):
* Source/WebCore/rendering/style/ShapeValue.cpp:
(WebCore::ShapeValue::operator== const):
(WebCore::ShapeValue::canBlend const):
(WebCore::ShapeValue::blend const):
* Source/WebCore/rendering/style/StyleGridData.cpp:
(WebCore::StyleGridData::computeCachedTrackData):
(WebCore::operator&lt;&lt;):
* Source/WebCore/style/StyleInterpolationFunctions.h:
(WebCore::Style::Interpolation::canInterpolate):
(WebCore::Style::Interpolation::blendFunc):
* Source/WebCore/style/values/StyleValueTypes.h:
* Source/WebCore/style/values/images/StyleGradient.cpp:
(WebCore::Style::createPlatformGradient):
* Source/WebCore/style/values/shapes/StyleBasicShape.cpp:
(WebCore::Style::Blending&lt;BasicShape&gt;::canBlend):
(WebCore::Style::Blending&lt;BasicShape&gt;::blend):
* Source/WebCore/style/values/shapes/StyleCircleFunction.cpp:
(WebCore::Style::Blending&lt;Circle&gt;::canBlend):
(WebCore::Style::Blending&lt;Circle&gt;::blend):
* Source/WebCore/style/values/shapes/StyleEllipseFunction.cpp:
(WebCore::Style::Blending&lt;Ellipse&gt;::canBlend):
(WebCore::Style::Blending&lt;Ellipse&gt;::blend):
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::staticCheck):
* Source/WebKit/Platform/IPC/ArgumentCoders.h:
* Source/WebKit/Platform/IPC/MessageReceiveQueueMap.cpp:
(IPC::MessageReceiveQueueMap::get const):
* Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm:
(WebKit::MediaPlaybackTargetContextSerialized::platformContext const):
* Source/WebKit/Shared/Cocoa/CoreIPCContacts.mm:
(WebKit::nsArrayFromVectorOfLabeledValues):
* Source/WebKit/UIProcess/WebProcessActivityState.cpp:
(WebKit::WebProcessActivityState::takeMutedCaptureAssertion):
(WebKit::WebProcessActivityState::updateWebProcessSuspensionDelay):
(WebKit::WebProcessActivityState::process const):
* Tools/TestWebKitAPI/Tests/WTF/CompactVariant.cpp:
(TestWebKitAPI::TEST(WTF_CompactVariant, SmartPointers)):
(TestWebKitAPI::TEST(WTF_CompactVariant, ArgumentConstructInPlaceType)):
(TestWebKitAPI::TEST(WTF_CompactVariant, ArgumentConstructInPlaceIndex)):
(TestWebKitAPI::TEST(WTF_CompactVariant, CopyConstruct)):
(TestWebKitAPI::TEST(WTF_CompactVariant, CopyAssignment)):
(TestWebKitAPI::TEST(WTF_CompactVariant, MoveConstruct)):
(TestWebKitAPI::TEST(WTF_CompactVariant, MoveAssignment)):
(TestWebKitAPI::TEST(WTF_CompactVariant, ConstructThenReassign)):
(TestWebKitAPI::TEST(WTF_CompactVariant, SwitchOn)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PrivateClickMeasurement.mm:
(addValuesToTable):

Canonical link: <a href="https://commits.webkit.org/293819@main">https://commits.webkit.org/293819@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc0e25be05dfe6ad58feabcdc800ea0ea4ff2d9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9947 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105135 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50588 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102048 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28145 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76136 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33215 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90321 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56495 "Found 2 new API test failures: /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /TestWebKit:WebKit.OnDeviceChangeCrash (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15050 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8316 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49957 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92665 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84973 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107495 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98614 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27120 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85095 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27483 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86526 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84620 "run-api-tests-without-change (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29292 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7021 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20956 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16274 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27057 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32285 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122240 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26868 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34125 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30184 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28427 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->