### PR TITLE
Cursors should be closed when its transaction finishes

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
@@ -33,6 +33,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -45,13 +46,10 @@ class MemoryObjectStore;
 
 typedef HashMap<IDBKeyData, ThreadSafeDataBuffer, IDBKeyDataHash, IDBKeyDataHashTraits> KeyValueMap;
 
-class MemoryBackingStoreTransaction final : public CanMakeThreadSafeCheckedPtr<MemoryBackingStoreTransaction> {
-    WTF_MAKE_TZONE_ALLOCATED(MemoryBackingStoreTransaction);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MemoryBackingStoreTransaction);
+class MemoryBackingStoreTransaction final : public RefCountedAndCanMakeWeakPtr<MemoryBackingStoreTransaction> {
 public:
-    static std::unique_ptr<MemoryBackingStoreTransaction> create(MemoryIDBBackingStore&, const IDBTransactionInfo&);
+    static Ref<MemoryBackingStoreTransaction> create(MemoryIDBBackingStore&, const IDBTransactionInfo&);
 
-    MemoryBackingStoreTransaction(MemoryIDBBackingStore&, const IDBTransactionInfo&);
     ~MemoryBackingStoreTransaction();
 
     bool isVersionChange() const { return m_info.mode() == IDBTransactionMode::Versionchange; }
@@ -82,6 +80,7 @@ public:
     void addCursor(MemoryCursor&);
 
 private:
+    MemoryBackingStoreTransaction(MemoryIDBBackingStore&, const IDBTransactionInfo&);
     void finish();
 
     CheckedRef<MemoryIDBBackingStore> m_backingStore;

--- a/Source/WebCore/Modules/indexeddb/server/MemoryCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryCursor.cpp
@@ -36,6 +36,7 @@ namespace IDBServer {
 
 MemoryCursor::MemoryCursor(const IDBCursorInfo& info, MemoryBackingStoreTransaction& transaction)
     : m_info(info)
+    , m_transaction(transaction)
 {
     ASSERT(!isMainThread());
 
@@ -45,6 +46,11 @@ MemoryCursor::MemoryCursor(const IDBCursorInfo& info, MemoryBackingStoreTransact
 MemoryCursor::~MemoryCursor()
 {
     ASSERT(!isMainThread());
+}
+
+MemoryBackingStoreTransaction* MemoryCursor::transaction() const
+{
+    return m_transaction.get();
 }
 
 } // namespace IDBServer

--- a/Source/WebCore/Modules/indexeddb/server/MemoryCursor.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryCursor.h
@@ -47,12 +47,14 @@ public:
     virtual void iterate(const IDBKeyData&, const IDBKeyData& primaryKey, uint32_t count, IDBGetResult&) = 0;
 
     IDBCursorInfo info() const { return m_info; }
+    MemoryBackingStoreTransaction* transaction() const;
 
 protected:
     MemoryCursor(const IDBCursorInfo&, MemoryBackingStoreTransaction&);
 
 private:
     IDBCursorInfo m_info;
+    WeakPtr<MemoryBackingStoreTransaction> m_transaction;
 };
 
 } // namespace IDBServer

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h
@@ -51,6 +51,7 @@ public:
     uint64_t databaseVersion() final;
     void setDatabaseInfo(const IDBDatabaseInfo&);
     bool hasObjectStore(IDBObjectStoreIdentifier objectStoreIdentifier) { return !!infoForObjectStore(objectStoreIdentifier); }
+    MemoryObjectStore* objectStoreForName(const String& name) const;
 
     void renameObjectStoreForVersionChangeAbort(MemoryObjectStore&, const String& oldName);
     void removeObjectStoreForVersionChangeAbort(MemoryObjectStore&);
@@ -104,8 +105,7 @@ private:
     IDBDatabaseIdentifier m_identifier;
     std::unique_ptr<IDBDatabaseInfo> m_databaseInfo;
 
-    HashMap<IDBResourceIdentifier, std::unique_ptr<MemoryBackingStoreTransaction>> m_transactions;
-
+    HashMap<IDBResourceIdentifier, Ref<MemoryBackingStoreTransaction>> m_transactions;
     HashMap<IDBObjectStoreIdentifier, RefPtr<MemoryObjectStore>> m_objectStoresByIdentifier;
     HashMap<String, RefPtr<MemoryObjectStore>> m_objectStoresByName;
 };

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
@@ -90,6 +90,7 @@ public:
     void cursorDidBecomeDirty(MemoryIndexCursor&);
 
     void notifyCursorsOfValueChange(const IDBKeyData& indexKey, const IDBKeyData& primaryKey);
+    void transactionFinished(MemoryBackingStoreTransaction&);
 
     void writeTransactionStarted(MemoryBackingStoreTransaction&);
     void writeTransactionFinished(MemoryBackingStoreTransaction&);
@@ -108,7 +109,7 @@ private:
     IDBIndexInfo m_info;
     WeakPtr<MemoryObjectStore> m_objectStore;
 
-    CheckedPtr<MemoryBackingStoreTransaction> m_writeTransaction;
+    WeakPtr<MemoryBackingStoreTransaction> m_writeTransaction;
     HashMap<IDBKeyData, Vector<IDBKeyData>, IDBKeyDataHash, IDBKeyDataHashTraits> m_transactionModifiedRecords;
     std::unique_ptr<IndexValueStore> m_records;
 

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp
@@ -63,6 +63,19 @@ MemoryIndex* MemoryObjectStore::indexForIdentifier(IDBIndexIdentifier identifier
     return m_indexesByIdentifier.get(identifier);
 }
 
+void MemoryObjectStore::transactionFinished(MemoryBackingStoreTransaction& transaction)
+{
+    if (transaction.isWriting())
+        writeTransactionFinished(transaction);
+
+    m_cursors.removeIf([&](auto& pair) {
+        return pair.value->transaction() == &transaction;
+    });
+
+    for (auto& index : m_indexesByIdentifier.values())
+        index->transactionFinished(transaction);
+}
+
 void MemoryObjectStore::writeTransactionStarted(MemoryBackingStoreTransaction& transaction)
 {
     LOG(IndexedDB, "MemoryObjectStore::writeTransactionStarted");
@@ -525,6 +538,9 @@ void MemoryObjectStore::registerIndex(Ref<MemoryIndex>&& index)
 
 MemoryObjectStoreCursor* MemoryObjectStore::maybeOpenCursor(const IDBCursorInfo& info, MemoryBackingStoreTransaction& transaction)
 {
+    if (transaction.isWriting() && m_writeTransaction != &transaction)
+        return nullptr;
+
     auto result = m_cursors.add(info.identifier(), nullptr);
     if (!result.isNewEntry)
         return nullptr;

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
@@ -62,6 +62,7 @@ public:
 
     ~MemoryObjectStore();
 
+    void transactionFinished(MemoryBackingStoreTransaction&);
     void writeTransactionStarted(MemoryBackingStoreTransaction&);
     void writeTransactionFinished(MemoryBackingStoreTransaction&);
     void transactionAborted(MemoryBackingStoreTransaction&);
@@ -122,7 +123,7 @@ private:
 
     IDBObjectStoreInfo m_info;
 
-    CheckedPtr<MemoryBackingStoreTransaction> m_writeTransaction;
+    WeakPtr<MemoryBackingStoreTransaction> m_writeTransaction;
     uint64_t m_keyGeneratorValueBeforeTransaction { 1 };
     uint64_t m_keyGeneratorValue { 1 };
 


### PR DESCRIPTION
#### 8a8fb03ae11d1ee5ca7907efb81f183ff1e617ec
<pre>
Cursors should be closed when its transaction finishes
<a href="https://bugs.webkit.org/show_bug.cgi?id=291717">https://bugs.webkit.org/show_bug.cgi?id=291717</a>
<a href="https://rdar.apple.com/148116063">rdar://148116063</a>

Reviewed by Chris Dumez.

According to spec, cursor&apos;s lifetime should be tied to its transaction, not its source (object store or index). This
means when transaction ends, cursor should also be closed. To implement this, now we make MemoryCursor keep track of
the transaction it is created in, and ensures its owner (MemoryObjectStore and MemoryIndex) releases it when
corresponding transaction finishes.

* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp:
(WebCore::IDBServer::MemoryBackingStoreTransaction::create):
(WebCore::IDBServer::MemoryBackingStoreTransaction::finish):
* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h:
* Source/WebCore/Modules/indexeddb/server/MemoryCursor.cpp:
(WebCore::IDBServer::MemoryCursor::MemoryCursor):
(WebCore::IDBServer::MemoryCursor::transaction const):
* Source/WebCore/Modules/indexeddb/server/MemoryCursor.h:
* Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.cpp:
(WebCore::IDBServer::MemoryIDBBackingStore::openCursor):
(WebCore::IDBServer::MemoryIDBBackingStore::iterateCursor):
(WebCore::IDBServer::MemoryIDBBackingStore::objectStoreForName const):
* Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h:
* Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp:
(WebCore::IDBServer::MemoryIndex::maybeOpenCursor):
(WebCore::IDBServer::MemoryIndex::transactionFinished):
* Source/WebCore/Modules/indexeddb/server/MemoryIndex.h:
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp:
(WebCore::IDBServer::MemoryObjectStore::transactionFinished):
(WebCore::IDBServer::MemoryObjectStore::maybeOpenCursor):
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h:

Originally-landed-as: 283286.620@safari-7620-branch. <a href="https://rdar.apple.com/141673897">rdar://141673897</a>
Canonical link: <a href="https://commits.webkit.org/293857@main">https://commits.webkit.org/293857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e05835ed4b7d4825ca805a72b2a841f9200e095

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100082 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10024 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105212 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50663 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102123 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20036 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28203 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76183 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33253 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15304 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90388 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56544 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/99555 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15119 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8384 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50033 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85029 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107571 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19915 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85137 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27558 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86594 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84671 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21520 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29347 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7083 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21031 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27132 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32361 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26943 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30259 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28502 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->