### PR TITLE
[JSC] WASM JIT compiler uses the wrong comparison for br_if after i32.ne or i64.ne

### DIFF
--- a/JSTests/wasm/stress/if-fold.js
+++ b/JSTests/wasm/stress/if-fold.js
@@ -1,0 +1,31 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = `
+(module
+    (func (export "test32")
+        (loop $loop
+            i32.const 1000
+            i32.const 1000
+            i32.ne
+            br_if $loop)
+    )
+
+    (func (export "test64")
+        (loop $loop
+            i64.const 1000
+            i64.const 1000
+            i64.ne
+            br_if $loop)
+    )
+)
+`;
+
+async function test() {
+  const instance = await instantiate(wat, {}, {});
+  const { test32, test64 } = instance.exports;
+  assert.eq(test32(), undefined);
+  assert.eq(test64(), undefined);
+}
+
+await assert.asyncTest(test());

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -3352,7 +3352,7 @@ BBQJIT::BranchFoldResult BBQJIT::tryFoldFusedBranchCompare(OpType opType, Expres
     case OpType::I32Eq:
         return left.asI32() == right.asI32() ? BranchAlwaysTaken : BranchNeverTaken;
     case OpType::I32Ne:
-        return left.asI32() == right.asI32() ? BranchAlwaysTaken : BranchNeverTaken;
+        return left.asI32() != right.asI32() ? BranchAlwaysTaken : BranchNeverTaken;
     case OpType::I64LtS:
         return left.asI64() < right.asI64() ? BranchAlwaysTaken : BranchNeverTaken;
     case OpType::I64LtU:
@@ -3372,7 +3372,7 @@ BBQJIT::BranchFoldResult BBQJIT::tryFoldFusedBranchCompare(OpType opType, Expres
     case OpType::I64Eq:
         return left.asI64() == right.asI64() ? BranchAlwaysTaken : BranchNeverTaken;
     case OpType::I64Ne:
-        return left.asI64() == right.asI64() ? BranchAlwaysTaken : BranchNeverTaken;
+        return left.asI64() != right.asI64() ? BranchAlwaysTaken : BranchNeverTaken;
     case OpType::F32Lt:
         return left.asF32() < right.asF32() ? BranchAlwaysTaken : BranchNeverTaken;
     case OpType::F32Gt:


### PR DESCRIPTION
#### 7bb4eb9855e0d1940ec3af407751d2a33a525c25
<pre>
[JSC] WASM JIT compiler uses the wrong comparison for br_if after i32.ne or i64.ne
<a href="https://bugs.webkit.org/show_bug.cgi?id=291795">https://bugs.webkit.org/show_bug.cgi?id=291795</a>
<a href="https://rdar.apple.com/149638249">rdar://149638249</a>

Reviewed by Keith Miller.

Constant folding for branch is wrong in != condition in WasmBBQJIT.

* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::tryFoldFusedBranchCompare):

Canonical link: <a href="https://commits.webkit.org/294022@main">https://commits.webkit.org/294022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e685ef550c8af440e49546249f01ce2afc27df4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105728 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51179 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20551 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28717 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76599 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/33642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103598 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15763 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56955 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15578 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8872 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50555 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/93255 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85492 "Passed tests") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108082 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/99199 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27709 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20349 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85557 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87067 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85095 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29784 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21697 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16368 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27644 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32895 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122825 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27455 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34255 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30773 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29013 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->