### PR TITLE
WebCore::WidgetNotification should be an enum class

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -5044,7 +5044,7 @@ void LocalFrameView::willPaintContents(GraphicsContext& context, const IntRect&,
 
     paintingState.isFlatteningPaintOfRootFrame = (m_paintBehavior & PaintBehavior::FlattenCompositingLayers) && !m_frame->ownerElement() && !context.detectingContentfulPaint();
     if (paintingState.isFlatteningPaintOfRootFrame)
-        notifyWidgetsInAllFrames(WillPaintFlattened);
+        notifyWidgetsInAllFrames(WidgetNotification::WillPaintFlattened);
 
     ASSERT(!m_isPainting);
     m_isPainting = true;
@@ -5055,7 +5055,7 @@ void LocalFrameView::didPaintContents(GraphicsContext& context, const IntRect& d
     m_isPainting = false;
 
     if (paintingState.isFlatteningPaintOfRootFrame)
-        notifyWidgetsInAllFrames(DidPaintFlattened);
+        notifyWidgetsInAllFrames(WidgetNotification::DidPaintFlattened);
 
     m_paintBehavior = paintingState.paintBehavior;
     m_lastPaintTime = MonotonicTime::now();

--- a/Source/WebCore/platform/Widget.h
+++ b/Source/WebCore/platform/Widget.h
@@ -68,7 +68,7 @@ class PlatformMouseEvent;
 class RegionContext;
 class ScrollView;
 
-enum WidgetNotification { WillPaintFlattened, DidPaintFlattened };
+enum class WidgetNotification : uint8_t { WillPaintFlattened, DidPaintFlattened };
 
 // The Widget class serves as a base class for three kinds of objects:
 // (1) Scrollable areas (ScrollView)

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -836,11 +836,11 @@ bool PluginView::performDictionaryLookupAtLocation(const WebCore::FloatPoint& po
 void PluginView::notifyWidget(WidgetNotification notification)
 {
     switch (notification) {
-    case WillPaintFlattened:
+    case WidgetNotification::WillPaintFlattened:
         if (shouldCreateTransientPaintingSnapshot())
             m_transientPaintingSnapshot = protectedPlugin()->snapshot();
         break;
-    case DidPaintFlattened:
+    case WidgetNotification::DidPaintFlattened:
         m_transientPaintingSnapshot = nullptr;
         break;
     }


### PR DESCRIPTION
#### 39e5eb173599b280dfdb1d324ae6e9e2180afbeb
<pre>
WebCore::WidgetNotification should be an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=291733">https://bugs.webkit.org/show_bug.cgi?id=291733</a>
<a href="https://rdar.apple.com/149537666">rdar://149537666</a>

Reviewed by Aditya Keerthi and Megan Gardner.

This is a mechanical patch that converts WidgetNotfication to an enum
class.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::willPaintContents):
(WebCore::LocalFrameView::didPaintContents):
  Adopt the WidgetNotification scope region.
* Source/WebCore/platform/Widget.h:
  Provide a uint8_t backing type.
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::performDictionaryLookupAtLocation):

Canonical link: <a href="https://commits.webkit.org/293879@main">https://commits.webkit.org/293879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/285179f6316ab2e2595f48f2ea4b965ed48b2ed5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100172 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19820 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10119 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105302 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50754 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102213 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28293 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/76261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/33320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56623 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15199 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8474 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50123 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85107 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8557 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107661 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27285 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27648 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86683 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84758 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21533 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29428 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/7161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/21140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27222 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32455 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27033 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30349 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28592 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->