### PR TITLE
AX: After ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE), descendants of !canHaveChildren() objects can become orphaned, causing various incorrect AT behaviors

### DIFF
--- a/LayoutTests/accessibility/mac/orphaned-text-in-button-expected.txt
+++ b/LayoutTests/accessibility/mac/orphaned-text-in-button-expected.txt
@@ -1,0 +1,14 @@
+This test ensures that static text within a button can still return a valid parent.
+
+PASS: button.stringForTextMarkerRange(markerRange).length === 1 === true
+PASS: button.boundsForRange(1, 2) was equal or approximately equal to (x: -1, y: -1, w: 13, h: 13).
+PASS: textMarkerElement.role.toLowerCase().includes('statictext') === true
+PASS: textMarkerElement.parentElement().role.toLowerCase().includes('button') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+Foo
+
+

--- a/LayoutTests/accessibility/mac/orphaned-text-in-button.html
+++ b/LayoutTests/accessibility/mac/orphaned-text-in-button.html
@@ -1,0 +1,40 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<button id="button"><p>Foo</p></button>
+    
+<script>
+var output = "This test ensures that static text within a button can still return a valid parent.\n\n";
+// This matters because although anything descending from a button is accessibility-is-ignored, VoiceOver and other
+// ATs can still access ignored objects through text markers, e.g. via NSAccessibilityUIElementForTextMarkerAttribute.
+// Then, if the AT tries to do something with the object but finds it to be detached, it often behaves incorrectly.
+
+if (window.accessibilityController) {
+    var button = accessibilityController.accessibleElementById("button");
+
+    // This sequence of actions roughly simulates the real bug that inspired this. Navigating by character through the
+    // button text, VoiceOver wasn't able to draw anything for the cursor because the StaticText associated with the
+    // marker had no parent, thus it couldn't create a VoiceOver internal element for the static text.
+    var markerRange = button.textMarkerRangeForElement(button);
+    var startMarker = button.startTextMarkerForTextMarkerRange(markerRange);
+    startMarker = button.nextTextMarker(startMarker);
+    var endMarker = button.nextTextMarker(startMarker);
+    markerRange = button.textMarkerRangeForMarkers(startMarker, endMarker);
+    output += expect("button.stringForTextMarkerRange(markerRange).length === 1", "true");
+    output += expectRectWithVariance("button.boundsForRange(1, 2)", -1, -1, 13, 13, 2);
+
+    var textMarkerElement = button.accessibilityElementForTextMarker(endMarker);
+    output += expect("textMarkerElement.role.toLowerCase().includes('statictext')", "true");
+    output += expect("textMarkerElement.parentElement().role.toLowerCase().includes('button')", "true");
+
+    debug(output);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AccessibilityListBoxOption.h
+++ b/Source/WebCore/accessibility/AccessibilityListBoxOption.h
@@ -57,6 +57,12 @@ private:
     AccessibilityObject* parentObject() const final;
 
     bool isAccessibilityListBoxOptionInstance() const final { return true; }
+    void addChildren() final
+    {
+        m_childrenInitialized = true;
+        m_childrenDirty = false;
+        m_subtreeDirty = false;
+    }
     bool canHaveChildren() const final { return false; }
     HTMLSelectElement* listBoxOptionParentNode() const;
     int listBoxOptionIndex() const;

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -591,7 +591,7 @@ void AccessibilityNodeObject::addChildren()
     });
 
     RefPtr node = this->node();
-    if (!node || !canHaveChildren())
+    if (!node)
         return;
 
     // The only time we add children from the DOM tree to a node with a renderer is when it's a canvas.


### PR DESCRIPTION
#### 3ebfc2b3a2576dff38122413858c423034309fbb
<pre>
AX: After ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE), descendants of !canHaveChildren() objects can become orphaned, causing various incorrect AT behaviors
<a href="https://bugs.webkit.org/show_bug.cgi?id=291762">https://bugs.webkit.org/show_bug.cgi?id=291762</a>
<a href="https://rdar.apple.com/149563180">rdar://149563180</a>

Reviewed by Joshua Hoffman.

After ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE), each object in the isolated tree should have the same parentObject() as
its main-thread equivalent. We did do this correctly, at least as far as storing the right AXIsolatedObject::m_parentID.
However, the isolated tree is a copy of the main-thread tree, and Accessibility{Node,Render}Object::addChildren() exited
early for any object that !canHaveChildren(). This meant that when we created the isolated tree, we never create isolated
objects for these descendants, and thus when we go to look up the object stored in a descendants m_parentID, we fail
to get anything.

Orphaned objects (those who return nil for NSAccessibilityParentAttribute) cause VoiceOver to fail to create its own
internal element for that object, in turn causing lots of wrong behaviors. The issue that motivated this was navigating
by character inside a button&apos;s text, and no bounding box was being drawn.

Fix this by allowing !canHaveChildren() objects to insert children. We already consider descendants of !canHaveChildren
objects to be ignored, so inserting children for !canHaveChildren objects allows us to have a full and complete accessibility
tree while maintaining the correct AT-facing behavior (because we ignore these descendants).

This change exposed one existing bug that caused this:

ASSERT(isTableComponent(child) || isTableComponent(*this) || child.parentObject() == this);

to fire in AccessibilityObject::insertChild. This was caught by  imported/w3c/web-platform-tests/accname/name/comp_name_from_content.html
only because this test happened to use ::before on a button element, which now adds children. But this issue has been
around ever since <a href="https://github.com/WebKit/WebKit/commit/6a44b38c10d068df677abf94c3f1d96e75fefb7a">https://github.com/WebKit/WebKit/commit/6a44b38c10d068df677abf94c3f1d96e75fefb7a</a> landed, as that changed
AccessibilityRenderObject::addChildren to add ::before and ::after as children without making the analagous change to
AccessibilityRenderObject::parentObject to force ::before and ::after to consider their generating element to be their parent.

This same ASSERT was hit for AccessibilityListBoxOption, which have an unusal DOM structure. Fix this by overriding
addChildren for this subclass to do nothing, matching the behavior before this commit and preventing the ASSERT.

* LayoutTests/accessibility/mac/orphaned-text-in-button-expected.txt: Added.
* LayoutTests/accessibility/mac/orphaned-text-in-button.html: Added.
* Source/WebCore/accessibility/AccessibilityListBoxOption.h:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::addChildren):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::parentObject const):
(WebCore::AccessibilityRenderObject::addChildren):

Canonical link: <a href="https://commits.webkit.org/293929@main">https://commits.webkit.org/293929@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66a23e2dacb594d54d8cc68165a87011e60d7faa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105439 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50893 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102350 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20263 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28432 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76376 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/33438 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103316 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56732 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15328 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8614 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50260 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85252 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8695 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107798 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27422 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20123 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85327 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86808 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84865 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21577 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29548 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/7288 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21334 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27359 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32592 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27170 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30486 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28729 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->