### PR TITLE
[Filters] Unify applying CSS and SVG filters

### DIFF
--- a/LayoutTests/css3/filters/identity-filters.html
+++ b/LayoutTests/css3/filters/identity-filters.html
@@ -1,3 +1,4 @@
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-200" />
 <style>
     td {
         padding: 5px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/css-reference-large-svg-filter.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/css-reference-large-svg-filter.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="fuzzy" content="maxDifference=0-179; totalPixels=0-2992" />
     <title>CSS Filter References Large SVG Filter Effect</title>
     <link rel="author" title="Michael Ludwig" href="mailto:michaelludwig@google.com">
     <link rel="help" href="https://crbug.com/1466359">

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2153,7 +2153,6 @@ webkit.org/b/245347 imported/w3c/web-platform-tests/css/css-color/deprecated-sam
 webkit.org/b/264001 [ Debug ] imported/w3c/web-platform-tests/requestidlecallback/callback-multiple-calls.html [ Pass Failure ]
 
 # webkit.org/b/264419 ([ Sonoma 14.1+ ] Multiple tests are constantly failing following update from 14.0.)
-webkit.org/b/264544 [ Sonoma+ ] css3/filters/effect-opacity-hw.html [ ImageOnlyFailure ]
 
 webkit.org/b/264527 imported/w3c/web-platform-tests/css/css-cascade/idlharness.html [ Pass Failure ]
 

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -79,7 +79,6 @@ page/scrolling/ScrollingStateNode.h
 platform/PODRedBlackTree.h
 platform/Scrollbar.h
 platform/cocoa/TelephoneNumberDetectorCocoa.cpp
-platform/graphics/ImageBufferContextSwitcher.h
 platform/graphics/StringTruncator.cpp
 platform/graphics/ca/PlatformCALayer.h
 platform/graphics/ca/TileController.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -673,7 +673,6 @@ rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
 rendering/svg/legacy/LegacyRenderSVGPath.cpp
 rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
 rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
-rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
 rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.cpp
 rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
 rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -401,7 +401,6 @@ rendering/RenderImageResource.cpp
 rendering/RenderLayer.cpp
 rendering/RenderLayerBacking.cpp
 rendering/RenderLayerCompositor.cpp
-rendering/RenderLayerFilters.cpp
 rendering/RenderLayerModelObject.cpp
 rendering/RenderListBox.cpp
 rendering/RenderListItem.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2850,6 +2850,7 @@ rendering/RenderDeprecatedFlexibleBox.cpp
 rendering/RenderElement.cpp
 rendering/RenderEmbeddedObject.cpp
 rendering/RenderFileUploadControl.cpp
+rendering/RenderFilterResource.cpp
 rendering/RenderFlexibleBox.cpp
 rendering/RenderFragmentContainer.cpp
 rendering/RenderFragmentContainerSet.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -13835,6 +13835,8 @@
 		724ED3301A3A8B2300F5F13C /* JSEXTBlendMinMax.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSEXTBlendMinMax.h; sourceTree = "<group>"; };
 		724EE54E1DC7F25B00A91FFB /* ActivityState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ActivityState.h; sourceTree = "<group>"; };
 		724EE54F1DC7F25B00A91FFB /* ActivityStateChangeObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ActivityStateChangeObserver.h; sourceTree = "<group>"; };
+		724EEE3A2D13529500922C10 /* RenderFilterResource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RenderFilterResource.h; sourceTree = "<group>"; };
+		724EEE3B2D13529500922C10 /* RenderFilterResource.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RenderFilterResource.cpp; sourceTree = "<group>"; };
 		7252396B254CADC200F5FB15 /* NativeImage.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NativeImage.cpp; sourceTree = "<group>"; };
 		725F64BC2C7D633100F87348 /* ElementTextDirection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ElementTextDirection.h; sourceTree = "<group>"; };
 		725F64BD2C7D633100F87348 /* ElementTextDirection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ElementTextDirection.cpp; sourceTree = "<group>"; };
@@ -40055,6 +40057,8 @@
 				0F5B7A5310F65D7A00376302 /* RenderEmbeddedObject.h */,
 				066C772E0AB603FD00238CC4 /* RenderFileUploadControl.cpp */,
 				066C772F0AB603FD00238CC4 /* RenderFileUploadControl.h */,
+				724EEE3B2D13529500922C10 /* RenderFilterResource.cpp */,
+				724EEE3A2D13529500922C10 /* RenderFilterResource.h */,
 				53C8298B13D8D92700DE2DEB /* RenderFlexibleBox.cpp */,
 				53C8298C13D8D92700DE2DEB /* RenderFlexibleBox.h */,
 				D70AD65513E1342B005B50B4 /* RenderFragmentContainer.cpp */,

--- a/Source/WebCore/html/canvas/CanvasLayerContextSwitcher.cpp
+++ b/Source/WebCore/html/canvas/CanvasLayerContextSwitcher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,7 +39,7 @@ RefPtr<CanvasLayerContextSwitcher> CanvasLayerContextSwitcher::create(CanvasRend
     if (!effectiveDrawingContext)
         return nullptr;
 
-    auto targetSwitcher = GraphicsContextSwitcher::create(*effectiveDrawingContext, bounds, context.colorSpace(), WTFMove(filter));
+    auto targetSwitcher = GraphicsContextSwitcher::create(*effectiveDrawingContext, context.colorSpace(), bounds, WTFMove(filter));
     if (!targetSwitcher)
         return nullptr;
 
@@ -54,12 +54,14 @@ CanvasLayerContextSwitcher::CanvasLayerContextSwitcher(CanvasRenderingContext2DB
 {
     ASSERT(m_targetSwitcher);
     ASSERT(m_effectiveDrawingContext);
-    m_targetSwitcher->beginDrawSourceImage(*m_effectiveDrawingContext, context.globalAlpha());
+    m_targetSwitcher->beginDrawSourceImage(*m_effectiveDrawingContext, std::nullopt, context.globalAlpha());
 }
 
 CanvasLayerContextSwitcher::~CanvasLayerContextSwitcher()
 {
-    m_targetSwitcher->endDrawSourceImage(*m_effectiveDrawingContext, DestinationColorSpace::SRGB());
+    auto state = m_targetSwitcher->endDrawSourceImage(*m_effectiveDrawingContext);
+    if (state == SwitcherState::SourcePainted)
+        m_targetSwitcher->drawOutputImage(*m_effectiveDrawingContext, DestinationColorSpace::SRGB());
 }
 
 GraphicsContext* CanvasLayerContextSwitcher::drawingContext() const

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -123,14 +123,10 @@ RefPtr<Filter> CanvasRenderingContext2D::createFilter(const FloatRect& bounds) c
         return nullptr;
 
     auto preferredFilterRenderingModes = page->preferredFilterRenderingModes();
-    auto filter = CSSFilterRenderer::create(*renderer, state().filter, preferredFilterRenderingModes, { 1, 1 }, bounds, *context);
-    if (!filter)
-        return nullptr;
-
     auto outsets = calculateFilterOutsets(bounds);
+    auto filterRegion = bounds + toFloatBoxExtent(outsets);
 
-    filter->setFilterRegion(bounds + toFloatBoxExtent(outsets));
-    return filter;
+    return CSSFilterRenderer::create(*renderer, state().filter, preferredFilterRenderingModes, { 1, 1 }, filterRegion, bounds, *context);
 }
 
 IntOutsets CanvasRenderingContext2D::calculateFilterOutsets(const FloatRect& bounds) const

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/Document.h>
+#include <WebCore/DocumentInlines.h>
 #include <WebCore/Element.h>
 #include <WebCore/FloatPoint.h>
 #include <WebCore/ScrollTypes.h>

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -225,7 +225,12 @@ static IntRect scaledImageBufferRect(const FloatRect& rect, const FloatSize& sca
 {
     auto scaledRect = rect;
     scaledRect.scale(scale);
-    return enclosingIntRect(scaledRect);
+
+    auto scaledImageBufferRect = enclosingIntRect(scaledRect);
+    if (ImageBuffer::sizeNeedsClamping(scaledImageBufferRect.size()))
+        scaledImageBufferRect = IntRect(scaledRect);
+
+    return scaledImageBufferRect;
 }
 
 static FloatSize clampingScaleForImageBufferSize(const FloatSize& size)

--- a/Source/WebCore/platform/graphics/GraphicsContextSwitcher.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextSwitcher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,17 +36,37 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(GraphicsContextSwitcher);
 
-std::unique_ptr<GraphicsContextSwitcher> GraphicsContextSwitcher::create(GraphicsContext& destinationContext, const FloatRect& sourceImageRect, const DestinationColorSpace& colorSpace, RefPtr<Filter>&& filter, FilterResults* results)
+std::unique_ptr<GraphicsContextSwitcher> GraphicsContextSwitcher::create(GraphicsContext& destinationContext, const DestinationColorSpace& colorSpace, const FloatRect& sourceImageRect, RefPtr<Filter>&& filter, FilterResults* results)
 {
     if (filter && filter->filterRenderingModes().contains(FilterRenderingMode::GraphicsContext))
         return makeUnique<TransparencyLayerContextSwitcher>(destinationContext, sourceImageRect, WTFMove(filter));
 
-    return makeUnique<ImageBufferContextSwitcher>(destinationContext, sourceImageRect, colorSpace, WTFMove(filter), results);
+    return makeUnique<ImageBufferContextSwitcher>(destinationContext, colorSpace, sourceImageRect, WTFMove(filter), results);
 }
 
-GraphicsContextSwitcher::GraphicsContextSwitcher(RefPtr<Filter>&& filter)
-    : m_filter(WTFMove(filter))
+GraphicsContextSwitcher::GraphicsContextSwitcher(const FloatRect& sourceImageRect, RefPtr<Filter>&& filter)
+    : m_sourceImageRect(sourceImageRect)
+    , m_filter(WTFMove(filter))
 {
+}
+
+TextStream& operator<<(TextStream& ts, SwitcherState state)
+{
+    switch (state) {
+    case SwitcherState::None:
+        ts << "none";
+        break;
+    case SwitcherState::PaintingSource:
+        ts << "painting source";
+        break;
+    case SwitcherState::SourcePainted:
+        ts << "source painted";
+        break;
+    case SwitcherState::CycleDetected:
+        ts << "cycle detected";
+        break;
+    }
+    return ts;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/GraphicsContextSwitcher.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextSwitcher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,27 +35,38 @@ class Filter;
 class FilterResults;
 class GraphicsContext;
 
+enum class SwitcherState : uint8_t {
+    None,
+    PaintingSource,
+    SourcePainted,
+    CycleDetected
+};
+
 class GraphicsContextSwitcher {
     WTF_MAKE_TZONE_ALLOCATED(GraphicsContextSwitcher);
 public:
-    static std::unique_ptr<GraphicsContextSwitcher> create(GraphicsContext& destinationContext, const FloatRect& sourceImageRect, const DestinationColorSpace&, RefPtr<Filter>&& = nullptr, FilterResults* = nullptr);
+    static std::unique_ptr<GraphicsContextSwitcher> create(GraphicsContext& destinationContext, const DestinationColorSpace&, const FloatRect& sourceImageRect, RefPtr<Filter>&&, FilterResults* = nullptr);
 
     virtual ~GraphicsContextSwitcher() = default;
 
-    virtual GraphicsContext* drawingContext(GraphicsContext& destinationContext) const { return &destinationContext; }
+    SwitcherState state() const { return m_state; }
+    void setState(SwitcherState state) { m_state = state; }
 
     virtual bool hasSourceImage() const { return false; }
+    virtual GraphicsContext* drawingContext(GraphicsContext& destinationContext) const { return &destinationContext; }
 
-    virtual void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect& clipRect) = 0;
-    virtual void endClipAndDrawSourceImage(GraphicsContext& destinationContext, const DestinationColorSpace&) = 0;
-
-    virtual void beginDrawSourceImage(GraphicsContext& destinationContext, float opacity = 1.f) = 0;
-    virtual void endDrawSourceImage(GraphicsContext& destinationContext, const DestinationColorSpace&) = 0;
+    virtual SwitcherState beginDrawSourceImage(GraphicsContext& destinationContext, std::optional<FloatRect> clipRect = std::nullopt, float opacity = 1.f) = 0;
+    virtual SwitcherState endDrawSourceImage(GraphicsContext& destinationContext) = 0;
+    virtual void drawOutputImage(GraphicsContext& destinationContext, const DestinationColorSpace&) = 0;
 
 protected:
-    explicit GraphicsContextSwitcher(RefPtr<Filter>&&);
+    explicit GraphicsContextSwitcher(const FloatRect& sourceImageRect, RefPtr<Filter>&&);
 
+    FloatRect m_sourceImageRect;
     RefPtr<Filter> m_filter;
+    SwitcherState m_state { SwitcherState::None };
 };
+
+WTF::TextStream& operator<<(WTF::TextStream&, SwitcherState);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -443,7 +443,7 @@ RefPtr<NativeImage> ImageBuffer::filteredNativeImage(Filter& filter, Function<vo
 
     if (filter.filterRenderingModes().contains(FilterRenderingMode::GraphicsContext)) {
         ASSERT(targetSwitcher);
-        targetSwitcher->endDrawSourceImage(context(), colorSpace());
+        targetSwitcher->endDrawSourceImage(context());
         return copyImageBufferToNativeImage(*this, CopyBackingStore, PreserveResolution::No);
     }
 

--- a/Source/WebCore/platform/graphics/ImageBufferContextSwitcher.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferContextSwitcher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,12 +36,11 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ImageBufferContextSwitcher);
 
-ImageBufferContextSwitcher::ImageBufferContextSwitcher(GraphicsContext& destinationContext, const FloatRect& sourceImageRect, const DestinationColorSpace& colorSpace, RefPtr<Filter>&& filter, FilterResults* results)
-    : GraphicsContextSwitcher(WTFMove(filter))
-    , m_sourceImageRect(sourceImageRect)
+ImageBufferContextSwitcher::ImageBufferContextSwitcher(GraphicsContext& destinationContext, const DestinationColorSpace& colorSpace, const FloatRect& sourceImageRect, RefPtr<Filter>&& filter, FilterResults* results)
+    : GraphicsContextSwitcher(sourceImageRect, WTFMove(filter))
     , m_results(results)
 {
-    if (sourceImageRect.isEmpty())
+    if (m_sourceImageRect.isEmpty())
         return;
 
     if (m_filter)
@@ -58,30 +57,34 @@ ImageBufferContextSwitcher::ImageBufferContextSwitcher(GraphicsContext& destinat
     m_sourceImage->context().mergeAllChanges(state);
 }
 
-GraphicsContext* ImageBufferContextSwitcher::drawingContext(GraphicsContext& context) const
+GraphicsContext* ImageBufferContextSwitcher::drawingContext(GraphicsContext& destinationContext) const
 {
-    return m_sourceImage ? &m_sourceImage->context() : &context;
+    return m_sourceImage ? &m_sourceImage->context() : &destinationContext;
 }
 
-void ImageBufferContextSwitcher::beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect&)
+SwitcherState ImageBufferContextSwitcher::beginDrawSourceImage(GraphicsContext& destinationContext, std::optional<FloatRect> clipRect, float)
 {
-    if (auto* context = drawingContext(destinationContext)) {
-        context->save();
-        context->clearRect(repaintRect);
-        context->clip(repaintRect);
-    }
+    ASSERT(m_state != SwitcherState::PaintingSource);
+
+    if (clipRect)
+        drawingContext(destinationContext)->clearRect(*clipRect);
+
+    m_state = SwitcherState::PaintingSource;
+    return m_state;
 }
 
-void ImageBufferContextSwitcher::endClipAndDrawSourceImage(GraphicsContext& destinationContext, const DestinationColorSpace& colorSpace)
+SwitcherState ImageBufferContextSwitcher::endDrawSourceImage(GraphicsContext&)
 {
-    if (auto* context = drawingContext(destinationContext))
-        context->restore();
-
-    endDrawSourceImage(destinationContext, colorSpace);
+    ASSERT(m_state == SwitcherState::PaintingSource);
+    m_state = SwitcherState::SourcePainted;
+    return m_state;
 }
 
-void ImageBufferContextSwitcher::endDrawSourceImage(GraphicsContext& destinationContext, const DestinationColorSpace& colorSpace)
+void ImageBufferContextSwitcher::drawOutputImage(GraphicsContext& destinationContext, const DestinationColorSpace& colorSpace)
 {
+    if (m_state != SwitcherState::SourcePainted)
+        return;
+
     if (!m_filter) {
         if (m_sourceImage)
             destinationContext.drawImageBuffer(*m_sourceImage, m_sourceImageRect, { destinationContext.compositeOperation(), destinationContext.blendMode() });

--- a/Source/WebCore/platform/graphics/ImageBufferContextSwitcher.h
+++ b/Source/WebCore/platform/graphics/ImageBufferContextSwitcher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,22 +35,17 @@ class ImageBuffer;
 class ImageBufferContextSwitcher final : public GraphicsContextSwitcher {
     WTF_MAKE_TZONE_ALLOCATED(ImageBufferContextSwitcher);
 public:
-    ImageBufferContextSwitcher(GraphicsContext& destinationContext, const FloatRect& sourceImageRect, const DestinationColorSpace&, RefPtr<Filter>&& = nullptr, FilterResults* = nullptr);
+    ImageBufferContextSwitcher(GraphicsContext& destinationContext, const DestinationColorSpace&, const FloatRect& sourceImageRect, RefPtr<Filter>&&, FilterResults* = nullptr);
 
 private:
-    GraphicsContext* drawingContext(GraphicsContext& destinationContext) const override;
+    GraphicsContext* drawingContext(GraphicsContext& destinationContext) const final;
+    bool hasSourceImage() const final { return m_sourceImage; }
 
-    bool hasSourceImage() const override { return m_sourceImage; }
-
-    void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect& clipRect) override;
-    void endClipAndDrawSourceImage(GraphicsContext& destinationContext, const DestinationColorSpace&) override;
-
-    void beginDrawSourceImage(GraphicsContext&, float = 1.f) override { }
-    void endDrawSourceImage(GraphicsContext& destinationContext, const DestinationColorSpace&) override;
+    SwitcherState beginDrawSourceImage(GraphicsContext&, std::optional<FloatRect> clipRect = std::nullopt, float = 1.f) final;
+    SwitcherState endDrawSourceImage(GraphicsContext& destinationContext) final;
+    void drawOutputImage(GraphicsContext& destinationContext, const DestinationColorSpace&) final;
 
     RefPtr<ImageBuffer> m_sourceImage;
-    FloatRect m_sourceImageRect;
-
     FilterResults* m_results { nullptr };
 };
 

--- a/Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.cpp
+++ b/Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,40 +35,35 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TransparencyLayerContextSwitcher);
 
 TransparencyLayerContextSwitcher::TransparencyLayerContextSwitcher(GraphicsContext& destinationContext, const FloatRect& sourceImageRect, RefPtr<Filter>&& filter)
-    : GraphicsContextSwitcher(WTFMove(filter))
+    : GraphicsContextSwitcher(sourceImageRect, WTFMove(filter))
 {
     if (m_filter)
         m_filterStyles = m_filter->createFilterStyles(destinationContext, sourceImageRect);
 }
 
-void TransparencyLayerContextSwitcher::beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect&, const FloatRect& clipRect)
+SwitcherState TransparencyLayerContextSwitcher::beginDrawSourceImage(GraphicsContext& destinationContext, std::optional<FloatRect> clipRect, float opacity)
 {
-    destinationContext.save();
-    destinationContext.beginTransparencyLayer(1);
+    ASSERT(m_state != SwitcherState::PaintingSource);
+    m_state = SwitcherState::PaintingSource;
 
-    for (auto& filterStyle : m_filterStyles) {
-        destinationContext.save();
-        destinationContext.clip(intersection(filterStyle.imageRect, clipRect));
-        destinationContext.setStyle(filterStyle.style);
-        destinationContext.beginTransparencyLayer(1);
-    }
-}
-
-void TransparencyLayerContextSwitcher::beginDrawSourceImage(GraphicsContext& destinationContext, float opacity)
-{
     destinationContext.save();
     destinationContext.beginTransparencyLayer(opacity);
 
     for (auto& filterStyle : m_filterStyles) {
         destinationContext.save();
-        destinationContext.clip(filterStyle.imageRect);
+        destinationContext.clip(clipRect ? intersection(filterStyle.imageRect, *clipRect) : filterStyle.imageRect);
         destinationContext.setStyle(filterStyle.style);
         destinationContext.beginTransparencyLayer(1);
     }
+
+    return m_state;
 }
 
-void TransparencyLayerContextSwitcher::endDrawSourceImage(GraphicsContext& destinationContext, const DestinationColorSpace&)
+SwitcherState TransparencyLayerContextSwitcher::endDrawSourceImage(GraphicsContext& destinationContext)
 {
+    ASSERT(m_state == SwitcherState::PaintingSource);
+    m_state = SwitcherState::None;
+
     for ([[maybe_unused]] auto& filterStyle : makeReversedRange(m_filterStyles)) {
         destinationContext.endTransparencyLayer();
         destinationContext.restore();
@@ -76,6 +71,13 @@ void TransparencyLayerContextSwitcher::endDrawSourceImage(GraphicsContext& desti
 
     destinationContext.endTransparencyLayer();
     destinationContext.restore();
+
+    return m_state;
+}
+
+void TransparencyLayerContextSwitcher::drawOutputImage(GraphicsContext&, const DestinationColorSpace&)
+{
+    ASSERT_NOT_REACHED();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.h
+++ b/Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,11 +37,9 @@ public:
     TransparencyLayerContextSwitcher(GraphicsContext& destinationContext, const FloatRect& sourceImageRect, RefPtr<Filter>&&);
 
 private:
-    void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect& clipRect) override;
-    void endClipAndDrawSourceImage(GraphicsContext& destinationContext, const DestinationColorSpace& colorSpace) override { endDrawSourceImage(destinationContext, colorSpace); }
-
-    void beginDrawSourceImage(GraphicsContext& destinationContext, float opacity = 1.f) override;
-    void endDrawSourceImage(GraphicsContext& destinationContext, const DestinationColorSpace&) override;
+    SwitcherState beginDrawSourceImage(GraphicsContext& destinationContext, std::optional<FloatRect> clipRect = std::nullopt, float opacity = 1.f) final;
+    SwitcherState endDrawSourceImage(GraphicsContext& destinationContext) final;
+    void drawOutputImage(GraphicsContext& destinationContext, const DestinationColorSpace&) final;
 
     FilterStyleVector m_filterStyles;
 };

--- a/Source/WebCore/platform/graphics/filters/Filter.cpp
+++ b/Source/WebCore/platform/graphics/filters/Filter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,6 +44,7 @@ Filter::Filter(Filter::Type filterType, const FloatSize& filterScale, const Floa
     , m_filterScale(filterScale)
     , m_filterRegion(filterRegion)
 {
+    clampFilterRegionIfNeeded();
 }
 
 FloatPoint Filter::scaledByFilterScale(const FloatPoint& point) const
@@ -101,12 +102,30 @@ void Filter::setFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFil
     ASSERT(m_filterRenderingModes.contains(FilterRenderingMode::Software));
 }
 
+FilterResults& Filter::ensureResults(const Function<std::unique_ptr<FilterResults>()>& resultsCreator)
+{
+    if (!m_results)
+        m_results = resultsCreator();
+    return *m_results;
+}
+
+void Filter::clearEffectResult(FilterEffect& effect)
+{
+    if (m_results)
+        m_results->clearEffectResult(effect);
+}
+
 RefPtr<FilterImage> Filter::apply(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, FilterResults& results)
 {
     RefPtr<FilterImage> input;
 
     if (sourceImage) {
-        auto absoluteSourceImageRect = enclosingIntRect(scaledByFilterScale(sourceImageRect));
+        auto scaledSourceImageRect = scaledByFilterScale(sourceImageRect);
+
+        auto absoluteSourceImageRect = enclosingIntRect(scaledSourceImageRect);
+        if (ImageBuffer::sizeNeedsClamping(absoluteSourceImageRect.size()))
+            absoluteSourceImageRect = IntRect(scaledSourceImageRect);
+
         input = FilterImage::create(m_filterRegion, sourceImageRect, absoluteSourceImageRect, Ref { *sourceImage }, results.allocator());
         if (!input)
             return nullptr;

--- a/Source/WebCore/platform/graphics/filters/Filter.h
+++ b/Source/WebCore/platform/graphics/filters/Filter.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
  * Copyright (C) 2013 Google Inc. All rights reserved.
- * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -23,6 +23,7 @@
 
 #include <WebCore/FilterEffectVector.h>
 #include <WebCore/FilterFunction.h>
+#include <WebCore/FilterResults.h>
 #include <WebCore/FloatPoint3D.h>
 #include <WebCore/FloatRect.h>
 #include <WebCore/GraphicsTypes.h>
@@ -33,7 +34,6 @@ namespace WebCore {
 
 class FilterEffect;
 class FilterImage;
-class FilterResults;
 
 class Filter : public FilterFunction {
     using FilterFunction::apply;
@@ -49,7 +49,6 @@ public:
     void setFilterScale(const FloatSize& filterScale) { m_filterScale = filterScale; }
 
     FloatRect filterRegion() const { return m_filterRegion; }
-    void setFilterRegion(const FloatRect& filterRegion) { m_filterRegion = filterRegion; }
 
     virtual FloatSize resolvedSize(const FloatSize& size) const { return size; }
     virtual FloatPoint3D resolvedPoint3D(const FloatPoint3D& point) const { return point; }
@@ -62,8 +61,12 @@ public:
     FloatRect clipToMaxEffectRect(const FloatRect& imageRect, const FloatRect& primitiveSubregion) const;
 
     virtual FilterEffectVector effectsOfType(FilterFunction::Type) const = 0;
+    virtual void mergeEffects(const Filter&) = 0;
 
     bool clampFilterRegionIfNeeded();
+
+    WEBCORE_EXPORT FilterResults& ensureResults(const Function<std::unique_ptr<FilterResults>()>&);
+    void clearEffectResult(FilterEffect&);
 
     WEBCORE_EXPORT RefPtr<FilterImage> apply(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, FilterResults&);
     WEBCORE_EXPORT FilterStyleVector createFilterStyles(GraphicsContext&, const FloatRect& sourceImageRect) const;
@@ -79,6 +82,8 @@ private:
     OptionSet<FilterRenderingMode> m_filterRenderingModes { FilterRenderingMode::Software };
     FloatSize m_filterScale;
     FloatRect m_filterRegion;
+
+    std::unique_ptr<FilterResults> m_results;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/FilterEffect.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterEffect.cpp
@@ -162,7 +162,11 @@ RefPtr<FilterImage> FilterEffect::apply(const Filter& filter, std::span<const Re
 
     auto primitiveSubregion = calculatePrimitiveSubregion(filter, inputPrimitiveSubregions(inputs), geometry);
     auto imageRect = calculateImageRect(filter, inputImageRects(inputs), primitiveSubregion);
-    auto absoluteImageRect = enclosingIntRect(filter.scaledByFilterScale(imageRect));
+    auto scaledImageRect = filter.scaledByFilterScale(imageRect);
+
+    auto absoluteImageRect = enclosingIntRect(scaledImageRect);
+    if (ImageBuffer::sizeNeedsClamping(absoluteImageRect.size()))
+        absoluteImageRect = IntRect(scaledImageRect);
 
     if (absoluteImageRect.isEmpty() || ImageBuffer::sizeNeedsClamping(absoluteImageRect.size())) {
         LOG_WITH_STREAM(Filters, stream << "FilterEffect " << filterName() << " " << this << " apply(): " << *this << " absoluteImageRect " << absoluteImageRect << " is empty or needs clamping; bailing.");

--- a/Source/WebCore/platform/graphics/filters/FilterImage.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.cpp
@@ -47,6 +47,7 @@ RefPtr<FilterImage> FilterImage::create(const FloatRect& primitiveSubregion, con
 
 RefPtr<FilterImage> FilterImage::create(const FloatRect& primitiveSubregion, const FloatRect& imageRect, const IntRect& absoluteImageRect, Ref<ImageBuffer>&& imageBuffer, ImageBufferAllocator& allocator)
 {
+    ASSERT(!ImageBuffer::sizeNeedsClamping(absoluteImageRect.size()));
     return adoptRef(*new FilterImage(primitiveSubregion, imageRect, absoluteImageRect, WTFMove(imageBuffer), allocator));
 }
 
@@ -201,9 +202,9 @@ static void copyImageBytes(const PixelBuffer& sourcePixelBuffer, PixelBuffer& de
 
 static RefPtr<PixelBuffer> getConvertedPixelBuffer(ImageBuffer& imageBuffer, AlphaPremultiplication alphaFormat, const IntRect& sourceRect, DestinationColorSpace colorSpace, ImageBufferAllocator& allocator)
 {
-    auto clampedSize = ImageBuffer::clampedSize(sourceRect.size());
-    auto convertedImageBuffer = allocator.createImageBuffer(clampedSize, colorSpace, RenderingMode::Unaccelerated);
-    
+    ASSERT(!ImageBuffer::sizeNeedsClamping(sourceRect.size()));
+
+    auto convertedImageBuffer = allocator.createImageBuffer(sourceRect.size(), colorSpace, RenderingMode::Unaccelerated);
     if (!convertedImageBuffer)
         return nullptr;
 
@@ -216,10 +217,11 @@ static RefPtr<PixelBuffer> getConvertedPixelBuffer(ImageBuffer& imageBuffer, Alp
 static RefPtr<PixelBuffer> getConvertedPixelBuffer(PixelBuffer& sourcePixelBuffer, AlphaPremultiplication alphaFormat, DestinationColorSpace colorSpace, ImageBufferAllocator& allocator)
 {
     auto sourceRect = IntRect { { } , sourcePixelBuffer.size() };
-    auto clampedSize = ImageBuffer::clampedSize(sourceRect.size());
-
     auto& sourceColorSpace = sourcePixelBuffer.format().colorSpace;
-    auto imageBuffer = allocator.createImageBuffer(clampedSize, sourceColorSpace, RenderingMode::Unaccelerated);
+
+    ASSERT(!ImageBuffer::sizeNeedsClamping(sourceRect.size()));
+
+    auto imageBuffer = allocator.createImageBuffer(sourceRect.size(), sourceColorSpace, RenderingMode::Unaccelerated);
     if (!imageBuffer)
         return nullptr;
 
@@ -262,7 +264,6 @@ PixelBuffer* FilterImage::pixelBuffer(AlphaPremultiplication alphaFormat)
     }
 
     IntSize logicalSize(m_absoluteImageRect.size());
-    ASSERT(!ImageBuffer::sizeNeedsClamping(logicalSize));
 
     pixelBuffer = m_allocator.createPixelBuffer(format, logicalSize);
     if (!pixelBuffer)

--- a/Source/WebCore/platform/graphics/filters/FilterResults.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterResults.cpp
@@ -55,7 +55,7 @@ size_t FilterResults::memoryCost() const
 
 bool FilterResults::canCacheResult(const FilterImage& result) const
 {
-    static constexpr size_t maxAllowedMemoryCost = 100 * MB;
+    static constexpr size_t maxAllowedMemoryCost = 200 * MB;
     CheckedSize totalMemoryCost = memoryCost();
 
     totalMemoryCost += result.memoryCost();

--- a/Source/WebCore/platform/graphics/filters/FilterResults.h
+++ b/Source/WebCore/platform/graphics/filters/FilterResults.h
@@ -61,6 +61,4 @@ private:
     std::unique_ptr<ImageBufferAllocator> m_allocator;
 };
 
-using FilterResultsCreator = Function<std::unique_ptr<FilterResults>()>;
-
 } // namespace WebCore

--- a/Source/WebCore/rendering/CSSFilterRenderer.cpp
+++ b/Source/WebCore/rendering/CSSFilterRenderer.cpp
@@ -48,12 +48,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSFilterRenderer);
 
-RefPtr<CSSFilterRenderer> CSSFilterRenderer::createGeneric(RenderElement& renderer, const auto& filter, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext)
+RefPtr<CSSFilterRenderer> CSSFilterRenderer::createGeneric(RenderElement& renderer, const auto& filter, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
 {
-    bool hasFilterThatMovesPixels = filter.hasFilterThatMovesPixels();
-    bool hasFilterThatShouldBeRestrictedBySecurityOrigin = filter.hasFilterThatShouldBeRestrictedBySecurityOrigin();
-
-    auto filterRenderer = adoptRef(*new CSSFilterRenderer(filterScale, hasFilterThatMovesPixels, hasFilterThatShouldBeRestrictedBySecurityOrigin));
+    auto filterRenderer = adoptRef(*new CSSFilterRenderer(filterScale, filterRegion, renderingResourceIdentifier));
 
     if (!filterRenderer->buildFilterFunctions(renderer, filter, preferredFilterRenderingModes, targetBoundingBox, destinationContext)) {
         LOG_WITH_STREAM(Filters, stream << "CSSFilterRenderer::create: failed to build filters " << filter);
@@ -67,15 +64,14 @@ RefPtr<CSSFilterRenderer> CSSFilterRenderer::createGeneric(RenderElement& render
     return filterRenderer;
 }
 
-
-RefPtr<CSSFilterRenderer> CSSFilterRenderer::create(RenderElement& renderer, const Style::Filter& filter, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext)
+RefPtr<CSSFilterRenderer> CSSFilterRenderer::create(RenderElement& renderer, const Style::Filter& filter, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
 {
-    return createGeneric(renderer, filter, preferredFilterRenderingModes, filterScale, targetBoundingBox, destinationContext);
+    return createGeneric(renderer, filter, preferredFilterRenderingModes, filterScale, filterRegion, targetBoundingBox, destinationContext, renderingResourceIdentifier);
 }
 
-RefPtr<CSSFilterRenderer> CSSFilterRenderer::create(RenderElement& renderer, const FilterOperations& operations, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext)
+RefPtr<CSSFilterRenderer> CSSFilterRenderer::create(RenderElement& renderer, const FilterOperations& operations, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
 {
-    return createGeneric(renderer, operations, preferredFilterRenderingModes, filterScale, targetBoundingBox, destinationContext);
+    return createGeneric(renderer, operations, preferredFilterRenderingModes, filterScale, filterRegion, targetBoundingBox, destinationContext, renderingResourceIdentifier);
 }
 
 Ref<CSSFilterRenderer> CSSFilterRenderer::create(Vector<Ref<FilterFunction>>&& functions)
@@ -83,19 +79,17 @@ Ref<CSSFilterRenderer> CSSFilterRenderer::create(Vector<Ref<FilterFunction>>&& f
     return adoptRef(*new CSSFilterRenderer(WTFMove(functions)));
 }
 
-Ref<CSSFilterRenderer> CSSFilterRenderer::create(Vector<Ref<FilterFunction>>&& functions, OptionSet<FilterRenderingMode> filterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion)
+Ref<CSSFilterRenderer> CSSFilterRenderer::create(Vector<Ref<FilterFunction>>&& functions, OptionSet<FilterRenderingMode> filterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
 {
-    Ref filter = adoptRef(*new CSSFilterRenderer(WTFMove(functions), filterScale, filterRegion));
+    Ref filter = adoptRef(*new CSSFilterRenderer(WTFMove(functions), filterScale, filterRegion, renderingResourceIdentifier));
     // Setting filter rendering modes cannot be moved to the constructor because it ends up
     // calling supportedFilterRenderingModes() which is a virtual function.
     filter->setFilterRenderingModes(filterRenderingModes);
     return filter;
 }
 
-CSSFilterRenderer::CSSFilterRenderer(const FloatSize& filterScale, bool hasFilterThatMovesPixels, bool hasFilterThatShouldBeRestrictedBySecurityOrigin)
-    : Filter(Filter::Type::CSSFilterRenderer, filterScale)
-    , m_hasFilterThatMovesPixels(hasFilterThatMovesPixels)
-    , m_hasFilterThatShouldBeRestrictedBySecurityOrigin(hasFilterThatShouldBeRestrictedBySecurityOrigin)
+CSSFilterRenderer::CSSFilterRenderer(const FloatSize& filterScale, const FloatRect& filterRegion, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
+    : Filter(Type::CSSFilterRenderer, filterScale, filterRegion, renderingResourceIdentifier)
 {
 }
 
@@ -105,8 +99,8 @@ CSSFilterRenderer::CSSFilterRenderer(Vector<Ref<FilterFunction>>&& functions)
 {
 }
 
-CSSFilterRenderer::CSSFilterRenderer(Vector<Ref<FilterFunction>>&& functions, const FloatSize& filterScale, const FloatRect& filterRegion)
-    : Filter(Type::CSSFilterRenderer, filterScale, filterRegion)
+CSSFilterRenderer::CSSFilterRenderer(Vector<Ref<FilterFunction>>&& functions, const FloatSize& filterScale, const FloatRect& filterRegion, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
+    : Filter(Type::CSSFilterRenderer, filterScale, filterRegion, renderingResourceIdentifier)
     , m_functions(WTFMove(functions))
 {
     clampFilterRegionIfNeeded();
@@ -241,6 +235,12 @@ static RefPtr<SVGFilterRenderer> createReferenceFilter(CSSFilterRenderer& filter
     if (filterRegion.isEmpty())
         return nullptr;
 
+    auto filterScale = filter.filterScale();
+
+    // Ensure the reference SVGFilterRenderer has the same clamping ratio as the parent CSSFilter.
+    if (ImageBuffer::sizeNeedsClamping(filterRegion.size(), filterScale))
+        filterRegion = filter.filterRegion();
+
     return SVGFilterRenderer::create(contextElement.get(), *filterElement, preferredFilterRenderingModes, filter.filterScale(), filterRegion, targetBoundingBox, destinationContext);
 }
 
@@ -343,6 +343,35 @@ OptionSet<FilterRenderingMode> CSSFilterRenderer::supportedFilterRenderingModes(
     return modes;
 }
 
+void CSSFilterRenderer::mergeEffects(const Filter& otherFilter)
+{
+    RefPtr otherCssFilter = dynamicDowncast<CSSFilterRenderer>(otherFilter);
+    if (!otherCssFilter)
+        return;
+
+    auto& otherFunctions = otherCssFilter->functions();
+    ASSERT(m_functions.size() == otherFunctions.size());
+
+    for (unsigned index = 0; index < m_functions.size(); ++index) {
+        if (m_functions[index]->isSVGFilterRenderer()) {
+            RefPtr svgFilter = dynamicDowncast<SVGFilterRenderer>(m_functions[index]);
+            RefPtr otherSVGFilter = dynamicDowncast<SVGFilterRenderer>(otherFunctions[index]);
+            if (!svgFilter || !otherSVGFilter)
+                return;
+
+            svgFilter->mergeEffects(*otherSVGFilter);
+            continue;
+        }
+
+        RefPtr effect = dynamicDowncast<FilterEffect>(m_functions[index]);
+        if (!effect)
+            return;
+
+        clearEffectResult(*effect);
+        m_functions[index] = otherFunctions[index];
+    }
+}
+
 RefPtr<FilterImage> CSSFilterRenderer::apply(FilterImage* sourceImage, FilterResults& results)
 {
     ASSERT(filterRenderingModes().contains(FilterRenderingMode::Software));
@@ -383,12 +412,6 @@ FilterStyleVector CSSFilterRenderer::createFilterStyles(GraphicsContext& context
     return styles;
 }
 
-void CSSFilterRenderer::setFilterRegion(const FloatRect& filterRegion)
-{
-    Filter::setFilterRegion(filterRegion);
-    clampFilterRegionIfNeeded();
-}
-
 bool CSSFilterRenderer::isIdentity(RenderElement& renderer, const Style::Filter& filter)
 {
     if (filter.hasFilterThatShouldBeRestrictedBySecurityOrigin())
@@ -408,6 +431,7 @@ bool CSSFilterRenderer::isIdentity(RenderElement& renderer, const Style::Filter&
 
     return true;
 }
+
 bool CSSFilterRenderer::isIdentity(RenderElement& renderer, const FilterOperations& operations)
 {
     if (operations.hasFilterThatShouldBeRestrictedBySecurityOrigin())

--- a/Source/WebCore/rendering/CSSFilterRenderer.h
+++ b/Source/WebCore/rendering/CSSFilterRenderer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,19 +43,16 @@ struct Filter;
 class CSSFilterRenderer final : public Filter {
     WTF_MAKE_TZONE_ALLOCATED(CSSFilterRenderer);
 public:
-    static RefPtr<CSSFilterRenderer> create(RenderElement&, const Style::Filter&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
-    static RefPtr<CSSFilterRenderer> create(RenderElement&, const FilterOperations&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
+    static RefPtr<CSSFilterRenderer> create(RenderElement&, const Style::Filter&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext, std::optional<RenderingResourceIdentifier> = std::nullopt);
+    static RefPtr<CSSFilterRenderer> create(RenderElement&, const FilterOperations&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext, std::optional<RenderingResourceIdentifier> = std::nullopt);
     WEBCORE_EXPORT static Ref<CSSFilterRenderer> create(Vector<Ref<FilterFunction>>&&);
-    WEBCORE_EXPORT static Ref<CSSFilterRenderer> create(Vector<Ref<FilterFunction>>&&, OptionSet<FilterRenderingMode>, const FloatSize& filterScale, const FloatRect& filterRegion);
+    WEBCORE_EXPORT static Ref<CSSFilterRenderer> create(Vector<Ref<FilterFunction>>&&, OptionSet<FilterRenderingMode>, const FloatSize& filterScale, const FloatRect& filterRegion, std::optional<RenderingResourceIdentifier>);
 
     const Vector<Ref<FilterFunction>>& functions() const { return m_functions; }
 
-    void setFilterRegion(const FloatRect&);
-
-    bool hasFilterThatMovesPixels() const { return m_hasFilterThatMovesPixels; }
-    bool hasFilterThatShouldBeRestrictedBySecurityOrigin() const { return m_hasFilterThatShouldBeRestrictedBySecurityOrigin; }
-
     FilterEffectVector effectsOfType(FilterFunction::Type) const final;
+
+    void mergeEffects(const Filter&) final;
 
     RefPtr<FilterImage> apply(FilterImage* sourceImage, FilterResults&) final;
     FilterStyleVector createFilterStyles(GraphicsContext&, const FilterStyle& sourceStyle) const final;
@@ -66,11 +63,11 @@ public:
     static IntOutsets calculateOutsets(RenderElement&, const FilterOperations&, const FloatRect& targetBoundingBox);
 
 private:
-    static RefPtr<CSSFilterRenderer> createGeneric(RenderElement&, const auto&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
+    static RefPtr<CSSFilterRenderer> createGeneric(RenderElement&, const auto&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext, std::optional<RenderingResourceIdentifier>);
 
-    CSSFilterRenderer(const FloatSize& filterScale, bool hasFilterThatMovesPixels, bool hasFilterThatShouldBeRestrictedBySecurityOrigin);
+    CSSFilterRenderer(const FloatSize& filterScale, const FloatRect& filterRegion, std::optional<RenderingResourceIdentifier>);
     CSSFilterRenderer(Vector<Ref<FilterFunction>>&&);
-    CSSFilterRenderer(Vector<Ref<FilterFunction>>&&, const FloatSize& filterScale, const FloatRect& filterRegion);
+    CSSFilterRenderer(Vector<Ref<FilterFunction>>&&, const FloatSize& filterScale, const FloatRect& filterRegion, std::optional<RenderingResourceIdentifier>);
 
     RefPtr<FilterFunction> buildFilterFunction(RenderElement&, const FilterOperation&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
     bool buildFilterFunctions(RenderElement&, const auto&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
@@ -78,9 +75,6 @@ private:
     OptionSet<FilterRenderingMode> supportedFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes) const final;
 
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const final;
-
-    bool m_hasFilterThatMovesPixels { false };
-    bool m_hasFilterThatShouldBeRestrictedBySecurityOrigin { false };
 
     Vector<Ref<FilterFunction>> m_functions;
 };

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -64,6 +64,7 @@
 #include "RenderInline.h"
 #include "RenderIterator.h"
 #include "RenderLayer.h"
+#include "RenderLayerFilters.h"
 #include "RenderLayerScrollableArea.h"
 #include "RenderLayoutState.h"
 #include "RenderListMarker.h"
@@ -3459,6 +3460,12 @@ void RenderBlock::updateDescendantTransformsAfterLayout()
         if (box && box->hasLayer())
             box->layer()->updateTransform();
     }
+}
+
+void RenderBlock::updateLayerFiltersAfterLayout()
+{
+    if (auto* layerFilters = style().layerFilters())
+        layerFilters->removeClient(*this);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -235,6 +235,7 @@ public:
     virtual bool hasLineIfEmpty() const;
 
     void updateDescendantTransformsAfterLayout();
+    void updateLayerFiltersAfterLayout();
 
     virtual bool canPerformSimplifiedLayout() const;
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -629,6 +629,7 @@ void RenderBlockFlow::layoutBlock(RelayoutChildren relayoutChildren, LayoutUnit 
     }
 
     updateDescendantTransformsAfterLayout();
+    updateLayerFiltersAfterLayout();
 
     // Add overflow from children (unless we're multi-column, since in that case all our child overflow is clipped anyway).
     computeOverflow(oldClientAfterEdge);

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -383,6 +383,7 @@ void RenderDeprecatedFlexibleBox::layoutBlock(RelayoutChildren relayoutChildren,
             layoutOutOfFlowBoxes(relayoutChildren);
 
         updateDescendantTransformsAfterLayout();
+        updateLayerFiltersAfterLayout();
 
         computeOverflow(oldClientAfterEdge);
     }

--- a/Source/WebCore/rendering/RenderFilterResource.cpp
+++ b/Source/WebCore/rendering/RenderFilterResource.cpp
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 2025 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RenderFilterResource.h"
+
+#include "Filter.h"
+#include "FilterResults.h"
+#include "GraphicsContextSwitcher.h"
+#include "Logging.h"
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(FilterClient);
+
+SwitcherState RenderFilterResource::beginDrawSourceImage(RenderElement& renderer, const FloatRect& targetBoundingBox, std::optional<FloatRect> clipRect, GraphicsContext*& context)
+{
+    ASSERT(context);
+
+    LOG(Filters, "RenderFilterResource %p apply renderer %p", this, &renderer);
+
+    if (auto* filterClient = m_rendererFilterClientCache.get(renderer)) {
+        auto& targetSwitcher = filterClient->targetSwitcher;
+        ASSERT(targetSwitcher);
+
+        if (targetSwitcher->state() == SwitcherState::PaintingSource) {
+            targetSwitcher->setState(SwitcherState::CycleDetected);
+            return SwitcherState::CycleDetected;
+        }
+
+        auto state = targetSwitcher->beginDrawSourceImage(*context, clipRect);
+        if (state != SwitcherState::PaintingSource)
+            return state;
+
+        filterClient->savedContext = context;
+        context = targetSwitcher->drawingContext(*context);
+        return state;
+    }
+
+    auto createResult = createFilter(renderer, targetBoundingBox, *context);
+    if (!createResult)
+        return SwitcherState::None;
+
+    auto& filter = std::get<Ref<Filter>>(*createResult);
+    auto& sourceImageRect = std::get<FloatRect>(*createResult);
+
+    auto& filterResults = filter->ensureResults([&]() {
+        return makeUnique<FilterResults>();
+    });
+
+    auto colorSpace = operatingColorSpace();
+
+    auto targetSwitcher = GraphicsContextSwitcher::create(*context, colorSpace, sourceImageRect, Ref { filter }, &filterResults);
+    if (!targetSwitcher)
+        return SwitcherState::None;
+
+    auto savedContext = context;
+
+    auto state = targetSwitcher->beginDrawSourceImage(*context, clipRect);
+    if (state != SwitcherState::PaintingSource)
+        return state;
+
+    context = targetSwitcher->drawingContext(*context);
+
+    auto filterClient = makeUnique<FilterClient>(FilterClient { WTFMove(filter), sourceImageRect, WTFMove(targetSwitcher), savedContext, false });
+    auto addResult = m_rendererFilterClientCache.set(renderer, WTFMove(filterClient));
+    ASSERT_UNUSED(addResult, addResult.isNewEntry);
+
+    return SwitcherState::PaintingSource;
+}
+
+SwitcherState RenderFilterResource::endDrawSourceImage(RenderElement& renderer, GraphicsContext*& context)
+{
+    ASSERT(context);
+
+    auto findResult = m_rendererFilterClientCache.find(renderer);
+    if (findResult == m_rendererFilterClientCache.end())
+        return SwitcherState::None;
+
+    auto& filterClient = *findResult->value;
+    auto& targetSwitcher = filterClient.targetSwitcher;
+    ASSERT(targetSwitcher);
+
+    switch (targetSwitcher->state()) {
+    case SwitcherState::None:
+        RELEASE_ASSERT_NOT_REACHED();
+        return SwitcherState::None;
+
+    case SwitcherState::PaintingSource:
+        if (!filterClient.savedContext) {
+            removeClient(renderer);
+            return SwitcherState::None;
+        }
+
+        context = filterClient.savedContext;
+        filterClient.savedContext = nullptr;
+        targetSwitcher->endDrawSourceImage(*context);
+        break;
+
+    case SwitcherState::SourcePainted:
+        break;
+
+    case SwitcherState::CycleDetected:
+        // We have a cycle if we are already applying the data.
+        // This can occur due to FeImage referencing a source that makes use of the FEImage itself.
+        // This is the first place we've hit the cycle, so set the state back to PaintingSource so the return stack
+        // will continue correctly.
+        targetSwitcher->setState(SwitcherState::PaintingSource);
+        break;
+    }
+
+    if (filterClient.markedForRemoval) {
+        m_rendererFilterClientCache.remove(findResult);
+        return SwitcherState::None;
+    }
+
+    return targetSwitcher->state();
+}
+
+void RenderFilterResource::applyFilter(RenderElement& renderer, GraphicsContext& context)
+{
+    if (auto* targetSwitcher = this->targetSwitcher(renderer))
+        targetSwitcher->drawOutputImage(context, destinationColorSpace());
+
+    LOG_WITH_STREAM(Filters, stream << "FilterResource " << this << " postApply done\n");
+}
+
+bool RenderFilterResource::hasSourceImage(RenderElement& renderer) const
+{
+    if (auto* targetSwitcher = this->targetSwitcher(renderer))
+        return targetSwitcher->hasSourceImage();
+    return false;
+}
+
+GraphicsContextSwitcher* RenderFilterResource::targetSwitcher(RenderElement& renderer) const
+{
+    if (auto* filterClient = m_rendererFilterClientCache.get(renderer))
+        return filterClient->targetSwitcher.get();
+    return nullptr;
+}
+
+FloatRect RenderFilterResource::sourceImageRect(RenderElement& renderer) const
+{
+    if (auto* filterClient = m_rendererFilterClientCache.get(renderer))
+        return filterClient->sourceImageRect;
+    return { };
+}
+
+FloatRect RenderFilterResource::filterRegion(RenderElement& renderer) const
+{
+    if (auto* filterClient = m_rendererFilterClientCache.get(renderer))
+        return filterClient->filter->filterRegion();
+    return { };
+}
+
+Vector<CheckedRef<RenderElement>> RenderFilterResource::allClients() const
+{
+    return WTF::map(m_rendererFilterClientCache, [](auto& pair) -> CheckedRef<RenderElement> {
+        return { pair.key };
+    });
+}
+
+void RenderFilterResource::clearEffectResult(FilterEffect& effect)
+{
+    LOG(Filters, "RenderFilterResource %p didChangeEffect effect %p", this, &effect);
+
+    for (const auto& pair : m_rendererFilterClientCache) {
+        const auto& filterClient = *pair.value;
+
+        auto& targetSwitcher = filterClient.targetSwitcher;
+        ASSERT(targetSwitcher);
+
+        if (targetSwitcher->state() != SwitcherState::SourcePainted)
+            continue;
+
+        // Rebuild the effect result and repaint the image on the screen.
+        filterClient.filter->clearEffectResult(effect);
+    }
+}
+
+void RenderFilterResource::removeClient(RenderElement& client)
+{
+    LOG(Filters, "RenderFilterResource %p removing client %p", this, &client);
+
+    auto findResult = m_rendererFilterClientCache.find(client);
+    if (findResult == m_rendererFilterClientCache.end())
+        return;
+
+    auto& filterClient = *findResult->value;
+    if (filterClient.savedContext)
+        filterClient.markedForRemoval = true;
+    else
+        m_rendererFilterClientCache.remove(findResult);
+}
+
+void RenderFilterResource::removeAllClients()
+{
+    LOG(Filters, "RenderFilterResource %p removeAllClientsFromCache", this);
+    m_rendererFilterClientCache.clear();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/RenderFilterResource.h
+++ b/Source/WebCore/rendering/RenderFilterResource.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2025 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Filter.h"
+#include "GraphicsContextSwitcher.h"
+#include <wtf/HashMap.h>
+#include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class GraphicsContext;
+class GraphicsContextSwitcher;
+class Filter;
+
+struct FilterClient {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(FilterClient);
+public:
+    Ref<Filter> filter;
+    FloatRect sourceImageRect;
+    std::unique_ptr<GraphicsContextSwitcher> targetSwitcher;
+    GraphicsContext* savedContext { nullptr };
+    bool markedForRemoval { false };
+};
+
+class RenderFilterResource {
+public:
+    virtual ~RenderFilterResource() = default;
+
+    SwitcherState beginDrawSourceImage(RenderElement&, const FloatRect& targetBoundingBox, std::optional<FloatRect> clipRect, GraphicsContext*&);
+    SwitcherState endDrawSourceImage(RenderElement&, GraphicsContext*&);
+    void applyFilter(RenderElement&, GraphicsContext&);
+
+    bool hasSourceImage(RenderElement&) const;
+    FloatRect sourceImageRect(RenderElement&) const;
+    FloatRect filterRegion(RenderElement&) const;
+    GraphicsContextSwitcher* targetSwitcher(RenderElement&) const;
+
+    Vector<CheckedRef<RenderElement>> allClients() const;
+
+    void clearEffectResult(FilterEffect&);
+    void removeClient(RenderElement&);
+    void removeAllClients();
+
+protected:
+    RenderFilterResource() = default;
+
+    virtual std::optional<std::tuple<Ref<Filter>, FloatRect>> createFilter(RenderElement&, const FloatRect& targetBoundingBox, GraphicsContext&) = 0;
+    virtual DestinationColorSpace operatingColorSpace() const { return DestinationColorSpace::SRGB(); }
+    virtual DestinationColorSpace destinationColorSpace() const { return DestinationColorSpace::SRGB(); }
+
+    HashMap<SingleThreadWeakRef<RenderElement>, std::unique_ptr<FilterClient>> m_rendererFilterClientCache;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -483,6 +483,7 @@ void RenderFlexibleBox::layoutBlock(RelayoutChildren relayoutChildren, LayoutUni
         computeOverflow(layoutOverflowLogicalBottom(*this));
 
         updateDescendantTransformsAfterLayout();
+        updateLayerFiltersAfterLayout();
     }
 
     updateLayerTransform();

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -532,6 +532,7 @@ void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
         computeOverflow(layoutOverflowLogicalBottom(*this));
 
         updateDescendantTransformsAfterLayout();
+        updateLayerFiltersAfterLayout();
     }
 
     updateLayerTransform();
@@ -679,6 +680,7 @@ void RenderGrid::layoutMasonry(RelayoutChildren relayoutChildren)
         computeOverflow(layoutOverflowLogicalBottom(*this));
 
         updateDescendantTransformsAfterLayout();
+        updateLayerFiltersAfterLayout();
     }
 
     updateLayerTransform();

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -398,7 +398,7 @@ RenderLayer::~RenderLayer()
         removeReflection();
 
     clearLayerScrollableArea();
-    clearLayerFilters();
+    removeLayerFilterClient();
     clearLayerClipPath();
 
     // Child layers will be deleted by their corresponding render objects, so
@@ -1052,10 +1052,12 @@ bool RenderLayer::shouldPaintWithFilters(OptionSet<PaintBehavior> paintBehavior)
 
 bool RenderLayer::requiresFullLayerImageForFilters() const
 {
-    if (!shouldPaintWithFilters())
-        return false;
+    return shouldPaintWithFilters() && renderer().style().filter().hasFilterThatMovesPixels();
+}
 
-    return m_filters && m_filters->hasFilterThatMovesPixels();
+bool RenderLayer::requireSecurityOriginAccessForWidgets() const
+{
+    return shouldPaintWithFilters() && renderer().style().filter().hasFilterThatShouldBeRestrictedBySecurityOrigin();
 }
 
 OptionSet<RenderLayer::UpdateLayerPositionsFlag> RenderLayer::flagsForUpdateLayerPositions(RenderLayer& startingLayer)
@@ -2518,7 +2520,6 @@ RenderLayer* RenderLayer::enclosingFilterRepaintLayer() const
 void RenderLayer::setFilterBackendNeedsRepaintingInRect(const LayoutRect& rect)
 {
     ASSERT(requiresFullLayerImageForFilters());
-    ASSERT(m_filters);
 
     if (rect.isEmpty())
         return;
@@ -2526,8 +2527,6 @@ void RenderLayer::setFilterBackendNeedsRepaintingInRect(const LayoutRect& rect)
     LayoutRect rectForRepaint = rect;
     rectForRepaint.expand(toLayoutBoxExtent(filterOutsets()));
 
-    m_filters->expandDirtySourceRect(rectForRepaint);
-    
     RenderLayer* parentLayer = enclosingFilterRepaintLayer();
     ASSERT(parentLayer);
     FloatQuad repaintQuad(rectForRepaint);
@@ -3415,7 +3414,7 @@ void RenderLayer::paintLayerWithEffects(GraphicsContext& context, const LayerPai
         RegionContextStateSaver regionContextStateSaver(paintingInfo.regionContext);
         if (parent()) {
             auto options = paintFlags.contains(PaintLayerFlag::PaintingOverflowContents) ? clipRectOptionsForPaintingOverflowContents : clipRectDefaultOptions;
-            if (shouldHaveFiltersForPainting(context, paintFlags, paintingInfo.paintBehavior))
+            if (shouldHaveLayerFiltersForPainting(context, paintFlags, paintingInfo.paintBehavior))
                 options.add(ClipRectsOption::OutsideFilter);
             if (paintFlags & PaintLayerFlag::TemporaryClipRects)
                 options.add(ClipRectsOption::Temporary);
@@ -3607,7 +3606,7 @@ void RenderLayer::clearLayerClipPath()
         svgClipper->removeClientFromCache(renderer());
 }
 
-bool RenderLayer::shouldHaveFiltersForPainting(GraphicsContext& context, OptionSet<PaintLayerFlag> paintFlags, OptionSet<PaintBehavior> paintBehavior) const
+bool RenderLayer::shouldHaveLayerFiltersForPainting(GraphicsContext& context, OptionSet<PaintLayerFlag> paintFlags, OptionSet<PaintBehavior> paintBehavior) const
 {
     if (context.paintingDisabled())
         return false;
@@ -3621,53 +3620,66 @@ bool RenderLayer::shouldHaveFiltersForPainting(GraphicsContext& context, OptionS
     return true;
 }
 
-RenderLayerFilters* RenderLayer::filtersForPainting(GraphicsContext& context, OptionSet<PaintLayerFlag> paintFlags, OptionSet<PaintBehavior> paintBehavior)
+RenderLayerFilters* RenderLayer::layerFiltersForPainting(GraphicsContext& context, OptionSet<PaintLayerFlag> paintFlags, OptionSet<PaintBehavior> paintBehavior)
 {
-    if (!shouldHaveFiltersForPainting(context, paintFlags, paintBehavior))
+    if (!shouldHaveLayerFiltersForPainting(context, paintFlags, paintBehavior))
         return nullptr;
 
     return &ensureLayerFilters();
 }
 
-GraphicsContext* RenderLayer::setupFilters(GraphicsContext& destinationContext, LayerPaintingInfo& paintingInfo, OptionSet<PaintLayerFlag>& paintFlags, const LayoutSize& offsetFromRoot, const ClipRect& backgroundRect)
+SwitcherState RenderLayer::beginFiltersDrawSourceImage(LayerPaintingInfo& paintingInfo, OptionSet<PaintLayerFlag> paintFlags, const LayoutSize& offsetFromRoot, const LayoutRect& clipRect, GraphicsContext*& context)
 {
-    auto* paintingFilters = filtersForPainting(destinationContext, paintFlags, paintingInfo.paintBehavior);
-    if (!paintingFilters)
-        return nullptr;
-
-    LayoutRect filterRepaintRect = paintingFilters->dirtySourceRect();
-    filterRepaintRect.move(offsetFromRoot);
+    auto* layerFilters = layerFiltersForPainting(*context, paintFlags, paintingInfo.paintBehavior);
+    if (!layerFilters)
+        return SwitcherState::None;
 
     auto rootRelativeBounds = calculateLayerBounds(paintingInfo.rootLayer, offsetFromRoot, { RenderLayer::PreserveAncestorFlags });
+    if (rootRelativeBounds.isEmpty())
+        return SwitcherState::None;
 
-    GraphicsContext* filterContext = paintingFilters->beginFilterEffect(renderer(), destinationContext, enclosingIntRect(rootRelativeBounds), enclosingIntRect(paintingInfo.paintDirtyRect), enclosingIntRect(filterRepaintRect), backgroundRect.rect());
-    if (!filterContext)
-        return nullptr;
+    // If the filter needs the full source image, we need to avoid using the clip rectangles.
+    // Otherwise, if for example this layer has overflow:hidden, a drop shadow will not compute correctly.
+    // Note that we will still apply the clipping on the final rendering of the filter.
+    paintingInfo.requireSecurityOriginAccessForWidgets = requireSecurityOriginAccessForWidgets();
 
-    paintingInfo.paintDirtyRect = paintingFilters->repaintRect();
-    if (paintingFilters->hasFilterThatMovesPixels()) {
+    if (requiresFullLayerImageForFilters()) {
         m_suppressAncestorClippingInsideFilter = true;
         paintFlags.add(PaintLayerFlag::TemporaryClipRects);
     }
-    paintingInfo.requireSecurityOriginAccessForWidgets = paintingFilters->hasFilterThatShouldBeRestrictedBySecurityOrigin();
 
-    return filterContext;
+    auto state = layerFilters->beginDrawSourceImage(renderer(), rootRelativeBounds, clipRect, context);
+    if (state == SwitcherState::PaintingSource)
+        paintingInfo.paintDirtyRect = LayoutRect(layerFilters->filterRegion(renderer()));
+
+    return state;
 }
 
-void RenderLayer::applyFilters(GraphicsContext& originalContext, const LayerPaintingInfo& paintingInfo, OptionSet<PaintBehavior> behavior, const ClipRect& backgroundRect)
+SwitcherState RenderLayer::endFiltersDrawSourceImage(GraphicsContext*& context)
 {
-    GraphicsContextStateSaver stateSaver(originalContext, false);
-    bool needsClipping = m_filters->hasSourceImage();
+    if (auto* layerFilters = this->layerFilters())
+        return layerFilters->endDrawSourceImage(renderer(), context);
+    return SwitcherState::None;
+}
+
+void RenderLayer::applyFilters(GraphicsContext& context, const LayerPaintingInfo& paintingInfo, OptionSet<PaintBehavior> behavior, const ClipRect& backgroundRect)
+{
+    auto* layerFilters = this->layerFilters();
+    if (!layerFilters)
+        return;
+
+    GraphicsContextStateSaver stateSaver(context, false);
+    bool needsClipping = layerFilters->hasSourceImage(renderer());
 
     m_suppressAncestorClippingInsideFilter = false;
 
     if (needsClipping) {
         RegionContextStateSaver regionContextStateSaver(paintingInfo.regionContext);
 
-        clipToRect(originalContext, stateSaver, regionContextStateSaver, paintingInfo, behavior, backgroundRect);
+        clipToRect(context, stateSaver, regionContextStateSaver, paintingInfo, behavior, backgroundRect);
     }
 
-    m_filters->applyFilterEffect(originalContext);
+    layerFilters->applyFilter(renderer(), context);
 }
 
 void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPaintingInfo& paintingInfo, OptionSet<PaintLayerFlag> paintFlags)
@@ -3812,7 +3824,7 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
 
     // Apply clip-path to context.
     LayoutSize columnAwareOffsetFromRoot = offsetFromRoot;
-    if (renderer().enclosingFragmentedFlow() && (renderer().hasClipPath() || shouldHaveFiltersForPainting(context, paintFlags, paintingInfo.paintBehavior)))
+    if (renderer().enclosingFragmentedFlow() && (renderer().hasClipPath() || shouldHaveLayerFiltersForPainting(context, paintFlags, paintingInfo.paintBehavior)))
         columnAwareOffsetFromRoot = toLayoutSize(convertToLayerCoords(paintingInfo.rootLayer, LayoutPoint(), AdjustForColumns));
 
     GraphicsContextStateSaver stateSaver(context, false);
@@ -3871,7 +3883,7 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
     { // Scope for filter-related state changes.
         ClipRect backgroundRect;
 
-        if (shouldHaveFiltersForPainting(context, paintFlags, paintBehavior)) {
+        if (shouldHaveLayerFiltersForPainting(context, paintFlags, paintBehavior)) {
             // When we called collectFragments() last time, paintDirtyRect was reset to represent the filter bounds.
             // Now we need to compute the backgroundRect uncontaminated by filters, in order to clip the filtered result.
             // Note that we also use paintingInfo here, not localPaintingInfo which filters also contaminated.
@@ -3893,10 +3905,10 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
         }
 
         LayerPaintingInfo localPaintingInfo(paintingInfo);
-        GraphicsContext* filterContext = setupFilters(context, localPaintingInfo, localPaintFlags, columnAwareOffsetFromRoot, backgroundRect);
-        GraphicsContext& currentContext = filterContext ? *filterContext : context;
+        auto* currentContext = &context;
+        auto state = beginFiltersDrawSourceImage(localPaintingInfo, paintFlags, columnAwareOffsetFromRoot, backgroundRect.rect(), currentContext);
 
-        if (filterContext)
+        if (state == SwitcherState::PaintingSource)
             localPaintingInfo.paintBehavior.add(PaintBehavior::DontShowVisitedLinks);
 
         // If this layer's renderer is a child of the subtreePaintRoot, we render unconditionally, which
@@ -3919,52 +3931,56 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
             collectFragments(layerFragments, localPaintingInfo.rootLayer, paintDirtyRect, ExcludeCompositedPaginatedLayers, PaintingClipRects, clipRectOptions, offsetFromRoot);
             updatePaintingInfoForFragments(layerFragments, localPaintingInfo, localPaintFlags, shouldPaintContent, offsetFromRoot);
         }
-        
+
         if (isPaintingCompositedBackground) {
             // Paint only the backgrounds for all of the fragments of the layer.
             if (shouldPaintContent && !selectionOnly) {
-                paintBackgroundForFragments(layerFragments, currentContext, context, paintingInfo.paintDirtyRect, haveTransparency,
+                paintBackgroundForFragments(layerFragments, *currentContext, context, paintingInfo.paintDirtyRect, haveTransparency,
                     localPaintingInfo, paintBehavior, subtreePaintRootForRenderer);
             }
         }
 
         // Now walk the sorted list of children with negative z-indices.
         if (shouldPaintNegativeZIndexChildren)
-            paintList(negativeZOrderLayers(), currentContext, paintingInfo, localPaintFlags);
-        
+            paintList(negativeZOrderLayers(), *currentContext, paintingInfo, localPaintFlags);
+
         if (isPaintingCompositedForeground && shouldPaintContent)
-            paintForegroundForFragments(layerFragments, currentContext, context, paintingInfo.paintDirtyRect, haveTransparency, localPaintingInfo, paintBehavior, subtreePaintRootForRenderer);
+            paintForegroundForFragments(layerFragments, *currentContext, context, paintingInfo.paintDirtyRect, haveTransparency, localPaintingInfo, paintBehavior, subtreePaintRootForRenderer);
 
         if (isCollectingEventRegion && !isInsideSkippedSubtree)
-            collectEventRegionForFragments(layerFragments, currentContext, localPaintingInfo, paintBehavior);
+            collectEventRegionForFragments(layerFragments, *currentContext, localPaintingInfo, paintBehavior);
 
         if (isCollectingAccessibilityRegion)
-            collectAccessibilityRegionsForFragments(layerFragments, currentContext, localPaintingInfo, paintBehavior);
+            collectAccessibilityRegionsForFragments(layerFragments, *currentContext, localPaintingInfo, paintBehavior);
 
         if (shouldPaintOutline)
-            paintOutlineForFragments(layerFragments, currentContext, localPaintingInfo, paintBehavior, subtreePaintRootForRenderer);
+            paintOutlineForFragments(layerFragments, *currentContext, localPaintingInfo, paintBehavior, subtreePaintRootForRenderer);
 
         if (isPaintingCompositedForeground) {
             // Paint any child layers that have overflow.
-            paintList(normalFlowLayers(), currentContext, paintingInfo, localPaintFlags);
+            paintList(normalFlowLayers(), *currentContext, paintingInfo, localPaintFlags);
 
             // Now walk the sorted list of children with positive z-indices.
-            paintList(positiveZOrderLayers(), currentContext, localPaintingInfo, localPaintFlags);
+            paintList(positiveZOrderLayers(), *currentContext, localPaintingInfo, localPaintFlags);
         }
 
         if (m_scrollableArea) {
             if (isPaintingOverlayScrollbars && m_scrollableArea->hasScrollbars())
-                paintOverflowControlsForFragments(layerFragments, currentContext, localPaintingInfo);
+                paintOverflowControlsForFragments(layerFragments, *currentContext, localPaintingInfo);
         }
 
-        if (filterContext) {
-            applyFilters(context, paintingInfo, paintBehavior, backgroundRect);
+        if (state == SwitcherState::PaintingSource) {
+            state = endFiltersDrawSourceImage(currentContext);
+
+            if (state == SwitcherState::SourcePainted)
+                applyFilters(*currentContext, paintingInfo, paintBehavior, backgroundRect);
+
             // Painting a snapshot might have temporarily overriden the filter painting strategy,
             // make sure it gets reset.
             updateFilterPaintingStrategy();
         }
     }
-    
+
     if (shouldPaintContent && !(selectionOnly || selectionAndBackgroundsOnly)) {
         if (shouldPaintMask(paintingInfo.paintBehavior, localPaintFlags)) {
             // Paint the mask for the fragments.
@@ -4238,7 +4254,7 @@ void RenderLayer::paintTransformedLayerIntoFragments(GraphicsContext& context, c
     LayoutRect transformedExtent = transparencyClipBox(*this, paginatedLayer, PaintingTransparencyClipBox, RootOfTransparencyClipBox, paintingInfo.paintBehavior);
 
     auto clipRectOptions = paintFlags.contains(PaintLayerFlag::PaintingOverflowContents) ? clipRectOptionsForPaintingOverflowContents : clipRectDefaultOptions;
-    if (shouldHaveFiltersForPainting(context, paintFlags, paintingInfo.paintBehavior))
+    if (shouldHaveLayerFiltersForPainting(context, paintFlags, paintingInfo.paintBehavior))
         clipRectOptions.add(ClipRectsOption::OutsideFilter);
     if (paintFlags & PaintLayerFlag::TemporaryClipRects)
         clipRectOptions.add(ClipRectsOption::Temporary);
@@ -6362,18 +6378,26 @@ RenderStyle RenderLayer::createReflectionStyle()
 
 RenderLayerFilters& RenderLayer::ensureLayerFilters()
 {
-    if (m_filters)
-        return *m_filters;
-    
-    m_filters = makeUnique<RenderLayerFilters>(*this);
-    m_filters->setPreferredFilterRenderingModes(renderer().page().preferredFilterRenderingModes());
-    m_filters->setFilterScale({ page().deviceScaleFactor(), page().deviceScaleFactor() });
-    return *m_filters;
+    auto& layerFilters = const_cast<RenderStyle&>(renderer().style()).ensureLayerFilters();
+    layerFilters.addReferenceFilterClient(*this);
+    return layerFilters;
 }
 
-void RenderLayer::clearLayerFilters()
+RenderLayerFilters* RenderLayer::layerFilters() const
 {
-    m_filters = nullptr;
+    return renderer().style().layerFilters();
+}
+
+void RenderLayer::removeReferenceFilterClients()
+{
+    if (auto* layerFilters = this->layerFilters())
+        layerFilters->removeReferenceFilterClient(*this);
+}
+
+void RenderLayer::removeLayerFilterClient()
+{
+    if (auto* layerFilters = this->layerFilters())
+        layerFilters->removeClient(renderer());
 }
 
 RenderLayerScrollableArea* RenderLayer::ensureLayerScrollableArea()
@@ -6404,14 +6428,14 @@ void RenderLayer::clearLayerScrollableArea()
 void RenderLayer::updateFiltersAfterStyleChange(StyleDifference diff, const RenderStyle* oldStyle)
 {
     if (renderer().style().filter().hasReferenceFilter())
-        ensureLayerFilters().updateReferenceFilterClients(renderer().style().filter());
+        ensureLayerFilters().addReferenceFilterClient(*this);
     else if (!shouldPaintWithFilters())
-        clearLayerFilters();
-    else if (m_filters)
-        m_filters->removeReferenceFilterClients();
+        removeLayerFilterClient();
+    else
+        removeReferenceFilterClients();
 
     auto filterChanged = [&] {
-        if (!m_filters)
+        if (!layerFilters())
             return false;
         if (diff < StyleDifference::RepaintLayer)
             return false;
@@ -6425,7 +6449,7 @@ void RenderLayer::updateFiltersAfterStyleChange(StyleDifference diff, const Rend
         return false;
     };
     if (filterChanged())
-        clearLayerFilters();
+        removeLayerFilterClient();
 }
 
 void RenderLayer::updateLayerScrollableArea()
@@ -6458,8 +6482,7 @@ void RenderLayer::updateFilterPaintingStrategy()
     if (!shouldPaintWithFilters()) {
         // Don't delete the whole filter info here, because we might use it
         // for loading SVG reference filter files.
-        if (m_filters)
-            m_filters->clearFilter();
+        removeLayerFilterClient();
 
         // Early-return only if we *don't* have reference filters.
         // For reference filters, we still want the FilterEffect graph built
@@ -6473,9 +6496,7 @@ void RenderLayer::updateFilterPaintingStrategy()
 
 IntOutsets RenderLayer::filterOutsets() const
 {
-    if (m_filters)
-        return m_filters->calculateOutsets(renderer(), localBoundingBox());
-    return renderer().style().filter().outsets();
+    return RenderLayerFilters::calculateOutsets(renderer(), localBoundingBox());
 }
 
 static RenderLayer* parentLayerCrossFrame(const RenderLayer& layer)

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -90,6 +90,8 @@ class RenderView;
 class Scrollbar;
 class TransformationMatrix;
 
+enum class SwitcherState : uint8_t;
+
 enum BorderRadiusClippingRule { IncludeSelfForBorderRadius, DoNotIncludeSelfForBorderRadius };
 enum IncludeSelfOrNot { IncludeSelf, ExcludeSelf };
 enum CrossFrameBoundaries : bool { No, Yes };
@@ -915,6 +917,7 @@ public:
 
     bool shouldPaintWithFilters(OptionSet<PaintBehavior> = { }) const;
     bool requiresFullLayerImageForFilters() const;
+    bool requireSecurityOriginAccessForWidgets() const;
 
     Element* enclosingElement() const;
 
@@ -1180,15 +1183,18 @@ private:
     void clearLayerClipPath();
 
     RenderLayerFilters& ensureLayerFilters();
-    void clearLayerFilters();
+    RenderLayerFilters* layerFilters() const;
+    void removeReferenceFilterClients();
+    void removeLayerFilterClient();
 
     void updateLayerScrollableArea();
     void clearLayerScrollableArea();
 
-    bool shouldHaveFiltersForPainting(GraphicsContext&, OptionSet<PaintLayerFlag>, OptionSet<PaintBehavior>) const;
-    RenderLayerFilters* filtersForPainting(GraphicsContext&, OptionSet<PaintLayerFlag>, OptionSet<PaintBehavior>);
-    GraphicsContext* setupFilters(GraphicsContext& destinationContext, LayerPaintingInfo&, OptionSet<PaintLayerFlag>&, const LayoutSize& offsetFromRoot, const ClipRect& backgroundRect);
-    void applyFilters(GraphicsContext& originalContext, const LayerPaintingInfo&, OptionSet<PaintBehavior>, const ClipRect& backgroundRect);
+    bool shouldHaveLayerFiltersForPainting(GraphicsContext&, OptionSet<PaintLayerFlag>, OptionSet<PaintBehavior>) const;
+    RenderLayerFilters* layerFiltersForPainting(GraphicsContext&, OptionSet<PaintLayerFlag>, OptionSet<PaintBehavior>);
+    SwitcherState beginFiltersDrawSourceImage(LayerPaintingInfo&, OptionSet<PaintLayerFlag>, const LayoutSize& offsetFromRoot, const LayoutRect& clipRect, GraphicsContext*&);
+    SwitcherState endFiltersDrawSourceImage(GraphicsContext*&);
+    void applyFilters(GraphicsContext&, const LayerPaintingInfo&, OptionSet<PaintBehavior>, const ClipRect&);
 
     void paintLayer(GraphicsContext&, const LayerPaintingInfo&, OptionSet<PaintLayerFlag>);
     void paintLayerWithEffects(GraphicsContext&, const LayerPaintingInfo&, OptionSet<PaintLayerFlag>);
@@ -1466,7 +1472,6 @@ private:
 
     IntRect m_blockSelectionGapsBounds;
 
-    std::unique_ptr<RenderLayerFilters> m_filters;
     std::unique_ptr<RenderLayerBacking> m_backing;
     std::unique_ptr<RenderLayerScrollableArea> m_scrollableArea;
 

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Adobe Systems Incorporated. All rights reserved.
- * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -13,7 +13,7 @@
  *    copyright notice, this list of conditions and the following
  *    disclaimer in the documentation and/or other materials
  *    provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY
  * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
@@ -34,58 +34,62 @@
 #include "CSSFilterRenderer.h"
 #include "CachedSVGDocument.h"
 #include "CachedSVGDocumentReference.h"
-#include "ContainerNodeInlines.h"
-#include "GraphicsContextSwitcher.h"
 #include "LegacyRenderSVGResourceFilter.h"
-#include "Logging.h"
 #include "ReferenceFilterOperation.h"
-#include "RenderObjectInlines.h"
-#include "RenderSVGShape.h"
-#include "RenderStyleInlines.h"
-#include <wtf/NeverDestroyed.h>
-#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderLayerFilters);
 
-RenderLayerFilters::RenderLayerFilters(RenderLayer& layer)
-    : m_layer(layer)
+bool RenderLayerFilters::isIdentity(RenderElement& renderer)
 {
+    const auto& operations = renderer.style().filter();
+    return CSSFilterRenderer::isIdentity(renderer, operations);
 }
 
-RenderLayerFilters::~RenderLayerFilters()
+IntOutsets RenderLayerFilters::calculateOutsets(RenderElement& renderer, const FloatRect& targetBoundingBox)
 {
-    removeReferenceFilterClients();
+    const auto& operations = renderer.style().filter();
+    return CSSFilterRenderer::calculateOutsets(renderer, operations, targetBoundingBox);
 }
 
-bool RenderLayerFilters::hasFilterThatMovesPixels() const
+std::optional<std::tuple<Ref<Filter>, FloatRect>> RenderLayerFilters::createFilter(RenderElement& renderer, const FloatRect& targetBoundingBox, GraphicsContext& context)
 {
-    return m_filter && m_filter->hasFilterThatMovesPixels();
+    auto preferredFilterRenderingModes = renderer.page().preferredFilterRenderingModes();
+    auto filterScale = FloatSize { renderer.page().deviceScaleFactor(), renderer.page().deviceScaleFactor() };
+
+    const auto& operations = renderer.style().filter();
+
+    auto filterRegion = targetBoundingBox;
+
+    if (operations.hasFilterThatMovesPixels()) {
+        // For CSSFilterRenderer, filterRegion = targetBoundingBox + filter->outsets()
+        auto outsets = CSSFilterRenderer::calculateOutsets(renderer, operations, targetBoundingBox);
+        filterRegion.expand(toLayoutBoxExtent(outsets));
+    }
+
+    auto filter = CSSFilterRenderer::create(renderer, operations, preferredFilterRenderingModes, filterScale, filterRegion, targetBoundingBox, context, RenderingResourceIdentifier::generate());
+    if (!filter)
+        return std::nullopt;
+
+    return { { filter.releaseNonNull(), targetBoundingBox } };
 }
 
-bool RenderLayerFilters::hasFilterThatShouldBeRestrictedBySecurityOrigin() const
+SwitcherState RenderLayerFilters::beginDrawSourceImage(RenderElement& renderer, const FloatRect& targetBoundingBox, const FloatRect& clipRect, GraphicsContext*& context)
 {
-    return m_filter && m_filter->hasFilterThatShouldBeRestrictedBySecurityOrigin();
+    LOG_WITH_STREAM(Filters, stream << "\nRenderLayerFilters " << this << " beginDrawSourceImage\n");
+    return RenderFilterResource::beginDrawSourceImage(renderer, targetBoundingBox, clipRect, context);
 }
 
-bool RenderLayerFilters::hasSourceImage() const
+SwitcherState RenderLayerFilters::endDrawSourceImage(RenderElement& renderer, GraphicsContext*& context)
 {
-    return m_targetSwitcher && m_targetSwitcher->hasSourceImage();
+    LOG_WITH_STREAM(Filters, stream << "RenderLayerFilters " << this << " endDrawSourceImage\n");
+    return RenderFilterResource::endDrawSourceImage(renderer, context);
 }
 
-void RenderLayerFilters::notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
+void RenderLayerFilters::addReferenceFilterClient(RenderLayer& layer)
 {
-    // FIXME: This really shouldn't have to invalidate layer composition,
-    // but tests like css3/filters/effect-reference-delete.html fail if that doesn't happen.
-    if (auto* enclosingElement = m_layer->enclosingElement())
-        enclosingElement->invalidateStyleAndLayerComposition();
-    m_layer->renderer().repaint();
-}
-
-void RenderLayerFilters::updateReferenceFilterClients(const Style::Filter& filter)
-{
-    removeReferenceFilterClients();
+    auto& filter = layer.renderer().style().filter();
 
     for (auto& value : filter) {
         Ref operation = value.value;
@@ -99,20 +103,20 @@ void RenderLayerFilters::updateReferenceFilterClients(const Style::Filter& filte
             cachedSVGDocument->addClient(*this);
             m_externalSVGReferences.append(cachedSVGDocument);
         } else {
-            // Reference is internal; add layer as a client so we can trigger filter repaint on SVG attribute change.
-            RefPtr filterElement = m_layer->renderer().document().getElementById(referenceOperation->fragment());
+            RefPtr filterElement = layer.renderer().document().getElementById(referenceOperation->fragment());
             if (!filterElement)
                 continue;
+
             CheckedPtr renderer = dynamicDowncast<LegacyRenderSVGResourceFilter>(filterElement->renderer());
             if (!renderer)
                 continue;
-            renderer->addClientRenderLayer(m_layer);
+            renderer->addClientRenderLayer(layer);
             m_internalSVGReferences.append(WTFMove(filterElement));
         }
     }
 }
 
-void RenderLayerFilters::removeReferenceFilterClients()
+void RenderLayerFilters::removeReferenceFilterClient(RenderLayer& layer)
 {
     for (auto& resourceHandle : m_externalSVGReferences)
         resourceHandle->removeClient(*this);
@@ -120,116 +124,11 @@ void RenderLayerFilters::removeReferenceFilterClients()
     m_externalSVGReferences.clear();
 
     for (auto& filterElement : m_internalSVGReferences) {
-        if (CheckedPtr renderer = filterElement->renderer())
-            downcast<LegacyRenderSVGResourceContainer>(*renderer).removeClientRenderLayer(m_layer);
+        if (auto* renderer = filterElement->renderer())
+            downcast<LegacyRenderSVGResourceContainer>(*renderer).removeClientRenderLayer(layer);
     }
+
     m_internalSVGReferences.clear();
-}
-
-bool RenderLayerFilters::isIdentity(RenderElement& renderer)
-{
-    const auto& filter = renderer.style().filter();
-    return CSSFilterRenderer::isIdentity(renderer, filter);
-}
-
-IntOutsets RenderLayerFilters::calculateOutsets(RenderElement& renderer, const FloatRect& targetBoundingBox)
-{
-    const auto& filter = renderer.style().filter();
-
-    if (!filter.hasFilterThatMovesPixels())
-        return { };
-
-    return CSSFilterRenderer::calculateOutsets(renderer, filter, targetBoundingBox);
-}
-
-GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, GraphicsContext& context, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect)
-{
-    auto expandedDirtyRect = dirtyRect;
-    auto targetBoundingBox = intersection(filterBoxRect, dirtyRect);
-
-    auto outsets = calculateOutsets(renderer, targetBoundingBox);
-    if (!outsets.isZero()) {
-        LayoutBoxExtent flippedOutsets { outsets.bottom(), outsets.left(), outsets.top(), outsets.right() };
-        expandedDirtyRect.expand(flippedOutsets);
-    }
-
-    if (is<RenderSVGShape>(renderer))
-        targetBoundingBox = enclosingLayoutRect(renderer.objectBoundingBox());
-    else {
-        // Calculate targetBoundingBox since it will be used if the filter is created.
-        targetBoundingBox = intersection(filterBoxRect, expandedDirtyRect);
-    }
-
-    if (targetBoundingBox.isEmpty())
-        return nullptr;
-
-    if (!m_filter || m_targetBoundingBox != targetBoundingBox) {
-        m_targetBoundingBox = targetBoundingBox;
-        // FIXME: This rebuilds the entire effects chain even if the filter style didn't change.
-        m_filter = CSSFilterRenderer::create(renderer, renderer.style().filter(), m_preferredFilterRenderingModes, m_filterScale, m_targetBoundingBox, context);
-    }
-
-    if (!m_filter)
-        return nullptr;
-
-    Ref filter = *m_filter;
-    auto filterRegion = m_targetBoundingBox;
-
-    if (filter->hasFilterThatMovesPixels()) {
-        // For CSSFilterRenderer, filterRegion = targetBoundingBox + filter->outsets()
-        filterRegion.expand(toLayoutBoxExtent(outsets));
-    } else if (auto* shape = dynamicDowncast<RenderSVGShape>(renderer))
-        filterRegion = shape->currentSVGLayoutRect();
-
-    if (filterRegion.isEmpty())
-        return nullptr;
-
-    // For CSSFilterRenderer, sourceImageRect = filterRegion.
-    bool hasUpdatedBackingStore = false;
-    if (m_filterRegion != filterRegion) {
-        m_filterRegion = filterRegion;
-        hasUpdatedBackingStore = true;
-    }
-
-    filter->setFilterRegion(m_filterRegion);
-
-    if (!filter->hasFilterThatMovesPixels())
-        m_repaintRect = dirtyRect;
-    else if (hasUpdatedBackingStore || !hasSourceImage())
-        m_repaintRect = filterRegion;
-    else {
-        m_repaintRect = dirtyRect;
-        m_repaintRect.unite(layerRepaintRect);
-        m_repaintRect.intersect(filterRegion);
-    }
-
-    resetDirtySourceRect();
-
-    if (!m_targetSwitcher || hasUpdatedBackingStore) {
-        FloatRect sourceImageRect;
-        if (is<RenderSVGShape>(renderer))
-            sourceImageRect = renderer.strokeBoundingBox();
-        else
-            sourceImageRect = m_targetBoundingBox;
-        m_targetSwitcher = GraphicsContextSwitcher::create(context, sourceImageRect, DestinationColorSpace::SRGB(), { WTFMove(filter) });
-    }
-
-    if (!m_targetSwitcher)
-        return nullptr;
-
-    m_targetSwitcher->beginClipAndDrawSourceImage(context, m_repaintRect, clipRect);
-
-    return m_targetSwitcher->drawingContext(context);
-}
-
-void RenderLayerFilters::applyFilterEffect(GraphicsContext& destinationContext)
-{
-    LOG_WITH_STREAM(Filters, stream << "\nRenderLayerFilters " << this << " applyFilterEffect");
-
-    ASSERT(m_targetSwitcher);
-    m_targetSwitcher->endClipAndDrawSourceImage(destinationContext, DestinationColorSpace::SRGB());
-
-    LOG_WITH_STREAM(Filters, stream << "RenderLayerFilters " << this << " applyFilterEffect done\n");
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerFilters.h
+++ b/Source/WebCore/rendering/RenderLayerFilters.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Adobe Systems Incorporated. All rights reserved.
- * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -13,7 +13,7 @@
  *    copyright notice, this list of conditions and the following
  *    disclaimer in the documentation and/or other materials
  *    provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY
  * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
@@ -32,67 +32,32 @@
 
 #include "CachedResourceHandle.h"
 #include "CachedSVGDocumentClient.h"
-#include "FilterRenderingMode.h"
-#include "RenderLayer.h"
+#include "RenderFilterResource.h"
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
-class CSSFilterRenderer;
 class CachedSVGDocument;
-class Element;
-class FilterOperations;
-class GraphicsContextSwitcher;
 
-class RenderLayerFilters final : private CachedSVGDocumentClient {
+class RenderLayerFilters final : private CachedSVGDocumentClient, public RenderFilterResource {
     WTF_MAKE_TZONE_ALLOCATED(RenderLayerFilters);
 public:
-    explicit RenderLayerFilters(RenderLayer&);
-    virtual ~RenderLayerFilters();
-
-    const LayoutRect& dirtySourceRect() const { return m_dirtySourceRect; }
-    void expandDirtySourceRect(const LayoutRect& rect) { m_dirtySourceRect.unite(rect); }
-
-    CSSFilterRenderer* filter() const { return m_filter.get(); }
-    void clearFilter() { m_filter = nullptr; }
-    
-    bool hasFilterThatMovesPixels() const;
-    bool hasFilterThatShouldBeRestrictedBySecurityOrigin() const;
-    bool hasSourceImage() const;
-
-    void updateReferenceFilterClients(const Style::Filter&);
-    void removeReferenceFilterClients();
-
-    void setPreferredFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes) { m_preferredFilterRenderingModes = preferredFilterRenderingModes; }
-    void setFilterScale(const FloatSize& filterScale) { m_filterScale = filterScale; }
+    RenderLayerFilters() = default;
 
     static bool isIdentity(RenderElement&);
     static IntOutsets calculateOutsets(RenderElement&, const FloatRect& targetBoundingBox);
 
-    // Per render
-    LayoutRect repaintRect() const { return m_repaintRect; }
+    SwitcherState beginDrawSourceImage(RenderElement&, const FloatRect& targetBoundingBox, const FloatRect& clipRect, GraphicsContext*&);
+    SwitcherState endDrawSourceImage(RenderElement&, GraphicsContext*&);
 
-    GraphicsContext* beginFilterEffect(RenderElement&, GraphicsContext&, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect);
-    void applyFilterEffect(GraphicsContext& destinationContext);
+    void addReferenceFilterClient(RenderLayer&);
+    void removeReferenceFilterClient(RenderLayer&);
 
 private:
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
-    void resetDirtySourceRect() { m_dirtySourceRect = LayoutRect(); }
+    std::optional<std::tuple<Ref<Filter>, FloatRect>> createFilter(RenderElement&, const FloatRect& targetBoundingBox, GraphicsContext&) final;
 
-    const CheckedRef<RenderLayer> m_layer;
     Vector<RefPtr<Element>> m_internalSVGReferences;
     Vector<CachedResourceHandle<CachedSVGDocument>> m_externalSVGReferences;
-
-    LayoutRect m_targetBoundingBox;
-    LayoutRect m_dirtySourceRect;
-    LayoutRect m_repaintRect;
-
-    OptionSet<FilterRenderingMode> m_preferredFilterRenderingModes { FilterRenderingMode::Software };
-    FloatSize m_filterScale { 1, 1 };
-    FloatRect m_filterRegion;
-
-    RefPtr<CSSFilterRenderer> m_filter;
-    std::unique_ptr<GraphicsContextSwitcher> m_targetSwitcher;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -48,6 +48,7 @@
 #include "RenderTheme.h"
 #include "RenderView.h"
 #include "RenderedDocumentMarker.h"
+#include "Settings.h"
 #include "StyleTextDecorationLine.h"
 #include "StyleTextDecorationThickness.h"
 #include "StyledMarkedText.h"

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -41,6 +41,7 @@
 #include "PathTraversalState.h"
 #include "RenderBlock.h"
 #include "RenderElement.h"
+#include "RenderLayerFilters.h"
 #include "RenderStyleDifference.h"
 #include "RenderStyleSetters.h"
 #include "RenderTheme.h"
@@ -99,6 +100,7 @@ struct SameSizeAsRenderStyle : CanMakeCheckedPtr<SameSizeAsRenderStyle> {
     } m_inheritedFlags;
     void* pseudos;
     void* dataRefSvgStyle;
+    void* layerFilters;
 
 #if ASSERT_ENABLED || ENABLE(SECURITY_ASSERTIONS)
     bool deletionCheck;
@@ -3814,6 +3816,13 @@ void RenderStyle::dumpDifferences(TextStream& ts, const RenderStyle& other) cons
 }
 #endif
 
+
+RenderLayerFilters& RenderStyle::ensureLayerFilters()
+{
+    if (!m_layerFilters)
+        m_layerFilters = makeUnique<RenderLayerFilters>();
+    return *m_layerFilters;
+}
 
 } // namespace WebCore
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -65,6 +65,7 @@ class LayoutUnit;
 class OutlineValue;
 class PositionArea;
 class RenderElement;
+class RenderLayerFilters;
 class RenderStyle;
 class SVGRenderStyle;
 class ScrollTimeline;
@@ -2505,6 +2506,9 @@ public:
     inline bool insideSubmitButton() const;
     inline void setInsideSubmitButton(bool);
 
+    RenderLayerFilters* layerFilters() const { return m_layerFilters.get(); }
+    RenderLayerFilters& ensureLayerFilters();
+
 private:
     struct NonInheritedFlags {
         bool operator==(const NonInheritedFlags&) const = default;
@@ -2636,6 +2640,9 @@ private:
     std::unique_ptr<PseudoStyleCache> m_cachedPseudoStyles;
 
     DataRef<SVGRenderStyle> m_svgStyle;
+
+    // list of associated pseudo styles
+    std::unique_ptr<RenderLayerFilters> m_layerFilters;
 
 #if ASSERT_ENABLED || ENABLE(SECURITY_ASSERTIONS)
     bool m_deletionHasBegun { false };

--- a/Source/WebCore/rendering/style/StyleFilterImage.cpp
+++ b/Source/WebCore/rendering/style/StyleFilterImage.cpp
@@ -136,11 +136,9 @@ RefPtr<Image> StyleFilterImage::image(const RenderElement* renderer, const Float
     auto preferredFilterRenderingModes = renderer->protectedPage()->preferredFilterRenderingModes();
     auto sourceImageRect = FloatRect { { }, size };
 
-    auto cssFilter = CSSFilterRenderer::create(const_cast<RenderElement&>(*renderer), m_filter, preferredFilterRenderingModes, FloatSize { 1, 1 }, sourceImageRect, NullGraphicsContext());
+    auto cssFilter = CSSFilterRenderer::create(const_cast<RenderElement&>(*renderer), m_filter, preferredFilterRenderingModes, FloatSize { 1, 1 }, sourceImageRect, sourceImageRect, NullGraphicsContext());
     if (!cssFilter)
         return &Image::nullImage();
-
-    cssFilter->setFilterRegion(sourceImageRect);
 
     auto sourceImage = ImageBuffer::create(size, destinationContext.renderingMode(), RenderingPurpose::DOM, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8, renderer->hostWindow());
     if (!sourceImage)

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -63,6 +63,7 @@
 #include "SVGCircleElement.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGEllipseElement.h"
+#include "SVGFilterRenderer.h"
 #include "SVGInlineTextBoxInlines.h"
 #include "SVGLineElement.h"
 #include "SVGPathElement.h"

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
@@ -4,7 +4,7 @@
  * Copyright (C) 2005 Eric Seidel <eric@webkit.org>
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
- * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -25,22 +25,15 @@
 #include "config.h"
 #include "LegacyRenderSVGResourceFilter.h"
 
-#include "FilterEffect.h"
-#include "FloatPoint.h"
-#include "GraphicsContext.h"
-#include "IntRect.h"
 #include "LegacyRenderSVGResourceFilterInlines.h"
-#include "Logging.h"
 #include "RenderElementInlines.h"
 #include "RenderObjectInlines.h"
-#include "SVGElementTypeHelpers.h"
+#include "SVGFilterRenderer.h"
 #include "SVGRenderingContext.h"
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 
-WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(FilterData);
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(LegacyRenderSVGResourceFilter);
 
 LegacyRenderSVGResourceFilter::LegacyRenderSVGResourceFilter(SVGFilterElement& element, RenderStyle&& style)
@@ -48,177 +41,14 @@ LegacyRenderSVGResourceFilter::LegacyRenderSVGResourceFilter(SVGFilterElement& e
 {
 }
 
-LegacyRenderSVGResourceFilter::~LegacyRenderSVGResourceFilter() = default;
-
 bool LegacyRenderSVGResourceFilter::isIdentity() const
 {
     return SVGFilterRenderer::isIdentity(protectedFilterElement());
 }
 
-void LegacyRenderSVGResourceFilter::removeAllClientsFromCache()
+FloatRect LegacyRenderSVGResourceFilter::drawingRegion(RenderElement& renderer) const
 {
-    LOG(Filters, "LegacyRenderSVGResourceFilter %p removeAllClientsFromCache", this);
-
-    m_rendererFilterDataMap.clear();
-}
-
-void LegacyRenderSVGResourceFilter::removeClientFromCache(RenderElement& client)
-{
-    LOG(Filters, "LegacyRenderSVGResourceFilter %p removing client %p", this, &client);
-    
-    auto findResult = m_rendererFilterDataMap.find(client);
-    if (findResult != m_rendererFilterDataMap.end()) {
-        FilterData& filterData = *findResult->value;
-        if (filterData.savedContext)
-            filterData.state = FilterData::MarkedForRemoval;
-        else
-            m_rendererFilterDataMap.remove(findResult);
-    }
-}
-
-auto LegacyRenderSVGResourceFilter::applyResource(RenderElement& renderer, const RenderStyle&, GraphicsContext*& context, OptionSet<RenderSVGResourceMode> resourceMode) -> OptionSet<ApplyResult>
-{
-    ASSERT(context);
-    ASSERT_UNUSED(resourceMode, !resourceMode);
-
-    LOG(Filters, "LegacyRenderSVGResourceFilter %p applyResource renderer %p", this, &renderer);
-
-    if (m_rendererFilterDataMap.contains(renderer)) {
-        FilterData* filterData = m_rendererFilterDataMap.get(renderer);
-        if (filterData->state == FilterData::PaintingSource || filterData->state == FilterData::Applying) {
-            filterData->state = FilterData::CycleDetected;
-            return { }; // Already built, or we're in a cycle, or we're marked for removal. Regardless, just do nothing more now.
-        }
-        
-        ASSERT(filterData->targetSwitcher);
-        if (filterData->targetSwitcher->hasSourceImage())
-            return { };
-
-        filterData->targetSwitcher->beginDrawSourceImage(*context);
-        return { ApplyResult::ResourceApplied };
-    }
-
-    auto addResult = m_rendererFilterDataMap.set(renderer, makeUnique<FilterData>());
-    auto filterData = addResult.iterator->value.get();
-
-    Ref filterElement = this->filterElement();
-    RefPtr contextElement = dynamicDowncast<SVGElement>(renderer.element());
-    auto targetBoundingBox = renderer.objectBoundingBox();
-
-    auto filterRegion = SVGLengthContext::resolveRectangle(contextElement.get(), filterElement.get(), filterElement->filterUnits(), targetBoundingBox);
-    if (filterRegion.isEmpty()) {
-        m_rendererFilterDataMap.remove(renderer);
-        return { };
-    }
-
-    // Determine absolute transformation matrix for filter.
-    auto absoluteTransform = SVGRenderingContext::calculateTransformationToOutermostCoordinateSystem(renderer);
-    if (!absoluteTransform.isInvertible()) {
-        m_rendererFilterDataMap.remove(renderer);
-        return { };
-    }
-
-    // Eliminate shear of the absolute transformation matrix, to be able to produce unsheared tile images for feTile.
-    FloatSize filterScale(absoluteTransform.xScale(), absoluteTransform.yScale());
-
-    // Determine absolute boundaries of the filter and the drawing region.
-    filterData->sourceImageRect = renderer.strokeBoundingBox();
-    filterData->sourceImageRect.intersect(filterRegion);
-
-    // Determine scale factor for filter. The size of intermediate ImageBuffers shouldn't be bigger than kMaxFilterSize.
-    ImageBuffer::sizeNeedsClamping(filterData->sourceImageRect.size(), filterScale);
-
-    auto preferredFilterModes = renderer.page().preferredFilterRenderingModes();
-
-    // Create the SVGFilterRenderer object.
-    filterData->filter = SVGFilterRenderer::create(contextElement.get(), filterElement, preferredFilterModes, filterScale, filterRegion, targetBoundingBox, *context, RenderingResourceIdentifier::generate());
-    if (!filterData->filter) {
-        m_rendererFilterDataMap.remove(renderer);
-        return { };
-    }
-
-    filterData->filter->clampFilterRegionIfNeeded();
-
-#if USE(CAIRO)
-    auto colorSpace = DestinationColorSpace::SRGB();
-#else
-    auto colorSpace = DestinationColorSpace::LinearSRGB();
-#endif
-
-    auto& results = filterData->filter->ensureResults([&]() {
-        return makeUnique<FilterResults>();
-    });
-
-    filterData->targetSwitcher = GraphicsContextSwitcher::create(*context, filterData->sourceImageRect, colorSpace, filterData->filter, &results);
-    if (!filterData->targetSwitcher) {
-        m_rendererFilterDataMap.remove(renderer);
-        return { };
-    }
-    
-    // If the sourceImageRect is empty, we have something like <g filter=".."/>.
-    // Even if the target objectBoundingBox() is empty, we still have to draw the last effect result image in postApplyResource.
-    if (filterData->sourceImageRect.isEmpty()) {
-        ASSERT(m_rendererFilterDataMap.contains(renderer));
-        filterData->savedContext = context;
-        return { };
-    }
-
-    filterData->targetSwitcher->beginDrawSourceImage(*context);
-
-    filterData->savedContext = context;
-    context = filterData->targetSwitcher->drawingContext(*context);
-
-    ASSERT(m_rendererFilterDataMap.contains(renderer));
-    return { ApplyResult::ResourceApplied };
-}
-
-void LegacyRenderSVGResourceFilter::postApplyResource(RenderElement& renderer, GraphicsContext*& context, OptionSet<RenderSVGResourceMode> resourceMode, const Path*, const RenderElement*)
-{
-    ASSERT(context);
-    ASSERT_UNUSED(resourceMode, !resourceMode);
-
-    auto findResult = m_rendererFilterDataMap.find(renderer);
-    if (findResult == m_rendererFilterDataMap.end())
-        return;
-
-    FilterData& filterData = *findResult->value;
-
-    LOG_WITH_STREAM(Filters, stream << "\nRenderSVGResourceFilter " << this << " postApplyResource - renderer " << &renderer << " filter state " << filterData.state);
-
-    switch (filterData.state) {
-    case FilterData::MarkedForRemoval:
-        m_rendererFilterDataMap.remove(findResult);
-        return;
-
-    case FilterData::CycleDetected:
-    case FilterData::Applying:
-        // We have a cycle if we are already applying the data.
-        // This can occur due to FeImage referencing a source that makes use of the FEImage itself.
-        // This is the first place we've hit the cycle, so set the state back to PaintingSource so the return stack
-        // will continue correctly.
-        filterData.state = FilterData::PaintingSource;
-        return;
-
-    case FilterData::PaintingSource:
-        if (!filterData.savedContext) {
-            removeClientFromCacheAndMarkForInvalidation(renderer);
-            return;
-        }
-
-        context = filterData.savedContext;
-        filterData.savedContext = nullptr;
-        break;
-
-    case FilterData::Built:
-        break;
-    }
-
-    if (filterData.targetSwitcher) {
-        filterData.state = FilterData::Built;
-        filterData.targetSwitcher->endDrawSourceImage(*context, DestinationColorSpace::LinearSRGB());
-    }
-
-    LOG_WITH_STREAM(Filters, stream << "LegacyRenderSVGResourceFilter " << this << " postApplyResource done\n");
+    return RenderFilterResource::sourceImageRect(renderer);
 }
 
 FloatRect LegacyRenderSVGResourceFilter::resourceBoundingBox(const RenderObject& object, RepaintRectCalculation)
@@ -231,58 +61,94 @@ FloatRect LegacyRenderSVGResourceFilter::resourceBoundingBox(const RenderObject&
 
     RefPtr contextElement = dynamicDowncast<SVGElement>(renderer->element());
 
-    return SVGLengthContext::resolveRectangle(contextElement.get(), filterElement.get(), filterElement->filterUnits(), object.objectBoundingBox());
+    return SVGLengthContext::resolveRectangle<SVGFilterElement>(contextElement.get(), filterElement.get(), filterElement->filterUnits(), object.objectBoundingBox());
+}
+
+std::optional<std::tuple<Ref<Filter>, FloatRect>> LegacyRenderSVGResourceFilter::createFilter(RenderElement& renderer, const FloatRect& targetBoundingBox, GraphicsContext& context)
+{
+    Ref filterElement = this->filterElement();
+    RefPtr contextElement = dynamicDowncast<SVGElement>(renderer.element());
+
+    auto filterRegion = SVGLengthContext::resolveRectangle(contextElement.get(), filterElement.get(), filterElement->filterUnits(), targetBoundingBox);
+    if (filterRegion.isEmpty())
+        return std::nullopt;
+
+    // Determine absolute transformation matrix for filter.
+    auto absoluteTransform = SVGRenderingContext::calculateTransformationToOutermostCoordinateSystem(renderer);
+    if (!absoluteTransform.isInvertible())
+        return std::nullopt;
+
+
+    // Eliminate shear of the absolute transformation matrix, to be able to produce unsheared tile images for feTile.
+    FloatSize filterScale(absoluteTransform.xScale(), absoluteTransform.yScale());
+
+    auto sourceImageRect = renderer.strokeBoundingBox();
+    sourceImageRect.intersect(filterRegion);
+
+    // Determine scale factor for filter. The size of intermediate ImageBuffers shouldn't be bigger than kMaxFilterSize.
+    ImageBuffer::sizeNeedsClamping(sourceImageRect.size(), filterScale);
+
+    auto preferredFilterModes = renderer.page().preferredFilterRenderingModes();
+
+    auto filter = SVGFilterRenderer::create(contextElement.get(), filterElement, preferredFilterModes, filterScale, filterRegion, targetBoundingBox, context, RenderingResourceIdentifier::generate());
+    if (!filter)
+        return std::nullopt;
+
+    filter->clampFilterRegionIfNeeded();
+
+    return { { filter.releaseNonNull(), sourceImageRect } };
+}
+
+DestinationColorSpace LegacyRenderSVGResourceFilter::operatingColorSpace() const
+{
+#if USE(CAIRO)
+    return DestinationColorSpace::SRGB();
+#else
+    return DestinationColorSpace::LinearSRGB();
+#endif
+}
+
+auto LegacyRenderSVGResourceFilter::applyResource(RenderElement& renderer, const RenderStyle&, GraphicsContext*& context, OptionSet<RenderSVGResourceMode> resourceMode) -> OptionSet<ApplyResult>
+{
+    ASSERT(context);
+    ASSERT_UNUSED(resourceMode, !resourceMode);
+
+    if (RenderFilterResource::beginDrawSourceImage(renderer, renderer.objectBoundingBox(), std::nullopt, context) == SwitcherState::PaintingSource)
+        return { ApplyResult::ResourceApplied };
+
+    return { };
+}
+
+void LegacyRenderSVGResourceFilter::postApplyResource(RenderElement& renderer, GraphicsContext*& context, OptionSet<RenderSVGResourceMode> resourceMode, const Path*, const RenderElement*)
+{
+    ASSERT(context);
+    ASSERT_UNUSED(resourceMode, !resourceMode);
+
+    auto state = RenderFilterResource::endDrawSourceImage(renderer, context);
+    if (state == SwitcherState::SourcePainted)
+        RenderFilterResource::applyFilter(renderer, *context);
 }
 
 void LegacyRenderSVGResourceFilter::markFilterForRepaint(FilterEffect& effect)
 {
-    LOG(Filters, "LegacyRenderSVGResourceFilter %p markFilterForRepaint effect %p", this, &effect);
-
-    for (const auto& objectFilterDataPair : m_rendererFilterDataMap) {
-        const auto& filterData = objectFilterDataPair.value;
-        if (filterData->state != FilterData::Built)
-            continue;
-
-        // Repaint the image on the screen.
-        markClientForInvalidation(objectFilterDataPair.key, RepaintInvalidation);
-
-        filterData->filter->clearEffectResult(effect);
-    }
+    RenderFilterResource::clearEffectResult(effect);
+    for (auto client : RenderFilterResource::allClients())
+        markClientForInvalidation(client, RepaintInvalidation);
 }
 
 void LegacyRenderSVGResourceFilter::markFilterForRebuild()
 {
-    LOG(Filters, "LegacyRenderSVGResourceFilter %p markFilterForRebuild", this);
-
-    removeAllClientsFromCacheAndMarkForInvalidation();
+    removeAllClientsFromCache();
 }
 
-FloatRect LegacyRenderSVGResourceFilter::drawingRegion(RenderObject& object) const
+void LegacyRenderSVGResourceFilter::removeAllClientsFromCache()
 {
-    FilterData* filterData = m_rendererFilterDataMap.get(object);
-    return filterData ? filterData->sourceImageRect : FloatRect();
+    RenderFilterResource::removeAllClients();
 }
 
-TextStream& operator<<(TextStream& ts, FilterData::FilterDataState state)
+void LegacyRenderSVGResourceFilter::removeClientFromCache(RenderElement& renderer)
 {
-    switch (state) {
-    case FilterData::PaintingSource:
-        ts << "painting source"_s;
-        break;
-    case FilterData::Applying:
-        ts << "applying"_s;
-        break;
-    case FilterData::Built:
-        ts << "built"_s;
-        break;
-    case FilterData::CycleDetected:
-        ts << "cycle detected"_s;
-        break;
-    case FilterData::MarkedForRemoval:
-        ts << "marked for removal"_s;
-        break;
-    }
-    return ts;
+    RenderFilterResource::removeClient(renderer);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h
@@ -4,6 +4,7 @@
  * Copyright (C) 2005 Eric Seidel <eric@webkit.org>
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -23,74 +24,54 @@
 
 #pragma once
 
-#include "FilterResults.h"
-#include "GraphicsContextSwitcher.h"
 #include "LegacyRenderSVGResourceContainer.h"
-#include "SVGFilterRenderer.h"
+#include "RenderFilterResource.h"
 #include "SVGUnitTypes.h"
-#include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
-class GraphicsContext;
 class SVGFilterElement;
 
-struct FilterData {
-    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(FilterData);
-    WTF_MAKE_NONCOPYABLE(FilterData);
-public:
-    enum FilterDataState { PaintingSource, Applying, Built, CycleDetected, MarkedForRemoval };
-
-    FilterData() = default;
-
-    RefPtr<SVGFilterRenderer> filter;
-
-    std::unique_ptr<GraphicsContextSwitcher> targetSwitcher;
-    FloatRect sourceImageRect;
-
-    GraphicsContext* savedContext { nullptr };
-    FilterDataState state { PaintingSource };
-};
-
-class LegacyRenderSVGResourceFilter final : public LegacyRenderSVGResourceContainer {
+class LegacyRenderSVGResourceFilter final : public LegacyRenderSVGResourceContainer, public RenderFilterResource {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(LegacyRenderSVGResourceFilter);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGResourceFilter);
 public:
     LegacyRenderSVGResourceFilter(SVGFilterElement&, RenderStyle&&);
-    virtual ~LegacyRenderSVGResourceFilter();
 
     inline SVGFilterElement& filterElement() const;
     inline Ref<SVGFilterElement> protectedFilterElement() const;
-    bool isIdentity() const;
-
-    void removeAllClientsFromCache() override;
-    void removeClientFromCache(RenderElement&) override;
-
-    OptionSet<ApplyResult> applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) override;
-    void postApplyResource(RenderElement&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>, const Path*, const RenderElement*) override;
-
-    FloatRect resourceBoundingBox(const RenderObject&, RepaintRectCalculation) override;
 
     inline SVGUnitTypes::SVGUnitType filterUnits() const;
     inline SVGUnitTypes::SVGUnitType primitiveUnits() const;
 
+    RenderSVGResourceType resourceType() const final { return FilterResourceType; }
+
+    bool isIdentity() const;
+
+    FloatRect drawingRegion(RenderElement&) const;
+    FloatRect resourceBoundingBox(const RenderObject&, RepaintRectCalculation) final;
+
+    OptionSet<ApplyResult> applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) final;
+    void postApplyResource(RenderElement&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>, const Path*, const RenderElement*) final;
+
     void markFilterForRepaint(FilterEffect&);
     void markFilterForRebuild();
 
-    RenderSVGResourceType resourceType() const override { return FilterResourceType; }
-
-    FloatRect drawingRegion(RenderObject&) const;
+    void removeAllClientsFromCache() final;
+    void removeClientFromCache(RenderElement&) final;
 
 private:
     void element() const = delete;
 
-    ASCIILiteral renderName() const override { return "RenderSVGResourceFilter"_s; }
+    std::optional<std::tuple<Ref<Filter>, FloatRect>> createFilter(RenderElement&, const FloatRect& targetBoundingBox, GraphicsContext&) final;
+    DestinationColorSpace operatingColorSpace() const final;
+    DestinationColorSpace destinationColorSpace() const final { return DestinationColorSpace::LinearSRGB(); }
 
-    HashMap<SingleThreadWeakRef<RenderObject>, std::unique_ptr<FilterData>> m_rendererFilterDataMap;
+    ASCIILiteral renderName() const final { return "RenderSVGResourceFilter"_s; }
+
+    HashMap<SingleThreadWeakRef<RenderObject>, std::unique_ptr<FilterClient>> m_rendererFilterClientCache;
 };
-
-WTF::TextStream& operator<<(WTF::TextStream&, FilterData::FilterDataState);
 
 } // namespace WebCore
 

--- a/Source/WebCore/svg/SVGFEComponentTransferElement.cpp
+++ b/Source/WebCore/svg/SVGFEComponentTransferElement.cpp
@@ -71,6 +71,16 @@ void SVGFEComponentTransferElement::svgAttributeChanged(const QualifiedName& att
     SVGFilterPrimitiveStandardAttributes::svgAttributeChanged(attrName);
 }
 
+bool SVGFEComponentTransferElement::isIdentity() const
+{
+    for (auto& child : childrenOfType<SVGComponentTransferFunctionElement>(*this)) {
+        auto type = child.type();
+        if (type != ComponentTransferType::FECOMPONENTTRANSFER_TYPE_UNKNOWN && type != ComponentTransferType::FECOMPONENTTRANSFER_TYPE_IDENTITY)
+            return false;
+    }
+    return true;
+}
+
 RefPtr<FilterEffect> SVGFEComponentTransferElement::createFilterEffect(const FilterEffectVector&, const GraphicsContext&) const
 {
     ComponentTransferFunctions functions;

--- a/Source/WebCore/svg/SVGFEComponentTransferElement.h
+++ b/Source/WebCore/svg/SVGFEComponentTransferElement.h
@@ -52,6 +52,7 @@ private:
     void svgAttributeChanged(const QualifiedName&) override;
 
     Vector<AtomString> filterEffectInputsNames() const override { return { AtomString { in1() } }; }
+    bool isIdentity() const override;
     RefPtr<FilterEffect> createFilterEffect(const FilterEffectVector&, const GraphicsContext& destinationContext) const override;
 
     Ref<SVGAnimatedString> m_in1 { SVGAnimatedString::create(this) };

--- a/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
  * Copyright (C) 2013 Google Inc. All rights reserved.
- * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -56,9 +56,9 @@ RefPtr<SVGFilterRenderer> SVGFilterRenderer::create(SVGElement *contextElement, 
     return filter;
 }
 
-Ref<SVGFilterRenderer> SVGFilterRenderer::create(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&& expression, FilterEffectVector&& effects, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier, OptionSet<FilterRenderingMode> filterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion)
+Ref<SVGFilterRenderer> SVGFilterRenderer::create(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&& expression, FilterEffectVector&& effects, OptionSet<FilterRenderingMode> filterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
 {
-    Ref filter = adoptRef(*new SVGFilterRenderer(targetBoundingBox, primitiveUnits, WTFMove(expression), WTFMove(effects), renderingResourceIdentifier, filterScale, filterRegion));
+    Ref filter = adoptRef(*new SVGFilterRenderer(targetBoundingBox, primitiveUnits, WTFMove(expression), WTFMove(effects), filterScale, filterRegion, renderingResourceIdentifier));
     // Setting filter rendering modes cannot be moved to the constructor because it ends up
     // calling supportedFilterRenderingModes() which is a virtual function.
     filter->setFilterRenderingModes(filterRenderingModes);
@@ -72,7 +72,7 @@ SVGFilterRenderer::SVGFilterRenderer(const FloatSize& filterScale, const FloatRe
 {
 }
 
-SVGFilterRenderer::SVGFilterRenderer(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&& expression, FilterEffectVector&& effects, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier, const FloatSize& filterScale, const FloatRect& filterRegion)
+SVGFilterRenderer::SVGFilterRenderer(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&& expression, FilterEffectVector&& effects, const FloatSize& filterScale, const FloatRect& filterRegion, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
     : Filter(Filter::Type::SVGFilterRenderer, filterScale, filterRegion, renderingResourceIdentifier)
     , m_targetBoundingBox(targetBoundingBox)
     , m_primitiveUnits(primitiveUnits)
@@ -278,21 +278,13 @@ FilterEffectVector SVGFilterRenderer::effectsOfType(FilterFunction::Type filterT
     return effects;
 }
 
-FilterResults& SVGFilterRenderer::ensureResults(NOESCAPE const FilterResultsCreator& resultsCreator)
+void SVGFilterRenderer::mergeEffects(const Filter& filter)
 {
-    if (!m_results)
-        m_results = resultsCreator();
-    return *m_results;
-}
+    RefPtr svgFilter = dynamicDowncast<SVGFilterRenderer>(filter);
+    if (!svgFilter)
+        return;
 
-void SVGFilterRenderer::clearEffectResult(FilterEffect& effect)
-{
-    if (m_results)
-        m_results->clearEffectResult(effect);
-}
-
-void SVGFilterRenderer::mergeEffects(const FilterEffectVector& effects)
-{
+    auto& effects = svgFilter->effects();
     ASSERT(m_effects.size() == effects.size());
 
     for (unsigned index = 0; index < m_effects.size(); ++index) {

--- a/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
  * Copyright (C) 2013 Google Inc. All rights reserved.
- * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -22,7 +22,6 @@
 #pragma once
 
 #include <WebCore/Filter.h>
-#include <WebCore/FilterResults.h>
 #include <WebCore/FloatRect.h>
 #include <WebCore/SVGFilterExpression.h>
 #include <WebCore/SVGUnitTypes.h>
@@ -39,7 +38,7 @@ class SVGFilterElement;
 class SVGFilterRenderer final : public Filter {
 public:
     static RefPtr<SVGFilterRenderer> create(SVGElement* contextElement, SVGFilterElement&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext, std::optional<RenderingResourceIdentifier> = std::nullopt);
-    WEBCORE_EXPORT static Ref<SVGFilterRenderer> create(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&, FilterEffectVector&&, std::optional<RenderingResourceIdentifier>, OptionSet<FilterRenderingMode>, const FloatSize& filterScale, const FloatRect& filterRegion);
+    WEBCORE_EXPORT static Ref<SVGFilterRenderer> create(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&, FilterEffectVector&&, OptionSet<FilterRenderingMode>, const FloatSize& filterScale, const FloatRect& filterRegion, std::optional<RenderingResourceIdentifier>);
 
     static bool isIdentity(SVGFilterElement&);
     static IntOutsets calculateOutsets(SVGFilterElement&, const FloatRect& targetBoundingBox);
@@ -52,9 +51,7 @@ public:
 
     FilterEffectVector effectsOfType(FilterFunction::Type) const final;
 
-    WEBCORE_EXPORT FilterResults& ensureResults(NOESCAPE const FilterResultsCreator&);
-    void clearEffectResult(FilterEffect&);
-    WEBCORE_EXPORT void mergeEffects(const FilterEffectVector&);
+    void mergeEffects(const Filter&) final;
 
     RefPtr<FilterImage> apply(FilterImage* sourceImage, FilterResults&) final;
     FilterStyleVector createFilterStyles(GraphicsContext&, const FilterStyle& sourceStyle) const final;
@@ -66,7 +63,7 @@ public:
     WEBCORE_EXPORT static bool isValidSVGFilterExpression(const SVGFilterExpression&, const FilterEffectVector&);
 private:
     SVGFilterRenderer(const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, std::optional<RenderingResourceIdentifier>);
-    SVGFilterRenderer(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&, FilterEffectVector&&, std::optional<RenderingResourceIdentifier>, const FloatSize& filterScale, const FloatRect& filterRegion);
+    SVGFilterRenderer(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&, FilterEffectVector&&, const FloatSize& filterScale, const FloatRect& filterRegion, std::optional<RenderingResourceIdentifier>);
 
     static std::optional<std::tuple<SVGFilterExpression, FilterEffectVector>> buildExpression(SVGElement* contextElement, SVGFilterElement&, const SVGFilterRenderer&, const GraphicsContext& destinationContext);
     void setExpression(SVGFilterExpression&& expression) { m_expression = WTFMove(expression); }
@@ -85,8 +82,6 @@ private:
 
     SVGFilterExpression m_expression;
     FilterEffectVector m_effects;
-
-    std::unique_ptr<FilterResults> m_results;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
@@ -368,9 +368,7 @@ void RemoteGraphicsContext::drawFilteredImageBufferInternal(std::optional<Render
 
 void RemoteGraphicsContext::drawFilteredImageBuffer(std::optional<RenderingResourceIdentifier> sourceImageIdentifier, const FloatRect& sourceImageRect, Ref<Filter>&& filter)
 {
-    RefPtr svgFilter = dynamicDowncast<SVGFilterRenderer>(filter);
-
-    if (!svgFilter || !svgFilter->hasValidRenderingResourceIdentifier()) {
+    if (!filter->hasValidRenderingResourceIdentifier()) {
 #if HAVE(IOSURFACE)
         FilterResults results(makeUnique<ImageBufferShareableAllocator>(m_sharedResourceCache->resourceOwner(), &m_sharedResourceCache->ioSurfacePool()));
 #else
@@ -381,12 +379,10 @@ void RemoteGraphicsContext::drawFilteredImageBuffer(std::optional<RenderingResou
     }
 
     RefPtr cachedFilter = resourceCache().cachedFilter(filter->renderingResourceIdentifier());
-    RefPtr cachedSVGFilter = dynamicDowncast<SVGFilterRenderer>(WTFMove(cachedFilter));
-    MESSAGE_CHECK(cachedSVGFilter);
 
-    cachedSVGFilter->mergeEffects(svgFilter->effects());
+    cachedFilter->mergeEffects(filter);
 
-    auto& results = cachedSVGFilter->ensureResults([&]() {
+    auto& results = cachedFilter->ensureResults([&]() {
 #if HAVE(IOSURFACE)
         auto allocator = makeUnique<ImageBufferShareableAllocator>(m_sharedResourceCache->resourceOwner(), &m_sharedResourceCache->ioSurfacePool());
 #else
@@ -395,7 +391,7 @@ void RemoteGraphicsContext::drawFilteredImageBuffer(std::optional<RenderingResou
         return makeUnique<FilterResults>(WTFMove(allocator));
     });
 
-    drawFilteredImageBufferInternal(sourceImageIdentifier, sourceImageRect, *cachedSVGFilter, results);
+    drawFilteredImageBufferInternal(sourceImageIdentifier, sourceImageRect, *cachedFilter, results);
 }
 
 void RemoteGraphicsContext::drawGlyphs(RenderingResourceIdentifier fontIdentifier, IPC::ArrayReferenceTuple<GlyphBufferGlyph, FloatSize> glyphsAdvances, FloatPoint localAnchor, FontSmoothingMode fontSmoothingMode)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7592,6 +7592,7 @@ class WebCore::FilterOperations {
     OptionSet<WebCore::FilterRenderingMode> filterRenderingModes();
     WebCore::FloatSize filterScale();
     WebCore::FloatRect filterRegion();
+    std::optional<WebCore::RenderingResourceIdentifier> renderingResourceIdentifierIfExists();
 }
 
 [AdditionalEncoder=StreamConnectionEncoder, RefCounted] class WebCore::SVGFilterRenderer {
@@ -7599,11 +7600,11 @@ class WebCore::FilterOperations {
     WebCore::SVGUnitTypes::SVGUnitType primitiveUnits();
     WebCore::SVGFilterExpression expression();
     [Validator='WebCore::SVGFilterRenderer::isValidSVGFilterExpression(*expression, *effects)'] Vector<Ref<WebCore::FilterEffect>> effects();
-    std::optional<WebCore::RenderingResourceIdentifier> renderingResourceIdentifierIfExists();
 
     OptionSet<WebCore::FilterRenderingMode> filterRenderingModes();
     WebCore::FloatSize filterScale();
     WebCore::FloatRect filterRegion();
+    std::optional<WebCore::RenderingResourceIdentifier> renderingResourceIdentifierIfExists();
 }
 
 [Nested] enum class WebCore::UserStyleLevel : bool;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
@@ -247,8 +247,7 @@ void RemoteGraphicsContextProxy::drawFilteredImageBuffer(ImageBuffer* sourceImag
         }
     }
 
-    RefPtr svgFilter = dynamicDowncast<SVGFilterRenderer>(filter);
-    if (svgFilter && svgFilter->hasValidRenderingResourceIdentifier())
+    if (filter.hasValidRenderingResourceIdentifier())
         recordResourceUse(filter);
 
     std::optional<RenderingResourceIdentifier> identifier;


### PR DESCRIPTION
#### 07501fa5d5d094052cbaea1ab0d0acc36d80ff21
<pre>
[Filters] Unify applying CSS and SVG filters
<a href="https://bugs.webkit.org/show_bug.cgi?id=291726">https://bugs.webkit.org/show_bug.cgi?id=291726</a>
<a href="https://rdar.apple.com/149522196">rdar://149522196</a>

Reviewed by NOBODY (OOPS!).

This is still WIP.

This will allow enabling CoreGraphics filters and will fix SVG filters for LBSE.

* LayoutTests/css3/filters/identity-filters.html:
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/css-reference-large-svg-filter.html:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/canvas/CanvasLayerContextSwitcher.cpp:
(WebCore::CanvasLayerContextSwitcher::create):
(WebCore::CanvasLayerContextSwitcher::CanvasLayerContextSwitcher):
(WebCore::CanvasLayerContextSwitcher::~CanvasLayerContextSwitcher):
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
(WebCore::CanvasRenderingContext2D::createFilter const):
* Source/WebCore/page/scrolling/ScrollAnchoringController.h:
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::scaledImageBufferRect):
* Source/WebCore/platform/graphics/GraphicsContextSwitcher.cpp:
(WebCore::GraphicsContextSwitcher::create):
(WebCore::GraphicsContextSwitcher::GraphicsContextSwitcher):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/GraphicsContextSwitcher.h:
(WebCore::GraphicsContextSwitcher::state const):
(WebCore::GraphicsContextSwitcher::setState):
(WebCore::GraphicsContextSwitcher::drawingContext const):
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::filteredNativeImage):
* Source/WebCore/platform/graphics/ImageBufferContextSwitcher.cpp:
(WebCore::ImageBufferContextSwitcher::ImageBufferContextSwitcher):
(WebCore::ImageBufferContextSwitcher::drawingContext const):
(WebCore::ImageBufferContextSwitcher::beginDrawSourceImage):
(WebCore::ImageBufferContextSwitcher::endDrawSourceImage):
(WebCore::ImageBufferContextSwitcher::drawOutputImage):
(WebCore::ImageBufferContextSwitcher::beginClipAndDrawSourceImage): Deleted.
(WebCore::ImageBufferContextSwitcher::endClipAndDrawSourceImage): Deleted.
* Source/WebCore/platform/graphics/ImageBufferContextSwitcher.h:
* Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.cpp:
(WebCore::TransparencyLayerContextSwitcher::TransparencyLayerContextSwitcher):
(WebCore::TransparencyLayerContextSwitcher::beginDrawSourceImage):
(WebCore::TransparencyLayerContextSwitcher::endDrawSourceImage):
(WebCore::TransparencyLayerContextSwitcher::drawOutputImage):
(WebCore::TransparencyLayerContextSwitcher::beginClipAndDrawSourceImage): Deleted.
* Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.h:
* Source/WebCore/platform/graphics/filters/Filter.cpp:
(WebCore::Filter::Filter):
(WebCore::Filter::ensureResults):
(WebCore::Filter::clearEffectResult):
(WebCore::Filter::apply):
* Source/WebCore/platform/graphics/filters/Filter.h:
(WebCore::Filter::filterRegion const):
(WebCore::Filter::setFilterRegion): Deleted.
* Source/WebCore/platform/graphics/filters/FilterEffect.cpp:
(WebCore::FilterEffect::apply):
* Source/WebCore/platform/graphics/filters/FilterImage.cpp:
(WebCore::FilterImage::create):
(WebCore::getConvertedPixelBuffer):
(WebCore::FilterImage::pixelBuffer):
* Source/WebCore/platform/graphics/filters/FilterResults.cpp:
(WebCore::FilterResults::canCacheResult const):
* Source/WebCore/platform/graphics/filters/FilterResults.h:
* Source/WebCore/rendering/CSSFilterRenderer.cpp:
(WebCore::CSSFilterRenderer::createGeneric):
(WebCore::CSSFilterRenderer::create):
(WebCore::CSSFilterRenderer::CSSFilterRenderer):
(WebCore::createReferenceFilter):
(WebCore::CSSFilterRenderer::mergeEffects):
(WebCore::CSSFilterRenderer::setFilterRegion): Deleted.
* Source/WebCore/rendering/CSSFilterRenderer.h:
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::updateLayerFiltersAfterLayout):
* Source/WebCore/rendering/RenderBlock.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutBlock):
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp:
(WebCore::RenderDeprecatedFlexibleBox::layoutBlock):
* Source/WebCore/rendering/RenderFilterResource.cpp: Added.
(WebCore::RenderFilterResource::beginDrawSourceImage):
(WebCore::RenderFilterResource::endDrawSourceImage):
(WebCore::RenderFilterResource::applyFilter):
(WebCore::RenderFilterResource::hasSourceImage const):
(WebCore::RenderFilterResource::targetSwitcher const):
(WebCore::RenderFilterResource::sourceImageRect const):
(WebCore::RenderFilterResource::filterRegion const):
(WebCore::RenderFilterResource::allClients const):
(WebCore::RenderFilterResource::clearEffectResult):
(WebCore::RenderFilterResource::removeClient):
(WebCore::RenderFilterResource::removeAllClients):
* Source/WebCore/rendering/RenderFilterResource.h: Added.
(WebCore::RenderFilterResource::operatingColorSpace const):
(WebCore::RenderFilterResource::destinationColorSpace const):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::layoutBlock):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::layoutGrid):
(WebCore::RenderGrid::layoutMasonry):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::~RenderLayer):
(WebCore::RenderLayer::requiresFullLayerImageForFilters const):
(WebCore::RenderLayer::requireSecurityOriginAccessForWidgets const):
(WebCore::RenderLayer::setFilterBackendNeedsRepaintingInRect):
(WebCore::RenderLayer::paintLayerWithEffects):
(WebCore::RenderLayer::shouldHaveLayerFiltersForPainting const):
(WebCore::RenderLayer::layerFiltersForPainting):
(WebCore::RenderLayer::beginFiltersDrawSourceImage):
(WebCore::RenderLayer::endFiltersDrawSourceImage):
(WebCore::RenderLayer::applyFilters):
(WebCore::RenderLayer::paintLayerContents):
(WebCore::RenderLayer::paintTransformedLayerIntoFragments):
(WebCore::RenderLayer::calculateClipRects const):
(WebCore::RenderLayer::shouldHaveFiltersForPainting const): Deleted.
(WebCore::RenderLayer::filtersForPainting): Deleted.
(WebCore::RenderLayer::setupFilters): Deleted.
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::isIdentity):
(WebCore::RenderLayerFilters::calculateOutsets):
(WebCore::RenderLayerFilters::createFilter):
(WebCore::RenderLayerFilters::beginDrawSourceImage):
(WebCore::RenderLayerFilters::endDrawSourceImage):
(WebCore::RenderLayerFilters::addReferenceFilterClient):
(WebCore::RenderLayerFilters::removeReferenceFilterClient):
(WebCore::RenderLayerFilters::RenderLayerFilters): Deleted.
(WebCore::RenderLayerFilters::~RenderLayerFilters): Deleted.
(WebCore::RenderLayerFilters::hasFilterThatMovesPixels const): Deleted.
(WebCore::RenderLayerFilters::hasFilterThatShouldBeRestrictedBySecurityOrigin const): Deleted.
(WebCore::RenderLayerFilters::hasSourceImage const): Deleted.
(WebCore::RenderLayerFilters::notifyFinished): Deleted.
(WebCore::RenderLayerFilters::updateReferenceFilterClients): Deleted.
(WebCore::RenderLayerFilters::removeReferenceFilterClients): Deleted.
(WebCore::RenderLayerFilters::beginFilterEffect): Deleted.
(WebCore::RenderLayerFilters::applyFilterEffect): Deleted.
* Source/WebCore/rendering/RenderLayerFilters.h:
* Source/WebCore/rendering/TextBoxPainter.cpp:
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::ensureLayerFilters):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/StyleFilterImage.cpp:
(WebCore::StyleFilterImage::image const):
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp:
(WebCore::LegacyRenderSVGResourceFilter::drawingRegion const):
(WebCore::LegacyRenderSVGResourceFilter::resourceBoundingBox):
(WebCore::LegacyRenderSVGResourceFilter::createFilter):
(WebCore::LegacyRenderSVGResourceFilter::operatingColorSpace const):
(WebCore::LegacyRenderSVGResourceFilter::applyResource):
(WebCore::LegacyRenderSVGResourceFilter::postApplyResource):
(WebCore::LegacyRenderSVGResourceFilter::markFilterForRepaint):
(WebCore::LegacyRenderSVGResourceFilter::markFilterForRebuild):
(WebCore::LegacyRenderSVGResourceFilter::removeAllClientsFromCache):
(WebCore::LegacyRenderSVGResourceFilter::removeClientFromCache):
(WebCore::operator&lt;&lt;): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h:
* Source/WebCore/svg/SVGFEComponentTransferElement.cpp:
(WebCore::SVGFEComponentTransferElement::isIdentity const):
* Source/WebCore/svg/SVGFEComponentTransferElement.h:
* Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp:
(WebCore::SVGFilterRenderer::create):
(WebCore::SVGFilterRenderer::SVGFilterRenderer):
(WebCore::SVGFilterRenderer::mergeEffects):
(WebCore::SVGFilterRenderer::ensureResults): Deleted.
(WebCore::SVGFilterRenderer::clearEffectResult): Deleted.
* Source/WebCore/svg/graphics/filters/SVGFilterRenderer.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp:
(WebKit::RemoteGraphicsContext::drawFilteredImageBuffer):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp:
(WebKit::RemoteGraphicsContextProxy::drawFilteredImageBuffer):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b8af42a5dbfc94812d51f1536b1895a154e8d32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128034 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/312 "Hash 6b8af42a for PR 44240 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38860 "Hash 6b8af42a for PR 44240 does not build (failure)") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/df96346b-d3d3-4666-be3a-30a74dad0dd1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129906 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/209 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/190 "Hash 6b8af42a for PR 44240 does not build (failure)") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b0e49db6-032d-4899-8e02-479cca656be6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130982 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/209 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/38860 "Hash 6b8af42a for PR 44240 does not build (failure)") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f28bc9a9-47f6-4eeb-8fff-071956c7f43f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/209 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/38860 "Hash 6b8af42a for PR 44240 does not build (failure)") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/209 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/38860 "Hash 6b8af42a for PR 44240 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137892 "Hash 6b8af42a for PR 44240 does not build (failure)") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/173 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/190 "Hash 6b8af42a for PR 44240 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/137892 "Hash 6b8af42a for PR 44240 does not build (failure)") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/198 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/38860 "Hash 6b8af42a for PR 44240 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/137892 "Hash 6b8af42a for PR 44240 does not build (failure)") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/38860 "Hash 6b8af42a for PR 44240 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52347 "Hash 6b8af42a for PR 44240 does not build (failure)") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/219 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/138 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-26-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/179 "Hash 6b8af42a for PR 44240 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->