### PR TITLE
Address UncountedLocalVarsCheckerExpectations Safer CPP warnings in the UIProcess

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,14 +1,3 @@
-UIProcess/API/C/WKContext.cpp
-UIProcess/API/C/WKContextMenuListener.cpp
-UIProcess/API/C/WKInspector.cpp
-UIProcess/API/C/WKPage.cpp
-UIProcess/API/C/WKUserScriptRef.cpp
-UIProcess/API/C/WKWebsiteDataStoreRef.cpp
-UIProcess/API/C/mac/WKPagePrivateMac.mm
-UIProcess/API/Cocoa/WKFrameInfo.mm
-UIProcess/API/Cocoa/WKNSURLAuthenticationChallenge.mm
-UIProcess/API/Cocoa/WKWebViewTesting.mm
-UIProcess/API/Cocoa/_WKDataTask.mm
 WebProcess/Automation/WebAutomationSessionProxy.cpp
 WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
 WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp

--- a/Source/WebKit/UIProcess/API/C/WKContext.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKContext.cpp
@@ -160,12 +160,12 @@ void WKContextSetHistoryClient(WKContextRef contextRef, const WKContextHistoryCl
         }
     };
 
-    WebKit::WebProcessPool& processPool = *WebKit::toImpl(contextRef);
-    processPool.setHistoryClient(makeUnique<HistoryClient>(wkClient));
+    Ref processPool = *WebKit::toImpl(contextRef);
+    processPool->setHistoryClient(makeUnique<HistoryClient>(wkClient));
 
-    bool addsVisitedLinks = processPool.historyClient().addsVisitedLinks();
+    bool addsVisitedLinks = processPool->historyClient().addsVisitedLinks();
 
-    for (Ref process : processPool.processes()) {
+    for (Ref process : processPool->processes()) {
         for (Ref page : process->pages())
             page->setAddsVisitedLinks(addsVisitedLinks);
     }

--- a/Source/WebKit/UIProcess/API/C/WKContextMenuListener.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKContextMenuListener.cpp
@@ -50,11 +50,11 @@ void WKContextMenuListenerUseContextMenuItems(WKContextMenuListenerRef listenerR
     Vector<Ref<WebContextMenuItem>> items;
     items.reserveInitialCapacity(newSize);
     for (size_t i = 0; i < newSize; ++i) {
-        WebContextMenuItem* item = array->at<WebContextMenuItem>(i);
+        RefPtr item = array->at<WebContextMenuItem>(i);
         if (!item)
             continue;
         
-        items.append(*item);
+        items.append(item.releaseNonNull());
     }
 
     toImpl(listenerRef)->useContextMenuItems(WTFMove(items));

--- a/Source/WebKit/UIProcess/API/C/WKInspector.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKInspector.cpp
@@ -102,7 +102,7 @@ bool WKInspectorIsAttached(WKInspectorRef inspectorRef)
 
 void WKInspectorAttach(WKInspectorRef inspectorRef)
 {
-    auto inspector = toImpl(inspectorRef);
+    Ref inspector = *toImpl(inspectorRef);
     inspector->attach(inspector->attachmentSide());
 }
 

--- a/Source/WebKit/UIProcess/API/C/WKUserScriptRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKUserScriptRef.cpp
@@ -40,8 +40,8 @@ WKTypeID WKUserScriptGetTypeID()
 WKUserScriptRef WKUserScriptCreate(WKStringRef sourceRef, WKURLRef url, WKArrayRef includeURLPatterns, WKArrayRef excludeURLPatterns, _WKUserScriptInjectionTime injectionTime, bool forMainFrameOnly)
 {
     auto baseURLString = toWTFString(url);
-    auto allowlist = toImpl(includeURLPatterns);
-    auto blocklist = toImpl(excludeURLPatterns);
+    RefPtr allowlist = toImpl(includeURLPatterns);
+    RefPtr blocklist = toImpl(excludeURLPatterns);
 
     auto baseURL = baseURLString.isEmpty() ? aboutBlankURL() : URL(URL(), baseURLString);
     return toAPILeakingRef(API::UserScript::create(WebCore::UserScript { toWTFString(sourceRef), WTFMove(baseURL), allowlist ? allowlist->toStringVector() : Vector<String>(), blocklist ? blocklist->toStringVector() : Vector<String>(), toUserScriptInjectionTime(injectionTime), forMainFrameOnly ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames }, API::ContentWorld::pageContentWorldSingleton()));

--- a/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
@@ -185,28 +185,28 @@ void WKWebsiteDataStoreSetStatisticsExpiredStatistic(WKWebsiteDataStoreRef dataS
 
 void WKWebsiteDataStoreSetStatisticsPrevalentResource(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, bool value, void* context, WKWebsiteDataStoreStatisticsPrevalentResourceFunction completionHandler)
 {
-    auto& websiteDataStore = *WebKit::toImpl(dataStoreRef);
+    Ref websiteDataStore = *WebKit::toImpl(dataStoreRef);
 
     if (value)
-        websiteDataStore.setPrevalentResource(URL { WebKit::toImpl(host)->string() }, [context, completionHandler] {
+        websiteDataStore->setPrevalentResource(URL { WebKit::toImpl(host)->string() }, [context, completionHandler] {
             completionHandler(context);
         });
     else
-        websiteDataStore.clearPrevalentResource(URL { WebKit::toImpl(host)->string() }, [context, completionHandler] {
+        websiteDataStore->clearPrevalentResource(URL { WebKit::toImpl(host)->string() }, [context, completionHandler] {
             completionHandler(context);
         });
 }
 
 void WKWebsiteDataStoreSetStatisticsVeryPrevalentResource(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, bool value, void* context, WKWebsiteDataStoreStatisticsVeryPrevalentResourceFunction completionHandler)
 {
-    auto& websiteDataStore = *WebKit::toImpl(dataStoreRef);
+    Ref websiteDataStore = *WebKit::toImpl(dataStoreRef);
 
     if (value)
-        websiteDataStore.setVeryPrevalentResource(URL { WebKit::toImpl(host)->string() }, [context, completionHandler] {
+        websiteDataStore->setVeryPrevalentResource(URL { WebKit::toImpl(host)->string() }, [context, completionHandler] {
             completionHandler(context);
         });
     else
-        websiteDataStore.clearPrevalentResource(URL { WebKit::toImpl(host)->string() }, [context, completionHandler] {
+        websiteDataStore->clearPrevalentResource(URL { WebKit::toImpl(host)->string() }, [context, completionHandler] {
             completionHandler(context);
         });
 }
@@ -255,14 +255,14 @@ void WKWebsiteDataStoreIsStatisticsRegisteredAsRedirectingTo(WKWebsiteDataStoreR
 
 void WKWebsiteDataStoreSetStatisticsHasHadUserInteraction(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, bool value, void* context, WKWebsiteDataStoreStatisticsHasHadUserInteractionFunction completionHandler)
 {
-    auto& dataStore = *WebKit::toImpl(dataStoreRef);
+    Ref dataStore = *WebKit::toImpl(dataStoreRef);
 
     if (value)
-        dataStore.logUserInteraction(URL { WebKit::toImpl(host)->string() }, [context, completionHandler] {
+        dataStore->logUserInteraction(URL { WebKit::toImpl(host)->string() }, [context, completionHandler] {
             completionHandler(context);
         });
     else
-        dataStore.clearUserInteraction(URL { WebKit::toImpl(host)->string() }, [context, completionHandler] {
+        dataStore->clearUserInteraction(URL { WebKit::toImpl(host)->string() }, [context, completionHandler] {
             completionHandler(context);
         });
 }
@@ -545,7 +545,7 @@ void WKWebsiteDataStoreSetManagedDomainsForTesting(WKArrayRef originURLsRef, voi
     HashSet<WebCore::RegistrableDomain> domains;
     domains.reserveInitialCapacity(newSize);
     for (size_t i = 0; i < newSize; ++i) {
-        auto* originURL = originURLsArray->at<API::URL>(i);
+        RefPtr originURL = originURLsArray->at<API::URL>(i);
         if (!originURL)
             continue;
 
@@ -568,16 +568,16 @@ void WKWebsiteDataStoreStatisticsResetToConsistentState(WKWebsiteDataStoreRef da
         completionHandler(context);
     });
 
-    auto& store = *WebKit::toImpl(dataStoreRef);
-    store.clearResourceLoadStatisticsInWebProcesses([callbackAggregator] { });
-    store.resetCacheMaxAgeCapForPrevalentResources([callbackAggregator] { });
-    store.resetCrossSiteLoadsWithLinkDecorationForTesting([callbackAggregator] { });
-    store.setResourceLoadStatisticsShouldDowngradeReferrerForTesting(true, [callbackAggregator] { });
-    store.setResourceLoadStatisticsShouldBlockThirdPartyCookiesForTesting(false, WebCore::ThirdPartyCookieBlockingMode::OnlyAccordingToPerDomainPolicy, [callbackAggregator] { });
-    store.setResourceLoadStatisticsShouldEnbleSameSiteStrictEnforcementForTesting(true, [callbackAggregator] { });
-    store.setResourceLoadStatisticsFirstPartyWebsiteDataRemovalModeForTesting(false, [callbackAggregator] { });
-    store.resetParametersToDefaultValues([callbackAggregator] { });
-    store.scheduleClearInMemoryAndPersistent(WebKit::ShouldGrandfatherStatistics::No, [callbackAggregator] { });
+    Ref store = *WebKit::toImpl(dataStoreRef);
+    store->clearResourceLoadStatisticsInWebProcesses([callbackAggregator] { });
+    store->resetCacheMaxAgeCapForPrevalentResources([callbackAggregator] { });
+    store->resetCrossSiteLoadsWithLinkDecorationForTesting([callbackAggregator] { });
+    store->setResourceLoadStatisticsShouldDowngradeReferrerForTesting(true, [callbackAggregator] { });
+    store->setResourceLoadStatisticsShouldBlockThirdPartyCookiesForTesting(false, WebCore::ThirdPartyCookieBlockingMode::OnlyAccordingToPerDomainPolicy, [callbackAggregator] { });
+    store->setResourceLoadStatisticsShouldEnbleSameSiteStrictEnforcementForTesting(true, [callbackAggregator] { });
+    store->setResourceLoadStatisticsFirstPartyWebsiteDataRemovalModeForTesting(false, [callbackAggregator] { });
+    store->resetParametersToDefaultValues([callbackAggregator] { });
+    store->scheduleClearInMemoryAndPersistent(WebKit::ShouldGrandfatherStatistics::No, [callbackAggregator] { });
 }
 
 void WKWebsiteDataStoreRemoveAllFetchCaches(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreRemoveFetchCacheRemovalFunction callback)

--- a/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
+++ b/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
@@ -130,9 +130,7 @@ _WKRemoteObjectRegistry *WKPageGetObjectRegistry(WKPageRef pageRef)
 
 bool WKPageIsURLKnownHSTSHost(WKPageRef page, WKURLRef url)
 {
-    WebKit::WebPageProxy* webPageProxy = WebKit::toImpl(page);
-
-    return webPageProxy->configuration().processPool().isURLKnownHSTSHost(WebKit::toImpl(url)->string());
+    return WebKit::toProtectedImpl(page)->configuration().processPool().isURLKnownHSTSHost(WebKit::toImpl(url)->string());
 }
 
 WKNavigation *WKPageLoadURLRequestReturningNavigation(WKPageRef pageRef, WKURLRequestRef urlRequestRef)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
@@ -72,7 +72,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (WKWebView *)webView
 {
-    auto page = _frameInfo->page();
+    RefPtr page = _frameInfo->page();
     return page ? page->cocoaView().autorelease() : nil;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNSURLAuthenticationChallenge.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNSURLAuthenticationChallenge.mm
@@ -38,7 +38,7 @@
 
 - (NSObject *)_web_createTarget
 {
-    WebKit::AuthenticationChallengeProxy& challenge = *reinterpret_cast<WebKit::AuthenticationChallengeProxy*>(&self._apiObject);
+    Ref challenge = *reinterpret_cast<WebKit::AuthenticationChallengeProxy*>(&self._apiObject);
 
     static dispatch_once_t token;
     static NeverDestroyed<RetainPtr<WKNSURLAuthenticationChallengeSender>> sender;
@@ -46,7 +46,7 @@
         sender.get() = adoptNS([[WKNSURLAuthenticationChallengeSender alloc] init]);
     });
 
-    return [[NSURLAuthenticationChallenge alloc] initWithAuthenticationChallenge:mac(challenge.core()) sender:sender.get().get()];
+    return [[NSURLAuthenticationChallenge alloc] initWithAuthenticationChallenge:mac(challenge->core()) sender:sender.get().get()];
 }
 
 - (WebKit::AuthenticationChallengeProxy&)_web_authenticationChallengeProxy
@@ -70,45 +70,45 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     checkChallenge(challenge);
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    WebKit::AuthenticationChallengeProxy& webChallenge = ((WKNSURLAuthenticationChallenge *)challenge)._web_authenticationChallengeProxy;
+    Ref<WebKit::AuthenticationChallengeProxy> webChallenge = ((WKNSURLAuthenticationChallenge *)challenge)._web_authenticationChallengeProxy;
 ALLOW_DEPRECATED_DECLARATIONS_END
-    webChallenge.listener().completeChallenge(WebKit::AuthenticationChallengeDisposition::Cancel);
+    webChallenge->listener().completeChallenge(WebKit::AuthenticationChallengeDisposition::Cancel);
 }
 
 - (void)continueWithoutCredentialForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
 {
     checkChallenge(challenge);
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    WebKit::AuthenticationChallengeProxy& webChallenge = ((WKNSURLAuthenticationChallenge *)challenge)._web_authenticationChallengeProxy;
+    Ref<WebKit::AuthenticationChallengeProxy> webChallenge = ((WKNSURLAuthenticationChallenge *)challenge)._web_authenticationChallengeProxy;
 ALLOW_DEPRECATED_DECLARATIONS_END
-    webChallenge.listener().completeChallenge(WebKit::AuthenticationChallengeDisposition::UseCredential);
+    webChallenge->listener().completeChallenge(WebKit::AuthenticationChallengeDisposition::UseCredential);
 }
 
 - (void)useCredential:(NSURLCredential *)credential forAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
 {
     checkChallenge(challenge);
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    WebKit::AuthenticationChallengeProxy& webChallenge = ((WKNSURLAuthenticationChallenge *)challenge)._web_authenticationChallengeProxy;
+    Ref<WebKit::AuthenticationChallengeProxy> webChallenge = ((WKNSURLAuthenticationChallenge *)challenge)._web_authenticationChallengeProxy;
 ALLOW_DEPRECATED_DECLARATIONS_END
-    webChallenge.listener().completeChallenge(WebKit::AuthenticationChallengeDisposition::UseCredential, WebCore::Credential(credential));
+    webChallenge->listener().completeChallenge(WebKit::AuthenticationChallengeDisposition::UseCredential, WebCore::Credential(credential));
 }
 
 - (void)performDefaultHandlingForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
 {
     checkChallenge(challenge);
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    WebKit::AuthenticationChallengeProxy& webChallenge = ((WKNSURLAuthenticationChallenge *)challenge)._web_authenticationChallengeProxy;
+    Ref<WebKit::AuthenticationChallengeProxy> webChallenge = ((WKNSURLAuthenticationChallenge *)challenge)._web_authenticationChallengeProxy;
 ALLOW_DEPRECATED_DECLARATIONS_END
-    webChallenge.listener().completeChallenge(WebKit::AuthenticationChallengeDisposition::PerformDefaultHandling);
+    webChallenge->listener().completeChallenge(WebKit::AuthenticationChallengeDisposition::PerformDefaultHandling);
 }
 
 - (void)rejectProtectionSpaceAndContinueWithChallenge:(NSURLAuthenticationChallenge *)challenge
 {
     checkChallenge(challenge);
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    WebKit::AuthenticationChallengeProxy& webChallenge = ((WKNSURLAuthenticationChallenge *)challenge)._web_authenticationChallengeProxy;
+    Ref<WebKit::AuthenticationChallengeProxy> webChallenge = ((WKNSURLAuthenticationChallenge *)challenge)._web_authenticationChallengeProxy;
 ALLOW_DEPRECATED_DECLARATIONS_END
-    webChallenge.listener().completeChallenge(WebKit::AuthenticationChallengeDisposition::RejectProtectionSpaceAndContinue);
+    webChallenge->listener().completeChallenge(WebKit::AuthenticationChallengeDisposition::RejectProtectionSpaceAndContinue);
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -209,7 +209,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 - (NSDictionary *)_contentsOfUserInterfaceItem:(NSString *)userInterfaceItem
 {
     if ([userInterfaceItem isEqualToString:@"validationBubble"]) {
-        auto* validationBubble = _page->validationBubble();
+        RefPtr validationBubble = _page->validationBubble();
         String message = validationBubble ? validationBubble->message() : emptyString();
         double fontSize = validationBubble ? validationBubble->fontSize() : 0;
         return @{ userInterfaceItem: @{ @"message": message.createNSString().get(), @"fontSize": @(fontSize) } };
@@ -288,7 +288,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
 - (unsigned long)_countOfUpdatesWithLayerChanges
 {
-    if (auto* drawingAreaProxy = dynamicDowncast<WebKit::RemoteLayerTreeDrawingAreaProxy>(_page->drawingArea()))
+    if (RefPtr drawingAreaProxy = dynamicDowncast<WebKit::RemoteLayerTreeDrawingAreaProxy>(_page->drawingArea()))
         return drawingAreaProxy->countOfTransactionsWithNonEmptyLayerChanges();
 
     return 0;
@@ -329,7 +329,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 - (void)_resetNavigationGestureStateForTesting
 {
 #if PLATFORM(MAC)
-    if (auto gestureController = _impl->gestureController())
+    if (RefPtr gestureController = _impl->gestureController())
         gestureController->reset();
 #else
     if (_gestureController)
@@ -429,7 +429,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 - (BOOL)_wirelessVideoPlaybackDisabled
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    if (auto* playbackSessionManager = _page->playbackSessionManager())
+    if (RefPtr playbackSessionManager = _page->playbackSessionManager())
         return playbackSessionManager->wirelessVideoPlaybackDisabled();
 #endif
     return false;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKDataTask.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKDataTask.mm
@@ -126,7 +126,7 @@ private:
 
 - (WKWebView *)webView
 {
-    auto* page = _dataTask->page();
+    RefPtr page = _dataTask->page();
     if (!page)
         return nil;
     return page->cocoaView().get();


### PR DESCRIPTION
#### af36205db1971681e4bd0b0c1a61d727f3c5985d
<pre>
Address UncountedLocalVarsCheckerExpectations Safer CPP warnings in the UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=291753">https://bugs.webkit.org/show_bug.cgi?id=291753</a>

Reviewed by Darin Adler and Ryosuke Niwa.

* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/UIProcess/API/C/WKContext.cpp:
(WKContextSetHistoryClient):
* Source/WebKit/UIProcess/API/C/WKContextMenuListener.cpp:
(WKContextMenuListenerUseContextMenuItems):
* Source/WebKit/UIProcess/API/C/WKInspector.cpp:
(WKInspectorAttach):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageGoBack):
(WKPageGetSessionHistoryURLValueType):
(WKPageGetSessionBackForwardListItemValueType):
(WKPageSetPageContextMenuClient):
(WKPageSetPageLoaderClient):
(WKPageSetPageNavigationClient):
(WKPageLookUpFrameFromHandle):
* Source/WebKit/UIProcess/API/C/WKUserScriptRef.cpp:
(WKUserScriptCreate):
* Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp:
(WKWebsiteDataStoreSetStatisticsPrevalentResource):
(WKWebsiteDataStoreSetStatisticsVeryPrevalentResource):
(WKWebsiteDataStoreSetStatisticsHasHadUserInteraction):
(WKWebsiteDataStoreSetManagedDomainsForTesting):
(WKWebsiteDataStoreStatisticsResetToConsistentState):
* Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm:
(WKPageIsURLKnownHSTSHost):
* Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm:
(-[WKFrameInfo webView]):
* Source/WebKit/UIProcess/API/Cocoa/WKNSURLAuthenticationChallenge.mm:
(-[WKNSURLAuthenticationChallenge _web_createTarget]):
(-[WKNSURLAuthenticationChallengeSender cancelAuthenticationChallenge:]):
(-[WKNSURLAuthenticationChallengeSender continueWithoutCredentialForAuthenticationChallenge:]):
(-[WKNSURLAuthenticationChallengeSender useCredential:forAuthenticationChallenge:]):
(-[WKNSURLAuthenticationChallengeSender performDefaultHandlingForAuthenticationChallenge:]):
(-[WKNSURLAuthenticationChallengeSender rejectProtectionSpaceAndContinueWithChallenge:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _contentsOfUserInterfaceItem:]):
(-[WKWebView _countOfUpdatesWithLayerChanges]):
(-[WKWebView _resetNavigationGestureStateForTesting]):
(-[WKWebView _wirelessVideoPlaybackDisabled]):
* Source/WebKit/UIProcess/API/Cocoa/_WKDataTask.mm:
(-[_WKDataTask webView]):

Canonical link: <a href="https://commits.webkit.org/293862@main">https://commits.webkit.org/293862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0572edf8bd1a0e41273c6523ad27879d17eb20b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10064 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105249 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50700 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20073 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28240 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76215 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33282 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90424 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56576 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15153 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50070 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85065 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8505 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107608 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27232 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19949 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85169 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27595 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86631 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84704 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21526 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29379 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7116 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21087 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27169 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32400 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26980 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30296 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28539 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->