### PR TITLE
Don't apply unaffected properties on inline style mutation

### DIFF
--- a/Source/WebCore/css/CSSToStyleMap.cpp
+++ b/Source/WebCore/css/CSSToStyleMap.cpp
@@ -233,8 +233,7 @@ void CSSToStyleMap::mapFillXPosition(CSSPropertyID propertyID, FillLayer& layer,
         length = Style::BuilderConverter::convertPositionComponentX(m_builderState, value);
 
     layer.setXPosition(length);
-    if (value.isPair())
-        layer.setBackgroundXOrigin(fromCSSValue<Edge>(value.first()));
+    layer.setBackgroundXOrigin(value.isPair() ? fromCSSValue<Edge>(value.first()) : Edge::Left);
 }
 
 void CSSToStyleMap::mapFillYPosition(CSSPropertyID propertyID, FillLayer& layer, const CSSValue& value)
@@ -252,8 +251,7 @@ void CSSToStyleMap::mapFillYPosition(CSSPropertyID propertyID, FillLayer& layer,
         length = Style::BuilderConverter::convertPositionComponentY(m_builderState, value);
 
     layer.setYPosition(length);
-    if (value.isPair())
-        layer.setBackgroundYOrigin(fromCSSValue<Edge>(value.first()));
+    layer.setBackgroundYOrigin(value.isPair() ? fromCSSValue<Edge>(value.first()) : Edge::Top);
 }
 
 void CSSToStyleMap::mapFillMaskMode(CSSPropertyID propertyID, FillLayer& layer, const CSSValue& value)

--- a/Source/WebCore/platform/animation/Animation.h
+++ b/Source/WebCore/platform/animation/Animation.h
@@ -66,12 +66,21 @@ public:
 
     bool isEmpty() const
     {
-        return !m_directionSet && !m_durationSet && !m_fillModeSet
-            && !m_nameSet && !m_playStateSet && !m_iterationCountSet
-            && !m_delaySet && !m_timingFunctionSet && !m_propertySet
-            && !m_isNone && !m_compositeOperationSet && !m_timelineSet
-            && !m_allowsDiscreteTransitionsSet && !m_rangeStartSet
-            && !m_rangeEndSet;
+        return !m_nameSet
+            && !m_isNone
+            && (!m_directionSet || m_directionFilled)
+            && (!m_durationSet || m_durationFilled)
+            && (!m_fillModeSet || m_fillModeFilled)
+            && (!m_playStateSet || m_playStateFilled)
+            && (!m_iterationCountSet || m_iterationCountFilled)
+            && (!m_delaySet || m_delayFilled)
+            && (!m_timingFunctionSet || m_timingFunctionFilled)
+            && (!m_propertySet || m_propertyFilled)
+            && (!m_compositeOperationSet || m_compositeOperationFilled)
+            && (!m_timelineSet || m_timelineFilled)
+            && (!m_allowsDiscreteTransitionsSet || m_allowsDiscreteTransitionsFilled)
+            && (!m_rangeStartSet || m_rangeStartFilled)
+            && (!m_rangeEndSet || m_rangeEndFilled);
     }
 
     bool isEmptyOrZeroDuration() const
@@ -84,7 +93,11 @@ public:
     void clearDuration() { m_durationSet = false; m_durationFilled = false; }
     void clearFillMode() { m_fillModeSet = false; m_fillModeFilled = false; }
     void clearIterationCount() { m_iterationCountSet = false; m_iterationCountFilled = false; }
-    void clearName() { m_nameSet = false; }
+    void clearName()
+    {
+        m_nameSet = false;
+        m_name = initialName();
+    }
     void clearPlayState() { m_playStateSet = false; m_playStateFilled = false; }
     void clearProperty() { m_propertySet = false; m_propertyFilled = false; }
     void clearTimeline() { m_timelineSet = false; m_timelineFilled = false; }

--- a/Source/WebCore/style/MatchResultCache.cpp
+++ b/Source/WebCore/style/MatchResultCache.cpp
@@ -27,54 +27,161 @@
 #include "MatchResultCache.h"
 
 #include "MatchResult.h"
+#include "ResolvedStyle.h"
 #include "StyleProperties.h"
 #include "StyledElement.h"
+#include <wtf/BitSet.h>
 
 namespace WebCore {
 namespace Style {
 
+// Cache entries contain a MatchResult object that references element's mutable inline style.
+// As a result the cache entry mutates when element's inline style mutates.
+// We save the original properties and values so we can check which properties have changed.
+// If a property changes we null the value and assume it will change in the future too.
+//
+// It would be nicer if the cache entries were immutable but doing that in a sufficiently
+// performant way is tricky.
+
+struct OriginalInlineProperty {
+    CSSPropertyID propertyID;
+    RefPtr<const CSSValue> valueIfUnchanged;
+};
+
+struct MatchResultCache::Entry : CanMakeCheckedPtr<MatchResultCache::Entry> {
+    UnadjustedStyle unadjustedStyle;
+    Ref<const MutableStyleProperties> inlineStyle;
+    Vector<OriginalInlineProperty> originalInlineProperties;
+
+    Entry(UnadjustedStyle&& unadjustedStyle, const MutableStyleProperties& inlineStyle)
+        : unadjustedStyle(WTFMove(unadjustedStyle))
+        , inlineStyle(inlineStyle)
+    {
+        originalInlineProperties.reserveInitialCapacity(inlineStyle.size());
+        for (auto property : inlineStyle) {
+            originalInlineProperties.append({
+                .propertyID = property.id(),
+                .valueIfUnchanged = property.value()
+            });
+        }
+    }
+
+    WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(Entry);
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+};
+
 MatchResultCache::MatchResultCache() = default;
 MatchResultCache::~MatchResultCache() = default;
 
-RefPtr<const MatchResult> MatchResultCache::get(const Element& element)
+inline UnadjustedStyle copy(const UnadjustedStyle& other)
 {
-    auto it = m_cachedMatchResults.find(element);
-    if (it == m_cachedMatchResults.end())
+    return {
+        .style = RenderStyle::clonePtr(*other.style),
+        .userAgentAppearanceStyle = other.userAgentAppearanceStyle ? RenderStyle::clonePtr(*other.userAgentAppearanceStyle) : nullptr,
+        .relations = other.relations ? makeUnique<Relations>(*other.relations) : std::unique_ptr<Relations> { },
+        .matchResult = other.matchResult
+    };
+}
+
+bool MatchResultCache::isUsableAfterInlineStyleChange(const MatchResultCache::Entry& entry, const StyleProperties& currentInlineStyle)
+{
+    if (entry.inlineStyle.ptr() != &currentInlineStyle)
+        return false;
+
+    Ref inlineStyle = entry.inlineStyle;
+
+    // Only allow the same exact properties after a change. This way the previous values in RenderStyle are guranteed to get overwritten.
+    // Adding properties could be allowed without other changes. Removal would require resetting the removed property to initial
+    // value in the style builder.
+
+    auto size = entry.originalInlineProperties.size();
+    if (size != inlineStyle->size())
+        return false;
+
+    for (size_t index = 0; index < size; ++index) {
+        if (entry.originalInlineProperties[index].propertyID != inlineStyle->propertyAt(index).id())
+            return false;
+    }
+    return true;
+}
+
+PropertyCascade::IncludedProperties MatchResultCache::computeAndUpdateChangedProperties(MatchResultCache::Entry& entry)
+{
+    auto& originalProperties = entry.originalInlineProperties;
+    auto& inlineStyle = entry.inlineStyle.get();
+
+    PropertyCascade::IncludedProperties result;
+
+    auto size = originalProperties.size();
+    for (size_t index = 0; index < size; ++index) {
+        auto currentProperty = inlineStyle.propertyAt(index);
+        auto propertyID = currentProperty.id();
+
+        ASSERT(originalProperties[index].propertyID == propertyID);
+
+        if (originalProperties[index].valueIfUnchanged == currentProperty.value())
+            continue;
+
+        // Assume that if a value changes ones then it will change more. Don't track changes anymore.
+        originalProperties[index].valueIfUnchanged = nullptr;
+
+        // FIXME: Support custom properties.
+        if (propertyID == CSSPropertyCustom)
+            return PropertyCascade::normalProperties();
+
+        // Only use partial applying with low-priority properties since we know changes to them can't
+        // affect values of other properties.
+        // FIXME: CSSPropertyLineHeight shouldn't be a low-priority property as others can depend on it via `lh` unit.
+        if (propertyID < firstLowPriorityProperty || propertyID == CSSPropertyLineHeight)
+            return PropertyCascade::normalProperties();
+
+        result.ids.append(propertyID);
+    }
+
+    return result;
+}
+
+const std::optional<CachedMatchResult> MatchResultCache::resultWithCurrentInlineStyle(const Element& element)
+{
+    auto it = m_entries.find(element);
+    if (it == m_entries.end())
         return { };
 
-    auto& matchResult = *it->value;
+    auto& entry = *it->value;
 
-    auto inlineStyleMatches = [&] {
-        auto* styledElement = dynamicDowncast<StyledElement>(element);
-        if (!styledElement || !styledElement->inlineStyle())
-            return false;
+    auto* styledElement = dynamicDowncast<StyledElement>(element);
+    RefPtr inlineStyle = styledElement ? styledElement->inlineStyle() : nullptr;
 
-        auto& inlineStyle = *styledElement->inlineStyle();
-
-        for (auto& declaration : matchResult.authorDeclarations) {
-            if (&declaration.properties.get() == &inlineStyle)
-                return true;
-        }
-        return false;
-    }();
-
-    if (!inlineStyleMatches) {
-        m_cachedMatchResults.remove(it);
+    if (!inlineStyle || !isUsableAfterInlineStyleChange(entry, *inlineStyle)) {
+        m_entries.remove(it);
         return { };
     }
 
-    return &matchResult;
+    auto changedProperties = computeAndUpdateChangedProperties(entry);
+
+    return CachedMatchResult {
+        .unadjustedStyle = copy(entry.unadjustedStyle),
+        .changedProperties = WTFMove(changedProperties),
+        .styleToUpdate = *entry.unadjustedStyle.style
+    };
 }
 
-void MatchResultCache::update(const Element& element, const MatchResult& matchResult)
+void MatchResultCache::update(CachedMatchResult& result, const RenderStyle& style)
+{
+    result.styleToUpdate.get() = RenderStyle::clone(style);
+}
+
+void MatchResultCache::set(const Element& element, const UnadjustedStyle& unadjustedStyle)
 {
     // For now we cache match results if there is mutable inline style. This way we can avoid
     // selector matching when it gets mutated again.
     auto* styledElement = dynamicDowncast<StyledElement>(element);
-    if (styledElement && styledElement->inlineStyle() && styledElement->inlineStyle()->isMutable())
-        m_cachedMatchResults.set(element, &matchResult);
+    auto* inlineStyle = styledElement ? dynamicDowncast<MutableStyleProperties>(styledElement->inlineStyle()) : nullptr;
+
+    if (inlineStyle)
+        m_entries.set(element, makeUniqueRef<Entry>(copy(unadjustedStyle), *inlineStyle));
     else
-        m_cachedMatchResults.remove(element);
+        m_entries.remove(element);
 }
 
 }

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -51,10 +51,21 @@ public:
         StartingStyle = 1 << 5,
         NonCacheable = 1 << 6,
     };
-    static constexpr OptionSet<PropertyType> normalProperties() { return { PropertyType::NonInherited,  PropertyType::Inherited }; }
-    static constexpr OptionSet<PropertyType> startingStyleProperties() { return normalProperties() | PropertyType::StartingStyle; }
 
-    PropertyCascade(const MatchResult&, CascadeLevel, OptionSet<PropertyType> includedProperties, const UncheckedKeyHashSet<AnimatableCSSProperty>* = nullptr, const StyleProperties* positionTryFallbackProperties = nullptr);
+    static constexpr OptionSet<PropertyType> normalPropertyTypes() { return { PropertyType::NonInherited,  PropertyType::Inherited }; }
+    static constexpr OptionSet<PropertyType> startingStylePropertyTypes() { return normalPropertyTypes() | PropertyType::StartingStyle; }
+
+    struct IncludedProperties {
+        OptionSet<PropertyType> types;
+        // Ids are mutually exclusive with types. They are low-priority only.
+        Vector<CSSPropertyID> ids { };
+
+        bool isEmpty() const { return !types && ids.isEmpty(); }
+    };
+
+    static IncludedProperties normalProperties() { return { normalPropertyTypes() }; }
+
+    PropertyCascade(const MatchResult&, CascadeLevel, IncludedProperties&&, const UncheckedKeyHashSet<AnimatableCSSProperty>* = nullptr, const StyleProperties* positionTryFallbackProperties = nullptr);
     PropertyCascade(const PropertyCascade&, CascadeLevel, std::optional<ScopeOrdinal> rollbackScope = { }, std::optional<CascadeLayerPriority> maximumCascadeLayerPriorityForRollback = { });
 
     ~PropertyCascade();
@@ -89,6 +100,8 @@ public:
     PropertyBitSet& propertyIsPresent() { return m_propertyIsPresent; }
     const PropertyBitSet& propertyIsPresent() const { return m_propertyIsPresent; }
 
+    bool applyLowPriorityOnly() const { return !m_includedProperties.ids.isEmpty(); }
+
 private:
     void buildCascade();
     bool addNormalMatches(CascadeLevel);
@@ -108,7 +121,7 @@ private:
     void sortLogicalGroupPropertyIDs();
 
     const MatchResult& m_matchResult;
-    const OptionSet<PropertyType> m_includedProperties;
+    const IncludedProperties m_includedProperties;
     const CascadeLevel m_maximumCascadeLevel;
     const std::optional<ScopeOrdinal> m_rollbackScope;
     const std::optional<CascadeLayerPriority> m_maximumCascadeLayerPriorityForRollback;

--- a/Source/WebCore/style/ResolvedStyle.h
+++ b/Source/WebCore/style/ResolvedStyle.h
@@ -26,6 +26,13 @@
 namespace WebCore {
 namespace Style {
 
+struct UnadjustedStyle {
+    std::unique_ptr<RenderStyle> style;
+    std::unique_ptr<RenderStyle> userAgentAppearanceStyle;
+    std::unique_ptr<Relations> relations { };
+    RefPtr<const MatchResult> matchResult { };
+};
+
 struct ResolvedStyle {
     std::unique_ptr<RenderStyle> style;
     std::unique_ptr<Relations> relations { };

--- a/Source/WebCore/style/StyleAdjuster.h
+++ b/Source/WebCore/style/StyleAdjuster.h
@@ -49,6 +49,7 @@ class Adjuster {
 public:
     Adjuster(const Document&, const RenderStyle& parentStyle, const RenderStyle* parentBoxStyle, Element*);
 
+    static void adjustFromBuilder(RenderStyle&);
     void adjust(RenderStyle&, const RenderStyle* userAgentAppearanceStyle) const;
     void adjustAnimatedStyle(RenderStyle&, OptionSet<AnimationImpact>) const;
 

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -93,8 +93,8 @@ static auto positionTryFallbackProperties(const BuilderContext& context)
     return context.positionTryFallback ? context.positionTryFallback->properties.get() : nullptr;
 }
 
-Builder::Builder(RenderStyle& style, BuilderContext&& context, const MatchResult& matchResult, CascadeLevel cascadeLevel, OptionSet<PropertyCascade::PropertyType> includedProperties, const UncheckedKeyHashSet<AnimatableCSSProperty>* animatedPropertes)
-    : m_cascade(matchResult, cascadeLevel, includedProperties, animatedPropertes, positionTryFallbackProperties(context))
+Builder::Builder(RenderStyle& style, BuilderContext&& context, const MatchResult& matchResult, CascadeLevel cascadeLevel, PropertyCascade::IncludedProperties&& includedProperties, const UncheckedKeyHashSet<AnimatableCSSProperty>* animatedPropertes)
+    : m_cascade(matchResult, cascadeLevel, WTFMove(includedProperties), animatedPropertes, positionTryFallbackProperties(context))
     , m_state(*this, style, WTFMove(context))
 {
 }
@@ -109,11 +109,16 @@ void Builder::applyAllProperties()
     applyTopPriorityProperties();
     applyHighPriorityProperties();
     applyNonHighPriorityProperties();
+
+    adjustAfterApplying();
 }
 
 // Top priority properties affect resolution of high priority properties.
 void Builder::applyTopPriorityProperties()
 {
+    if (m_cascade.applyLowPriorityOnly())
+        return;
+
     applyProperties(firstTopPriorityProperty, lastTopPriorityProperty);
     m_state.adjustStyleForInterCharacterRuby();
 }
@@ -121,6 +126,9 @@ void Builder::applyTopPriorityProperties()
 // High priority properties may affect resolution of other properties (they are mostly font related).
 void Builder::applyHighPriorityProperties()
 {
+    if (m_cascade.applyLowPriorityOnly())
+        return;
+
     applyProperties(firstHighPriorityProperty, lastHighPriorityProperty);
     m_state.updateFont();
     // This needs to apply before other properties for the `lh` unit, but after updating the font.
@@ -137,6 +145,11 @@ void Builder::applyNonHighPriorityProperties()
     applyCustomProperties();
 
     ASSERT(!m_state.fontDirty());
+}
+
+void Builder::adjustAfterApplying()
+{
+    Adjuster::adjustFromBuilder(m_state.style());
 }
 
 void Builder::applyLogicalGroupProperties()

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -38,13 +38,14 @@ namespace Style {
 class Builder {
     WTF_MAKE_TZONE_ALLOCATED(Builder);
 public:
-    Builder(RenderStyle&, BuilderContext&&, const MatchResult&, CascadeLevel, OptionSet<PropertyCascade::PropertyType> = PropertyCascade::normalProperties(), const UncheckedKeyHashSet<AnimatableCSSProperty>* animatedProperties = nullptr);
+    Builder(RenderStyle&, BuilderContext&&, const MatchResult&, CascadeLevel, PropertyCascade::IncludedProperties&& = PropertyCascade::normalProperties(), const UncheckedKeyHashSet<AnimatableCSSProperty>* animatedProperties = nullptr);
     ~Builder();
 
     void applyAllProperties();
     void applyTopPriorityProperties();
     void applyHighPriorityProperties();
     void applyNonHighPriorityProperties();
+    void adjustAfterApplying();
 
     void applyProperty(CSSPropertyID propertyID) { applyProperties(propertyID, propertyID); }
     void applyCustomProperty(const AtomString& name);


### PR DESCRIPTION
#### f1331f824341b2ff50f8db07d52de739de614349
<pre>
Don&apos;t apply unaffected properties on inline style mutation
<a href="https://bugs.webkit.org/show_bug.cgi?id=285900">https://bugs.webkit.org/show_bug.cgi?id=285900</a>
<a href="https://rdar.apple.com/142870737">rdar://142870737</a>

Reviewed by Simon Fraser.

We already cache match results for inline style mutations.
With this patch we also apply the cached results partially so only the changed properties are re-applied.

Partial applying can be used with normal priority properties that we know don&apos;t have any dependencies.

* Source/WebCore/css/CSSToStyleMap.cpp:
(WebCore::CSSToStyleMap::mapFillXPosition):
(WebCore::CSSToStyleMap::mapFillYPosition):

The optimization relies on overwriting propertues on existing style that is not initialized with initial values.
Fix some cases where we failed to overwrite a property fully.

* Source/WebCore/platform/animation/Animation.h:
(WebCore::Animation::isEmpty const):

Same as above.
Animation is also empty if all properties have been filled rather than being explicitly set.

(WebCore::Animation::clearName):

Same as above.

* Source/WebCore/style/MatchResultCache.cpp:
(WebCore::Style::MatchResultCache::Entry::Entry):
(WebCore::Style::copyStyle):
(WebCore::Style::copy):
(WebCore::Style::MatchResultCache::isUsableAfterInlineStyleChange):

We can only use this cache entry if the same properties were affected.

(WebCore::Style::MatchResultCache::computeAndUpdateChangedProperties):

Figure out the changed properties from the previous inline style.
We only need to apply these.

(WebCore::Style::MatchResultCache::resultWithCurrentInlineStyle):
(WebCore::Style::MatchResultCache::update):

Update the style in the cache entry after computing it.

(WebCore::Style::MatchResultCache::set):
(WebCore::Style::MatchResultCache::get): Deleted.
* Source/WebCore/style/MatchResultCache.h:
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::PropertyCascade):
(WebCore::Style::PropertyCascade::addMatch):

Support providing a list of property ids to apply.

(WebCore::Style::PropertyCascade::shouldApplyAfterAnimation):
* Source/WebCore/style/PropertyCascade.h:

Make IncludedProperties a struct.

(WebCore::Style::PropertyCascade::normalPropertyTypes):
(WebCore::Style::PropertyCascade::startingStylePropertyTypes):
(WebCore::Style::PropertyCascade::IncludedProperties::isEmpty const):
(WebCore::Style::PropertyCascade::normalProperties):
(WebCore::Style::PropertyCascade::applyLowPriorityOnly const):
(WebCore::Style::PropertyCascade::startingStyleProperties): Deleted.
* Source/WebCore/style/ResolvedStyle.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::shouldTreatAutoZIndexAsZero):
(WebCore::Style::Adjuster::adjustFromBuilder):

Add an adjust function that is called from style builder for adjustments that are cacheable.

(WebCore::Style::Adjuster::adjust const):
* Source/WebCore/style/StyleAdjuster.h:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::Builder):
(WebCore::Style::Builder::applyAllProperties):
(WebCore::Style::Builder::applyTopPriorityProperties):
(WebCore::Style::Builder::applyHighPriorityProperties):
(WebCore::Style::Builder::adjustAfterApplying):
* Source/WebCore/style/StyleBuilder.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::State::takeUserAgentAppearanceStyle):
(WebCore::Style::Resolver::initializeStateAndStyle):
(WebCore::Style::Resolver::unadjustedStyleForElement):

To rebuild a style from a cache entry we need to original style from style builder
before any adjustments. Split styleForElement() into two parts so TreeResolver can
get the unadjusted style.

(WebCore::Style::Resolver::styleForElement):
(WebCore::Style::Resolver::unadjustedStyleForCachedMatchResult):

Support applying cached matched result partially on top of an existing style.

(WebCore::Style::Resolver::styleForPseudoElement):
(WebCore::Style::Resolver::applyMatchedProperties):

Add a IncludedProperties parameter.

(WebCore::Style::Resolver::setGlobalStateAfterApplyingProperties):
(WebCore::Style::Resolver::styleForElementWithCachedMatchResult): Deleted.
* Source/WebCore/style/StyleResolver.h:
(WebCore::Style::Resolver::initializeStateAndStyle):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::styleForStyleable):
(WebCore::Style::TreeResolver::resolveStartingStyle):
(WebCore::Style::TreeResolver::resolveAfterChangeStyleForNonAnimated):
(WebCore::Style::TreeResolver::resolveAgainInDifferentContext):
(WebCore::Style::TreeResolver::applyCascadeAfterAnimation):
(WebCore::Style::TreeResolver::generatePositionOption):

Canonical link: <a href="https://commits.webkit.org/293848@main">https://commits.webkit.org/293848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ea19683f77b3a7cf151ccd1292b069292a843c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105219 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50670 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102130 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20043 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28210 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76189 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33258 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15310 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90395 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56550 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15125 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8391 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50040 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85035 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8475 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107578 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27202 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19923 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85143 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27565 "Failed to checkout and rebase branch from PR 44243") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86601 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84677 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21512 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7090 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21040 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27139 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32368 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26950 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30266 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28509 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->