### PR TITLE
Small optimization of StringBuilder::toString()

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
+++ b/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
@@ -122,8 +122,7 @@ void IntlPluralRules::initializePluralRules(JSGlobalObject* globalObject, JSValu
 
     appendNumberFormatDigitOptionsToSkeleton(this, skeletonBuilder);
 
-    String skeleton = skeletonBuilder.toString();
-    StringView skeletonView(skeleton);
+    StringView skeletonView { skeletonBuilder.toString() };
     auto upconverted = skeletonView.upconvertedCharacters();
 
     m_numberFormatter = std::unique_ptr<UNumberFormatter, UNumberFormatterDeleter>(unumf_openForSkeletonAndLocale(upconverted.get(), skeletonView.length(), locale.data(), &status));

--- a/Source/WebCore/Modules/applepay/cocoa/PaymentContactCocoa.mm
+++ b/Source/WebCore/Modules/applepay/cocoa/PaymentContactCocoa.mm
@@ -89,8 +89,7 @@ static RetainPtr<PKContact> convert(unsigned version, const ApplePayPaymentConta
                 builder.append('\n');
         }
 
-        // FIXME: StringBuilder should hava a toNSString() function to avoid the extra String allocation.
-        [address setStreet:builder.toString().createNSString().get()];
+        [address setStreet:builder.createNSString().get()];
 
         if (!contact.subLocality.isEmpty())
             [address setSubLocality:contact.subLocality.createNSString().get()];

--- a/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
@@ -147,7 +147,7 @@ ExceptionOr<String> canonicalizeIPv6Hostname(StringView value, BaseURLStringType
         result.append(toASCIILower(codepoint));
     }
 
-    return result.toString();
+    return String { result.toString() };
 }
 
 // https://urlpattern.spec.whatwg.org/#canonicalize-a-port, combined with https://urlpattern.spec.whatwg.org/#process-port-for-init

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -817,7 +817,7 @@ auto TextManipulationController::replace(const ManipulationItemData& item, const
             newValue.append(replacementTokens[i].content);
         }
         if (item.attributeName == nullQName())
-            element->setTextContent(newValue.toString());
+            element->setTextContent(String { newValue.toString() });
         else if (RefPtr input = dynamicDowncast<HTMLInputElement>(*element); input && item.attributeName == HTMLNames::valueAttr)
             input->setValue(newValue.toString());
         else

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -1314,7 +1314,7 @@ static void fillContainerFromString(ContainerNode& paragraph, const String& stri
         // append the non-tab textual part
         if (!s.isEmpty()) {
             if (!tabText.isEmpty()) {
-                paragraph.appendChild(createTabSpanElement(document, tabText.toString()));
+                paragraph.appendChild(createTabSpanElement(document, String { tabText.toString() }));
                 tabText.clear();
             }
             Ref textNode = document->createTextNode(stringWithRebalancedWhitespace(s, first, i + 1 == numEntries));
@@ -1326,7 +1326,7 @@ static void fillContainerFromString(ContainerNode& paragraph, const String& stri
         if (i + 1 != numEntries)
             tabText.append('\t');
         else if (!tabText.isEmpty())
-            paragraph.appendChild(createTabSpanElement(document, tabText.toString()));
+            paragraph.appendChild(createTabSpanElement(document, String { tabText.toString() }));
 
         first = false;
     }

--- a/Source/WebCore/html/BaseDateAndTimeInputType.h
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.h
@@ -88,7 +88,7 @@ private:
         DateTimeFormatValidator() { }
 
         void visitField(DateTimeFormat::FieldType, int);
-        void visitLiteral(String&&) { }
+        void visitLiteral(const String&) { }
 
         bool validateFormat(const String& format, const BaseDateAndTimeInputType&);
 

--- a/Source/WebCore/html/EmailInputType.cpp
+++ b/Source/WebCore/html/EmailInputType.cpp
@@ -122,7 +122,7 @@ ValueOrReference<String> EmailInputType::sanitizeValue(const String& proposedVal
             strippedValue.append(',');
         strippedValue.append(addresses[i].trim(isASCIIWhitespace));
     }
-    return strippedValue.toString();
+    return String { strippedValue.toString() };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/shadow/DateTimeEditElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.cpp
@@ -60,7 +60,7 @@ public:
 private:
     // DateTimeFormat::TokenHandler functions:
     void visitField(DateTimeFormat::FieldType, int);
-    void visitLiteral(String&&);
+    void visitLiteral(const String&);
 
     Ref<DateTimeEditElement> m_editElement;
     const DateTimeEditElement::LayoutParameters& m_parameters;
@@ -167,7 +167,7 @@ void DateTimeEditBuilder::visitField(DateTimeFormat::FieldType fieldType, int co
     }
 }
 
-void DateTimeEditBuilder::visitLiteral(String&& text)
+void DateTimeEditBuilder::visitLiteral(const String& text)
 {
     ASSERT(text.length());
 
@@ -185,7 +185,7 @@ void DateTimeEditBuilder::visitLiteral(String&& text)
     if (text.endsWith(' '))
         element->setInlineStyleProperty(CSSPropertyMarginInlineEnd, -1, CSSUnitType::CSS_PX);
 
-    element->appendChild(Text::create(m_editElement->document(), WTFMove(text)));
+    element->appendChild(Text::create(m_editElement->document(), String { text }));
     m_editElement->fieldsWrapperElement().appendChild(element);
 }
 

--- a/Source/WebCore/loader/cocoa/BundleResourceLoader.mm
+++ b/Source/WebCore/loader/cocoa/BundleResourceLoader.mm
@@ -51,7 +51,7 @@ void loadResourceFromBundle(ResourceLoader& loader, const String& subdirectory)
     ASSERT(RunLoop::isMain());
 
     loadQueue().dispatch([protectedLoader = Ref { loader }, url = loader.request().url().isolatedCopy(), subdirectory = subdirectory.isolatedCopy()]() mutable {
-        auto *relativePath = [subdirectory.createNSString() stringByAppendingString: url.path().toString().createNSString().get()];
+        auto *relativePath = [subdirectory.createNSString() stringByAppendingString: url.path().createNSString().get()];
         auto *bundle = [NSBundle bundleWithIdentifier:@"com.apple.WebCore"];
         auto *path = [bundle pathForResource:relativePath ofType:nil];
         auto *data = [NSData dataWithContentsOfFile:path];

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -730,7 +730,7 @@ void NetworkStorageSession::deleteAllCookiesModifiedSince(WallTime timePoint, Co
 
 Vector<Cookie> NetworkStorageSession::domCookiesForHost(const URL& firstParty)
 {
-    RetainPtr host = firstParty.host().toString().createNSString();
+    RetainPtr host = firstParty.host().createNSString();
 
     // _getCookiesForDomain only returned unpartitioned (i.e., nil partition) cookies
     RetainPtr<NSArray> unpartitionedCookies = [nsCookieStorage() _getCookiesForDomain:host.get()];

--- a/Source/WebCore/platform/text/DateTimeFormat.h
+++ b/Source/WebCore/platform/text/DateTimeFormat.h
@@ -96,7 +96,7 @@ public:
     public:
         virtual ~TokenHandler() = default;
         virtual void visitField(FieldType, int numberOfPatternCharacters) = 0;
-        virtual void visitLiteral(String&&) = 0;
+        virtual void visitLiteral(const String&) = 0;
     };
 
     // Returns true if succeeded, false if failed.

--- a/Source/WebCore/platform/text/PlatformLocale.cpp
+++ b/Source/WebCore/platform/text/PlatformLocale.cpp
@@ -54,7 +54,7 @@ public:
 private:
     // DateTimeFormat::TokenHandler functions.
     void visitField(DateTimeFormat::FieldType, int) final;
-    void visitLiteral(String&&) final;
+    void visitLiteral(const String&) final;
 
     String zeroPadString(const String&, size_t width);
     void appendNumber(int number, size_t width);
@@ -169,10 +169,10 @@ void DateTimeStringBuilder::visitField(DateTimeFormat::FieldType fieldType, int 
     }
 }
 
-void DateTimeStringBuilder::visitLiteral(String&& text)
+void DateTimeStringBuilder::visitLiteral(const String& text)
 {
     ASSERT(text.length());
-    m_builder.append(WTFMove(text));
+    m_builder.append(text);
 }
 
 String DateTimeStringBuilder::toString()
@@ -366,7 +366,7 @@ String Locale::formatDateTime(const DateComponents& date, FormatType formatType)
     return builder.toString();
 }
 
-String Locale::localizedDecimalSeparator()
+const String& Locale::localizedDecimalSeparator()
 {
     initializeLocaleData();
     return m_decimalSymbols[DecimalSeparatorIndex];

--- a/Source/WebCore/platform/text/PlatformLocale.h
+++ b/Source/WebCore/platform/text/PlatformLocale.h
@@ -119,7 +119,7 @@ public:
     // December. These strings should not be abbreviations.
     virtual const Vector<String>& monthLabels() = 0;
 
-    String localizedDecimalSeparator();
+    const String& localizedDecimalSeparator();
 
     enum FormatType { FormatTypeUnspecified, FormatTypeShort, FormatTypeMedium };
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2086,7 +2086,7 @@ ExceptionOr<String> Internals::dumpMarkerRects(const String& markerTypeString)
     rectString.append("marker rects: "_s);
     for (const auto& rect : rects)
         rectString.append('(', rect.x(), ", "_s, rect.y(), ", "_s, FormattedNumber::fixedPrecision(rect.width()), ", "_s, rect.height(), ") "_s);
-    return rectString.toString();
+    return String { rectString.toString() };
 }
 
 ExceptionOr<void> Internals::setMarkedTextMatchesAreHighlighted(bool flag)
@@ -4363,7 +4363,7 @@ ExceptionOr<String> Internals::getCurrentCursorInfo()
     if (cursor.imageScaleFactor() != 1)
         result.append(" scale="_s, cursor.imageScaleFactor());
 #endif
-    return result.toString();
+    return String { result.toString() };
 #else
     return "FAIL: Cursor details not available on this platform."_str;
 #endif
@@ -4984,7 +4984,7 @@ ExceptionOr<String> Internals::mediaSessionRestrictions(const String& mediaTypeS
             builder.append(',');
         builder.append("interruptedplaybacknotpermitted"_s);
     }
-    return builder.toString();
+    return String { builder.toString() };
 }
 
 void Internals::setMediaElementRestrictions(HTMLMediaElement& element, StringView restrictionsString)
@@ -5650,7 +5650,7 @@ ExceptionOr<String> Internals::scrollSnapOffsets(Element& element)
         serializeOffsets(result, offsetInfo->verticalSnapOffsets);
     }
 
-    return result.toString();
+    return String { result.toString() };
 }
 
 ExceptionOr<bool> Internals::isScrollSnapInProgress(Element& element)

--- a/Source/WebCore/testing/Internals.mm
+++ b/Source/WebCore/testing/Internals.mm
@@ -267,7 +267,7 @@ RetainPtr<VKCImageAnalysis> Internals::fakeImageAnalysisResultForTesting(const V
             fullText.append(newlineCharacter);
     }
 
-    return adoptNS((id)[[FakeImageAnalysisResult alloc] initWithString:fullText.toString().createNSString().get()]);
+    return adoptNS((id)[[FakeImageAnalysisResult alloc] initWithString:fullText.createNSString().get()]);
 }
 
 #endif // ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)

--- a/Source/WebCore/xml/XMLErrors.cpp
+++ b/Source/WebCore/xml/XMLErrors.cpp
@@ -144,7 +144,7 @@ void XMLErrors::insertErrorMessageBlock()
         documentElement = WTFMove(body);
     }
 
-    Ref reportElement = createXHTMLParserErrorHeader(document, m_errorMessages.toString());
+    Ref reportElement = createXHTMLParserErrorHeader(document, String { m_errorMessages.toString() });
 
 #if ENABLE(XSLT)
     if (document->transformSourceDocument()) {

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
@@ -2152,7 +2152,7 @@ void ResourceLoadStatisticsStore::setDomainsAsPrevalent(StdSet<unsigned>&& domai
         ITP_RELEASE_LOG_DATABASE_ERROR("setDomainsAsPrevalent: failed to step statement");
 }
 
-void ResourceLoadStatisticsStore::dumpResourceLoadStatistics(CompletionHandler<void(String&&)>&& completionHandler)
+void ResourceLoadStatisticsStore::dumpResourceLoadStatistics(CompletionHandler<void(const String&)>&& completionHandler)
 {
     ASSERT(!RunLoop::isMain());
     if (m_dataRecordsBeingRemoved) {

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
@@ -117,7 +117,7 @@ public:
     void cancelPendingStatisticsProcessingRequest();
     void mergeStatistics(Vector<ResourceLoadStatistics>&&);
     void runIncrementalVacuumCommand();
-    void dumpResourceLoadStatistics(CompletionHandler<void(String&&)>&&);
+    void dumpResourceLoadStatistics(CompletionHandler<void(const String&)>&&);
     bool isNewResourceLoadStatisticsDatabaseFile() const { return m_isNewResourceLoadStatisticsDatabaseFile; }
     void setIsNewResourceLoadStatisticsDatabaseFile(bool isNewResourceLoadStatisticsDatabaseFile) { m_isNewResourceLoadStatisticsDatabaseFile = isNewResourceLoadStatisticsDatabaseFile; }
 

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
@@ -996,8 +996,8 @@ void WebResourceLoadStatisticsStore::dumpResourceLoadStatistics(CompletionHandle
     ASSERT(RunLoop::isMain());
 
     postTask([this, completionHandler = WTFMove(completionHandler)]() mutable {
-        auto innerCompletionHandler = [completionHandler = WTFMove(completionHandler)](String&& result) mutable {
-            postTaskReply([result = WTFMove(result).isolatedCopy(), completionHandler = WTFMove(completionHandler)]() mutable {
+        auto innerCompletionHandler = [completionHandler = WTFMove(completionHandler)](const String& result) mutable {
+            postTaskReply([result = result.isolatedCopy(), completionHandler = WTFMove(completionHandler)]() mutable {
                 completionHandler(WTFMove(result));
             });
         };

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -2044,7 +2044,7 @@ void NetworkStorageManager::cacheStorageClearMemoryRepresentation(const WebCore:
     callback();
 }
 
-void NetworkStorageManager::cacheStorageRepresentation(CompletionHandler<void(String&&)>&& callback)
+void NetworkStorageManager::cacheStorageRepresentation(CompletionHandler<void(const String&)>&& callback)
 {
     Vector<String> originStrings;
     auto targetTypes = OptionSet<WebsiteDataType> { WebsiteDataType::DOMCache };

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -247,7 +247,7 @@ private:
     void cacheStorageRemoveRecords(WebCore::DOMCacheIdentifier, WebCore::ResourceRequest&&, WebCore::CacheQueryOptions&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
     void cacheStoragePutRecords(IPC::Connection&, WebCore::DOMCacheIdentifier, Vector<WebCore::DOMCacheEngine::CrossThreadRecord>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
     void cacheStorageClearMemoryRepresentation(const WebCore::ClientOrigin&, CompletionHandler<void()>&&);
-    void cacheStorageRepresentation(CompletionHandler<void(String&&)>&&);
+    void cacheStorageRepresentation(CompletionHandler<void(const String&)>&&);
 
     void cloneSessionStorageNamespace(StorageNamespaceIdentifier, StorageNamespaceIdentifier);
     bool shouldManageServiceWorkerRegistrationsByOrigin();

--- a/Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm
@@ -162,7 +162,7 @@ static NSMutableAttributedString *browsingDetailsText(const URL& url, SSBService
         auto malwareDescription = adoptNS([[NSMutableAttributedString alloc] initWithString:description]);
         replace(malwareDescription.get(), @"%safeBrowsingProvider%", localizedProviderDisplayName(result).createNSString().get());
         auto statusLink = adoptNS([[NSMutableAttributedString alloc] initWithString:WEB_UI_NSSTRING(@"the status of “%site%”", "Part of malware description")]);
-        replace(statusLink.get(), @"%site%", url.host().toString().createNSString().get());
+        replace(statusLink.get(), @"%site%", url.host().createNSString().get());
         addLinkAndReplace(malwareDescription.get(), statusStringToReplace, [statusLink string], malwareDetailsURL(url, result).get());
 
         auto ifYouUnderstand = adoptNS([[NSMutableAttributedString alloc] initWithString:WEB_UI_NSSTRING(@"If you understand the risks involved, you can %visit-this-unsafe-site-link%.", "Action from safe browsing warning")]);

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -682,7 +682,7 @@ inline static RetainPtr<NSString> textRelativeToSelectionStart(WKRelativeTextRan
             break;
         }
     }
-    return string.toString().createNSString();
+    return string.createNSString();
 }
 
 @implementation WKRelativeTextPosition

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
@@ -393,7 +393,7 @@ NSString *WebExtensionAPIAction::parseIconPath(NSString *path, const URL& baseUR
     // Resolve paths as relative against the base URL, unless it is a data URL.
     if ([path hasPrefix:@"data:"])
         return path;
-    return URL { baseURL, path }.path().toString().createNSString().autorelease();
+    return URL { baseURL, path }.path().createNSString().autorelease();
 }
 
 NSMutableDictionary *WebExtensionAPIAction::parseIconPathsDictionary(NSDictionary *input, const URL& baseURL, bool forVariants, NSString *inputKey, NSString **outExceptionString)

--- a/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
@@ -1238,7 +1238,7 @@ TEST_F(ContentExtensionTest, WideNFA)
     }
     ruleList.append(']');
     
-    auto backend = makeBackend(ruleList.toString());
+    auto backend = makeBackend(String { ruleList.toString() });
 
     testRequest(backend, mainDocumentRequest("http://webkit.org/AAA"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(backend, mainDocumentRequest("http://webkit.org/YAA"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PermissionsAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PermissionsAPI.mm
@@ -126,7 +126,7 @@ TEST(PermissionsAPI, DataURL)
     for (size_t cptr = 0; cptr < sizeof(script) - 1; ++cptr)
         urlEncodeIfNeeded(script[cptr], buffer);
 
-    RetainPtr request = adoptNS([[NSURLRequest alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:buffer.toString().createNSString().get()]).get()]);
+    RetainPtr request = adoptNS([[NSURLRequest alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:buffer.createNSString().get()]).get()]);
     [webView loadRequest:request.get()];
     TestWebKitAPI::Util::run(&didReceiveMessage);
     EXPECT_FALSE(didReceiveQueryPermission);


### PR DESCRIPTION
#### 69caf04f9d07e31dcf6c723c1cc716af020168f8
<pre>
Small optimization of StringBuilder::toString()
<a href="https://bugs.webkit.org/show_bug.cgi?id=291777">https://bugs.webkit.org/show_bug.cgi?id=291777</a>

Reviewed by Darin Adler.

Small optimization of StringBuilder::toString():
- Update StringBuilder::toString() to return a const reference to reduce ref-counting churn
- Add a StringBuilder::toNSString() to avoid people using `toString().createNSString()`

* Source/JavaScriptCore/runtime/IntlPluralRules.cpp:
(JSC::IntlPluralRules::initializePluralRules):
* Source/WTF/wtf/text/StringBuilder.h:
(WTF::StringBuilder::toString):
(WTF::StringBuilder::createNSString const):
* Source/WebCore/Modules/applepay/cocoa/PaymentContactCocoa.mm:
(WebCore::convert):
* Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp:
(WebCore::canonicalizeIPv6Hostname):
* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::TextManipulationController::replace):
* Source/WebCore/editing/markup.cpp:
(WebCore::fillContainerFromString):
* Source/WebCore/html/BaseDateAndTimeInputType.h:
* Source/WebCore/html/shadow/DateTimeEditElement.cpp:
(WebCore::DateTimeEditBuilder::visitLiteral):
* Source/WebCore/loader/cocoa/BundleResourceLoader.mm:
(WebCore::BundleResourceLoader::loadResourceFromBundle):
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::domCookiesForHost):
* Source/WebCore/platform/text/DateTimeFormat.h:
* Source/WebCore/platform/text/PlatformLocale.cpp:
(WebCore::DateTimeStringBuilder::visitLiteral):
(WebCore::Locale::localizedDecimalSeparator):
* Source/WebCore/platform/text/PlatformLocale.h:
* Source/WebCore/testing/Internals.mm:
(WebCore::Internals::fakeImageAnalysisResultForTesting):
* Source/WebCore/xml/XMLErrors.cpp:
(WebCore::XMLErrors::insertErrorMessageBlock):
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::ResourceLoadStatisticsStore::dumpResourceLoadStatistics):
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp:
(WebKit::WebResourceLoadStatisticsStore::dumpResourceLoadStatistics):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::cacheStorageRepresentation):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm:
(WebKit::browsingDetailsText):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(textRelativeToSelectionStart):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm:
(WebKit::WebExtensionAPIAction::parseIconPath):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PermissionsAPI.mm:
(TestWebKitAPI::TEST(PermissionsAPI, DataURL)):

Canonical link: <a href="https://commits.webkit.org/294279@main">https://commits.webkit.org/294279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0795eb8913a72fdb4afa8ea194889a9baa5d7498

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11211 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106394 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51873 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103287 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29402 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77107 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34145 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91451 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57454 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16176 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9461 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51221 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/93913 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86060 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9537 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108750 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/99855 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28374 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20880 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86086 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28736 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85639 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21802 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30367 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8074 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22473 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28304 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33575 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/123481 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28116 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34360 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31436 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29674 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->