### PR TITLE
Track column indexes explicitly in RenderTableCol.

### DIFF
--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -247,8 +247,6 @@ void RenderTable::removeCaption(RenderTableCaption& oldCaption)
 void RenderTable::invalidateCachedColumns()
 {
     m_columnRenderersValid = false;
-    m_columnRenderers.shrink(0);
-    m_effectiveColumnIndexMap.clear();
 }
 
 void RenderTable::invalidateCachedColumnOffsets()
@@ -1043,20 +1041,16 @@ RenderTableCol* RenderTable::firstColumn() const
 void RenderTable::updateColumnCache() const
 {
     ASSERT(m_hasColElements);
-    ASSERT(m_columnRenderers.isEmpty());
-    ASSERT(m_effectiveColumnIndexMap.isEmpty());
     ASSERT(!m_columnRenderersValid);
 
     unsigned columnIndex = 0;
     for (RenderTableCol* columnRenderer = firstColumn(); columnRenderer; columnRenderer = columnRenderer->nextColumn()) {
+        columnRenderer->setColumnIndex(columnIndex);
         if (columnRenderer->isTableColumnGroupWithColumnChildren())
             continue;
-        m_columnRenderers.append(columnRenderer);
-        // FIXME: We should look to compute the effective column index successively from previous values instead of
-        // calling colToEffCol(), which is in O(numEffCols()). Although it's unlikely that this is a hot function.
-        m_effectiveColumnIndexMap.add(*columnRenderer, colToEffCol(columnIndex));
         columnIndex += columnRenderer->span();
     }
+    m_tableColumnSpan = columnIndex;
     m_columnRenderersValid = true;
 }
 
@@ -1064,14 +1058,21 @@ unsigned RenderTable::effectiveIndexOfColumn(const RenderTableCol& column) const
 {
     if (!m_columnRenderersValid)
         updateColumnCache();
-    const RenderTableCol* columnToUse = &column;
-    if (columnToUse->isTableColumnGroupWithColumnChildren())
-        columnToUse = columnToUse->nextColumn(); // First column in column-group
-    auto it = m_effectiveColumnIndexMap.find(columnToUse);
-    ASSERT(it != m_effectiveColumnIndexMap.end());
-    if (it == m_effectiveColumnIndexMap.end())
-        return std::numeric_limits<unsigned>::max();
-    return it->value;
+    return colToEffCol(column.columnIndex());
+}
+
+unsigned RenderTable::spanOfColumn(const RenderTableCol& column) const
+{
+    if (!m_columnRenderersValid)
+        updateColumnCache();
+    if (!column.firstChild())
+        return column.span();
+    // |column| is a column group with children, so its span is the sum
+    // of its childrens' spans.
+    RenderObject* next = column.nextSibling();
+    if (RenderTableCol* nextColumn = next ? dynamicDowncast<RenderTableCol>(next) : nullptr)
+        return nextColumn->columnIndex() - column.columnIndex();
+    return m_tableColumnSpan - column.columnIndex();
 }
 
 LayoutUnit RenderTable::offsetTopForColumn(const RenderTableCol& column) const
@@ -1096,32 +1097,13 @@ LayoutUnit RenderTable::offsetLeftForColumn(const RenderTableCol& column) const
 
 LayoutUnit RenderTable::offsetWidthForColumn(const RenderTableCol& column) const
 {
-    const RenderTableCol* currentColumn = &column;
-    bool hasColumnChildren;
-    if ((hasColumnChildren = currentColumn->isTableColumnGroupWithColumnChildren()))
-        currentColumn = currentColumn->nextColumn(); // First column in column-group
+    unsigned index = effectiveIndexOfColumn(column);
+    unsigned span = spanOfColumn(column);
     unsigned numberOfEffectiveColumns = numEffCols();
+    if (!span || index >= numberOfEffectiveColumns)
+        return 0;
     ASSERT_WITH_SECURITY_IMPLICATION(m_columnPos.size() >= numberOfEffectiveColumns + 1);
-    LayoutUnit width;
-    LayoutUnit spacing = m_hSpacing;
-    while (currentColumn) {
-        unsigned columnIndex = effectiveIndexOfColumn(*currentColumn);
-        unsigned span = currentColumn->span();
-        while (span && columnIndex < numberOfEffectiveColumns) {
-            width += m_columnPos[columnIndex + 1] - m_columnPos[columnIndex] - spacing;
-            span -= m_columns[columnIndex].span;
-            ++columnIndex;
-            if (span)
-                width += spacing;
-        }
-        if (!hasColumnChildren)
-            break;
-        currentColumn = currentColumn->nextColumn();
-        if (!currentColumn || currentColumn->isTableColumnGroup())
-            break;
-        width += spacing;
-    }
-    return width;
+    return m_columnPos[effectiveColumnAfter(index, span)] - m_columnPos[index] - m_hSpacing;
 }
 
 LayoutUnit RenderTable::offsetHeightForColumn(const RenderTableCol& column) const
@@ -1147,8 +1129,8 @@ RenderTableCol* RenderTable::slowColElement(unsigned col, bool* startEdge, bool*
         updateColumnCache();
 
     unsigned columnCount = 0;
-    for (auto& columnRenderer : m_columnRenderers) {
-        if (!columnRenderer)
+    for (RenderTableCol* columnRenderer = firstColumn(); columnRenderer; columnRenderer = columnRenderer->nextColumn()) {
+        if (columnRenderer->isTableColumnGroupWithColumnChildren())
             continue;
         unsigned span = columnRenderer->span();
         unsigned startCol = columnCount;
@@ -1160,7 +1142,7 @@ RenderTableCol* RenderTable::slowColElement(unsigned col, bool* startEdge, bool*
                 *startEdge = startCol == col;
             if (endEdge)
                 *endEdge = endCol == col;
-            return columnRenderer.get();
+            return columnRenderer;
         }
     }
     return nullptr;

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -146,6 +146,21 @@ public:
         return c;
     }
 
+    unsigned effectiveColumnAfter(unsigned index, unsigned span) const
+    {
+        unsigned numColumns = numEffCols();
+        if (!m_hasCellColspanThatDeterminesTableWidth
+            && index <= numColumns
+            && numColumns - index <= span)
+            return index + span;
+        unsigned currentSpan = 0;
+        while (index < numColumns && currentSpan < span) {
+            currentSpan += m_columns[index].span;
+            ++index;
+        }
+        return index;
+    }
+
     LayoutUnit borderSpacingInRowDirection() const
     {
         if (unsigned effectiveColumnCount = numEffCols())
@@ -203,6 +218,9 @@ public:
     LayoutUnit offsetWidthForColumn(const RenderTableCol&) const;
     LayoutUnit offsetHeightForColumn(const RenderTableCol&) const;
     
+    unsigned effectiveIndexOfColumn(const RenderTableCol&) const;
+    unsigned spanOfColumn(const RenderTableCol&) const;
+
     void markForPaginationRelayoutIfNeeded() final;
 
     void willInsertTableColumn(RenderTableCol& child, RenderObject* beforeChild);
@@ -266,11 +284,8 @@ protected:
     mutable Vector<LayoutUnit> m_columnPos;
     mutable Vector<ColumnStruct> m_columns;
     mutable Vector<SingleThreadWeakPtr<RenderTableCaption>> m_captions;
-    mutable Vector<SingleThreadWeakPtr<RenderTableCol>> m_columnRenderers;
 
-    unsigned effectiveIndexOfColumn(const RenderTableCol&) const;
-    using EffectiveColumnIndexMap = UncheckedKeyHashMap<SingleThreadWeakRef<const RenderTableCol>, unsigned>;
-    mutable EffectiveColumnIndexMap m_effectiveColumnIndexMap;
+    mutable unsigned m_tableColumnSpan { 0 }; // total span of all RenderTableCol elements
 
     mutable SingleThreadWeakPtr<RenderTableSection> m_head;
     mutable SingleThreadWeakPtr<RenderTableSection> m_foot;

--- a/Source/WebCore/rendering/RenderTableCol.h
+++ b/Source/WebCore/rendering/RenderTableCol.h
@@ -45,6 +45,9 @@ public:
     unsigned span() const { return m_span; }
     void setSpan(unsigned span) { m_span = span; }
 
+    unsigned columnIndex() const { return m_columnIndex; }
+    void setColumnIndex(unsigned columnIndex) { m_columnIndex = columnIndex; }
+
     bool isTableColumnGroupWithColumnChildren() const { return firstChild(); }
     bool isTableColumn() const { return style().display() == DisplayType::TableColumn; }
     bool isTableColumnGroup() const { return style().display() == DisplayType::TableColumnGroup; }
@@ -91,6 +94,7 @@ private:
     CheckedPtr<RenderTable> checkedTable() const;
 
     unsigned m_span { 1 };
+    unsigned m_columnIndex { 0 };
 };
 
 inline RenderTableCol* RenderTableCol::enclosingColumnGroupIfAdjacentBefore() const


### PR DESCRIPTION
<pre>
Track column indexes explicitly in RenderTableCol.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278001">https://bugs.webkit.org/show_bug.cgi?id=278001</a>

Reviewed by NOBODY (OOPS!).

Several table rendering operations require column indexes.
There are two kinds of column index. The natural index
includes all `span` attributes, while the effective index
collapses columns whose cells all have span &gt;1 into a
single effective span index.

The RenderTable::colToEffCol function translates natural
to effective indexes. The RenderTable::effectiveIndexOfColumn
function translates a RenderTableCol object reference to
its effective index, using a hash table maintained by
the RenderTable (m_effectiveColumnIndexMap). Other functions
used a vector of RenderTableCol, m_columnRenderers (that
stored some null pointers for column groups).

These data structures do not help much in computing the
indexes and widths required for rendering. For instance,
RenderTable::offsetWidthForColumn contains complex traversal
logic. If you want to compute other aspects of column
positioning, you'd have to repeat that logic.

This commit removes m_effectiveColumnIndexMap and
m_columnRenderers. Instead, each column stores its natural
index directly in RenderTableCol::m_columnIndex. This is
set by RenderTable::updateColumnCache (the function
previously responsible for maintaining m_columnRenderers,
etc.). The table also stores its total natural span in
RenderTable::m_tableColumnSpan. And the table gains
RenderTable::spanOfColumn(column), which returns the
natural span of a column, and effectiveColumnAfter(),
which returns the effective column index a given span after
a natural index.

These changes simplify offsetWidthForColumn and
effectiveIndexOfColumn and reduce memory use. They also
facilitate future changes for column backgrounds.

* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::invalidateCachedColumns):
Remove complex column caches.
(WebCore::RenderTable::updateColumnCache const):
Store column index in column.
(WebCore::RenderTable::effectiveIndexOfColumn const):
(WebCore::RenderTable::spanOfColumn const): New functions.
(WebCore::RenderTable::offsetWidthForColumn const):
Use RenderTableCol::columnIndex() and new helpers.
(WebCore::RenderTable::slowColElement const):
Use direct traversal rather than m_columnRenderers.
* Source/WebCore/rendering/RenderTable.h:
(WebCore::RenderTable::effectiveColumnAfter const):
New function.
* Source/WebCore/rendering/RenderTableCol.h:
Add m_columnIndex.
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36542790b4f024140af1b38098ed5fcb55ad2dff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17625 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112749 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58072 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109496 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35716 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81637 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110461 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22110 "Found 1 new test failure: media/video-unmuted-after-play-holds-sleep-assertion.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96921 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62018 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21549 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15059 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57512 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91480 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15093 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115850 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34600 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25514 "Found 3 new test failures: inspector/model/remote-object-get-properties.html inspector/runtime/getDisplayableProperties.html inspector/runtime/getProperties.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90674 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34976 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93171 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90415 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35333 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13111 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30361 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34521 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40077 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34267 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37626 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35930 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->