### PR TITLE
[Writing Tools] Support compiling ENABLE_WRITING_TOOLS on the public SDK (Part 7)

### DIFF
--- a/Source/WebKit/Configurations/WebKitSwift.xcconfig
+++ b/Source/WebKit/Configurations/WebKitSwift.xcconfig
@@ -64,7 +64,9 @@ FRAMEWORK_LDFLAGS_xrsimulator[sdk=xr*2.*] = -framework LinearMediaKit;
 
 // Use handwritten SPI modules on public SDKs.
 SWIFT_INCLUDE_PATHS = $(SWIFT_INCLUDE_PATHS_$(USE_INTERNAL_SDK));
-SWIFT_INCLUDE_PATHS_ = $(SRCROOT)/Platform/spi/visionos $(SRCROOT)/Platform/spi/ios $(inherited);
+SWIFT_INCLUDE_PATHS_ = $(SRCROOT)/Platform/spi/visionos $(SRCROOT)/Platform/spi/ios $(SRCROOT)/Platform/spi/Cocoa/Modules $(inherited);
+
+USER_HEADER_SEARCH_PATHS = $(inherited) $(SRCROOT)/Platform/spi/Cocoa/Modules;
 
 WEBKITSWIFT_HEADERS_FOLDER_PATH = $(WK_LIBRARY_HEADERS_FOLDER_PATH)/WebKitSwift;
 

--- a/Source/WebKit/Platform/spi/Cocoa/Modules/WritingTools/WritingToolsSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/Modules/WritingTools/WritingToolsSPI.h
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#import <pal/spi/cocoa/WritingToolsSPI.h>

--- a/Source/WebKit/Platform/spi/Cocoa/Modules/WritingTools/module.modulemap
+++ b/Source/WebKit/Platform/spi/Cocoa/Modules/WritingTools/module.modulemap
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+module WritingTools_SPI [system] {
+    umbrella header "WritingToolsSPI.h"
+    link framework "WritingTools"
+    export *
+}

--- a/Source/WebKit/Platform/spi/Cocoa/Modules/WritingToolsUI/WritingToolsUISPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/Modules/WritingToolsUI/WritingToolsUISPI.h
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#import <pal/spi/cocoa/WritingToolsUISPI.h>

--- a/Source/WebKit/Platform/spi/Cocoa/Modules/WritingToolsUI/module.modulemap
+++ b/Source/WebKit/Platform/spi/Cocoa/Modules/WritingToolsUI/module.modulemap
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+module WritingToolsUI_Private_SPI [system] {
+    umbrella header "WritingToolsUISPI.h"
+    link framework "WritingToolsUI"
+    export *
+}

--- a/Source/WebKit/Platform/spi/ios/UIKit_SPI.swiftinterface
+++ b/Source/WebKit/Platform/spi/ios/UIKit_SPI.swiftinterface
@@ -4,20 +4,12 @@ import _Concurrency
 import Foundation
 import Swift
 @_exported import UIKit
-@_inheritsConvenienceInitializers @available(iOS 18.0, visionOS 2.0, *)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
+@_inheritsConvenienceInitializers
 @objc open class UITextEffectTextChunk : ObjectiveC.NSObject, Swift.Identifiable {
   @objc override dynamic public init()
-  @available(iOS 18.0, visionOS 2.0, *)
-  @available(tvOS, unavailable)
-  @available(watchOS, unavailable)
   public typealias ID = Swift.ObjectIdentifier
   @objc deinit
 }
-@available(iOS 18.0, visionOS 2.0, *)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
 @objc public protocol UITextEffectViewSource {
   @objc func targetedPreview(for chunk: UIKit_SPI.UITextEffectTextChunk) async -> UIKit.UITargetedPreview
   @objc optional func canGenerateTargetedPreviews() async -> Swift.Bool
@@ -25,14 +17,9 @@ import Swift
   @objc func updateTextChunkVisibilityForAnimation(_ chunk: UIKit_SPI.UITextEffectTextChunk, visible: Swift.Bool) async
   @objc optional func updatedTargetedPreviewGeometry(for chunk: UIKit_SPI.UITextEffectTextChunk, previous: CoreFoundation.CGRect) async -> CoreFoundation.CGRect
 }
-@objc @_hasMissingDesignatedInitializers @available(iOS 18.0, visionOS 2.0, *)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
+@objc @_hasMissingDesignatedInitializers
 @_Concurrency.MainActor public class UITextEffectView : UIKit.UIView {
   @_Concurrency.MainActor weak public var source: (any UIKit_SPI.UITextEffectViewSource)?
-  @available(iOS 18.1, visionOS 2.1, *)
-  @available(tvOS, unavailable)
-  @available(watchOS, unavailable)
   @_Concurrency.MainActor public var hasActiveEffects: Swift.Bool {
     get
   }
@@ -54,9 +41,6 @@ import Swift
   }
   @objc deinit
 }
-@available(iOS 18.0, visionOS 2.0, *)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
 extension UIKit_SPI.UITextEffectView {
   @_Concurrency.MainActor public protocol TextEffect {
     @_Concurrency.MainActor var id: UIKit_SPI.UITextEffectView.EffectID { get }
@@ -64,13 +48,7 @@ extension UIKit_SPI.UITextEffectView {
     @_Concurrency.MainActor var view: UIKit_SPI.UITextEffectView? { get }
   }
 }
-@available(iOS 18.0, visionOS 2.0, *)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
 extension UIKit_SPI.UITextEffectView {
-  @available(iOS 18.0, visionOS 2.0, *)
-  @available(tvOS, unavailable)
-  @available(watchOS, unavailable)
   @_Concurrency.MainActor public class ReplacementTextEffect : UIKit_SPI.UITextEffectView.TextEffect {
     @_Concurrency.MainActor public var view: UIKit_SPI.UITextEffectView?
     @_Concurrency.MainActor public var chunk: UIKit_SPI.UITextEffectTextChunk
@@ -93,13 +71,7 @@ extension UIKit_SPI.UITextEffectView.ReplacementTextEffect.Delegate {
   public func performReplacementAndGeneratePreview(for chunk: UIKit_SPI.UITextEffectTextChunk, effect: UIKit_SPI.UITextEffectView.ReplacementTextEffect, animation: UIKit_SPI.UITextEffectView.ReplacementTextEffect.AnimationParameters) async -> UIKit.UITargetedPreview?
   public func performReplacement(for chunk: UIKit_SPI.UITextEffectTextChunk, effect: UIKit_SPI.UITextEffectView.ReplacementTextEffect, animation: UIKit_SPI.UITextEffectView.ReplacementTextEffect.AnimationParameters) async
 }
-@available(iOS 18.0, visionOS 2.0, *)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
 extension UIKit_SPI.UITextEffectView {
-  @available(iOS 18.0, visionOS 2.0, *)
-  @available(tvOS, unavailable)
-  @available(watchOS, unavailable)
   @_Concurrency.MainActor public class PonderingEffect : UIKit_SPI.UITextEffectView.TextEffect {
     @_Concurrency.MainActor final public let chunk: UIKit_SPI.UITextEffectTextChunk
     @_Concurrency.MainActor weak public var view: UIKit_SPI.UITextEffectView?
@@ -109,24 +81,16 @@ extension UIKit_SPI.UITextEffectView {
     @objc deinit
   }
 }
-@objc @_hasMissingDesignatedInitializers @available(iOS 18.0, visionOS 2.0, *)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
+@objc @_hasMissingDesignatedInitializers
 @_Concurrency.MainActor public class UIDirectionalLightEffectView : UIKit.UIView {
   @objc deinit
 }
-@available(iOS 18.0, visionOS 2.0, *)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
 extension UIKit_SPI.UIDirectionalLightEffectView {
   public struct Configuration {
     public let fillColor: UIKit.UIColor
     public static let pondering: UIKit_SPI.UIDirectionalLightEffectView.Configuration
   }
 }
-@available(iOS 18.1, visionOS 2.1, *)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
 extension UIKit.UIColor {
   public static var ponderingFill: UIKit.UIColor {
     get

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3195,6 +3195,10 @@
 		07275C832D00F782002315A5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		07275C8E2D011396002315A5 /* Empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Empty.swift; sourceTree = "<group>"; };
 		0728820E2DB53C02006F4A2B /* UIKit_SPI.swiftinterface */ = {isa = PBXFileReference; lastKnownFileType = text; path = UIKit_SPI.swiftinterface; sourceTree = "<group>"; };
+		0728821D2DB58B3F006F4A2B /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		0728821E2DB58B48006F4A2B /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		072882262DB5C2A1006F4A2B /* WritingToolsSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WritingToolsSPI.h; sourceTree = "<group>"; };
+		072882272DB5C34C006F4A2B /* WritingToolsUISPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WritingToolsUISPI.h; sourceTree = "<group>"; };
 		07297F9C1C1711EA003F0735 /* DeviceIdHashSaltStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DeviceIdHashSaltStorage.cpp; sourceTree = "<group>"; };
 		07297F9C1C17BBEA003F0735 /* UserMediaPermissionCheckProxy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UserMediaPermissionCheckProxy.cpp; sourceTree = "<group>"; };
 		07297F9D1C17BBEA003F0735 /* UserMediaPermissionCheckProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserMediaPermissionCheckProxy.h; sourceTree = "<group>"; };
@@ -8515,7 +8519,6 @@
 		FA580B102DA64085005E4965 /* UnifiedSource158.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource158.cpp; sourceTree = "<group>"; };
 		FA580B112DA64085005E4965 /* UnifiedSource159.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource159.cpp; sourceTree = "<group>"; };
 		FA580B122DA64085005E4965 /* UnifiedSource160.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource160.cpp; sourceTree = "<group>"; };
-		FA580B272DA64B5F005E4965 /* UnifiedSource161.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource161.cpp; path = "UnifiedSource161.cpp"; sourceTree = "<group>"; };
 		FA580B282DA64B5F005E4965 /* UnifiedSource162.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource162.cpp; path = "UnifiedSource162.cpp"; sourceTree = "<group>"; };
 		FA580B292DA64B5F005E4965 /* UnifiedSource163.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource163.cpp; path = "UnifiedSource163.cpp"; sourceTree = "<group>"; };
 		FA580B2A2DA64B5F005E4965 /* UnifiedSource164.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource164.cpp; path = "UnifiedSource164.cpp"; sourceTree = "<group>"; };
@@ -8783,6 +8786,33 @@
 				07275C832D00F782002315A5 /* Info.plist */,
 			);
 			path = _WebKit_SwiftUI;
+			sourceTree = "<group>";
+		};
+		0728821A2DB58AA3006F4A2B /* Modules */ = {
+			isa = PBXGroup;
+			children = (
+				0728821B2DB58AC2006F4A2B /* WritingTools */,
+				0728821C2DB58AFD006F4A2B /* WritingToolsUI */,
+			);
+			path = Modules;
+			sourceTree = "<group>";
+		};
+		0728821B2DB58AC2006F4A2B /* WritingTools */ = {
+			isa = PBXGroup;
+			children = (
+				0728821D2DB58B3F006F4A2B /* module.modulemap */,
+				072882262DB5C2A1006F4A2B /* WritingToolsSPI.h */,
+			);
+			path = WritingTools;
+			sourceTree = "<group>";
+		};
+		0728821C2DB58AFD006F4A2B /* WritingToolsUI */ = {
+			isa = PBXGroup;
+			children = (
+				0728821E2DB58B48006F4A2B /* module.modulemap */,
+				072882272DB5C34C006F4A2B /* WritingToolsUISPI.h */,
+			);
+			path = WritingToolsUI;
 			sourceTree = "<group>";
 		};
 		0736B752260D039F00E06994 /* MediaSession */ = {
@@ -11771,6 +11801,7 @@
 		3754D5411B3A2998003A4C7F /* Cocoa */ = {
 			isa = PBXGroup;
 			children = (
+				0728821A2DB58AA3006F4A2B /* Modules */,
 				E3CAAA432413278A00CED2E2 /* AccessibilitySupportSPI.h */,
 				E3B8F7F72BA8AC4D006E97B6 /* AccessibilityUtilitiesSPI.h */,
 				9565083726D87A2B00E15CB7 /* AppleMediaServicesSPI.h */,

--- a/Source/WebKit/WebKitSwift/TextAnimation/TextAnimationManager.swift
+++ b/Source/WebKit/WebKitSwift/TextAnimation/TextAnimationManager.swift
@@ -2,7 +2,7 @@
 // Copyright (C) 2024 Apple Inc. All rights reserved.
 //
 
-#if canImport(WritingTools) && canImport(UIKit)
+#if ENABLE_WRITING_TOOLS && canImport(UIKit)
 
 import OSLog
 import WebKit

--- a/Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift
@@ -30,9 +30,13 @@ import Foundation
 import AppKit
 // WritingToolsUI is not present in the base system, but WebKit is, so it must be weak-linked.
 // WritingToolsUI need not be soft-linked from WebKitSwift because although WTUI links WebKit, WebKit does not directly link WebKitSwift.
+#if USE_APPLE_INTERNAL_SDK
 @_weakLinked internal import WritingToolsUI_Private._WTTextEffectView
 @_weakLinked internal import WritingToolsUI_Private._WTSweepTextEffect
 @_weakLinked internal import WritingToolsUI_Private._WTReplaceTextEffect
+#else
+@_weakLinked internal import WritingToolsUI_Private_SPI
+#endif // USE_APPLE_INTERNAL_SDK
 
 #else
 

--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceReplacementTextEffectCoordinator.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceReplacementTextEffectCoordinator.swift
@@ -27,11 +27,20 @@ import Foundation
 import WebKit
 import WebKitSwift
 @_spi(Private) import WebKit
+
+#if USE_APPLE_INTERNAL_SDK
 @_spiOnly import WritingTools
+#else
+@_spiOnly import WritingTools_SPI
+#endif
 
 #if os(macOS)
+#if USE_APPLE_INTERNAL_SDK
 @_weakLinked internal import WritingToolsUI_Private._WTTextEffectView
-#endif
+#else
+@_weakLinked internal import WritingToolsUI_Private_SPI
+#endif // USE_APPLE_INTERNAL_SDK
+#endif // os(macOS)
 
 // MARK: Implementation
 

--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.swift
@@ -27,11 +27,20 @@ import Foundation
 import WebKit
 import WebKitSwift
 @_spi(Private) import WebKit
+
+#if USE_APPLE_INTERNAL_SDK
 @_spiOnly import WritingTools
+#else
+@_spiOnly import WritingTools_SPI
+#endif
 
 #if os(macOS)
+#if USE_APPLE_INTERNAL_SDK
 @_weakLinked internal import WritingToolsUI_Private._WTTextEffectView
-#endif
+#else
+@_weakLinked internal import WritingToolsUI_Private_SPI
+#endif // USE_APPLE_INTERNAL_SDK
+#endif // os(macOS)
 
 // MARK: Implementation
 


### PR DESCRIPTION
#### ac24e45fd8e99c6b32fe7eb3dae39821d3226ba8
<pre>
[Writing Tools] Support compiling ENABLE_WRITING_TOOLS on the public SDK (Part 7)
<a href="https://bugs.webkit.org/show_bug.cgi?id=291835">https://bugs.webkit.org/show_bug.cgi?id=291835</a>
<a href="https://rdar.apple.com/149657096">rdar://149657096</a>

Reviewed by Abrar Rahman Protyasha and Megan Gardner.

More work towards ENABLE_WRITING_TOOLS on the public SDK, this time primarily adding support
for using Obj-C SPI from Swift. To do this, dummy Clang modules are created that use the PAL
SPI forward declarations while linking the real frameworks.

* Source/WebKit/Configurations/WebKitSwift.xcconfig:

Adjust SWIFT_INCLUDE_PATHS and USER_HEADER_SEARCH_PATHS so that the modules are accessible from WKS.

* Source/WebKit/Platform/spi/Cocoa/Modules/WritingTools/WritingToolsSPI.h: Added.
* Source/WebKit/Platform/spi/Cocoa/Modules/WritingToolsUI/WritingToolsUISPI.h: Added.

Add dummy &quot;umbrella&quot; headers corresponding to each framework, which just import the SPI declarations from PAL.

* Source/WebKit/Platform/spi/Cocoa/Modules/WritingTools/module.modulemap: Added.
* Source/WebKit/Platform/spi/Cocoa/Modules/WritingToolsUI/module.modulemap: Added.

Create a Clang module for each of the frameworks, exporting everything inside their umbrella headers.

* Source/WebKit/Platform/spi/ios/UIKit_SPI.swiftinterface:

Drive-by fix: remove availability declarations so that watchOS and tvOS public SDK compile fine.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Add the new files.

* Source/WebKit/WebKitSwift/TextAnimation/TextAnimationManager.swift:

Drive-by fix: use ENABLE_WRITING_TOOLS for consistency, since `canImport(WritingTools)` is not true on the public
SDK (since the module is &quot;WritingTools_SPI&quot;).

* Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift:
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceReplacementTextEffectCoordinator.swift:
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.swift:

Import the dummy SPI modules when using the public SDK.

Canonical link: <a href="https://commits.webkit.org/293940@main">https://commits.webkit.org/293940@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d74fe7ab897ac86f2eafd7ce496c60d98d7e43f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10321 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105506 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50958 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28496 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/76420 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33477 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103377 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/15566 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90663 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56775 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/15383 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8664 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50325 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/85303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/8746 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107861 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27488 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20165 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85374 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27851 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86863 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84910 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21588 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29596 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/7330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21408 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27423 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32664 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27234 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30552 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28792 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->