### PR TITLE
FilterEffect::takeImageInputs returns a no-op when insufficient inputs are provided

### DIFF
--- a/LayoutTests/ipc/insufficient-svgfilter-inputs-crash-expected.txt
+++ b/LayoutTests/ipc/insufficient-svgfilter-inputs-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/insufficient-svgfilter-inputs-crash.html
+++ b/LayoutTests/ipc/insufficient-svgfilter-inputs-crash.html
@@ -1,0 +1,92 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+    
+    window.setTimeout(async () => {
+        if (!window.IPC)
+            return window.testRunner?.notifyDone();
+    
+        const { CoreIPC } = await import('./coreipc.js');
+    
+        const streamConnection = CoreIPC.newStreamConnection();
+
+        const renderingBackendIdentifier = Math.floor(Math.random() * 0x1000000);
+        CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, {
+            renderingBackendIdentifier: renderingBackendIdentifier,
+            connectionHandle: streamConnection
+        });
+        const remoteRenderingBackend = streamConnection.newInterface("RemoteRenderingBackend", renderingBackendIdentifier);
+    
+        const didInitializeReply = streamConnection.connection.waitForMessage(renderingBackendIdentifier, IPC.messages.RemoteRenderingBackendProxy_DidInitialize.name, 1)
+        streamConnection.connection.setSemaphores(didInitializeReply[0].value, didInitializeReply[1].value);
+    
+        const imageBufferIdentifier = Math.floor(Math.random() * 0x1000000);
+        const contextIdentifier = Math.floor(Math.random() * 0x1000000);
+        remoteRenderingBackend.CreateImageBuffer({
+            logicalSize: {width: 128, height: 128},
+            renderingMode: 0,
+            renderingPurpose: 0,
+            resolutionScale: 1.0,
+            colorSpace: {serializableColorSpace: {alias: {m_cgColorSpace: {alias: {variantType: 'WebCore::ColorSpace', variant: 1}}}}},
+            pixelFormat: 0,
+            identifier: imageBufferIdentifier,
+            contextIdentifier: contextIdentifier,
+        });
+        const didCreateBackendReply = streamConnection.connection.waitForMessage(imageBufferIdentifier, IPC.messages.RemoteImageBufferProxy_DidCreateBackend.name, 1);
+    
+        const remoteImageBuffer = streamConnection.newInterface("RemoteImageBuffer", imageBufferIdentifier);
+    
+        remoteImageBuffer.FilteredNativeImage({
+            filter: {
+                subclasses: {
+                    variantType: 'WebCore::SVGFilter',
+                    variant: {
+                        targetBoundingBox: {
+                            location: {x: 0, y: 0},
+                            size: {width: 0, height: 0},
+                        },
+                        primitiveUnits: 0,
+                        expression: {
+                            alias: [
+                                {index: 0, level: 0, geometry: 0},
+                            ]
+                        },
+                        effects: [
+                            {
+                                subclasses: {
+                                    variantType: 'WebCore::FEBlend',
+                                    variant: {
+                                        blendMode: 8,
+                                        operatingColorSpace: {serializableColorSpace: {alias: {m_cgColorSpace: {alias: {variantType: 'WebCore::ColorSpace', variant: 1}}}}}
+                                    }
+                                }
+                            }
+                        ],
+                        renderingResourceIdentifierIfExists: {},
+                        filterRenderingModes: 1,
+                        filterScale: {width: 0, height: 0},
+                        filterRegion: {
+                            location: {x: 0, y: 0},
+                            size: {width: 0, height: 0}
+                        },
+                    }
+                },
+            }
+        });
+
+        streamConnection.connection.invalidate();
+
+        // Allow some time for the GPUP to receive the FilteredNativeImage message, otherwise we can finish
+        // the test before we detect a possible GPUP crash.
+        setTimeout(()=>{
+            window.testRunner?.notifyDone();
+        }, 500);
+    }, 20);
+    
+    </script>
+    
+    This test passes if WebKit does not crash.
+    

--- a/Source/WebCore/platform/graphics/filters/FilterEffect.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterEffect.cpp
@@ -50,7 +50,17 @@ bool FilterEffect::operator==(const FilterEffect& other) const
 FilterImageVector FilterEffect::takeImageInputs(FilterImageVector& stack) const
 {
     unsigned inputsSize = numberOfImageInputs();
-    ASSERT(stack.size() >= inputsSize);
+
+    if (stack.size() < inputsSize) {
+        LOG_WITH_STREAM(Filters, stream
+            << "FilterEffect " << filterName() << " " << this << " takeImageInputs(): " << *this
+            << "Not enough inputs. Needed "
+            << inputsSize
+            << ", stack size "
+            << stack.size());
+        return { };
+    }
+
     if (!inputsSize)
         return { };
 
@@ -147,7 +157,8 @@ RefPtr<FilterImage> FilterEffect::apply(const Filter& filter, FilterImage& input
 
 RefPtr<FilterImage> FilterEffect::apply(const Filter& filter, const FilterImageVector& inputs, FilterResults& results, const std::optional<FilterEffectGeometry>& geometry)
 {
-    ASSERT(inputs.size() == numberOfImageInputs());
+    if (inputs.size() != numberOfImageInputs())
+        return nullptr;
 
     if (RefPtr result = results.effectResult(*this))
         return result;


### PR DESCRIPTION
#### f3e9985497a95dccf364dbdb82b52738baffaefa
<pre>
FilterEffect::takeImageInputs returns a no-op when insufficient inputs are provided
<a href="https://bugs.webkit.org/show_bug.cgi?id=291826">https://bugs.webkit.org/show_bug.cgi?id=291826</a>
<a href="https://rdar.apple.com/147489771">rdar://147489771</a>

Reviewed by Brent Fulgham.

We prevent a fatal crash in FilterEffect::takeImageInputs when an untrusted
or malformed IPC message results in fewer image inputs than expected.
While this scenario may not occur with valid SVG content, it can be triggered
through direct IPC. Instead of crashing, we now return a no-op,
allowing the filter evaluation to continue safely.

* Source/WebCore/platform/graphics/filters/FilterEffect.cpp:
(WebCore::FilterEffect::takeImageInputs const):
(WebCore::FilterEffect::apply):

Canonical link: <a href="https://commits.webkit.org/293928@main">https://commits.webkit.org/293928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be1ba24913f42c960795f2f8cdfa8ef775e91913

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19915 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105396 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50849 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102307 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28389 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76338 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33400 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15469 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90563 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56695 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15290 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8562 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50217 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85200 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107755 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27379 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20074 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85288 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27742 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86770 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84827 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21578 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29512 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7246 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/21269 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27316 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32549 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27127 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30443 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28686 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->