### PR TITLE
Standardize on move arguments for ResourceRequest and ResourceResponse

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchLoader.cpp
+++ b/Source/WebCore/Modules/fetch/FetchLoader.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2016 Canon Inc.
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted, provided that the following conditions
@@ -66,7 +66,7 @@ void FetchLoader::startLoadingBlobURL(ScriptExecutionContext& context, const URL
 
     ThreadableBlobRegistry::registerBlobURL(context.securityOrigin(), context.policyContainer(), m_urlForReading, blobURL);
 
-    ResourceRequest request(m_urlForReading);
+    ResourceRequest request(URL { m_urlForReading });
     request.setInitiatorIdentifier(context.resourceRequestIdentifier());
     request.setHTTPMethod("GET"_s);
 

--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Canon Inc.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted, provided that the following conditions
@@ -186,8 +187,8 @@ ExceptionOr<void> FetchRequest::initializeWith(const String& url, Init&& init)
     m_options.mode = Mode::Cors;
     m_options.credentials = Credentials::SameOrigin;
     m_referrer = "client"_s;
-    m_request.setURL(requestURL);
-    m_requestURL = { WTFMove(requestURL), scriptExecutionContext()->topOrigin().data() };
+    m_request.setURL(WTFMove(requestURL));
+    m_requestURL = { m_request.url(), scriptExecutionContext()->topOrigin().data() };
     m_request.setInitiatorIdentifier(scriptExecutionContext()->resourceRequestIdentifier());
 
     auto optionsResult = initializeOptions(init);

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -193,7 +193,7 @@ void HTMLModelElement::setSourceURL(const URL& url)
     // FIXME: Set other options.
 
     auto crossOriginAttribute = parseCORSSettingsAttribute(attributeWithoutSynchronization(HTMLNames::crossoriginAttr));
-    auto request = createPotentialAccessControlRequest(ResourceRequest { m_sourceURL }, WTFMove(options), document(), crossOriginAttribute);
+    auto request = createPotentialAccessControlRequest(ResourceRequest { URL { m_sourceURL } }, WTFMove(options), document(), crossOriginAttribute);
     request.setInitiator(*this);
 
     auto resource = document().protectedCachedResourceLoader()->requestModelResource(WTFMove(request));

--- a/Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2022 Igalia S.L.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -135,7 +136,7 @@ NotificationResourcesLoader::ResourceLoader::ResourceLoader(ScriptExecutionConte
     options.sendLoadCallbacks = SendCallbackPolicy::SendCallbacks;
     options.dataBufferingPolicy = DataBufferingPolicy::DoNotBufferData;
     options.contentSecurityPolicyEnforcement = context.shouldBypassMainWorldContentSecurityPolicy() ? ContentSecurityPolicyEnforcement::DoNotEnforce : ContentSecurityPolicyEnforcement::EnforceConnectSrcDirective;
-    m_loader = ThreadableLoader::create(context, *this, ResourceRequest(url), options);
+    m_loader = ThreadableLoader::create(context, *this, ResourceRequest(URL { url }), options);
 }
 
 NotificationResourcesLoader::ResourceLoader::~ResourceLoader()

--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2009, 2012 Google Inc.  All rights reserved.
+ * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -99,8 +100,9 @@ std::optional<ResourceRequest> ThreadableWebSocketChannel::webSocketConnectReque
     if (!validatedURL)
         return { };
 
-    ResourceRequest request { validatedURL->url };
-    request.setHTTPUserAgent(document.userAgent(validatedURL->url));
+    auto userAgent = document.userAgent(validatedURL->url);
+    ResourceRequest request { WTFMove(validatedURL->url) };
+    request.setHTTPUserAgent(userAgent);
     request.setDomainForCachePartition(document.domainForCachePartition());
     request.setAllowCookies(validatedURL->areCookiesAllowed);
     request.setFirstPartyForCookies(document.firstPartyForCookies());

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2011 Google Inc.  All rights reserved.
  * Copyright (C) Research In Motion Limited 2011. All rights reserved.
- * Copyright (C) 2018-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -195,7 +195,7 @@ ResourceRequest WebSocketHandshake::clientHandshakeRequest(NOESCAPE const Functi
 
     auto cookie = m_allowCookies ? cookieRequestHeaderFieldValue(httpURLForAuthenticationAndCookies()) : emptyString();
     auto extensions = m_extensionDispatcher.createHeaderValue();
-    ResourceRequest request { m_url };
+    ResourceRequest request { URL { m_url } };
     request.setHTTPMethod("GET"_s);
     request.setHTTPHeaderField(HTTPHeaderName::Connection, "Upgrade"_s);
     request.setHTTPHeaderField(HTTPHeaderName::Host, hostName(m_url, m_secure));

--- a/Source/WebCore/bindings/js/CachedScriptFetcher.cpp
+++ b/Source/WebCore/bindings/js/CachedScriptFetcher.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017 Yusuke Suzuki <utatane.tea@gmail.com>
+ * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -63,7 +64,7 @@ CachedResourceHandle<CachedScript> CachedScriptFetcher::requestScriptWithCache(D
     options.fetchPriority = m_fetchPriority;
     options.nonce = m_nonce;
 
-    auto request = createPotentialAccessControlRequest(sourceURL, WTFMove(options), document, crossOriginMode);
+    auto request = createPotentialAccessControlRequest(URL { sourceURL }, WTFMove(options), document, crossOriginMode);
     request.upgradeInsecureRequestIfNeeded(document);
     request.setCharset(m_charset);
     request.setPriority(WTFMove(resourceLoadPriority));

--- a/Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp
+++ b/Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -74,7 +74,7 @@ void WorkerModuleScriptLoader::load(ScriptExecutionContext& context, URL&& sourc
         }
     }
 
-    ResourceRequest request { m_sourceURL };
+    ResourceRequest request { URL { m_sourceURL } };
 
     FetchOptions fetchOptions;
     fetchOptions.mode = FetchOptions::Mode::Cors;

--- a/Source/WebCore/css/CSSImageValue.cpp
+++ b/Source/WebCore/css/CSSImageValue.cpp
@@ -1,6 +1,6 @@
 /*
  * (C) 1999-2003 Lars Knoll (knoll@kde.org)
- * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -114,7 +114,7 @@ CachedImage* CSSImageValue::loadImage(CachedResourceLoader& loader, const Resour
         ResourceLoaderOptions loadOptions = options;
         CSS::applyModifiersToLoaderOptions(m_location.modifiers, loadOptions);
 
-        CachedResourceRequest request(ResourceRequest(m_location.resolved), loadOptions);
+        CachedResourceRequest request(ResourceRequest(URL { m_location.resolved }), loadOptions);
         if (m_initiatorType.isEmpty())
             request.setInitiatorType(cachedResourceRequestInitiatorTypes().css);
         else

--- a/Source/WebCore/css/StyleRuleImport.cpp
+++ b/Source/WebCore/css/StyleRuleImport.cpp
@@ -1,7 +1,7 @@
 /*
  * (C) 1999-2003 Lars Knoll (knoll@kde.org)
  * (C) 2002-2003 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2002-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2002-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -135,7 +135,7 @@ void StyleRuleImport::requestStyleSheet()
 
     // FIXME: Skip Content Security Policy check when stylesheet is in a user agent shadow tree.
     // See <https://bugs.webkit.org/show_bug.cgi?id=146663>.
-    CachedResourceRequest request(absURL, CachedResourceLoader::defaultCachedResourceOptions(), std::nullopt, String(m_parentStyleSheet->charset()));
+    CachedResourceRequest request(WTFMove(absURL), CachedResourceLoader::defaultCachedResourceOptions(), std::nullopt, String(m_parentStyleSheet->charset()));
     request.setInitiatorType(cachedResourceRequestInitiatorTypes().css);
     if (m_cachedSheet)
         m_cachedSheet->removeClient(m_styleSheetClient);

--- a/Source/WebCore/fileapi/FileReaderLoader.cpp
+++ b/Source/WebCore/fileapi/FileReaderLoader.cpp
@@ -100,7 +100,7 @@ void FileReaderLoader::start(ScriptExecutionContext* scriptExecutionContext, con
     ThreadableBlobRegistry::registerBlobURL(securityOrigin.get(), scriptExecutionContext->policyContainer(), m_urlForReading, blobURL);
 
     // Construct and load the request.
-    ResourceRequest request(m_urlForReading);
+    ResourceRequest request(URL { m_urlForReading });
     request.setHTTPMethod("GET"_s);
     request.setHiddenFromInspector(true);
 

--- a/Source/WebCore/html/DOMURL.cpp
+++ b/Source/WebCore/html/DOMURL.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Simon Hausmann <hausmann@kde.org>
- * Copyright (C) 2003, 2006, 2007, 2008, 2009, 2010, 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
  *           (C) 2006 Graham Dennis (graham.dennis@gmail.com)
  * Copyright (C) 2011 Google Inc. All rights reserved.
  * Copyright (C) 2012 Motorola Mobility Inc.
@@ -123,12 +123,12 @@ URLSearchParams& DOMURL::searchParams()
 void DOMURL::revokeObjectURL(ScriptExecutionContext& scriptExecutionContext, const String& urlString)
 {
     URL url { urlString };
-    ResourceRequest request(url);
+    ResourceRequest request(WTFMove(url));
     request.setDomainForCachePartition(scriptExecutionContext.domainForCachePartition());
 
     MemoryCache::removeRequestFromSessionCaches(scriptExecutionContext, request);
 
-    scriptExecutionContext.publicURLManager().revoke(url);
+    scriptExecutionContext.publicURLManager().revoke(request.url());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2003-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2009 Rob Buis (rwlbuis@gmail.com)
  * Copyright (C) 2011 Google Inc. All rights reserved.
  *
@@ -401,7 +401,7 @@ void HTMLLinkElement::process()
         options.referrerPolicy = params.referrerPolicy;
         options.fetchPriority = fetchPriority();
 
-        auto request = createPotentialAccessControlRequest(m_url, WTFMove(options), document, crossOrigin());
+        auto request = createPotentialAccessControlRequest(URL { m_url }, WTFMove(options), document, crossOrigin());
         request.setPriority(WTFMove(priority));
         request.setCharset(WTFMove(charset));
         request.setInitiator(*this);

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1832,7 +1832,7 @@ void HTMLMediaElement::loadResource(const URL& initialURL, const ContentType& in
 
     // If the URL should be loaded from the application cache, pass the URL of the cached file to the media engine.
     RefPtr<ApplicationCacheResource> resource;
-    if (!url.isEmpty() && frame->loader().documentLoader()->applicationCacheHost().shouldLoadResourceFromApplicationCache(ResourceRequest(url), resource)) {
+    if (!url.isEmpty() && frame->loader().documentLoader()->applicationCacheHost().shouldLoadResourceFromApplicationCache(ResourceRequest(URL { url }), resource)) {
         // Resources that are not present in the manifest will always fail to load (at least, after the
         // cache has been primed the first time), making the testing of offline applications simpler.
         if (!resource || resource->path().isEmpty()) {
@@ -1988,7 +1988,7 @@ bool HTMLMediaElement::needsContentTypeToPlay() const
 
 Ref<HTMLMediaElement::SnifferPromise> HTMLMediaElement::sniffForContentType(const URL& url)
 {
-    ResourceRequest request(url);
+    ResourceRequest request(URL { url });
     request.setAllowCookies(true);
     // https://mimesniff.spec.whatwg.org/#reading-the-resource-header defines a maximum size of 1445 bytes fetch.
     m_sniffer = MediaResourceSniffer::create(mediaPlayerCreateResourceLoader(), WTFMove(request), 1445);

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Google Inc. All rights reserved.
- * Copyright (C) 2015-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -1011,7 +1011,7 @@ void InspectorNetworkAgent::loadResource(const Inspector::Protocol::Network::Fra
     }
 
     URL url = context->completeURL(urlString);
-    ResourceRequest request(url);
+    ResourceRequest request(WTFMove(url));
     request.setHTTPMethod("GET"_s);
     request.setHiddenFromInspector(true);
 
@@ -1325,7 +1325,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptRequest
         data = SharedBuffer::create(content.utf8().span());
 
     // Mimic data URL load behavior - report didReceiveResponse & didFinishLoading.
-    ResourceResponse response(pendingRequest->m_loader->url(), mimeType, data->size(), String());
+    ResourceResponse response(URL { pendingRequest->m_loader->url() }, String { mimeType }, data->size(), String());
     response.setSource(ResourceResponse::Source::InspectorOverride);
     response.setHTTPStatusCode(status);
     response.setHTTPStatusText(String { statusText });

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Google Inc. All rights reserved.
- * Copyright (C) 2015-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -220,7 +220,7 @@ CachedResource* InspectorPageAgent::cachedResource(const LocalFrame* frame, cons
 
     CachedResource* cachedResource = frame->document()->cachedResourceLoader().cachedResource(MemoryCache::removeFragmentIdentifierIfNeeded(url));
     if (!cachedResource) {
-        ResourceRequest request(url);
+        ResourceRequest request(URL { url });
         request.setDomainForCachePartition(frame->document()->domainForCachePartition());
         cachedResource = MemoryCache::singleton().resourceForRequest(request, frame->page()->sessionID());
     }

--- a/Source/WebCore/loader/ApplicationManifestLoader.cpp
+++ b/Source/WebCore/loader/ApplicationManifestLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -58,7 +58,7 @@ bool ApplicationManifestLoader::startLoading()
     if (!frame)
         return false;
 
-    ResourceRequest resourceRequest = m_url;
+    ResourceRequest resourceRequest { URL { m_url } };
     resourceRequest.setPriority(ResourceLoadPriority::Low);
 #if !ERROR_DISABLED
     // Copy this because we may want to access it after transferring the

--- a/Source/WebCore/loader/CrossOriginAccessControl.cpp
+++ b/Source/WebCore/loader/CrossOriginAccessControl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2021 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -86,7 +86,7 @@ void updateRequestForAccessControl(ResourceRequest& request, SecurityOrigin& sec
 
 ResourceRequest createAccessControlPreflightRequest(const ResourceRequest& request, SecurityOrigin& securityOrigin, const String& referrer, bool includeFetchMetadata)
 {
-    ResourceRequest preflightRequest(request.url());
+    ResourceRequest preflightRequest { URL { request.url() } };
     static const double platformDefaultTimeout = 0;
     preflightRequest.setTimeoutInterval(platformDefaultTimeout);
     updateRequestForAccessControl(preflightRequest, securityOrigin, StoredCredentialsPolicy::DoNotUse);

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2011 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -244,8 +244,8 @@ Document* DocumentLoader::document() const
 
 void DocumentLoader::replaceRequestURLForSameDocumentNavigation(const URL& url)
 {
-    m_originalRequestCopy.setURL(url);
-    m_request.setURL(url);
+    m_originalRequestCopy.setURL(URL { url });
+    m_request.setURL(URL { url });
 }
 
 void DocumentLoader::setRequest(const ResourceRequest& req)
@@ -562,7 +562,7 @@ void DocumentLoader::handleSubstituteDataLoadNow()
 
     ResourceResponse response = m_substituteData.response();
     if (response.url().isEmpty())
-        response = ResourceResponse(m_request.url(), m_substituteData.mimeType(), m_substituteData.content()->size(), m_substituteData.textEncoding());
+        response = ResourceResponse(URL { m_request.url() }, String { m_substituteData.mimeType() }, m_substituteData.content()->size(), String { m_substituteData.textEncoding() });
 
 #if ENABLE(CONTENT_EXTENSIONS)
     if (RefPtr page = m_frame ? m_frame->page() : nullptr) {
@@ -2092,13 +2092,13 @@ bool DocumentLoader::maybeLoadEmpty()
         return false;
 
     if (m_request.url().isEmpty() && !protectedFrameLoader()->stateMachine().creatingInitialEmptyDocument()) {
-        m_request.setURL(aboutBlankURL());
+        m_request.setURL(URL { aboutBlankURL() });
         if (isLoadingMainResource())
             frameLoaderClient->dispatchDidChangeProvisionalURL();
     }
 
     String mimeType = shouldLoadEmpty ? textHTMLContentTypeAtom() : frameLoaderClient->generatedMIMETypeForURLScheme(m_request.url().protocol());
-    m_response = ResourceResponse(m_request.url(), mimeType, 0, "UTF-8"_s);
+    m_response = ResourceResponse(URL { m_request.url() }, WTFMove(mimeType), 0, "UTF-8"_s);
 
     bool isDisplayingInitialEmptyDocument = frameLoader()->stateMachine().isDisplayingInitialEmptyDocument();
     if (!isDisplayingInitialEmptyDocument) {
@@ -2117,7 +2117,7 @@ bool DocumentLoader::maybeLoadEmpty()
 
 void DocumentLoader::loadErrorDocument()
 {
-    m_response = ResourceResponse(m_request.url(), textHTMLContentTypeAtom(), 0, "UTF-8"_s);
+    m_response = ResourceResponse(URL { m_request.url() }, String { textHTMLContentTypeAtom() }, 0, "UTF-8"_s);
     SetForScope isInFinishedLoadingOfEmptyDocument { m_isInFinishedLoadingOfEmptyDocument, true };
 
     commitIfReady();
@@ -2188,7 +2188,7 @@ void DocumentLoader::startLoadingMainResource()
     auto url = m_request.url();
     auto fragmentDirective = url.consumeFragmentDirective();
 
-    m_request.setURL(url, m_request.didFilterLinkDecoration());
+    m_request.setURL(WTFMove(url), m_request.didFilterLinkDecoration());
     frame = m_frame.get();
     if (frame) {
         RefPtr page = frame->protectedPage();
@@ -2371,7 +2371,7 @@ void DocumentLoader::loadMainResource(ResourceRequest&& request)
     // If there was a fragment identifier on m_request, the cache will have stripped it. m_request should include
     // the fragment identifier, so add that back in.
     if (equalIgnoringFragmentIdentifier(m_request.url(), updatedRequest.url()))
-        updatedRequest.setURL(m_request.url());
+        updatedRequest.setURL(URL { m_request.url() });
     setRequest(updatedRequest);
 }
 
@@ -2637,7 +2637,7 @@ ResourceError DocumentLoader::contentFilterDidBlock(ContentFilterUnblockHandler 
 
 void DocumentLoader::handleProvisionalLoadFailureFromContentFilter(const URL& blockedPageURL, SubstituteData& substituteData)
 {
-    protectedFrameLoader()->load(FrameLoadRequest(*frame(), blockedPageURL, substituteData));
+    protectedFrameLoader()->load(FrameLoadRequest(*frame(), URL { blockedPageURL }, substituteData));
 }
 
 #if HAVE(WEBCONTENTRESTRICTIONS)

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -398,7 +398,7 @@ void DocumentThreadableLoader::responseReceived(CachedResource& resource, const 
     ResourceResponse responseWithCorrectFragmentIdentifier;
     if (response.source() != ResourceResponse::Source::ServiceWorker && response.url().fragmentIdentifier() != m_responseURL.fragmentIdentifier()) {
         responseWithCorrectFragmentIdentifier = response;
-        responseWithCorrectFragmentIdentifier.setURL(m_responseURL);
+        responseWithCorrectFragmentIdentifier.setURL(URL { m_responseURL });
     }
 
     if (!m_responsesCanBeOpaque) {

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Nokia Corporation and/or its subsidiary(-ies)
  * Copyright (C) 2008, 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
  * Copyright (C) 2009 Adam Barth. All rights reserved.
@@ -209,7 +209,7 @@ public:
         UserGestureIndicator gestureIndicator { userGestureToForward() };
 
         bool refresh = equalIgnoringFragmentIdentifier(localFrame->document()->url(), url());
-        ResourceRequest resourceRequest { url(), referrer(), refresh ? ResourceRequestCachePolicy::ReloadIgnoringCacheData : ResourceRequestCachePolicy::UseProtocolCachePolicy };
+        ResourceRequest resourceRequest { URL { url() }, String { referrer() }, refresh ? ResourceRequestCachePolicy::ReloadIgnoringCacheData : ResourceRequestCachePolicy::UseProtocolCachePolicy };
         if (initiatedByMainFrame() == InitiatedByMainFrame::Yes)
             resourceRequest.setRequester(ResourceRequestRequester::Main);
         FrameLoadRequest frameLoadRequest { protectedInitiatingDocument(), *protectedSecurityOrigin(), WTFMove(resourceRequest), selfTargetFrameName(), initiatedByMainFrame() };
@@ -244,7 +244,7 @@ public:
     {
         UserGestureIndicator gestureIndicator { userGestureToForward() };
 
-        ResourceRequest resourceRequest { url(), referrer(), ResourceRequestCachePolicy::UseProtocolCachePolicy };
+        ResourceRequest resourceRequest { URL { url() }, String { referrer() }, ResourceRequestCachePolicy::UseProtocolCachePolicy };
         FrameLoadRequest frameLoadRequest { protectedInitiatingDocument(), *protectedSecurityOrigin(), WTFMove(resourceRequest), selfTargetFrameName(), initiatedByMainFrame() };
         frameLoadRequest.setLockHistory(lockHistory());
         frameLoadRequest.setLockBackForwardList(lockBackForwardList());
@@ -273,7 +273,7 @@ public:
     {
         UserGestureIndicator gestureIndicator { userGestureToForward() };
 
-        ResourceRequest resourceRequest { url(), referrer(), ResourceRequestCachePolicy::ReloadIgnoringCacheData };
+        ResourceRequest resourceRequest { URL { url() }, String { referrer() }, ResourceRequestCachePolicy::ReloadIgnoringCacheData };
         FrameLoadRequest frameLoadRequest { protectedInitiatingDocument(), *protectedSecurityOrigin(), WTFMove(resourceRequest), selfTargetFrameName(), initiatedByMainFrame() };
         frameLoadRequest.setLockHistory(lockHistory());
         frameLoadRequest.setLockBackForwardList(lockBackForwardList());
@@ -505,10 +505,10 @@ public:
         UserGestureIndicator gestureIndicator { userGestureToForward() };
 
         Ref originDocument = m_originDocument.get();
-        ResourceResponse replacementResponse { originDocument->url(), textPlainContentTypeAtom(), 0, "UTF-8"_s };
+        ResourceResponse replacementResponse { URL { originDocument->url() }, String { textPlainContentTypeAtom() }, 0, "UTF-8"_s };
         SubstituteData replacementData { SharedBuffer::create(), originDocument->url(), replacementResponse, SubstituteData::SessionHistoryVisibility::Hidden };
 
-        ResourceRequest resourceRequest { originDocument->url(), emptyString(), ResourceRequestCachePolicy::ReloadIgnoringCacheData };
+        ResourceRequest resourceRequest { URL { originDocument->url() }, emptyString(), ResourceRequestCachePolicy::ReloadIgnoringCacheData };
         if (RefPtr documentLoader = originDocument->loader())
             resourceRequest.setIsAppInitiated(documentLoader->lastNavigationWasAppInitiated());
         FrameLoadRequest frameLoadRequest { originDocument.copyRef(), originDocument->protectedSecurityOrigin(), WTFMove(resourceRequest), { }, initiatedByMainFrame() };

--- a/Source/WebCore/loader/PingLoader.cpp
+++ b/Source/WebCore/loader/PingLoader.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
  * Copyright (C) 2015 Roopesh Chander (roop@roopc.net)
- * Copyright (C) 2015-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -82,7 +82,7 @@ static bool processContentRuleListsForLoad(const LocalFrame& frame, ResourceRequ
 
 #endif
 
-void PingLoader::loadImage(LocalFrame& frame, const URL& url)
+void PingLoader::loadImage(LocalFrame& frame, URL&& url)
 {
     ASSERT(frame.document());
     Ref document = *frame.document();
@@ -97,7 +97,7 @@ void PingLoader::loadImage(LocalFrame& frame, const URL& url)
         return;
     }
 
-    ResourceRequest request(url);
+    ResourceRequest request(WTFMove(url));
 #if ENABLE(CONTENT_EXTENSIONS)
     if (processContentRuleListsForLoad(frame, request, ContentExtensions::ResourceType::Image))
         return;
@@ -118,14 +118,15 @@ void PingLoader::loadImage(LocalFrame& frame, const URL& url)
 }
 
 // http://www.whatwg.org/specs/web-apps/current-work/multipage/links.html#hyperlink-auditing
-void PingLoader::sendPing(LocalFrame& frame, const URL& pingURL, const URL& destinationURL)
+void PingLoader::sendPing(LocalFrame& frame, URL&& sendPingURL, const URL& destinationURL)
 {
     ASSERT(frame.document());
 
-    if (!pingURL.protocolIsInHTTPFamily())
+    if (!sendPingURL.protocolIsInHTTPFamily())
         return;
 
-    ResourceRequest request(pingURL);
+    ResourceRequest request(WTFMove(sendPingURL));
+    const auto& pingURL = request.url();
     request.setRequester(ResourceRequestRequester::Ping);
 
 #if ENABLE(CONTENT_EXTENSIONS)
@@ -159,7 +160,7 @@ void PingLoader::sendPing(LocalFrame& frame, const URL& pingURL, const URL& dest
     startPingLoad(frame, request, WTFMove(originalRequestHeader), ShouldFollowRedirects::Yes, ContentSecurityPolicyImposition::DoPolicyCheck, ReferrerPolicy::NoReferrer);
 }
 
-void PingLoader::sendViolationReport(LocalFrame& frame, const URL& reportURL, Ref<FormData>&& report, ViolationReportType reportType)
+void PingLoader::sendViolationReport(LocalFrame& frame, URL&& violationReportURL, Ref<FormData>&& report, ViolationReportType reportType)
 {
     ASSERT(frame.document());
 
@@ -168,7 +169,8 @@ void PingLoader::sendViolationReport(LocalFrame& frame, const URL& reportURL, Re
     if (reportType == ViolationReportType::CrossOriginOpenerPolicy && Page::nonUtilityPageCount() <= 1)
         return;
 
-    ResourceRequest request(reportURL);
+    ResourceRequest request(WTFMove(violationReportURL));
+    const auto& reportURL = request.url();
 #if ENABLE(CONTENT_EXTENSIONS)
     if (processContentRuleListsForLoad(frame, request, ContentExtensions::ResourceType::CSPReport))
         return;

--- a/Source/WebCore/loader/PingLoader.h
+++ b/Source/WebCore/loader/PingLoader.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -49,9 +49,9 @@ enum class ViolationReportType : uint8_t;
 
 class PingLoader {
 public:
-    static void loadImage(LocalFrame&, const URL&);
-    static void sendPing(LocalFrame&, const URL& pingURL, const URL& destinationURL);
-    WEBCORE_EXPORT static void sendViolationReport(LocalFrame&, const URL& reportURL, Ref<FormData>&& report, ViolationReportType);
+    static void loadImage(LocalFrame&, URL&&);
+    static void sendPing(LocalFrame&, URL&& pingURL, const URL& destinationURL);
+    WEBCORE_EXPORT static void sendViolationReport(LocalFrame&, URL&& reportURL, Ref<FormData>&& report, ViolationReportType);
 
     static String sanitizeURLForReport(const URL&);
 

--- a/Source/WebCore/loader/appcache/ApplicationCacheHost.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheHost.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2016 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -105,7 +105,7 @@ void ApplicationCacheHost::maybeLoadMainResource(const ResourceRequest& request,
             if (request.url().hasFragmentIdentifier()) {
                 URL url = responseToUse.url();
                 url.setFragmentIdentifier(request.url().fragmentIdentifier());
-                responseToUse.setURL(url);
+                responseToUse.setURL(WTFMove(url));
             }
 
             substituteData = SubstituteData(&resource->data(),

--- a/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008, 2009, 2010, 2011 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1129,13 +1129,13 @@ RefPtr<ApplicationCache> ApplicationCacheStorage::loadCache(unsigned storageID)
         String mimeType = cacheStatement->columnText(3);
         String textEncodingName = cacheStatement->columnText(4);
         
-        ResourceResponse response(url, mimeType, size, textEncodingName);
+        ResourceResponse response(WTFMove(url), WTFMove(mimeType), size, WTFMove(textEncodingName));
         response.setHTTPStatusCode(httpStatusCode);
 
         String headers = cacheStatement->columnText(5);
         parseHeaders(headers, response);
         
-        auto resource = ApplicationCacheResource::create(url, response, type, WTFMove(data), path);
+        auto resource = ApplicationCacheResource::create(response.url(), response, type, WTFMove(data), path);
 
         if (type & ApplicationCacheResource::Manifest)
             cache->setManifestResource(WTFMove(resource));

--- a/Source/WebCore/loader/archive/ArchiveResource.cpp
+++ b/Source/WebCore/loader/archive/ArchiveResource.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008, 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,7 +49,7 @@ RefPtr<ArchiveResource> ArchiveResource::create(RefPtr<FragmentedSharedBuffer>&&
     if (!data)
         return nullptr;
     if (response.isNull()) {
-        ResourceResponse syntheticResponse(url, mimeType, data->size(), textEncoding);
+        ResourceResponse syntheticResponse(URL { url }, String { mimeType }, data->size(), String { textEncoding });
         // Provide a valid HTTP status code for http URLs since we have logic in WebCore that validates it.
         if (url.protocolIsInHTTPFamily())
             syntheticResponse.setHTTPStatusCode(200);

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -720,7 +720,7 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::create(const String& markupString, bo
                 auto addResult = uniqueSubresources.add(subresourceURL.string(), emptyString());
                 auto resource = documentLoader->subresource(subresourceURL);
                 if (!resource) {
-                    ResourceRequest request(subresourceURL);
+                    ResourceRequest request(URL { subresourceURL });
                     request.setDomainForCachePartition(frame.document()->domainForCachePartition());
                     if (auto* cachedResource = MemoryCache::singleton().resourceForRequest(request, frame.page()->sessionID()))
                         resource = ArchiveResource::create(cachedResource->resourceBuffer(), subresourceURL, cachedResource->response());

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -3,7 +3,7 @@
     Copyright (C) 2001 Dirk Mueller (mueller@kde.org)
     Copyright (C) 2002 Waldo Bastian (bastian@kde.org)
     Copyright (C) 2006 Samuel Weinig (sam.weinig@gmail.com)
-    Copyright (C) 2004, 2005, 2006, 2007 Apple Inc. All rights reserved.
+    Copyright (C) 2004-2025 Apple Inc. All rights reserved.
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Library General Public
@@ -96,7 +96,7 @@ CachedImage::CachedImage(const URL& url, Image* image, PAL::SessionID sessionID,
 
     // Use the incoming URL in the response field. This ensures that code using the response directly,
     // such as origin checks for security, actually see something.
-    mutableResponse().setURL(url);
+    mutableResponse().setURL(URL { url });
 
     setAllowsOrientationOverride(isCORSSameOrigin() || m_image->sourceURL().protocolIsData());
 }

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -3,7 +3,7 @@
     Copyright (C) 2001 Dirk Mueller (mueller@kde.org)
     Copyright (C) 2002 Waldo Bastian (bastian@kde.org)
     Copyright (C) 2006 Samuel Weinig (sam.weinig@gmail.com)
-    Copyright (C) 2004-2011, 2014, 2018 Apple Inc. All rights reserved.
+    Copyright (C) 2004-2025 Apple Inc. All rights reserved.
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Library General Public
@@ -114,7 +114,7 @@ CachedResource::CachedResource(CachedResourceRequest&& request, Type type, PAL::
 
 // FIXME: For this constructor, we should probably mandate that the URL has no fragment identifier.
 CachedResource::CachedResource(const URL& url, Type type, PAL::SessionID sessionID, const CookieJar* cookieJar)
-    : m_resourceRequest(url)
+    : m_resourceRequest(URL { url })
     , m_sessionID(sessionID)
     , m_cookieJar(cookieJar)
     , m_fragmentIdentifierForRequest(CachedResourceRequest::splitFragmentIdentifierFromRequestURL(m_resourceRequest))
@@ -241,7 +241,7 @@ void CachedResource::load(CachedResourceLoader& cachedResourceLoader)
     if (!m_fragmentIdentifierForRequest.isNull()) {
         URL url = request.url();
         url.setFragmentIdentifier(m_fragmentIdentifierForRequest);
-        request.setURL(url);
+        request.setURL(WTFMove(url));
         m_fragmentIdentifierForRequest = String();
     }
 

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -2,7 +2,7 @@
     Copyright (C) 1998 Lars Knoll (knoll@mpi-hd.mpg.de)
     Copyright (C) 2001 Dirk Mueller (mueller@kde.org)
     Copyright (C) 2002 Waldo Bastian (bastian@kde.org)
-    Copyright (C) 2004-2023 Apple Inc. All rights reserved.
+    Copyright (C) 2004-2025 Apple Inc. All rights reserved.
     Copyright (C) 2009 Torch Mobile Inc. http://www.torchmobile.com/
 
     This library is free software; you can redistribute it and/or
@@ -270,7 +270,7 @@ ResourceErrorOr<CachedResourceHandle<CachedImage>> CachedResourceLoader::request
             }
             URL requestURL = request.resourceRequest().url();
             if (requestURL.isValid() && canRequest(CachedResource::Type::ImageResource, requestURL, request.options(), ForPreload::No, isRequestUpgradable ? MixedContentChecker::IsUpgradable::Yes : MixedContentChecker::IsUpgradable::No, request.isLinkPreload()))
-                PingLoader::loadImage(*frame, requestURL);
+                PingLoader::loadImage(*frame, WTFMove(requestURL));
             return CachedResourceHandle<CachedImage> { };
         }
     }
@@ -903,7 +903,7 @@ bool CachedResourceLoader::shouldContinueAfterNotifyingLoadedFromMemoryCache(con
     if (!frame() || resource.status() != CachedResource::Cached)
         return true;
 
-    ResourceRequest newRequest = ResourceRequest(resource.url());
+    ResourceRequest newRequest = ResourceRequest(URL { resource.url() });
     newRequest.setRequester(request.resourceRequest().requester());
     newRequest.setInitiatorIdentifier(request.resourceRequest().initiatorIdentifier());
     if (auto inspectorInitiatorNodeIdentifier = request.resourceRequest().inspectorInitiatorNodeIdentifier())
@@ -1202,7 +1202,7 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
                 return makeUnexpected(ResourceError { errorDomainWebKitInternal, 0, url, "Resource blocked by content blocker"_s, ResourceError::Type::AccessControl });
             }
             if (type == CachedResource::Type::MainResource && RegistrableDomain { resourceRequest.url() } != originalDomain) {
-                frame->loader().load(FrameLoadRequest { frame, { resourceRequest.url() } });
+                frame->loader().load(FrameLoadRequest { frame, { URL { resourceRequest.url() } } });
                 return makeUnexpected(ResourceError { errorDomainWebKitInternal, 0, url, "Loading in a new process"_s, ResourceError::Type::Cancellation });
             }
         }

--- a/Source/WebCore/loader/cache/CachedResourceRequest.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012 Google, Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -64,7 +65,7 @@ String CachedResourceRequest::splitFragmentIdentifierFromRequestURL(ResourceRequ
     URL url = request.url();
     auto fragmentIdentifier = url.fragmentIdentifier().toString();
     url.removeFragmentIdentifier();
-    request.setURL(url);
+    request.setURL(WTFMove(url));
     return fragmentIdentifier;
 }
 
@@ -111,7 +112,7 @@ void upgradeInsecureResourceRequestIfNeeded(ResourceRequest& request, Document& 
     if (url == request.url())
         return;
 
-    request.setURL(url);
+    request.setURL(WTFMove(url));
 }
 
 void CachedResourceRequest::upgradeInsecureRequestIfNeeded(Document& document, ContentSecurityPolicy::AlwaysUpgradeRequest alwaysUpgradeRequest)
@@ -257,7 +258,7 @@ void CachedResourceRequest::removeFragmentIdentifierIfNeeded()
 {
     URL url = MemoryCache::removeFragmentIdentifierIfNeeded(m_resourceRequest.url());
     if (url.string() != m_resourceRequest.url())
-        m_resourceRequest.setURL(url);
+        m_resourceRequest.setURL(WTFMove(url));
 }
 
 #if ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebCore/loader/cache/CachedSVGDocumentReference.cpp
+++ b/Source/WebCore/loader/cache/CachedSVGDocumentReference.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012 Google Inc. All rights reserved.
+ * Copyright (C) 2013-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -52,7 +53,7 @@ void CachedSVGDocumentReference::load(CachedResourceLoader& loader, const Resour
 
     auto fetchOptions = options;
     fetchOptions.mode = FetchOptions::Mode::SameOrigin;
-    CachedResourceRequest request(ResourceRequest(m_location.resolved), fetchOptions);
+    CachedResourceRequest request(ResourceRequest(URL { m_location.resolved }), fetchOptions);
     request.setInitiatorType(cachedResourceRequestInitiatorTypes().css);
     m_document = loader.requestSVGDocument(WTFMove(request)).value_or(nullptr);
     if (CachedResourceHandle document = m_document)

--- a/Source/WebCore/loader/cocoa/BundleResourceLoader.mm
+++ b/Source/WebCore/loader/cocoa/BundleResourceLoader.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -65,7 +65,7 @@ void loadResourceFromBundle(ResourceLoader& loader, const String& subdirectory)
 
         RunLoop::protectedMain()->dispatch([protectedLoader = WTFMove(protectedLoader), url = WTFMove(url).isolatedCopy(), buffer = SharedBuffer::create(data)]() mutable {
             auto mimeType = MIMETypeRegistry::mimeTypeForPath(url.path());
-            ResourceResponse response { url, mimeType, static_cast<long long>(buffer->size()), MIMETypeRegistry::isTextMIMEType(mimeType) ? "UTF-8"_s : String() };
+            ResourceResponse response { WTFMove(url), WTFMove(mimeType), static_cast<long long>(buffer->size()), MIMETypeRegistry::isTextMIMEType(mimeType) ? "UTF-8"_s : String() };
             response.setHTTPStatusCode(200);
             response.setHTTPStatusText("OK"_s);
             response.setSource(ResourceResponse::Source::Network);

--- a/Source/WebCore/loader/icon/IconLoader.cpp
+++ b/Source/WebCore/loader/icon/IconLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2017 Apple Inc.  All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -64,7 +64,7 @@ void IconLoader::startLoading()
     if (!frame)
         return;
 
-    ResourceRequest resourceRequest = m_url;
+    ResourceRequest resourceRequest = URL { m_url };
     resourceRequest.setPriority(ResourceLoadPriority::Low);
 #if !ERROR_DISABLED
     // Copy this because we may want to access it after transferring the

--- a/Source/WebCore/loader/soup/ResourceLoaderSoup.cpp
+++ b/Source/WebCore/loader/soup/ResourceLoaderSoup.cpp
@@ -65,7 +65,7 @@ void ResourceLoader::loadGResource()
         GUniquePtr<char> fileName(g_path_get_basename(url.path().utf8().data()));
         GUniquePtr<char> contentType(g_content_type_guess(fileName.get(), data, dataSize, nullptr));
         auto contentTypeString = String::fromLatin1(contentType.get());
-        ResourceResponse response { url, extractMIMETypeFromMediaType(contentTypeString), static_cast<long long>(dataSize), extractCharsetFromMediaType(contentTypeString).toString() };
+        ResourceResponse response { WTFMove(url), extractMIMETypeFromMediaType(contentTypeString), static_cast<long long>(dataSize), extractCharsetFromMediaType(contentTypeString).toString() };
         response.setHTTPStatusCode(200);
         response.setHTTPStatusText("OK"_s);
         response.setHTTPHeaderField(HTTPHeaderName::ContentType, contentTypeString);

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2010 Igalia S.L
  *
  * Redistribution and use in source and binary forms, with or without
@@ -267,7 +267,7 @@ static void openNewWindow(const URL& urlToLoad, LocalFrame& frame, Event* event,
     if (!oldPage)
         return;
 
-    FrameLoadRequest frameLoadRequest { frame.protectedDocument().releaseNonNull(), frame.document()->protectedSecurityOrigin(), ResourceRequest(urlToLoad, frame.loader().outgoingReferrer()), { }, InitiatedByMainFrame::Unknown };
+    FrameLoadRequest frameLoadRequest { frame.protectedDocument().releaseNonNull(), frame.document()->protectedSecurityOrigin(), ResourceRequest(URL { urlToLoad }, frame.loader().outgoingReferrer()), { }, InitiatedByMainFrame::Unknown };
     frameLoadRequest.setShouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy);
     frameLoadRequest.setNewFrameOpenerPolicy(NewFrameOpenerPolicy::Suppress);
 
@@ -1081,8 +1081,9 @@ void ContextMenuController::populate()
     if (!m_context.hitTestResult().isContentEditable()) {
         Ref loader = frame->loader();
         URL linkURL = m_context.hitTestResult().absoluteLinkURL();
-        if (!linkURL.isEmpty()) {
-            if (loader->client().canHandleRequest(ResourceRequest(linkURL))) {
+        const bool linkURLEmpty = linkURL.isEmpty();
+        if (!linkURLEmpty) {
+            if (loader->client().canHandleRequest(ResourceRequest(WTFMove(linkURL)))) {
                 appendItem(OpenLinkItem, m_contextMenu.get());
                 appendItem(OpenLinkInNewWindowItem, m_contextMenu.get());
                 appendItem(DownloadFileItem, m_contextMenu.get());
@@ -1092,7 +1093,7 @@ void ContextMenuController::populate()
 
         URL imageURL = m_context.hitTestResult().absoluteImageURL();
         if (!imageURL.isEmpty()) {
-            if (!linkURL.isEmpty())
+            if (!linkURLEmpty)
                 appendItem(*separatorItem(), m_contextMenu.get());
 
             appendItem(OpenImageInNewWindowItem, m_contextMenu.get());
@@ -1131,8 +1132,9 @@ void ContextMenuController::populate()
         }
 
         URL mediaURL = m_context.hitTestResult().absoluteMediaURL();
-        if (!mediaURL.isEmpty()) {
-            if (!linkURL.isEmpty() || !imageURL.isEmpty())
+        const bool mediaURLEmpty = mediaURL.isEmpty();
+        if (!mediaURLEmpty) {
+            if (!linkURLEmpty || !imageURL.isEmpty())
                 appendItem(*separatorItem(), m_contextMenu.get());
 
             appendItem(MediaPlayPause, m_contextMenu.get());
@@ -1149,7 +1151,7 @@ void ContextMenuController::populate()
             appendItem(ToggleVideoEnhancedFullscreen, m_contextMenu.get());
             appendItem(ToggleVideoViewer, m_contextMenu.get());
 #endif
-            if (m_context.hitTestResult().isDownloadableMedia() && loader->client().canHandleRequest(ResourceRequest(mediaURL))) {
+            if (m_context.hitTestResult().isDownloadableMedia() && loader->client().canHandleRequest(ResourceRequest(WTFMove(mediaURL)))) {
                 appendItem(*separatorItem(), m_contextMenu.get());
                 appendItem(CopyMediaLinkItem, m_contextMenu.get());
                 appendItem(OpenMediaInNewWindowItem, m_contextMenu.get());
@@ -1159,7 +1161,7 @@ void ContextMenuController::populate()
 
         auto selectedRange = frame->selection().selection().range();
         bool selectionIsInsideImageOverlay = selectedRange && ImageOverlay::isInsideOverlay(*selectedRange);
-        if (selectionIsInsideImageOverlay || (linkURL.isEmpty() && mediaURL.isEmpty() && imageURL.isEmpty())) {
+        if (selectionIsInsideImageOverlay || (linkURLEmpty && mediaURLEmpty && imageURL.isEmpty())) {
             if (!imageURL.isEmpty())
                 appendItem(*separatorItem(), m_contextMenu.get());
             
@@ -1320,7 +1322,7 @@ void ContextMenuController::populate()
         Ref loader = frame->loader();
         URL linkURL = m_context.hitTestResult().absoluteLinkURL();
         if (!linkURL.isEmpty()) {
-            if (loader->client().canHandleRequest(ResourceRequest(linkURL))) {
+            if (loader->client().canHandleRequest(ResourceRequest(WTFMove(linkURL)))) {
                 appendItem(OpenLinkItem, m_contextMenu.get());
                 appendItem(OpenLinkInNewWindowItem, m_contextMenu.get());
                 appendItem(DownloadFileItem, m_contextMenu.get());

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2009, 2012 Ericsson AB. All rights reserved.
- * Copyright (C) 2010, 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2011, Code Aurora Forum. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -95,7 +95,7 @@ void EventSource::connect()
     ASSERT(m_state == CONNECTING);
     ASSERT(!m_requestInFlight);
 
-    ResourceRequest request { m_url };
+    ResourceRequest request { URL { m_url } };
     request.setRequester(ResourceRequestRequester::EventSource);
     request.setHTTPMethod("GET"_s);
     request.setHTTPHeaderField(HTTPHeaderName::Accept, "text/event-stream"_s);

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies)
  *
  * Redistribution and use in source and binary forms, with or without
@@ -2594,7 +2594,7 @@ ExceptionOr<RefPtr<Frame>> LocalDOMWindow::createWindow(const String& urlString,
     String referrer = windowFeatures.wantsNoReferrer() ? String() : SecurityPolicy::generateReferrerHeader(firstFrame.document()->referrerPolicy(), completedURL, firstFrame.loader().outgoingReferrerURL(), OriginAccessPatternsForWebProcess::singleton());
     auto initiatedByMainFrame = activeFrame->isMainFrame() ? InitiatedByMainFrame::Yes : InitiatedByMainFrame::Unknown;
 
-    ResourceRequest resourceRequest { completedURL, referrer };
+    ResourceRequest resourceRequest { URL { completedURL }, referrer };
     RefPtr openerDocumentLoader = openerFrame.document() ? openerFrame.document()->loader() : nullptr;
     if (openerDocumentLoader)
         resourceRequest.setIsAppInitiated(openerDocumentLoader->lastNavigationWasAppInitiated());
@@ -2638,7 +2638,7 @@ ExceptionOr<RefPtr<Frame>> LocalDOMWindow::createWindow(const String& urlString,
         prepareDialogFunction(*localNewFrame->document()->protectedWindow());
 
     if (created == CreatedNewPage::Yes) {
-        ResourceRequest resourceRequest { completedURL, referrer, ResourceRequestCachePolicy::UseProtocolCachePolicy };
+        ResourceRequest resourceRequest { WTFMove(completedURL), referrer, ResourceRequestCachePolicy::UseProtocolCachePolicy };
         FrameLoader::addSameSiteInfoToRequestIfNeeded(resourceRequest, openerDocument.get());
         FrameLoadRequest frameLoadRequest { activeWindow.protectedDocument().releaseNonNull(), activeWindow.document()->protectedSecurityOrigin(), WTFMove(resourceRequest), selfTargetFrameName(), initiatedByMainFrame };
         frameLoadRequest.setShouldOpenExternalURLsPolicy(activeDocument->shouldOpenExternalURLsPolicyToPropagate());

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2023 Igalia S.L. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -402,7 +403,7 @@ Navigation::Result Navigation::reload(ReloadOptions&& options, Ref<DeferredPromi
     auto initiatedByMainFrame = lexicalFrame && lexicalFrame->isMainFrame() ? InitiatedByMainFrame::Yes : InitiatedByMainFrame::Unknown;
     RefPtr frame = this->frame();
     RefPtr document = frame->document();
-    ResourceRequest resourceRequest { document->url(), frame->protectedLoader()->outgoingReferrer(), ResourceRequestCachePolicy::ReloadIgnoringCacheData };
+    ResourceRequest resourceRequest { URL { document->url() }, frame->protectedLoader()->outgoingReferrer(), ResourceRequestCachePolicy::ReloadIgnoringCacheData };
     FrameLoadRequest frameLoadRequest { *document, document->securityOrigin(), WTFMove(resourceRequest), selfTargetFrameName(), initiatedByMainFrame };
     frameLoadRequest.setLockHistory(LockHistory::Yes);
     frameLoadRequest.setLockBackForwardList(LockBackForwardList::Yes);
@@ -438,7 +439,7 @@ Navigation::Result Navigation::navigate(const String& url, NavigateOptions&& opt
 
     RefPtr apiMethodTracker = maybeSetUpcomingNonTraversalTracker(WTFMove(committed), WTFMove(finished), WTFMove(options.info), serializedState.releaseReturnValue());
 
-    auto request = FrameLoadRequest(*frame(), newURL);
+    auto request = FrameLoadRequest(*frame(), WTFMove(newURL));
     request.setNavigationHistoryBehavior(options.history);
     request.setIsFromNavigationAPI(true);
     frame()->loader().loadFrameRequest(WTFMove(request), nullptr, { });

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Google, Inc. All rights reserved.
- * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1163,7 +1163,7 @@ void ContentSecurityPolicy::upgradeInsecureRequestIfNeeded(ResourceRequest& requ
 {
     URL url = request.url();
     upgradeInsecureRequestIfNeeded(url, requestType, alwaysUpgradeRequest);
-    request.setURL(url);
+    request.setURL(WTFMove(url));
 }
 
 void ContentSecurityPolicy::upgradeInsecureRequestIfNeeded(URL& url, InsecureRequestType requestType, AlwaysUpgradeRequest alwaysUpgradeRequest) const

--- a/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.mm
+++ b/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -111,7 +111,7 @@ void NetworkExtensionContentFilter::willSendRequest(ResourceRequest& request, co
         return;
     }
 
-    request.setURL(modifiedRequestURL);
+    request.setURL(WTFMove(modifiedRequestURL));
 }
 
 void NetworkExtensionContentFilter::responseReceived(const ResourceResponse& response)

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -249,7 +249,7 @@ bool MediaPlayerPrivateWebM::createResourceClient()
     if (!player)
         return false;
 
-    ResourceRequest request(m_assetURL);
+    ResourceRequest request(URL { m_assetURL });
     request.setAllowCookies(true);
     if (m_contentReceived) {
         if (m_contentLength <= m_contentReceived)

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -618,7 +618,7 @@ static void webKitWebSrcMakeRequest(WebKitWebSrc* src, DataMutexLocker<WebKitWeb
     GST_DEBUG_OBJECT(src, "Posting task to request R%u %s requestedPosition=%" G_GUINT64_FORMAT " stopPosition=%" G_GUINT64_FORMAT, members->requestNumber, priv->originalURI.data(), members->requestedPosition, members->stopPosition);
     URL url { String::fromLatin1(priv->originalURI.data()) };
 
-    ResourceRequest request(url);
+    ResourceRequest request(WTFMove(url));
     request.setAllowCookies(true);
     request.setHTTPReferrer(members->referrer);
 

--- a/Source/WebCore/platform/network/BlobResourceHandle.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandle.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -570,7 +571,7 @@ void BlobResourceHandle::notifyResponseOnSuccess()
 {
     ASSERT(isMainThread());
 
-    ResourceResponse response(firstRequest().url(), extractMIMETypeFromMediaType(m_blobData->contentType()), m_totalRemainingSize, String());
+    ResourceResponse response(URL { firstRequest().url() }, extractMIMETypeFromMediaType(m_blobData->contentType()), m_totalRemainingSize, String());
     response.setHTTPStatusCode(m_isRangeRequest ? httpPartialContent : httpOK);
     response.setHTTPStatusText(m_isRangeRequest ? httpPartialContentText : httpOKText);
 

--- a/Source/WebCore/platform/network/ResourceRequestBase.cpp
+++ b/Source/WebCore/platform/network/ResourceRequestBase.cpp
@@ -138,16 +138,6 @@ void ResourceRequestBase::setURL(URL&& url, bool didFilterLinkDecoration)
     m_platformRequestUpdated = false;
 }
 
-void ResourceRequestBase::setURL(const URL& url, bool didFilterLinkDecoration)
-{ 
-    updateResourceRequest(); 
-
-    m_requestData.m_url = url;
-    m_requestData.m_didFilterLinkDecoration = didFilterLinkDecoration;
-    
-    m_platformRequestUpdated = false;
-}
-
 static bool shouldUseGet(const ResourceRequestBase& request, const ResourceResponse& redirectResponse)
 {
     if (equalLettersIgnoringASCIICase(request.httpMethod(), "get"_s) || equalLettersIgnoringASCIICase(request.httpMethod(), "head"_s))

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -68,7 +68,7 @@ public:
     struct RequestData {
         RequestData() { }
 
-        RequestData(URL&& url, URL&& firstPartyForCookies, double timeoutInterval, String&& httpMethod, HTTPHeaderMap&& httpHeaderFields, Vector<String>&& responseContentDispositionEncodingFallbackArray, const ResourceRequestCachePolicy& cachePolicy, const SameSiteDisposition& sameSiteDisposition, const ResourceLoadPriority& priority, const ResourceRequestRequester& requester, bool allowCookies, bool isTopSite, bool isAppInitiated = true, bool privacyProxyFailClosedForUnreachableNonMainHosts = false, bool useAdvancedPrivacyProtections = false, bool didFilterLinkDecoration = false, bool isPrivateTokenUsageByThirdPartyAllowed = false, bool wasSchemeOptimisticallyUpgraded = false)
+        RequestData(URL&& url, URL&& firstPartyForCookies, double timeoutInterval, String&& httpMethod, HTTPHeaderMap&& httpHeaderFields, Vector<String>&& responseContentDispositionEncodingFallbackArray, ResourceRequestCachePolicy cachePolicy, SameSiteDisposition sameSiteDisposition, ResourceLoadPriority priority, ResourceRequestRequester requester, bool allowCookies, bool isTopSite, bool isAppInitiated = true, bool privacyProxyFailClosedForUnreachableNonMainHosts = false, bool useAdvancedPrivacyProtections = false, bool didFilterLinkDecoration = false, bool isPrivateTokenUsageByThirdPartyAllowed = false, bool wasSchemeOptimisticallyUpgraded = false)
             : m_url(WTFMove(url))
             , m_firstPartyForCookies(WTFMove(firstPartyForCookies))
             , m_timeoutInterval(timeoutInterval)
@@ -90,40 +90,12 @@ public:
         {
         }
 
-        RequestData(const URL& url, const URL& firstPartyForCookies, double timeoutInterval, const String& httpMethod, const HTTPHeaderMap& httpHeaderFields, const Vector<String>& responseContentDispositionEncodingFallbackArray, const ResourceRequestCachePolicy& cachePolicy, const SameSiteDisposition& sameSiteDisposition, const ResourceLoadPriority& priority, const ResourceRequestRequester& requester, bool allowCookies, bool isTopSite, bool isAppInitiated = true, bool privacyProxyFailClosedForUnreachableNonMainHosts = false, bool useAdvancedPrivacyProtections = false, bool didFilterLinkDecoration = false, bool isPrivateTokenUsageByThirdPartyAllowed = false, bool wasSchemeOptimisticallyUpgraded = false)
-            : m_url(url)
-            , m_firstPartyForCookies(firstPartyForCookies)
-            , m_timeoutInterval(timeoutInterval)
-            , m_httpMethod(httpMethod)
-            , m_httpHeaderFields(httpHeaderFields)
-            , m_responseContentDispositionEncodingFallbackArray(responseContentDispositionEncodingFallbackArray)
-            , m_cachePolicy(cachePolicy)
-            , m_sameSiteDisposition(sameSiteDisposition)
-            , m_priority(priority)
-            , m_requester(requester)
-            , m_isTopSite(isTopSite)
-            , m_allowCookies(allowCookies)
-            , m_isAppInitiated(isAppInitiated)
-            , m_privacyProxyFailClosedForUnreachableNonMainHosts(privacyProxyFailClosedForUnreachableNonMainHosts)
-            , m_useAdvancedPrivacyProtections(useAdvancedPrivacyProtections)
-            , m_didFilterLinkDecoration(didFilterLinkDecoration)
-            , m_isPrivateTokenUsageByThirdPartyAllowed(isPrivateTokenUsageByThirdPartyAllowed)
-            , m_wasSchemeOptimisticallyUpgraded(wasSchemeOptimisticallyUpgraded)
-        {
-        }
-        
         RequestData(URL&& url, ResourceRequestCachePolicy cachePolicy)
             : m_url(WTFMove(url))
             , m_cachePolicy(cachePolicy)
         {
         }
 
-        RequestData(const URL& url, ResourceRequestCachePolicy cachePolicy)
-            : m_url(url)
-            , m_cachePolicy(cachePolicy)
-        {
-        }
-        
         URL m_url;
         URL m_firstPartyForCookies;
         double m_timeoutInterval { s_defaultTimeoutInterval }; // 0 is a magic value for platform default on platforms that have one.
@@ -162,7 +134,6 @@ public:
     
     WEBCORE_EXPORT const URL& url() const;
     WEBCORE_EXPORT void setURL(URL&&, bool didFilterLinkDecoration = false);
-    WEBCORE_EXPORT void setURL(const URL&, bool didFilterLinkDecoration = false);
 
     void redirectAsGETIfNeeded(const ResourceRequestBase &, const ResourceResponse&);
 
@@ -329,17 +300,6 @@ protected:
 
     ResourceRequestBase(URL&& url, ResourceRequestCachePolicy policy)
         : m_requestData({ WTFMove(url), policy })
-        , m_resourceRequestUpdated(true)
-        , m_platformRequestUpdated(false)
-        , m_resourceRequestBodyUpdated(true)
-        , m_platformRequestBodyUpdated(false)
-        , m_hiddenFromInspector(false)
-    {
-        m_requestData.m_allowCookies = true;
-    }
-
-    ResourceRequestBase(const URL& url, ResourceRequestCachePolicy policy)
-        : m_requestData({ url, policy })
         , m_resourceRequestUpdated(true)
         , m_platformRequestUpdated(false)
         , m_resourceRequestBodyUpdated(true)

--- a/Source/WebCore/platform/network/ResourceResponseBase.cpp
+++ b/Source/WebCore/platform/network/ResourceResponseBase.cpp
@@ -70,26 +70,6 @@ ResourceResponseBase::ResourceResponseBase(URL&& url, String&& mimeType, long lo
 {
 }
 
-ResourceResponseBase::ResourceResponseBase(URL&& url, String&& mimeType, long long expectedLength, const String& textEncodingName)
-    : m_url(WTFMove(url))
-    , m_mimeType(WTFMove(mimeType))
-    , m_expectedContentLength(expectedLength)
-    , m_textEncodingName(textEncodingName)
-    , m_certificateInfo(CertificateInfo()) // Empty but valid for synthetic responses.
-    , m_isNull(false)
-{
-}
-
-ResourceResponseBase::ResourceResponseBase(const URL& url, const String& mimeType, long long expectedLength, const String& textEncodingName)
-    : m_url(url)
-    , m_mimeType(mimeType)
-    , m_expectedContentLength(expectedLength)
-    , m_textEncodingName(textEncodingName)
-    , m_certificateInfo(CertificateInfo()) // Empty but valid for synthetic responses.
-    , m_isNull(false)
-{
-}
-
 ResourceResponseBase::ResourceResponseBase(std::optional<ResourceResponseData>&& data)
     : m_url(data ? WTFMove(data->url) : URL { })
     , m_mimeType(data ? WTFMove(data->mimeType) : AtomString { })
@@ -201,7 +181,7 @@ ResourceResponse ResourceResponseBase::fromCrossThreadData(CrossThreadData&& dat
 ResourceResponse ResourceResponseBase::syntheticRedirectResponse(const URL& fromURL, const URL& toURL)
 {
     ResourceResponse redirectResponse;
-    redirectResponse.setURL(fromURL);
+    redirectResponse.setURL(URL { fromURL });
     redirectResponse.setHTTPStatusCode(302);
     redirectResponse.setHTTPVersion("HTTP/1.1"_s);
     redirectResponse.setHTTPHeaderField(HTTPHeaderName::Location, toURL.string());
@@ -212,7 +192,7 @@ ResourceResponse ResourceResponseBase::syntheticRedirectResponse(const URL& from
 
 ResourceResponse ResourceResponseBase::dataURLResponse(const URL& url, const DataURLDecoder::Result& result)
 {
-    ResourceResponse dataResponse { url, result.mimeType, static_cast<long long>(result.data.size()), result.charset };
+    ResourceResponse dataResponse { URL { url }, String { result.mimeType }, static_cast<long long>(result.data.size()), String { result.charset } };
     dataResponse.setHTTPStatusCode(200);
     dataResponse.setHTTPStatusText("OK"_s);
     dataResponse.setHTTPHeaderField(HTTPHeaderName::ContentType, result.contentType);
@@ -234,7 +214,7 @@ ResourceResponse ResourceResponseBase::filter(const ResourceResponse& response, 
         ResourceResponse opaqueResponse;
         opaqueResponse.setTainting(Tainting::Opaqueredirect);
         opaqueResponse.setType(Type::Opaqueredirect);
-        opaqueResponse.setURL(response.url());
+        opaqueResponse.setURL(URL { response.url() });
         return opaqueResponse;
     }
 
@@ -287,16 +267,6 @@ void ResourceResponseBase::setURL(URL&& url)
     m_isNull = false;
 
     m_url = WTFMove(url);
-
-    // FIXME: Should invalidate or update platform response if present.
-}
-
-void ResourceResponseBase::setURL(const URL& url)
-{
-    lazyInit(CommonFieldsOnly);
-    m_isNull = false;
-
-    m_url = url;
 
     // FIXME: Should invalidate or update platform response if present.
 }

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -88,7 +88,6 @@ public:
 
     WEBCORE_EXPORT const URL& url() const;
     WEBCORE_EXPORT void setURL(URL&&);
-    WEBCORE_EXPORT void setURL(const URL&);
 
     WEBCORE_EXPORT const String& mimeType() const;
     WEBCORE_EXPORT void setMimeType(String&&);
@@ -234,8 +233,6 @@ protected:
 
     WEBCORE_EXPORT ResourceResponseBase();
     WEBCORE_EXPORT ResourceResponseBase(URL&&, String&& mimeType, long long expectedLength, String&& textEncodingName);
-    WEBCORE_EXPORT ResourceResponseBase(URL&&, String&& mimeType, long long expectedLength, const String& textEncodingName);
-    WEBCORE_EXPORT ResourceResponseBase(const URL&, const String& mimeType, long long expectedLength, const String& textEncodingName);
 
     WEBCORE_EXPORT void lazyInit(InitLevel) const;
 

--- a/Source/WebCore/platform/network/cf/ResourceRequest.h
+++ b/Source/WebCore/platform/network/cf/ResourceRequest.h
@@ -59,18 +59,8 @@ public:
     {
     }
 
-    explicit ResourceRequest(const String& url)
-        : ResourceRequestBase(URL({ }, url), ResourceRequestCachePolicy::UseProtocolCachePolicy)
-    {
-    }
-
     ResourceRequest(URL&& url)
         : ResourceRequestBase(WTFMove(url), ResourceRequestCachePolicy::UseProtocolCachePolicy)
-    {
-    }
-
-    ResourceRequest(const URL& url)
-        : ResourceRequestBase(url, ResourceRequestCachePolicy::UseProtocolCachePolicy)
     {
     }
 
@@ -80,12 +70,6 @@ public:
         setHTTPReferrer(referrer);
     }
 
-    ResourceRequest(const URL& url, const String& referrer, ResourceRequestCachePolicy policy = ResourceRequestCachePolicy::UseProtocolCachePolicy)
-        : ResourceRequestBase(url, policy)
-    {
-        setHTTPReferrer(referrer);
-    }
-    
     ResourceRequest()
         : ResourceRequestBase(URL(), ResourceRequestCachePolicy::UseProtocolCachePolicy)
     {
@@ -93,13 +77,10 @@ public:
     
     WEBCORE_EXPORT ResourceRequest(NSURLRequest *);
 
-    ResourceRequest(ResourceRequestBase&& base
-        , const String& cachePartition
-        , bool hiddenFromInspector
-    )
+    ResourceRequest(ResourceRequestBase&& base, String&& cachePartition, bool hiddenFromInspector)
         : ResourceRequestBase(WTFMove(base))
     {
-        m_cachePartition = cachePartition;
+        m_cachePartition = WTFMove(cachePartition);
         m_hiddenFromInspector = hiddenFromInspector;
     }
 

--- a/Source/WebCore/platform/network/cf/ResourceResponse.h
+++ b/Source/WebCore/platform/network/cf/ResourceResponse.h
@@ -60,12 +60,6 @@ public:
         m_initLevel = AllFields;
     }
 
-    ResourceResponse(const URL& url, const String& mimeType, long long expectedLength, const String& textEncodingName)
-        : ResourceResponseBase(url, mimeType, expectedLength, textEncodingName)
-    {
-        m_initLevel = AllFields;
-    }
-
     WEBCORE_EXPORT void disableLazyInitialization();
 
     unsigned memoryUsage() const

--- a/Source/WebCore/platform/network/curl/ResourceRequest.h
+++ b/Source/WebCore/platform/network/curl/ResourceRequest.h
@@ -38,29 +38,13 @@ public:
     {
     }
 
-    explicit ResourceRequest(const String& url)
-        : ResourceRequestBase(URL({ }, url), ResourceRequestCachePolicy::UseProtocolCachePolicy)
-    {
-    }
-
     ResourceRequest(URL&& url)
         : ResourceRequestBase(WTFMove(url), ResourceRequestCachePolicy::UseProtocolCachePolicy)
     {
     }
 
-    ResourceRequest(const URL& url)
-        : ResourceRequestBase(url, ResourceRequestCachePolicy::UseProtocolCachePolicy)
-    {
-    }
-
     ResourceRequest(URL&& url, const String& referrer, ResourceRequestCachePolicy policy = ResourceRequestCachePolicy::UseProtocolCachePolicy)
         : ResourceRequestBase(WTFMove(url), policy)
-    {
-        setHTTPReferrer(referrer);
-    }
-
-    ResourceRequest(const URL& url, const String& referrer, ResourceRequestCachePolicy policy = ResourceRequestCachePolicy::UseProtocolCachePolicy)
-        : ResourceRequestBase(url, policy)
     {
         setHTTPReferrer(referrer);
     }

--- a/Source/WebCore/platform/network/curl/ResourceResponse.h
+++ b/Source/WebCore/platform/network/curl/ResourceResponse.h
@@ -44,11 +44,6 @@ public:
     {
     }
 
-    ResourceResponse(const URL& url, const String& mimeType, long long expectedLength, const String& textEncodingName)
-        : ResourceResponseBase(url, mimeType, expectedLength, textEncodingName)
-    {
-    }
-
     ResourceResponse(ResourceResponseBase&& base)
         : ResourceResponseBase(WTFMove(base))
     {

--- a/Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp
+++ b/Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp
@@ -81,7 +81,7 @@ static bool isAppendableHeader(const String &key)
 ResourceResponse::ResourceResponse(CurlResponse& response)
     : ResourceResponseBase()
 {
-    setURL(response.url);
+    setURL(URL { response.url });
     setExpectedContentLength(response.expectedContentLength);
     setHTTPStatusCode(response.statusCode ? response.statusCode : response.httpConnectCode);
 

--- a/Source/WebCore/platform/network/mac/ResourceHandleMac.mm
+++ b/Source/WebCore/platform/network/mac/ResourceHandleMac.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -141,7 +141,7 @@ void ResourceHandle::createNSURLConnection(id delegate, bool shouldUseCredential
         URL urlWithCredentials(firstRequest().url());
         urlWithCredentials.setUser(d->m_user);
         urlWithCredentials.setPassword(d->m_password);
-        firstRequest().setURL(urlWithCredentials);
+        firstRequest().setURL(WTFMove(urlWithCredentials));
     }
 
     if (shouldUseCredentialStorage && firstRequest().url().protocolIsInHTTPFamily()) {

--- a/Source/WebCore/platform/network/soup/ResourceRequest.h
+++ b/Source/WebCore/platform/network/soup/ResourceRequest.h
@@ -49,29 +49,13 @@ public:
     {
     }
 
-    explicit ResourceRequest(const String& url)
-        : ResourceRequestBase(URL({ }, url), ResourceRequestCachePolicy::UseProtocolCachePolicy)
-    {
-    }
-
     ResourceRequest(URL&& url)
         : ResourceRequestBase(WTFMove(url), ResourceRequestCachePolicy::UseProtocolCachePolicy)
     {
     }
 
-    ResourceRequest(const URL& url)
-        : ResourceRequestBase(url, ResourceRequestCachePolicy::UseProtocolCachePolicy)
-    {
-    }
-
     ResourceRequest(URL&& url, const String& referrer, ResourceRequestCachePolicy policy = ResourceRequestCachePolicy::UseProtocolCachePolicy)
         : ResourceRequestBase(WTFMove(url), policy)
-    {
-        setHTTPReferrer(referrer);
-    }
-
-    ResourceRequest(const URL& url, const String& referrer, ResourceRequestCachePolicy policy = ResourceRequestCachePolicy::UseProtocolCachePolicy)
-        : ResourceRequestBase(url, policy)
     {
         setHTTPReferrer(referrer);
     }

--- a/Source/WebCore/platform/network/soup/ResourceResponse.h
+++ b/Source/WebCore/platform/network/soup/ResourceResponse.h
@@ -42,11 +42,6 @@ public:
     {
     }
 
-    ResourceResponse(const URL& url, const String& mimeType, long long expectedLength, const String& textEncodingName)
-        : ResourceResponseBase(url, mimeType, expectedLength, textEncodingName)
-    {
-    }
-
     ResourceResponse(ResourceResponseBase&& base)
         : ResourceResponseBase(WTFMove(base))
     {

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -5,7 +5,7 @@
  * Copyright (C) 2011 Torch Mobile (Beijing) Co. Ltd. All rights reserved.
  * Copyright (C) 2012 University of Szeged
  * Copyright (C) 2012 Renata Hodovan <reni@webkit.org>
- * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2019 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -641,7 +641,7 @@ void SVGUseElement::updateExternalDocument()
         options.mode = FetchOptions::Mode::SameOrigin;
         options.destination = FetchOptions::Destination::Image;
         options.sniffContent = ContentSniffingPolicy::DoNotSniffContent;
-        CachedResourceRequest request { ResourceRequest { externalDocumentURL }, options };
+        CachedResourceRequest request { ResourceRequest { WTFMove(externalDocumentURL) }, options };
         request.setInitiator(*this);
         m_externalDocument = document->protectedCachedResourceLoader()->requestSVGDocument(WTFMove(request)).value_or(nullptr);
         if (CachedResourceHandle externalDocument = m_externalDocument)

--- a/Source/WebCore/testing/MockContentFilter.cpp
+++ b/Source/WebCore/testing/MockContentFilter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -91,7 +91,7 @@ void MockContentFilter::willSendRequest(ResourceRequest& request, const Resource
         return;
     }
 
-    request.setURL(modifiedRequestURL);
+    request.setURL(WTFMove(modifiedRequestURL));
 }
 
 void MockContentFilter::responseReceived(const ResourceResponse&)

--- a/Source/WebCore/workers/WorkerFontLoadRequest.cpp
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2009 Torch Mobile, Inc.
  * Copyright (C) 2021 Metrological Group B.V.
  * Copyright (C) 2021 Igalia S.L.
@@ -53,7 +53,7 @@ void WorkerFontLoadRequest::load(WorkerGlobalScope& workerGlobalScope)
 {
     m_context = workerGlobalScope;
 
-    ResourceRequest request { m_url };
+    ResourceRequest request { URL { m_url } };
     ASSERT(request.httpMethod() == "GET"_s);
 
     FetchOptions fetchOptions;

--- a/Source/WebCore/workers/WorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/WorkerScriptLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2009-2025 Apple Inc. All Rights Reserved.
  * Copyright (C) 2009, 2011 Google Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -191,7 +191,7 @@ const URL& WorkerScriptLoader::responseURL() const
 
 std::unique_ptr<ResourceRequest> WorkerScriptLoader::createResourceRequest(const String& initiatorIdentifier)
 {
-    auto request = makeUnique<ResourceRequest>(m_url);
+    auto request = makeUnique<ResourceRequest>(URL { m_url });
     request->setHTTPMethod("GET"_s);
     request->setInitiatorIdentifier(initiatorIdentifier);
     return request;

--- a/Source/WebCore/workers/service/ServiceWorkerJob.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerJob.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -99,7 +99,7 @@ void ServiceWorkerJob::startScriptFetch(FetchOptions::Cache cachePolicy)
 
 static ResourceRequest scriptResourceRequest(ScriptExecutionContext& context, const URL& url)
 {
-    ResourceRequest request { url };
+    ResourceRequest request { URL { url } };
     request.setInitiatorIdentifier(context.resourceRequestIdentifier());
     return request;
 }

--- a/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -106,7 +106,7 @@ static void processResponse(Ref<Client>&& client, Expected<Ref<FetchResponse>, s
 
     // As per https://fetch.spec.whatwg.org/#main-fetch step 9, copy request's url list in response's url list if empty.
     if (resourceResponse.url().isNull())
-        resourceResponse.setURL(requestURL);
+        resourceResponse.setURL(URL { requestURL });
 
     if (resourceResponse.isRedirection() && resourceResponse.httpHeaderFields().contains(HTTPHeaderName::Location)) {
         client->didReceiveRedirection(resourceResponse);

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -578,7 +578,7 @@ URL static inline originURL(const SecurityOrigin& origin)
 
 ResourceRequest SWServer::createScriptRequest(const URL& url, const ServiceWorkerJobData& jobData, SWServerRegistration& registration)
 {
-    ResourceRequest request { url };
+    ResourceRequest request { URL { url } };
 
     auto topOrigin = jobData.topOrigin.securityOrigin();
     auto origin = SecurityOrigin::create(jobData.scriptURL);

--- a/Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -53,7 +53,7 @@ void SharedWorkerScriptLoader::load(CompletionHandler<void(WorkerFetchResult&&, 
     m_completionHandler = WTFMove(completionHandler);
 
     auto source = m_options.type == WorkerType::Module ? WorkerScriptLoader::Source::ModuleScript : WorkerScriptLoader::Source::ClassicWorkerScript;
-    m_loader->loadAsynchronously(*m_worker->scriptExecutionContext(), ResourceRequest(m_url), source, m_worker->workerFetchOptions(m_options, FetchOptions::Destination::Sharedworker), ContentSecurityPolicyEnforcement::EnforceWorkerSrcDirective, ServiceWorkersMode::All, *this, WorkerRunLoop::defaultMode(), ScriptExecutionContextIdentifier::generate());
+    m_loader->loadAsynchronously(*m_worker->scriptExecutionContext(), ResourceRequest(URL { m_url }), source, m_worker->workerFetchOptions(m_options, FetchOptions::Destination::Sharedworker), ContentSecurityPolicyEnforcement::EnforceWorkerSrcDirective, ServiceWorkersMode::All, *this, WorkerRunLoop::defaultMode(), ScriptExecutionContextIdentifier::generate());
 }
 
 void SharedWorkerScriptLoader::didReceiveResponse(ScriptExecutionContextIdentifier mainContextIdentifier, std::optional<ResourceLoaderIdentifier> identifier, const ResourceResponse&)

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2004-2016 Apple Inc. All rights reserved.
+ *  Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  *  Copyright (C) 2005-2007 Alexey Proskuryakov <ap@webkit.org>
  *  Copyright (C) 2007, 2008 Julien Chaffraix <jchaffraix@webkit.org>
  *  Copyright (C) 2008, 2011 Google Inc. All rights reserved.
@@ -601,7 +601,7 @@ ExceptionOr<void> XMLHttpRequest::createRequest()
     if (m_async && m_upload && m_upload->hasEventListeners())
         m_uploadListenerFlag = true;
 
-    ResourceRequest request(m_url);
+    ResourceRequest request(URL { m_url });
     request.setRequester(ResourceRequestRequester::XHR);
     request.setInitiatorIdentifier(scriptExecutionContext()->resourceRequestIdentifier());
     request.setHTTPMethod(m_method);

--- a/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
+++ b/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the XSL implementation.
  *
- * Copyright (C) 2004-2024 Apple, Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple, Inc. All rights reserved.
  * Copyright (C) 2005, 2006 Alexey Proskuryakov <ap@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
@@ -123,7 +123,7 @@ static xmlDocPtr docLoaderFunc(const xmlChar* uri,
             FetchOptions options;
             options.mode = FetchOptions::Mode::SameOrigin;
             options.credentials = FetchOptions::Credentials::Include;
-            cachedResourceLoader->frame()->loader().loadResourceSynchronously(url, ClientCredentialPolicy::MayAskClientForCredentials, options, { }, error, response, data);
+            cachedResourceLoader->frame()->loader().loadResourceSynchronously(URL { url }, ClientCredentialPolicy::MayAskClientForCredentials, options, { }, error, response, data);
             if (error.isNull())
                 requestAllowed = cachedResourceLoader->document()->protectedSecurityOrigin()->canRequest(response.url(), OriginAccessPatternsForWebProcess::singleton());
             else if (data)

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000 Peter Kelly <pmk@post.com>
- * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Alexey Proskuryakov <ap@webkit.org>
  * Copyright (C) 2007 Samuel Weinig <sam@webkit.org>
  * Copyright (C) 2008 Nokia Corporation and/or its subsidiary(-ies)
@@ -507,7 +507,7 @@ static void* openFunc(const char* uri)
             FetchOptions options;
             options.mode = FetchOptions::Mode::SameOrigin;
             options.credentials = FetchOptions::Credentials::Include;
-            cachedResourceLoader->frame()->loader().loadResourceSynchronously(url, ClientCredentialPolicy::MayAskClientForCredentials, options, { }, error, response, data);
+            cachedResourceLoader->frame()->loader().loadResourceSynchronously(URL { url }, ClientCredentialPolicy::MayAskClientForCredentials, options, { }, error, response, data);
 
             if (response.url().isEmpty()) {
                 if (Page* page = document ? document->page() : nullptr)

--- a/Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp
+++ b/Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -207,25 +207,25 @@ void BackgroundFetchLoad::didSendData(uint64_t totalBytesSent, uint64_t totalByt
 void BackgroundFetchLoad::wasBlocked()
 {
     BGLOAD_RELEASE_LOG("wasBlocked");
-    didFinish(blockedError(ResourceRequest { currentURL() }));
+    didFinish(blockedError(ResourceRequest { URL { currentURL() } }));
 }
 
 void BackgroundFetchLoad::cannotShowURL()
 {
     BGLOAD_RELEASE_LOG("cannotShowURL");
-    didFinish(cannotShowURLError(ResourceRequest { currentURL() }));
+    didFinish(cannotShowURLError(ResourceRequest { URL { currentURL() } }));
 }
 
 void BackgroundFetchLoad::wasBlockedByRestrictions()
 {
     BGLOAD_RELEASE_LOG("wasBlockedByRestrictions");
-    didFinish(wasBlockedByRestrictionsError(ResourceRequest { currentURL() }));
+    didFinish(wasBlockedByRestrictionsError(ResourceRequest { URL { currentURL() } }));
 }
 
 void BackgroundFetchLoad::wasBlockedByDisabledFTP()
 {
     BGLOAD_RELEASE_LOG("wasBlockedByDisabledFTP");
-    didFinish(ftpDisabledError(ResourceRequest(currentURL())));
+    didFinish(ftpDisabledError(ResourceRequest(URL { currentURL() })));
 }
 
 const URL& BackgroundFetchLoad::currentURL() const

--- a/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -101,7 +101,7 @@ void EarlyHintsResourceLoader::handleEarlyHintsResponse(ResourceResponse&& respo
 
 ResourceRequest EarlyHintsResourceLoader::constructPreconnectRequest(const ResourceRequest& originalRequest, const URL& url)
 {
-    ResourceRequest request { url };
+    ResourceRequest request { URL { url } };
 
     // firstPartyForCookies and user agent are part of the HTTP socket pool keys in CFNetwork: rdar://59434166
     auto firstPartyForCookies = originalRequest.firstPartyForCookies();

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2016 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -262,7 +263,7 @@ void NetworkDataTaskBlob::dispatchDidReceiveResponse()
     LOG(NetworkSession, "%p - NetworkDataTaskBlob::dispatchDidReceiveResponse()", this);
 
     Ref<NetworkDataTaskBlob> protectedThis(*this);
-    ResourceResponse response(m_firstRequest.url(), extractMIMETypeFromMediaType(m_blobData->contentType()), m_totalRemainingSize, String());
+    ResourceResponse response(URL { m_firstRequest.url() }, extractMIMETypeFromMediaType(m_blobData->contentType()), m_totalRemainingSize, String());
     response.setHTTPStatusCode(m_isRangeRequest ? httpPartialContent : httpOK);
     response.setHTTPStatusText(m_isRangeRequest ? httpPartialContentText : httpOKText);
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -2171,7 +2171,7 @@ WebCore::ResourceError NetworkResourceLoader::contentFilterDidBlock(WebCore::Con
             if (m_wasStarted || unblocked)
                 request = m_parameters.request;
             else
-                request = ResourceRequest(aboutBlankURL());
+                request = ResourceRequest(URL { aboutBlankURL() });
             auto error = WebKit::blockedByContentFilterError(request);
             m_contentFilter->setBlockedError(error);
             m_contentFilter->handleProvisionalLoadFailure(error);

--- a/Source/WebKit/NetworkProcess/PingLoad.cpp
+++ b/Source/WebKit/NetworkProcess/PingLoad.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -200,25 +200,25 @@ void PingLoad::didSendData(uint64_t totalBytesSent, uint64_t totalBytesExpectedT
 void PingLoad::wasBlocked()
 {
     PING_RELEASE_LOG("wasBlocked");
-    didFinish(blockedError(ResourceRequest { currentURL() }));
+    didFinish(blockedError(ResourceRequest { URL { currentURL() } }));
 }
 
 void PingLoad::cannotShowURL()
 {
     PING_RELEASE_LOG("cannotShowURL");
-    didFinish(cannotShowURLError(ResourceRequest { currentURL() }));
+    didFinish(cannotShowURLError(ResourceRequest { URL { currentURL() } }));
 }
 
 void PingLoad::wasBlockedByRestrictions()
 {
     PING_RELEASE_LOG("wasBlockedByRestrictions");
-    didFinish(wasBlockedByRestrictionsError(ResourceRequest { currentURL() }));
+    didFinish(wasBlockedByRestrictionsError(ResourceRequest { URL { currentURL() } }));
 }
 
 void PingLoad::wasBlockedByDisabledFTP()
 {
     PING_RELEASE_LOG("wasBlockedByDisabledFTP");
-    didFinish(ftpDisabledError(ResourceRequest(currentURL())));
+    didFinish(ftpDisabledError(ResourceRequest(URL { currentURL() })));
 }
 
 void PingLoad::timeoutTimerFired()

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -90,7 +90,7 @@ static inline Key makeSubresourcesKey(const Key& resourceKey, const Salt& salt)
 
 static inline ResourceRequest constructRevalidationRequest(const Key& key, const SubresourceInfo& subResourceInfo, const Entry* entry)
 {
-    ResourceRequest revalidationRequest(key.identifier());
+    ResourceRequest revalidationRequest(URL { key.identifier() });
     revalidationRequest.setHTTPHeaderFields(subResourceInfo.requestHeaders());
     revalidationRequest.setFirstPartyForCookies(subResourceInfo.firstPartyForCookies());
     revalidationRequest.setIsSameSite(subResourceInfo.isSameSite());

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -2143,7 +2143,7 @@ void NetworkSessionCocoa::loadImageForDecoding(WebCore::ResourceRequest&& reques
         void wasBlockedByDisabledFTP() final { completeWithBlockedError(); }
         void completeWithBlockedError()
         {
-            didCompleteWithError(blockedError({ m_url }), WebCore::NetworkLoadMetrics { });
+            didCompleteWithError(blockedError({ URL { m_url } }), WebCore::NetworkLoadMetrics { });
         }
 
         RefPtr<Client> m_selfReference;

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -349,7 +349,7 @@ void NetworkDataTaskCurl::willPerformHTTPRedirection()
     ResourceRequest request = m_firstRequest;
     if (!redirectedURL.hasFragmentIdentifier() && request.url().hasFragmentIdentifier())
         redirectedURL.setFragmentIdentifier(request.url().fragmentIdentifier());
-    request.setURL(redirectedURL);
+    request.setURL(WTFMove(redirectedURL));
 
     m_hasCrossOriginRedirect = m_hasCrossOriginRedirect || !SecurityOrigin::create(m_response.url())->canRequest(request.url(), WebCore::EmptyOriginAccessPatterns::singleton());
 

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -616,7 +616,7 @@ void NetworkDataTaskSoup::applyAuthenticationToRequest(ResourceRequest& request)
     auto url = request.url();
     url.setUser(m_user);
     url.setPassword(m_password);
-    request.setURL(url);
+    request.setURL(WTFMove(url));
 
     m_user = String();
     m_password = String();
@@ -917,7 +917,7 @@ void NetworkDataTaskSoup::continueHTTPRedirection()
     URL redirectedURL = URL(m_response.url(), m_response.httpHeaderField(HTTPHeaderName::Location));
     if (!redirectedURL.hasFragmentIdentifier() && request.url().hasFragmentIdentifier())
         redirectedURL.setFragmentIdentifier(request.url().fragmentIdentifier());
-    request.setURL(redirectedURL);
+    request.setURL(WTFMove(redirectedURL));
 
     m_networkLoadMetrics.hasCrossOriginRedirect = m_networkLoadMetrics.hasCrossOriginRedirect || !SecurityOrigin::create(m_currentRequest.url())->canRequest(request.url(), WebCore::EmptyOriginAccessPatterns::singleton());
 
@@ -1113,7 +1113,7 @@ void NetworkDataTaskSoup::didRequestNextPart(GRefPtr<GInputStream>&& inputStream
     m_inputStream = WTFMove(inputStream);
     auto* headers = soup_multipart_input_stream_get_headers(m_multipartInputStream.get());
     auto contentType = String::fromLatin1(soup_message_headers_get_one(headers, "Content-Type"));
-    m_response = ResourceResponse(m_firstRequest.url(), extractMIMETypeFromMediaType(contentType),
+    m_response = ResourceResponse(URL { m_firstRequest.url() }, extractMIMETypeFromMediaType(contentType),
         soup_message_headers_get_content_length(headers), extractCharsetFromMediaType(contentType).toString());
     m_response.updateFromSoupMessageHeaders(headers);
     dispatchDidReceiveResponse();
@@ -1688,7 +1688,7 @@ void NetworkDataTaskSoup::fileQueryInfoCallback(GFile* file, GAsyncResult* resul
 
 void NetworkDataTaskSoup::didGetFileInfo(GFileInfo* info)
 {
-    m_response.setURL(m_firstRequest.url());
+    m_response.setURL(URL { m_firstRequest.url() });
     if (g_file_info_get_file_type(info) == G_FILE_TYPE_DIRECTORY) {
         m_response.setMimeType("text/html"_s);
         m_response.setExpectedContentLength(-1);

--- a/Source/WebKit/Shared/API/glib/WebKitURIRequest.cpp
+++ b/Source/WebKit/Shared/API/glib/WebKitURIRequest.cpp
@@ -149,7 +149,7 @@ void webkit_uri_request_set_uri(WebKitURIRequest* request, const char* uri)
     if (url == request->priv->resourceRequest.url())
         return;
 
-    request->priv->resourceRequest.setURL(url);
+    request->priv->resourceRequest.setURL(WTFMove(url));
 
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK/WPE port
     g_object_notify_by_pspec(G_OBJECT(request), sObjProperties[PROP_URI]);

--- a/Source/WebKit/UIProcess/API/APINavigation.cpp
+++ b/Source/WebKit/UIProcess/API/APINavigation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,6 +33,7 @@
 #include <WebCore/ResourceResponse.h>
 #include <wtf/DebugUtilities.h>
 #include <wtf/HexNumber.h>
+#include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
 namespace API {
@@ -76,7 +77,7 @@ Navigation::Navigation(WebCore::ProcessIdentifier processID, WebCore::ResourceRe
 Navigation::Navigation(WebCore::ProcessIdentifier processID, Ref<WebBackForwardListFrameItem>&& targetFrameItem, RefPtr<WebBackForwardListItem>&& fromItem, FrameLoadType backForwardFrameLoadType)
     : m_navigationID(WebCore::NavigationIdentifier::generate())
     , m_processID(processID)
-    , m_originalRequest(targetFrameItem->protectedMainFrame()->url())
+    , m_originalRequest(WTF::URL { targetFrameItem->protectedMainFrame()->url() })
     , m_currentRequest(m_originalRequest)
     , m_targetFrameItem(WTFMove(targetFrameItem))
     , m_fromItem(WTFMove(fromItem))

--- a/Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.cpp
@@ -245,7 +245,7 @@ static void webkitURISchemeRequestReadCallback(GInputStream* inputStream, GAsync
     WebKitURISchemeResponse* resp = priv->response.get();
     if (!priv->bytesRead) {
         auto contentType = String::fromLatin1(webKitURISchemeResponseGetContentType(resp).data());
-        ResourceResponse response(priv->task->request().url(), extractMIMETypeFromMediaType(contentType), webKitURISchemeResponseGetStreamLength(resp), emptyString());
+        ResourceResponse response(URL { priv->task->request().url() }, extractMIMETypeFromMediaType(contentType), webKitURISchemeResponseGetStreamLength(resp), String { emptyString() });
         response.setTextEncodingName(extractCharsetFromMediaType(contentType).toString());
         const CString& statusMessage = webKitURISchemeResponseGetStatusMessage(resp);
         if (statusMessage.isNull()) {

--- a/Source/WebKit/UIProcess/AboutSchemeHandler.cpp
+++ b/Source/WebKit/UIProcess/AboutSchemeHandler.cpp
@@ -65,7 +65,7 @@ void AboutSchemeHandler::platformStartTask(WebPageProxy&, WebURLSchemeTask& task
         return;
     }
 
-    WebCore::ResourceResponse response(url, "text/html"_s, 0, "UTF-8"_s);
+    WebCore::ResourceResponse response(WTF::URL { url }, "text/html"_s, 0, "UTF-8"_s);
     task.didReceiveResponse(response);
     task.didComplete({ });
 }

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -416,7 +416,7 @@ void SystemPreviewController::begin(const URL& url, const WebCore::SecurityOrigi
         if (!webPageProxy)
             return completionHandler();
         RELEASE_LOG(SystemPreview, "SystemPreview began on %lld", protectedThis->m_systemPreviewInfo.element.elementIdentifier ? protectedThis->m_systemPreviewInfo.element.elementIdentifier->toUInt64() : 0);
-        auto request = WebCore::ResourceRequest(url);
+        auto request = WebCore::ResourceRequest(URL { url });
         bool shouldRunAtForegroundPriority = false;
         webPageProxy->dataTaskWithRequest(WTFMove(request), topOrigin, shouldRunAtForegroundPriority, [weakThis, completionHandler = WTFMove(completionHandler)] (Ref<API::DataTask>&& task) mutable {
             if (!weakThis)

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -62,7 +62,7 @@ DownloadProxy::DownloadProxy(DownloadProxyMap& downloadProxyMap, WebsiteDataStor
     , m_downloadID(DownloadID::generate())
     , m_request(resourceRequest)
     , m_originatingPage(originatingPage)
-    , m_frameInfo(frameInfoData ? API::FrameInfo::create(FrameInfoData { *frameInfoData }, originatingPage) : API::FrameInfo::create(legacyEmptyFrameInfo(ResourceRequest { aboutBlankURL() }), originatingPage))
+    , m_frameInfo(frameInfoData ? API::FrameInfo::create(FrameInfoData { *frameInfoData }, originatingPage) : API::FrameInfo::create(legacyEmptyFrameInfo(ResourceRequest { URL { aboutBlankURL() } }), originatingPage))
 #if HAVE(MODERN_DOWNLOADPROGRESS)
     , m_assertion(ProcessAssertion::create(getCurrentProcessID(), "WebKit DownloadProxy DecideDestination"_s, ProcessAssertionType::FinishTaskInterruptable))
 #endif

--- a/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp
@@ -248,7 +248,7 @@ void RemoteInspectorProtocolHandler::platformStartTask(WebPageProxy& pageProxy, 
 
     auto html = htmlBuilder.toString().utf8();
     auto data = SharedBuffer::create(html.span());
-    ResourceResponse response(requestURL, "text/html"_s, html.length(), "UTF-8"_s);
+    ResourceResponse response(WTFMove(requestURL), "text/html"_s, html.length(), "UTF-8"_s);
     task.didReceiveResponse(response);
     task.didReceiveData(WTFMove(data));
     task.didComplete(ResourceError());

--- a/Source/WebKit/UIProcess/Inspector/win/InspectorResourceURLSchemeHandler.cpp
+++ b/Source/WebKit/UIProcess/Inspector/win/InspectorResourceURLSchemeHandler.cpp
@@ -56,7 +56,7 @@ void InspectorResourceURLSchemeHandler::platformStartTask(WebPageProxy&, WebURLS
     auto contentType = WebCore::File::contentTypeForFile(path);
     if (contentType.isEmpty())
         contentType = "application/octet-stream"_s;
-    WebCore::ResourceResponse response(requestURL, contentType, file->size(), "UTF-8"_s);
+    WebCore::ResourceResponse response(WTFMove(requestURL), WTFMove(contentType), file->size(), "UTF-8"_s);
     auto data = WebCore::SharedBuffer::create(file->span());
 
     task.didReceiveResponse(response);

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -368,7 +368,7 @@ void ProvisionalPageProxy::goToBackForwardItem(API::Navigation& navigation, WebB
         existingNetworkResourceLoadIdentifierToResume = WTFMove(existingNetworkResourceLoadIdentifierToResume),
         navigation = Ref { navigation },
         sandboxExtensionHandle = WTFMove(sandboxExtensionHandle)
-    ] (std::optional<SandboxExtension::Handle> sandboxExtension) mutable {
+    ] (std::optional<SandboxExtension::Handle>&& sandboxExtension) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2218,7 +2218,7 @@ public:
     void microphoneMuteStatusChanged(bool isMuting);
 #endif
 
-    void maybeInitializeSandboxExtensionHandle(WebProcessProxy&, const URL&, const URL& resourceDirectoryURL, bool checkAssumedReadAccessToResourceURL, CompletionHandler<void(std::optional<SandboxExtensionHandle>)>&&);
+    void maybeInitializeSandboxExtensionHandle(WebProcessProxy&, const URL&, const URL& resourceDirectoryURL, bool checkAssumedReadAccessToResourceURL, CompletionHandler<void(std::optional<SandboxExtensionHandle>&&)>&&);
 
 #if ENABLE(WEB_AUTHN)
     void setMockWebAuthenticationConfiguration(WebCore::MockWebAuthenticationConfiguration&&);

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -619,7 +619,7 @@ bool WebProcessProxy::shouldSendPendingMessage(const PendingMessage& message)
         if (loadParameters && resourceDirectoryURL && pageID && checkAssumedReadAccessToResourceURL) {
             if (RefPtr page = WebProcessProxy::webPage(*pageID)) {
                 auto url = loadParameters->request.url();
-                page->maybeInitializeSandboxExtensionHandle(static_cast<WebProcessProxy&>(*this), url, *resourceDirectoryURL,  *checkAssumedReadAccessToResourceURL, [weakThis = WeakPtr { *this }, destinationID, loadParameters = WTFMove(loadParameters)] (std::optional<SandboxExtension::Handle> sandboxExtension) mutable {
+                page->maybeInitializeSandboxExtensionHandle(static_cast<WebProcessProxy&>(*this), url, *resourceDirectoryURL,  *checkAssumedReadAccessToResourceURL, [weakThis = WeakPtr { *this }, destinationID, loadParameters = WTFMove(loadParameters)] (std::optional<SandboxExtension::Handle>&& sandboxExtension) mutable {
                     if (!weakThis)
                         return;
                     if (sandboxExtension)
@@ -644,7 +644,7 @@ bool WebProcessProxy::shouldSendPendingMessage(const PendingMessage& message)
             return false;
         auto destinationID = decoder->destinationID();
         auto frameState = parameters->frameState;
-        auto completionHandler = [weakThis = WeakPtr { *this }, parameters = WTFMove(parameters), destinationID] (std::optional<SandboxExtension::Handle> sandboxExtension) mutable {
+        auto completionHandler = [weakThis = WeakPtr { *this }, parameters = WTFMove(parameters), destinationID] (std::optional<SandboxExtension::Handle>&& sandboxExtension) mutable {
             if (!weakThis)
                 return;
             if (sandboxExtension)

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -946,7 +946,7 @@ void WebLoaderStrategy::preconnectTo(FrameLoader& frameLoader, const URL& url, S
     if (!webPage)
         return completionHandler(internalError(url));
 
-    preconnectTo(ResourceRequest { url }, *webPage, *webFrame, storedCredentialsPolicy, shouldPreconnectAsFirstParty, WTFMove(completionHandler));
+    preconnectTo(ResourceRequest { URL { url } }, *webPage, *webFrame, storedCredentialsPolicy, shouldPreconnectAsFirstParty, WTFMove(completionHandler));
 }
 
 void WebLoaderStrategy::preconnectTo(WebCore::ResourceRequest&& request, WebPage& webPage, WebFrame& webFrame, WebCore::StoredCredentialsPolicy storedCredentialsPolicy, ShouldPreconnectAsFirstParty shouldPreconnectAsFirstParty, PreconnectCompletionHandler&& completionHandler)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -556,7 +556,7 @@ void PDFPluginBase::startByteRangeRequest(NetscapePlugInStreamLoaderClient& stre
 
     auto resourceRequest = documentLoader->request();
     resourceRequest.setRequester(ResourceRequestRequester::Unspecified);
-    resourceRequest.setURL(m_view->mainResourceURL());
+    resourceRequest.setURL(URL { m_view->mainResourceURL() });
     resourceRequest.setHTTPHeaderField(HTTPHeaderName::Range, makeString("bytes="_s, position, '-', position + count - 1));
     resourceRequest.setCachePolicy(ResourceRequestCachePolicy::DoNotUseAnyCache);
 

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1031,7 +1031,7 @@ void PluginView::loadMainResource()
         referrer = { };
 
     ASSERT(!m_pendingResourceRequest);
-    m_pendingResourceRequest = WTF::makeUnique<ResourceRequest>(m_mainResourceURL, referrer);
+    m_pendingResourceRequest = WTF::makeUnique<ResourceRequest>(URL { m_mainResourceURL }, referrer);
     m_pendingResourceRequestTimer.startOneShot(0_s);
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -102,7 +102,7 @@ std::optional<NavigationActionData> WebFrameLoaderClient::navigationActionData(c
     FrameInfoData originatingFrameInfoData {
         navigationAction.initiatedByMainFrame() == InitiatedByMainFrame::Yes,
         FrameType::Local,
-        ResourceRequest { requester.url },
+        ResourceRequest { URL { requester.url } },
         requester.securityOrigin->data(),
         { },
         WTFMove(originatingFrameID),

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1914,7 +1914,7 @@ void WebLocalFrameLoaderClient::sendH2Ping(const URL& url, CompletionHandler<voi
         webPage->webPageProxyIdentifier(),
         webPage->identifier(),
         m_frame->frameID(),
-        ResourceRequest(url)
+        ResourceRequest(URL { url })
     };
     parameters.createSandboxExtensionHandlesIfNecessary();
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2045,7 +2045,7 @@ void WebPage::loadURLInFrame(URL&& url, const String& referrer, FrameIdentifier 
         return;
 
     RefPtr coreLocalFrame = frame->coreLocalFrame();
-    coreLocalFrame->loader().load(FrameLoadRequest(*coreLocalFrame, ResourceRequest(url, referrer)));
+    coreLocalFrame->loader().load(FrameLoadRequest(*coreLocalFrame, ResourceRequest(URL { url }, referrer)));
 }
 
 void WebPage::loadDataInFrame(std::span<const uint8_t> data, String&& type, String&& encodingName, URL&& baseURL, FrameIdentifier frameID)
@@ -2056,9 +2056,9 @@ void WebPage::loadDataInFrame(std::span<const uint8_t> data, String&& type, Stri
     ASSERT(&mainWebFrame() != frame);
 
     Ref sharedBuffer = SharedBuffer::create(data);
-    ResourceResponse response(baseURL, type, sharedBuffer->size(), encodingName);
+    ResourceResponse response(URL { baseURL }, WTFMove(type), sharedBuffer->size(), WTFMove(encodingName));
     SubstituteData substituteData(WTFMove(sharedBuffer), baseURL, WTFMove(response), SubstituteData::SessionHistoryVisibility::Hidden);
-    frame->coreLocalFrame()->loader().load(FrameLoadRequest(*frame->coreLocalFrame(), ResourceRequest(baseURL), WTFMove(substituteData)));
+    frame->coreLocalFrame()->loader().load(FrameLoadRequest(*frame->coreLocalFrame(), ResourceRequest(WTFMove(baseURL)), WTFMove(substituteData)));
 }
 
 #if !PLATFORM(COCOA)
@@ -2167,7 +2167,7 @@ void WebPage::loadRequestWaitingForProcessLaunch(LoadParameters&&, URL&&, WebPag
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-void WebPage::loadDataImpl(std::optional<WebCore::NavigationIdentifier> navigationID, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad, std::optional<WebsitePoliciesData>&& websitePolicies, Ref<FragmentedSharedBuffer>&& sharedBuffer, ResourceRequest&& request, ResourceResponse&& response, const URL& unreachableURL, const UserData& userData, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, SubstituteData::SessionHistoryVisibility sessionHistoryVisibility, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy)
+void WebPage::loadDataImpl(std::optional<WebCore::NavigationIdentifier> navigationID, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad, std::optional<WebsitePoliciesData>&& websitePolicies, Ref<FragmentedSharedBuffer>&& sharedBuffer, ResourceRequest&& request, ResourceResponse&& response, URL&& unreachableURL, const UserData& userData, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, SubstituteData::SessionHistoryVisibility sessionHistoryVisibility, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy)
 {
 #if ENABLE(APP_BOUND_DOMAINS)
     Ref mainFrame = m_mainFrame.copyRef();
@@ -2226,7 +2226,7 @@ void WebPage::loadData(LoadParameters&& loadParameters)
         corePage()->markAsServiceWorkerPage();
 
     ResourceResponse response(URL(), WTFMove(loadParameters.MIMEType), sharedBuffer->size(), WTFMove(loadParameters.encodingName));
-    loadDataImpl(loadParameters.navigationID, loadParameters.shouldTreatAsContinuingLoad, WTFMove(loadParameters.websitePolicies), sharedBuffer.releaseNonNull(), ResourceRequest(baseURL), WTFMove(response), URL(), loadParameters.userData, loadParameters.isNavigatingToAppBoundDomain, loadParameters.sessionHistoryVisibility, loadParameters.shouldOpenExternalURLsPolicy);
+    loadDataImpl(loadParameters.navigationID, loadParameters.shouldTreatAsContinuingLoad, WTFMove(loadParameters.websitePolicies), sharedBuffer.releaseNonNull(), ResourceRequest(WTFMove(baseURL)), WTFMove(response), URL(), loadParameters.userData, loadParameters.isNavigatingToAppBoundDomain, loadParameters.sessionHistoryVisibility, loadParameters.shouldOpenExternalURLsPolicy);
 }
 
 void WebPage::loadAlternateHTML(LoadParameters&& loadParameters)
@@ -2244,7 +2244,7 @@ void WebPage::loadAlternateHTML(LoadParameters&& loadParameters)
     m_mainFrame->coreLocalFrame()->loader().setProvisionalLoadErrorBeingHandledURL(provisionalLoadErrorURL);
 
     ResourceResponse response(URL(), WTFMove(loadParameters.MIMEType), sharedBuffer->size(), WTFMove(loadParameters.encodingName));
-    loadDataImpl(loadParameters.navigationID, loadParameters.shouldTreatAsContinuingLoad, WTFMove(loadParameters.websitePolicies), sharedBuffer.releaseNonNull(), ResourceRequest(baseURL), WTFMove(response), unreachableURL, loadParameters.userData, loadParameters.isNavigatingToAppBoundDomain, WebCore::SubstituteData::SessionHistoryVisibility::Hidden);
+    loadDataImpl(loadParameters.navigationID, loadParameters.shouldTreatAsContinuingLoad, WTFMove(loadParameters.websitePolicies), sharedBuffer.releaseNonNull(), ResourceRequest(WTFMove(baseURL)), WTFMove(response), WTFMove(unreachableURL), loadParameters.userData, loadParameters.isNavigatingToAppBoundDomain, WebCore::SubstituteData::SessionHistoryVisibility::Hidden);
     m_mainFrame->coreLocalFrame()->loader().setProvisionalLoadErrorBeingHandledURL({ });
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2098,7 +2098,7 @@ private:
 
     void startTextManipulationForFrame(WebCore::Frame&);
 
-    void loadDataImpl(std::optional<WebCore::NavigationIdentifier>, WebCore::ShouldTreatAsContinuingLoad, std::optional<WebsitePoliciesData>&&, Ref<WebCore::FragmentedSharedBuffer>&&, WebCore::ResourceRequest&&, WebCore::ResourceResponse&&, const URL& failingURL, const UserData&, std::optional<NavigatingToAppBoundDomain>, WebCore::SubstituteData::SessionHistoryVisibility, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow);
+    void loadDataImpl(std::optional<WebCore::NavigationIdentifier>, WebCore::ShouldTreatAsContinuingLoad, std::optional<WebsitePoliciesData>&&, Ref<WebCore::FragmentedSharedBuffer>&&, WebCore::ResourceRequest&&, WebCore::ResourceResponse&&, URL&& failingURL, const UserData&, std::optional<NavigatingToAppBoundDomain>, WebCore::SubstituteData::SessionHistoryVisibility, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow);
 
     // Actions
     void tryClose(CompletionHandler<void(bool)>&&);


### PR DESCRIPTION
#### 178f41b935d42088ca8260366c3b64532e860591
<pre>
Standardize on move arguments for ResourceRequest and ResourceResponse
<a href="https://bugs.webkit.org/show_bug.cgi?id=291770">https://bugs.webkit.org/show_bug.cgi?id=291770</a>
<a href="https://rdar.apple.com/149577600">rdar://149577600</a>

Reviewed by Ryosuke Niwa.

In Bug 291754 and Bug 291589 we added move parameters to various methods. This resulted
in code duplication.

Instead, standardize on move parameters and explicitly perform copies at the relevant call
sites. This helps us find missing move opportunities, and helps us see API where a lot of
copying is needed.

* Source/WebCore/Modules/fetch/FetchLoader.cpp:
(WebCore::FetchLoader::startLoadingBlobURL):
* Source/WebCore/Modules/fetch/FetchRequest.cpp:
(WebCore::FetchRequest::initializeWith):
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::setSourceURL):
* Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp:
(WebCore::NotificationResourcesLoader::ResourceLoader::ResourceLoader):
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp:
(WebCore::ThreadableWebSocketChannel::webSocketConnectRequest):
* Source/WebCore/Modules/websockets/WebSocketHandshake.cpp:
(WebCore::WebSocketHandshake::clientHandshakeRequest const):
* Source/WebCore/bindings/js/CachedScriptFetcher.cpp:
(WebCore::CachedScriptFetcher::requestScriptWithCache const):
* Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp:
(WebCore::WorkerModuleScriptLoader::load):
* Source/WebCore/css/CSSImageValue.cpp:
(WebCore::CSSImageValue::loadImage):
* Source/WebCore/css/StyleRuleImport.cpp:
(WebCore::StyleRuleImport::requestStyleSheet):
* Source/WebCore/fileapi/FileReaderLoader.cpp:
(WebCore::FileReaderLoader::start):
* Source/WebCore/html/DOMURL.cpp:
(WebCore::DOMURL::revokeObjectURL):
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::process):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::loadResource):
(WebCore::HTMLMediaElement::sniffForContentType):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::loadResource):
(WebCore::InspectorNetworkAgent::interceptRequestWithResponse):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::cachedResource):
* Source/WebCore/loader/ApplicationManifestLoader.cpp:
(WebCore::ApplicationManifestLoader::startLoading):
* Source/WebCore/loader/CrossOriginAccessControl.cpp:
(WebCore::createAccessControlPreflightRequest):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::replaceRequestURLForSameDocumentNavigation):
(WebCore::DocumentLoader::handleSubstituteDataLoadNow):
(WebCore::DocumentLoader::maybeLoadEmpty):
(WebCore::DocumentLoader::loadErrorDocument):
(WebCore::DocumentLoader::startLoadingMainResource):
(WebCore::DocumentLoader::loadMainResource):
(WebCore::DocumentLoader::handleProvisionalLoadFailureFromContentFilter):
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::responseReceived):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::initForSynthesizedDocument):
(WebCore::FrameLoader::changeLocation):
(WebCore::FrameLoader::loadURLIntoChildFrame):
(WebCore::FrameLoader::loadArchive):
(WebCore::FrameLoader::loadURL):
(WebCore::FrameLoader::defaultSubstituteDataForURL):
(WebCore::FrameLoader::willLoadMediaElementURL):
(WebCore::FrameLoader::reloadWithOverrideEncoding):
(WebCore::FrameLoader::reload):
(WebCore::FrameLoader::commitProvisionalLoad):
(WebCore::FrameLoader::updateRequestAndAddExtraFields):
(WebCore::FrameLoader::loadPostRequest):
(WebCore::FrameLoader::loadDifferentDocumentItem):
(WebCore::FrameLoader::tellClientAboutPastMemoryCacheLoads):
* Source/WebCore/loader/NavigationScheduler.cpp:
* Source/WebCore/loader/PingLoader.cpp:
(WebCore::PingLoader::loadImage):
(WebCore::PingLoader::sendPing):
(WebCore::PingLoader::sendViolationReport):
* Source/WebCore/loader/appcache/ApplicationCacheHost.cpp:
(WebCore::ApplicationCacheHost::maybeLoadMainResource):
* Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp:
(WebCore::ApplicationCacheStorage::loadCache):
* Source/WebCore/loader/archive/ArchiveResource.cpp:
(WebCore::ArchiveResource::create):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::create):
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::CachedImage):
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::CachedResource):
(WebCore::CachedResource::load):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::shouldContinueAfterNotifyingLoadedFromMemoryCache):
(WebCore::CachedResourceLoader::requestResource):
* Source/WebCore/loader/cache/CachedResourceRequest.cpp:
(WebCore::CachedResourceRequest::splitFragmentIdentifierFromRequestURL):
(WebCore::upgradeInsecureResourceRequestIfNeeded):
(WebCore::CachedResourceRequest::removeFragmentIdentifierIfNeeded):
* Source/WebCore/loader/cache/CachedSVGDocumentReference.cpp:
(WebCore::CachedSVGDocumentReference::load):
* Source/WebCore/loader/cocoa/BundleResourceLoader.mm:
(WebCore::BundleResourceLoader::loadResourceFromBundle):
* Source/WebCore/loader/icon/IconLoader.cpp:
(WebCore::IconLoader::startLoading):
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::openNewWindow):
(WebCore::ContextMenuController::populate):
* Source/WebCore/page/EventSource.cpp:
(WebCore::EventSource::connect):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::createWindow):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::reload):
(WebCore::Navigation::navigate):
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::upgradeInsecureRequestIfNeeded const):
* Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.mm:
(WebCore::NetworkExtensionContentFilter::willSendRequest):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::createResourceClient):
* Source/WebCore/platform/network/BlobResourceHandle.cpp:
(WebCore::BlobResourceHandle::notifyResponseOnSuccess):
* Source/WebCore/platform/network/ResourceRequestBase.cpp:
* Source/WebCore/platform/network/ResourceRequestBase.h:
(WebCore::ResourceRequestBase::RequestData::RequestData):
(WebCore::ResourceRequestBase::m_hiddenFromInspector):
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::ResourceResponseBase::ResourceResponseBase):
(WebCore::ResourceResponseBase::syntheticRedirectResponse):
(WebCore::ResourceResponseBase::dataURLResponse):
(WebCore::ResourceResponseBase::filter):
* Source/WebCore/platform/network/ResourceResponseBase.h:
* Source/WebCore/platform/network/cf/ResourceRequest.h:
(WebCore::ResourceRequest::ResourceRequest):
* Source/WebCore/platform/network/cf/ResourceResponse.h:
* Source/WebCore/platform/network/curl/ResourceRequest.h:
(WebCore::ResourceRequest::ResourceRequest):
* Source/WebCore/platform/network/curl/ResourceResponse.h:
(WebCore::ResourceResponse::ResourceResponse):
* Source/WebCore/platform/network/mac/ResourceHandleMac.mm:
(WebCore::ResourceHandle::createNSURLConnection):
* Source/WebCore/platform/network/soup/ResourceRequest.h:
(WebCore::ResourceRequest::ResourceRequest):
* Source/WebCore/platform/network/soup/ResourceResponse.h:
(WebCore::ResourceResponse::ResourceResponse):
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::updateExternalDocument):
* Source/WebCore/testing/MockContentFilter.cpp:
(WebCore::MockContentFilter::willSendRequest):
* Source/WebCore/workers/WorkerFontLoadRequest.cpp:
(WebCore::WorkerFontLoadRequest::load):
* Source/WebCore/workers/WorkerScriptLoader.cpp:
(WebCore::WorkerScriptLoader::createResourceRequest):
* Source/WebCore/workers/service/ServiceWorkerJob.cpp:
(WebCore::scriptResourceRequest):
* Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp:
(WebCore::ServiceWorkerFetch::processResponse):
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::createScriptRequest):
* Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp:
(WebCore::SharedWorkerScriptLoader::load):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::createRequest):
* Source/WebCore/xml/XSLTProcessorLibxslt.cpp:
(WebCore::docLoaderFunc):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::openFunc):
* Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp:
(WebKit::BackgroundFetchLoad::wasBlocked):
(WebKit::BackgroundFetchLoad::cannotShowURL):
(WebKit::BackgroundFetchLoad::wasBlockedByRestrictions):
(WebKit::BackgroundFetchLoad::wasBlockedByDisabledFTP):
* Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp:
(WebKit::EarlyHintsResourceLoader::constructPreconnectRequest):
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp:
(WebKit::NetworkDataTaskBlob::dispatchDidReceiveResponse):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::contentFilterDidBlock):
* Source/WebKit/NetworkProcess/PingLoad.cpp:
(WebKit::PingLoad::wasBlocked):
(WebKit::PingLoad::cannotShowURL):
(WebKit::PingLoad::wasBlockedByRestrictions):
(WebKit::PingLoad::wasBlockedByDisabledFTP):
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp:
(WebKit::NetworkCache::constructRevalidationRequest):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::loadImageForDecoding):
* Source/WebKit/UIProcess/API/APINavigation.cpp:
(API::Navigation::Navigation):
* Source/WebKit/UIProcess/AboutSchemeHandler.cpp:
(WebKit::AboutSchemeHandler::platformStartTask):
* Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp:
(WebKit::DownloadProxy::DownloadProxy):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::loadFile):
(WebKit::WebPageProxy::loadSimulatedRequest):
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::restoreFromSessionState):
(WebKit::WebPageProxy::didFailProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::didSameDocumentNavigationForFrameViaJS):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::preconnectTo):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::startByteRangeRequest):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::loadMainResource):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::navigationActionData const):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::sendH2Ping):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::loadURLInFrame):
(WebKit::WebPage::loadDataInFrame):
(WebKit::WebPage::loadData):
(WebKit::WebPage::loadAlternateHTML):

Canonical link: <a href="https://commits.webkit.org/294030@main">https://commits.webkit.org/294030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f8c80710da710e9f646f82087e7316172ed8e52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20290 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105775 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51226 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102679 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20598 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76639 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33673 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15809 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90905 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56994 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15621 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/8912 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50602 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/85533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108130 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27756 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85594 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28119 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87106 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85135 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29829 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7558 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21744 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16373 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27691 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/32956 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27502 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30820 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29060 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->