### PR TITLE
Web Inspector: Closing JSContext inspector while execution is paused hangs owner app

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.h
@@ -105,7 +105,13 @@ private:
 #endif
 
     ThreadSafeWeakPtr<RemoteControllableTarget> m_target WTF_GUARDED_BY_LOCK(m_targetMutex);
-    bool m_connected { false };
+
+    enum class ConnectionState {
+        Pending,
+        Connected,
+        Closed,
+    };
+    std::atomic<ConnectionState> m_connectionState { ConnectionState::Pending };
 
 #if PLATFORM(COCOA)
     RetainPtr<NSString> m_connectionIdentifier;


### PR DESCRIPTION
#### 8867ffb89ae174fb48924753375a451875bf26ea
<pre>
Web Inspector: Closing JSContext inspector while execution is paused hangs owner app
<a href="https://rdar.apple.com/142537911">rdar://142537911</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291711">https://bugs.webkit.org/show_bug.cgi?id=291711</a>

Reviewed by Devin Rousso.

When closing Web Inspector and disconnecting the frontend from the
debuggable, we have the logic to resume code execution if it was paused.
Resuming execution by default notifies the frontend via RemoteConnectionToTarget::sendMessageToFrontend,
which tries to grab the m_targetMutex, but that was already grabbed
in RemoteConnectionToTarget::close (in the callback with dispatchAsyncOnTarget).
This resulted in a deadlock.

   - The reason why this deadlocking only happens for JSContexts is
     because the other kinds of debuggables call into a different thread
     at some point to complete the disconnecting process. PageDebuggable
     and WebPageDebuggable call callOnMainThreadAndWait in the
     debuggables&apos; disconnect method; for service workers, postDebuggerTask
     is used in ServiceWorkerInspectorProxy::disconnectFromWorker.
     JSContext does everything on the same thread that calls disconnect.

If the frontend were going to be closed anyway, RemoteConnectionToTarget
should be able to avoid sending the frontend any messages, and that&apos;s
the logic behind this patch.

* Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.cpp:
(Inspector::RemoteConnectionToTarget::setup):
(Inspector::RemoteConnectionToTarget::sendMessageToTarget):
(Inspector::RemoteConnectionToTarget::close):
(Inspector::RemoteConnectionToTarget::targetClosed):
(Inspector::RemoteConnectionToTarget::sendMessageToFrontend):
* Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.h:
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteConnectionToTargetCocoa.mm:
(Inspector::RemoteConnectionToTarget::setup):
(Inspector::RemoteConnectionToTarget::targetClosed):
(Inspector::RemoteConnectionToTarget::close):
(Inspector::RemoteConnectionToTarget::sendMessageToTarget):
(Inspector::RemoteConnectionToTarget::sendMessageToFrontend):

Canonical link: <a href="https://commits.webkit.org/293950@main">https://commits.webkit.org/293950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d751641995d1e6c44724919464460558c5d7b4e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105526 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50978 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28516 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76435 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33492 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103397 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15582 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90686 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56790 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15399 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8689 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50346 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/93052 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85315 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107881 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98998 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27508 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20179 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85389 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27871 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86886 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84926 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21597 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29611 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7345 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21428 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27443 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32700 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122624 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27254 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34211 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30572 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28812 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->