### PR TITLE
[Writing Tools] Support compiling ENABLE_WRITING_TOOLS on the public SDK (Part 4)

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/WritingToolsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/WritingToolsSPI.h
@@ -143,6 +143,12 @@ typedef NS_ENUM(NSInteger, WTTextSuggestionState) {
 
 // MARK: WTTextViewDelegate
 
+#if PLATFORM(IOS_FAMILY)
+@class UIView;
+#else
+@class NSView;
+#endif
+
 @protocol WTTextViewDelegate
 
 - (void)proofreadingSessionWithUUID:(NSUUID *)sessionUUID updateState:(WTTextSuggestionState)state forSuggestionWithUUID:(NSUUID *)suggestionUUID;

--- a/Source/WebCore/PAL/pal/spi/cocoa/WritingToolsUISPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/WritingToolsUISPI.h
@@ -39,6 +39,7 @@ DECLARE_SYSTEM_HEADER
 
 #else
 
+#import <AppKit/AppKit.h>
 #import <CoreGraphics/CoreGraphics.h>
 
 // MARK: Forward-declared Writing Tools types

--- a/Source/WebKit/Configurations/WebKitSwift.xcconfig
+++ b/Source/WebKit/Configurations/WebKitSwift.xcconfig
@@ -64,7 +64,7 @@ FRAMEWORK_LDFLAGS_xrsimulator[sdk=xr*2.*] = -framework LinearMediaKit;
 
 // Use handwritten SPI modules on public SDKs.
 SWIFT_INCLUDE_PATHS = $(SWIFT_INCLUDE_PATHS_$(USE_INTERNAL_SDK));
-SWIFT_INCLUDE_PATHS_ = $(SRCROOT)/Platform/spi/visionos $(inherited);
+SWIFT_INCLUDE_PATHS_ = $(SRCROOT)/Platform/spi/visionos $(SRCROOT)/Platform/spi/ios $(inherited);
 
 WEBKITSWIFT_HEADERS_FOLDER_PATH = $(WK_LIBRARY_HEADERS_FOLDER_PATH)/WebKitSwift;
 

--- a/Source/WebKit/Platform/spi/ios/UIKit_SPI.swiftinterface
+++ b/Source/WebKit/Platform/spi/ios/UIKit_SPI.swiftinterface
@@ -1,0 +1,134 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -enable-objc-interop -autolink-force-load -enable-library-evolution -module-link-name swiftUIKit -swift-version 5 -enforce-exclusivity=checked -O -library-level spi -module-abi-name UIKit  -enable-bare-slash-regex -user-module-version 8506 -module-name UIKit_SPI
+import _Concurrency
+import Foundation
+import Swift
+@_exported import UIKit
+@_inheritsConvenienceInitializers @available(iOS 18.0, visionOS 2.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@objc open class UITextEffectTextChunk : ObjectiveC.NSObject, Swift.Identifiable {
+  @objc override dynamic public init()
+  @available(iOS 18.0, visionOS 2.0, *)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  public typealias ID = Swift.ObjectIdentifier
+  @objc deinit
+}
+@available(iOS 18.0, visionOS 2.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@objc public protocol UITextEffectViewSource {
+  @objc func targetedPreview(for chunk: UIKit_SPI.UITextEffectTextChunk) async -> UIKit.UITargetedPreview
+  @objc optional func canGenerateTargetedPreviews() async -> Swift.Bool
+  @objc optional func canGenerateTargetedPreviewForChunk(_: UIKit_SPI.UITextEffectTextChunk) async -> Swift.Bool
+  @objc func updateTextChunkVisibilityForAnimation(_ chunk: UIKit_SPI.UITextEffectTextChunk, visible: Swift.Bool) async
+  @objc optional func updatedTargetedPreviewGeometry(for chunk: UIKit_SPI.UITextEffectTextChunk, previous: CoreFoundation.CGRect) async -> CoreFoundation.CGRect
+}
+@objc @_hasMissingDesignatedInitializers @available(iOS 18.0, visionOS 2.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@_Concurrency.MainActor public class UITextEffectView : UIKit.UIView {
+  @_Concurrency.MainActor weak public var source: (any UIKit_SPI.UITextEffectViewSource)?
+  @available(iOS 18.1, visionOS 2.1, *)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  @_Concurrency.MainActor public var hasActiveEffects: Swift.Bool {
+    get
+  }
+  @_Concurrency.MainActor public init(source: any UIKit_SPI.UITextEffectViewSource)
+  @_Concurrency.MainActor @objc override dynamic public func didMoveToSuperview()
+  @discardableResult
+  @_Concurrency.MainActor public func addEffect(_ effect: any UIKit_SPI.UITextEffectView.TextEffect) -> UIKit_SPI.UITextEffectView.EffectID
+  @_Concurrency.MainActor public func removeEffect(_ effectID: UIKit_SPI.UITextEffectView.EffectID)
+  @_Concurrency.MainActor public func removeAllEffects()
+  @_Concurrency.MainActor public func isEffectValid(_ effectID: UIKit_SPI.UITextEffectView.EffectID) -> Swift.Bool
+  @_Concurrency.MainActor @objc override dynamic public func didMoveToWindow()
+  @_Concurrency.MainActor @objc override dynamic public func layoutSubviews()
+  public struct EffectID : Swift.Hashable {
+    public static func == (a: UIKit_SPI.UITextEffectView.EffectID, b: UIKit_SPI.UITextEffectView.EffectID) -> Swift.Bool
+    public func hash(into hasher: inout Swift.Hasher)
+    public var hashValue: Swift.Int {
+      get
+    }
+  }
+  @objc deinit
+}
+@available(iOS 18.0, visionOS 2.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+extension UIKit_SPI.UITextEffectView {
+  @_Concurrency.MainActor public protocol TextEffect {
+    @_Concurrency.MainActor var id: UIKit_SPI.UITextEffectView.EffectID { get }
+    @_Concurrency.MainActor var chunk: UIKit_SPI.UITextEffectTextChunk { get }
+    @_Concurrency.MainActor var view: UIKit_SPI.UITextEffectView? { get }
+  }
+}
+@available(iOS 18.0, visionOS 2.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+extension UIKit_SPI.UITextEffectView {
+  @available(iOS 18.0, visionOS 2.0, *)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  @_Concurrency.MainActor public class ReplacementTextEffect : UIKit_SPI.UITextEffectView.TextEffect {
+    @_Concurrency.MainActor public var view: UIKit_SPI.UITextEffectView?
+    @_Concurrency.MainActor public var chunk: UIKit_SPI.UITextEffectTextChunk
+    @_Concurrency.MainActor final public let delegate: any UIKit_SPI.UITextEffectView.ReplacementTextEffect.Delegate
+    @_Concurrency.MainActor public var id: UIKit_SPI.UITextEffectView.EffectID
+    @_disfavoredOverload @_Concurrency.MainActor public init(chunk: UIKit_SPI.UITextEffectTextChunk, view: UIKit_SPI.UITextEffectView, delegate: any UIKit_SPI.UITextEffectView.ReplacementTextEffect.Delegate)
+    @_Concurrency.MainActor public init(chunk: UIKit_SPI.UITextEffectTextChunk, view: UIKit_SPI.UITextEffectView, delegate: any UIKit_SPI.UITextEffectView.ReplacementTextEffect.Delegate, fromColor: UIKit.UIColor = UIDirectionalLightEffectView.Configuration.pondering.fillColor)
+    public protocol Delegate {
+      func performReplacementAndGeneratePreview(for chunk: UIKit_SPI.UITextEffectTextChunk, effect: UIKit_SPI.UITextEffectView.ReplacementTextEffect, animation: UIKit_SPI.UITextEffectView.ReplacementTextEffect.AnimationParameters) async -> UIKit.UITargetedPreview?
+      @_Concurrency.MainActor func replacementEffectDidComplete(_ effect: UIKit_SPI.UITextEffectView.ReplacementTextEffect)
+    }
+    public struct AnimationParameters {
+      public let duration: Foundation.TimeInterval
+      public let delay: Foundation.TimeInterval
+    }
+    @objc deinit
+  }
+}
+extension UIKit_SPI.UITextEffectView.ReplacementTextEffect.Delegate {
+  public func performReplacementAndGeneratePreview(for chunk: UIKit_SPI.UITextEffectTextChunk, effect: UIKit_SPI.UITextEffectView.ReplacementTextEffect, animation: UIKit_SPI.UITextEffectView.ReplacementTextEffect.AnimationParameters) async -> UIKit.UITargetedPreview?
+  public func performReplacement(for chunk: UIKit_SPI.UITextEffectTextChunk, effect: UIKit_SPI.UITextEffectView.ReplacementTextEffect, animation: UIKit_SPI.UITextEffectView.ReplacementTextEffect.AnimationParameters) async
+}
+@available(iOS 18.0, visionOS 2.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+extension UIKit_SPI.UITextEffectView {
+  @available(iOS 18.0, visionOS 2.0, *)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  @_Concurrency.MainActor public class PonderingEffect : UIKit_SPI.UITextEffectView.TextEffect {
+    @_Concurrency.MainActor final public let chunk: UIKit_SPI.UITextEffectTextChunk
+    @_Concurrency.MainActor weak public var view: UIKit_SPI.UITextEffectView?
+    @_Concurrency.MainActor public var id: UIKit_SPI.UITextEffectView.EffectID
+    @_disfavoredOverload @_Concurrency.MainActor required public init(chunk: UIKit_SPI.UITextEffectTextChunk, view: UIKit_SPI.UITextEffectView)
+    @_Concurrency.MainActor required public init(chunk: UIKit_SPI.UITextEffectTextChunk, view: UIKit_SPI.UITextEffectView, lightConfiguration: UIKit_SPI.UIDirectionalLightEffectView.Configuration = .pondering)
+    @objc deinit
+  }
+}
+@objc @_hasMissingDesignatedInitializers @available(iOS 18.0, visionOS 2.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@_Concurrency.MainActor public class UIDirectionalLightEffectView : UIKit.UIView {
+  @objc deinit
+}
+@available(iOS 18.0, visionOS 2.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+extension UIKit_SPI.UIDirectionalLightEffectView {
+  public struct Configuration {
+    public let fillColor: UIKit.UIColor
+    public static let pondering: UIKit_SPI.UIDirectionalLightEffectView.Configuration
+  }
+}
+@available(iOS 18.1, visionOS 2.1, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+extension UIKit.UIColor {
+  public static var ponderingFill: UIKit.UIColor {
+    get
+  }
+}

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3194,6 +3194,7 @@
 		07275C662D00E3CA002315A5 /* SwiftUI.swiftoverlay */ = {isa = PBXFileReference; lastKnownFileType = text; path = SwiftUI.swiftoverlay; sourceTree = "<group>"; };
 		07275C832D00F782002315A5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		07275C8E2D011396002315A5 /* Empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Empty.swift; sourceTree = "<group>"; };
+		0728820E2DB53C02006F4A2B /* UIKit_SPI.swiftinterface */ = {isa = PBXFileReference; lastKnownFileType = text; path = UIKit_SPI.swiftinterface; sourceTree = "<group>"; };
 		07297F9C1C1711EA003F0735 /* DeviceIdHashSaltStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DeviceIdHashSaltStorage.cpp; sourceTree = "<group>"; };
 		07297F9C1C17BBEA003F0735 /* UserMediaPermissionCheckProxy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UserMediaPermissionCheckProxy.cpp; sourceTree = "<group>"; };
 		07297F9D1C17BBEA003F0735 /* UserMediaPermissionCheckProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserMediaPermissionCheckProxy.h; sourceTree = "<group>"; };
@@ -16251,6 +16252,7 @@
 				DDDFE826284699E6006F1EE5 /* SafariServicesSPI.h */,
 				079D1D9926960CD300883577 /* SystemStatusSPI.h */,
 				CE1A0BD11A48E6C60054EF74 /* TextInputSPI.h */,
+				0728820E2DB53C02006F4A2B /* UIKit_SPI.swiftinterface */,
 				CEE4AE2A1A5DCF430002F49B /* UIKitSPI.h */,
 			);
 			path = ios;

--- a/Source/WebKit/WebKitSwift/TextAnimation/TextAnimationManager.swift
+++ b/Source/WebKit/WebKitSwift/TextAnimation/TextAnimationManager.swift
@@ -7,8 +7,12 @@
 import OSLog
 import WebKit
 import WebKitSwift
-internal import UIKit_Private
+
+#if USE_APPLE_INTERNAL_SDK
 @_spi(TextEffects) import UIKit
+#else
+import UIKit_SPI
+#endif // USE_APPLE_INTERNAL_SDK
 
 @objc public enum WKTextAnimationType: Int {
     case initial

--- a/Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift
@@ -26,16 +26,23 @@ import Foundation
 #if HAVE_WRITING_TOOLS_FRAMEWORK
 
 #if canImport(AppKit) && !targetEnvironment(macCatalyst)
+
 import AppKit
 // WritingToolsUI is not present in the base system, but WebKit is, so it must be weak-linked.
 // WritingToolsUI need not be soft-linked from WebKitSwift because although WTUI links WebKit, WebKit does not directly link WebKitSwift.
 @_weakLinked internal import WritingToolsUI_Private._WTTextEffectView
 @_weakLinked internal import WritingToolsUI_Private._WTSweepTextEffect
 @_weakLinked internal import WritingToolsUI_Private._WTReplaceTextEffect
+
 #else
-internal import UIKit_Private
+
+#if USE_APPLE_INTERNAL_SDK
 @_spi(TextEffects) import UIKit
-#endif
+#else
+import UIKit_SPI
+#endif // USE_APPLE_INTERNAL_SDK
+
+#endif // canImport(AppKit) && !targetEnvironment(macCatalyst)
 
 import WebKitSwift
 // Work around rdar://145157171 by manually importing the cross-import module.

--- a/Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h
+++ b/Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h
@@ -52,6 +52,12 @@ DECLARE_SYSTEM_HEADER
 - (void)hasMarkedTextWithCompletionHandler:(void(^)(BOOL hasMarkedText))completionHandler;
 - (void)attributedSubstringForProposedRange:(NSRange)range completionHandler:(void(^)(NSAttributedString *, NSRange actualRange))completionHandler;
 - (void)firstRectForCharacterRange:(NSRange)range completionHandler:(void(^)(NSRect firstRect, NSRange actualRange))completionHandler;
+
+@optional
+
+- (void)insertTextPlaceholderWithSize:(CGSize)size completionHandler:(void (^)(NSTextPlaceholder *))completionHandler;
+
+- (void)removeTextPlaceholder:(NSTextPlaceholder *)placeholder willInsertText:(BOOL)willInsertText completionHandler:(void (^)(void))completionHandler;
 @end
 
 @protocol NSInspectorBarClient <NSObject>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -27,6 +27,7 @@
 
 #if ENABLE(WRITING_TOOLS)
 
+#import "AppKitSPI.h"
 #import "InstanceMethodSwizzler.h"
 #import "PlatformUtilities.h"
 #import "Test.h"


### PR DESCRIPTION
#### ce1eafc8bc2caf6669a00722b1ac06e7edb3e74d
<pre>
[Writing Tools] Support compiling ENABLE_WRITING_TOOLS on the public SDK (Part 4)
<a href="https://bugs.webkit.org/show_bug.cgi?id=291811">https://bugs.webkit.org/show_bug.cgi?id=291811</a>
<a href="https://rdar.apple.com/149644885">rdar://149644885</a>

Reviewed by Aditya Keerthi.

More iOS-specific work for ENABLE_WRITING_TOOLS on the public SDK.

Since some WebKit Swift files use Swift UIKit SPI, a dummy `.swiftinterface` file and module must be
created so that the symbols can be found when compiling with the public SDK, similar to the existing
`QuickLook_SPI` module.

* Source/WebCore/PAL/pal/spi/cocoa/WritingToolsSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/WritingToolsUISPI.h:
* Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:

Drive-by fix: add some missing forward declarations and imports.

* Source/WebKit/Configurations/WebKitSwift.xcconfig:

Add the `ios` SPI directory to the Swift include paths, similar to the existing `visionos` directory included.

* Source/WebKit/Platform/spi/ios/UIKit_SPI.swiftinterface: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Make a manually-created swiftinterface file similar to the real UIKit and UIKitCore swiftinterfaces,
only including the symbols used in WebKit/WebKitSwift, and using a unique module name `UIKit_SPI`.

* Source/WebKit/WebKitSwift/TextAnimation/TextAnimationManager.swift:
* Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift:

When compiling with the public SDK, use the `UIKit_SPI` module so that the symbols can be accessed.
Also remove an unused import.

Canonical link: <a href="https://commits.webkit.org/293923@main">https://commits.webkit.org/293923@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/482e2062f8c2a3086f00a2f1d75a7af247dfc626

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105390 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50843 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102301 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20214 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28383 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76333 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33391 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15464 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90560 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56690 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15284 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8559 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50211 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85194 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8641 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107749 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27373 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20068 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85285 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27736 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86767 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84824 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21572 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29508 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7243 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21259 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27310 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32543 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27121 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30437 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28680 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->