### PR TITLE
ServiceWorkerRegistryData is often copied to completion handlers when caller is attempting to Move the data

### DIFF
--- a/Source/WebCore/workers/service/server/SWRegistrationStore.h
+++ b/Source/WebCore/workers/service/server/SWRegistrationStore.h
@@ -44,7 +44,7 @@ public:
     virtual void clearAll(CompletionHandler<void()>&&) = 0;
     virtual void flushChanges(CompletionHandler<void()>&&) = 0;
     virtual void closeFiles(CompletionHandler<void()>&&) = 0;
-    virtual void importRegistrations(CompletionHandler<void(std::optional<Vector<ServiceWorkerContextData>>)>&&) = 0;
+    virtual void importRegistrations(CompletionHandler<void(std::optional<Vector<ServiceWorkerContextData>>&&)>&&) = 0;
     virtual void updateRegistration(const ServiceWorkerContextData&) = 0;
     virtual void removeRegistration(const ServiceWorkerRegistrationKey&) = 0;
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp
@@ -79,7 +79,7 @@ void WebSWRegistrationStore::closeFiles(CompletionHandler<void()>&& callback)
         callback();
 }
 
-void WebSWRegistrationStore::importRegistrations(CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerContextData>>)>&& callback)
+void WebSWRegistrationStore::importRegistrations(CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerContextData>>&&)>&& callback)
 {
     if (RefPtr manager = m_manager.get())
         manager->importServiceWorkerRegistrations(WTFMove(callback));

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h
@@ -55,7 +55,7 @@ private:
     void clearAll(CompletionHandler<void()>&&);
     void flushChanges(CompletionHandler<void()>&&);
     void closeFiles(CompletionHandler<void()>&&);
-    void importRegistrations(CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerContextData>>)>&&);
+    void importRegistrations(CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerContextData>>&&)>&&);
     void updateRegistration(const WebCore::ServiceWorkerContextData&);
     void removeRegistration(const WebCore::ServiceWorkerRegistrationKey&);
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -2145,7 +2145,7 @@ void NetworkStorageManager::clearServiceWorkerRegistrations(CompletionHandler<vo
     });
 }
 
-void NetworkStorageManager::importServiceWorkerRegistrations(CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerContextData>>)>&& completionHandler)
+void NetworkStorageManager::importServiceWorkerRegistrations(CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerContextData>>&&)>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
 
@@ -2169,7 +2169,7 @@ void NetworkStorageManager::importServiceWorkerRegistrations(CompletionHandler<v
                 removeOriginStorageManagerIfPossible(origin);
             }
             if (hasResult)
-                result = registrations;
+                result = WTFMove(registrations);
         }
 
         RunLoop::protectedMain()->dispatch([protectedThis = WTFMove(protectedThis), result = crossThreadCopy(WTFMove(result)), completionHandler = WTFMove(completionHandler)]() mutable {

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -145,7 +145,7 @@ public:
     void notifyBackgroundFetchChange(const String&, BackgroundFetchChange);
     void closeServiceWorkerRegistrationFiles(CompletionHandler<void()>&&);
     void clearServiceWorkerRegistrations(CompletionHandler<void()>&&);
-    void importServiceWorkerRegistrations(CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerContextData>>)>&&);
+    void importServiceWorkerRegistrations(CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerContextData>>&&)>&&);
     void updateServiceWorkerRegistrations(Vector<WebCore::ServiceWorkerContextData>&&, Vector<WebCore::ServiceWorkerRegistrationKey>&&, CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerScripts>>)>&&);
     const String& path() const { return m_pathNormalizedMainThread; }
     const String& customIDBStoragePath() const { return m_customIDBStoragePathNormalizedMainThread; }


### PR DESCRIPTION
#### 686de01dd3e866d98c950b4054ff65953aa97474
<pre>
ServiceWorkerRegistryData is often copied to completion handlers when caller is attempting to Move the data
<a href="https://bugs.webkit.org/show_bug.cgi?id=291701">https://bugs.webkit.org/show_bug.cgi?id=291701</a>
<a href="https://rdar.apple.com/149497889">rdar://149497889</a>

Reviewed by Sihui Liu.

The signature for `importServiceWorkerRegistrations` takes a CompletionHandler that takes
`std::optional&lt;Vector&lt;WebCore::ServiceWorkerContextData&gt;&gt;` as its argument. This requires a copy of
the Vector of items.

The only caller of this API attempts to Move this vector, so the signature should allow the move.

* Source/WebCore/workers/service/server/SWRegistrationStore.h: Indicate move operation.
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp:
(WebKit::WebSWRegistrationStore::importRegistrations): Ditto.
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::importServiceWorkerRegistrations): Ditto.
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:

Canonical link: <a href="https://commits.webkit.org/293859@main">https://commits.webkit.org/293859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b972706bdc2be93ca06530a2bc87b3b08166b22

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100025 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105153 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50606 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102066 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19979 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28128 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76142 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33223 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103032 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15340 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90338 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56502 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15066 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8333 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49975 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84985 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107513 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27138 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19861 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85099 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27501 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86543 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84625 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29304 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7036 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20974 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16292 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27075 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32304 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26886 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30202 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28445 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->