### PR TITLE
REGRESSION(287602@main): [Debug] Networking process consistently crashes during Apple Pay sheet presentment on ENABLE_APPLE_PAY_REMOTE_UI builds

### DIFF
--- a/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.messages.in
+++ b/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.messages.in
@@ -24,8 +24,8 @@
 
 #if ENABLE(APPLE_PAY)
 
+// Currently DispatchedFrom=Networking when APPLE_PAY_REMOTE_UI and DispatchedFrom=UI when !APPLE_PAY_REMOTE_UI
 [
-    DispatchedFrom=UI,
     DispatchedTo=WebContent
 ]
 messages -> WebPaymentCoordinator {


### PR DESCRIPTION
#### fa3ef110e7667e0299e44ed2959ac1e4890f4154
<pre>
REGRESSION(287602@main): [Debug] Networking process consistently crashes during Apple Pay sheet presentment on ENABLE_APPLE_PAY_REMOTE_UI builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=291739">https://bugs.webkit.org/show_bug.cgi?id=291739</a>
<a href="https://rdar.apple.com/149540206">rdar://149540206</a>

Reviewed by Alex Christensen.

WebPaymentCoordinatorProxy lives in the networking process or in the UI
process, depending on whether ENABLE_APPLE_PAY_REMOTE_UI is true or not,
respectively. As such, it is incorrect to unconditionally claim that the
WebPaymentCoordinator messages are dispatched from the UI process.

This patch removes that claim and avoids debug assertions on _any_ Apple
Pay functionality on ENABLE_APPLE_PAY_REMOTE_UI platforms (i.e. iOS and
visionOS).

* Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.messages.in:

Canonical link: <a href="https://commits.webkit.org/293876@main">https://commits.webkit.org/293876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bb6f404343dd70c7cdb335be1e8bd5b0d688c79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100094 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19742 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105224 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50675 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28215 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76194 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33265 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103101 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15316 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90401 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56555 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15131 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50045 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85042 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107583 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27207 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19927 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85149 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27570 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86607 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84683 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21532 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29358 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7096 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21051 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27144 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32373 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26955 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30271 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28514 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->