### PR TITLE
[Writing Tools] Support compiling ENABLE_WRITING_TOOLS on the public SDK (Part 2)

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/WritingToolsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/WritingToolsSPI.h
@@ -184,40 +184,4 @@ typedef NS_ENUM(NSInteger, WTAction) {
 
 #endif // USE(APPLE_INTERNAL_SDK)
 
-// MARK: Platform-agnostic types.
-
-#if PLATFORM(IOS_FAMILY)
-
-using PlatformWritingToolsBehavior = UIWritingToolsBehavior;
-
-constexpr auto PlatformWritingToolsBehaviorNone = UIWritingToolsBehaviorNone;
-constexpr auto PlatformWritingToolsBehaviorDefault = UIWritingToolsBehaviorDefault;
-constexpr auto PlatformWritingToolsBehaviorLimited = UIWritingToolsBehaviorLimited;
-constexpr auto PlatformWritingToolsBehaviorComplete = UIWritingToolsBehaviorComplete;
-
-using PlatformWritingToolsResultOptions = UIWritingToolsResultOptions;
-
-constexpr auto PlatformWritingToolsResultPlainText = UIWritingToolsResultPlainText;
-constexpr auto PlatformWritingToolsResultRichText = UIWritingToolsResultRichText;
-constexpr auto PlatformWritingToolsResultList = UIWritingToolsResultList;
-constexpr auto PlatformWritingToolsResultTable = UIWritingToolsResultTable;
-
-#else
-
-using PlatformWritingToolsBehavior = NSWritingToolsBehavior;
-
-constexpr auto PlatformWritingToolsBehaviorNone = NSWritingToolsBehaviorNone;
-constexpr auto PlatformWritingToolsBehaviorDefault = NSWritingToolsBehaviorDefault;
-constexpr auto PlatformWritingToolsBehaviorLimited = NSWritingToolsBehaviorLimited;
-constexpr auto PlatformWritingToolsBehaviorComplete = NSWritingToolsBehaviorComplete;
-
-using PlatformWritingToolsResultOptions = NSWritingToolsResultOptions;
-
-constexpr auto PlatformWritingToolsResultPlainText = NSWritingToolsResultPlainText;
-constexpr auto PlatformWritingToolsResultRichText = NSWritingToolsResultRichText;
-constexpr auto PlatformWritingToolsResultList = NSWritingToolsResultList;
-constexpr auto PlatformWritingToolsResultTable = NSWritingToolsResultTable;
-
-#endif // PLATFORM(IOS_FAMILY)
-
 #endif // ENABLE(WRITING_TOOLS)

--- a/Source/WebCore/platform/cocoa/CocoaWritingToolsTypes.h
+++ b/Source/WebCore/platform/cocoa/CocoaWritingToolsTypes.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import <wtf/Platform.h>
+
+#if ENABLE(WRITING_TOOLS)
+
+#if PLATFORM(IOS_FAMILY)
+
+using CocoaWritingToolsBehavior = UIWritingToolsBehavior;
+
+constexpr auto CocoaWritingToolsBehaviorNone = UIWritingToolsBehaviorNone;
+constexpr auto CocoaWritingToolsBehaviorDefault = UIWritingToolsBehaviorDefault;
+constexpr auto CocoaWritingToolsBehaviorLimited = UIWritingToolsBehaviorLimited;
+constexpr auto CocoaWritingToolsBehaviorComplete = UIWritingToolsBehaviorComplete;
+
+using CocoaWritingToolsResultOptions = UIWritingToolsResultOptions;
+
+constexpr auto CocoaWritingToolsResultPlainText = UIWritingToolsResultPlainText;
+constexpr auto CocoaWritingToolsResultRichText = UIWritingToolsResultRichText;
+constexpr auto CocoaWritingToolsResultList = UIWritingToolsResultList;
+constexpr auto CocoaWritingToolsResultTable = UIWritingToolsResultTable;
+
+#else
+
+using CocoaWritingToolsBehavior = NSWritingToolsBehavior;
+
+constexpr auto CocoaWritingToolsBehaviorNone = NSWritingToolsBehaviorNone;
+constexpr auto CocoaWritingToolsBehaviorDefault = NSWritingToolsBehaviorDefault;
+constexpr auto CocoaWritingToolsBehaviorLimited = NSWritingToolsBehaviorLimited;
+constexpr auto CocoaWritingToolsBehaviorComplete = NSWritingToolsBehaviorComplete;
+
+using CocoaWritingToolsResultOptions = NSWritingToolsResultOptions;
+
+constexpr auto CocoaWritingToolsResultPlainText = NSWritingToolsResultPlainText;
+constexpr auto CocoaWritingToolsResultRichText = NSWritingToolsResultRichText;
+constexpr auto CocoaWritingToolsResultList = NSWritingToolsResultList;
+constexpr auto CocoaWritingToolsResultTable = NSWritingToolsResultTable;
+
+#endif // PLATFORM(IOS_FAMILY)
+
+#endif // ENABLE(WRITING_TOOLS)

--- a/Source/WebKit/Platform/spi/mac/AppKitSPI.h
+++ b/Source/WebKit/Platform/spi/mac/AppKitSPI.h
@@ -64,7 +64,14 @@ DECLARE_SYSTEM_HEADER
 @end
 #endif
 
+@class NSTextPlaceholder;
+
 @protocol NSTextInputClient_Async
+@optional
+
+- (void)insertTextPlaceholderWithSize:(CGSize)size completionHandler:(void (^)(NSTextPlaceholder *))completionHandler;
+
+- (void)removeTextPlaceholder:(NSTextPlaceholder *)placeholder willInsertText:(BOOL)willInsertText completionHandler:(void (^)(void))completionHandler;
 @end
 
 typedef NS_OPTIONS(NSUInteger, NSWindowShadowOptions) {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -76,6 +76,9 @@
 #import "WKFindResultInternal.h"
 #import "WKFrameInfoInternal.h"
 #import "WKHistoryDelegatePrivate.h"
+#import "WKIntelligenceReplacementTextEffectCoordinator.h"
+#import "WKIntelligenceSmartReplyTextEffectCoordinator.h"
+#import "WKIntelligenceTextEffectCoordinator.h"
 #import "WKLayoutMode.h"
 #import "WKNSData.h"
 #import "WKNSURLExtras.h"
@@ -2359,18 +2362,18 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
 
 #pragma mark - WTWritingToolsDelegate conformance
 
-- (PlatformWritingToolsResultOptions)allowedWritingToolsResultOptions
+- (CocoaWritingToolsResultOptions)allowedWritingToolsResultOptions
 {
     auto& editorState = _page->editorState();
     if (editorState.isContentEditable && !editorState.isContentRichlyEditable)
-        return PlatformWritingToolsResultPlainText;
+        return CocoaWritingToolsResultPlainText;
 
-    return PlatformWritingToolsResultPlainText | PlatformWritingToolsResultRichText | PlatformWritingToolsResultList | PlatformWritingToolsResultTable;
+    return CocoaWritingToolsResultPlainText | CocoaWritingToolsResultRichText | CocoaWritingToolsResultList | CocoaWritingToolsResultTable;
 }
 
-- (PlatformWritingToolsBehavior)writingToolsBehavior
+- (CocoaWritingToolsBehavior)writingToolsBehavior
 {
-    return WebKit::convertToPlatformWritingToolsBehavior(_page->writingToolsBehavior());
+    return WebKit::convertToCocoaWritingToolsBehavior(_page->writingToolsBehavior());
 }
 
 - (void)willBeginWritingToolsSession:(WTSession *)session requestContexts:(void (^)(NSArray<WTContext *> *))completion
@@ -2636,9 +2639,7 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
 - (void)intelligenceTextEffectCoordinator:(id<WKIntelligenceTextEffectCoordinating>)coordinator rectsForProofreadingSuggestionsInRange:(NSRange)range completion:(void (^)(NSArray<NSValue *> *))completion
 {
     _page->proofreadingSessionSuggestionTextRectsInRootViewCoordinates(range, [completion = makeBlockPtr(completion)](auto&& rects) {
-        RetainPtr nsArray = createNSArray(rects, [](auto& rect) {
-            return [NSValue valueWithRect:rect];
-        });
+        RetainPtr nsArray = createNSArray(rects);
 
         completion(nsArray.get());
     });

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -616,14 +616,14 @@ static NSString *defaultApplicationNameForUserAgent()
     return [self _multiRepresentationHEICInsertionEnabled];
 }
 
-- (void)setWritingToolsBehavior:(PlatformWritingToolsBehavior)writingToolsBehavior
+- (void)setWritingToolsBehavior:(CocoaWritingToolsBehavior)writingToolsBehavior
 {
     _pageConfiguration->setWritingToolsBehavior(WebKit::convertToWebWritingToolsBehavior(writingToolsBehavior));
 }
 
-- (PlatformWritingToolsBehavior)writingToolsBehavior
+- (CocoaWritingToolsBehavior)writingToolsBehavior
 {
-    return WebKit::convertToPlatformWritingToolsBehavior(_pageConfiguration->writingToolsBehavior());
+    return WebKit::convertToCocoaWritingToolsBehavior(_pageConfiguration->writingToolsBehavior());
 }
 
 #endif // ENABLE(WRITING_TOOLS)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -28,11 +28,8 @@
 #ifdef __cplusplus
 
 #import "PDFPluginIdentifier.h"
-#import "WKIntelligenceReplacementTextEffectCoordinator.h"
-#import "WKIntelligenceSmartReplyTextEffectCoordinator.h"
-#import "WKIntelligenceTextEffectCoordinator.h"
-#import "WKTextAnimationType.h"
 #import <WebCore/CocoaView.h>
+#import <WebCore/CocoaWritingToolsTypes.h>
 #import <WebCore/FixedContainerEdges.h>
 #import <WebKit/WKShareSheet.h>
 #import <WebKit/WKWebViewConfiguration.h>
@@ -73,9 +70,9 @@
 #define WK_WEB_VIEW_PROTOCOLS <WKBEScrollViewDelegate, WTWritingToolsDelegate, UITextInputTraits>
 #else
 #define WK_WEB_VIEW_PROTOCOLS <WKBEScrollViewDelegate>
-#endif
+#endif // ENABLE(WRITING_TOOLS)
 
-#endif
+#endif // PLATFORM(IOS_FAMILY)
 
 #if PLATFORM(MAC)
 
@@ -83,9 +80,9 @@
 #define WK_WEB_VIEW_PROTOCOLS <WKShareSheetDelegate, WTWritingToolsDelegate, NSTextInputTraits>
 #else
 #define WK_WEB_VIEW_PROTOCOLS <WKShareSheetDelegate>
-#endif
+#endif // ENABLE(WRITING_TOOLS)
 
-#endif
+#endif // PLATFORM(MAC)
 
 #if !defined(WK_WEB_VIEW_PROTOCOLS)
 #define WK_WEB_VIEW_PROTOCOLS
@@ -148,6 +145,7 @@ class ViewGestureController;
 #if ENABLE(WRITING_TOOLS)
 @class WTTextSuggestion;
 @class WTSession;
+@protocol WKIntelligenceTextEffectCoordinating;
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -479,7 +477,7 @@ struct PerWebProcessState {
 
 - (void)_proofreadingSessionUpdateState:(WebCore::WritingTools::TextSuggestionState)state forSuggestionWithUUID:(NSUUID *)replacementUUID;
 
-- (PlatformWritingToolsResultOptions)allowedWritingToolsResultOptions;
+- (CocoaWritingToolsResultOptions)allowedWritingToolsResultOptions;
 
 - (void)_didEndPartialIntelligenceTextAnimation;
 - (BOOL)_writingToolsTextReplacementsFinished;

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(MAC)
 
 #import "AppKitSPI.h"
+#import "WKIntelligenceTextEffectCoordinator.h"
 #import "WKTextAnimationType.h"
 #import "WKTextFinderClient.h"
 #import "WKWebViewConfigurationPrivate.h"

--- a/Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WRITING_TOOLS)
 
+#import <WebCore/CocoaWritingToolsTypes.h>
 #import <WebCore/WritingToolsTypes.h>
 #import <pal/spi/cocoa/WritingToolsSPI.h>
 #import <wtf/RetainPtr.h>
@@ -54,7 +55,7 @@ namespace WebKit {
 
 #pragma mark - Conversions from web types to platform types.
 
-PlatformWritingToolsBehavior convertToPlatformWritingToolsBehavior(WebCore::WritingTools::Behavior);
+CocoaWritingToolsBehavior convertToCocoaWritingToolsBehavior(WebCore::WritingTools::Behavior);
 
 WTRequestedTool convertToPlatformRequestedTool(WebCore::WritingTools::RequestedTool);
 
@@ -64,7 +65,7 @@ RetainPtr<WTContext> convertToPlatformContext(const WebCore::WritingTools::Conte
 
 #pragma mark - Conversions from platform types to web types.
 
-WebCore::WritingTools::Behavior convertToWebWritingToolsBehavior(PlatformWritingToolsBehavior);
+WebCore::WritingTools::Behavior convertToWebWritingToolsBehavior(CocoaWritingToolsBehavior);
 
 WebCore::WritingTools::RequestedTool convertToWebRequestedTool(WTRequestedTool);
 

--- a/Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.mm
@@ -37,20 +37,20 @@ namespace WebKit {
 
 #pragma mark - Conversions from web types to platform types.
 
-PlatformWritingToolsBehavior convertToPlatformWritingToolsBehavior(WebCore::WritingTools::Behavior behavior)
+CocoaWritingToolsBehavior convertToCocoaWritingToolsBehavior(WebCore::WritingTools::Behavior behavior)
 {
     switch (behavior) {
     case WebCore::WritingTools::Behavior::None:
-        return PlatformWritingToolsBehaviorNone;
+        return CocoaWritingToolsBehaviorNone;
 
     case WebCore::WritingTools::Behavior::Default:
-        return PlatformWritingToolsBehaviorDefault;
+        return CocoaWritingToolsBehaviorDefault;
 
     case WebCore::WritingTools::Behavior::Limited:
-        return PlatformWritingToolsBehaviorLimited;
+        return CocoaWritingToolsBehaviorLimited;
 
     case WebCore::WritingTools::Behavior::Complete:
-        return PlatformWritingToolsBehaviorComplete;
+        return CocoaWritingToolsBehaviorComplete;
     }
 }
 
@@ -80,19 +80,19 @@ RetainPtr<WTContext> convertToPlatformContext(const WebCore::WritingTools::Conte
 
 #pragma mark - Conversions from platform types to web types.
 
-WebCore::WritingTools::Behavior convertToWebWritingToolsBehavior(PlatformWritingToolsBehavior behavior)
+WebCore::WritingTools::Behavior convertToWebWritingToolsBehavior(CocoaWritingToolsBehavior behavior)
 {
     switch (behavior) {
-    case PlatformWritingToolsBehaviorNone:
+    case CocoaWritingToolsBehaviorNone:
         return WebCore::WritingTools::Behavior::None;
 
-    case PlatformWritingToolsBehaviorDefault:
+    case CocoaWritingToolsBehaviorDefault:
         return WebCore::WritingTools::Behavior::Default;
 
-    case PlatformWritingToolsBehaviorLimited:
+    case CocoaWritingToolsBehaviorLimited:
         return WebCore::WritingTools::Behavior::Limited;
 
-    case PlatformWritingToolsBehaviorComplete:
+    case CocoaWritingToolsBehaviorComplete:
         return WebCore::WritingTools::Behavior::Complete;
     }
 }

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -13992,7 +13992,7 @@ inline static NSString *extendSelectionCommand(UITextLayoutDirection direction)
     [self reloadInputViews];
 }
 
-- (PlatformWritingToolsResultOptions)allowedWritingToolsResultOptions
+- (CocoaWritingToolsResultOptions)allowedWritingToolsResultOptions
 {
     return [_webView allowedWritingToolsResultOptions];
 }

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -7156,9 +7156,9 @@ static CGImageRef selectionImage(WebCore::LocalFrame* frame, bool forceBlackText
 
 // Disable Writing Tools in WebKitLegacy.
 
-- (NSInteger /* PlatformWritingToolsBehavior */)writingToolsBehavior
+- (NSInteger /* CocoaWritingToolsBehavior */)writingToolsBehavior
 {
-    return -1; // PlatformWritingToolsBehaviorNone
+    return -1; // CocoaWritingToolsBehaviorNone
 }
 
 - (BOOL)providesWritingToolsContextMenu

--- a/Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h
+++ b/Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h
@@ -52,8 +52,6 @@ DECLARE_SYSTEM_HEADER
 - (void)hasMarkedTextWithCompletionHandler:(void(^)(BOOL hasMarkedText))completionHandler;
 - (void)attributedSubstringForProposedRange:(NSRange)range completionHandler:(void(^)(NSAttributedString *, NSRange actualRange))completionHandler;
 - (void)firstRectForCharacterRange:(NSRange)range completionHandler:(void(^)(NSRect firstRect, NSRange actualRange))completionHandler;
-- (void)insertTextPlaceholderWithSize:(CGSize)size completionHandler:(void (^)(NSTextPlaceholder *))completionHandler;
-- (void)removeTextPlaceholder:(NSTextPlaceholder *)placeholder willInsertText:(BOOL)willInsertText completionHandler:(void (^)(void))completionHandler;
 @end
 
 @protocol NSInspectorBarClient <NSObject>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -39,6 +39,7 @@
 #import "WKWebViewConfigurationExtras.h"
 #import <SoftLinking/WeakLinking.h>
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+#import <WebCore/CocoaWritingToolsTypes.h>
 #import <WebCore/ColorCocoa.h>
 #import <WebCore/FloatRect.h>
 #import <WebCore/IntRect.h>
@@ -153,15 +154,15 @@ using PlatformTextPlaceholder = NSTextPlaceholder;
 
 - (instancetype)initWithHTMLString:(NSString *)string
 {
-    return [self initWithHTMLString:string writingToolsBehavior:PlatformWritingToolsBehaviorComplete];
+    return [self initWithHTMLString:string writingToolsBehavior:CocoaWritingToolsBehaviorComplete];
 }
 
-- (instancetype)initWithHTMLString:(NSString *)string writingToolsBehavior:(PlatformWritingToolsBehavior)behavior
+- (instancetype)initWithHTMLString:(NSString *)string writingToolsBehavior:(CocoaWritingToolsBehavior)behavior
 {
     return [self initWithHTMLString:string writingToolsBehavior:behavior attachmentElementEnabled:NO];
 }
 
-- (instancetype)initWithHTMLString:(NSString *)string writingToolsBehavior:(PlatformWritingToolsBehavior)behavior attachmentElementEnabled:(BOOL)attachmentElementEnabled
+- (instancetype)initWithHTMLString:(NSString *)string writingToolsBehavior:(CocoaWritingToolsBehavior)behavior attachmentElementEnabled:(BOOL)attachmentElementEnabled
 {
     auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [configuration setWritingToolsBehavior:behavior];
@@ -206,7 +207,7 @@ using PlatformTextPlaceholder = NSTextPlaceholder;
 #endif
 }
 
-- (PlatformWritingToolsResultOptions)allowedWritingToolsResultOptionsForTesting
+- (CocoaWritingToolsResultOptions)allowedWritingToolsResultOptionsForTesting
 {
 #if PLATFORM(IOS_FAMILY)
     return [[self textInputContentView] allowedWritingToolsResultOptions];
@@ -215,7 +216,7 @@ using PlatformTextPlaceholder = NSTextPlaceholder;
 #endif
 }
 
-- (PlatformWritingToolsBehavior)writingToolsBehaviorForTesting
+- (CocoaWritingToolsBehavior)writingToolsBehaviorForTesting
 {
 #if PLATFORM(IOS_FAMILY)
     return [[self textInputContentView] writingToolsBehavior];
@@ -802,7 +803,7 @@ TEST(WritingTools, ProofreadingWithUntitledImageAttachment)
         "    <p>Hello<img src='sunset-in-cupertino-200px.png'></img></p>"
         "  </body>"
         "</html>";
-    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:markupString.get() writingToolsBehavior:PlatformWritingToolsBehaviorComplete attachmentElementEnabled:YES]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:markupString.get() writingToolsBehavior:CocoaWritingToolsBehaviorComplete attachmentElementEnabled:YES]);
     [webView focusDocumentBodyAndSelectAll];
     [webView stringByEvaluatingJavaScript:@"HTMLAttachmentElement.getAttachmentIdentifier(document.querySelector('img'))"];
 
@@ -1794,7 +1795,7 @@ TEST(WritingTools, CompositionWithImageAttachmentRoundTrip)
 {
     auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<p>AAAA BBBB</p><img src='sunset-in-cupertino-200px.png'></img><p>CCCC DDDD</p>" writingToolsBehavior:PlatformWritingToolsBehaviorComplete attachmentElementEnabled:YES]);
+    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<p>AAAA BBBB</p><img src='sunset-in-cupertino-200px.png'></img><p>CCCC DDDD</p>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete attachmentElementEnabled:YES]);
 
     [webView selectAll:nil];
 
@@ -1835,7 +1836,7 @@ TEST(WritingTools, CompositionWithNonImageAttachmentRoundTrip)
 {
     auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>" writingToolsBehavior:PlatformWritingToolsBehaviorComplete attachmentElementEnabled:YES]);
+    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete attachmentElementEnabled:YES]);
 
     __auto_type modifySelection = ^(unsigned start, unsigned end) {
         NSString *modifySelectionJavascript = [NSString stringWithFormat:@""
@@ -2355,45 +2356,45 @@ TEST(WritingTools, ShowDetailsForSuggestions)
 
 TEST(WritingTools, WantsInlineEditing)
 {
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable>Hello World</body>" writingToolsBehavior:PlatformWritingToolsBehaviorDefault]);
+    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable>Hello World</body>" writingToolsBehavior:CocoaWritingToolsBehaviorDefault]);
 
     [webView _setEditable:NO];
-    EXPECT_EQ([webView writingToolsBehaviorForTesting], PlatformWritingToolsBehaviorNone);
+    EXPECT_EQ([webView writingToolsBehaviorForTesting], CocoaWritingToolsBehaviorNone);
 
     [webView _setEditable:YES];
-    EXPECT_EQ([webView writingToolsBehaviorForTesting], PlatformWritingToolsBehaviorComplete);
+    EXPECT_EQ([webView writingToolsBehaviorForTesting], CocoaWritingToolsBehaviorComplete);
 }
 
 TEST(WritingTools, WritingToolsBehaviorNonEditableWithSelection)
 {
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body>Hello World</body>" writingToolsBehavior:PlatformWritingToolsBehaviorComplete]);
+    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body>Hello World</body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
 
     [webView selectAll:nil];
     [webView waitForNextPresentationUpdate];
 
-    EXPECT_EQ([webView writingToolsBehaviorForTesting], PlatformWritingToolsBehaviorLimited);
+    EXPECT_EQ([webView writingToolsBehaviorForTesting], CocoaWritingToolsBehaviorLimited);
 }
 
 TEST(WritingTools, WritingToolsBehaviorWithNoSelection)
 {
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable>Hello World</body>" writingToolsBehavior:PlatformWritingToolsBehaviorComplete]);
+    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable>Hello World</body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
 
-    EXPECT_EQ([webView writingToolsBehaviorForTesting], PlatformWritingToolsBehaviorNone);
+    EXPECT_EQ([webView writingToolsBehaviorForTesting], CocoaWritingToolsBehaviorNone);
 }
 
 TEST(WritingTools, WritingToolsBehaviorEditableWithSelection)
 {
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable>Hello World</body>" writingToolsBehavior:PlatformWritingToolsBehaviorComplete]);
+    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable>Hello World</body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
     [webView focusDocumentBodyAndSelectAll];
 
-    EXPECT_EQ([webView writingToolsBehaviorForTesting], PlatformWritingToolsBehaviorComplete);
+    EXPECT_EQ([webView writingToolsBehaviorForTesting], CocoaWritingToolsBehaviorComplete);
 }
 
 TEST(WritingTools, AllowedInputOptionsNonEditable)
 {
     auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body></body>"]);
 
-    EXPECT_EQ(PlatformWritingToolsResultPlainText | PlatformWritingToolsResultRichText | PlatformWritingToolsResultList | PlatformWritingToolsResultTable, [webView allowedWritingToolsResultOptionsForTesting]);
+    EXPECT_EQ(CocoaWritingToolsResultPlainText | CocoaWritingToolsResultRichText | CocoaWritingToolsResultList | CocoaWritingToolsResultTable, [webView allowedWritingToolsResultOptionsForTesting]);
 }
 
 TEST(WritingTools, AllowedInputOptionsEditable)
@@ -2402,7 +2403,7 @@ TEST(WritingTools, AllowedInputOptionsEditable)
     [webView _setEditable:YES];
     [webView focusDocumentBodyAndSelectAll];
 
-    EXPECT_EQ(PlatformWritingToolsResultPlainText | PlatformWritingToolsResultRichText | PlatformWritingToolsResultList | PlatformWritingToolsResultTable, [webView allowedWritingToolsResultOptionsForTesting]);
+    EXPECT_EQ(CocoaWritingToolsResultPlainText | CocoaWritingToolsResultRichText | CocoaWritingToolsResultList | CocoaWritingToolsResultTable, [webView allowedWritingToolsResultOptionsForTesting]);
 }
 
 TEST(WritingTools, AllowedInputOptionsRichText)
@@ -2410,7 +2411,7 @@ TEST(WritingTools, AllowedInputOptionsRichText)
     auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
-    EXPECT_EQ(PlatformWritingToolsResultPlainText | PlatformWritingToolsResultRichText | PlatformWritingToolsResultList | PlatformWritingToolsResultTable, [webView allowedWritingToolsResultOptionsForTesting]);
+    EXPECT_EQ(CocoaWritingToolsResultPlainText | CocoaWritingToolsResultRichText | CocoaWritingToolsResultList | CocoaWritingToolsResultTable, [webView allowedWritingToolsResultOptionsForTesting]);
 }
 
 TEST(WritingTools, AllowedInputOptionsPlainText)
@@ -2418,12 +2419,12 @@ TEST(WritingTools, AllowedInputOptionsPlainText)
     auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable=\"plaintext-only\"></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
-    EXPECT_EQ(PlatformWritingToolsResultPlainText, [webView allowedWritingToolsResultOptionsForTesting]);
+    EXPECT_EQ(CocoaWritingToolsResultPlainText, [webView allowedWritingToolsResultOptionsForTesting]);
 }
 
 TEST(WritingTools, EphemeralSessionWithDifferingTextLengths)
 {
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<p>AAAA BBBB CCCC DDDD</p><img src='sunset-in-cupertino-200px.png'></img><p>CCCC DDDD</p>" writingToolsBehavior:PlatformWritingToolsBehaviorDefault]);
+    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<p>AAAA BBBB CCCC DDDD</p><img src='sunset-in-cupertino-200px.png'></img><p>CCCC DDDD</p>" writingToolsBehavior:CocoaWritingToolsBehaviorDefault]);
     [webView _setEditable:NO];
     [webView selectAll:nil];
 
@@ -2447,7 +2448,7 @@ TEST(WritingTools, EphemeralSessionWithDeeplyNestedContent)
 {
     NSString *text = @"The oceanic whitetip shark is a large requiem shark inhabiting tropical and warm temperate seas. It has a stocky body with long, white-tipped, rounded fins. The species is typically solitary but can congregate around food concentrations.";
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:[NSString stringWithFormat:@"<body><div><div><div><div><div><div><div><div><div><div><p>%@</p></div></div></div></div></div></div></div></div></div></div></body>", text] writingToolsBehavior:PlatformWritingToolsBehaviorDefault]);
+    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:[NSString stringWithFormat:@"<body><div><div><div><div><div><div><div><div><div><div><p>%@</p></div></div></div></div></div></div></div></div></div></div></body>", text] writingToolsBehavior:CocoaWritingToolsBehaviorDefault]);
     [webView selectAll:nil];
 
     [webView waitForNextPresentationUpdate];
@@ -2621,7 +2622,7 @@ static void expectScheduleShowAffordanceForSelectionRectCalled(bool expectation)
 
 TEST(WritingTools, APIWithBehaviorNone)
 {
-    // If `PlatformWritingToolsBehaviorNone`, there should be no affordance, no context menu item, and no inline editing support.
+    // If `CocoaWritingToolsBehaviorNone`, there should be no affordance, no context menu item, and no inline editing support.
 
 #if PLATFORM(MAC)
     InstanceMethodSwizzler swizzler(PAL::getWTWritingToolsClass(), @selector(scheduleShowAffordanceForSelectionRect:ofView:forDelegate:), imp_implementationWithBlock(^(id object, NSRect rect, NSView *view, id delegate) {
@@ -2641,7 +2642,7 @@ TEST(WritingTools, APIWithBehaviorNone)
     }];
 #endif
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>" writingToolsBehavior:PlatformWritingToolsBehaviorNone]);
+    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorNone]);
     [webView setUIDelegate:delegate.get()];
 
     [webView focusDocumentBodyAndSelectAll];
@@ -2650,7 +2651,7 @@ TEST(WritingTools, APIWithBehaviorNone)
 
     [webView waitForNextPresentationUpdate];
 
-    EXPECT_EQ([webView writingToolsBehaviorForTesting], PlatformWritingToolsBehaviorNone);
+    EXPECT_EQ([webView writingToolsBehaviorForTesting], CocoaWritingToolsBehaviorNone);
 
 #if PLATFORM(MAC)
     [webView mouseDownAtPoint:NSMakePoint(10, 10) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
@@ -2664,7 +2665,7 @@ TEST(WritingTools, APIWithBehaviorNone)
 
 TEST(WritingTools, APIWithBehaviorDefault)
 {
-    // If `PlatformWritingToolsBehaviorDefault` (or `Limited`), there should be a context menu item, but no affordance nor inline editing support.
+    // If `CocoaWritingToolsBehaviorDefault` (or `Limited`), there should be a context menu item, but no affordance nor inline editing support.
 
 #if PLATFORM(MAC)
     if (![PAL::getWTWritingToolsViewControllerClass() isAvailable])
@@ -2687,7 +2688,7 @@ TEST(WritingTools, APIWithBehaviorDefault)
     }];
 #endif
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>" writingToolsBehavior:PlatformWritingToolsBehaviorDefault]);
+    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorDefault]);
     [webView setUIDelegate:delegate.get()];
 
     [webView focusDocumentBodyAndSelectAll];
@@ -2696,7 +2697,7 @@ TEST(WritingTools, APIWithBehaviorDefault)
 
     [webView waitForNextPresentationUpdate];
 
-    EXPECT_EQ([webView writingToolsBehaviorForTesting], PlatformWritingToolsBehaviorLimited);
+    EXPECT_EQ([webView writingToolsBehaviorForTesting], CocoaWritingToolsBehaviorLimited);
 
 #if PLATFORM(MAC)
     [webView mouseDownAtPoint:NSMakePoint(10, 10) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
@@ -2710,7 +2711,7 @@ TEST(WritingTools, APIWithBehaviorDefault)
 
 TEST(WritingTools, APIWithBehaviorComplete)
 {
-    // If `PlatformWritingToolsBehaviorComplete`, there should be a context menu item, an affordance, and inline editing support.
+    // If `CocoaWritingToolsBehaviorComplete`, there should be a context menu item, an affordance, and inline editing support.
 
 #if PLATFORM(MAC)
     if (![PAL::getWTWritingToolsViewControllerClass() isAvailable])
@@ -2733,7 +2734,7 @@ TEST(WritingTools, APIWithBehaviorComplete)
     }];
 #endif
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>" writingToolsBehavior:PlatformWritingToolsBehaviorComplete]);
+    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
     [webView setUIDelegate:delegate.get()];
 
     [webView focusDocumentBodyAndSelectAll];
@@ -2742,7 +2743,7 @@ TEST(WritingTools, APIWithBehaviorComplete)
 
     [webView waitForNextPresentationUpdate];
 
-    EXPECT_EQ([webView writingToolsBehaviorForTesting], PlatformWritingToolsBehaviorComplete);
+    EXPECT_EQ([webView writingToolsBehaviorForTesting], CocoaWritingToolsBehaviorComplete);
 
 #if PLATFORM(MAC)
     [webView mouseDownAtPoint:NSMakePoint(10, 10) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
@@ -2894,7 +2895,7 @@ TEST(WritingTools, ShowAffordance)
         didCallScheduleShowAffordanceForSelectionRect = true;
     }));
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>" writingToolsBehavior:PlatformWritingToolsBehaviorComplete]);
+    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
     [webView focusDocumentBodyAndSelectAll];
 
     expectScheduleShowAffordanceForSelectionRectCalled(true);
@@ -2940,7 +2941,7 @@ TEST(WritingTools, ShowAffordanceForMultipleLines)
         count++;
     }));
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='first'>AAAA BBBB CCCC</p><p>DDDD</p></body>" writingToolsBehavior:PlatformWritingToolsBehaviorComplete]);
+    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='first'>AAAA BBBB CCCC</p><p>DDDD</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
     [webView focusDocumentBodyAndSelectAll];
 
     expectScheduleShowAffordanceForSelectionRectCalled(true);
@@ -2961,7 +2962,7 @@ TEST(WritingTools, ShowPanelWithNoSelection)
         done = true;
     }));
 
-    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='text'>This is some content that should be rewritten.</p></body>" writingToolsBehavior:PlatformWritingToolsBehaviorComplete]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='text'>This is some content that should be rewritten.</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
 
     [webView _showWritingTools];
 
@@ -2987,7 +2988,7 @@ TEST(WritingTools, ShowPanelWithCaretSelection)
         done = true;
     }));
 
-    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='text'>This is some content that should be rewritten.</p></body>" writingToolsBehavior:PlatformWritingToolsBehaviorComplete]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='text'>This is some content that should be rewritten.</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
     [webView focusDocumentBodyAndSelectAll];
 
     NSString *setSelectionJavaScript = @""
@@ -3029,7 +3030,7 @@ TEST(WritingTools, ShowPanelWithRangedSelection)
         done = true;
     }));
 
-    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='text'>This is some content that should be rewritten.</p></body>" writingToolsBehavior:PlatformWritingToolsBehaviorComplete]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='text'>This is some content that should be rewritten.</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
     [webView focusDocumentBodyAndSelectAll];
 
     [webView _showWritingTools];
@@ -3055,7 +3056,7 @@ TEST(WritingTools, DISABLED_ShowToolWithRangedSelection)
         done = true;
     }));
 
-    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='text'>This is some content that should be rewritten.</p></body>" writingToolsBehavior:PlatformWritingToolsBehaviorComplete]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='text'>This is some content that should be rewritten.</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
     [webView focusDocumentBodyAndSelectAll];
 
     RetainPtr menuItem = adoptNS([[NSMenuItem alloc] initWithTitle:@"Test" action:nil keyEquivalent:@""]);
@@ -3083,7 +3084,7 @@ TEST(WritingTools, DISABLED_ShowInvalidToolWithRangedSelection)
         done = true;
     }));
 
-    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='text'>This is some content that should be rewritten.</p></body>" writingToolsBehavior:PlatformWritingToolsBehaviorComplete]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='text'>This is some content that should be rewritten.</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
     [webView focusDocumentBodyAndSelectAll];
 
     RetainPtr menuItem = adoptNS([[NSMenuItem alloc] initWithTitle:@"Test" action:nil keyEquivalent:@""]);
@@ -3199,7 +3200,7 @@ TEST(WritingTools, DISABLED_ContextMenuItemsNonEditable)
         gotProposedMenu = true;
     }];
 
-    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body><p>AAAA BBBB CCCC</p></body>" writingToolsBehavior:PlatformWritingToolsBehaviorComplete]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body><p>AAAA BBBB CCCC</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
     [webView setUIDelegate:delegate.get()];
 
     [webView focusDocumentBodyAndSelectAll];
@@ -3235,7 +3236,7 @@ TEST(WritingTools, DISABLED_ContextMenuItemsEditable)
         gotProposedMenu = true;
     }];
 
-    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p>AAAA BBBB CCCC</p></body>" writingToolsBehavior:PlatformWritingToolsBehaviorComplete]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p>AAAA BBBB CCCC</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
     [webView setUIDelegate:delegate.get()];
 
     [webView focusDocumentBodyAndSelectAll];
@@ -3271,7 +3272,7 @@ TEST(WritingTools, DISABLED_ContextMenuItemsEditableEmpty)
         gotProposedMenu = true;
     }];
 
-    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable></body>" writingToolsBehavior:PlatformWritingToolsBehaviorComplete]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable></body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
     [webView setUIDelegate:delegate.get()];
 
     [webView focusDocumentBodyAndSelectAll];
@@ -3296,7 +3297,7 @@ TEST(WritingTools, DISABLED_ContextMenuItemsEditableEmpty)
 
 TEST(WritingTools, AppMenuNonEditable)
 {
-    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body><p>AAAA BBBB CCCC</p></body>" writingToolsBehavior:PlatformWritingToolsBehaviorComplete]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body><p>AAAA BBBB CCCC</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
 
     [webView focusDocumentBodyAndSelectAll];
 
@@ -3316,7 +3317,7 @@ TEST(WritingTools, AppMenuNonEditable)
 
 TEST(WritingTools, AppMenuEditable)
 {
-    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p>AAAA BBBB CCCC</p></body>" writingToolsBehavior:PlatformWritingToolsBehaviorComplete]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p>AAAA BBBB CCCC</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
 
     [webView focusDocumentBodyAndSelectAll];
 
@@ -3336,7 +3337,7 @@ TEST(WritingTools, AppMenuEditable)
 
 TEST(WritingTools, AppMenuEditableEmpty)
 {
-    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable></body>" writingToolsBehavior:PlatformWritingToolsBehaviorComplete]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable></body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
 
     [webView focusDocumentBodyAndSelectAll];
 
@@ -4069,7 +4070,7 @@ TEST(WritingTools, PDFTextSelections)
 
     selectAllText(webView.get());
     [webView waitForNextPresentationUpdate];
-    EXPECT_EQ([webView writingToolsBehaviorForTesting], PlatformWritingToolsBehaviorNone);
+    EXPECT_EQ([webView writingToolsBehaviorForTesting], CocoaWritingToolsBehaviorNone);
 }
 #endif
 


### PR DESCRIPTION
#### c82dcaa5c84f2b04b05756afbf2e3fa7b3356392
<pre>
[Writing Tools] Support compiling ENABLE_WRITING_TOOLS on the public SDK (Part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=291798">https://bugs.webkit.org/show_bug.cgi?id=291798</a>
<a href="https://rdar.apple.com/149620168">rdar://149620168</a>

Reviewed by Wenson Hsieh.

More work towards supporting compiling ENABLE_WRITING_TOOLS on the public SDK.

The primary change in this PR is to refactor and rename the platform agnostic type definitions of `PlatformWritingToolsBehavior`
and `PlatformWritingToolsResultOptions` into their own file because of several reasons:

* The types they abstract over are API, and so they don&apos;t even make sense in the SPI folder/file

* There is precedent for files that are platform-agnostic abstractions, such as ColorCocoa and
PlatformView/CocoaView (the fact there&apos;s two of these is weird itself but that&apos;s a different issue).

* When the SPI file becomes the fake umbrella header for the clang module that will be added in a subsequent PR,
it musn&apos;t contain any C++, which `using` declarations are.

There are several additional miscellaneous fixes in support of being able to build for the public SDK,
which will be detailed below.

* Source/WebCore/PAL/pal/spi/cocoa/WritingToolsSPI.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/cocoa/CocoaWritingToolsTypes.h: Added.

Move and rename the definitions of `PlatformWritingToolsBehavior` and `PlatformWritingToolsResultOptions`.

* Source/WebKit/Platform/spi/mac/AppKitSPI.h:
* Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h:

Move the forward declaration of some methods to the main `AppKitSPI.h` file so that it can be referenced
from WebKit in addition to TestWebKitAPI.

* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView allowedWritingToolsResultOptions]):
(-[WKWebView writingToolsBehavior]):

Use renamed types.

(-[WKWebView intelligenceTextEffectCoordinator:rectsForProofreadingSuggestionsInRange:completion:]):

The `[NSValue valueWithRect:]` method is oddly not available on the public SDK on iOS, so replace this
with the convenience form of `createNSArray` which is actually nicer and shorter anyways, and does the proper thing.

Add includes that are now needed after removing them from the header.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration setWritingToolsBehavior:]):
(-[WKWebViewConfiguration writingToolsBehavior]):

Use renamed types.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:

Remove some unnecessary includes, and add a new necessary one.

* Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.h:
* Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.mm:
(WebKit::convertToCocoaWritingToolsBehavior):
(WebKit::convertToWebWritingToolsBehavior):
(WebKit::convertToPlatformWritingToolsBehavior): Deleted.

Rename types and functions, add needed includes.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView allowedWritingToolsResultOptions]):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(-[WebHTMLView writingToolsBehavior]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(-[WritingToolsWKWebView initWithHTMLString:]):
(-[WritingToolsWKWebView initWithHTMLString:writingToolsBehavior:]):
(-[WritingToolsWKWebView initWithHTMLString:writingToolsBehavior:attachmentElementEnabled:]):
(-[WritingToolsWKWebView allowedWritingToolsResultOptionsForTesting]):
(-[WritingToolsWKWebView writingToolsBehaviorForTesting]):
(TEST(WritingTools, ProofreadingWithUntitledImageAttachment)):
(TEST(WritingTools, CompositionWithImageAttachmentRoundTrip)):
(TEST(WritingTools, CompositionWithNonImageAttachmentRoundTrip)):
(TEST(WritingTools, WantsInlineEditing)):
(TEST(WritingTools, WritingToolsBehaviorNonEditableWithSelection)):
(TEST(WritingTools, WritingToolsBehaviorWithNoSelection)):
(TEST(WritingTools, WritingToolsBehaviorEditableWithSelection)):
(TEST(WritingTools, AllowedInputOptionsNonEditable)):
(TEST(WritingTools, AllowedInputOptionsEditable)):
(TEST(WritingTools, AllowedInputOptionsRichText)):
(TEST(WritingTools, AllowedInputOptionsPlainText)):
(TEST(WritingTools, EphemeralSessionWithDifferingTextLengths)):
(TEST(WritingTools, EphemeralSessionWithDeeplyNestedContent)):
(TEST(WritingTools, APIWithBehaviorNone)):
(TEST(WritingTools, APIWithBehaviorDefault)):
(TEST(WritingTools, APIWithBehaviorComplete)):
(TEST(WritingTools, ShowAffordance)):
(TEST(WritingTools, ShowAffordanceForMultipleLines)):
(TEST(WritingTools, ShowPanelWithNoSelection)):
(TEST(WritingTools, ShowPanelWithCaretSelection)):
(TEST(WritingTools, ShowPanelWithRangedSelection)):
(TEST(WritingTools, DISABLED_ShowToolWithRangedSelection)):
(TEST(WritingTools, DISABLED_ShowInvalidToolWithRangedSelection)):
(TEST(WritingTools, DISABLED_ContextMenuItemsNonEditable)):
(TEST(WritingTools, DISABLED_ContextMenuItemsEditable)):
(TEST(WritingTools, DISABLED_ContextMenuItemsEditableEmpty)):
(TEST(WritingTools, AppMenuNonEditable)):
(TEST(WritingTools, AppMenuEditable)):
(TEST(WritingTools, AppMenuEditableEmpty)):
(TEST(WritingTools, PDFTextSelections)):

Rename types/methods.

Canonical link: <a href="https://commits.webkit.org/293899@main">https://commits.webkit.org/293899@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edea3dc681e42611ff9a79853e03ded57931c53b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19883 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10181 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105364 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50817 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102275 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20188 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28357 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76311 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33370 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103241 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90535 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56671 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15260 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8534 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50185 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85168 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107723 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27347 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20043 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85263 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27710 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86742 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84802 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21548 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29483 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7218 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21220 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27284 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32517 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27095 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30411 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28654 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->