### PR TITLE
AX: Vend AXSubrole=AXLandmarkForm for labeled form elements

### DIFF
--- a/LayoutTests/accessibility/mac/search-predicate-expected.txt
+++ b/LayoutTests/accessibility/mac/search-predicate-expected.txt
@@ -37,7 +37,7 @@ PASS: resultElement.childAtIndex(0).stringValue === 'AXValue: first heading leve
 PASS: resultElement.role === 'AXRole: AXGroup'
 PASS: resultElement.childAtIndex(0).stringValue === 'AXValue: serif blue italic text'
 PASS: resultElement.role === 'AXRole: AXGroup'
-PASS: resultElement.subrole === 'AXSubrole: AXLandmarkBanner'
+PASS: resultElement.subrole === 'AXSubrole: AXLandmarkForm'
 PASS: resultElement.role === 'AXRole: AXLink'
 PASS: resultElement.childAtIndex(0).stringValue === 'AXValue: link'
 PASS: resultElement.role === 'AXRole: AXList'

--- a/LayoutTests/accessibility/mac/search-predicate.html
+++ b/LayoutTests/accessibility/mac/search-predicate.html
@@ -12,7 +12,7 @@
 <blockquote>second block quote level 1</blockquote>
 <p style="color:black; font-family:sans-serif; font-weight:bold; text-decoration:underline;">sans-serif black bold text with underline</p>
 <p style="color:blue; font-family:serif; font-style:italic;">serif blue italic text</p>
-<form>
+<form aria-label="form">
 <input type="text" /><br />
 <input type="checkbox" value="Checkbox" /> checkbox<br />
 <input type="submit" value="Submit" />
@@ -170,7 +170,7 @@
         // Landmark.
         resultElement = containerElement.uiElementForSearchPredicate(startElement, true, "AXLandmarkSearchKey", "", false);
         output += expect("resultElement.role", "'AXRole: AXGroup'");
-        output += expect("resultElement.subrole", "'AXSubrole: AXLandmarkBanner'");
+        output += expect("resultElement.subrole", "'AXSubrole: AXLandmarkForm'");
 
         // Link.
         resultElement = containerElement.uiElementForSearchPredicate(startElement, true, "AXLinkSearchKey", "", false);

--- a/LayoutTests/platform/mac-wk1/accessibility/roles-exposed-expected.txt
+++ b/LayoutTests/platform/mac-wk1/accessibility/roles-exposed-expected.txt
@@ -122,8 +122,8 @@ footer
 
 form
       AXRole: AXGroup
-      AXSubrole:
-      AXRoleDescription: group
+      AXSubrole: AXLandmarkForm
+      AXRoleDescription: form
 
 header
       AXRole: AXGroup

--- a/LayoutTests/platform/mac-wk2/accessibility/roles-exposed-expected.txt
+++ b/LayoutTests/platform/mac-wk2/accessibility/roles-exposed-expected.txt
@@ -122,8 +122,8 @@ footer
 
 form
       AXRole: AXGroup
-      AXSubrole:
-      AXRoleDescription: group
+      AXSubrole: AXLandmarkForm
+      AXRoleDescription: form
 
 header
       AXRole: AXGroup

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -154,6 +154,7 @@ bool AXCoreObject::isImplicitlyInteractive() const
 bool AXCoreObject::isLandmark() const
 {
     switch (roleValue()) {
+    case AccessibilityRole::Form:
     case AccessibilityRole::LandmarkBanner:
     case AccessibilityRole::LandmarkComplementary:
     case AccessibilityRole::LandmarkContentInfo:
@@ -1095,6 +1096,8 @@ String AXCoreObject::roleDescription()
 String AXCoreObject::ariaLandmarkRoleDescription() const
 {
     switch (roleValue()) {
+    case AccessibilityRole::Form:
+        return AXARIAContentGroupText("ARIALandmarkForm"_s);
     case AccessibilityRole::LandmarkBanner:
         return AXARIAContentGroupText("ARIALandmarkBanner"_s);
     case AccessibilityRole::LandmarkComplementary:

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -250,6 +250,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     // ARIA content subroles.
     switch (role) {
+    case AccessibilityRole::Form:
+        return "AXLandmarkForm"_s;
     case AccessibilityRole::LandmarkBanner:
         return "AXLandmarkBanner"_s;
     case AccessibilityRole::LandmarkComplementary:

--- a/Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h
+++ b/Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h
@@ -65,6 +65,7 @@
 #define NSAccessibilityFieldsetSubrole @"AXFieldset"
 #define NSAccessibilityFileUploadButtonSubrole @"AXFileUploadButton"
 #define NSAccessibilityFooterSubrole @"AXFooter"
+#define NSAccessibilityFormSubrole @"AXLandmarkForm"
 #define NSAccessibilityInsertStyleGroupSubrole @"AXInsertStyleGroup"
 #define NSAccessibilityKeyboardInputStyleGroupSubrole @"AXKeyboardInputStyleGroup"
 #define NSAccessibilityLandmarkBannerSubrole @"AXLandmarkBanner"

--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -1909,6 +1909,9 @@
 /* accessibility role description for a footer */
 "footer" = "footer";
 
+/* accessibility role description for a form */
+ "form" = "form";
+
 /* Web Push Notification string to indicate the name of the Web App/Web Site a notification was sent from, such as 'from Wikipedia' */
 "from %@" = "from %@";
 

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -827,6 +827,8 @@ String AXARIAContentGroupText(StringView ariaType)
         return WEB_UI_STRING("complementary", "An ARIA accessibility group that acts as a region of complementary information.");
     if (ariaType == "ARIALandmarkContentInfo"_s)
         return WEB_UI_STRING("content information", "An ARIA accessibility group that contains content.");
+    if (ariaType == "ARIALandmarkForm"_s)
+        return WEB_UI_STRING("form", "An ARIA accessibility group that acts as a form region.");
     if (ariaType == "ARIALandmarkMain"_s)
         return WEB_UI_STRING("main", "An ARIA accessibility group that is the main portion of the website.");
     if (ariaType == "ARIALandmarkNavigation"_s)


### PR DESCRIPTION
#### a8728728ea0d85f52ec9162e6cee680f854fa5a7
<pre>
AX: Vend AXSubrole=AXLandmarkForm for labeled form elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=233907">https://bugs.webkit.org/show_bug.cgi?id=233907</a>
<a href="https://rdar.apple.com/86135614">rdar://86135614</a>

Reviewed by Tyler Wilcock.

Per ARIA specification, elements with a role of &quot;form&quot; (i.e., &lt;form&gt; or role=&quot;form&quot;) require an accessible name
and when not provided, this is an authoring error: <a href="https://w3c.github.io/aria/#document-handling_author-errors_roles.">https://w3c.github.io/aria/#document-handling_author-errors_roles.</a>
Form elements can be labelled like other landmarks (e.g., via aria-label, aria-labelledby) and additionally, native &lt;form&gt; elements
can be labeled with the title attribute.

This commit ensures that form elements are exposed as navigable landmarks when supplied with an accname. Form elements also now
vend AXSubrole=AXLandmarkForm to align with the classification of other landmarks.

* LayoutTests/accessibility/mac/search-predicate-expected.txt: Updated test expectation.
* LayoutTests/accessibility/mac/search-predicate.html: Updated &lt;form&gt; test.
* LayoutTests/platform/mac-wk1/accessibility/roles-exposed-expected.txt Updated test expectation.
* LayoutTests/platform/mac-wk2/accessibility/roles-exposed-expected.txt Updated test expectation.
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::isLandmark const):
(WebCore::AXCoreObject::ariaLandmarkRoleDescription const):
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
(WebCore::AccessibilityObject::subrolePlatformString const):
* Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h:
* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::AXARIAContentGroupText):

Canonical link: <a href="https://commits.webkit.org/294748@main">https://commits.webkit.org/294748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/618fc3b9b592af554b313359b759cd26b072934b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22612 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108106 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53579 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104977 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22935 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31113 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78255 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35205 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17756 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92879 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58590 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10925 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52936 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10992 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110479 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30075 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22149 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87243 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30439 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89085 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86866 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22110 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31714 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9424 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/24337 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30002 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35324 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29810 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33137 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31372 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->