### PR TITLE
Remove Portal Crossing component when drag ends

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKPageHostedModelView.mm
+++ b/Source/WebKit/UIProcess/ios/WKPageHostedModelView.mm
@@ -109,8 +109,7 @@
         REEntityAddComponentByClass(_stereoContentEntity.get(), RENetworkComponentGetComponentType());
         REPtr<REComponentRef> stereoContentComponent = REEntityGetOrAddComponentByClass(_stereoContentEntity.get(), REEmbeddedStereoContentComponentGetComponentType());
         REPtr<REComponentRef> worldRootComponent = REEntityGetOrAddComponentByClass(_stereoContentEntity.get(), REWorldRootComponentGetComponentType());
-        REPtr<REComponentRef> portalCrossingComponent = REEntityGetOrAddComponentByClass(_stereoContentEntity.get(), REPortalCrossingFlagsComponentGetComponentType());
-        if (stereoContentComponent && worldRootComponent && portalCrossingComponent) {
+        if (stereoContentComponent && worldRootComponent) {
             REPtr<REWorldRootRef> worldRoot = adoptRE(RECreateWorldRoot());
             REEmbeddedStereoContentComponentSetWorldRoot(stereoContentComponent.get(), worldRoot.get());
             REWorldRootComponentSetWorldRoot(worldRootComponent.get(), worldRoot.get());
@@ -124,9 +123,6 @@
 
             // FIXME: https://bugs.webkit.org/show_bug.cgi?id=290950
             REEmbeddedStereoContentComponentSetLightingBlendDistance(stereoContentComponent.get(), 0.0);
-
-            REPortalCrossingFlagsComponentSetEnabled(portalCrossingComponent.get(), false);
-            REPortalCrossingFlagsComponentSetInherited(portalCrossingComponent.get(), false);
 
             REEntitySetParent(_stereoContentEntity.get(), _rootEntity.get());
 
@@ -301,7 +297,10 @@
 - (void)setPortalCrossing:(BOOL)enabled
 {
 #if HAVE(RE_STEREO_CONTENT_SUPPORT)
-    if (REPtr<REComponentRef> portalCrossingComponent = REEntityGetOrAddComponentByClass(_stereoContentEntity.get(), REPortalCrossingFlagsComponentGetComponentType())) {
+    if (!enabled) {
+        REEntityRemoveComponentByClass(_stereoContentEntity.get(), REPortalCrossingFlagsComponentGetComponentType());
+        RENetworkMarkEntityMetadataDirty(_stereoContentEntity.get());
+    } else if (REPtr<REComponentRef> portalCrossingComponent = REEntityGetOrAddComponentByClass(_stereoContentEntity.get(), REPortalCrossingFlagsComponentGetComponentType())) {
         REPortalCrossingFlagsComponentSetEnabled(portalCrossingComponent.get(), enabled);
         REPortalCrossingFlagsComponentSetInherited(portalCrossingComponent.get(), enabled);
         RENetworkMarkComponentDirty(portalCrossingComponent.get());


### PR DESCRIPTION
#### c7fbe9a05fd6da036e9cc1d56788dec659d4ae3c
<pre>
Remove Portal Crossing component when drag ends
<a href="https://bugs.webkit.org/show_bug.cgi?id=291783">https://bugs.webkit.org/show_bug.cgi?id=291783</a>
<a href="https://rdar.apple.com/149234418">rdar://149234418</a>

Reviewed by NOBODY (OOPS!).

Previously, model elements should get clipped by the front of the portal plane when the model extends
past the portal plane. With the portal crossing component, the clipping behavior has changed. To
restore the original behavior, we need to remove the component entirely when we disable the crossing
component.

* Source/WebKit/UIProcess/ios/WKPageHostedModelView.mm:
(-[WKPageHostedModelView init]):
(-[WKPageHostedModelView setPortalCrossing:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7fbe9a05fd6da036e9cc1d56788dec659d4ae3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10280 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105462 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50917 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28455 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76386 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33447 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15527 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90629 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56741 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15344 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50281 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92991 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85265 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8712 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107820 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27447 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20132 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85342 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27810 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86829 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84878 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29557 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7306 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/21359 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27382 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32621 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27193 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30511 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28751 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->