### PR TITLE
REGRESSION(293802@main): [MacOS Debug] ASSERTION FAILED: WTF::Ref<WTF::Thread, WTF::RawPtrTraits<WTF::Thread>, WTF::DefaultRefDerefTraits<WTF::Thread>>::ptr() const

### DIFF
--- a/Source/WebCore/style/MatchResultCache.cpp
+++ b/Source/WebCore/style/MatchResultCache.cpp
@@ -141,7 +141,7 @@ const std::optional<CachedMatchResult> MatchResultCache::resultWithCurrentInline
     if (it == m_entries.end())
         return { };
 
-    CheckedRef entry = *it->value;
+    auto& entry = *it->value;
 
     auto* styledElement = dynamicDowncast<StyledElement>(element);
     RefPtr inlineStyle = styledElement ? styledElement->inlineStyle() : nullptr;
@@ -154,9 +154,9 @@ const std::optional<CachedMatchResult> MatchResultCache::resultWithCurrentInline
     auto changedProperties = computeAndUpdateChangedProperties(entry);
 
     return CachedMatchResult {
-        .unadjustedStyle = copy(entry->unadjustedStyle),
+        .unadjustedStyle = copy(entry.unadjustedStyle),
         .changedProperties = WTFMove(changedProperties),
-        .styleToUpdate = *entry->unadjustedStyle.style
+        .styleToUpdate = *entry.unadjustedStyle.style
     };
 }
 


### PR DESCRIPTION
#### afbd9c78096be73620ec80bcb837afb2be3a00f4
<pre>
REGRESSION(293802@main): [MacOS Debug] ASSERTION FAILED: WTF::Ref&lt;WTF::Thread, WTF::RawPtrTraits&lt;WTF::Thread&gt;, WTF::DefaultRefDerefTraits&lt;WTF::Thread&gt;&gt;::ptr() const
<a href="https://bugs.webkit.org/show_bug.cgi?id=291702">https://bugs.webkit.org/show_bug.cgi?id=291702</a>

Unreviewed build fix/followup.

* Source/WebCore/style/MatchResultCache.cpp:
(WebCore::Style::MatchResultCache::resultWithCurrentInlineStyle):

Remove the mistaken (and unnecessary) use of CheckedRef.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afbd9c78096be73620ec80bcb837afb2be3a00f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19666 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9958 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105146 "Failed to checkout and rebase branch from PR 44215") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50599 "Failed to checkout and rebase branch from PR 44215") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102059 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19972 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28140 "Failed to checkout and rebase branch from PR 44215") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/105146 "Failed to checkout and rebase branch from PR 44215") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/50599 "Failed to checkout and rebase branch from PR 44215") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103025 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15252 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90333 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/105146 "Failed to checkout and rebase branch from PR 44215") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15062 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8328 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49968 "Failed to checkout and rebase branch from PR 44215") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8413 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107506 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27131 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19848 "Build was cancelled. Recent messages:OS: Sequoia (15.3), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85094 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27494 "Failed to checkout and rebase branch from PR 44215") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86538 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84619 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/21492 "The change is no longer eligible for processing.") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7031 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20967 "Failed to checkout and rebase branch from PR 44215") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27068 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32297 "Failed to checkout and rebase branch from PR 44215") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26879 "Failed to checkout and rebase branch from PR 44215") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30195 "Failed to checkout and rebase branch from PR 44215") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28438 "Failed to checkout and rebase branch from PR 44215") | | | 
<!--EWS-Status-Bubble-End-->