### PR TITLE
Sync `svg/animations` from WPT upstream

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2179,6 +2179,7 @@ imported/w3c/web-platform-tests/svg/animations/conditional-processing-01.html [ 
 imported/w3c/web-platform-tests/svg/animations/stop-animation-01.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/animations/switch-animation-01.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/animations/switch-animation-02.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/svg/animations/animate-display-to-none-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/embedded/image-crossorigin.sub.html [ Skip ]
 imported/w3c/web-platform-tests/svg/embedded/image-embedding-svg-with-near-integral-width.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/embedded/image-fractional-width-vertical-fidelity.svg [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -10722,6 +10722,7 @@
         "web-platform-tests/shadow-dom/untriaged/shadow-trees/shadow-root-001-ref.html",
         "web-platform-tests/shadow-dom/untriaged/shadow-trees/shadow-root-002-ref.html",
         "web-platform-tests/shadow-dom/untriaged/styles/not-apply-in-shadow-root-001-ref.html",
+        "web-platform-tests/svg/animations/reftests/reference/green-100x100.svg",
         "web-platform-tests/svg/coordinate-systems/support/abspos-ref.html",
         "web-platform-tests/svg/coordinate-systems/support/simple.svg",
         "web-platform-tests/svg/coordinate-systems/support/viewBox-change-repaint-001-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-display-to-none-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-display-to-none-001-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-display-to-none-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-display-to-none-001.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Test that underlying style gets restored when seeking away from the
+  'to' portion of a SVG/SMIL animation to 'display:none'</title>
+<link rel="help" href="https://www.w3.org/TR/smil-animation/#ToAttribute">
+<link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
+<link rel="match" href="../struct/reftests/reference/green-100x100.html">
+<script>
+  function go() {
+    svgElem.pauseAnimations();
+
+    /* Seek to 75% of the way through duration, when the animation should be
+     * imposing the "to" value. (This is necessary to trigger the bug
+     * that we're regression-testing for here.) */
+    svgElem.setCurrentTime(3);
+
+    /* Now, seek back to 25% of the way through duration, when the underlying
+     * value should be restored. This should make the green rect show up
+     * in our reftest screenshot. */
+    svgElem.setCurrentTime(1);
+  }
+</script>
+<body onload="go()">
+<svg id="svgElem">
+  <rect width="100" height="100" fill="red"/>
+  <rect width="100" height="100" fill="green">
+    <animate attributeName="display" to="none"
+             begin="0s" dur="4s"/>
+  </rect>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/crashtests/firefox-bug-1930221.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/crashtests/firefox-bug-1930221.html
@@ -1,0 +1,7 @@
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById("x").beginElementAt(-1369430904473181976352858)
+})
+</script>
+<svg>
+<animate id="x" begin="a" />

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/crashtests/firefox-bug-1949899.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/crashtests/firefox-bug-1949899.html
@@ -1,0 +1,9 @@
+<script>
+function go() {
+  a.setAttribute("repeatDur", "indefinite")
+  a.setAttribute("fill", "freeze")
+}
+</script>
+<body onload="go()">
+<svg>
+<animateMotion id="a" min="300ms" repeatDur="0s">

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/crashtests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/crashtests/w3c-import.log
@@ -1,0 +1,18 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/svg/animations/crashtests/firefox-bug-1930221.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/animations/crashtests/firefox-bug-1949899.html

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/historical-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/historical-expected.txt
@@ -1,0 +1,4 @@
+
+PASS discard element
+PASS SVGDiscardElement
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/historical.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/historical.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+<meta charset="utf-8">
+<title>Historical features of SVG Animation</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg width="100" height="100" id="test-discard">
+  <rect x="0" y="0" width="50" height="50" fill="black" transform="translate(0, 0)">
+    <animateTransform attributeName="transform" begin="0s" dur="0.1s" from="0, 0" to="50, 50"/>
+    <discard begin="0.1s"/>
+  </rect>
+</svg>
+
+<script>
+async_test(t => {
+  const testDiscardEl = document.getElementById('test-discard');
+  t.step_timeout(() => {
+    for (const tag of ["rect", "animateTransform", "discard"]) {
+      assert_not_equals(testDiscardEl.querySelector(tag), null, tag);
+    }
+    t.done();
+  }, 500);
+}, 'discard element');
+
+test(() => {
+  assert_equals(window.SVGDiscardElement, undefined);
+}, 'SVGDiscardElement');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/reftests/reference/green-100x100.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/reftests/reference/green-100x100.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/reftests/reference/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/reftests/reference/w3c-import.log
@@ -1,0 +1,17 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/svg/animations/reftests/reference/green-100x100.svg

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/w3c-import.log
@@ -30,6 +30,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-color-transparent.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-css-xml-attributeType.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-currentColor.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-display-to-none-001-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-display-to-none-001.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-dynamic-update-attributeName.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-elem-02-t-drt.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-elem-14-t-drt.html
@@ -106,6 +108,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/first-interval-in-the-past-contribute.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/first-interval-in-the-past-dont-contribute.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/force-use-shadow-tree-recreation-while-animating.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/animations/historical.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/interval-restart-events.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/keysplines-x-limits.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/keysplines-y-limits.html


### PR DESCRIPTION
#### d767e232791f782fdcd8f0d72fd04c836716246f
<pre>
Sync `svg/animations` from WPT upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=291806">https://bugs.webkit.org/show_bug.cgi?id=291806</a>
<a href="https://rdar.apple.com/149630148">rdar://149630148</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/8d124dbe46f46f55531f28f13eccf1113f794c12">https://github.com/web-platform-tests/wpt/commit/8d124dbe46f46f55531f28f13eccf1113f794c12</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/reftests/reference/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/reftests/reference/green-100x100.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/historical.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/historical-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/crashtests/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/crashtests/firefox-bug-1949899.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/crashtests/firefox-bug-1930221.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-display-to-none-001.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-display-to-none-001-expected.html:

Canonical link: <a href="https://commits.webkit.org/293910@main">https://commits.webkit.org/293910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8651ecde3f01eb36f8fd6a4a76a17a6424e892e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100242 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10189 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105372 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50825 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20196 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28365 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76318 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33377 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103249 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15448 "Found 1 new test failure: fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90543 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56677 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15268 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8542 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50193 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85177 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8624 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107731 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27355 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20051 "Found 1 new test failure: fast/css/view-transitions-hide-under-page-background-color.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85270 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86750 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84809 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21554 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29491 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7226 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21233 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27292 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27103 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30419 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28662 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->