### PR TITLE
Document::cssParserContext() should return a reference

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		1470EAF32BD6F6D900E26254 /* WeakPtrImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 1470EAF22BD6F6D900E26254 /* WeakPtrImpl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1470EAF52BD6F8AF00E26254 /* WeakPtrFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 1470EAF42BD6F8AF00E26254 /* WeakPtrFactory.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1470EAF72BD6FB3F00E26254 /* CanMakeWeakPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = 1470EAF62BD6FB3F00E26254 /* CanMakeWeakPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		14F1EB422DDF9BFF009BBD4B /* OptionalOrReference.h in Headers */ = {isa = PBXBuildFile; fileRef = 14F1EB412DDF9BFF009BBD4B /* OptionalOrReference.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1A1D8B9E1731879800141DA4 /* FunctionDispatcher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A1D8B9D1731879800141DA4 /* FunctionDispatcher.cpp */; };
 		1C08E3682985D8F300CAE594 /* IOReturnSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C08E3662985D7D300CAE594 /* IOReturnSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C08E3692985D8F800CAE594 /* IOTypesSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C08E3672985D7D400CAE594 /* IOTypesSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1185,6 +1186,7 @@
 		1470EAF62BD6FB3F00E26254 /* CanMakeWeakPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanMakeWeakPtr.h; sourceTree = "<group>"; };
 		149EF16216BBFE0D000A4331 /* TriState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TriState.h; sourceTree = "<group>"; };
 		14E785E71DFB330100209BD1 /* OrdinalNumber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OrdinalNumber.h; sourceTree = "<group>"; };
+		14F1EB412DDF9BFF009BBD4B /* OptionalOrReference.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OptionalOrReference.h; sourceTree = "<group>"; };
 		14F3B0F615E45E4600210069 /* SaturatedArithmetic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SaturatedArithmetic.h; sourceTree = "<group>"; };
 		1A1D8B9B173186CE00141DA4 /* FunctionDispatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FunctionDispatcher.h; sourceTree = "<group>"; };
 		1A1D8B9D1731879800141DA4 /* FunctionDispatcher.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FunctionDispatcher.cpp; sourceTree = "<group>"; };
@@ -2466,6 +2468,7 @@
 				8348BA0D21FBC0D400FD3054 /* ObjectIdentifier.cpp */,
 				83A8AC3D1FABBE94002064AC /* ObjectIdentifier.h */,
 				CD48A87024C8A21600F5800C /* Observer.h */,
+				14F1EB412DDF9BFF009BBD4B /* OptionalOrReference.h */,
 				1A4656181C7FC68E00F5920F /* OptionSet.h */,
 				275DFB6B238BDF72001230E2 /* OptionSetHash.h */,
 				0F9495831C571CC900413A48 /* OrderMaker.h */,
@@ -3591,6 +3594,7 @@
 				DDF306E127C08654006A526F /* objcSPI.h in Headers */,
 				DD3DC88327A4BF8E007E5B61 /* ObjectIdentifier.h in Headers */,
 				DD3DC86027A4BF8E007E5B61 /* Observer.h in Headers */,
+				14F1EB422DDF9BFF009BBD4B /* OptionalOrReference.h in Headers */,
 				DD3DC92E27A4BF8E007E5B61 /* OptionSet.h in Headers */,
 				DD3DC90927A4BF8E007E5B61 /* OptionSetHash.h in Headers */,
 				DD3DC86827A4BF8E007E5B61 /* OrderMaker.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -207,6 +207,7 @@ set(WTF_PUBLIC_HEADERS
     ObjectIdentifier.h
     Observer.h
     OptionSet.h
+    OptionalOrReference.h
     OptionSetHash.h
     OrderMaker.h
     OverflowPolicy.h

--- a/Source/WebCore/css/CSSStyleProperties.h
+++ b/Source/WebCore/css/CSSStyleProperties.h
@@ -30,6 +30,7 @@
 #include "StyleRuleType.h"
 #include "StyledElement.h"
 #include <wtf/HashMap.h>
+#include <wtf/OptionalOrReference.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/WeakPtr.h>
@@ -92,7 +93,7 @@ public:
 protected:
     enum class MutationType : uint8_t { NoChanges, StyleAttributeChanged, PropertyChanged };
 
-    virtual CSSParserContext cssParserContext() const;
+    virtual OptionalOrReference<CSSParserContext> cssParserContext() const;
 
     MutableStyleProperties* m_propertySet;
     UncheckedKeyHashMap<CSSValue*, WeakPtr<DeprecatedCSSOMValue>> m_cssomValueWrappers;
@@ -149,7 +150,7 @@ private:
 
     bool willMutate() final WARN_UNUSED_RETURN;
     void didMutate(MutationType) final;
-    CSSParserContext cssParserContext() const final;
+    OptionalOrReference<CSSParserContext> cssParserContext() const final;
 
     StyleRuleType m_parentRuleType;
     CSSRule* m_parentRule;
@@ -170,7 +171,7 @@ private:
 
     bool willMutate() final WARN_UNUSED_RETURN;
     void didMutate(MutationType) final;
-    CSSParserContext cssParserContext() const final;
+    OptionalOrReference<CSSParserContext> cssParserContext() const final;
 
     WeakPtr<StyledElement, WeakPtrImplWithEventTargetData> m_parentElement;
 };

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -159,7 +159,7 @@ CSSStyleSheet::CSSStyleSheet(Ref<StyleSheetContents>&& contents, Document& docum
         if (auto queries = mediaList->mediaQueries(); !queries.isEmpty())
             setMediaQueries(WTFMove(queries));
     }, [this](String&& mediaString) {
-        setMediaQueries(MQ::MediaQueryParser::parse(mediaString, { }));
+        setMediaQueries(MQ::MediaQueryParser::parse(mediaString, strictCSSParserContext()));
     });
 }
 

--- a/Source/WebCore/css/MediaList.cpp
+++ b/Source/WebCore/css/MediaList.cpp
@@ -93,7 +93,7 @@ String MediaList::mediaText() const
 
 void MediaList::setMediaText(const String& value)
 {
-    setMediaQueries(MQ::MediaQueryParser::parse(value, { }));
+    setMediaQueries(MQ::MediaQueryParser::parse(value, strictCSSParserContext()));
 }
 
 String MediaList::item(unsigned index) const
@@ -126,7 +126,7 @@ void MediaList::appendMedium(const String& value)
     if (value.isEmpty())
         return;
 
-    auto newQuery = MQ::MediaQueryParser::parse(value, { });
+    auto newQuery = MQ::MediaQueryParser::parse(value, strictCSSParserContext());
 
     auto queries = mediaQueries();
     queries.appendVector(newQuery);

--- a/Source/WebCore/css/MediaQueryMatcher.cpp
+++ b/Source/WebCore/css/MediaQueryMatcher.cpp
@@ -99,7 +99,7 @@ RefPtr<MediaQueryList> MediaQueryMatcher::matchMedia(const String& query)
     if (!m_document)
         return nullptr;
 
-    auto queries = MQ::MediaQueryParser::parse(query, MediaQueryParserContext(*m_document));
+    auto queries = MQ::MediaQueryParser::parse(query, m_document->cssParserContext());
     bool matches = evaluate(queries);
     return MediaQueryList::create(*m_document, *this, WTFMove(queries), matches);
 }

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -637,7 +637,7 @@ RefPtr<StyleRuleImport> CSSParser::consumeImportRule(CSSParserTokenRange prelude
     auto supports = consumeSupports();
     if (!supports)
         return nullptr; // Discard import rule with incorrect syntax.
-    auto mediaQueries = MQ::MediaQueryParser::parse(prelude, MediaQueryParserContext(m_context));
+    auto mediaQueries = MQ::MediaQueryParser::parse(prelude, m_context);
 
     return StyleRuleImport::create(uri, WTFMove(mediaQueries), WTFMove(cascadeLayerName), WTFMove(*supports));
 }
@@ -719,7 +719,7 @@ RefPtr<StyleRuleMedia> CSSParser::consumeMediaRule(CSSParserTokenRange prelude, 
     if (RefPtr observerWrapper = m_observerWrapper.get())
         observerWrapper->observer().endRuleBody(observerWrapper->endOffset(block));
 
-    return StyleRuleMedia::create(MQ::MediaQueryParser::parse(prelude, { m_context }), WTFMove(rules));
+    return StyleRuleMedia::create(MQ::MediaQueryParser::parse(prelude, m_context), WTFMove(rules));
 }
 
 RefPtr<StyleRuleSupports> CSSParser::consumeSupportsRule(CSSParserTokenRange prelude, CSSParserTokenRange block)

--- a/Source/WebCore/css/parser/SizesAttributeParser.cpp
+++ b/Source/WebCore/css/parser/SizesAttributeParser.cpp
@@ -133,7 +133,7 @@ bool SizesAttributeParser::parse(CSSParserTokenRange range, const CSSParserConte
         auto length = calculateLengthInPixels(lengthTokenStart.rangeUntil(lengthTokenEnd));
         if (!length)
             continue;
-        auto mediaCondition = MQ::MediaQueryParser::parseCondition(mediaConditionStart.rangeUntil(lengthTokenStart), MediaQueryParserContext(context));
+        auto mediaCondition = MQ::MediaQueryParser::parseCondition(mediaConditionStart.rangeUntil(lengthTokenStart), context);
         if (!mediaCondition)
             continue;
         bool matches = mediaConditionMatches(*mediaCondition);

--- a/Source/WebCore/css/query/GenericMediaQueryParser.h
+++ b/Source/WebCore/css/query/GenericMediaQueryParser.h
@@ -27,6 +27,7 @@
 #include "CSSParserContext.h"
 #include "CSSParserTokenRange.h"
 #include "GenericMediaQueryTypes.h"
+#include "MediaQueryParserContext.h"
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/text/AtomStringHash.h>
 
@@ -171,7 +172,7 @@ std::optional<Feature> GenericMediaQueryParser<ConcreteParser>::consumeAndValida
 template<typename ConcreteParser>
 bool GenericMediaQueryParser<ConcreteParser>::validateFeature(Feature& feature, const MediaQueryParserContext& context, State& state)
 {
-    auto* schema = ConcreteParser::schemaForFeatureName(feature.name, context, state);
+    auto* schema = ConcreteParser::schemaForFeatureName(feature.name, context.context, state);
     if (!schema)
         return false;
     return FeatureParser::validateFeatureAgainstSchema(feature, *schema);

--- a/Source/WebCore/css/query/MediaQueryParser.cpp
+++ b/Source/WebCore/css/query/MediaQueryParser.cpp
@@ -40,7 +40,7 @@ Vector<const FeatureSchema*> MediaQueryParser::featureSchemas()
     return Features::allSchemas();
 }
 
-MediaQueryList MediaQueryParser::parse(const String& string, const MediaQueryParserContext& context)
+MediaQueryList MediaQueryParser::parse(const String& string, const CSSParserContext& context)
 {
     auto tokenizer = CSSTokenizer::tryCreate(string);
     if (!tokenizer)
@@ -50,12 +50,12 @@ MediaQueryList MediaQueryParser::parse(const String& string, const MediaQueryPar
     return parse(range, context);
 }
 
-MediaQueryList MediaQueryParser::parse(CSSParserTokenRange range, const MediaQueryParserContext& context)
+MediaQueryList MediaQueryParser::parse(CSSParserTokenRange range, const CSSParserContext& context)
 {
     return consumeMediaQueryList(range, context);
 }
 
-std::optional<MediaQuery> MediaQueryParser::parseCondition(CSSParserTokenRange range, const MediaQueryParserContext& context)
+std::optional<MediaQuery> MediaQueryParser::parseCondition(CSSParserTokenRange range, const CSSParserContext& context)
 {
     range.consumeWhitespace();
 
@@ -69,7 +69,7 @@ std::optional<MediaQuery> MediaQueryParser::parseCondition(CSSParserTokenRange r
     return MediaQuery { { }, { }, condition };
 }
 
-MediaQueryList MediaQueryParser::consumeMediaQueryList(CSSParserTokenRange& range, const MediaQueryParserContext& context)
+MediaQueryList MediaQueryParser::consumeMediaQueryList(CSSParserTokenRange& range, const CSSParserContext& context)
 {
     range.consumeWhitespace();
 
@@ -102,7 +102,7 @@ MediaQueryList MediaQueryParser::consumeMediaQueryList(CSSParserTokenRange& rang
     return list;
 }
 
-std::optional<MediaQuery> MediaQueryParser::consumeMediaQuery(CSSParserTokenRange& range, const MediaQueryParserContext& context)
+std::optional<MediaQuery> MediaQueryParser::consumeMediaQuery(CSSParserTokenRange& range, const CSSParserContext& context)
 {
     // <media-condition>
 
@@ -175,19 +175,19 @@ std::optional<MediaQuery> MediaQueryParser::consumeMediaQuery(CSSParserTokenRang
     return MediaQuery { prefix, mediaType, condition };
 }
 
-const FeatureSchema* MediaQueryParser::schemaForFeatureName(const AtomString& name, const MediaQueryParserContext& context, State& state)
+const FeatureSchema* MediaQueryParser::schemaForFeatureName(const AtomString& name, const CSSParserContext& context, State& state)
 {
     auto* schema = GenericMediaQueryParser<MediaQueryParser>::schemaForFeatureName(name, context, state);
 
     if (schema == &Features::prefersDarkInterface()) {
-        if (!context.context.useSystemAppearance && !isUASheetBehavior(context.context.mode))
+        if (!context.useSystemAppearance && !isUASheetBehavior(context.mode))
             return nullptr;
     }
     
     return schema;
 }
 
-const MediaProgressProviding* MediaQueryParser::mediaProgressProvidingSchemaForFeatureName(const AtomString& name, const MediaQueryParserContext&)
+const MediaProgressProviding* MediaQueryParser::mediaProgressProvidingSchemaForFeatureName(const AtomString& name, const CSSParserContext&)
 {
     using Map = MemoryCompactLookupOnlyRobinHoodHashMap<AtomString, const MediaProgressProviding*>;
 

--- a/Source/WebCore/css/query/MediaQueryParser.h
+++ b/Source/WebCore/css/query/MediaQueryParser.h
@@ -34,18 +34,18 @@ namespace MQ {
 struct MediaProgressProviding;
 
 struct MediaQueryParser : public GenericMediaQueryParser<MediaQueryParser>  {
-    static MediaQueryList parse(const String&, const MediaQueryParserContext&);
-    static MediaQueryList parse(CSSParserTokenRange, const MediaQueryParserContext&);
-    static std::optional<MediaQuery> parseCondition(CSSParserTokenRange, const MediaQueryParserContext&);
+    static MediaQueryList parse(const String&, const CSSParserContext&);
+    static MediaQueryList parse(CSSParserTokenRange, const CSSParserContext&);
+    static std::optional<MediaQuery> parseCondition(CSSParserTokenRange, const CSSParserContext&);
 
-    static MediaQueryList consumeMediaQueryList(CSSParserTokenRange&, const MediaQueryParserContext&);
-    static std::optional<MediaQuery> consumeMediaQuery(CSSParserTokenRange&, const MediaQueryParserContext&);
+    static MediaQueryList consumeMediaQueryList(CSSParserTokenRange&, const CSSParserContext&);
+    static std::optional<MediaQuery> consumeMediaQuery(CSSParserTokenRange&, const CSSParserContext&);
 
-    static const FeatureSchema* schemaForFeatureName(const AtomString&, const MediaQueryParserContext&, State&);
+    static const FeatureSchema* schemaForFeatureName(const AtomString&, const CSSParserContext&, State&);
     static Vector<const FeatureSchema*> featureSchemas();
 
     // Accessor used by calc()'s media-progress() function to find a MediaProgressProviding by name.
-    static const MediaProgressProviding* mediaProgressProvidingSchemaForFeatureName(const AtomString&, const MediaQueryParserContext&);
+    static const MediaProgressProviding* mediaProgressProvidingSchemaForFeatureName(const AtomString&, const CSSParserContext&);
 };
 
 void serialize(StringBuilder&, const MediaQueryList&);

--- a/Source/WebCore/dom/DOMImplementation.cpp
+++ b/Source/WebCore/dom/DOMImplementation.cpp
@@ -133,7 +133,7 @@ Ref<CSSStyleSheet> DOMImplementation::createCSSStyleSheet(const String&, const S
     // FIXME: Title should be set.
     // FIXME: Media could have wrong syntax, in which case we should generate an exception.
     auto sheet = CSSStyleSheet::create(StyleSheetContents::create());
-    sheet->setMediaQueries(MQ::MediaQueryParser::parse(media, { }));
+    sheet->setMediaQueries(MQ::MediaQueryParser::parse(media, strictCSSParserContext()));
     return sheet;
 }
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5216,7 +5216,7 @@ void Document::processColorScheme(const String& colorSchemeString)
 
 void Document::metaElementColorSchemeChanged()
 {
-    const auto& context = this->cssParserContext();
+    auto& context = this->cssParserContext();
 
     auto parseColorScheme = [&](const auto& metaElement) -> std::optional<CSS::ColorScheme> {
         const AtomString& nameValue = metaElement.attributeWithoutSynchronization(nameAttr);
@@ -10886,7 +10886,7 @@ CSSCounterStyleRegistry& Document::counterStyleRegistry()
     return styleScope().counterStyleRegistry();
 }
 
-CSSParserContext Document::cssParserContext() const
+const CSSParserContext& Document::cssParserContext() const
 {
     if (!m_cachedCSSParserContext)
         m_cachedCSSParserContext = makeUnique<CSSParserContext>(*this, URL { }, ""_s);

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -677,7 +677,7 @@ public:
     const CSSCounterStyleRegistry& counterStyleRegistry() const;
     CSSCounterStyleRegistry& counterStyleRegistry();
 
-    WEBCORE_EXPORT CSSParserContext cssParserContext() const;
+    WEBCORE_EXPORT const CSSParserContext& cssParserContext() const;
     void invalidateCachedCSSParserContext();
 
     bool gotoAnchorNeededAfterStylesheetsLoad() { return m_gotoAnchorNeededAfterStylesheetsLoad; }

--- a/Source/WebCore/dom/InlineStyleSheetOwner.cpp
+++ b/Source/WebCore/dom/InlineStyleSheetOwner.cpp
@@ -152,7 +152,7 @@ void InlineStyleSheetOwner::createSheet(Element& element, const String& text)
         return;
     }
 
-    auto mediaQueries = MQ::MediaQueryParser::parse(m_media, MediaQueryParserContext(document));
+    auto mediaQueries = MQ::MediaQueryParser::parse(m_media, document->cssParserContext());
 
     if (CheckedPtr scope = m_styleScope.get())
         scope->addPendingSheet(element);

--- a/Source/WebCore/dom/ProcessingInstruction.cpp
+++ b/Source/WebCore/dom/ProcessingInstruction.cpp
@@ -199,7 +199,7 @@ void ProcessingInstruction::setCSSStyleSheet(const String& href, const URL& base
     Ref cssSheet = CSSStyleSheet::create(StyleSheetContents::create(href, parserContext), *this, sheet->isCORSSameOrigin());
     cssSheet->setDisabled(m_alternate);
     cssSheet->setTitle(m_title);
-    cssSheet->setMediaQueries(MQ::MediaQueryParser::parse(m_media, MediaQueryParserContext(document)));
+    cssSheet->setMediaQueries(MQ::MediaQueryParser::parse(m_media, document->cssParserContext()));
 
     m_sheet = WTFMove(cssSheet);
 

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -379,7 +379,7 @@ void StyledElement::addPropertyToPresentationalHintStyle(MutableStyleProperties&
     
 void StyledElement::addPropertyToPresentationalHintStyle(MutableStyleProperties& style, CSSPropertyID propertyID, const String& value)
 {
-    style.setProperty(propertyID, value, CSSParserContext(document()));
+    style.setProperty(propertyID, value, protectedDocument()->cssParserContext());
 }
 
 void StyledElement::addPropertyToPresentationalHintStyle(MutableStyleProperties& style, CSSPropertyID propertyID, Ref<CSSValue>&& value)

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -585,7 +585,7 @@ void HTMLLinkElement::initializeStyleSheet(Ref<StyleSheetContents>&& styleSheet,
     }
 
     m_sheet = CSSStyleSheet::create(WTFMove(styleSheet), *this, cachedStyleSheet.isCORSSameOrigin());
-    m_sheet->setMediaQueries(MQ::MediaQueryParser::parse(m_media, context));
+    m_sheet->setMediaQueries(MQ::MediaQueryParser::parse(m_media, context.context));
     if (!isInShadowTree())
         m_sheet->setTitle(title());
 
@@ -674,7 +674,7 @@ bool HTMLLinkElement::mediaAttributeMatches() const
     std::optional<RenderStyle> documentStyle;
     if (document().hasLivingRenderTree())
         documentStyle = Style::resolveForDocument(document());
-    auto mediaQueryList = MQ::MediaQueryParser::parse(m_media, { document() });
+    auto mediaQueryList = MQ::MediaQueryParser::parse(m_media, document().cssParserContext());
     LOG(MediaQueries, "HTMLLinkElement::mediaAttributeMatches");
 
     MQ::MediaQueryEvaluator evaluator(document().frame()->view()->mediaType(), document(), documentStyle ? &*documentStyle : nullptr);

--- a/Source/WebCore/html/HTMLMetaElement.cpp
+++ b/Source/WebCore/html/HTMLMetaElement.cpp
@@ -80,7 +80,7 @@ bool HTMLMetaElement::mediaAttributeMatches()
 
     if (!m_mediaQueryList) {
         auto mediaText = attributeWithoutSynchronization(mediaAttr).convertToASCIILowercase();
-        m_mediaQueryList = MQ::MediaQueryParser::parse(mediaText, { document });
+        m_mediaQueryList = MQ::MediaQueryParser::parse(mediaText, document->cssParserContext());
     }
 
     std::optional<RenderStyle> documentStyle;

--- a/Source/WebCore/html/HTMLSourceElement.cpp
+++ b/Source/WebCore/html/HTMLSourceElement.cpp
@@ -206,7 +206,7 @@ const MQ::MediaQueryList& HTMLSourceElement::parsedMediaAttribute(Document& docu
 {
     if (!m_cachedParsedMediaAttribute) {
         auto& value = attributeWithoutSynchronization(mediaAttr);
-        m_cachedParsedMediaAttribute = MQ::MediaQueryParser::parse(value, MediaQueryParserContext { document });
+        m_cachedParsedMediaAttribute = MQ::MediaQueryParser::parse(value, document.cssParserContext());
     }
     return m_cachedParsedMediaAttribute.value();
 }

--- a/Source/WebCore/html/HTMLStyleElement.cpp
+++ b/Source/WebCore/html/HTMLStyleElement.cpp
@@ -90,7 +90,7 @@ void HTMLStyleElement::attributeChanged(const QualifiedName& name, const AtomStr
     case AttributeNames::mediaAttr:
         m_styleSheetOwner.setMedia(newValue);
         if (RefPtr sheet = this->sheet()) {
-            sheet->setMediaQueries(MQ::MediaQueryParser::parse(newValue, MediaQueryParserContext(document())));
+            sheet->setMediaQueries(MQ::MediaQueryParser::parse(newValue, protectedDocument()->cssParserContext()));
             if (auto* scope = m_styleSheetOwner.styleScope())
                 scope->didChangeStyleSheetContents();
         } else

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -262,7 +262,7 @@ private:
             }
             if (match(attributeName, mediaAttr) && m_mediaAttribute.isNull()) {
                 m_mediaAttribute = attributeValue.toString();
-                auto mediaQueries = MQ::MediaQueryParser::parse(m_mediaAttribute, { document.get() });
+                auto mediaQueries = MQ::MediaQueryParser::parse(m_mediaAttribute, document->cssParserContext());
                 RefPtr documentElement = document->documentElement();
                 LOG(MediaQueries, "HTMLPreloadScanner %p processAttribute evaluating media queries", this);
                 m_mediaMatched = MQ::MediaQueryEvaluator { document->printing() ? printAtom() : screenAtom(), document, documentElement ? documentElement->computedStyle() : nullptr }.evaluate(mediaQueries);

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
@@ -90,7 +90,7 @@ void HTMLResourcePreloader::preload(std::unique_ptr<PreloadRequest> preload)
     ASSERT(document->frame());
     ASSERT(document->renderView());
 
-    auto queries = MQ::MediaQueryParser::parse(preload->media(), { document.get() });
+    auto queries = MQ::MediaQueryParser::parse(preload->media(), document->cssParserContext());
     if (!MQ::MediaQueryEvaluator { screenAtom(), document, document->renderStyle() }.evaluate(queries))
         return;
 

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -337,7 +337,7 @@ std::unique_ptr<LinkPreloadResourceClient> LinkLoader::preloadIfNeeded(const Lin
             document.addConsoleMessage(MessageSource::Other, MessageLevel::Error, "<link rel=preload> has an invalid `imagesrcset` value"_s);
         return nullptr;
     }
-    auto queries = MQ::MediaQueryParser::parse(params.media, { document });
+    auto queries = MQ::MediaQueryParser::parse(params.media, document.cssParserContext());
     if (!MQ::MediaQueryEvaluator { screenAtom(), document, document.renderStyle() }.evaluate(queries))
         return nullptr;
     if (!isSupportedType(type.value(), params.mimeType, document))


### PR DESCRIPTION
#### 6a9292ad54735f7eb30651960723c3de9552dac3
<pre>
Document::cssParserContext() should return a reference
<a href="https://bugs.webkit.org/show_bug.cgi?id=291761">https://bugs.webkit.org/show_bug.cgi?id=291761</a>
<a href="https://rdar.apple.com/149561463">rdar://149561463</a>

Reviewed by Sam Weinig.

This removes 500K string refcounts from Speedometer, primarily by enabling
InlineCSSStyleProperties::cssParserContext() to reuse Document::cssParserContext()
in the common case.

That&apos;s 500K / 34MM, so this patch is not a measurable speedup on its own; but
the reduction is countable, and this is also an opportunity to land
OptionalOrReference&lt;T&gt; with a real use case, to complement ValueOrReference&lt;T&gt;.

* Source/WTF/wtf/OptionalOrReference.h: Copied from Source/WTF/wtf/ValueOrReference.h.
(WTF::OptionalOrReference::OptionalOrReference): New helper type that&apos;s just
like ValueOrReference&lt;T&gt; but doesn&apos;t require T() to be efficient.

Canonical link: <a href="https://commits.webkit.org/295371@main">https://commits.webkit.org/295371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d84b8d865aea69ef4c64c52a2816faf9c8c2cc35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110071 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55530 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106896 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33114 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79621 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107862 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94629 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59928 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12706 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54913 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97537 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88862 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12753 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112513 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103474 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32021 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23539 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88701 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32385 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90855 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88329 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33216 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10983 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27335 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17019 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31946 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37301 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/127753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31738 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/127753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35079 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33297 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->