### PR TITLE
[WebGPU] device.onuncapturederror = ... does not work

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/operation/uncapturederror-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/operation/uncapturederror-expected.txt
@@ -1,27 +1,9 @@
 
 PASS :iff_uncaptured:useOnuncapturederror=false;errorType="out-of-memory"
 PASS :iff_uncaptured:useOnuncapturederror=false;errorType="validation"
-FAIL :iff_uncaptured:useOnuncapturederror=true;errorType="out-of-memory" assert_unreached:
-  - EXCEPTION: Error: there were outstanding immediateAsyncExpectations (e.g. expectUncapturedError) at the end of the test
-    assert@http://127.0.0.1:8000/webgpu/common/util/util.js:37:20
-    finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:119:11
-    runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:532:28
-    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:680:31
-    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
- Reached unreachable code
-FAIL :iff_uncaptured:useOnuncapturederror=true;errorType="validation" assert_unreached:
-  - EXCEPTION: Error: there were outstanding immediateAsyncExpectations (e.g. expectUncapturedError) at the end of the test
-    assert@http://127.0.0.1:8000/webgpu/common/util/util.js:37:20
-    finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:119:11
-    runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:532:28
-    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:680:31
-    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
- Reached unreachable code
+PASS :iff_uncaptured:useOnuncapturederror=true;errorType="out-of-memory"
+PASS :iff_uncaptured:useOnuncapturederror=true;errorType="validation"
 PASS :only_original_device_is_event_target:
 PASS :uncapturederror_from_non_originating_thread:
-FAIL :onuncapturederror_order_wrt_addEventListener: assert_unreached:
-  - EXCEPTION: Error: timeout1
-    @http://127.0.0.1:8000/webgpu/common/util/util.js:141:37
-    @http://127.0.0.1:8000/resources/testharness.js:983:20
- Reached unreachable code
+PASS :onuncapturederror_order_wrt_addEventListener:
 

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -688,21 +688,33 @@ bool GPUDevice::addEventListener(const AtomString& eventType, Ref<EventListener>
 {
     auto result = EventTarget::addEventListener(eventType, WTF::move(eventListener), options);
 #if PLATFORM(COCOA)
-    if (eventType == WebCore::eventNames().uncapturederrorEvent) {
-        m_backing->resolveUncapturedErrorEvent([eventType, pendingActivity = makePendingActivity(*this), weakThis = WeakPtr { *this }](bool hasUncapturedError, std::optional<WebGPU::Error>&& error) {
-            RefPtr protectedThis = weakThis.get();
-            if (!protectedThis || !hasUncapturedError)
-                return;
-
-            RefPtr context = protectedThis->scriptExecutionContext();
-            if (!context)
-                return;
-
-            queueTaskToDispatchEvent(*protectedThis, TaskSource::WebGPU, GPUUncapturedErrorEvent::create(WebCore::eventNames().uncapturederrorEvent, GPUUncapturedErrorEventInit { .error = createGPUErrorFromWebGPUError(error) }));
-        });
-    }
+    if (eventType == WebCore::eventNames().uncapturederrorEvent)
+        listenForUncapturedErrors();
 #endif
     return result;
+}
+
+void GPUDevice::listenForUncapturedErrors()
+{
+    if (m_listeningForUncapturedErrors)
+        return;
+#if PLATFORM(COCOA)
+    m_listeningForUncapturedErrors = true;
+    m_backing->resolveUncapturedErrorEvent([pendingActivity = makePendingActivity(*this), weakThis = WeakPtr { *this }](bool hasUncapturedError, std::optional<WebGPU::Error>&& error) {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || !hasUncapturedError)
+            return;
+
+        protectedThis->m_listeningForUncapturedErrors = false;
+
+        RefPtr context = protectedThis->scriptExecutionContext();
+        if (!context)
+            return;
+
+        queueTaskToDispatchEvent(*protectedThis, TaskSource::WebGPU, GPUUncapturedErrorEvent::create(WebCore::eventNames().uncapturederrorEvent, GPUUncapturedErrorEventInit { .error = createGPUErrorFromWebGPUError(error) }));
+        protectedThis->listenForUncapturedErrors();
+    });
+#endif
 }
 
 #if ENABLE(VIDEO)

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -144,6 +144,7 @@ public:
 
     bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) override;
     using EventTarget::addEventListener;
+    void listenForUncapturedErrors();
 
     using LostPromise = DOMPromiseProxy<IDLInterface<GPUDeviceLostInfo>>;
     LostPromise& lost() LIFETIME_BOUND;
@@ -188,6 +189,7 @@ private:
     const Ref<GPUAdapterInfo> m_adapterInfo;
 
     bool m_waitingForDeviceLostPromise { false };
+    bool m_listeningForUncapturedErrors { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.idl
@@ -37,6 +37,8 @@
 
     [SameObject] readonly attribute GPUQueue queue;
 
+    attribute EventHandler onuncapturederror;
+
     [CallWith=CurrentScriptExecutionContext] undefined destroy();
 
     GPUBuffer createBuffer(GPUBufferDescriptor descriptor);

--- a/Source/WebCore/Modules/WebGPU/GPUDeviceUncapturedError.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUDeviceUncapturedError.idl
@@ -23,7 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// onuncapturederror moved to GPUDevice.idl
 partial interface GPUDevice {
-    [Exposed=(Window, Worker)]
-    attribute EventHandler onuncapturederror;
 };


### PR DESCRIPTION
#### 689ebe5973bafc70d4f7bb1dd2c61b36739f4c3d
<pre>
[WebGPU] device.onuncapturederror = ... does not work
<a href="https://bugs.webkit.org/show_bug.cgi?id=291775">https://bugs.webkit.org/show_bug.cgi?id=291775</a>
radar://149577124

Reviewed by Tadeu Zagallo.

As noted in <a href="https://github.com/gpuweb/cts/issues/4361">https://github.com/gpuweb/cts/issues/4361</a> we did
not correctly handle device.onuncapturederror = syntax which
works in Chrome and FireFox.

uncapturederror.html is now all passing

* LayoutTests/http/tests/webgpu/webgpu/api/operation/uncapturederror-expected.txt:
* Source/WebCore/Modules/WebGPU/GPUDevice.cpp:
(WebCore::GPUDevice::addEventListener):
(WebCore::GPUDevice::listenForUncapturedErrors):
* Source/WebCore/Modules/WebGPU/GPUDevice.h:
* Source/WebCore/Modules/WebGPU/GPUDevice.idl:
* Source/WebCore/Modules/WebGPU/GPUDeviceUncapturedError.idl:

Canonical link: <a href="https://commits.webkit.org/312043@main">https://commits.webkit.org/312043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9819b01db112a0e0574fdd4edb14889aafffdd37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25343 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167640 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112895 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32304 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123040 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86370 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142667 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103709 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24362 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22763 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15412 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134048 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20447 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170132 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15875 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131227 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31927 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26829 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131341 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35530 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31872 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142240 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89860 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26039 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19049 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31383 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97397 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30903 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31176 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31057 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->