### PR TITLE
Address Safer CPP warnings in AutomationFrontendDispatchers.h

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -30,7 +30,6 @@ heap/SlotVisitor.h
 heap/WeakSet.h
 inspector/InspectorAgentBase.h
 inspector/InspectorBackendDispatchers.h
-inspector/InspectorFrontendDispatchers.h
 inspector/JSGlobalObjectConsoleClient.h
 inspector/JSGlobalObjectInspectorController.h
 inspector/agents/InspectorDebuggerAgent.h

--- a/Source/JavaScriptCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -20,9 +20,7 @@ heap/Heap.h
 heap/HeapSnapshotBuilder.h
 heap/JITStubRoutineSet.h
 inspector/InspectorAgentBase.h
-inspector/InspectorFrontendDispatchers.h
 inspector/JSJavaScriptCallFrame.h
-inspector/agents/InspectorTargetAgent.h
 jit/JIT.h
 jit/JITPlan.h
 jit/JITSafepoint.h

--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -73,7 +73,6 @@ heap/MarkingConstraintSolver.cpp
 heap/ParallelSourceAdapter.h
 heap/SubspaceInlines.h
 inspector/ConsoleMessage.cpp
-inspector/InspectorFrontendDispatchers.cpp
 inspector/InspectorProtocolObjects.h
 inspector/JSGlobalObjectInspectorController.cpp
 inspector/JSInjectedScriptHost.cpp

--- a/Source/JavaScriptCore/inspector/InspectorAgentBase.h
+++ b/Source/JavaScriptCore/inspector/InspectorAgentBase.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <JavaScriptCore/InspectorFrontendRouter.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
@@ -36,14 +38,13 @@ class JSGlobalObject;
 namespace Inspector {
 
 class BackendDispatcher;
-class FrontendRouter;
 class InjectedScriptManager;
 class InspectorEnvironment;
 
 struct AgentContext {
     InspectorEnvironment& environment;
     InjectedScriptManager& injectedScriptManager;
-    FrontendRouter& frontendRouter;
+    CheckedRef<FrontendRouter> frontendRouter;
     BackendDispatcher& backendDispatcher;
 };
 

--- a/Source/JavaScriptCore/inspector/InspectorFrontendRouter.cpp
+++ b/Source/JavaScriptCore/inspector/InspectorFrontendRouter.cpp
@@ -28,8 +28,11 @@
 
 #include "InspectorFrontendChannel.h"
 #include <wtf/Assertions.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace Inspector {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FrontendRouter);
 
 Ref<FrontendRouter> FrontendRouter::create()
 {

--- a/Source/JavaScriptCore/inspector/InspectorFrontendRouter.h
+++ b/Source/JavaScriptCore/inspector/InspectorFrontendRouter.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include <JavaScriptCore/JSExportMacros.h>
+#include <wtf/CheckedRef.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -33,7 +35,9 @@ namespace Inspector {
 
 class FrontendChannel;
 
-class FrontendRouter : public RefCounted<FrontendRouter> {
+class FrontendRouter final : public RefCounted<FrontendRouter>, public CanMakeThreadSafeCheckedPtr<FrontendRouter> {
+    WTF_MAKE_TZONE_ALLOCATED(FrontendRouter);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrontendRouter);
 public:
     JS_EXPORT_PRIVATE static Ref<FrontendRouter> create();
 

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
@@ -302,7 +302,7 @@ JSAgentContext JSGlobalObjectInspectorController::jsAgentContext()
     AgentContext baseContext = {
         *this,
         m_injectedScriptManager,
-        m_frontendRouter,
+        m_frontendRouter.get(),
         m_backendDispatcher
     };
 

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.h
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.h
@@ -118,7 +118,6 @@ private:
     const Ref<WTF::Stopwatch> m_executionStopwatch;
     std::unique_ptr<JSGlobalObjectDebugger> m_debugger;
 
-    AgentRegistry m_agents;
     InspectorConsoleAgent* m_consoleAgent { nullptr };
 
     // Lazy, but also on-demand agents.
@@ -127,6 +126,8 @@ private:
 
     const Ref<FrontendRouter> m_frontendRouter;
     const Ref<BackendDispatcher> m_backendDispatcher;
+
+    AgentRegistry m_agents;
 
     // Used to keep the JSGlobalObject and VM alive while we are debugging it.
     JSC::Strong<JSC::JSGlobalObject> m_strongGlobalObject;

--- a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
@@ -166,7 +166,7 @@ void InspectorTargetAgent::didCommitProvisionalTarget(const String& oldTargetID,
 
 FrontendChannel::ConnectionType InspectorTargetAgent::connectionType() const
 {
-    return Ref { m_router }->hasLocalFrontend() ? Inspector::FrontendChannel::ConnectionType::Local : Inspector::FrontendChannel::ConnectionType::Remote;
+    return m_router->hasLocalFrontend() ? Inspector::FrontendChannel::ConnectionType::Local : Inspector::FrontendChannel::ConnectionType::Remote;
 }
 
 void InspectorTargetAgent::connectToTargets()

--- a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h
@@ -68,7 +68,7 @@ private:
     void connectToTargets();
     void disconnectFromTargets();
 
-    Inspector::FrontendRouter& m_router;
+    const CheckedRef<Inspector::FrontendRouter> m_router;
     const UniqueRef<TargetFrontendDispatcher> m_frontendDispatcher;
     const Ref<TargetBackendDispatcher> m_backendDispatcher;
     UncheckedKeyHashMap<String, InspectorTarget*> m_targets;

--- a/Source/JavaScriptCore/inspector/scripts/codegen/cpp_generator_templates.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/cpp_generator_templates.py
@@ -189,10 +189,13 @@ ${returnAssignments}
 """${classAndExportMacro} ${domainName}FrontendDispatcher {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(${domainName}FrontendDispatcher);
 public:
-    ${domainName}FrontendDispatcher(FrontendRouter& frontendRouter) : m_frontendRouter(frontendRouter) { }
+    ${domainName}FrontendDispatcher(FrontendRouter&);
+    ~${domainName}FrontendDispatcher();
+    WTF_MAKE_NONCOPYABLE(${domainName}FrontendDispatcher);
+    WTF_MAKE_NONMOVABLE(${domainName}FrontendDispatcher);
 ${eventDeclarations}
 private:
-    FrontendRouter& m_frontendRouter;
+    const CheckedRef<FrontendRouter> m_frontendRouter;
 };""")
 
     ProtocolObjectBuilderDeclarationPrelude = (

--- a/Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_frontend_dispatcher_header.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_frontend_dispatcher_header.py
@@ -72,6 +72,9 @@ class CppFrontendDispatcherHeaderGenerator(CppGenerator):
     def _generate_secondary_header_includes(self):
         header_includes = [
             (["JavaScriptCore", "WebKit", "WebDriverBidi"], (self.model().framework.name, "%sProtocolObjects.h" % self.protocol_name(), True)),
+            (["JavaScriptCore", "WebKit", "WebDriverBidi"], ("WTF", "wtf/CheckedRef.h")),
+            (["JavaScriptCore", "WebKit", "WebDriverBidi"], ("WTF", "wtf/Noncopyable.h")),
+            (["JavaScriptCore", "WebKit", "WebDriverBidi"], ("WTF", "wtf/Nonmovable.h")),
             (["JavaScriptCore", "WebKit", "WebDriverBidi"], ("WTF", "wtf/JSONValues.h")),
             (["JavaScriptCore", "WebKit", "WebDriverBidi"], ("WTF", "wtf/text/WTFString.h")),
         ]

--- a/Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_frontend_dispatcher_implementation.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_frontend_dispatcher_implementation.py
@@ -77,6 +77,8 @@ class CppFrontendDispatcherImplementationGenerator(CppGenerator):
     def _generate_dispatcher_implementations_for_domain(self, domain):
         implementations = []
         events = self.events_for_domain(domain)
+        implementations.append('%sFrontendDispatcher::%sFrontendDispatcher(FrontendRouter& frontendRouter) : m_frontendRouter(frontendRouter) { }' % (domain.domain_name, domain.domain_name))
+        implementations.append('%sFrontendDispatcher::~%sFrontendDispatcher() = default;' % (domain.domain_name, domain.domain_name))
         for event in events:
             implementations.append(self._generate_dispatcher_implementation_for_event(event, domain))
 
@@ -144,6 +146,6 @@ class CppFrontendDispatcherImplementationGenerator(CppGenerator):
             lines.append('    protocol_jsonMessage->setObject("params"_s, WTFMove(protocol_paramsObject));')
 
         lines.append('')
-        lines.append('    m_frontendRouter.sendEvent(protocol_jsonMessage->toJSONString());')
+        lines.append('    m_frontendRouter->sendEvent(protocol_jsonMessage->toJSONString());')
         lines.append('}')
         return self.wrap_with_guard_for_condition(event.condition, "\n".join(lines))

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/command-targetType-matching-domain-debuggableType.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/command-targetType-matching-domain-debuggableType.json-result
@@ -337,7 +337,10 @@ void DomainBackendDispatcher::Command(long protocol_requestId, RefPtr<JSON::Obje
 #pragma once
 
 #include "TestProtocolObjects.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -347,10 +350,13 @@ class FrontendRouter;
 class DomainFrontendDispatcher {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(DomainFrontendDispatcher);
 public:
-    DomainFrontendDispatcher(FrontendRouter& frontendRouter) : m_frontendRouter(frontendRouter) { }
+    DomainFrontendDispatcher(FrontendRouter&);
+    ~DomainFrontendDispatcher();
+    WTF_MAKE_NONCOPYABLE(DomainFrontendDispatcher);
+    WTF_MAKE_NONMOVABLE(DomainFrontendDispatcher);
     void Event();
 private:
-    FrontendRouter& m_frontendRouter;
+    const CheckedRef<FrontendRouter> m_frontendRouter;
 };
 
 } // namespace Inspector
@@ -393,12 +399,16 @@ private:
 
 namespace Inspector {
 
+DomainFrontendDispatcher::DomainFrontendDispatcher(FrontendRouter& frontendRouter) : m_frontendRouter(frontendRouter) { }
+
+DomainFrontendDispatcher::~DomainFrontendDispatcher() = default;
+
 void DomainFrontendDispatcher::Event()
 {
     auto protocol_jsonMessage = JSON::Object::create();
     protocol_jsonMessage->setString("method"_s, "Domain.Event"_s);
 
-    m_frontendRouter.sendEvent(protocol_jsonMessage->toJSONString());
+    m_frontendRouter->sendEvent(protocol_jsonMessage->toJSONString());
 }
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result
@@ -522,7 +522,10 @@ void DatabaseBackendDispatcher::executeSQLAsync(long protocol_requestId, RefPtr<
 #pragma once
 
 #include "TestProtocolObjects.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result
@@ -436,7 +436,10 @@ void DatabaseBackendDispatcher::executeNoOptionalParameters(long protocol_reques
 #pragma once
 
 #include "TestProtocolObjects.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/definitions-with-mac-platform.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/definitions-with-mac-platform.json-result
@@ -358,7 +358,10 @@ void NetworkBackendDispatcher::loadResource(long protocol_requestId, RefPtr<JSON
 #pragma once
 
 #include "TestProtocolObjects.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -369,12 +372,15 @@ class FrontendRouter;
 class NetworkFrontendDispatcher {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(NetworkFrontendDispatcher);
 public:
-    NetworkFrontendDispatcher(FrontendRouter& frontendRouter) : m_frontendRouter(frontendRouter) { }
+    NetworkFrontendDispatcher(FrontendRouter&);
+    ~NetworkFrontendDispatcher();
+    WTF_MAKE_NONCOPYABLE(NetworkFrontendDispatcher);
+    WTF_MAKE_NONMOVABLE(NetworkFrontendDispatcher);
 #if EVENT-MAC
     void resourceLoaded();
 #endif // EVENT-MAC
 private:
-    FrontendRouter& m_frontendRouter;
+    const CheckedRef<FrontendRouter> m_frontendRouter;
 };
 #endif // DOMAIN-MAC
 
@@ -419,13 +425,17 @@ private:
 namespace Inspector {
 
 #if DOMAIN-MAC
+NetworkFrontendDispatcher::NetworkFrontendDispatcher(FrontendRouter& frontendRouter) : m_frontendRouter(frontendRouter) { }
+
+NetworkFrontendDispatcher::~NetworkFrontendDispatcher() = default;
+
 #if EVENT-MAC
 void NetworkFrontendDispatcher::resourceLoaded()
 {
     auto protocol_jsonMessage = JSON::Object::create();
     protocol_jsonMessage->setString("method"_s, "Network.resourceLoaded"_s);
 
-    m_frontendRouter.sendEvent(protocol_jsonMessage->toJSONString());
+    m_frontendRouter->sendEvent(protocol_jsonMessage->toJSONString());
 }
 #endif // EVENT-MAC
 #endif // DOMAIN-MAC

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-debuggableTypes.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-debuggableTypes.json-result
@@ -337,7 +337,10 @@ void DomainBackendDispatcher::Command(long protocol_requestId, RefPtr<JSON::Obje
 #pragma once
 
 #include "TestProtocolObjects.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -347,10 +350,13 @@ class FrontendRouter;
 class DomainFrontendDispatcher {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(DomainFrontendDispatcher);
 public:
-    DomainFrontendDispatcher(FrontendRouter& frontendRouter) : m_frontendRouter(frontendRouter) { }
+    DomainFrontendDispatcher(FrontendRouter&);
+    ~DomainFrontendDispatcher();
+    WTF_MAKE_NONCOPYABLE(DomainFrontendDispatcher);
+    WTF_MAKE_NONMOVABLE(DomainFrontendDispatcher);
     void Event();
 private:
-    FrontendRouter& m_frontendRouter;
+    const CheckedRef<FrontendRouter> m_frontendRouter;
 };
 
 } // namespace Inspector
@@ -393,12 +399,16 @@ private:
 
 namespace Inspector {
 
+DomainFrontendDispatcher::DomainFrontendDispatcher(FrontendRouter& frontendRouter) : m_frontendRouter(frontendRouter) { }
+
+DomainFrontendDispatcher::~DomainFrontendDispatcher() = default;
+
 void DomainFrontendDispatcher::Event()
 {
     auto protocol_jsonMessage = JSON::Object::create();
     protocol_jsonMessage->setString("method"_s, "Domain.Event"_s);
 
-    m_frontendRouter.sendEvent(protocol_jsonMessage->toJSONString());
+    m_frontendRouter->sendEvent(protocol_jsonMessage->toJSONString());
 }
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result
@@ -524,7 +524,10 @@ void DatabaseBackendDispatcher::executeSQLAsync(long protocol_requestId, RefPtr<
 #pragma once
 
 #include "TestProtocolObjects.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -534,10 +537,13 @@ class FrontendRouter;
 class DatabaseFrontendDispatcher {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(DatabaseFrontendDispatcher);
 public:
-    DatabaseFrontendDispatcher(FrontendRouter& frontendRouter) : m_frontendRouter(frontendRouter) { }
+    DatabaseFrontendDispatcher(FrontendRouter&);
+    ~DatabaseFrontendDispatcher();
+    WTF_MAKE_NONCOPYABLE(DatabaseFrontendDispatcher);
+    WTF_MAKE_NONMOVABLE(DatabaseFrontendDispatcher);
     void didEncounterError(RefPtr<Protocol::Database::Error>&& opt_sqlError);
 private:
-    FrontendRouter& m_frontendRouter;
+    const CheckedRef<FrontendRouter> m_frontendRouter;
 };
 
 } // namespace Inspector
@@ -580,6 +586,10 @@ private:
 
 namespace Inspector {
 
+DatabaseFrontendDispatcher::DatabaseFrontendDispatcher(FrontendRouter& frontendRouter) : m_frontendRouter(frontendRouter) { }
+
+DatabaseFrontendDispatcher::~DatabaseFrontendDispatcher() = default;
+
 void DatabaseFrontendDispatcher::didEncounterError(RefPtr<Protocol::Database::Error>&& opt_sqlError)
 {
     auto protocol_jsonMessage = JSON::Object::create();
@@ -589,7 +599,7 @@ void DatabaseFrontendDispatcher::didEncounterError(RefPtr<Protocol::Database::Er
         protocol_paramsObject->setObject("sqlError"_s, opt_sqlError.releaseNonNull());
     protocol_jsonMessage->setObject("params"_s, WTFMove(protocol_paramsObject));
 
-    m_frontendRouter.sendEvent(protocol_jsonMessage->toJSONString());
+    m_frontendRouter->sendEvent(protocol_jsonMessage->toJSONString());
 }
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetType-matching-domain-debuggableType.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetType-matching-domain-debuggableType.json-result
@@ -337,7 +337,10 @@ void DomainBackendDispatcher::Command(long protocol_requestId, RefPtr<JSON::Obje
 #pragma once
 
 #include "TestProtocolObjects.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -347,10 +350,13 @@ class FrontendRouter;
 class DomainFrontendDispatcher {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(DomainFrontendDispatcher);
 public:
-    DomainFrontendDispatcher(FrontendRouter& frontendRouter) : m_frontendRouter(frontendRouter) { }
+    DomainFrontendDispatcher(FrontendRouter&);
+    ~DomainFrontendDispatcher();
+    WTF_MAKE_NONCOPYABLE(DomainFrontendDispatcher);
+    WTF_MAKE_NONMOVABLE(DomainFrontendDispatcher);
     void Event();
 private:
-    FrontendRouter& m_frontendRouter;
+    const CheckedRef<FrontendRouter> m_frontendRouter;
 };
 
 } // namespace Inspector
@@ -393,12 +399,16 @@ private:
 
 namespace Inspector {
 
+DomainFrontendDispatcher::DomainFrontendDispatcher(FrontendRouter& frontendRouter) : m_frontendRouter(frontendRouter) { }
+
+DomainFrontendDispatcher::~DomainFrontendDispatcher() = default;
+
 void DomainFrontendDispatcher::Event()
 {
     auto protocol_jsonMessage = JSON::Object::create();
     protocol_jsonMessage->setString("method"_s, "Domain.Event"_s);
 
-    m_frontendRouter.sendEvent(protocol_jsonMessage->toJSONString());
+    m_frontendRouter->sendEvent(protocol_jsonMessage->toJSONString());
 }
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetTypes.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetTypes.json-result
@@ -337,7 +337,10 @@ void DomainBackendDispatcher::Command(long protocol_requestId, RefPtr<JSON::Obje
 #pragma once
 
 #include "TestProtocolObjects.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -347,10 +350,13 @@ class FrontendRouter;
 class DomainFrontendDispatcher {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(DomainFrontendDispatcher);
 public:
-    DomainFrontendDispatcher(FrontendRouter& frontendRouter) : m_frontendRouter(frontendRouter) { }
+    DomainFrontendDispatcher(FrontendRouter&);
+    ~DomainFrontendDispatcher();
+    WTF_MAKE_NONCOPYABLE(DomainFrontendDispatcher);
+    WTF_MAKE_NONMOVABLE(DomainFrontendDispatcher);
     void Event();
 private:
-    FrontendRouter& m_frontendRouter;
+    const CheckedRef<FrontendRouter> m_frontendRouter;
 };
 
 } // namespace Inspector
@@ -393,12 +399,16 @@ private:
 
 namespace Inspector {
 
+DomainFrontendDispatcher::DomainFrontendDispatcher(FrontendRouter& frontendRouter) : m_frontendRouter(frontendRouter) { }
+
+DomainFrontendDispatcher::~DomainFrontendDispatcher() = default;
+
 void DomainFrontendDispatcher::Event()
 {
     auto protocol_jsonMessage = JSON::Object::create();
     protocol_jsonMessage->setString("method"_s, "Domain.Event"_s);
 
-    m_frontendRouter.sendEvent(protocol_jsonMessage->toJSONString());
+    m_frontendRouter->sendEvent(protocol_jsonMessage->toJSONString());
 }
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domains-with-varying-command-sizes.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domains-with-varying-command-sizes.json-result
@@ -584,7 +584,10 @@ void Network3BackendDispatcher::loadResource7(long protocol_requestId, RefPtr<JS
 #pragma once
 
 #include "TestProtocolObjects.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result
@@ -384,7 +384,10 @@ void CommandDomainBackendDispatcher::command(long protocol_requestId, RefPtr<JSO
 #pragma once
 
 #include "TestProtocolObjects.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -394,7 +397,10 @@ class FrontendRouter;
 class EventDomainFrontendDispatcher {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(EventDomainFrontendDispatcher);
 public:
-    EventDomainFrontendDispatcher(FrontendRouter& frontendRouter) : m_frontendRouter(frontendRouter) { }
+    EventDomainFrontendDispatcher(FrontendRouter&);
+    ~EventDomainFrontendDispatcher();
+    WTF_MAKE_NONCOPYABLE(EventDomainFrontendDispatcher);
+    WTF_MAKE_NONMOVABLE(EventDomainFrontendDispatcher);
         // Named after parameter 'parameterRequired' while generating command/event event.
         enum class ParameterRequired {
             Shared = 0,
@@ -409,7 +415,7 @@ public:
         }; // enum class ParameterOptional
     void event(Protocol::TypeDomain::Enum enumRequired, std::optional<Protocol::TypeDomain::Enum>&& opt_enumOptional, const String& parameterRequired, const String& opt_parameterOptional);
 private:
-    FrontendRouter& m_frontendRouter;
+    const CheckedRef<FrontendRouter> m_frontendRouter;
 };
 
 } // namespace Inspector
@@ -452,6 +458,10 @@ private:
 
 namespace Inspector {
 
+EventDomainFrontendDispatcher::EventDomainFrontendDispatcher(FrontendRouter& frontendRouter) : m_frontendRouter(frontendRouter) { }
+
+EventDomainFrontendDispatcher::~EventDomainFrontendDispatcher() = default;
+
 void EventDomainFrontendDispatcher::event(Protocol::TypeDomain::Enum enumRequired, std::optional<Protocol::TypeDomain::Enum>&& opt_enumOptional, const String& parameterRequired, const String& opt_parameterOptional)
 {
     auto protocol_jsonMessage = JSON::Object::create();
@@ -465,7 +475,7 @@ void EventDomainFrontendDispatcher::event(Protocol::TypeDomain::Enum enumRequire
         protocol_paramsObject->setString("parameterOptional"_s, opt_parameterOptional);
     protocol_jsonMessage->setObject("params"_s, WTFMove(protocol_paramsObject));
 
-    m_frontendRouter.sendEvent(protocol_jsonMessage->toJSONString());
+    m_frontendRouter->sendEvent(protocol_jsonMessage->toJSONString());
 }
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/event-targetType-matching-domain-debuggableType.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/event-targetType-matching-domain-debuggableType.json-result
@@ -337,7 +337,10 @@ void DomainBackendDispatcher::Command(long protocol_requestId, RefPtr<JSON::Obje
 #pragma once
 
 #include "TestProtocolObjects.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -347,10 +350,13 @@ class FrontendRouter;
 class DomainFrontendDispatcher {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(DomainFrontendDispatcher);
 public:
-    DomainFrontendDispatcher(FrontendRouter& frontendRouter) : m_frontendRouter(frontendRouter) { }
+    DomainFrontendDispatcher(FrontendRouter&);
+    ~DomainFrontendDispatcher();
+    WTF_MAKE_NONCOPYABLE(DomainFrontendDispatcher);
+    WTF_MAKE_NONMOVABLE(DomainFrontendDispatcher);
     void Event();
 private:
-    FrontendRouter& m_frontendRouter;
+    const CheckedRef<FrontendRouter> m_frontendRouter;
 };
 
 } // namespace Inspector
@@ -393,12 +399,16 @@ private:
 
 namespace Inspector {
 
+DomainFrontendDispatcher::DomainFrontendDispatcher(FrontendRouter& frontendRouter) : m_frontendRouter(frontendRouter) { }
+
+DomainFrontendDispatcher::~DomainFrontendDispatcher() = default;
+
 void DomainFrontendDispatcher::Event()
 {
     auto protocol_jsonMessage = JSON::Object::create();
     protocol_jsonMessage->setString("method"_s, "Domain.Event"_s);
 
-    m_frontendRouter.sendEvent(protocol_jsonMessage->toJSONString());
+    m_frontendRouter->sendEvent(protocol_jsonMessage->toJSONString());
 }
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/events-with-optional-parameters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/events-with-optional-parameters.json-result
@@ -261,7 +261,10 @@ namespace Inspector {
 #pragma once
 
 #include "TestProtocolObjects.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -271,11 +274,14 @@ class FrontendRouter;
 class DatabaseFrontendDispatcher {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(DatabaseFrontendDispatcher);
 public:
-    DatabaseFrontendDispatcher(FrontendRouter& frontendRouter) : m_frontendRouter(frontendRouter) { }
+    DatabaseFrontendDispatcher(FrontendRouter&);
+    ~DatabaseFrontendDispatcher();
+    WTF_MAKE_NONCOPYABLE(DatabaseFrontendDispatcher);
+    WTF_MAKE_NONMOVABLE(DatabaseFrontendDispatcher);
     void didExecuteOptionalParameters(RefPtr<JSON::ArrayOf<String>>&& opt_columnNames, const String& opt_notes, std::optional<double>&& opt_timestamp, RefPtr<JSON::Object>&& opt_values, RefPtr<JSON::Value>&& opt_payload, RefPtr<Protocol::Database::Error>&& opt_sqlError, const String& opt_screenColor, RefPtr<Protocol::Database::ColorList>&& opt_alternateColors, const String& opt_printColor);
     void didExecuteNoOptionalParameters(Ref<JSON::ArrayOf<String>>&& columnNames, const String& notes, double timestamp, Ref<JSON::Object>&& values, Ref<JSON::Value>&& payload, Ref<Protocol::Database::Error>&& sqlError, const String& screenColor, Ref<Protocol::Database::ColorList>&& alternateColors, const String& printColor);
 private:
-    FrontendRouter& m_frontendRouter;
+    const CheckedRef<FrontendRouter> m_frontendRouter;
 };
 
 } // namespace Inspector
@@ -318,6 +324,10 @@ private:
 
 namespace Inspector {
 
+DatabaseFrontendDispatcher::DatabaseFrontendDispatcher(FrontendRouter& frontendRouter) : m_frontendRouter(frontendRouter) { }
+
+DatabaseFrontendDispatcher::~DatabaseFrontendDispatcher() = default;
+
 void DatabaseFrontendDispatcher::didExecuteOptionalParameters(RefPtr<JSON::ArrayOf<String>>&& opt_columnNames, const String& opt_notes, std::optional<double>&& opt_timestamp, RefPtr<JSON::Object>&& opt_values, RefPtr<JSON::Value>&& opt_payload, RefPtr<Protocol::Database::Error>&& opt_sqlError, const String& opt_screenColor, RefPtr<Protocol::Database::ColorList>&& opt_alternateColors, const String& opt_printColor)
 {
     auto protocol_jsonMessage = JSON::Object::create();
@@ -343,7 +353,7 @@ void DatabaseFrontendDispatcher::didExecuteOptionalParameters(RefPtr<JSON::Array
         protocol_paramsObject->setString("printColor"_s, opt_printColor);
     protocol_jsonMessage->setObject("params"_s, WTFMove(protocol_paramsObject));
 
-    m_frontendRouter.sendEvent(protocol_jsonMessage->toJSONString());
+    m_frontendRouter->sendEvent(protocol_jsonMessage->toJSONString());
 }
 
 void DatabaseFrontendDispatcher::didExecuteNoOptionalParameters(Ref<JSON::ArrayOf<String>>&& columnNames, const String& notes, double timestamp, Ref<JSON::Object>&& values, Ref<JSON::Value>&& payload, Ref<Protocol::Database::Error>&& sqlError, const String& screenColor, Ref<Protocol::Database::ColorList>&& alternateColors, const String& printColor)
@@ -362,7 +372,7 @@ void DatabaseFrontendDispatcher::didExecuteNoOptionalParameters(Ref<JSON::ArrayO
     protocol_paramsObject->setString("printColor"_s, printColor);
     protocol_jsonMessage->setObject("params"_s, WTFMove(protocol_paramsObject));
 
-    m_frontendRouter.sendEvent(protocol_jsonMessage->toJSONString());
+    m_frontendRouter->sendEvent(protocol_jsonMessage->toJSONString());
 }
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-command-targetTypes-value.json-error
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-command-targetTypes-value.json-error
@@ -1,1 +1,1 @@
-ERROR: Malformed domain specification: targetTypes list for command PageOnly is an unsupported string. Was: "['pagee']", Allowed values: itml, javascript, page, service-worker, web-page, worker
+ERROR: Malformed domain specification: targetTypes list for command PageOnly is an unsupported string. Was: "['pagee']", Allowed values: itml, javascript, page, service-worker, web-page, frame, worker

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-domain-targetTypes-value.json-error
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-domain-targetTypes-value.json-error
@@ -1,1 +1,1 @@
-ERROR: Malformed domain specification: targetTypes for domain PageOnly is an unsupported string. Was: "['pagee']", Allowed values: itml, javascript, page, service-worker, web-page, worker
+ERROR: Malformed domain specification: targetTypes for domain PageOnly is an unsupported string. Was: "['pagee']", Allowed values: itml, javascript, page, service-worker, web-page, frame, worker

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-event-targetTypes-value.json-error
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-event-targetTypes-value.json-error
@@ -1,1 +1,1 @@
-ERROR: Malformed domain specification: targetTypes for event PageOnly is an unsupported string. Was: "['pagee']", Allowed values: itml, javascript, page, service-worker, web-page, worker
+ERROR: Malformed domain specification: targetTypes for event PageOnly is an unsupported string. Was: "['pagee']", Allowed values: itml, javascript, page, service-worker, web-page, frame, worker

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/generate-domains-with-feature-guards.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/generate-domains-with-feature-guards.json-result
@@ -345,7 +345,10 @@ void Network1BackendDispatcher::loadResource(long protocol_requestId, RefPtr<JSO
 #pragma once
 
 #include "TestProtocolObjects.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -355,10 +358,13 @@ class FrontendRouter;
 class Network3FrontendDispatcher {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(Network3FrontendDispatcher);
 public:
-    Network3FrontendDispatcher(FrontendRouter& frontendRouter) : m_frontendRouter(frontendRouter) { }
+    Network3FrontendDispatcher(FrontendRouter&);
+    ~Network3FrontendDispatcher();
+    WTF_MAKE_NONCOPYABLE(Network3FrontendDispatcher);
+    WTF_MAKE_NONMOVABLE(Network3FrontendDispatcher);
     void resourceLoaded();
 private:
-    FrontendRouter& m_frontendRouter;
+    const CheckedRef<FrontendRouter> m_frontendRouter;
 };
 
 } // namespace Inspector
@@ -401,12 +407,16 @@ private:
 
 namespace Inspector {
 
+Network3FrontendDispatcher::Network3FrontendDispatcher(FrontendRouter& frontendRouter) : m_frontendRouter(frontendRouter) { }
+
+Network3FrontendDispatcher::~Network3FrontendDispatcher() = default;
+
 void Network3FrontendDispatcher::resourceLoaded()
 {
     auto protocol_jsonMessage = JSON::Object::create();
     protocol_jsonMessage->setString("method"_s, "Network3.resourceLoaded"_s);
 
-    m_frontendRouter.sendEvent(protocol_jsonMessage->toJSONString());
+    m_frontendRouter->sendEvent(protocol_jsonMessage->toJSONString());
 }
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/same-type-id-different-domain.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/same-type-id-different-domain.json-result
@@ -247,7 +247,10 @@ namespace Inspector {
 #pragma once
 
 #include "TestProtocolObjects.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/shadowed-optional-type-setters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/shadowed-optional-type-setters.json-result
@@ -247,7 +247,10 @@ namespace Inspector {
 #pragma once
 
 #include "TestProtocolObjects.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/should-strip-comments.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/should-strip-comments.json-result
@@ -247,7 +247,10 @@ namespace Inspector {
 #pragma once
 
 #include "TestProtocolObjects.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-aliased-primitive-type.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-aliased-primitive-type.json-result
@@ -247,7 +247,10 @@ namespace Inspector {
 #pragma once
 
 #include "TestProtocolObjects.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-array-type.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-array-type.json-result
@@ -257,7 +257,10 @@ namespace Inspector {
 #pragma once
 
 #include "TestProtocolObjects.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-enum-type.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-enum-type.json-result
@@ -259,7 +259,10 @@ namespace Inspector {
 #pragma once
 
 #include "TestProtocolObjects.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result
@@ -261,7 +261,10 @@ namespace Inspector {
 #pragma once
 
 #include "TestProtocolObjects.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result
@@ -259,7 +259,10 @@ namespace Inspector {
 #pragma once
 
 #include "TestProtocolObjects.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-with-open-parameters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-with-open-parameters.json-result
@@ -247,7 +247,10 @@ namespace Inspector {
 #pragma once
 
 #include "TestProtocolObjects.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/version.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/version.json-result
@@ -257,7 +257,10 @@ namespace Inspector {
 #pragma once
 
 #include "TestProtocolObjects.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {

--- a/Source/WebCore/inspector/InspectorController.cpp
+++ b/Source/WebCore/inspector/InspectorController.cpp
@@ -134,7 +134,7 @@ PageAgentContext InspectorController::pageAgentContext()
     AgentContext baseContext = {
         *this,
         m_injectedScriptManager,
-        m_frontendRouter,
+        m_frontendRouter.get(),
         m_backendDispatcher
     };
 

--- a/Source/WebCore/inspector/WorkerInspectorController.cpp
+++ b/Source/WebCore/inspector/WorkerInspectorController.cpp
@@ -196,7 +196,7 @@ WorkerAgentContext WorkerInspectorController::workerAgentContext()
     AgentContext baseContext = {
         *this,
         m_injectedScriptManager,
-        m_frontendRouter,
+        m_frontendRouter.get(),
         m_backendDispatcher,
     };
 

--- a/Source/WebKit/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -1,2 +1,0 @@
-AutomationFrontendDispatchers.h
-WebDriverBidiFrontendDispatchers.h

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1,4 +1,3 @@
-AutomationFrontendDispatchers.cpp
 AutomationProtocolObjects.h
 GeneratedSerializers.mm
 Platform/IPC/ArgumentCoders.h
@@ -45,7 +44,6 @@ UIProcess/API/Cocoa/_WKUserStyleSheet.mm
 UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm
 UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
 UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
-WebDriverBidiFrontendDispatchers.cpp
 WebDriverBidiProtocolObjects.h
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm


### PR DESCRIPTION
#### 0b227937825143b69dbc899c6537f6233100640a
<pre>
Address Safer CPP warnings in AutomationFrontendDispatchers.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=291751">https://bugs.webkit.org/show_bug.cgi?id=291751</a>

Reviewed by Geoffrey Garen and Devin Rousso.

* Source/JavaScriptCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/JavaScriptCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/JavaScriptCore/inspector/InspectorAgentBase.h:
* Source/JavaScriptCore/inspector/InspectorFrontendRouter.cpp:
* Source/JavaScriptCore/inspector/InspectorFrontendRouter.h:
(Inspector::FrontendRouter::hasFrontends const): Deleted.
(Inspector::FrontendRouter::frontendCount const): Deleted.
* Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp:
(Inspector::JSGlobalObjectInspectorController::jsAgentContext):
* Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.h:
* Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp:
(Inspector::InspectorTargetAgent::connectionType const):
* Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h:
* Source/JavaScriptCore/inspector/scripts/codegen/cpp_generator_templates.py:
* Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_frontend_dispatcher_header.py:
(CppFrontendDispatcherHeaderGenerator._generate_secondary_header_includes):
* Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_frontend_dispatcher_implementation.py:
(CppFrontendDispatcherImplementationGenerator._generate_dispatcher_implementations_for_domain):
(CppFrontendDispatcherImplementationGenerator._generate_dispatcher_implementation_for_event):
* Source/JavaScriptCore/inspector/scripts/tests/expected/command-targetType-matching-domain-debuggableType.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/definitions-with-mac-platform.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/domain-debuggableTypes.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetType-matching-domain-debuggableType.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetTypes.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/domains-with-varying-command-sizes.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/event-targetType-matching-domain-debuggableType.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/events-with-optional-parameters.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-command-targetTypes-value.json-error:
* Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-domain-targetTypes-value.json-error:
* Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-event-targetTypes-value.json-error:
* Source/JavaScriptCore/inspector/scripts/tests/expected/generate-domains-with-feature-guards.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/same-type-id-different-domain.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/shadowed-optional-type-setters.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/should-strip-comments.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-aliased-primitive-type.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-array-type.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-enum-type.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-with-open-parameters.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/version.json-result:
* Source/WebCore/inspector/InspectorController.cpp:
(WebCore::InspectorController::pageAgentContext):
* Source/WebCore/inspector/WorkerInspectorController.cpp:
(WebCore::WorkerInspectorController::workerAgentContext):
* Source/WebKit/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/301177@main">https://commits.webkit.org/301177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee03f33d08891f7b60b3a34141f7c8096f3cb774

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44815 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35554 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131998 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77013 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e6aaaba0-0f49-4130-b734-0e4b7bd636cf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45506 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53378 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95270 "29 flakes 32 failures") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/366c725d-021d-4add-80cf-de955943c409) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128102 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111909 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75812 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/271a579a-47d9-42aa-a726-33f8767f343f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35228 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30074 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75476 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117239 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106089 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134677 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123666 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51958 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39744 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103736 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52392 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108130 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103507 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26361 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48856 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27143 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49024 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51850 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57632 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156689 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51216 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39239 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54572 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52907 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->