### PR TITLE
Failing to load a web accessible resource from a subframe at about:blank

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -390,6 +390,10 @@ bool WebExtension::isWebAccessibleResource(const URL& resourceURL, const URL& pa
             continue;
 
         for (auto& pathPattern : data.resourcePathPatterns) {
+            // Because we remove the prefix slash from the resource path, we also have to remove it from the pattern path.
+            if (pathPattern.startsWith('/'))
+                pathPattern = pathPattern.substring(1);
+
             if (WebCore::matchesWildcardPattern(pathPattern, resourcePath))
                 return true;
         }


### PR DESCRIPTION
#### dbb4014be65b5a5020523c545b563179cdfd7891
<pre>
Failing to load a web accessible resource from a subframe at about:blank
<a href="https://bugs.webkit.org/show_bug.cgi?id=291696">https://bugs.webkit.org/show_bug.cgi?id=291696</a>
<a href="https://rdar.apple.com/149494286">rdar://149494286</a>

Reviewed by Timothy Hatcher.

This patch fixes a couple of bugs:

1) A subframe couldn&apos;t load a web accessible resource if its URL is about:blank.

2) A prefix slash in web accessible resource&apos;s resource path patterns would
   cause them to not be matched.

The first issue was caused by us inadvertently returning false from
isWebAccessibleResource in the extension URL scheme handler if a subframe was at
about:blank and trying to load a web accessible resource. The fix for this is to
use the parent frame&apos;s URL, rather than firstPartyForCookies, for the frame
document&apos;s URL if the frame isn&apos;t the main frame. This resolves a FIXME in the
code: <a href="https://rdar.apple.com/59193765">rdar://59193765</a>.

The second issue was caused by us dropping the prefix slash of the resource URL,
but not dropping it from the path pattern. Simply remove it from both.

I wrote new tests to validate these fixes.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm:
(WebKit::WebExtensionURLSchemeHandler::platformStartTask):
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::isWebAccessibleResource):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm:
(TestWebKitAPI::TEST(WKWebExtensionController, WebAccessibleResourcesWithLeadingSlash)):
(TestWebKitAPI::TEST(WKWebExtensionController, WebAccessibleResourceInSubframeFromAboutBlank)):

Canonical link: <a href="https://commits.webkit.org/293839@main">https://commits.webkit.org/293839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95ff7e40411aca33e11fd9b0eaa0ceead821d7c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105167 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50620 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102080 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28160 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76157 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33231 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103046 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15266 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90349 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56518 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15077 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8344 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49989 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84994 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8429 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107527 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27152 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19887 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85111 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27515 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86554 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84643 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21505 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29315 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7046 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20988 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27089 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32318 "Found 1 new failure in UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26900 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30216 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28459 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->