### PR TITLE
[iOS] [SelectionHonorsOverflowScrolling] chat.openai.com: selection highlight may rendering incorrectly while scrolling

### DIFF
--- a/LayoutTests/editing/selection/ios/hide-selection-in-overflow-scroller-with-sticky-children-expected.txt
+++ b/LayoutTests/editing/selection/ios/hide-selection-in-overflow-scroller-with-sticky-children-expected.txt
@@ -1,0 +1,18 @@
+Select me
+
+Sticky
+More text
+
+This test verifies that selection rects are hidden when scrolling an overflow scrollable container, if the selection covers a stickily-positioned container. To manually test, select the text below and scroll the red box; the selection should hide when scrolling and reappear when scrolling ends.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Selection appeared
+PASS Scrolled down
+PASS Selection disappeared
+PASS Ended touch
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/hide-selection-in-overflow-scroller-with-sticky-children.html
+++ b/LayoutTests/editing/selection/ios/hide-selection-in-overflow-scroller-with-sticky-children.html
@@ -3,6 +3,7 @@
 <script src="../../../resources/ui-helper.js"></script>
 <script src="../../../resources/js-test.js"></script>
 <head>
+<meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
 body, html {
@@ -18,8 +19,8 @@ body, html {
     border: 1px solid tomato;
 }
 
-.tall-content {
-    height: 5000px;
+.tall {
+    height: 200px;
 }
 
 .start {
@@ -29,12 +30,25 @@ body, html {
 .end {
     border: 1px solid teal;
 }
+
+.sticky {
+    bottom: 200px;
+    left: 200px;
+    width: 100px;
+    height: 100px;
+    border: solid 1px black;
+    border-radius: 1em;
+    position: sticky;
+    line-height: 100px;
+    text-align: center;
+    background: white;
+}
 </style>
 <script>
 jsTestIsAsync = true;
 
 addEventListener("load", async () => {
-    description("This test verifies that selection rects are hidden when scrolling an overflow scrollable container, if the selection spans across separate scroll views. To manually test, select the text below and scroll the red box; the selection should hide when scrolling and reappear when scrolling ends.")
+    description("This test verifies that selection rects are hidden when scrolling an overflow scrollable container, if the selection covers a stickily-positioned container. To manually test, select the text below and scroll the red box; the selection should hide when scrolling and reappear when scrolling ends.")
     if (!window.testRunner)
         return;
 
@@ -67,12 +81,14 @@ addEventListener("load", async () => {
 </script>
 </head>
 <body>
-    <p><span class="start">Select</span> me</p>
     <div class="scroller">
+        <div class="tall"></div>
+        <p><span class="start">Select</span> me</p>
+        <div class="sticky">Sticky</div>
+        <div class="tall"></div>
         <p>More <span class="end">text</span></p>
-        <div class="tall-content"></div>
     </div>
-    <pre id="description"></pre>
-    <pre id="console"></pre>
+    <p id="description"></p>
+    <p id="console"></p>
 </body>
 </html>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -513,6 +513,7 @@ struct ImageAnalysisContextMenuActionData {
     CGPoint _lastInteractionLocation;
     std::optional<WebKit::TransactionID> _layerTreeTransactionIdAtLastInteractionStart;
 
+    __weak UIView *_cachedSelectionContainerView;
     __weak UIView *_lastSiblingBeforeSelectionHighlight;
     WebKit::WKSelectionDrawingInfo _lastSelectionDrawingInfo;
     RetainPtr<WKTextRange> _cachedSelectedTextRange;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -6144,9 +6144,6 @@ void WebPage::computeEnclosingLayerID(EditorState& state, const VisibleSelection
         }
     }
 
-    if (!state.visualData->enclosingScrollingNodeID)
-        return;
-
     if (selection.isCaret()) {
         state.visualData->scrollingNodeIDAtStart = state.visualData->enclosingScrollingNodeID;
         state.visualData->scrollingNodeIDAtEnd = state.visualData->enclosingScrollingNodeID;


### PR DESCRIPTION
#### d1b62f9aff9556545f4fd31c779521b637f4a04a
<pre>
[iOS] [SelectionHonorsOverflowScrolling] chat.openai.com: selection highlight may rendering incorrectly while scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=291774">https://bugs.webkit.org/show_bug.cgi?id=291774</a>
<a href="https://rdar.apple.com/149245485">rdar://149245485</a>

Reviewed by Abrar Rahman Protyasha.

Fall back to the legacy behavior of hiding selection views while scrolling in a couple of cases, to
ensure that selecting text in the main chat window on ChatGPT doesn&apos;t lead to incorrectly-positioned
selection highlights (and instead reverts to shipping behavior):

1.  The selection starts somewhere in the main scroll view, but ends in a subscrollable region (or
    vice versa).

2.  The selection encompasses composited layers (e.g. `position: sticky;`) that are parented outside
    of the scroll view.

See below for more details.

* LayoutTests/editing/selection/ios/hide-selection-in-overflow-scroller-with-sticky-children-expected.txt: Added.
* LayoutTests/editing/selection/ios/hide-selection-in-overflow-scroller-with-sticky-children.html: Copied from LayoutTests/editing/selection/ios/hide-selection-in-separate-overflow-scrollers.html.

Add a new test to verify that the selection is hidden in the case where the selection both starts
and ends within a single subscrollable container, if the selection *also* covers a stickily-
positioned container (which ends up being composited outside of the scroll view).

* LayoutTests/editing/selection/ios/hide-selection-in-separate-overflow-scrollers.html:

Enable `SelectionHonorsOverflowScrolling` in this layout test to exercise the bug fix.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView cleanUpInteraction]):
(-[WKContentView _selectionChanged]):

Invalidate `_cachedSelectionContainerView` (see below).

(-[WKContentView _selectionContainerViewInternal]):

Make this revert to shipping behavior and install selection views directly on `WKContentView`, in
the case where at least one layer in the selected range lies outside of the layer corresponding to
the `enclosingLayerID` of the `EditorState`. This may require walking up the view hierarchy, so we
also add logic to cache the selection container view and avoid recomputing it unless the selection
may have changed.

(-[WKContentView _shouldHideSelectionDuringOverflowScroll:]):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::computeEnclosingLayerID const):

Currently, we have logic that falls back to shipping behavior in the case where the selection
endpoints lie in different subscrollers. However, this doesn&apos;t work when one of the endpoints lies
in the main scroller and the other lies in a subscroller, because the `enclosingScrollingNodeID` is
`nullopt`. Make this logic more robust by removing the early return that skips computing scrolling
node IDs for the selection endpoints in the case where the enclosing scroll view is the main
scroller, so that we can `return NO` from `-_shouldHideSelectionDuringOverflowScroll:` when only
one of the endpoints is in a subscrollable area.

Canonical link: <a href="https://commits.webkit.org/293884@main">https://commits.webkit.org/293884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b19330e6bdd7f449fc745b7cbdb5fb52a2b7856

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100173 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105303 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50755 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28294 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76257 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33319 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103180 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15381 "Found 1 new test failure: fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90469 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56618 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15198 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8466 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50124 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85106 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8549 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107662 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27286 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19991 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85212 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27649 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86675 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84748 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21540 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29424 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7155 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21141 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27223 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32456 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27034 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30350 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28593 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->