### PR TITLE
Update context menu images for internal clients

### DIFF
--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -713,18 +713,16 @@ void ContextMenuController::createAndAppendFontSubMenu(ContextMenuItem& fontMenu
 #if PLATFORM(COCOA)
     ContextMenuItem styles(ContextMenuItemType::Action, ContextMenuItemTagStyles, contextMenuItemTagStyles());
     ContextMenuItem showColors(ContextMenuItemType::Action, ContextMenuItemTagShowColors, contextMenuItemTagShowColors());
-#endif
-
-#if PLATFORM(COCOA)
     appendItem(showFonts, &fontMenu);
+    appendItem(*separatorItem(), &fontMenu);
 #endif
     appendItem(bold, &fontMenu);
     appendItem(italic, &fontMenu);
     appendItem(underline, &fontMenu);
+    appendItem(*separatorItem(), &fontMenu);
     appendItem(outline, &fontMenu);
 #if PLATFORM(COCOA)
     appendItem(styles, &fontMenu);
-    appendItem(*separatorItem(), &fontMenu);
     appendItem(showColors, &fontMenu);
 #endif
 

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -511,9 +511,9 @@ String contextMenuItemTagWritingTools()
 #endif
 
 #if ENABLE(UNIFIED_PDF)
-String contextMenuItemPDFOpenWithPreview()
+String contextMenuItemPDFOpenWithDefaultViewer(const String& appName)
 {
-    return WEB_UI_STRING("Open with Preview", "Open with Preview context menu item");
+    return WEB_UI_FORMAT_STRING("Open with %@", "Open with default PDF viewer context menu item", appName.createCFString().get());
 }
 #endif
 

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -181,7 +181,7 @@ namespace WebCore {
     String contextMenuItemTagWritingTools();
 #endif
 #if ENABLE(UNIFIED_PDF)
-    WEBCORE_EXPORT String contextMenuItemPDFOpenWithPreview();
+    WEBCORE_EXPORT String contextMenuItemPDFOpenWithDefaultViewer(const String& appName);
 #endif
 #if ENABLE(PDFJS) || ENABLE(UNIFIED_PDF)
     WEBCORE_EXPORT String contextMenuItemPDFSinglePage();

--- a/Source/WebKit/Platform/mac/MenuUtilities.mm
+++ b/Source/WebKit/Platform/mac/MenuUtilities.mm
@@ -169,16 +169,35 @@ NSString *symbolNameForAction(const WebCore::ContextMenuAction action, bool useA
     case WebCore::ContextMenuItemBaseApplicationTag:
     case WebCore::ContextMenuItemBaseCustomTag:
     case WebCore::ContextMenuItemLastCustomTag:
+    case WebCore::ContextMenuItemPDFContinuous:
+    case WebCore::ContextMenuItemPDFFacingPages:
+    case WebCore::ContextMenuItemPDFSinglePage:
+    case WebCore::ContextMenuItemPDFSinglePageContinuous:
+    case WebCore::ContextMenuItemPDFTwoPages:
+    case WebCore::ContextMenuItemPDFTwoPagesContinuous:
+    case WebCore::ContextMenuItemTagCheckGrammarWithSpelling:
+    case WebCore::ContextMenuItemTagCheckSpellingWhileTyping:
+    case WebCore::ContextMenuItemTagCorrectSpellingAutomatically:
     case WebCore::ContextMenuItemTagDictationAlternative:
     case WebCore::ContextMenuItemTagFontMenu:
     case WebCore::ContextMenuItemTagNoAction:
     case WebCore::ContextMenuItemTagNoGuessesFound:
     case WebCore::ContextMenuItemTagOther:
-    case WebCore::ContextMenuItemTagSpellingGuess:
+    case WebCore::ContextMenuItemTagOutline:
+    case WebCore::ContextMenuItemTagPDFFacingPagesScrolling:
+    case WebCore::ContextMenuItemTagPDFSinglePageScrolling:
+    case WebCore::ContextMenuItemTagShowMediaStats:
+    case WebCore::ContextMenuItemTagSmartCopyPaste:
+    case WebCore::ContextMenuItemTagSmartDashes:
+    case WebCore::ContextMenuItemTagSmartLinks:
+    case WebCore::ContextMenuItemTagSmartQuotes:
     case WebCore::ContextMenuItemTagSpeechMenu:
+    case WebCore::ContextMenuItemTagSpellingGuess:
     case WebCore::ContextMenuItemTagSpellingMenu:
+    case WebCore::ContextMenuItemTagStyles:
     case WebCore::ContextMenuItemTagSubstitutionsMenu:
     case WebCore::ContextMenuItemTagTextDirectionMenu:
+    case WebCore::ContextMenuItemTagTextReplacement:
     case WebCore::ContextMenuItemTagTransformationsMenu:
     case WebCore::ContextMenuItemTagWritingDirectionMenu:
     case WebCore::ContextMenuItemTagWritingTools:
@@ -187,22 +206,10 @@ NSString *symbolNameForAction(const WebCore::ContextMenuAction action, bool useA
         return @"sparkle.magnifyingglass";
     case WebCore::ContextMenuItemPDFActualSize:
         return @"text.magnifyingglass";
-    case WebCore::ContextMenuItemPDFContinuous:
-    case WebCore::ContextMenuItemPDFSinglePageContinuous:
-    case WebCore::ContextMenuItemTagPDFSinglePageScrolling:
-        return @"rectangle.stack";
-    case WebCore::ContextMenuItemPDFFacingPages:
-    case WebCore::ContextMenuItemPDFTwoPages:
-        return @"rectangle.split.2x1";
     case WebCore::ContextMenuItemPDFNextPage:
         return @"chevron.right";
     case WebCore::ContextMenuItemPDFPreviousPage:
         return @"chevron.left";
-    case WebCore::ContextMenuItemPDFSinglePage:
-        return @"rectangle.portrait";
-    case WebCore::ContextMenuItemPDFTwoPagesContinuous:
-    case WebCore::ContextMenuItemTagPDFFacingPagesScrolling:
-        return @"rectangle.stack.fill";
     case WebCore::ContextMenuItemPDFZoomIn:
         return @"plus.magnifyingglass";
     case WebCore::ContextMenuItemPDFZoomOut:
@@ -216,12 +223,8 @@ NSString *symbolNameForAction(const WebCore::ContextMenuAction action, bool useA
         return @"textformat.characters";
     case WebCore::ContextMenuItemTagChangeBack:
         return @"arrow.uturn.backward.circle";
-    case WebCore::ContextMenuItemTagCheckGrammarWithSpelling:
-        return @"character.magnify";
     case WebCore::ContextMenuItemTagCheckSpelling:
         return @"text.page.badge.magnifyingglass";
-    case WebCore::ContextMenuItemTagCheckSpellingWhileTyping:
-        return @"character.cursor.ibeam";
     case WebCore::ContextMenuItemTagCopy:
     case WebCore::ContextMenuItemTagCopyImageToClipboard:
     case WebCore::ContextMenuItemTagCopyLinkToClipboard:
@@ -231,8 +234,6 @@ NSString *symbolNameForAction(const WebCore::ContextMenuAction action, bool useA
         return @"text.quote";
     case WebCore::ContextMenuItemTagCopySubject:
         return @"circle.dashed.rectangle";
-    case WebCore::ContextMenuItemTagCorrectSpellingAutomatically:
-        return @"keyboard.badge.eye";
     case WebCore::ContextMenuItemTagCut:
         return [NSMenuItem _systemImageNameForAction:@selector(cut:)];
     case WebCore::ContextMenuItemTagDefaultDirection:
@@ -281,8 +282,6 @@ NSString *symbolNameForAction(const WebCore::ContextMenuAction action, bool useA
         return @"safari";
     case WebCore::ContextMenuItemTagOpenWithDefaultApplication:
         return @"arrow.up.forward.app";
-    case WebCore::ContextMenuItemTagOutline:
-        return @"character.circle";
     case WebCore::ContextMenuItemTagPaste:
         return [NSMenuItem _systemImageNameForAction:@selector(paste:)];
     case WebCore::ContextMenuItemTagPauseAllAnimations:
@@ -303,32 +302,18 @@ NSString *symbolNameForAction(const WebCore::ContextMenuAction action, bool useA
         return @"paintpalette";
     case WebCore::ContextMenuItemTagShowFonts:
         return @"text.and.command.macwindow";
-    case WebCore::ContextMenuItemTagShowMediaStats:
-        return @"info";
     case WebCore::ContextMenuItemTagShowSpellingPanel:
     case WebCore::ContextMenuItemTagShowSubstitutions:
         return useAlternateImage ? @"eye.slash" : @"text.and.command.macwindow";
-    case WebCore::ContextMenuItemTagSmartCopyPaste:
-        return @"list.clipboard";
-    case WebCore::ContextMenuItemTagSmartDashes:
-        return @"arrowtriangle.right.and.line.vertical.and.arrowtriangle.left";
-    case WebCore::ContextMenuItemTagSmartLinks:
-        return @"link";
-    case WebCore::ContextMenuItemTagSmartQuotes:
-        return @"quote.closing";
     case WebCore::ContextMenuItemTagStartSpeaking:
         return @"play.fill";
     case WebCore::ContextMenuItemTagStop:
     case WebCore::ContextMenuItemTagStopSpeaking:
         return @"stop.fill";
-    case WebCore::ContextMenuItemTagStyles:
-        return @"bold.italic.underline";
     case WebCore::ContextMenuItemTagTextDirectionLeftToRight:
-        return @"arrow.left.to.line";
+        return @"arrow.right";
     case WebCore::ContextMenuItemTagTextDirectionRightToLeft:
-        return @"arrow.right.to.line";
-    case WebCore::ContextMenuItemTagTextReplacement:
-        return @"text.page.badge.magnifyingglass";
+        return @"arrow.left";
     case WebCore::ContextMenuItemTagToggleMediaControls:
         return useAlternateImage ? @"eye" : @"eye.slash";
     case WebCore::ContextMenuItemTagToggleMediaLoop:
@@ -342,7 +327,7 @@ NSString *symbolNameForAction(const WebCore::ContextMenuAction action, bool useA
     case WebCore::ContextMenuItemTagTranslate:
         return @"translate";
     case WebCore::ContextMenuItemTagUnderline:
-        return @"underline";
+        return [NSMenuItem _systemImageNameForAction:@selector(underline:)];
     }
 
     return nil;

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -518,22 +518,16 @@ RetainPtr<NSMenuItem> WebContextMenuProxyMac::createShareMenuItem(ShareMenuItemT
     if (!shareMenuItem)
         return nil;
 
-#if ENABLE(CONTEXT_MENU_IMAGES_FOR_INTERNAL_CLIENTS)
-    RetainPtr<NSImage> actionImage;
-    bool shouldSetMenuItemImage = page()->protectedPreferences()->contextMenuImagesForInternalClientsEnabled() && [shareMenuItem respondsToSelector:@selector(_setActionImage:)];
-    if (shouldSetMenuItemImage)
-        actionImage = [shareMenuItem _actionImage];
-#endif
-
     if (usePlaceholder) {
         shareMenuItem = adoptNS([[NSMenuItem alloc] initWithTitle:[shareMenuItem title] action:@selector(performShare:) keyEquivalent:@""]);
-#if ENABLE(CONTEXT_MENU_IMAGES_FOR_INTERNAL_CLIENTS)
-        if (shouldSetMenuItemImage)
-            [shareMenuItem _setActionImage:actionImage.get()];
-#endif
         [shareMenuItem setTarget:[WKMenuTarget sharedMenuTarget]];
     } else
         [shareMenuItem setRepresentedObject:sharingServicePicker.get()];
+
+#if ENABLE(CONTEXT_MENU_IMAGES_FOR_INTERNAL_CLIENTS)
+    if (page()->protectedPreferences()->contextMenuImagesForInternalClientsEnabled() && ![shareMenuItem _hasActionImage])
+        [shareMenuItem _setActionImage:[NSImage imageWithSystemSymbolName:@"square.and.arrow.up" accessibilityDescription:nil]];
+#endif
 
     [shareMenuItem setIdentifier:_WKMenuItemIdentifierShareMenu];
     return shareMenuItem;
@@ -901,6 +895,10 @@ void WebContextMenuProxyMac::getContextMenuItem(const WebContextMenuItemData& it
         if ([NSMenuItem.class respondsToSelector:@selector(standardWritingToolsMenuItem)]) {
             RetainPtr menuItem = [NSMenuItem standardWritingToolsMenuItem];
             [[menuItem submenu] setAutoenablesItems:NO];
+#if ENABLE(CONTEXT_MENU_IMAGES_FOR_INTERNAL_CLIENTS)
+            if (page()->protectedPreferences()->contextMenuImagesForInternalClientsEnabled() && ![menuItem _hasActionImage])
+                [menuItem _setActionImage:[NSImage imageWithSystemSymbolName:@"apple.intelligence" accessibilityDescription:nil]];
+#endif
 
             for (NSMenuItem *subItem in [menuItem submenu].itemArray) {
                 if (subItem.isSeparatorItem)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -358,7 +358,7 @@ private:
         Copy,
         CopyLink,
         NextPage,
-        OpenWithPreview,
+        OpenWithDefaultViewer,
         PreviousPage,
         SinglePage,
         SinglePageContinuous,

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -2392,7 +2392,7 @@ ContextMenuAction UnifiedPDFPlugin::contextMenuActionFromTag(ContextMenuItemTag 
         return ContextMenuItemTagNoAction;
     case ContextMenuItemTag::NextPage:
         return ContextMenuItemPDFNextPage;
-    case ContextMenuItemTag::OpenWithPreview:
+    case ContextMenuItemTag::OpenWithDefaultViewer:
         return ContextMenuItemTagOpenWithDefaultApplication;
     case ContextMenuItemTag::PreviousPage:
         return ContextMenuItemPDFPreviousPage;
@@ -2424,7 +2424,7 @@ auto UnifiedPDFPlugin::toContextMenuItemTag(int tagValue) -> ContextMenuItemTag
         ContextMenuItemTag::Copy,
         ContextMenuItemTag::CopyLink,
         ContextMenuItemTag::NextPage,
-        ContextMenuItemTag::OpenWithPreview,
+        ContextMenuItemTag::OpenWithDefaultViewer,
         ContextMenuItemTag::PreviousPage,
         ContextMenuItemTag::SinglePage,
         ContextMenuItemTag::SinglePageContinuous,
@@ -2464,7 +2464,7 @@ std::optional<PDFContextMenu> UnifiedPDFPlugin::createContextMenu(const WebMouse
         addSeparator();
     }
 
-    menuItems.append(contextMenuItem(ContextMenuItemTag::OpenWithPreview));
+    menuItems.append(contextMenuItem(ContextMenuItemTag::OpenWithDefaultViewer));
 
     addSeparator();
 
@@ -2483,7 +2483,7 @@ std::optional<PDFContextMenu> UnifiedPDFPlugin::createContextMenu(const WebMouse
 
     auto contextMenuPoint = frameView->contentsToScreen(IntRect(frameView->windowToContents(contextMenuEventRootViewPoint), IntSize())).location();
 
-    return PDFContextMenu { contextMenuPoint, WTFMove(menuItems), { enumToUnderlyingType(ContextMenuItemTag::OpenWithPreview) } };
+    return PDFContextMenu { contextMenuPoint, WTFMove(menuItems), { enumToUnderlyingType(ContextMenuItemTag::OpenWithDefaultViewer) } };
 }
 
 bool UnifiedPDFPlugin::isDisplayModeContextMenuItemTag(ContextMenuItemTag tag) const
@@ -2508,8 +2508,9 @@ String UnifiedPDFPlugin::titleForContextMenuItemTag(ContextMenuItemTag tag) cons
         return contextMenuItemTagCopyLinkToClipboard();
     case ContextMenuItemTag::NextPage:
         return contextMenuItemPDFNextPage();
-    case ContextMenuItemTag::OpenWithPreview:
-        return contextMenuItemPDFOpenWithPreview();
+    // The title for the OpenWithDefaultViewer item is determined in the UI Process.
+    case ContextMenuItemTag::OpenWithDefaultViewer:
+        return ""_s;
     case ContextMenuItemTag::PreviousPage:
         return contextMenuItemPDFPreviousPage();
     case ContextMenuItemTag::SinglePage:
@@ -2547,7 +2548,7 @@ PDFContextMenuItem UnifiedPDFPlugin::contextMenuItem(ContextMenuItemTag tag, boo
         } else if (tag == ContextMenuItemTag::AutoSize)
             state = m_shouldUpdateAutoSizeScale == ShouldUpdateAutoSizeScale::Yes;
 
-        bool disableItemDueToLockedDocument = isLocked() && tag != ContextMenuItemTag::OpenWithPreview;
+        bool disableItemDueToLockedDocument = isLocked() && tag != ContextMenuItemTag::OpenWithDefaultViewer;
         auto itemEnabled = disableItemDueToLockedDocument ? ContextMenuItemEnablement::Disabled : ContextMenuItemEnablement::Enabled;
         auto itemHasAction = hasAction && !disableItemDueToLockedDocument ? ContextMenuItemHasAction::Yes : ContextMenuItemHasAction::No;
 
@@ -2639,8 +2640,8 @@ void UnifiedPDFPlugin::performContextMenuAction(ContextMenuItemTag tag, const In
     case ContextMenuItemTag::CopyLink:
         performCopyLinkOperation(contextMenuEventRootViewPoint);
         break;
-    // The OpenWithPreview action is handled in the UI Process.
-    case ContextMenuItemTag::OpenWithPreview: return;
+    // The OpenWithDefaultViewer action is handled in the UI Process.
+    case ContextMenuItemTag::OpenWithDefaultViewer: return;
     case ContextMenuItemTag::SinglePage:
     case ContextMenuItemTag::SinglePageContinuous:
     case ContextMenuItemTag::TwoPagesContinuous:


### PR DESCRIPTION
#### a025bc40ba4754766f3949c823bb88a3c42bc029
<pre>
Update context menu images for internal clients
<a href="https://bugs.webkit.org/show_bug.cgi?id=291707">https://bugs.webkit.org/show_bug.cgi?id=291707</a>
<a href="https://rdar.apple.com/149504756">rdar://149504756</a>

Reviewed by Abrar Rahman Protyasha.

Updated context menu images for internal clients
where needed, including removing unneeded ones.

The UnifiedPDF item which opened the PDF in an external
viewer now displays the name of the default viewer rather
than always displaying &quot;Preview&quot;. When context menu images
for internal clients is enabled, the image for this item
is set to the icon of the default PDF viewer.

In the &quot;Font&quot; submenu, the separator between &quot;Styles...&quot; and
&quot;Show Color&quot; has been moved above the &quot;Outline&quot; item, and
a new separator has been placed above the &quot;Bold&quot; item. This
results in a visually distinct section for the 3 checkable items
(Bold, Italic, Underline).

* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::createAndAppendFontSubMenu):
* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::contextMenuItemPDFOpenWithDefaultViewer):
(WebCore::contextMenuItemPDFOpenWithPreview): Deleted.
* Source/WebCore/platform/LocalizedStrings.h:
* Source/WebKit/Platform/mac/MenuUtilities.mm:
(WebKit::symbolNameForAction):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::WebContextMenuProxyMac::createShareMenuItem):
(WebKit::WebContextMenuProxyMac::getContextMenuItem):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::showPDFContextMenu):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::contextMenuActionFromTag const):
(WebKit::UnifiedPDFPlugin::toContextMenuItemTag):
(WebKit::UnifiedPDFPlugin::createContextMenu const):
(WebKit::UnifiedPDFPlugin::titleForContextMenuItemTag const):
(WebKit::UnifiedPDFPlugin::contextMenuItem const):
(WebKit::UnifiedPDFPlugin::performContextMenuAction):

Canonical link: <a href="https://commits.webkit.org/293840@main">https://commits.webkit.org/293840@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c590997df1ad57d8729c94ceea53cc1d505da5c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100048 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105200 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50629 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28169 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/76173 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33232 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15275 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90358 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56534 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15087 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8353 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49998 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85003 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8438 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107536 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27161 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19892 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85112 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27524 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86563 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84644 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21506 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29317 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7055 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20997 "Built successfully") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/16282 "The change is no longer eligible for processing.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27098 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32327 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26909 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30225 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28468 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->