### PR TITLE
[iOS] [SelectionHonorsOverflowScrolling] bing.com: Text selection UI appears behind link cards in search results

### DIFF
--- a/LayoutTests/editing/selection/ios/selection-covers-composited-layers-expected.txt
+++ b/LayoutTests/editing/selection/ios/selection-covers-composited-layers-expected.txt
@@ -1,0 +1,14 @@
+Start selecting here
+
+Hello
+End selection here
+
+Verifies that the highlight appears over selected content in composited layers
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS viewBeforeSelecting is not viewAfterSelecting
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/selection-covers-composited-layers.html
+++ b/LayoutTests/editing/selection/ios/selection-covers-composited-layers.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true SelectionHonorsOverflowScrolling=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    font-size: 16px;
+    font-family: system-ui;
+    margin: 0;
+}
+
+.text {
+    font-size: 20px;
+}
+
+.start {
+    border: 1px solid orange;
+}
+
+.end {
+    border: 1px solid cyan;
+}
+
+.container {
+    width: 200px;
+    height: 200px;
+    border: 4px solid red;
+    border-radius: 40px;
+    will-change: transform;
+    z-index: 1;
+    line-height: 200px;
+    text-align: center;
+    font-size: 80px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that the highlight appears over selected content in composited layers");
+
+    const container = document.querySelector(".container");
+    let {x, y} = UIHelper.midPointOfRect(container.getBoundingClientRect());
+    viewBeforeSelecting = await UIHelper.frontmostViewAtPoint(x, y);
+
+    const start = document.querySelector(".start");
+    await UIHelper.longPressElement(start);
+    await UIHelper.waitForSelectionToAppear();
+
+    const end = document.querySelector(".end");
+    const range = document.createRange();
+    range.setStartBefore(start);
+    range.setEndAfter(end);
+    getSelection().removeAllRanges();
+    getSelection().addRange(range);
+    await UIHelper.ensurePresentationUpdate();
+
+    viewAfterSelecting = await UIHelper.frontmostViewAtPoint(x, y);
+    shouldNotBe("viewBeforeSelecting", "viewAfterSelecting");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <p class="text"><span class="start">Start</span> selecting here</p>
+    <div class="container"><span>Hello</span></div>
+    <p class="text">End selection <span class="end">here</span></p>
+    <div id="description"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -150,7 +150,7 @@ public:
 
     bool hasMaskLayer() const { return m_maskLayer; }
 
-    GraphicsLayer* parentForSublayers() const;
+    WEBCORE_EXPORT GraphicsLayer* parentForSublayers() const;
     GraphicsLayer* childForSuperlayers() const;
     GraphicsLayer* childForSuperlayersExcludingViewTransitions() const;
 

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.h
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.h
@@ -63,6 +63,7 @@ enum class BoxSide : uint8_t;
 - (WebCore::FloatQuad)_wk_convertQuad:(const WebCore::FloatQuad&)quad toCoordinateSpace:(id<UICoordinateSpace>)destination;
 @property (nonatomic, readonly) UIScrollView *_wk_parentScrollView;
 @property (nonatomic, readonly) UIViewController *_wk_viewControllerForFullScreenPresentation;
+@property (nonatomic, readonly) UIView *_wk_previousSibling;
 @end
 
 @interface UIViewController (WebKitInternal)

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -269,6 +269,21 @@ static UIAxis axesForDelta(WebCore::FloatSize delta)
     };
 }
 
+- (UIView *)_wk_previousSibling
+{
+    RetainPtr superview = [self superview];
+    if (!superview)
+        return nil;
+
+    UIView *previousSibling = nil;
+    for (UIView *currentSibling in [superview subviews]) {
+        if (currentSibling == self)
+            break;
+        previousSibling = currentSibling;
+    }
+    return previousSibling;
+}
+
 @end
 
 @implementation UIViewController (WebKitInternal)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -513,6 +513,7 @@ struct ImageAnalysisContextMenuActionData {
     CGPoint _lastInteractionLocation;
     std::optional<WebKit::TransactionID> _layerTreeTransactionIdAtLastInteractionStart;
 
+    __weak UIView *_lastSiblingBeforeSelectionHighlight;
     WebKit::WKSelectionDrawingInfo _lastSelectionDrawingInfo;
     RetainPtr<WKTextRange> _cachedSelectedTextRange;
 

--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.h
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.h
@@ -70,6 +70,7 @@
 
 @property (nonatomic, readonly) NSArray<UIView *> *managedTextSelectionViews;
 @property (nonatomic, readonly) UIWKTextInteractionAssistant *textInteractionAssistant;
+@property (nonatomic, readonly) UIView *selectionHighlightView;
 
 @end
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -6090,6 +6090,9 @@ void WebPage::computeEnclosingLayerID(EditorState& state, const VisibleSelection
             if (RefPtr foregroundLayer = backing->foregroundLayer())
                 return foregroundLayer;
 
+            if (backing->isFrameLayerWithTiledBacking())
+                return backing->parentForSublayers();
+
             return backing->graphicsLayer();
         }();
 


### PR DESCRIPTION
#### 27e3e70bdb667dcd220ea1f2f45cbfc2b70e78be
<pre>
[iOS] [SelectionHonorsOverflowScrolling] bing.com: Text selection UI appears behind link cards in search results
<a href="https://bugs.webkit.org/show_bug.cgi?id=291705">https://bugs.webkit.org/show_bug.cgi?id=291705</a>
<a href="https://rdar.apple.com/149242162">rdar://149242162</a>

Reviewed by Abrar Rahman Protyasha.

When making a text selection that spans across (and contains) multiple composited layers, we
currently host the selection views inside the composited layer that&apos;s the common ancestor of the
selection start and end points, at a subview index that&apos;s right after the tile grid container view.
While this means that the selection will be correctly occluded by any positioned layers that should
cover the selection, it also means that the selection might be incorrectly occluded by content
contained in the selection itself.

To fix this, build off of the work in <a href="https://webkit.org/b/291663">https://webkit.org/b/291663</a> by using the platform layer IDs of
layers that (may) contain the selection, to insert UIKit&apos;s managed selection views *after* all such
views in the compositing view hierarchy.

* LayoutTests/editing/selection/ios/selection-covers-composited-layers-expected.txt: Added.
* LayoutTests/editing/selection/ios/selection-covers-composited-layers.html: Added.

Add a layout test to exercise the change, by verifying that the selection shows up on top of the
composited layer.

* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(-[UIView _wk_previousSibling]):

Add a helper method to grab the sibling view immediately before this `UIView` (or `nil`) if this
view is either unparented or the first subview in its parent.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView cleanUpInteraction]):
(-[WKContentView _updateChangedSelection:]):
(-[WKContentView _siblingBeforeSelectionHighlight]):

Add logic to keep track of the last previous sibling before the selection highlight view; we use
this information to detect when a new composited layer is inserted before the selection views, and
reinsert the managed selection views in the view hierarchy if needed. Without this adjustment, fixed
position containers that are added to the DOM after a selection is already created (e.g. when
scrolling down the page on bing.com) will be incorrectly occluded by the selection, until the user
adjusts the selection range.

* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.h:
* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:
(-[WKTextInteractionWrapper selectionHighlightView]):
(-[WKTextInteractionWrapper prepareToMoveSelectionContainer:]):

See above for more details.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::computeEnclosingLayerID const):

Use the `Page TiledBacking containment` view to host selection views; this allows us to slot the
hosted selection views *after* all composited views that may contain part of the selection.

Canonical link: <a href="https://commits.webkit.org/293843@main">https://commits.webkit.org/293843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4b322760c27f247746be091503fce4f8558c1da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105183 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50636 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28176 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76162 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33238 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103062 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15280 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90360 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56523 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15093 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8355 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50005 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85009 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8440 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107543 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19896 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85119 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27531 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84651 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21510 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29325 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7057 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21004 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27105 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32334 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26916 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30232 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28475 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->