### PR TITLE
[Screen Time Refactoring] Release logging is misleading

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -476,18 +476,18 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
             [_screenTimeWebpageController setURL:[self _mainFrameURL]];
         if (!showsSystemScreenTimeBlockingView && _screenTimeBlurredSnapshot) {
             [_screenTimeBlurredSnapshot setHidden:NO];
-            RELEASE_LOG(ScreenTime, "Screen Time has updated visibility to show blurred view.");
+            RELEASE_LOG(ScreenTime, "Screen Time has updated to use the blurred view for any blocked URL.");
         } else if (showsSystemScreenTimeBlockingView) {
             [[_screenTimeWebpageController view] setHidden:NO];
-            RELEASE_LOG(ScreenTime, "Screen Time has updated visibility to show system shield.");
+            RELEASE_LOG(ScreenTime, "Screen Time has updated to use the system shield for any blocked URL.");
         }
     } else {
         if (_screenTimeBlurredSnapshot) {
             [_screenTimeBlurredSnapshot setHidden:YES];
-            RELEASE_LOG(ScreenTime, "Screen Time has updated visibility to hide blurred view.");
+            RELEASE_LOG(ScreenTime, "Screen Time has updated to hide the blurred view for all URLs.");
         } else if (showsSystemScreenTimeBlockingView) {
             [[_screenTimeWebpageController view] setHidden:YES];
-            RELEASE_LOG(ScreenTime, "Screen Time has updated visibility to hide system shield.");
+            RELEASE_LOG(ScreenTime, "Screen Time has updated to hide the system shield for all URLs.");
         }
     }
 


### PR DESCRIPTION
#### 080ba831fd4ff2abf7f8bb117104af0af2578795
<pre>
[Screen Time Refactoring] Release logging is misleading
<a href="https://bugs.webkit.org/show_bug.cgi?id=291704">https://bugs.webkit.org/show_bug.cgi?id=291704</a>
<a href="https://rdar.apple.com/149502357">rdar://149502357</a>

Reviewed by Aditya Keerthi.

Currently, the release log to aid in debugging Screen Time
is causing confusing and is misleading.

For example, &quot;Screen Time has updated visibility to show system shield&quot;
does not mean that a Screen Time shield is up right now. It is
supposed to convey that if there is a blocked URL, we are
configured to show the system shield in the blocked case.

Thus, change release logging to be avoid confusion.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _updateScreenTimeBasedOnWindowVisibility]):

Canonical link: <a href="https://commits.webkit.org/293834@main">https://commits.webkit.org/293834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddea6aa74c7814e7dd84372c7cfdded3996af756

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105158 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50611 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28151 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76147 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33226 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15260 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90342 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56507 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15071 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49980 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84989 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107518 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27143 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19883 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85109 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27506 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86547 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84640 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29307 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7039 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20979 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16281 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27080 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32309 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26891 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30207 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28450 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->