### PR TITLE
[LegacySVG] The SVG image has incorrect size when it has fixed size and preserveAspectRatio="none" but the container has percent size

### DIFF
--- a/LayoutTests/svg/custom/svg-image-container-size-expected.html
+++ b/LayoutTests/svg/custom/svg-image-container-size-expected.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<img src="resources/rgb.svg" style="width: 384px; height: 128px; display: block">
+<div>
+  <img src="resources/rgb.svg" style="width: 384px; height: 128px;">
+</div>

--- a/LayoutTests/svg/custom/svg-image-container-size.html
+++ b/LayoutTests/svg/custom/svg-image-container-size.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<script>
+function runAfterLayoutAndPaint(callback, autoNotifyDone) {
+    if (!window.testRunner) {
+        // For manual test. Delay 500ms to allow us to see the visual change
+        // caused by the callback.
+        setTimeout(callback, 500);
+        return;
+    }
+
+    if (autoNotifyDone)
+        testRunner.waitUntilDone();
+
+    // We do requestAnimationFrame and setTimeout to ensure a frame has started
+    // and layout and paint have run. The requestAnimationFrame fires after the
+    // frame has started but before layout and paint. The setTimeout fires
+    // at the beginning of the next frame, meaning that the previous frame has
+    // completed layout and paint.
+    // See http://crrev.com/c/1395193/10/third_party/blink/web_tests/http/tests/resources/run-after-layout-and-paint.js
+    // for more discussions.
+    requestAnimationFrame(function() {
+        setTimeout(function() {
+            callback();
+            if (autoNotifyDone)
+                testRunner.notifyDone();
+        }, 1);
+    });
+}
+</script>
+<script>
+if (window.testRunner)
+  testRunner.waitUntilDone();
+
+function insertSVGImage() {
+    var image = document.createElementNS('http://www.w3.org/2000/svg', 'image');
+    image.setAttribute('width', 192);
+    image.setAttribute('height', 64);
+    image.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'resources/rgb.svg');
+    image.onload = function() {
+      runAfterLayoutAndPaint(function() {
+        if (window.testRunner)
+          testRunner.notifyDone();
+      });
+    };
+    document.querySelector('g').appendChild(image);
+}
+
+function startTest() {
+  runAfterLayoutAndPaint(insertSVGImage);
+}
+</script>
+<svg width="384" height="128" style="display: block">
+  <g transform="scale(2)"></g>
+</svg>
+<div>
+  <img src="resources/rgb.svg" onload="startTest()" style="width: 384px; height: 128px;">
+</div>

--- a/LayoutTests/svg/custom/svg-image-par-none-no-intrinsic-size-expected.html
+++ b/LayoutTests/svg/custom/svg-image-par-none-no-intrinsic-size-expected.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<div style="display: inline-block; width: 100px; height: 200px; background-color: green"></div>
+<svg width="100" height="200" preserveAspectRatio="none" viewBox="0 0 100 100">
+    <circle r="50" cx="50" cy="50" fill="green"/>
+</svg>

--- a/LayoutTests/svg/custom/svg-image-par-none-no-intrinsic-size.html
+++ b/LayoutTests/svg/custom/svg-image-par-none-no-intrinsic-size.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<svg width="100" height="200" style="background-color: red">
+  <image width="100" height="200" preserveAspectRatio="none"
+         xlink:href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 200'><rect width='100' height='200' fill='green'/></svg>"/>
+</svg>
+<svg width="100" height="200">
+    <image width="100" height="200" preserveAspectRatio="none"
+      xlink:href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle r='50' cx='50' cy='50' fill='green'/></svg>"/>
+</svg>

--- a/LayoutTests/svg/custom/svg-image-par-none-zero-intrinsic-size-expected.html
+++ b/LayoutTests/svg/custom/svg-image-par-none-zero-intrinsic-size-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/svg/custom/svg-image-par-none-zero-intrinsic-size.html
+++ b/LayoutTests/svg/custom/svg-image-par-none-zero-intrinsic-size.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<svg width="100" height="100" style="background-color: green">
+  <image width="100" height="100" preserveAspectRatio="none"
+         xlink:href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='0'><rect width='100' height='100' fill='red'/></svg>"/>
+</svg>

--- a/LayoutTests/svg/custom/svg-image-par-resize-expected.html
+++ b/LayoutTests/svg/custom/svg-image-par-resize-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<body>
+<svg width="300" height="200">
+  <image width="100" height="200" preserveAspectRatio="none"
+         xlink:href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='50' height='50'><rect width='100%' height='100%' fill='green'/></svg>"></image>
+</svg>
+</body>

--- a/LayoutTests/svg/custom/svg-image-par-resize.html
+++ b/LayoutTests/svg/custom/svg-image-par-resize.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<script src="../../fast/repaint/resources/async-text-based-repaint.js"></script>
+<body onload="runRepaintTest()">
+<svg width="300" height="200">
+  <image width="200" height="200" preserveAspectRatio="none"
+         xlink:href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='50' height='50'><rect width='100%' height='100%' fill='green'/></svg>"></image>
+</svg>
+<script>
+function runRepaintTest() {
+  document.querySelector('image').setAttribute('width', 100);
+  requestAnimationFrame(function() {
+    finishRepaintTest();
+  });
+}
+</script>
+</body>

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
@@ -1,8 +1,8 @@
 /*
  * Copyright (C) 2006 Alexander Kellett <lypanov@kde.org>
- * Copyright (C) 2006, 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2007 Rob Buis <buis@kde.org>
- * Copyright (C) 2009 Google, Inc.
+ * Copyright (C) 2009-2015 Google, Inc.
  * Copyright (C) 2010 Patrick Gansterer <paroga@paroga.com>
  *
  * This library is free software; you can redistribute it and/or
@@ -78,6 +78,8 @@ private:
     void paint(PaintInfo&, const LayoutPoint&) override;
 
     void invalidateBufferedForeground();
+
+    FloatSize computeImageViewportSize() const;
 
     bool nodeAtFloatPoint(const HitTestRequest&, HitTestResult&, const FloatPoint& pointInParent, HitTestAction) override;
 


### PR DESCRIPTION
#### c16c9be0f54a5c62a2fe42fc2034dada85e8d677
<pre>
[LegacySVG] The SVG image has incorrect size when it has fixed size and preserveAspectRatio=&quot;none&quot; but the container has percent size
<a href="https://bugs.webkit.org/show_bug.cgi?id=270550">https://bugs.webkit.org/show_bug.cgi?id=270550</a>
<a href="https://rdar.apple.com/124106110">rdar://124106110</a>

Reviewed by NOBODY (OOPS!).

This currently fixes the issue only in LegacySVG engine and LBSE has
different issue in similar area. It is good to add tests now for future tracking.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/a7bcf4b14d5f4734039492e28ec3d84fc1d9e00a">https://chromium.googlesource.com/chromium/blink/+/a7bcf4b14d5f4734039492e28ec3d84fc1d9e00a</a> ,
<a href="https://chromium.googlesource.com/chromium/blink/+/515b1afb793f3a081f409776a818371130d9b9da">https://chromium.googlesource.com/chromium/blink/+/515b1afb793f3a081f409776a818371130d9b9da</a> ,
<a href="https://chromium.googlesource.com/chromium/src.git/+/317042f2f80c911a08a37ca27d8916f3989a6c71">https://chromium.googlesource.com/chromium/src.git/+/317042f2f80c911a08a37ca27d8916f3989a6c71</a> ,
<a href="https://chromium.googlesource.com/chromium/src.git/+/f5404e4bd4aa7f6aaf919cb44adbaebf4b974601">https://chromium.googlesource.com/chromium/src.git/+/f5404e4bd4aa7f6aaf919cb44adbaebf4b974601</a>

When referencing an SVG image from &lt;svg:image&gt; with pAR set to &apos;none&apos;, and
said image had no intrinsic size, but a &apos;viewBox&apos;, the use of the intrinsic
size (which would be computed as 300x150) as the container size would
incorrect. The &apos;viewBox&apos; would resolve against 300x150, so if it defined
a different aspect ratio than that, the image would not appear correctly
scaled.

For pAR=none there&apos;re a number of cases to consider:
  1) The referenced image has a &apos;viewBox&apos;.
  2) The referenced image has intrinsic dimensions.
  3) The referenced image has none of the above.
For cases (1) and (2), we should use the &apos;viewBox&apos; and intrinsic dimensions
(respectively) to define the container size (~= the image&apos;s viewport maps
to the viewport defined by &lt;svg:image&gt;). In case (3) we try to use whatever
is left to use (300x150). (In practice cases (2) and (3) should be
equivalent.) Similarly, it fixes repainting issue around resize and scaling.

Lastly, if a referenced image had the same dimensions as the referencing &lt;image&gt;,
a container size would not be set. This could cause the wrong scaling (etc)
to be applied if there existed another reference to the same image resource
that ended up applying a different scale-factor.
To ensure that a container size is set in this case, determine if the
referenced image has a container size set or not by checking if what
the &quot;base&quot; image (as returned by CachedImage::image()) differs from the
renderer-specific image (as returned by CachedImage::imageForRenderer)

* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
(WebCore::containerSizeIsSetForRenderer):
(WebCore::LegacyRenderSVGImage::computeImageViewportSize const):
(WebCore::LegacyRenderSVGImage::updateImageViewport):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h:
* LayoutTests/svg/custom/svg-image-par-resize.html:
* LayoutTests/svg/custom/svg-image-par-resize-expected.html:
* LayoutTests/svg/custom/svg-image-par-none-zero-intrinsic-size.html:
* LayoutTests/svg/custom/svg-image-par-none-zero-intrinsic-size-expected.html:
* LayoutTests/svg/custom/svg-image-par-none-no-intrinsic-size.html:
* LayoutTests/svg/custom/svg-image-par-none-no-intrinsic-size-expected.html:
* LayoutTests/svg/custom/svg-image-container-size.html:
* LayoutTests/svg/custom/svg-image-container-size-expected.html:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c16c9be0f54a5c62a2fe42fc2034dada85e8d677

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119452 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64205 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115206 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33632 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41542 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86191 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41408 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26862 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101866 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66513 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26133 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19994 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63206 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96243 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20069 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122669 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40322 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30083 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95040 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40707 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98081 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94782 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39930 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17741 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36458 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40208 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45707 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39849 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43182 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41586 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->