### PR TITLE
[macOS] Improve context menu consistency and update images for internal clients

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/NSImageSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSImageSPI.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface NSImage (NSSystemSymbols)
-+ (nullable NSImage *)_imageWithSystemSymbolName:(NSString *) symbolName;
++ (nullable instancetype)imageWithPrivateSystemSymbolName:(NSString *)name accessibilityDescription:(nullable NSString *)description;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -1043,6 +1043,10 @@ void ContextMenuController::populate()
         appendItem(translateItem, m_contextMenu.get());
 #endif
 
+#if PLATFORM(COCOA)
+        appendItem(*separatorItem(), m_contextMenu.get());
+#endif
+
 #if !PLATFORM(GTK)
         appendItem(SearchWebItem, m_contextMenu.get());
         appendItem(*separatorItem(), m_contextMenu.get());

--- a/Source/WebKit/Platform/mac/MenuUtilities.h
+++ b/Source/WebKit/Platform/mac/MenuUtilities.h
@@ -41,7 +41,7 @@ NSString *menuItemTitleForTelephoneNumberGroup();
 #endif
 
 #if ENABLE(CONTEXT_MENU_IMAGES_FOR_INTERNAL_CLIENTS)
-NSString *symbolNameForAction(const WebCore::ContextMenuAction, bool);
+void addImageToMenuItem(NSMenuItem*, const WebCore::ContextMenuAction, bool);
 #endif
 
 #endif

--- a/Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm
+++ b/Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm
@@ -341,9 +341,11 @@ static NSArray<NSString *> *controlArray()
     if (iconImage)
         return iconImage.autorelease();
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    iconImage = [NSImage _imageWithSystemSymbolName:control];
-ALLOW_DEPRECATED_DECLARATIONS_END
+    if ([control isEqualToString:PDFHUDLaunchPreviewControl])
+        iconImage = [NSImage imageWithPrivateSystemSymbolName:control accessibilityDescription:nil];
+    else
+        iconImage = [NSImage imageWithSystemSymbolName:control accessibilityDescription:nil];
+
     if (!iconImage)
         return nil;
 

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -465,7 +465,7 @@ static void updateMenuItemImage(NSMenuItem *menuItem, const WebContextMenuItemDa
         break;
     }
 
-    [menuItem _setActionImage:[NSImage imageWithSystemSymbolName:symbolNameForAction(webMenuItem.action(), useAlternateImage) accessibilityDescription:nil]];
+    addImageToMenuItem(menuItem, webMenuItem.action(), useAlternateImage);
 }
 #endif
 
@@ -523,11 +523,6 @@ RetainPtr<NSMenuItem> WebContextMenuProxyMac::createShareMenuItem(ShareMenuItemT
         [shareMenuItem setTarget:[WKMenuTarget sharedMenuTarget]];
     } else
         [shareMenuItem setRepresentedObject:sharingServicePicker.get()];
-
-#if ENABLE(CONTEXT_MENU_IMAGES_FOR_INTERNAL_CLIENTS)
-    if (page()->protectedPreferences()->contextMenuImagesForInternalClientsEnabled() && ![shareMenuItem _hasActionImage])
-        [shareMenuItem _setActionImage:[NSImage imageWithSystemSymbolName:@"square.and.arrow.up" accessibilityDescription:nil]];
-#endif
 
     [shareMenuItem setIdentifier:_WKMenuItemIdentifierShareMenu];
     return shareMenuItem;
@@ -895,10 +890,6 @@ void WebContextMenuProxyMac::getContextMenuItem(const WebContextMenuItemData& it
         if ([NSMenuItem.class respondsToSelector:@selector(standardWritingToolsMenuItem)]) {
             RetainPtr menuItem = [NSMenuItem standardWritingToolsMenuItem];
             [[menuItem submenu] setAutoenablesItems:NO];
-#if ENABLE(CONTEXT_MENU_IMAGES_FOR_INTERNAL_CLIENTS)
-            if (page()->protectedPreferences()->contextMenuImagesForInternalClientsEnabled() && ![menuItem _hasActionImage])
-                [menuItem _setActionImage:[NSImage imageWithSystemSymbolName:@"apple.intelligence" accessibilityDescription:nil]];
-#endif
 
             for (NSMenuItem *subItem in [menuItem submenu].itemArray) {
                 if (subItem.isSeparatorItem)

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -621,7 +621,7 @@ void WebPageProxy::showPDFContextMenu(const WebKit::PDFContextMenu& contextMenu,
         [nsItem setState:item.state];
 #if ENABLE(CONTEXT_MENU_IMAGES_FOR_INTERNAL_CLIENTS)
         if (shouldSetImage && ![nsItem _hasActionImage])
-            [nsItem _setActionImage:[NSImage imageWithSystemSymbolName:symbolNameForAction(item.action, false) accessibilityDescription:nil]];
+            addImageToMenuItem(nsItem.get(), item.action, false);
 #endif
         if (item.hasAction == ContextMenuItemHasAction::Yes) {
             [nsItem setTarget:menuTarget.get()];

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -2568,9 +2568,9 @@ Vector<PDFContextMenuItem> UnifiedPDFPlugin::selectionContextMenuItems(const Int
         return { };
 
     Vector<PDFContextMenuItem> items {
-        contextMenuItem(ContextMenuItemTag::WebSearch),
-        separatorContextMenuItem(),
         contextMenuItem(ContextMenuItemTag::DictionaryLookup),
+        separatorContextMenuItem(),
+        contextMenuItem(ContextMenuItemTag::WebSearch),
         separatorContextMenuItem(),
         contextMenuItem(ContextMenuItemTag::Copy),
     };


### PR DESCRIPTION
#### 0382274f38a891a11585496bdf8e00a0b7e55fa0
<pre>
[macOS] Improve context menu consistency and update images for internal clients
<a href="https://bugs.webkit.org/show_bug.cgi?id=291771">https://bugs.webkit.org/show_bug.cgi?id=291771</a>
<a href="https://rdar.apple.com/142002509">rdar://142002509</a>

Reviewed by Tim Horton and Megan Gardner.

Swapped the location of the &quot;Look up&quot; and &quot;Search with...&quot; items in
UnifiedPDF&apos;s context menu and added an extra separator in order to
stay consistent with Preview&apos;s context menu. Updated the images used
when context menu images for internal clients are enabled. Replace
method `_imageWithSystemSymbolName` with `imageWithPrivateSystemSymbolName`
in `NSImageSPI.h`, and added checks to ensure it is called only when
strictly necessary.

* Source/WebCore/PAL/pal/spi/mac/NSImageSPI.h:
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::populate):
* Source/WebKit/Platform/mac/MenuUtilities.h:
* Source/WebKit/Platform/mac/MenuUtilities.mm:
(WebKit::symbolNameForAction):
(WebKit::addImageToMenuItem):
* Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm:
(-[WKPDFHUDView _imageForControlName:]):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::updateMenuItemImage):
(WebKit::WebContextMenuProxyMac::createShareMenuItem):
(WebKit::WebContextMenuProxyMac::getContextMenuItem):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::showPDFContextMenu):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::selectionContextMenuItems const):

Canonical link: <a href="https://commits.webkit.org/293881@main">https://commits.webkit.org/293881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06d7a65575c2302e61770b790dfdf61a03f75333

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100158 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19806 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105288 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50740 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102199 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28279 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76245 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33311 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103165 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15370 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90464 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56606 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15186 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8461 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50109 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85097 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107647 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27271 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19979 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85199 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27634 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86670 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84735 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21537 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29415 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7151 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21126 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27208 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32441 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27019 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30335 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28578 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->