### PR TITLE
[JSC] Type checking error after JIT optimization

### DIFF
--- a/JSTests/stress/string-value-of-should-throw-error-for-undefined.js
+++ b/JSTests/stress/string-value-of-should-throw-error-for-undefined.js
@@ -1,0 +1,21 @@
+//@ runDefault("--useConcurrentJIT=0", "--jitPolicyScale=0")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function opt() {
+    const v1 = Object.getPrototypeOf('').toString;
+    try {
+        v1.call();
+        return 0
+    } catch (e) {
+        return String(e);
+    }
+}
+
+
+shouldBe(opt(), `TypeError: Type error`);
+for (let i = 0; i < 10; i++)
+    shouldBe(opt(), `TypeError: Type error`);

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -1596,7 +1596,8 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     }
 
     case StringValueOf: {
-        clobberWorld();
+        if (node->child1().useKind() == UntypedUse)
+            clobberWorld();
         setTypeForNode(node, SpecString);
         break;
     }

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -806,7 +806,6 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case CreateAsyncGenerator:
     case InstanceOf:
     case InstanceOfMegamorphic:
-    case StringValueOf:
     case ObjectKeys:
     case ObjectGetOwnPropertyNames:
     case ObjectGetOwnPropertySymbols:
@@ -814,6 +813,18 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case ReflectOwnKeys:
         clobberTop();
         return;
+
+    case StringValueOf:
+        switch (node->child1().useKind()) {
+        case StringOrOtherUse:
+            read(World);
+            write(SideState);
+            def(PureValue(node));
+            return;
+        default:
+            clobberTop();
+            return;
+        }
 
     case ToNumber:
         switch (node->child1().useKind()) {

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -4073,9 +4073,6 @@ private:
 
         if (node->child1()->shouldSpeculateStringOrOther()) {
             fixEdge<StringOrOtherUse>(node->child1());
-            node->convertToToString();
-            // It does not need to look up a toString property for the StringObject case. So we can clear NodeMustGenerate.
-            node->clearFlags(NodeMustGenerate);
             return;
         }
 


### PR DESCRIPTION
#### 472bc719b29b73c49fc7e901d773666403078d16
<pre>
[JSC] Type checking error after JIT optimization
<a href="https://bugs.webkit.org/show_bug.cgi?id=291362">https://bugs.webkit.org/show_bug.cgi?id=291362</a>
<a href="https://rdar.apple.com/149470479">rdar://149470479</a>

Reviewed by Yijia Huang.

`String#toString` / `String#valueOf` with `undefined` / `null` should
throw an error. Thus, we should not fold it to ToString node with
StringOrOther.

* JSTests/stress/string-value-of-should-throw-error-for-undefined.js: Added.
(shouldBe):
(opt):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupStringValueOf):

Canonical link: <a href="https://commits.webkit.org/293973@main">https://commits.webkit.org/293973@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/906932aea5457d1ccba199ad9a909a496ba11e53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100440 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10391 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105577 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51028 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28566 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76479 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33532 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103447 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15632 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90728 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56835 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8731 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50403 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/93103 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85365 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8810 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107931 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/99048 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27558 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20225 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85432 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27921 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86928 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84970 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29655 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7387 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21522 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16348 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27493 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32742 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122674 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27304 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34218 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30622 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28862 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->