### PR TITLE
Reduce UncountedLocalVarsCheckerExpectations Safer CPP warnings in WebProcess/

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,12 +1,4 @@
 WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
 WebProcess/FullScreen/WebFullScreenManager.cpp
-WebProcess/InjectedBundle/API/c/WKBundle.cpp
-WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
 WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
-WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
-WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
 WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
-WebProcess/InjectedBundle/InjectedBundlePageContextMenuClient.cpp
-WebProcess/InjectedBundle/InjectedBundlePageEditorClient.cpp
-WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
-WebProcess/InjectedBundle/mac/InjectedBundleMac.mm

--- a/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
@@ -67,7 +67,7 @@ void MediaKeySystemPermissionRequestManager::startMediaKeySystemRequest(MediaKey
         return;
     }
 
-    auto& pendingRequests = m_pendingMediaKeySystemRequests.add(document, Vector<Ref<MediaKeySystemRequest>>()).iterator->value;
+    auto& pendingRequests = m_pendingMediaKeySystemRequests.add(document.get(), Vector<Ref<MediaKeySystemRequest>>()).iterator->value;
     if (pendingRequests.isEmpty())
         document->addMediaCanStartListener(*this);
     pendingRequests.append(request);
@@ -104,7 +104,7 @@ void MediaKeySystemPermissionRequestManager::cancelMediaKeySystemRequest(MediaKe
     if (!document)
         return;
 
-    auto iterator = m_pendingMediaKeySystemRequests.find(document);
+    auto iterator = m_pendingMediaKeySystemRequests.find(document.get());
     if (iterator == m_pendingMediaKeySystemRequests.end())
         return;
 

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
@@ -85,10 +85,10 @@ JSValueRef JSWebExtensionWrapper::wrap(JSContextRef context, JSWebExtensionWrapp
     if (auto result = getCachedWrapper(context, wrappers, object))
         return result;
 
-    auto objectClass = object->wrapperClass();
+    RefPtr objectClass = object->wrapperClass();
     ASSERT(objectClass);
 
-    auto wrapper = JSObjectMake(context, objectClass, object);
+    auto wrapper = JSObjectMake(context, objectClass.get(), object);
     ASSERT(wrapper);
 
     JSWeakObjectMapSet(context, wrappers, object, wrapper);
@@ -111,20 +111,19 @@ static JSWebExtensionWrappable* unwrapObject(JSObjectRef object)
 {
     ASSERT(object);
 
-    auto* wrappable = static_cast<JSWebExtensionWrappable*>(JSObjectGetPrivate(object));
-    ASSERT(wrappable);
-    return wrappable;
+    ASSERT(JSObjectGetPrivate(object));
+    return static_cast<JSWebExtensionWrappable*>(JSObjectGetPrivate(object));
 }
 
 void JSWebExtensionWrapper::initialize(JSContextRef, JSObjectRef object)
 {
-    if (auto* wrappable = unwrapObject(object))
+    if (RefPtr wrappable = unwrapObject(object))
         wrappable->ref();
 }
 
 void JSWebExtensionWrapper::finalize(JSObjectRef object)
 {
-    if (auto* wrappable = unwrapObject(object)) {
+    if (RefPtr wrappable = unwrapObject(object)) {
         JSObjectSetPrivate(object, nullptr);
         wrappable->deref();
     }

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -467,7 +467,7 @@ void WebFullScreenManager::updateMainVideoElement()
                 continue;
 
             mainVideoBounds = bounds;
-            mainVideo = video.ptr();
+            mainVideo = WTFMove(video);
         }
         return mainVideo;
     }());

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundle.cpp
@@ -224,7 +224,7 @@ void WKBundleResourceLoadStatisticsNotifyObserver(WKBundleRef, void* context, No
 void WKBundleExtendClassesForParameterCoder(WKBundleRef bundle, WKArrayRef classes)
 {
 #if PLATFORM(COCOA)
-    auto classList = WebKit::toImpl(classes);
+    RefPtr classList = WebKit::toImpl(classes);
     if (!classList)
         return;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
@@ -75,7 +75,7 @@ WKURLRef WKBundleFrameCopyProvisionalURL(WKBundleFrameRef frameRef)
 
 WKFrameLoadState WKBundleFrameGetFrameLoadState(WKBundleFrameRef frameRef)
 {
-    auto* coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame();
+    RefPtr coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame();
     if (!coreFrame)
         return kWKFrameLoadStateFinished;
 
@@ -251,7 +251,7 @@ WKDataRef WKBundleFrameCopyWebArchiveFilteringSubframes(WKBundleFrameRef frameRe
     UNUSED_PARAM(context);
 #endif
     
-    return 0;
+    return nullptr;
 }
 
 bool WKBundleFrameCallShouldCloseOnWebView(WKBundleFrameRef frameRef)
@@ -259,7 +259,7 @@ bool WKBundleFrameCallShouldCloseOnWebView(WKBundleFrameRef frameRef)
     if (!frameRef)
         return true;
 
-    auto* coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame();
+    RefPtr coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame();
     if (!coreFrame)
         return true;
 
@@ -274,7 +274,7 @@ WKBundleHitTestResultRef WKBundleFrameCreateHitTestResult(WKBundleFrameRef frame
 
 WKSecurityOriginRef WKBundleFrameCopySecurityOrigin(WKBundleFrameRef frameRef)
 {
-    auto* coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame();
+    RefPtr coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame();
     if (!coreFrame)
         return 0;
 
@@ -322,6 +322,6 @@ void* WKAccessibilityRootObject(WKBundleFrameRef frameRef)
     if (!axObjectCache)
         return nullptr;
 
-    auto* root = axObjectCache->rootObjectForFrame(*frame);
+    RefPtr root = axObjectCache->rootObjectForFrame(*frame);
     return root ? root->wrapper() : nullptr;
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
@@ -399,7 +399,7 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
 
 - (WKDOMDocument *)mainFrameDocument
 {
-    auto* webCoreMainFrame = dynamicDowncast<WebCore::LocalFrame>(_page->mainFrame());
+    RefPtr webCoreMainFrame = dynamicDowncast<WebCore::LocalFrame>(_page->mainFrame());
     if (!webCoreMainFrame)
         return nil;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
@@ -72,11 +72,8 @@ InjectedBundleDOMWindowExtension::~InjectedBundleDOMWindowExtension()
 
 RefPtr<WebFrame> InjectedBundleDOMWindowExtension::frame() const
 {
-    auto* frame = m_coreExtension->frame();
-    if (!frame)
-        return nullptr;
-
-    return WebFrame::fromCoreFrame(*frame);
+    RefPtr frame = m_coreExtension->frame();
+    return frame ? WebFrame::fromCoreFrame(*frame) : nullptr;
 }
 
 InjectedBundleScriptWorld* InjectedBundleDOMWindowExtension::world() const

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
@@ -62,11 +62,11 @@ RefPtr<InjectedBundleNodeHandle> InjectedBundleHitTestResult::urlElementHandle()
 
 RefPtr<WebFrame> InjectedBundleHitTestResult::frame() const
 {
-    auto* node = m_hitTestResult.innerNonSharedNode();
+    RefPtr node = m_hitTestResult.innerNonSharedNode();
     if (!node)
         return nullptr;
 
-    auto* frame = node->document().frame();
+    RefPtr frame = node->document().frame();
     if (!frame)
         return nullptr;
 
@@ -75,11 +75,8 @@ RefPtr<WebFrame> InjectedBundleHitTestResult::frame() const
 
 RefPtr<WebFrame> InjectedBundleHitTestResult::targetFrame() const
 {
-    auto* frame = m_hitTestResult.targetFrame();
-    if (!frame)
-        return nullptr;
-
-    return WebFrame::fromCoreFrame(*frame);
+    RefPtr frame = m_hitTestResult.targetFrame();
+    return frame ? WebFrame::fromCoreFrame(*frame) : nullptr;
 }
 
 String InjectedBundleHitTestResult::absoluteImageURL() const
@@ -155,7 +152,7 @@ IntRect InjectedBundleHitTestResult::imageRect() const
     if (!webFrame)
         return imageRect;
     
-    auto* coreFrame = webFrame->coreLocalFrame();
+    RefPtr coreFrame = webFrame->coreLocalFrame();
     if (!coreFrame)
         return imageRect;
     
@@ -169,12 +166,12 @@ IntRect InjectedBundleHitTestResult::imageRect() const
 RefPtr<WebImage> InjectedBundleHitTestResult::image() const
 {
     // For now, we only handle bitmap images.
-    auto* bitmapImage = dynamicDowncast<BitmapImage>(m_hitTestResult.image());
+    RefPtr bitmapImage = dynamicDowncast<BitmapImage>(m_hitTestResult.image());
     if (!bitmapImage)
         return nullptr;
 
     IntSize size(bitmapImage->size());
-    auto webImage = WebImage::create(size, { }, DestinationColorSpace::SRGB());
+    RefPtr webImage = WebImage::create(size, { }, DestinationColorSpace::SRGB());
     if (!webImage->context())
         return nullptr;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageContextMenuClient.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageContextMenuClient.cpp
@@ -71,7 +71,7 @@ bool InjectedBundlePageContextMenuClient::getCustomMenuFromDefaultItems(WebPage&
     
     size_t size = array->size();
     for (size_t i = 0; i < size; ++i) {
-        WebContextMenuItem* item = array->at<WebContextMenuItem>(i);
+        RefPtr item = array->at<WebContextMenuItem>(i);
         if (!item) {
             LOG(ContextMenu, "New menu entry at index %i is not a WebContextMenuItem", (int)i);
             continue;

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageEditorClient.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageEditorClient.cpp
@@ -156,10 +156,10 @@ void InjectedBundlePageEditorClient::getPasteboardDataForRange(WebPage& page, co
 
         ASSERT(typesArray->size() == dataArray->size());
 
-        for (auto type : typesArray->elementsOfType<API::String>())
+        for (RefPtr type : typesArray->elementsOfType<API::String>())
             pasteboardTypes.append(type->string());
 
-        for (auto item : dataArray->elementsOfType<API::Data>()) {
+        for (RefPtr item : dataArray->elementsOfType<API::Data>()) {
             auto buffer = SharedBuffer::create(item->span());
             pasteboardData.append(WTFMove(buffer));
         }

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
@@ -83,8 +83,8 @@ InjectedBundleScriptWorld* InjectedBundleScriptWorld::find(const String& name)
 
 InjectedBundleScriptWorld& InjectedBundleScriptWorld::normalWorldSingleton()
 {
-    static InjectedBundleScriptWorld& world = adoptRef(*new InjectedBundleScriptWorld(mainThreadNormalWorldSingleton(), String())).leakRef();
-    return world;
+    static NeverDestroyed<Ref<InjectedBundleScriptWorld>> world = adoptRef(*new InjectedBundleScriptWorld(mainThreadNormalWorldSingleton(), String())).leakRef();
+    return world.get();
 }
 
 InjectedBundleScriptWorld::InjectedBundleScriptWorld(DOMWrapperWorld& world, const String& name)

--- a/Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
@@ -221,7 +221,7 @@ void InjectedBundle::extendClassesForParameterCoder(API::Array& classes)
     auto mutableSet = adoptNS([classesForCoder() mutableCopy]);
 
     for (size_t i = 0; i < size; ++i) {
-        API::String* classNameString = classes.at<API::String>(i);
+        RefPtr classNameString = classes.at<API::String>(i);
         if (!classNameString) {
             WTFLogAlways("InjectedBundle::extendClassesForParameterCoder - No class provided as argument %d.\n", i);
             break;


### PR DESCRIPTION
#### 543f32094531976fd806f6594eb640b545ecff73
<pre>
Reduce UncountedLocalVarsCheckerExpectations Safer CPP warnings in WebProcess/
<a href="https://bugs.webkit.org/show_bug.cgi?id=291756">https://bugs.webkit.org/show_bug.cgi?id=291756</a>

Reviewed by Geoffrey Garen and Darin Adler.

* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::evaluateJavaScriptCallback):
* Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp:
(WebKit::MediaKeySystemPermissionRequestManager::startMediaKeySystemRequest):
(WebKit::MediaKeySystemPermissionRequestManager::cancelMediaKeySystemRequest):
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp:
(WebKit::JSWebExtensionWrapper::wrap):
(WebKit::unwrapObject):
(WebKit::JSWebExtensionWrapper::initialize):
(WebKit::JSWebExtensionWrapper::finalize):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::enterFullScreenForElement):
(WebKit::WebFullScreenManager::didEnterFullScreen):
(WebKit::WebFullScreenManager::updateMainVideoElement):
(WebKit::collectFullscreenElementsFromElement):
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp:
(WebKit::SampleBufferDisplayLayerManager::didReceiveLayerMessage):
* Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp:
(WebKit::GeolocationPermissionRequestManager::startRequestForGeolocation):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm:
(-[WKWebProcessPlugInFrame _securityOrigin]):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundle.cpp:
(WKBundleExtendClassesForParameterCoder):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp:
(WKBundleFrameGetFrameLoadState):
(WKBundleFrameCopyWebArchiveFilteringSubframes):
(WKBundleFrameCallShouldCloseOnWebView):
(WKBundleFrameCopySecurityOrigin):
(WKAccessibilityRootObject):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundlePageCopyContextMenuItems):
(WKBundlePageCopyContextMenuAtPointInWindow):
(WKAccessibilityFocusedObject):
(WKAccessibilityAnnounce):
(WKBundlePageReplaceStringMatches):
(WKBundlePageSetComposition):
(WKBundlePageSetUseDarkAppearance):
(WKBundlePageIsUsingDarkAppearance):
(WKBundlePageStartMonitoringScrollOperations):
(WKBundlePageRegisterScrollOperationCompletionCallback):
(WKBundlePageCallAfterTasksAndTimers):
(WKBundlePageSetCaptionDisplayMode):
(WKBundlePageCreateCaptionUserPreferencesTestingModeToken):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm:
(-[WKWebProcessPlugInBrowserContextController mainFrameDocument]):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleCSSStyleDeclarationHandle.cpp:
(WebKit::InjectedBundleCSSStyleDeclarationHandle::getOrCreate):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp:
(WebKit::InjectedBundleNodeHandle::getOrCreate):
(WebKit::InjectedBundleNodeHandle::renderedImage):
(WebKit::InjectedBundleNodeHandle::htmlInputElementAutoFillButtonBounds):
(WebKit::InjectedBundleNodeHandle::documentFrame):
(WebKit::InjectedBundleNodeHandle::htmlIFrameElementContentFrame):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp:
(WebKit::InjectedBundleRangeHandle::boundingRectInWindowCoordinates const):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp:
(WebKit::InjectedBundleDOMWindowExtension::frame const):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp:
(WebKit::InjectedBundleHitTestResult::frame const):
(WebKit::InjectedBundleHitTestResult::targetFrame const):
(WebKit::InjectedBundleHitTestResult::imageRect const):
(WebKit::InjectedBundleHitTestResult::image const):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageContextMenuClient.cpp:
(WebKit::InjectedBundlePageContextMenuClient::getCustomMenuFromDefaultItems):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageEditorClient.cpp:
(WebKit::InjectedBundlePageEditorClient::getPasteboardDataForRange):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp:
(WebKit::InjectedBundleScriptWorld::normalWorldSingleton):
* Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm:
(WebKit::InjectedBundle::extendClassesForParameterCoder):
* Source/WebKit/WebProcess/Inspector/WebInspectorClient.cpp:
(WebKit::WebInspectorClient::showPaintRect):
* Source/WebKit/WebProcess/Inspector/WebInspectorInternal.cpp:
(WebKit::WebInspector::showMainResourceForFrame):
* Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp:
(WebKit::UserMediaPermissionRequestManager::startUserMediaRequest):
(WebKit::UserMediaPermissionRequestManager::sendUserMediaRequest):
(WebKit::UserMediaPermissionRequestManager::cancelUserMediaRequest):
(WebKit::UserMediaPermissionRequestManager::enumerateMediaDevices):

Canonical link: <a href="https://commits.webkit.org/297700@main">https://commits.webkit.org/297700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdcfe7382940e07906636a8cc87b78444ed76bf5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112592 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22802 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/118791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/63056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40887 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/118791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/63056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115539 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101286 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/118791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/25615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/62550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/95708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19496 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122012 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111206 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39666 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29545 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/94559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97522 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/94296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24073 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/39414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/17216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/35754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39554 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/45042 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/39192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/42526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40932 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->