### PR TITLE
CustomElementRegistry.prototype.initialize doesn't work on a single element

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/CustomElementRegistry-initialize-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/CustomElementRegistry-initialize-expected.txt
@@ -6,4 +6,6 @@ PASS initialize sets element.customElementRegistry to a scoped registry
 PASS initialize does not set the registry of nested shadow tree to a scoped registry
 PASS initialize sets element.customElementRegistry permantently
 PASS initialize is no-op on a subtree with a non-null registry
+PASS initialize works on Document
+PASS initialize works on DocumentFragment
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/CustomElementRegistry-initialize.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/CustomElementRegistry-initialize.html
@@ -115,6 +115,27 @@ test(() => {
     assert_equals(shadowRoot.querySelector('ef').customElementRegistry, window.customElements);
 }, 'initialize is no-op on a subtree with a non-null registry');
 
+test(() => {
+    const doc = new Document();
+    assert_equals(doc.customElementRegistry, null);
+    const registry = new CustomElementRegistry();
+    registry.initialize(doc);
+    assert_equals(doc.customElementRegistry, registry);
+}, 'initialize works on Document');
+
+test(() => {
+    const doc = new Document();
+    const df = doc.createDocumentFragment();
+    const dummy = doc.createElement("dummy");
+    df.append(dummy);
+    assert_equals(dummy.customElementRegistry, null);
+    assert_equals(df.customElementRegistry, undefined);
+    const registry = new CustomElementRegistry();
+    registry.initialize(df);
+    assert_equals(dummy.customElementRegistry, registry);
+    assert_equals(df.customElementRegistry, undefined);
+}, 'initialize works on DocumentFragment');
+
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/pseudo-class-defined.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/pseudo-class-defined.window-expected.txt
@@ -1,0 +1,5 @@
+
+PASS "uncustomized" :defined doesn't care about your registry'
+PASS "custom" :defined doesn't care about your registry
+PASS pseudo-class-defined
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/pseudo-class-defined.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/pseudo-class-defined.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/pseudo-class-defined.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/pseudo-class-defined.window.js
@@ -1,0 +1,29 @@
+test(() => {
+  const otherDocument = new Document();
+  const element = otherDocument.createElement("blah");
+  assert_true(element.matches(":defined"));
+  const registry = new CustomElementRegistry();
+  registry.initialize(element);
+  assert_equals(element.customElementRegistry, registry);
+  assert_true(element.matches(":defined"));
+}, `"uncustomized" :defined doesn't care about your registry'`);
+
+test(() => {
+  const registry = new CustomElementRegistry();
+  registry.define("sw-r2d2", class extends HTMLElement {});
+  const element = document.createElement("sw-r2d2", { customElementRegistry: registry });
+  assert_equals(element.customElementRegistry, registry);
+  assert_true(element.matches(":defined"));
+}, `"custom" :defined doesn't care about your registry`);
+
+test(() => {
+  const otherDocument = new Document();
+  const element = otherDocument.createElementNS("http://www.w3.org/1999/xhtml", "sw-r2d2");
+  assert_false(element.matches(":defined"));
+  const registry = new CustomElementRegistry();
+  registry.define("sw-r2d2", class extends HTMLElement {});
+  registry.initialize(element);
+  assert_false(element.matches(":defined"));
+  registry.upgrade(element);
+  assert_true(element.matches(":defined"));
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-initialize-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-initialize-expected.txt
@@ -1,0 +1,29 @@
+
+PASS Document: customElementRegistry of an upgrade candidate created with a document without a browsing context uses null regsitry by default
+PASS Document: customElementRegistry of an upgrade candidate after calling CustomElementRegistry.prototype.initialize should return the registry
+PASS Document: customElementRegistry of an upgrade candidate created with an explicit customElementRegistry argument should return the registry
+PASS Document: customElementRegistry of an unknown element created with a document without a browsing context uses null regsitry by default
+PASS Document: customElementRegistry of an unknown element after calling CustomElementRegistry.prototype.initialize should return the registry
+PASS Document: customElementRegistry of an unknown element created with an explicit customElementRegistry argument should return the registry
+PASS Document: customElementRegistry of an upgrade candidate connected to a document without a browsing context uses null regsitry by default
+PASS Document: customElementRegistry of document and an upgrade candidate after calling CustomElementRegistry.prototype.initialize should return the registry
+PASS Document: customElementRegistry of an element created after calling CustomElementRegistry.prototype.initialize should return the registry
+PASS HTMLDocument: customElementRegistry of an upgrade candidate created with a document without a browsing context uses null regsitry by default
+PASS HTMLDocument: customElementRegistry of an upgrade candidate after calling CustomElementRegistry.prototype.initialize should return the registry
+PASS HTMLDocument: customElementRegistry of an upgrade candidate created with an explicit customElementRegistry argument should return the registry
+PASS HTMLDocument: customElementRegistry of an unknown element created with a document without a browsing context uses null regsitry by default
+PASS HTMLDocument: customElementRegistry of an unknown element after calling CustomElementRegistry.prototype.initialize should return the registry
+PASS HTMLDocument: customElementRegistry of an unknown element created with an explicit customElementRegistry argument should return the registry
+PASS HTMLDocument: customElementRegistry of an upgrade candidate connected to a document without a browsing context uses null regsitry by default
+PASS HTMLDocument: customElementRegistry of document and an upgrade candidate after calling CustomElementRegistry.prototype.initialize should return the registry
+PASS HTMLDocument: customElementRegistry of an element created after calling CustomElementRegistry.prototype.initialize should return the registry
+PASS XHTMLDocument: customElementRegistry of an upgrade candidate created with a document without a browsing context uses null regsitry by default
+PASS XHTMLDocument: customElementRegistry of an upgrade candidate after calling CustomElementRegistry.prototype.initialize should return the registry
+PASS XHTMLDocument: customElementRegistry of an upgrade candidate created with an explicit customElementRegistry argument should return the registry
+PASS XHTMLDocument: customElementRegistry of an unknown element created with a document without a browsing context uses null regsitry by default
+PASS XHTMLDocument: customElementRegistry of an unknown element after calling CustomElementRegistry.prototype.initialize should return the registry
+PASS XHTMLDocument: customElementRegistry of an unknown element created with an explicit customElementRegistry argument should return the registry
+PASS XHTMLDocument: customElementRegistry of an upgrade candidate connected to a document without a browsing context uses null regsitry by default
+PASS XHTMLDocument: customElementRegistry of document and an upgrade candidate after calling CustomElementRegistry.prototype.initialize should return the registry
+PASS XHTMLDocument: customElementRegistry of an element created after calling CustomElementRegistry.prototype.initialize should return the registry
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-initialize.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-initialize.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-initialize">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+
+function runTest(title, makeDocument, customElementRegistry) {
+    test(() => {
+        assert_equals(makeDocument().createElement('a-b').customElementRegistry, null);
+    }, `${title}: customElementRegistry of an upgrade candidate created with a document without a browsing context uses null regsitry by default`);
+
+    test(() => {
+        const element = makeDocument().createElement('a-b');
+        customElementRegistry.initialize(element);
+        assert_equals(element.customElementRegistry, customElementRegistry);
+    }, `${title}: customElementRegistry of an upgrade candidate after calling CustomElementRegistry.prototype.initialize should return the registry`);
+
+    test(() => {
+        const element = makeDocument().createElement('a-b', {customElementRegistry});
+        customElementRegistry.initialize(element);
+        assert_equals(element.customElementRegistry, customElementRegistry);
+    }, `${title}: customElementRegistry of an upgrade candidate created with an explicit customElementRegistry argument should return the registry`);
+
+    test(() => {
+        const element = makeDocument().createElement('foo');
+        assert_equals(element.customElementRegistry, null);
+    }, `${title}: customElementRegistry of an unknown element created with a document without a browsing context uses null regsitry by default`);
+
+    test(() => {
+        const element = makeDocument().createElement('foo');
+        customElementRegistry.initialize(element);
+        assert_equals(element.customElementRegistry, customElementRegistry);
+    }, `${title}: customElementRegistry of an unknown element after calling CustomElementRegistry.prototype.initialize should return the registry`);
+
+    test(() => {
+        const element = makeDocument().createElement('foo', {customElementRegistry});
+        assert_equals(element.customElementRegistry, customElementRegistry);
+    }, `${title}: customElementRegistry of an unknown element created with an explicit customElementRegistry argument should return the registry`);
+
+    const addElement = (doc) => {
+        const element = doc.createElement('b-c');
+        if (doc.body)
+            doc.body.appendChild(element);
+        else if (doc.documentElement)
+            doc.documentElement.appendChild(element);
+        else
+            doc.appendChild(element);
+        return element;
+    }
+
+    test(() => {
+        assert_equals(addElement(makeDocument()).customElementRegistry, null);
+    }, `${title}: customElementRegistry of an upgrade candidate connected to a document without a browsing context uses null regsitry by default`);
+
+    test(() => {
+        const doc = makeDocument();
+        const element = addElement(doc);
+        customElementRegistry.initialize(doc);
+        assert_equals(doc.customElementRegistry, customElementRegistry);
+        assert_equals(element.customElementRegistry, customElementRegistry);
+    }, `${title}: customElementRegistry of document and an upgrade candidate after calling CustomElementRegistry.prototype.initialize should return the registry`);
+
+    test(() => {
+        const doc = makeDocument();
+        const element = addElement(doc);
+        customElementRegistry.initialize(doc);
+        assert_equals(doc.customElementRegistry, customElementRegistry);
+        assert_equals(element.customElementRegistry, customElementRegistry);
+        element.innerHTML = '<a-b></a-b>';
+        assert_equals(element.querySelector('a-b').customElementRegistry, customElementRegistry);
+    }, `${title}: customElementRegistry of an element created after calling CustomElementRegistry.prototype.initialize should return the registry`);
+}
+
+runTest('Document', () => new Document, new CustomElementRegistry);
+runTest('HTMLDocument', () => document.implementation.createHTMLDocument(), new CustomElementRegistry);
+runTest('XHTMLDocument', () => document.implementation.createDocument('http://www.w3.org/1999/xhtml', 'html', null), new CustomElementRegistry);
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/CustomElementRegistry.cpp
+++ b/Source/WebCore/dom/CustomElementRegistry.cpp
@@ -199,20 +199,29 @@ void CustomElementRegistry::initialize(Node& root)
         return;
     }
 
-    if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(root); shadowRoot && shadowRoot->usesNullCustomElementRegistry()) {
+    if (RefPtr document = dynamicDowncast<Document>(*containerRoot); document && document->usesNullCustomElementRegistry()) {
+        document->clearUsesNullCustomElementRegistry();
+        document->setCustomElementRegistry(*this);
+    } else if (RefPtr shadowRoot = dynamicDowncast<ShadowRoot>(*containerRoot); shadowRoot && shadowRoot->usesNullCustomElementRegistry()) {
         ASSERT(shadowRoot->hasScopedCustomElementRegistry());
         shadowRoot->clearUsesNullCustomElementRegistry();
         shadowRoot->setCustomElementRegistry(*this);
-    }
+    } else if (auto* documentFragment = dynamicDowncast<DocumentFragment>(*containerRoot); documentFragment && documentFragment->usesNullCustomElementRegistry())
+        documentFragment->clearUsesNullCustomElementRegistry();
 
     RefPtr registryOfTreeScope = root.isInTreeScope() ? root.treeScope().customElementRegistry() : nullptr;
-    for (Ref element : descendantsOfType<Element>(*containerRoot)) {
-        if (element->usesNullCustomElementRegistry()) {
-            element->clearUsesNullCustomElementRegistry();
-            if (this != registryOfTreeScope)
-                addToScopedCustomElementRegistryMap(element, *this);
-        }
-    }
+    auto updateRegistryIfNeeded = [&](Element& element) {
+        if (!element.usesNullCustomElementRegistry())
+            return;
+        element.clearUsesNullCustomElementRegistry();
+        if (this != registryOfTreeScope)
+            addToScopedCustomElementRegistryMap(element, *this);
+    };
+
+    if (RefPtr element = dynamicDowncast<Element>(*containerRoot))
+        updateRegistryIfNeeded(*element);
+    for (Ref element : descendantsOfType<Element>(*containerRoot))
+        updateRegistryIfNeeded(element);
 }
 
 void CustomElementRegistry::addToScopedCustomElementRegistryMap(Element& element, CustomElementRegistry& registry)

--- a/Source/WebCore/dom/CustomElementRegistry.h
+++ b/Source/WebCore/dom/CustomElementRegistry.h
@@ -79,7 +79,7 @@ public:
     static CustomElementRegistry* registryForNodeOrTreeScope(const Node& node, const TreeScope& treeScope)
     {
         if (node.usesNullCustomElementRegistry()) {
-            ASSERT(is<Element>(node));
+            ASSERT(is<Element>(node) || node.isTreeScope() || node.isDocumentFragment());
             return nullptr;
         }
         if (auto* element = dynamicDowncast<Element>(node); UNLIKELY(element && element->usesScopedCustomElementRegistryMap()))

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -673,6 +673,9 @@ Document::Document(LocalFrame* frame, const Settings& settings, const URL& url, 
     if ((frame && frame->ownerElement()) || !url.isEmpty())
         setURL(url);
 
+    if (!frame)
+        setUsesNullCustomElementRegistry();
+
     initSecurityContext();
 
     InspectorInstrumentation::addEventListenersToNode(*this);
@@ -1471,13 +1474,18 @@ static ALWAYS_INLINE bool isStandardElementName(const AtomString& localName);
 static ALWAYS_INLINE Ref<HTMLElement> createUpgradeCandidateElement(Document& document, CustomElementRegistry* registry, const QualifiedName& name)
 {
     ASSERT(!isStandardElementName(name.localName())); // HTMLTagNames.in lists builtin SVG/MathML elements with "-" in their names explicitly as HTMLUnknownElement.
-    if (validateCustomElementNameWithoutCheckingStandardElementNames(name.localName()) != CustomElementNameValidationStatus::Valid)
-        return HTMLUnknownElement::create(name, document);
+
+    if (validateCustomElementNameWithoutCheckingStandardElementNames(name.localName()) != CustomElementNameValidationStatus::Valid) {
+        Ref element = HTMLUnknownElement::create(name, document);
+        if (!registry && document.usesNullCustomElementRegistry())
+            element->setUsesNullCustomElementRegistry();
+        return element;
+    }
 
     Ref element = HTMLMaybeFormAssociatedCustomElement::create(name, document);
 
-    if (!registry)
-        registry = document.customElementRegistry();
+    if (!registry && document.usesNullCustomElementRegistry())
+        element->setUsesNullCustomElementRegistry();
 
     element->setIsCustomElementUpgradeCandidate();
 
@@ -1539,7 +1547,7 @@ ExceptionOr<Ref<Element>> Document::createElementForBindings(const AtomString& n
         if (!document->isValidName(name))
             return Exception { ExceptionCode::InvalidCharacterError, makeString("Invalid qualified name: '"_s, name, '\'') };
 
-        return createElement(QualifiedName(nullAtom(), name, nullAtom()), false);
+        return createElement(QualifiedName(nullAtom(), name, nullAtom()), false, registry.get());
     }();
 
     if (result.hasException())
@@ -1738,7 +1746,7 @@ Ref<Element> Document::createElement(const QualifiedName& name, bool createdByPa
     if (UNLIKELY(registry && registry->isScoped()))
         CustomElementRegistry::addToScopedCustomElementRegistryMap(*element, *registry);
 
-    if (createdByParser && !registry)
+    if (!registry && usesNullCustomElementRegistry())
         element->setUsesNullCustomElementRegistry();
 
     // <image> uses imgTag so we need a special rule.
@@ -1781,7 +1789,7 @@ RefPtr<CustomElementRegistry> Document::customElementRegistryForBindings()
 {
     if (RefPtr window = document().domWindow())
         return &window->ensureCustomElementRegistry();
-    return nullptr;
+    return customElementRegistry();
 }
 
 static inline bool isPotentialCustomElementNameCharacter(char32_t character)
@@ -1965,7 +1973,7 @@ ExceptionOr<Ref<Element>> Document::createElementNS(const AtomString& namespaceU
         if (parsedName.namespaceURI() == xhtmlNamespaceURI)
             return createHTMLElementWithNameValidation(document, parsedName, registry.get());
 
-        return createElement(parsedName, false);
+        return createElement(parsedName, false, registry.get());
     }();
 
     if (result.hasException())

--- a/Source/WebCore/dom/DocumentFragment.cpp
+++ b/Source/WebCore/dom/DocumentFragment.cpp
@@ -41,6 +41,8 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(DocumentFragment);
 DocumentFragment::DocumentFragment(Document& document, OptionSet<TypeFlag> typeFlags)
     : ContainerNode(document, DOCUMENT_FRAGMENT_NODE, typeFlags)
 {
+    if (document.usesNullCustomElementRegistry())
+        setUsesNullCustomElementRegistry();
 }
 
 Ref<DocumentFragment> DocumentFragment::create(Document& document)


### PR DESCRIPTION
#### cbfaf8556c9e9733968bd24de9b9fe602f5ee974
<pre>
CustomElementRegistry.prototype.initialize doesn&apos;t work on a single element
<a href="https://bugs.webkit.org/show_bug.cgi?id=291723">https://bugs.webkit.org/show_bug.cgi?id=291723</a>

Reviewed by Anne van Kesteren.

Fix the bug in CustomElementRegistry::initialize which wasn&apos;t updating the registry of the root when it&apos;s not a shadow root.

This PR also changes so that Document now sets setUsesNullCustomElementRegistry() when it does not have a browsing context,
and fixes Document::createElement and friends to propagate the null registry status from Document to a newly created element.

Finally, this PR makes Document::customElementRegistryForBindings fallback to TreeScope::customElementRegistry() when no
LocalDOMWindow is associated with the document (i.e. registry is manually set by CustomElementRegistry::initialize).

This PR imports a WPT added in <a href="https://github.com/web-platform-tests/wpt/pull/52045">https://github.com/web-platform-tests/wpt/pull/52045</a> and updated in
<a href="https://github.com/web-platform-tests/wpt/pull/51976">https://github.com/web-platform-tests/wpt/pull/51976</a> and adds another WPT for more comprehensive testing of
CustomElementRegistry.prototype.initialize and customElementRegistry getter on Document and Element.

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/pseudo-class-defined.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/pseudo-class-defined.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/pseudo-class-defined.window.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-initialize-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-registry-initialize.html: Added.
* Source/WebCore/dom/CustomElementRegistry.cpp:
(WebCore::CustomElementRegistry::initialize):
* Source/WebCore/dom/CustomElementRegistry.h:
(WebCore::CustomElementRegistry::registryForNodeOrTreeScope):
* Source/WebCore/dom/Document.cpp:
(WebCore::m_syncData):
(WebCore::createUpgradeCandidateElement):
(WebCore::Document::createElementForBindings):
(WebCore::Document::createElement):
(WebCore::Document::customElementRegistryForBindings):
(WebCore::Document::createElementNS):
* Source/WebCore/dom/DocumentFragment.cpp:
(WebCore::DocumentFragment::DocumentFragment):

Canonical link: <a href="https://commits.webkit.org/293968@main">https://commits.webkit.org/293968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/839af89d4069dafe3f708458b5fea9023109a626

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100434 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10385 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105571 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51022 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102475 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20393 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28560 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76471 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33524 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103441 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15624 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90721 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56827 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15440 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8724 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50397 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85356 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8803 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107925 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27552 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20218 "Found 1 new test failure: imported/w3c/web-platform-tests/IndexedDB/idbfactory-open-request-error.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85424 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27915 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86921 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84962 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29649 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7380 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21515 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16345 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27487 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32730 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27298 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30616 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28856 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->