### PR TITLE
Use enum class in airplay/WebMediaSessionManager

### DIFF
--- a/Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp
+++ b/Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp
@@ -215,7 +215,7 @@ std::optional<PlaybackTargetClientContextIdentifier> WebMediaSessionManager::add
     m_clientState.append(makeUnique<ClientState>(client, contextId));
 
     if (m_externalOutputDeviceAvailable || m_playbackTarget)
-        scheduleDelayedTask(InitialConfigurationTask | TargetClientsConfigurationTask);
+        scheduleDelayedTask({ ConfigurationTaskFlags::InitialConfiguration, ConfigurationTaskFlags::TargetClientsConfiguration });
 
     return contextId;
 }
@@ -230,7 +230,7 @@ void WebMediaSessionManager::removePlaybackTargetPickerClient(WebMediaSessionMan
     ALWAYS_LOG_MEDIASESSIONMANAGER(__func__, m_clientState[index].get());
 
     m_clientState.remove(index);
-    scheduleDelayedTask(TargetMonitoringConfigurationTask | TargetClientsConfigurationTask);
+    scheduleDelayedTask({ ConfigurationTaskFlags::TargetMonitoringConfiguration, ConfigurationTaskFlags::TargetClientsConfiguration });
 }
 
 void WebMediaSessionManager::removeAllPlaybackTargetPickerClients(WebMediaSessionManagerClient& client)
@@ -244,7 +244,7 @@ void WebMediaSessionManager::removeAllPlaybackTargetPickerClients(WebMediaSessio
             m_clientState.remove(i - 1);
         }
     }
-    scheduleDelayedTask(TargetMonitoringConfigurationTask | TargetClientsConfigurationTask);
+    scheduleDelayedTask({ ConfigurationTaskFlags::TargetMonitoringConfiguration, ConfigurationTaskFlags::TargetClientsConfiguration });
 }
 
 void WebMediaSessionManager::showPlaybackTargetPicker(WebMediaSessionManagerClient& client, PlaybackTargetClientContextIdentifier contextId, const IntRect& rect, bool, bool useDarkAppearance)
@@ -284,13 +284,13 @@ void WebMediaSessionManager::clientStateDidChange(WebMediaSessionManagerClient& 
 
     constexpr MediaProducerMediaStateFlags updateConfigurationFlags { MediaProducerMediaState::RequiresPlaybackTargetMonitoring, MediaProducerMediaState::HasPlaybackTargetAvailabilityListener, MediaProducerMediaState::HasAudioOrVideo };
     if ((oldFlags & updateConfigurationFlags) != (newFlags & updateConfigurationFlags))
-        scheduleDelayedTask(TargetMonitoringConfigurationTask);
+        scheduleDelayedTask(ConfigurationTaskFlags::TargetMonitoringConfiguration);
 
     constexpr MediaProducerMediaStateFlags playingToTargetFlags { MediaProducerMediaState::IsPlayingToExternalDevice, MediaProducerMediaState::IsPlayingVideo };
     if ((oldFlags & playingToTargetFlags) != (newFlags & playingToTargetFlags)) {
         if (flagsAreSet(oldFlags, MediaProducerMediaState::IsPlayingVideo) && !flagsAreSet(newFlags, MediaProducerMediaState::IsPlayingVideo) && flagsAreSet(newFlags, MediaProducerMediaState::DidPlayToEnd))
             changedClientState->playedToEnd = true;
-        scheduleDelayedTask(WatchdogTimerConfigurationTask);
+        scheduleDelayedTask(ConfigurationTaskFlags::WatchdogTimerConfiguration);
     }
 
     if (!m_playbackTarget || !m_playbackTarget->hasActiveRoute() || !flagsAreSet(newFlags, MediaProducerMediaState::ExternalDeviceAutoPlayCandidate))
@@ -332,7 +332,7 @@ void WebMediaSessionManager::setPlaybackTarget(Ref<MediaPlaybackTarget>&& target
     ALWAYS_LOG_MEDIASESSIONMANAGER(__func__, "has active route = ", target->hasActiveRoute());
     m_playbackTarget = WTFMove(target);
     m_targetChanged = true;
-    scheduleDelayedTask(TargetClientsConfigurationTask);
+    scheduleDelayedTask(ConfigurationTaskFlags::TargetClientsConfiguration);
 }
 
 void WebMediaSessionManager::externalOutputDeviceAvailableDidChange(bool available)
@@ -347,7 +347,7 @@ void WebMediaSessionManager::playbackTargetPickerWasDismissed()
 {
     ALWAYS_LOG_MEDIASESSIONMANAGER(__func__);
     m_playbackTargetPickerDismissed = true;
-    scheduleDelayedTask(TargetClientsConfigurationTask);
+    scheduleDelayedTask(ConfigurationTaskFlags::TargetClientsConfiguration);
 }
 
 void WebMediaSessionManager::configureNewClients()
@@ -458,22 +458,22 @@ void WebMediaSessionManager::configurePlaybackTargetMonitoring()
 
 void WebMediaSessionManager::scheduleDelayedTask(ConfigurationTasks tasks)
 {
-    m_taskFlags |= tasks;
+    m_taskFlags.add(tasks);
     m_taskTimer.startOneShot(taskDelayInterval);
 }
 
 void WebMediaSessionManager::taskTimerFired()
 {
-    if (m_taskFlags & InitialConfigurationTask)
+    if (m_taskFlags.contains(ConfigurationTaskFlags::InitialConfiguration))
         configureNewClients();
-    if (m_taskFlags & TargetClientsConfigurationTask)
+    if (m_taskFlags.contains(ConfigurationTaskFlags::TargetClientsConfiguration))
         configurePlaybackTargetClients();
-    if (m_taskFlags & TargetMonitoringConfigurationTask)
+    if (m_taskFlags.contains(ConfigurationTaskFlags::TargetMonitoringConfiguration))
         configurePlaybackTargetMonitoring();
-    if (m_taskFlags & WatchdogTimerConfigurationTask)
+    if (m_taskFlags.contains(ConfigurationTaskFlags::WatchdogTimerConfiguration))
         configureWatchdogTimer();
 
-    m_taskFlags = NoTask;
+    m_taskFlags = { };
 }
 
 size_t WebMediaSessionManager::find(WebMediaSessionManagerClient* client, PlaybackTargetClientContextIdentifier contextId)

--- a/Source/WebCore/Modules/airplay/WebMediaSessionManager.h
+++ b/Source/WebCore/Modules/airplay/WebMediaSessionManager.h
@@ -64,6 +64,15 @@ public:
 
     bool alwaysOnLoggingAllowed() const;
 
+    enum class ConfigurationTaskFlags : uint8_t {
+        InitialConfiguration = 1 << 0,
+        TargetClientsConfiguration = 1 << 1,
+        TargetMonitoringConfiguration = 1 << 2,
+        WatchdogTimerConfiguration = 1 << 3,
+    };
+    using ConfigurationTasks = OptionSet<ConfigurationTaskFlags>;
+    String toString(ConfigurationTasks);
+
 protected:
     WebMediaSessionManager();
     virtual ~WebMediaSessionManager();
@@ -88,16 +97,6 @@ private:
     void configurePlaybackTargetMonitoring();
     void configureWatchdogTimer();
 
-    enum ConfigurationTaskFlags {
-        NoTask = 0,
-        InitialConfigurationTask = 1 << 0,
-        TargetClientsConfigurationTask = 1 << 1,
-        TargetMonitoringConfigurationTask = 1 << 2,
-        WatchdogTimerConfigurationTask = 1 << 3,
-    };
-    typedef unsigned ConfigurationTasks;
-    String toString(ConfigurationTasks);
-
     void scheduleDelayedTask(ConfigurationTasks);
     void taskTimerFired();
 
@@ -111,7 +110,7 @@ private:
     Vector<std::unique_ptr<ClientState>> m_clientState;
     RefPtr<MediaPlaybackTarget> m_playbackTarget;
     std::unique_ptr<WebCore::MediaPlaybackTargetPickerMock> m_pickerOverride;
-    ConfigurationTasks m_taskFlags { NoTask };
+    ConfigurationTasks m_taskFlags;
     std::unique_ptr<WebMediaSessionLogger> m_logger;
     Seconds m_currentWatchdogInterval;
     bool m_externalOutputDeviceAvailable { false };
@@ -130,6 +129,16 @@ template<typename> struct LogArgument;
 
 template<> struct LogArgument<WebCore::MediaProducerMediaStateFlags> {
     static String toString(WebCore::MediaProducerMediaStateFlags flags) { return WebCore::mediaProducerStateString(flags); }
+};
+
+template<> struct EnumTraits<WebCore::WebMediaSessionManager::ConfigurationTaskFlags> {
+    using values = EnumValues<
+        WebCore::WebMediaSessionManager::ConfigurationTaskFlags,
+        WebCore::WebMediaSessionManager::ConfigurationTaskFlags::InitialConfiguration,
+        WebCore::WebMediaSessionManager::ConfigurationTaskFlags::TargetClientsConfiguration,
+        WebCore::WebMediaSessionManager::ConfigurationTaskFlags::TargetMonitoringConfiguration,
+        WebCore::WebMediaSessionManager::ConfigurationTaskFlags::WatchdogTimerConfiguration
+    >;
 };
 
 } // namespace WTF


### PR DESCRIPTION
#### 9c42a4084e68e533e80491317c278c4ee6b252f6
<pre>
Use enum class in airplay/WebMediaSessionManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=291720">https://bugs.webkit.org/show_bug.cgi?id=291720</a>
<a href="https://rdar.apple.com/problem/149513676">rdar://problem/149513676</a>

Reviewed by Chris Dumez.

Using Safer CPP constructs to avoid type confusion, and make it easier to pass over WebKit IPC.

* Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp:
(WebCore::WebMediaSessionManager::addPlaybackTargetPickerClient):
(WebCore::WebMediaSessionManager::removePlaybackTargetPickerClient):
(WebCore::WebMediaSessionManager::removeAllPlaybackTargetPickerClients):
(WebCore::WebMediaSessionManager::clientStateDidChange):
(WebCore::WebMediaSessionManager::setPlaybackTarget):
(WebCore::WebMediaSessionManager::playbackTargetPickerWasDismissed):
(WebCore::WebMediaSessionManager::scheduleDelayedTask):
(WebCore::WebMediaSessionManager::taskTimerFired):
* Source/WebCore/Modules/airplay/WebMediaSessionManager.h:

Canonical link: <a href="https://commits.webkit.org/294064@main">https://commits.webkit.org/294064@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aff7c8e11c775ab9cf814063d790344f27f32a0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105314 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50766 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102225 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76265 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33324 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15389 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90491 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56627 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15207 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8489 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50135 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85114 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8572 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107673 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27297 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19997 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85220 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27660 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86698 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85206 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21682 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29435 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7174 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/21152 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27234 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32467 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27045 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30361 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28604 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->