### PR TITLE
Revert 293802@main

### DIFF
--- a/Source/WebCore/css/CSSToStyleMap.cpp
+++ b/Source/WebCore/css/CSSToStyleMap.cpp
@@ -233,7 +233,8 @@ void CSSToStyleMap::mapFillXPosition(CSSPropertyID propertyID, FillLayer& layer,
         length = Style::BuilderConverter::convertPositionComponentX(m_builderState, value);
 
     layer.setXPosition(length);
-    layer.setBackgroundXOrigin(value.isPair() ? fromCSSValue<Edge>(value.first()) : Edge::Left);
+    if (value.isPair())
+        layer.setBackgroundXOrigin(fromCSSValue<Edge>(value.first()));
 }
 
 void CSSToStyleMap::mapFillYPosition(CSSPropertyID propertyID, FillLayer& layer, const CSSValue& value)
@@ -251,7 +252,8 @@ void CSSToStyleMap::mapFillYPosition(CSSPropertyID propertyID, FillLayer& layer,
         length = Style::BuilderConverter::convertPositionComponentY(m_builderState, value);
 
     layer.setYPosition(length);
-    layer.setBackgroundYOrigin(value.isPair() ? fromCSSValue<Edge>(value.first()) : Edge::Top);
+    if (value.isPair())
+        layer.setBackgroundYOrigin(fromCSSValue<Edge>(value.first()));
 }
 
 void CSSToStyleMap::mapFillMaskMode(CSSPropertyID propertyID, FillLayer& layer, const CSSValue& value)

--- a/Source/WebCore/platform/animation/Animation.h
+++ b/Source/WebCore/platform/animation/Animation.h
@@ -66,21 +66,12 @@ public:
 
     bool isEmpty() const
     {
-        return !m_nameSet
-            && !m_isNone
-            && (!m_directionSet || m_directionFilled)
-            && (!m_durationSet || m_durationFilled)
-            && (!m_fillModeSet || m_fillModeFilled)
-            && (!m_playStateSet || m_playStateFilled)
-            && (!m_iterationCountSet || m_iterationCountFilled)
-            && (!m_delaySet || m_delayFilled)
-            && (!m_timingFunctionSet || m_timingFunctionFilled)
-            && (!m_propertySet || m_propertyFilled)
-            && (!m_compositeOperationSet || m_compositeOperationFilled)
-            && (!m_timelineSet || m_timelineFilled)
-            && (!m_allowsDiscreteTransitionsSet || m_allowsDiscreteTransitionsFilled)
-            && (!m_rangeStartSet || m_rangeStartFilled)
-            && (!m_rangeEndSet || m_rangeEndFilled);
+        return !m_directionSet && !m_durationSet && !m_fillModeSet
+            && !m_nameSet && !m_playStateSet && !m_iterationCountSet
+            && !m_delaySet && !m_timingFunctionSet && !m_propertySet
+            && !m_isNone && !m_compositeOperationSet && !m_timelineSet
+            && !m_allowsDiscreteTransitionsSet && !m_rangeStartSet
+            && !m_rangeEndSet;
     }
 
     bool isEmptyOrZeroDuration() const
@@ -93,11 +84,7 @@ public:
     void clearDuration() { m_durationSet = false; m_durationFilled = false; }
     void clearFillMode() { m_fillModeSet = false; m_fillModeFilled = false; }
     void clearIterationCount() { m_iterationCountSet = false; m_iterationCountFilled = false; }
-    void clearName()
-    {
-        m_nameSet = false;
-        m_name = initialName();
-    }
+    void clearName() { m_nameSet = false; }
     void clearPlayState() { m_playStateSet = false; m_playStateFilled = false; }
     void clearProperty() { m_propertySet = false; m_propertyFilled = false; }
     void clearTimeline() { m_timelineSet = false; m_timelineFilled = false; }

--- a/Source/WebCore/style/MatchResultCache.h
+++ b/Source/WebCore/style/MatchResultCache.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include "PropertyCascade.h"
-#include "ResolvedStyle.h"
 #include <wtf/WeakHashMap.h>
 
 namespace WebCore {
@@ -36,11 +34,7 @@ class WeakPtrImplWithEventTargetData;
 
 namespace Style {
 
-struct CachedMatchResult {
-    UnadjustedStyle unadjustedStyle;
-    PropertyCascade::IncludedProperties changedProperties;
-    CheckedRef<RenderStyle> styleToUpdate;
-};
+struct MatchResult;
 
 class MatchResultCache {
     WTF_MAKE_FAST_ALLOCATED;
@@ -48,16 +42,11 @@ public:
     MatchResultCache();
     ~MatchResultCache();
 
-    const std::optional<CachedMatchResult> resultWithCurrentInlineStyle(const Element&);
-    static void update(CachedMatchResult&, const RenderStyle&);
-    void set(const Element&, const UnadjustedStyle&);
+    RefPtr<const MatchResult> get(const Element&);
+    void update(const Element&, const MatchResult&);
 
 private:
-    struct Entry;
-    static bool isUsableAfterInlineStyleChange(CheckedRef<const MatchResultCache::Entry>, const StyleProperties& inlineStyle);
-    static PropertyCascade::IncludedProperties computeAndUpdateChangedProperties(MatchResultCache::Entry&);
-
-    WeakHashMap<const Element, UniqueRef<Entry>, WeakPtrImplWithEventTargetData> m_entries;
+    WeakHashMap<const Element, RefPtr<const MatchResult>, WeakPtrImplWithEventTargetData> m_cachedMatchResults;
 };
 
 }

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -42,14 +42,12 @@ namespace Style {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PropertyCascade);
 
-PropertyCascade::PropertyCascade(const MatchResult& matchResult, CascadeLevel maximumCascadeLevel, IncludedProperties&& includedProperties, const UncheckedKeyHashSet<AnimatableCSSProperty>* animatedProperties, const StyleProperties* positionTryFallbackProperties)
+PropertyCascade::PropertyCascade(const MatchResult& matchResult, CascadeLevel maximumCascadeLevel, OptionSet<PropertyType> includedProperties, const UncheckedKeyHashSet<AnimatableCSSProperty>* animatedProperties, const StyleProperties* positionTryFallbackProperties)
     : m_matchResult(matchResult)
-    , m_includedProperties(WTFMove(includedProperties))
+    , m_includedProperties(includedProperties)
     , m_maximumCascadeLevel(maximumCascadeLevel)
     , m_animationLayer(animatedProperties ? std::optional { AnimationLayer { *animatedProperties } } : std::nullopt)
 {
-    ASSERT(!m_includedProperties.isEmpty());
-
     if (positionTryFallbackProperties)
         m_positionTryFallbackProperties = MatchedProperties { *positionTryFallbackProperties };
 
@@ -213,7 +211,7 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Casca
     if (m_maximumCascadeLayerPriorityForRollback && !includePropertiesForRollback())
         return false;
 
-    if (matchedProperties.isStartingStyle == IsStartingStyle::Yes && !m_includedProperties.types.contains(PropertyType::StartingStyle))
+    if (matchedProperties.isStartingStyle == IsStartingStyle::Yes && !m_includedProperties.contains(PropertyType::StartingStyle))
         return false;
 
     auto propertyAllowlist = matchedProperties.allowlistType;
@@ -239,20 +237,17 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Casca
             if (propertyAllowlist == PropertyAllowlist::Marker && !isValidMarkerStyleProperty(propertyID))
                 return false;
 
-            if (m_includedProperties.types.containsAll(normalPropertyTypes()))
+            if (m_includedProperties.containsAll(normalProperties()))
                 return true;
 
-            if (m_includedProperties.ids.contains(propertyID))
-                return true;
-
-            if (matchedProperties.isCacheable == IsCacheable::Partially && m_includedProperties.types.contains(PropertyType::NonCacheable))
+            if (matchedProperties.isCacheable == IsCacheable::Partially && m_includedProperties.contains(PropertyType::NonCacheable))
                 return true;
 
             // If we have applied this property for some reason already we must apply anything that overrides it.
             if (hasProperty(propertyID, *current.value()))
                 return true;
 
-            if (m_includedProperties.types.containsAny({ PropertyType::AfterAnimation, PropertyType::AfterTransition })) {
+            if (m_includedProperties.containsAny({ PropertyType::AfterAnimation, PropertyType::AfterTransition })) {
                 if (shouldApplyAfterAnimation(current)) {
                     m_animationLayer->overriddenProperties.add(propertyID);
                     return true;
@@ -261,11 +256,11 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Casca
             }
 
             bool currentIsInherited = CSSProperty::isInheritedProperty(current.id());
-            if (m_includedProperties.types.contains(PropertyType::Inherited) && currentIsInherited)
+            if (m_includedProperties.contains(PropertyType::Inherited) && currentIsInherited)
                 return true;
-            if (m_includedProperties.types.contains(PropertyType::ExplicitlyInherited) && isValueID(*current.value(), CSSValueInherit))
+            if (m_includedProperties.contains(PropertyType::ExplicitlyInherited) && isValueID(*current.value(), CSSValueInherit))
                 return true;
-            if (m_includedProperties.types.contains(PropertyType::NonInherited) && !currentIsInherited)
+            if (m_includedProperties.contains(PropertyType::NonInherited) && !currentIsInherited)
                 return true;
 
             // Apply all logical group properties if we have applied any. They may override the ones we already applied.
@@ -303,7 +298,7 @@ bool PropertyCascade::shouldApplyAfterAnimation(const StyleProperties::PropertyR
     if (isAnimatedProperty) {
         // "Important declarations from all origins take precedence over animations."
         // https://drafts.csswg.org/css-cascade-5/#importance
-        return m_includedProperties.types.contains(PropertyType::AfterAnimation) && property.isImportant();
+        return m_includedProperties.contains(PropertyType::AfterAnimation) && property.isImportant();
     }
 
     // If we are animating custom properties they may affect other properties so we need to re-resolve them.

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -51,21 +51,10 @@ public:
         StartingStyle = 1 << 5,
         NonCacheable = 1 << 6,
     };
+    static constexpr OptionSet<PropertyType> normalProperties() { return { PropertyType::NonInherited,  PropertyType::Inherited }; }
+    static constexpr OptionSet<PropertyType> startingStyleProperties() { return normalProperties() | PropertyType::StartingStyle; }
 
-    static constexpr OptionSet<PropertyType> normalPropertyTypes() { return { PropertyType::NonInherited,  PropertyType::Inherited }; }
-    static constexpr OptionSet<PropertyType> startingStylePropertyTypes() { return normalPropertyTypes() | PropertyType::StartingStyle; }
-
-    struct IncludedProperties {
-        OptionSet<PropertyType> types;
-        // Ids are mutually exclusive with types. They are low-priority only.
-        Vector<CSSPropertyID> ids { };
-
-        bool isEmpty() const { return !types && ids.isEmpty(); }
-    };
-
-    static IncludedProperties normalProperties() { return { normalPropertyTypes() }; }
-
-    PropertyCascade(const MatchResult&, CascadeLevel, IncludedProperties&&, const UncheckedKeyHashSet<AnimatableCSSProperty>* = nullptr, const StyleProperties* positionTryFallbackProperties = nullptr);
+    PropertyCascade(const MatchResult&, CascadeLevel, OptionSet<PropertyType> includedProperties, const UncheckedKeyHashSet<AnimatableCSSProperty>* = nullptr, const StyleProperties* positionTryFallbackProperties = nullptr);
     PropertyCascade(const PropertyCascade&, CascadeLevel, std::optional<ScopeOrdinal> rollbackScope = { }, std::optional<CascadeLayerPriority> maximumCascadeLayerPriorityForRollback = { });
 
     ~PropertyCascade();
@@ -100,8 +89,6 @@ public:
     PropertyBitSet& propertyIsPresent() { return m_propertyIsPresent; }
     const PropertyBitSet& propertyIsPresent() const { return m_propertyIsPresent; }
 
-    bool applyLowPriorityOnly() const { return !m_includedProperties.ids.isEmpty(); }
-
 private:
     void buildCascade();
     bool addNormalMatches(CascadeLevel);
@@ -121,7 +108,7 @@ private:
     void sortLogicalGroupPropertyIDs();
 
     const MatchResult& m_matchResult;
-    const IncludedProperties m_includedProperties;
+    const OptionSet<PropertyType> m_includedProperties;
     const CascadeLevel m_maximumCascadeLevel;
     const std::optional<ScopeOrdinal> m_rollbackScope;
     const std::optional<CascadeLayerPriority> m_maximumCascadeLayerPriorityForRollback;

--- a/Source/WebCore/style/ResolvedStyle.h
+++ b/Source/WebCore/style/ResolvedStyle.h
@@ -26,13 +26,6 @@
 namespace WebCore {
 namespace Style {
 
-struct UnadjustedStyle {
-    std::unique_ptr<RenderStyle> style;
-    std::unique_ptr<RenderStyle> userAgentAppearanceStyle;
-    std::unique_ptr<Relations> relations { };
-    RefPtr<const MatchResult> matchResult { };
-};
-
 struct ResolvedStyle {
     std::unique_ptr<RenderStyle> style;
     std::unique_ptr<Relations> relations { };

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -432,49 +432,6 @@ static UnicodeBidi forceBidiIsolationForRuby(UnicodeBidi unicodeBidi)
     return UnicodeBidi::Isolate;
 }
 
-static bool shouldTreatAutoZIndexAsZero(const RenderStyle& style)
-{
-    return style.hasOpacity()
-        || style.hasTransformRelatedProperty()
-        || style.hasMask()
-        || style.clipPath()
-        || style.boxReflect()
-        || style.hasFilter()
-        || style.hasBackdropFilter()
-#if HAVE(CORE_MATERIAL)
-        || style.hasAppleVisualEffect()
-#endif
-        || style.hasBlendMode()
-        || style.hasIsolation()
-        || style.position() == PositionType::Sticky
-        || style.position() == PositionType::Fixed
-        || style.willChangeCreatesStackingContext();
-}
-
-void Adjuster::adjustFromBuilder(RenderStyle& style)
-{
-    // Do some adjustments that don't depend on element or parent style and are safe to cache.
-    // This allows copy-on-write to trigger before caching.
-
-    if (style.hasAutoSpecifiedZIndex()) {
-        if (shouldTreatAutoZIndexAsZero(style))
-            style.setUsedZIndex(0);
-    } else if (style.position() != PositionType::Static)
-        style.setUsedZIndex(style.specifiedZIndex());
-
-    // Cull out any useless layers and also repeat patterns into additional layers.
-    style.adjustBackgroundLayers();
-    style.adjustMaskLayers();
-
-    // Do the same for animations and transitions.
-    style.adjustAnimations();
-    style.adjustTransitions();
-
-    // Do the same for scroll-timeline and view-timeline longhands.
-    style.adjustScrollTimelines();
-    style.adjustViewTimelines();
-}
-
 void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearanceStyle) const
 {
     if (style.display() == DisplayType::Contents)
@@ -577,7 +534,10 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
         return style.position() == PositionType::Static && !parentBoxStyle.isDisplayFlexibleOrGridBox();
     };
 
-    bool hasAutoSpecifiedZIndex = hasAutoZIndex(style, m_parentBoxStyle, m_element.get());
+    if (hasAutoZIndex(style, m_parentBoxStyle, m_element.get()))
+        style.setHasAutoUsedZIndex();
+    else
+        style.setUsedZIndex(style.specifiedZIndex());
 
     // For SVG compatibility purposes we have to consider the 'animatedLocalTransform' besides the RenderStyle to query
     // if an element has a transform. SVG transforms are not stored on the RenderStyle, and thus we need a special case here.
@@ -602,16 +562,26 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
     // Auto z-index becomes 0 for the root element and transparent objects. This prevents
     // cases where objects that should be blended as a single unit end up with a non-transparent
     // object wedged in between them. Auto z-index also becomes 0 for objects that specify transforms/masks/reflections.
-    if (hasAutoSpecifiedZIndex) {
+    if (style.hasAutoUsedZIndex()) {
         if ((m_element && m_document->documentElement() == m_element.get())
+            || style.hasOpacity()
             || hasTransformRelatedProperty(style, m_element.get(), m_parentStyle)
-            || shouldTreatAutoZIndexAsZero(style)
+            || style.hasMask()
+            || style.clipPath()
+            || style.boxReflect()
+            || style.hasFilter()
+            || style.hasBackdropFilter()
+#if HAVE(CORE_MATERIAL)
+            || style.hasAppleVisualEffect()
+#endif
+            || style.hasBlendMode()
+            || style.hasIsolation()
+            || style.position() == PositionType::Sticky
+            || style.position() == PositionType::Fixed
+            || style.willChangeCreatesStackingContext()
             || isInTopLayerOrBackdrop(style, m_element.get()))
             style.setUsedZIndex(0);
-        else
-            style.setHasAutoUsedZIndex();
-    } else
-        style.setUsedZIndex(style.specifiedZIndex());
+    }
 
     if (RefPtr element = m_element) {
         // Textarea considers overflow visible as auto.
@@ -698,6 +668,18 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
     if (style.hasAutoUsedZIndex() && style.useTouchOverflowScrolling() && (isScrollableOverflow(style.overflowX()) || isScrollableOverflow(style.overflowY())))
         style.setUsedZIndex(0);
 #endif
+
+    // Cull out any useless layers and also repeat patterns into additional layers.
+    style.adjustBackgroundLayers();
+    style.adjustMaskLayers();
+
+    // Do the same for animations and transitions.
+    style.adjustAnimations();
+    style.adjustTransitions();
+
+    // Do the same for scroll-timeline and view-timeline longhands.
+    style.adjustScrollTimelines();
+    style.adjustViewTimelines();
 
 #if PLATFORM(COCOA)
     static const bool shouldAddIntrinsicMarginToFormControls = !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::DoesNotAddIntrinsicMarginsToFormControls);

--- a/Source/WebCore/style/StyleAdjuster.h
+++ b/Source/WebCore/style/StyleAdjuster.h
@@ -49,7 +49,6 @@ class Adjuster {
 public:
     Adjuster(const Document&, const RenderStyle& parentStyle, const RenderStyle* parentBoxStyle, Element*);
 
-    static void adjustFromBuilder(RenderStyle&);
     void adjust(RenderStyle&, const RenderStyle* userAgentAppearanceStyle) const;
     void adjustAnimatedStyle(RenderStyle&, OptionSet<AnimationImpact>) const;
 

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -38,14 +38,13 @@ namespace Style {
 class Builder {
     WTF_MAKE_TZONE_ALLOCATED(Builder);
 public:
-    Builder(RenderStyle&, BuilderContext&&, const MatchResult&, CascadeLevel, PropertyCascade::IncludedProperties&& = PropertyCascade::normalProperties(), const UncheckedKeyHashSet<AnimatableCSSProperty>* animatedProperties = nullptr);
+    Builder(RenderStyle&, BuilderContext&&, const MatchResult&, CascadeLevel, OptionSet<PropertyCascade::PropertyType> = PropertyCascade::normalProperties(), const UncheckedKeyHashSet<AnimatableCSSProperty>* animatedProperties = nullptr);
     ~Builder();
 
     void applyAllProperties();
     void applyTopPriorityProperties();
     void applyHighPriorityProperties();
     void applyNonHighPriorityProperties();
-    void adjustAfterApplying();
 
     void applyProperty(CSSPropertyID propertyID) { applyProperties(propertyID, propertyID); }
     void applyCustomProperty(const AtomString& name);

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -52,7 +52,6 @@
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
 #include "Logging.h"
-#include "MatchResultCache.h"
 #include "MediaList.h"
 #include "MutableCSSSelector.h"
 #include "NodeRenderStyle.h"
@@ -143,7 +142,6 @@ public:
     void setStyle(std::unique_ptr<RenderStyle> style) { m_style = WTFMove(style); }
     RenderStyle* style() const { return m_style.get(); }
     std::unique_ptr<RenderStyle> takeStyle() { return WTFMove(m_style); }
-    std::unique_ptr<RenderStyle> takeUserAgentAppearanceStyle() { return WTFMove(m_userAgentAppearanceStyle); }
 
     void setParentStyle(std::unique_ptr<RenderStyle> parentStyle)
     {
@@ -271,13 +269,11 @@ void Resolver::addKeyframeStyle(Ref<StyleRuleKeyframes>&& rule)
     document().keyframesRuleDidChange(animationName);
 }
 
-auto Resolver::initializeStateAndStyle(const Element& element, const ResolutionContext& context, std::unique_ptr<RenderStyle>&& initialStyle) -> State
+auto Resolver::initializeStateAndStyle(const Element& element, const ResolutionContext& context) -> State
 {
     auto state = State { element, context.parentStyle, context.documentElementStyle, context.treeResolutionState.get() };
 
-    if (initialStyle)
-        state.setStyle(WTFMove(initialStyle));
-    else if (state.parentStyle()) {
+    if (state.parentStyle()) {
         state.setStyle(RenderStyle::createPtrWithRegisteredInitialValues(document().customPropertyRegistry()));
         if (&element == document().documentElement() && !context.isSVGUseTreeRoot) {
             // Initial values for custom properties are inserted to the document element style. Don't overwrite them.
@@ -315,7 +311,7 @@ BuilderContext Resolver::builderContext(State& state)
     };
 }
 
-UnadjustedStyle Resolver::unadjustedStyleForElement(Element& element, const ResolutionContext& context, RuleMatchingBehavior matchingBehavior)
+ResolvedStyle Resolver::styleForElement(Element& element, const ResolutionContext& context, RuleMatchingBehavior matchingBehavior)
 {
     auto state = initializeStateAndStyle(element, context);
     auto& style = *state.style();
@@ -335,58 +331,28 @@ UnadjustedStyle Resolver::unadjustedStyleForElement(Element& element, const Reso
 
     auto elementStyleRelations = commitRelationsToRenderStyle(style, element, collector.styleRelations());
 
-    applyMatchedProperties(state, collector.matchResult(), PropertyCascade::normalProperties());
+    applyMatchedProperties(state, collector.matchResult());
 
-    return {
-        .style = state.takeStyle(),
-        .userAgentAppearanceStyle = state.takeUserAgentAppearanceStyle(),
-        .relations = WTFMove(elementStyleRelations),
-        .matchResult = collector.releaseMatchResult()
-    };
+    Adjuster adjuster(document(), *state.parentStyle(), context.parentBoxStyle, &element);
+    adjuster.adjust(style, state.userAgentAppearanceStyle());
+
+    return { state.takeStyle(), WTFMove(elementStyleRelations), collector.releaseMatchResult() };
 }
 
-ResolvedStyle Resolver::styleForElement(Element& element, const ResolutionContext& context, RuleMatchingBehavior matchingBehavior)
+ResolvedStyle Resolver::styleForElementWithCachedMatchResult(Element& element, const ResolutionContext& context, const MatchResult& matchResult, const RenderStyle& existingRenderStyle)
 {
-    auto unadjustedStyle = unadjustedStyleForElement(element, context, matchingBehavior);
-    auto& parentStyle = context.parentStyle ? *context.parentStyle : RenderStyle::defaultStyle();
+    auto state = initializeStateAndStyle(element, context);
+    auto& style = *state.style();
 
-    auto style = WTFMove(unadjustedStyle.style);
+    style.copyPseudoElementBitsFrom(existingRenderStyle);
+    copyRelations(style, existingRenderStyle);
 
-    Adjuster adjuster(document(), parentStyle, context.parentBoxStyle, &element);
-    adjuster.adjust(*style, unadjustedStyle.userAgentAppearanceStyle.get());
+    applyMatchedProperties(state, matchResult);
 
-    return {
-        .style = WTFMove(style),
-        .relations = WTFMove(unadjustedStyle.relations),
-        .matchResult = WTFMove(unadjustedStyle.matchResult)
-    };
-}
+    Adjuster adjuster(document(), *state.parentStyle(), context.parentBoxStyle, &element);
+    adjuster.adjust(style, state.userAgentAppearanceStyle());
 
-UnadjustedStyle Resolver::unadjustedStyleForCachedMatchResult(Element& element, const ResolutionContext& context, CachedMatchResult&& cachedResult)
-{
-    auto& unadjustedStyle = cachedResult.unadjustedStyle;
-
-    if (cachedResult.changedProperties.isEmpty()) {
-        // The cached result can be used as-is.
-        return WTFMove(unadjustedStyle);
-    }
-
-    bool applyPartially = !cachedResult.changedProperties.ids.isEmpty();
-
-    auto state = initializeStateAndStyle(element, context, applyPartially ? WTFMove(unadjustedStyle.style) : nullptr);
-    if (!applyPartially) {
-        state.style()->copyPseudoElementBitsFrom(*unadjustedStyle.style);
-        copyRelations(*state.style(), *unadjustedStyle.style);
-    }
-
-    applyMatchedProperties(state, *unadjustedStyle.matchResult, WTFMove(cachedResult.changedProperties));
-
-    return {
-        .style = state.takeStyle(),
-        .userAgentAppearanceStyle = state.takeUserAgentAppearanceStyle(),
-        .relations = WTFMove(unadjustedStyle.relations),
-        .matchResult = unadjustedStyle.matchResult
-    };
+    return { state.takeStyle(), { }, &matchResult };
 }
 
 std::unique_ptr<RenderStyle> Resolver::styleForKeyframe(Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, const StyleRuleKeyframe& keyframe, BlendingKeyframe& blendingKeyframe)
@@ -599,7 +565,7 @@ std::optional<ResolvedStyle> Resolver::styleForPseudoElement(Element& element, c
     if (!pseudoElementRequest.nameArgument().isNull())
         state.style()->setPseudoElementNameArgument(pseudoElementRequest.nameArgument());
 
-    applyMatchedProperties(state, collector.matchResult(), PropertyCascade::normalProperties());
+    applyMatchedProperties(state, collector.matchResult());
 
     Adjuster adjuster(document(), *state.parentStyle(), context.parentBoxStyle, nullptr);
     adjuster.adjust(*state.style(), state.userAgentAppearanceStyle());
@@ -707,13 +673,14 @@ void Resolver::clearCachedDeclarationsAffectedByViewportUnits()
     m_matchedDeclarationsCache.clearEntriesAffectedByViewportUnits();
 }
 
-void Resolver::applyMatchedProperties(State& state, const MatchResult& matchResult, PropertyCascade::IncludedProperties&& includedProperties)
+void Resolver::applyMatchedProperties(State& state, const MatchResult& matchResult)
 {
     auto& style = *state.style();
     auto& parentStyle = *state.parentStyle();
     auto& element = *state.element();
 
     unsigned cacheHash = MatchedDeclarationsCache::computeHash(matchResult, parentStyle.inheritedCustomProperties());
+    auto includedProperties = PropertyCascade::normalProperties();
 
     auto* cacheEntry = m_matchedDeclarationsCache.find(cacheHash, matchResult, parentStyle.inheritedCustomProperties());
 
@@ -749,11 +716,11 @@ void Resolver::applyMatchedProperties(State& state, const MatchResult& matchResu
         includedProperties = { };
 
         if (!inheritedEqual)
-            includedProperties.types.add(PropertyCascade::PropertyType::Inherited);
+            includedProperties.add(PropertyCascade::PropertyType::Inherited);
         if (!explicitlyInheritedEqual)
-            includedProperties.types.add(PropertyCascade::PropertyType::ExplicitlyInherited);
+            includedProperties.add(PropertyCascade::PropertyType::ExplicitlyInherited);
         if (!matchResult.nonCacheablePropertyIds.isEmpty())
-            includedProperties.types.add(PropertyCascade::PropertyType::NonCacheable);
+            includedProperties.add(PropertyCascade::PropertyType::NonCacheable);
     }
 
     if (elementTypeHasAppearanceFromUAStyle(element)) {
@@ -767,7 +734,7 @@ void Resolver::applyMatchedProperties(State& state, const MatchResult& matchResu
         state.setUserAgentAppearanceStyle(WTFMove(userAgentStyle));
     }
 
-    Builder builder(style, builderContext(state), matchResult, CascadeLevel::Author, WTFMove(includedProperties));
+    Builder builder(style, builderContext(state), matchResult, CascadeLevel::Author, includedProperties);
 
     // Top priority properties may affect resolution of high priority ones.
     builder.applyTopPriorityProperties();
@@ -778,29 +745,22 @@ void Resolver::applyMatchedProperties(State& state, const MatchResult& matchResu
     if (cacheEntry && !cacheEntry->isUsableAfterHighPriorityProperties(style)) {
         // High-priority properties may affect resolution of other properties. Kick out the existing cache entry and try again.
         m_matchedDeclarationsCache.remove(cacheHash);
-        applyMatchedProperties(state, matchResult, PropertyCascade::normalProperties());
+        applyMatchedProperties(state, matchResult);
         return;
     }
 
     builder.applyNonHighPriorityProperties();
-    builder.adjustAfterApplying();
 
-    setGlobalStateAfterApplyingProperties(builder.state());
+    for (auto& contentAttribute : builder.state().registeredContentAttributes())
+        ruleSets().mutableFeatures().registerContentAttribute(contentAttribute);
+    if (style.usesViewportUnits())
+        document().setHasStyleWithViewportUnits();
 
     if (cacheEntry || !cacheHash)
         return;
 
     if (MatchedDeclarationsCache::isCacheable(element, style, parentStyle))
         m_matchedDeclarationsCache.add(style, parentStyle, state.userAgentAppearanceStyle(), cacheHash, matchResult);
-}
-
-void Resolver::setGlobalStateAfterApplyingProperties(const BuilderState& builderState)
-{
-    // FIXME: This stuff should be somewhere else.
-    for (auto& contentAttribute : builderState.registeredContentAttributes())
-        ruleSets().mutableFeatures().registerContentAttribute(contentAttribute);
-    if (builderState.style().usesViewportUnits())
-        document().setHasStyleWithViewportUnits();
 }
 
 bool Resolver::hasSelectorForAttribute(const Element& element, const AtomString& attributeName) const

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -26,7 +26,6 @@
 #include "InspectorCSSOMWrappers.h"
 #include "MatchedDeclarationsCache.h"
 #include "MediaQueryEvaluator.h"
-#include "PropertyCascade.h"
 #include "RuleSet.h"
 #include "StyleScopeRuleSets.h"
 #include "TreeResolutionState.h"
@@ -73,10 +72,8 @@ enum class RuleMatchingBehavior: uint8_t {
 namespace Style {
 
 struct BuilderContext;
-struct CachedMatchResult;
 struct ResolvedStyle;
 struct SelectorMatchingState;
-struct UnadjustedStyle;
 
 struct ResolutionContext {
     const RenderStyle* parentStyle;
@@ -99,10 +96,8 @@ public:
     static Ref<Resolver> create(Document&, ScopeType);
     ~Resolver();
 
-    UnadjustedStyle unadjustedStyleForElement(Element&, const ResolutionContext&, RuleMatchingBehavior = RuleMatchingBehavior::MatchAllRules);
-    UnadjustedStyle unadjustedStyleForCachedMatchResult(Element&, const ResolutionContext&, CachedMatchResult&&);
-
     ResolvedStyle styleForElement(Element&, const ResolutionContext&, RuleMatchingBehavior = RuleMatchingBehavior::MatchAllRules);
+    ResolvedStyle styleForElementWithCachedMatchResult(Element&, const ResolutionContext&, const MatchResult&, const RenderStyle& existingRenderStyle);
 
     void keyframeStylesForAnimation(Element&, const RenderStyle& elementStyle, const ResolutionContext&, BlendingKeyframes&, const TimingFunction*);
 
@@ -175,11 +170,10 @@ private:
 
     class State;
 
-    State initializeStateAndStyle(const Element&, const ResolutionContext&, std::unique_ptr<RenderStyle>&& initialStyle = { });
+    State initializeStateAndStyle(const Element&, const ResolutionContext&);
     BuilderContext builderContext(State&);
 
-    void applyMatchedProperties(State&, const MatchResult&, PropertyCascade::IncludedProperties&&);
-    void setGlobalStateAfterApplyingProperties(const BuilderState&);
+    void applyMatchedProperties(State&, const MatchResult&);
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     const ScopeType m_scopeType;

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -172,32 +172,19 @@ ResolvedStyle TreeResolver::styleForStyleable(const Styleable& styleable, Resolu
         return { WTFMove(style) };
     }
 
-    auto unadjustedStyle = [&] {
-        if (resolutionType == ResolutionType::FullWithMatchResultCache) {
-            if (auto cachedResult = m_document->styleScope().matchResultCache().resultWithCurrentInlineStyle(element)) {
-                auto result = scope().resolver->unadjustedStyleForCachedMatchResult(element, resolutionContext, WTFMove(*cachedResult));
-                MatchResultCache::update(*cachedResult, *result.style);
-                return result;
-            }
-        }
-        auto result = scope().resolver->unadjustedStyleForElement(element, resolutionContext);
-        m_document->styleScope().matchResultCache().set(element, result);
-        return result;
-    }();
+    if (resolutionType == ResolutionType::FullWithMatchResultCache) {
+        if (auto cachedMatchResult = m_document->styleScope().matchResultCache().get(element))
+            return scope().resolver->styleForElementWithCachedMatchResult(element, resolutionContext, *cachedMatchResult, *existingStyle);
+    }
 
-    if (unadjustedStyle.relations)
-        commitRelations(WTFMove(unadjustedStyle.relations), *m_update);
+    auto elementStyle = scope().resolver->styleForElement(element, resolutionContext);
 
-    auto style = WTFMove(unadjustedStyle.style);
+    if (elementStyle.relations)
+        commitRelations(WTFMove(elementStyle.relations), *m_update);
 
-    Adjuster adjuster(m_document, *resolutionContext.parentStyle, resolutionContext.parentBoxStyle, &element);
-    adjuster.adjust(*style, unadjustedStyle.userAgentAppearanceStyle.get());
+    m_document->styleScope().matchResultCache().update(element, *elementStyle.matchResult);
 
-    return {
-        .style = WTFMove(style),
-        .relations = { },
-        .matchResult = WTFMove(unadjustedStyle.matchResult)
-    };
+    return elementStyle;
 }
 
 static void resetStyleForNonRenderedDescendants(Element& current)
@@ -835,7 +822,7 @@ std::unique_ptr<RenderStyle> TreeResolver::resolveStartingStyle(const ResolvedSt
     // We now resolve the starting style by applying all rules (including @starting-style ones) again.
     // We could compute it along with the primary style and include it in MatchedPropertiesCache but it is not
     // clear this would be benefitial as it is typically only used once.
-    return resolveAgainInDifferentContext(resolvedStyle, styleable, parentStyle, PropertyCascade::startingStylePropertyTypes(), { }, resolutionContext);
+    return resolveAgainInDifferentContext(resolvedStyle, styleable, parentStyle, PropertyCascade::startingStyleProperties(), { }, resolutionContext);
 }
 
 std::unique_ptr<RenderStyle> TreeResolver::resolveAfterChangeStyleForNonAnimated(const ResolvedStyle& resolvedStyle, const Styleable& styleable, const ResolutionContext& resolutionContext)
@@ -856,7 +843,7 @@ std::unique_ptr<RenderStyle> TreeResolver::resolveAfterChangeStyleForNonAnimated
 
     // "Likewise, define the after-change style as.. and inheriting from the after-change style of the parent."
     auto& parentStyle = parentAfterChangeStyle(styleable, resolutionContext);
-    return resolveAgainInDifferentContext(resolvedStyle, styleable, parentStyle, PropertyCascade::normalPropertyTypes(), { }, resolutionContext);
+    return resolveAgainInDifferentContext(resolvedStyle, styleable, parentStyle, PropertyCascade::normalProperties(), { }, resolutionContext);
 }
 
 std::unique_ptr<RenderStyle> TreeResolver::resolveAgainInDifferentContext(const ResolvedStyle& resolvedStyle, const Styleable& styleable, const RenderStyle& parentStyle, OptionSet<PropertyCascade::PropertyType> properties, std::optional<BuilderPositionTryFallback>&& positionTryFallback, const ResolutionContext& resolutionContext)
@@ -883,7 +870,7 @@ std::unique_ptr<RenderStyle> TreeResolver::resolveAgainInDifferentContext(const 
         WTFMove(builderContext),
         *resolvedStyle.matchResult,
         CascadeLevel::Author,
-        { properties }
+        properties
     };
 
     styleBuilder.applyAllProperties();
@@ -921,7 +908,7 @@ UncheckedKeyHashSet<AnimatableCSSProperty> TreeResolver::applyCascadeAfterAnimat
         WTFMove(builderContext),
         matchResult,
         CascadeLevel::Author,
-        { isTransition ? PropertyCascade::PropertyType::AfterTransition : PropertyCascade::PropertyType::AfterAnimation },
+        isTransition ? PropertyCascade::PropertyType::AfterTransition : PropertyCascade::PropertyType::AfterAnimation,
         &animatedProperties
     };
 
@@ -1408,7 +1395,7 @@ std::unique_ptr<RenderStyle> TreeResolver::generatePositionOption(const Position
         .tactics = fallback.tactics
     };
 
-    return resolveAgainInDifferentContext(resolvedStyle, styleable, *resolutionContext.parentStyle, PropertyCascade::normalPropertyTypes(), WTFMove(builderFallback), resolutionContext);
+    return resolveAgainInDifferentContext(resolvedStyle, styleable, *resolutionContext.parentStyle, PropertyCascade::normalProperties(), WTFMove(builderFallback), resolutionContext);
 }
 
 void TreeResolver::sortPositionOptionsIfNeeded(PositionOptions& options, const Styleable& styleable)


### PR DESCRIPTION
#### aa9152749c901eafc5008e561687ee2de74c6d51
<pre>
Revert 293802@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=291703">https://bugs.webkit.org/show_bug.cgi?id=291703</a>

Unreviewed.

It caused many assertions in debug tests.

* Source/WebCore/css/CSSToStyleMap.cpp:
(WebCore::CSSToStyleMap::mapFillXPosition):
(WebCore::CSSToStyleMap::mapFillYPosition):
* Source/WebCore/platform/animation/Animation.h:
(WebCore::Animation::isEmpty const):
(WebCore::Animation::clearName):
* Source/WebCore/style/MatchResultCache.cpp:
(WebCore::Style::MatchResultCache::get):
(WebCore::Style::MatchResultCache::update):
(WebCore::Style::MatchResultCache::Entry::Entry): Deleted.
(WebCore::Style::copy): Deleted.
(WebCore::Style::MatchResultCache::isUsableAfterInlineStyleChange): Deleted.
(WebCore::Style::MatchResultCache::computeAndUpdateChangedProperties): Deleted.
(WebCore::Style::MatchResultCache::resultWithCurrentInlineStyle): Deleted.
(WebCore::Style::MatchResultCache::set): Deleted.
* Source/WebCore/style/MatchResultCache.h:
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::PropertyCascade):
(WebCore::Style::PropertyCascade::addMatch):
(WebCore::Style::PropertyCascade::shouldApplyAfterAnimation):
* Source/WebCore/style/PropertyCascade.h:
(WebCore::Style::PropertyCascade::normalProperties):
(WebCore::Style::PropertyCascade::startingStyleProperties):
(WebCore::Style::PropertyCascade::normalPropertyTypes): Deleted.
(WebCore::Style::PropertyCascade::startingStylePropertyTypes): Deleted.
(WebCore::Style::PropertyCascade::IncludedProperties::isEmpty const): Deleted.
(WebCore::Style::PropertyCascade::applyLowPriorityOnly const): Deleted.
* Source/WebCore/style/ResolvedStyle.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
(WebCore::Style::shouldTreatAutoZIndexAsZero): Deleted.
(WebCore::Style::Adjuster::adjustFromBuilder): Deleted.
* Source/WebCore/style/StyleAdjuster.h:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::Builder):
(WebCore::Style::Builder::applyAllProperties):
(WebCore::Style::Builder::applyTopPriorityProperties):
(WebCore::Style::Builder::applyHighPriorityProperties):
(WebCore::Style::Builder::adjustAfterApplying): Deleted.
* Source/WebCore/style/StyleBuilder.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::State::takeStyle):
(WebCore::Style::Resolver::initializeStateAndStyle):
(WebCore::Style::Resolver::styleForElement):
(WebCore::Style::Resolver::styleForElementWithCachedMatchResult):
(WebCore::Style::Resolver::styleForPseudoElement):
(WebCore::Style::Resolver::applyMatchedProperties):
(WebCore::Style::Resolver::State::takeUserAgentAppearanceStyle): Deleted.
(WebCore::Style::Resolver::unadjustedStyleForElement): Deleted.
(WebCore::Style::Resolver::unadjustedStyleForCachedMatchResult): Deleted.
(WebCore::Style::Resolver::setGlobalStateAfterApplyingProperties): Deleted.
* Source/WebCore/style/StyleResolver.h:
(WebCore::Style::Resolver::initializeStateAndStyle): Deleted.
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::styleForStyleable):
(WebCore::Style::TreeResolver::resolveStartingStyle):
(WebCore::Style::TreeResolver::resolveAfterChangeStyleForNonAnimated):
(WebCore::Style::TreeResolver::resolveAgainInDifferentContext):
(WebCore::Style::TreeResolver::applyCascadeAfterAnimation):
(WebCore::Style::TreeResolver::generatePositionOption):

Canonical link: <a href="https://commits.webkit.org/293815@main">https://commits.webkit.org/293815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78e894d877f81b548ae9583fff66a831b46ce07e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9962 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/105150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/50603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102063 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28121 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/105150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/50603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103029 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/15253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/90327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/105150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/15063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/8322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/49972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/8407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/107510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/27135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/107510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/27498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/86532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/107510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/7027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/20971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16269 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27072 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/32301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/26883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/30199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/28442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->