### PR TITLE
[WebDriver][BiDi] Implement the browser module

### DIFF
--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -560,6 +560,8 @@ UIProcess/Authentication/WebCredential.cpp
 UIProcess/Authentication/WebProtectionSpace.cpp
 
 // FIXME(206266): AutomationProtocolObjects.h's "namespace Protocol" conflicts with objc/runtime.h's "typedef struct objc_object Protocol"
+UIProcess/Automation/BidiBrowserAgent.cpp @no-unify
+UIProcess/Automation/BidiUserContext.cpp @no-unify
 UIProcess/Automation/SimulatedInputDispatcher.cpp @no-unify
 UIProcess/Automation/WebAutomationSession.cpp @no-unify
 UIProcess/Automation/WebDriverBidiProcessor.cpp @no-unify

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -216,6 +216,7 @@ UIProcess/API/gtk/WebKitWebViewGtk4.cpp @no-unify
 UIProcess/API/soup/HTTPCookieStoreSoup.cpp
 
 UIProcess/Automation/cairo/WebAutomationSessionCairo.cpp
+UIProcess/Automation/glib/BidiBrowserAgentGlib.cpp @no-unify
 UIProcess/Automation/gtk/WebAutomationSessionGtk.cpp @no-unify
 
 UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp

--- a/Source/WebKit/UIProcess/Automation/BidiBrowserAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowserAgent.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2025 Microsoft Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "BidiBrowserAgent.h"
+
+#if ENABLE(WEBDRIVER_BIDI)
+
+#include "AutomationProtocolObjects.h"
+#include "BidiUserContext.h"
+#include "WebAutomationSession.h"
+#include "WebAutomationSessionMacros.h"
+#include "WebDriverBidiProtocolObjects.h"
+#include "WebProcessPool.h"
+#include "WebsiteDataStore.h"
+#include <pal/SessionID.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/text/StringBuilder.h>
+
+namespace WebKit {
+
+using namespace Inspector;
+using UserContextInfo = Inspector::Protocol::BidiBrowser::UserContextInfo;
+
+namespace {
+
+String toUserContextIDProtocolString(const PAL::SessionID& sessionID)
+{
+    StringBuilder builder;
+    builder.append(hex(sessionID.toUInt64(), 16));
+    return builder.toString();
+}
+
+const String& defaultUserContextID()
+{
+    static NeverDestroyed<const String> contextID(MAKE_STATIC_STRING_IMPL("default"));
+    return contextID;
+}
+
+} // namespace
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BidiBrowserAgent);
+
+BidiBrowserAgent::BidiBrowserAgent(WebAutomationSession& session, BackendDispatcher& backendDispatcher)
+    : m_session(session)
+    , m_browserDomainDispatcher(BidiBrowserBackendDispatcher::create(backendDispatcher, this))
+{
+}
+
+BidiBrowserAgent::~BidiBrowserAgent() = default;
+
+// MARK: Inspector::BidiBrowserDispatcherHandler methods.
+
+Inspector::CommandResult<void> BidiBrowserAgent::close()
+{
+    RefPtr session = m_session.get();
+    SYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    session->terminate();
+
+    return { };
+}
+
+Inspector::CommandResult<String> BidiBrowserAgent::createUserContext()
+{
+    String error;
+    auto userContext = platformCreateUserContext(error);
+    SYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(!userContext, InternalError, error);
+
+    PAL::SessionID sessionID = userContext->dataStore().sessionID();
+    String userContextID = toUserContextIDProtocolString(sessionID);
+    m_userContexts.set(userContextID, WTFMove(userContext));
+
+    return userContextID;
+}
+
+Inspector::CommandResult<Ref<JSON::ArrayOf<UserContextInfo>>> BidiBrowserAgent::getUserContexts()
+{
+    auto userContexts = JSON::ArrayOf<UserContextInfo>::create();
+    userContexts->addItem(UserContextInfo::create()
+        .setUserContext(defaultUserContextID())
+        .release());
+    for (const auto& pair : m_userContexts) {
+        userContexts->addItem(UserContextInfo::create()
+            .setUserContext(pair.key)
+            .release());
+    }
+    return userContexts;
+}
+
+Inspector::CommandResult<void> BidiBrowserAgent::removeUserContext(const String& userContext)
+{
+    // https://www.w3.org/TR/webdriver-bidi/#command-browser-removeUserContext step 2.
+    SYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(userContext == defaultUserContextID(), InvalidParameter, "Cannot delete default user context."_s);
+
+    auto it = m_userContexts.find(userContext);
+    // https://www.w3.org/TR/webdriver-bidi/#command-browser-removeUserContext step 4.
+    SYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(it == m_userContexts.end(), InvalidParameter, "no such user context"_s);
+
+    // TODO: track and close all pages that belong to this user context.
+    m_userContexts.remove(it);
+    return { };
+}
+
+#if !PLATFORM(GTK)
+std::unique_ptr<BidiUserContext> BidiBrowserAgent::platformCreateUserContext(String& error)
+{
+    error = "User context creation is not implemented for this platform yet."_s;
+    return nullptr;
+}
+#endif
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBDRIVER_BIDI)
+

--- a/Source/WebKit/UIProcess/Automation/BidiBrowserAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowserAgent.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025 Microsoft Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBDRIVER_BIDI)
+
+#include "WebDriverBidiBackendDispatchers.h"
+#include <JavaScriptCore/InspectorBackendDispatcher.h>
+#include <wtf/FastMalloc.h>
+#include <wtf/Forward.h>
+#include <wtf/WeakPtr.h>
+
+#if PLATFORM(GTK)
+#include <wtf/glib/GRefPtr.h>
+typedef struct _WebKitWebContext WebKitWebContext;
+#endif
+
+namespace WebKit {
+
+class BidiUserContext;
+class WebAutomationSession;
+class WebProcessPool;
+class WebsiteDataStore;
+
+class BidiBrowserAgent final : public Inspector::BidiBrowserBackendDispatcherHandler {
+    WTF_MAKE_TZONE_ALLOCATED(BidiBrowserAgent);
+public:
+    BidiBrowserAgent(WebAutomationSession&, Inspector::BackendDispatcher&);
+    ~BidiBrowserAgent() override;
+
+    // Inspector::BidiBrowserBackendDispatcherHandler methods.
+    Inspector::CommandResult<void> close() override;
+    Inspector::CommandResult<String> createUserContext() override;
+    Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::BidiBrowser::UserContextInfo>>> getUserContexts() override;
+    Inspector::CommandResult<void> removeUserContext(const String& userContext) override;
+
+private:
+    std::unique_ptr<BidiUserContext> platformCreateUserContext(String& error);
+
+    WeakPtr<WebAutomationSession> m_session;
+    Ref<Inspector::BidiBrowserBackendDispatcher> m_browserDomainDispatcher;
+    HashMap<String, std::unique_ptr<BidiUserContext>> m_userContexts;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBDRIVER_BIDI)

--- a/Source/WebKit/UIProcess/Automation/BidiUserContext.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiUserContext.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Microsoft Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "BidiUserContext.h"
+
+#if ENABLE(WEBDRIVER_BIDI)
+
+#include "WebProcessPool.h"
+#include "WebsiteDataStore.h"
+
+namespace WebKit {
+
+#if PLATFORM(GTK)
+BidiUserContext::BidiUserContext(WebsiteDataStore& dataStore, WebProcessPool& processPool, GRefPtr<WebKitWebContext>&& context)
+    : m_dataStore(dataStore)
+    , m_processPool(processPool)
+    , m_context(WTFMove(context))
+{
+};
+#else
+BidiUserContext::BidiUserContext(WebsiteDataStore& dataStore, WebProcessPool& processPool)
+    : m_dataStore(dataStore)
+    , m_processPool(processPool)
+{
+};
+#endif // PLATFORM(GTK)
+
+BidiUserContext::~BidiUserContext() = default;
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBDRIVER_BIDI)
+

--- a/Source/WebKit/UIProcess/Automation/BidiUserContext.h
+++ b/Source/WebKit/UIProcess/Automation/BidiUserContext.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025 Microsoft Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBDRIVER_BIDI)
+
+#include <wtf/FastMalloc.h>
+#include <wtf/Forward.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Ref.h>
+
+#if PLATFORM(GTK)
+#include <wtf/glib/GRefPtr.h>
+typedef struct _WebKitWebContext WebKitWebContext;
+#endif
+
+namespace WebKit {
+
+class WebProcessPool;
+class WebsiteDataStore;
+
+class BidiUserContext {
+    WTF_MAKE_NONCOPYABLE(BidiUserContext);
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+#if PLATFORM(GTK)
+    BidiUserContext(WebsiteDataStore&, WebProcessPool&, GRefPtr<WebKitWebContext>&&);
+#else
+    BidiUserContext(WebsiteDataStore&, WebProcessPool&);
+#endif
+    ~BidiUserContext();
+
+    WebsiteDataStore& dataStore() const { return m_dataStore.get(); }
+    WebProcessPool& processPool() const { return m_processPool.get(); }
+
+private:
+
+    Ref<WebsiteDataStore> m_dataStore;
+    Ref<WebProcessPool> m_processPool;
+#if PLATFORM(GTK)
+    GRefPtr<WebKitWebContext> m_context;
+#endif
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBDRIVER_BIDI)

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
@@ -36,11 +36,11 @@
 
 namespace WebKit {
 
+class BidiBrowserAgent;
 class WebAutomationSession;
 
 class WebDriverBidiProcessor final
     : public Inspector::FrontendChannel
-    , public Inspector::BidiBrowserBackendDispatcherHandler
     , public Inspector::BidiBrowsingContextBackendDispatcherHandler
     , public Inspector::BidiScriptBackendDispatcherHandler {
     WTF_MAKE_TZONE_ALLOCATED(WebDriverBidiProcessor);
@@ -64,9 +64,6 @@ public:
     void navigate(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, const String& url, std::optional<Inspector::Protocol::BidiBrowsingContext::ReadinessState>&&, Inspector::CommandCallbackOf<String, Inspector::Protocol::BidiBrowsingContext::Navigation>&&) override;
     void reload(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, std::optional<bool>&& optionalIgnoreCache, std::optional<Inspector::Protocol::BidiBrowsingContext::ReadinessState>&& optionalWait, Inspector::CommandCallbackOf<String, String>&&) override;
 
-    // Inspector::BidiBrowserBackendDispatcherHandler methods.
-    Inspector::Protocol::ErrorStringOr<void> close() override;
-
     // Inspector::BidiScriptBackendDispatcherHandler methods.
     void callFunction(const String& functionDeclaration, bool awaitPromise, Ref<JSON::Object>&& target, RefPtr<JSON::Array>&& optionalArguments, std::optional<Inspector::Protocol::BidiScript::ResultOwnership>&&, RefPtr<JSON::Object>&& optionalSerializationOptions, RefPtr<JSON::Object>&& optionalThis, std::optional<bool>&& optionalUserActivation, Inspector::CommandCallbackOf<Inspector::Protocol::BidiScript::EvaluateResultType, String, RefPtr<Inspector::Protocol::BidiScript::RemoteValue>, RefPtr<Inspector::Protocol::BidiScript::ExceptionDetails>>&&) override;
     void evaluate(const String& expression, bool awaitPromise, Ref<JSON::Object>&& target, std::optional<Inspector::Protocol::BidiScript::ResultOwnership>&&, RefPtr<JSON::Object>&& optionalSerializationOptions,  std::optional<bool>&& optionalUserActivation, Inspector::CommandCallbackOf<Inspector::Protocol::BidiScript::EvaluateResultType, String, RefPtr<Inspector::Protocol::BidiScript::RemoteValue>, RefPtr<Inspector::Protocol::BidiScript::ExceptionDetails>>&&) override;
@@ -83,9 +80,10 @@ private:
     Ref<Inspector::FrontendRouter> m_frontendRouter;
     Ref<Inspector::BackendDispatcher> m_backendDispatcher;
 
-    Ref<Inspector::BidiBrowserBackendDispatcher> m_browserDomainDispatcher;
     Ref<Inspector::BidiBrowsingContextBackendDispatcher> m_browsingContextDomainDispatcher;
     Ref<Inspector::BidiScriptBackendDispatcher> m_scriptDomainDispatcher;
+
+    std::unique_ptr<BidiBrowserAgent> m_browserAgent;
 
     std::unique_ptr<Inspector::BidiLogFrontendDispatcher> m_logDomainNotifier;
 };

--- a/Source/WebKit/UIProcess/Automation/glib/BidiBrowserAgentGlib.cpp
+++ b/Source/WebKit/UIProcess/Automation/glib/BidiBrowserAgentGlib.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025 Microsoft Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "BidiBrowserAgent.h"
+
+#if ENABLE(WEBDRIVER_BIDI)
+
+#include "BidiUserContext.h"
+#include "WebKitNetworkSession.h"
+#include "WebKitWebContextPrivate.h"
+#include "WebKitWebsiteDataManagerPrivate.h"
+
+namespace WebKit {
+
+using namespace Inspector;
+
+std::unique_ptr<BidiUserContext> BidiBrowserAgent::platformCreateUserContext(String& error)
+{
+#if ENABLE(2022_GLIB_API)
+    GRefPtr<WebKitNetworkSession> networkSession = adoptGRef(webkit_network_session_new_ephemeral());
+    GRefPtr<WebKitWebsiteDataManager> dataManager = webkit_network_session_get_website_data_manager(networkSession.get());
+#else
+    GRefPtr<WebKitWebsiteDataManager> dataManager = adoptGRef(webkit_website_data_manager_new_ephemeral());
+#endif
+
+    GRefPtr<WebKitWebContext> context = adoptGRef(WEBKIT_WEB_CONTEXT(g_object_new(WEBKIT_TYPE_WEB_CONTEXT,
+#if !ENABLE(2022_GLIB_API)
+        "website-data-manager", dataManager.get(),
+#endif
+    // WPE has PSON enabled by default and doesn't have such parameter.
+#if PLATFORM(GTK)
+#if !ENABLE(2022_GLIB_API)
+        "process-swap-on-cross-site-navigation-enabled", true,
+#endif
+#endif
+        nullptr)));
+    if (!context) {
+        error = "Failed to create GLib ephemeral context"_s;
+        return nullptr;
+    }
+
+    return makeUnique<BidiUserContext>(webkitWebsiteDataManagerGetDataStore(dataManager.get()), webkitWebContextGetProcessPool(context.get()), WTFMove(context));
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBDRIVER_BIDI)
+

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiBrowser.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiBrowser.json
@@ -15,8 +15,17 @@
         {
             "id": "UserContext",
             "description": "Unique string identifying a user context with separate storage.",
-            "spec": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/browser",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-browser-UserContext",
             "type": "string"
+        },
+        {
+            "id": "UserContextInfo",
+            "description": "Represents properties of a user context.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-browser-UserContextInfo",
+            "type": "object",
+            "properties": [
+                { "name": "userContext", "$ref": "BidiBrowser.UserContext", "description": "Id of the user context." }
+            ]
         }
     ],
     "commands": [
@@ -24,6 +33,30 @@
             "name": "close",
             "description": "Terminates the WebDriver session to which it is sent and cleans up remote end automation state.",
             "spec": "https://w3c.github.io/webdriver-bidi/#command-browser-close"
+        },
+        {
+            "name": "createUserContext",
+            "description": "Creates a user context.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-browser-createUserContext",
+            "returns": [
+                { "name": "userContext", "$ref": "BidiBrowser.UserContext", "description": "Identifier of created user context." }
+            ]
+        },
+        {
+            "name": "getUserContexts",
+            "description": "Returns a list of user contexts.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-browser-getUserContexts",
+            "returns": [
+                { "name": "userContexts", "type": "array", "items": { "$ref": "BidiBrowser.UserContextInfo" }, "description": "List of existing user contexts." }
+            ]
+        },
+        {
+            "name": "removeUserContext",
+            "description": "Closes a user context and all navigables in it without running beforeunload handlers.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-browser-removeUserContext",
+            "parameters": [
+                { "name": "userContext", "$ref": "BidiBrowser.UserContext", "description": "User context id." }
+            ]
         }
     ]
 }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2455,6 +2455,10 @@
 		EEA52F482D70545300D578B5 /* WKStageMode.h in Headers */ = {isa = PBXBuildFile; fileRef = EE0D3CDD2D3709BE00072978 /* WKStageMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EEA52F492D7055A700D578B5 /* WKStageMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0D3CDC2D3709BE00072978 /* WKStageMode.swift */; };
 		EEFE72792D64FE5600DC6214 /* StageModeInteractionState.h in Headers */ = {isa = PBXBuildFile; fileRef = EEFE72782D64FE5600DC6214 /* StageModeInteractionState.h */; };
+		F3A94F012DB6F3310023CE9D /* BidiUserContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F3A94F002DB6F3310023CE9D /* BidiUserContext.cpp */; };
+		F3A94F022DB6F3310023CE9D /* BidiUserContext.h in Headers */ = {isa = PBXBuildFile; fileRef = F3A94EFF2DB6F3310023CE9D /* BidiUserContext.h */; };
+		F3EEEE592DB318270038CC1D /* BidiBrowserAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = F3EEEE572DB318270038CC1D /* BidiBrowserAgent.h */; };
+		F3EEEE5A2DB318270038CC1D /* BidiBrowserAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F3EEEE582DB318270038CC1D /* BidiBrowserAgent.cpp */; };
 		F404455C2D5CFB56000E587E /* AppKitSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = F404455A2D5CFB56000E587E /* AppKitSoftLink.h */; };
 		F409BA181E6E64BC009DA28E /* WKDragDestinationAction.h in Headers */ = {isa = PBXBuildFile; fileRef = F409BA171E6E64B3009DA28E /* WKDragDestinationAction.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F40C3B712AB401C5007A3567 /* WKDatePickerPopoverController.h in Headers */ = {isa = PBXBuildFile; fileRef = F40C3B6F2AB40167007A3567 /* WKDatePickerPopoverController.h */; };
@@ -8307,6 +8311,10 @@
 		EE0D3CDD2D3709BE00072978 /* WKStageMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKStageMode.h; sourceTree = "<group>"; };
 		EEFE72782D64FE5600DC6214 /* StageModeInteractionState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StageModeInteractionState.h; sourceTree = "<group>"; };
 		F036978715F4BF0500C3A80E /* WebColorPicker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebColorPicker.cpp; sourceTree = "<group>"; };
+		F3A94EFF2DB6F3310023CE9D /* BidiUserContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiUserContext.h; sourceTree = "<group>"; };
+		F3A94F002DB6F3310023CE9D /* BidiUserContext.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiUserContext.cpp; sourceTree = "<group>"; };
+		F3EEEE572DB318270038CC1D /* BidiBrowserAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiBrowserAgent.h; sourceTree = "<group>"; };
+		F3EEEE582DB318270038CC1D /* BidiBrowserAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiBrowserAgent.cpp; sourceTree = "<group>"; };
 		F404455A2D5CFB56000E587E /* AppKitSoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppKitSoftLink.h; sourceTree = "<group>"; };
 		F404455B2D5CFB56000E587E /* AppKitSoftLink.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AppKitSoftLink.mm; sourceTree = "<group>"; };
 		F4063DDE2D71481E00F3FE6E /* LLVMProfiling.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LLVMProfiling.h; sourceTree = "<group>"; };
@@ -14046,6 +14054,10 @@
 				99C3AE221DAD8E1400AF5C16 /* mac */,
 				996D00442D7AA0CD0049C7D8 /* protocol */,
 				9955A6E91C7980BB00EB6A93 /* Automation.json */,
+				F3EEEE582DB318270038CC1D /* BidiBrowserAgent.cpp */,
+				F3EEEE572DB318270038CC1D /* BidiBrowserAgent.h */,
+				F3A94F002DB6F3310023CE9D /* BidiUserContext.cpp */,
+				F3A94EFF2DB6F3310023CE9D /* BidiUserContext.h */,
 				995226D5207D184600F78420 /* SimulatedInputDispatcher.cpp */,
 				995226D4207D184500F78420 /* SimulatedInputDispatcher.h */,
 				9955A6EA1C7980BB00EB6A93 /* WebAutomationSession.cpp */,
@@ -16914,6 +16926,8 @@
 				412915A129A8C7A300BE3091 /* BackgroundFetchStoreImpl.h in Headers */,
 				46A2B6091E5676A600C3DEDA /* BackgroundProcessResponsivenessTimer.h in Headers */,
 				95C943912523C0D00054F3D5 /* BaseBoardSPI.h in Headers */,
+				F3EEEE592DB318270038CC1D /* BidiBrowserAgent.h in Headers */,
+				F3A94F022DB6F3310023CE9D /* BidiUserContext.h in Headers */,
 				E164A2F2191AF14E0010737D /* BlobDataFileReferenceWithSandboxExtension.h in Headers */,
 				E170876C16D6CA6900F99226 /* BlobRegistryProxy.h in Headers */,
 				4F601432155C5AA2001FBDE0 /* BlockingResponseMap.h in Headers */,
@@ -20364,6 +20378,8 @@
 				9955A6F61C7986E300EB6A93 /* AutomationProtocolObjects.cpp in Sources */,
 				E326E357284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm in Sources */,
 				413E5C9229B0CF7C002F4987 /* BackgroundFetchStateCocoa.mm in Sources */,
+				F3EEEE5A2DB318270038CC1D /* BidiBrowserAgent.cpp in Sources */,
+				F3A94F012DB6F3310023CE9D /* BidiUserContext.cpp in Sources */,
 				1C62747E288B4C3E00CED3A2 /* CocoaHelpers.mm in Sources */,
 				49DC1DE127E5129100C1CB36 /* CSPExtensionUtilities.mm in Sources */,
 				522F792C28D531970069B45B /* CtapAuthenticator.cpp in Sources */,


### PR DESCRIPTION
#### 55e2a080047d0ddb30ce789103d3faa3dbcbf0f1
<pre>
[WebDriver][BiDi] Implement the browser module
<a href="https://bugs.webkit.org/show_bug.cgi?id=281941">https://bugs.webkit.org/show_bug.cgi?id=281941</a>

Reviewed by BJ Burg.

Basic implementation of UserContext management methods. Each user context
is a pair of a WebsiteDataStore and a WebProcessPool.

* Source/WebKit/Sources.txt:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/UIProcess/Automation/BidiBrowserAgent.cpp: Added. Browser
module logic is extracted into its own module for better readability and
encapsulation of the implementation details. The agent maintains the list
of all UserContexts, in the future they will be used to create pages (aka
BrowsingContexts).

(WebKit::BidiBrowserAgent::BidiBrowserAgent):
(WebKit::BidiBrowserAgent::close):
(WebKit::BidiBrowserAgent::createUserContext):
(WebKit::BidiBrowserAgent::getUserContexts):
(WebKit::BidiBrowserAgent::removeUserContext):
(WebKit::BidiBrowserAgent::platformCreateUserContext):
* Source/WebKit/UIProcess/Automation/BidiBrowserAgent.h: Added. An actual
implementation of the user context. It is mostly WebsiteDataStore that
provides user data isolation. After decoupling of the network process
from WebProcessPool in <a href="https://commits.webkit.org/229885@main">https://commits.webkit.org/229885@main</a>, we might
not need a separate process pool per user context for cookie store
isolatio. But we still need it for e.g. geo location overrides using
WebGeolocationManagerProxy which is a supplement to WebProcessPool.

* Source/WebKit/UIProcess/Automation/BidiUserContext.cpp: Added.
(WebKit::BidiUserContext::BidiUserContext):
* Source/WebKit/UIProcess/Automation/BidiUserContext.h: Added.
* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp:
(WebKit::WebDriverBidiProcessor::WebDriverBidiProcessor):
* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h:
* Source/WebKit/UIProcess/Automation/glib/BidiBrowserAgentGlib.cpp: Added.
(WebKit::BidiBrowserAgent::platformCreateUserContext):
* Source/WebKit/UIProcess/Automation/protocol/BidiBrowser.json:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/293942@main">https://commits.webkit.org/293942@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f1d4f6114051829672238c7fc4e2a5bc35d26e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100393 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20045 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105529 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50981 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20351 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28519 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/76438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103400 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15586 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90684 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56793 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15404 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50349 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/85318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8766 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107884 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27511 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27874 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84930 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21591 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29614 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/7343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21431 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27446 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32687 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27257 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30575 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28815 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->