### PR TITLE
Stop using unsafeMakeSpan() in BinaryPropertyList.cpp

### DIFF
--- a/Source/WebKitLegacy/mac/History/BinaryPropertyList.cpp
+++ b/Source/WebKitLegacy/mac/History/BinaryPropertyList.cpp
@@ -485,7 +485,7 @@ BinaryPropertyListSerializer::BinaryPropertyListSerializer(BinaryPropertyListWri
     , m_currentObjectReference(0)
 {
     auto bufferSize = m_offsetTableStart + m_plan.objectCount() * m_offsetSize + trailerSize;
-    m_buffer = unsafeMakeSpan(client.buffer(bufferSize), bufferSize);
+    m_buffer = client.buffer(bufferSize);
     ASSERT(m_objectReferenceSize > 0);
     ASSERT(m_offsetSize > 0);
 

--- a/Source/WebKitLegacy/mac/History/BinaryPropertyList.h
+++ b/Source/WebKitLegacy/mac/History/BinaryPropertyList.h
@@ -96,7 +96,7 @@ private:
 
     // Called by writePropertyList.
     // Returns the buffer that the writer should write into.
-    virtual UInt8* buffer(size_t) = 0;
+    virtual std::span<UInt8> buffer(size_t) = 0;
 
     friend class BinaryPropertyListPlan;
     friend class BinaryPropertyListSerializer;

--- a/Source/WebKitLegacy/mac/History/HistoryPropertyList.h
+++ b/Source/WebKitLegacy/mac/History/HistoryPropertyList.h
@@ -27,14 +27,17 @@
 #define HistoryPropertyList_h
 
 #include "BinaryPropertyList.h"
+#include <wtf/MallocSpan.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/text/WTFString.h>
 
 @class WebHistoryItem;
+struct CFMalloc;
 
 class HistoryPropertyListWriter : public BinaryPropertyListWriter {
 public:
     RetainPtr<CFDataRef> releaseData();
+    ~HistoryPropertyListWriter();
 
 protected:
     HistoryPropertyListWriter();
@@ -45,7 +48,7 @@ private:
     virtual void writeHistoryItems(BinaryPropertyListObjectStream&) = 0;
 
     virtual void writeObjects(BinaryPropertyListObjectStream&);
-    virtual UInt8* buffer(size_t);
+    virtual std::span<UInt8> buffer(size_t);
 
     const String m_displayTitleKey;
     const String m_lastVisitWasFailureKey;
@@ -54,8 +57,7 @@ private:
     const String m_titleKey;
     const String m_urlKey;
 
-    UInt8* m_buffer;
-    size_t m_bufferSize;
+    MallocSpan<UInt8, CFMalloc> m_buffer;
 };
 
 #endif // HistoryPropertyList_h

--- a/Source/WebKitLegacy/mac/History/HistoryPropertyList.mm
+++ b/Source/WebKitLegacy/mac/History/HistoryPropertyList.mm
@@ -32,6 +32,11 @@ using namespace WebCore;
 
 static const int currentFileVersion = 1;
 
+struct CFMalloc {
+    static void* malloc(size_t size) { return CFAllocatorAllocate(nullptr, size, 0); }
+    static void free(void* p) { CFAllocatorDeallocate(nullptr, p); }
+};
+
 HistoryPropertyListWriter::HistoryPropertyListWriter()
     : m_displayTitleKey("displayTitle"_s)
     , m_lastVisitWasFailureKey("lastVisitWasFailure"_s)
@@ -39,29 +44,26 @@ HistoryPropertyListWriter::HistoryPropertyListWriter()
     , m_redirectURLsKey("redirectURLs"_s)
     , m_titleKey("title"_s)
     , m_urlKey(emptyString())
-    , m_buffer(0)
 {
 }
 
-UInt8* HistoryPropertyListWriter::buffer(size_t size)
+HistoryPropertyListWriter::~HistoryPropertyListWriter() = default;
+
+std::span<UInt8> HistoryPropertyListWriter::buffer(size_t size)
 {
     ASSERT(!m_buffer);
-    m_buffer = static_cast<UInt8*>(CFAllocatorAllocate(0, size, 0));
-    m_bufferSize = size;
-    return m_buffer;
+    m_buffer = MallocSpan<UInt8, CFMalloc>::malloc(size);
+    return m_buffer.mutableSpan();
 }
 
 RetainPtr<CFDataRef> HistoryPropertyListWriter::releaseData()
 {
-    UInt8* buffer = m_buffer;
-    if (!buffer)
-        return 0;
-    m_buffer = 0;
-    RetainPtr<CFDataRef> data = adoptCF(CFDataCreateWithBytesNoCopy(0, buffer, m_bufferSize, 0));
-    if (!data) {
-        CFAllocatorDeallocate(0, buffer);
-        return 0;
-    }
+    if (!m_buffer)
+        return nullptr;
+    auto span = m_buffer.leakSpan();
+    RetainPtr data = adoptCF(CFDataCreateWithBytesNoCopy(0, span.data(), span.size(), 0));
+    if (!data)
+        adoptMallocSpan<UInt8, CFMalloc>(span); // We need to make sure we free the data if creating the CFData failed.
     return data;
 }
 


### PR DESCRIPTION
#### 8f4d4da6c5ed0570669f64ff44b52bc84e44b843
<pre>
Stop using unsafeMakeSpan() in BinaryPropertyList.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=291772">https://bugs.webkit.org/show_bug.cgi?id=291772</a>

Reviewed by Geoffrey Garen, Darin Adler, and Brady Eidson.

* Source/WebKitLegacy/mac/History/BinaryPropertyList.cpp:
(BinaryPropertyListSerializer::BinaryPropertyListSerializer):
* Source/WebKitLegacy/mac/History/BinaryPropertyList.h:
* Source/WebKitLegacy/mac/History/HistoryPropertyList.h:
* Source/WebKitLegacy/mac/History/HistoryPropertyList.mm:
(CFMalloc::malloc):
(CFMalloc::free):
(HistoryPropertyListWriter::HistoryPropertyListWriter):
(HistoryPropertyListWriter::buffer):
(HistoryPropertyListWriter::releaseData):

Canonical link: <a href="https://commits.webkit.org/294197@main">https://commits.webkit.org/294197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80b967f4c9e085f33cdd00b6bbeb6885a96b3709

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101121 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11086 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106269 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51748 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29277 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77028 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34054 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16249 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91332 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57375 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16066 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9361 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51096 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/85971 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108625 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28249 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85996 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28611 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87533 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85533 "Found 101 new API test failures: /TestWebKit:WebKit.EnumerateDevicesCrash, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/file-chooser-request, /TestWebKit:WebKit.PageLoadDidChangeLocationWithinPage, /WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-activate, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/simple, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/display-usermedia-permission-request, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/test-page-list, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/open-window-no-default-size, /TestWebKit:WebKit.LoadPageAfterCrash ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21763 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30259 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7975 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22347 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28179 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33448 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27991 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31311 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29549 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->