### PR TITLE
[Page color sampling] amossweets.com: content inset background fill is missing below the bottom header

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-transparent-pointer-events-none-container-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-transparent-pointer-events-none-container-expected.txt
@@ -1,0 +1,12 @@
+PASS colorsBeforeShowingPopup.top is null
+PASS colorsBeforeShowingPopup.left is null
+PASS colorsBeforeShowingPopup.right is null
+PASS colorsBeforeShowingPopup.bottom is "rgb(0, 122, 255)"
+PASS colorsAfterShowingPopup.top is "rgb(255, 59, 48)"
+PASS colorsAfterShowingPopup.left is "rgb(255, 59, 48)"
+PASS colorsAfterShowingPopup.right is "rgb(255, 59, 48)"
+PASS colorsAfterShowingPopup.bottom is "rgb(255, 59, 48)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Footer textPopup text

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-transparent-pointer-events-none-container.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-transparent-pointer-events-none-container.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body, html {
+            font-family: system-ui;
+            width: 100%;
+            height: 100%;
+            margin: 0;
+        }
+
+        .content {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            top: 0;
+            overflow-y: scroll;
+            padding: 0 1em;
+        }
+
+        .box {
+            width: 100%;
+            height: 100px;
+            margin-bottom: 50px;
+            box-sizing: border-box;
+            border-radius: 1em;
+        }
+
+        footer {
+            position: fixed;
+            bottom: 0;
+            width: 100%;
+            height: 50px;
+            background: rgb(0, 122, 255);
+            color: white;
+            line-height: 50px;
+            text-align: center;
+            z-index: 10;
+        }
+
+        .invisible-popup {
+            opacity: 0;
+            pointer-events: none;
+            background-color: rgb(255, 59, 48);
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            color: white;
+            text-align: center;
+            line-height: 100vh;
+            font-size: 20px;
+            z-index: 100;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    async function showPopup() {
+        document.querySelector(".invisible-popup").style.opacity = 1;
+        document.querySelector(".invisible-popup").style.pointerEvents = "auto";
+        await UIHelper.ensurePresentationUpdate();
+    }
+
+    addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(50, 50, 50, 50);
+        await UIHelper.ensurePresentationUpdate();
+        colorsBeforeShowingPopup = await UIHelper.fixedContainerEdgeColors();
+        shouldBeNull("colorsBeforeShowingPopup.top");
+        shouldBeNull("colorsBeforeShowingPopup.left");
+        shouldBeNull("colorsBeforeShowingPopup.right");
+        shouldBeEqualToString("colorsBeforeShowingPopup.bottom", "rgb(0, 122, 255)");
+
+        await showPopup();
+
+        colorsAfterShowingPopup = await UIHelper.fixedContainerEdgeColors();
+        shouldBeEqualToString("colorsAfterShowingPopup.top", "rgb(255, 59, 48)");
+        shouldBeEqualToString("colorsAfterShowingPopup.left", "rgb(255, 59, 48)");
+        shouldBeEqualToString("colorsAfterShowingPopup.right", "rgb(255, 59, 48)");
+        shouldBeEqualToString("colorsAfterShowingPopup.bottom", "rgb(255, 59, 48)");
+
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+    <pre id="console"></pre>
+    <pre id="description"></pre>
+    <footer>Footer text</footer>
+    <div class="invisible-popup">Popup text</div>
+</body>
+</html>


### PR DESCRIPTION
#### aad687aa65bdd029a44c2b194d43563b75b0a35d
<pre>
[Page color sampling] amossweets.com: content inset background fill is missing below the bottom header
<a href="https://bugs.webkit.org/show_bug.cgi?id=291799">https://bugs.webkit.org/show_bug.cgi?id=291799</a>
<a href="https://rdar.apple.com/149528268">rdar://149528268</a>

Reviewed by Abrar Rahman Protyasha.

After 293604@main, the bottom fixed-position container on amossweets.com no longer receives the
background color extension treatment; this is because another element with `pointer-events: none;`
and `opacity: 0;` covers the entire screen, and hit-testing in `findFixedContainer` just returns a
null container.

To fix this while still maintaining color extension for elements with `pointer-events: none;`, we
detect the case where hit-testing finds a transparent or hidden container (very low opacity, or with
no background and no child renderers) that has `pointer-events: none;`, and retry hit-testing again,
this time skipping containers with `pointer-events: none;`.

* LayoutTests/fast/page-color-sampling/color-sampling-ignores-transparent-pointer-events-none-container-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-transparent-pointer-events-none-container.html: Added.

Add a layout test to exercise the change; first, verify that hit-testing pierces through the fully
transparent popup that covers the view with `pointer-events: none;`, and then verify that revealing
the popup causes the sampled edge colors to change.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::isHiddenOrNearlyTransparent):
(WebCore::LocalFrameView::fixedContainerEdges const):

Canonical link: <a href="https://commits.webkit.org/293900@main">https://commits.webkit.org/293900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5215844d8f3dbc7804f001a9545a35849ec06b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10175 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105358 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50811 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28351 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76306 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33365 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103235 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15434 "Found 1 new test failure: fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90529 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56666 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15254 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8528 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50179 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85161 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8610 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107717 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27341 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20037 "Found 1 new test failure: fast/css/view-transitions-hide-under-page-background-color.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85257 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27704 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84796 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21549 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29477 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7212 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21212 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27278 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32511 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27089 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30405 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28648 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->