### PR TITLE
Track style changes as an OptionSet

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1992,9 +1992,9 @@ void AXObjectCache::onSlottedContentChange(const HTMLSlotElement& slot)
     childrenChanged(get(const_cast<HTMLSlotElement&>(slot)));
 }
 
-void AXObjectCache::onStyleChange(Element& element, Style::Change change, const RenderStyle* oldStyle, const RenderStyle* newStyle)
+void AXObjectCache::onStyleChange(Element& element, OptionSet<Style::Change> change, const RenderStyle* oldStyle, const RenderStyle* newStyle)
 {
-    if (change == Style::Change::None || !oldStyle || !newStyle)
+    if (!change || !oldStyle || !newStyle)
         return;
 
     RefPtr object = get(element);

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -384,7 +384,7 @@ public:
     void onScrollbarFrameRectChange(const Scrollbar&);
     void onSelectedChanged(Element&);
     void onSlottedContentChange(const HTMLSlotElement&);
-    void onStyleChange(Element&, Style::Change, const RenderStyle* oldStyle, const RenderStyle* newStyle);
+    void onStyleChange(Element&, OptionSet<Style::Change>, const RenderStyle* oldStyle, const RenderStyle* newStyle);
     void onStyleChange(RenderText&, StyleDifference, const RenderStyle* oldStyle, const RenderStyle& newStyle);
     void onTextSecurityChanged(HTMLInputElement&);
     void onTitleChange(Document&);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2777,8 +2777,8 @@ void Document::resolveStyle(ResolveStyleType type)
 
             auto newStyle = Style::resolveForDocument(*this);
 
-            auto documentChange = m_initialContainingBlockStyle ? Style::determineChange(newStyle, *m_initialContainingBlockStyle) : Style::Change::Renderer;
-            if (documentChange != Style::Change::None) {
+            auto documentChanges = m_initialContainingBlockStyle ? Style::determineChanges(newStyle, *m_initialContainingBlockStyle) : Style::Change::Renderer;
+            if (documentChanges) {
                 m_initialContainingBlockStyle = RenderStyle::clonePtr(newStyle);
                 // The used style may end up differing from the computed style due to propagation of properties from elements.
                 renderView()->setStyle(WTFMove(newStyle));

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4591,8 +4591,8 @@ const RenderStyle* Element::resolveComputedStyle(ResolveComputedStyleMode mode)
         computedStyle = style.get();
         ElementRareData& rareData = element->ensureElementRareData();
         if (auto* existing = rareData.computedStyle()) {
-            auto change = Style::determineChange(*existing, *style);
-            if (change > Style::Change::NonInherited) {
+            auto changes = Style::determineChanges(*existing, *style);
+            if (changes - Style::Change::NonInherited) {
                 for (Ref child : composedTreeChildren(*element)) {
                     if (RefPtr childElement = dynamicDowncast<Element>(WTFMove(child)))
                         childElement->setStateFlag(StateFlag::IsComputedStyleInvalidFlag);
@@ -5600,12 +5600,12 @@ void Element::clearHoverAndActiveStatusBeforeDetachingRenderer()
     document->userActionElements().clearActiveAndHovered(*this);
 }
 
-void Element::willRecalcStyle(Style::Change)
+void Element::willRecalcStyle(OptionSet<Style::Change>)
 {
     ASSERT(hasCustomStyleResolveCallbacks());
 }
 
-void Element::didRecalcStyle(Style::Change)
+void Element::didRecalcStyle(OptionSet<Style::Change>)
 {
     ASSERT(hasCustomStyleResolveCallbacks());
 }

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -729,8 +729,8 @@ public:
 
     void enqueueSecurityPolicyViolationEvent(SecurityPolicyViolationEventInit&&);
 
-    virtual void willRecalcStyle(Style::Change);
-    virtual void didRecalcStyle(Style::Change);
+    virtual void willRecalcStyle(OptionSet<Style::Change>);
+    virtual void didRecalcStyle(OptionSet<Style::Change>);
     virtual void willResetComputedStyle();
     virtual void willAttachRenderers();
     virtual void didAttachRenderers();

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -225,7 +225,7 @@ void HTMLFormControlElement::dispatchFormControlInputEvent()
     dispatchInputEvent();
 }
 
-void HTMLFormControlElement::didRecalcStyle(Style::Change)
+void HTMLFormControlElement::didRecalcStyle(OptionSet<Style::Change>)
 {
     // updateFromElement() can cause the selection to change, and in turn
     // trigger synchronous layout, so it must not be called during style recalc.

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -124,7 +124,7 @@ protected:
 
     bool isMouseFocusable() const override;
 
-    void didRecalcStyle(Style::Change) override;
+    void didRecalcStyle(OptionSet<Style::Change>) override;
 
     void dispatchBlurEvent(RefPtr<Element>&& newFocusedElement) override;
 

--- a/Source/WebCore/html/HTMLFrameSetElement.cpp
+++ b/Source/WebCore/html/HTMLFrameSetElement.cpp
@@ -191,7 +191,7 @@ void HTMLFrameSetElement::defaultEventHandler(Event& event)
     HTMLElement::defaultEventHandler(event);
 }
 
-void HTMLFrameSetElement::willRecalcStyle(Style::Change)
+void HTMLFrameSetElement::willRecalcStyle(OptionSet<Style::Change>)
 {
     if (needsStyleRecalc() && renderer())
         renderer()->setNeedsLayout();

--- a/Source/WebCore/html/HTMLFrameSetElement.h
+++ b/Source/WebCore/html/HTMLFrameSetElement.h
@@ -66,7 +66,7 @@ private:
     
     void defaultEventHandler(Event&) final;
 
-    void willRecalcStyle(Style::Change) final;
+    void willRecalcStyle(OptionSet<Style::Change>) final;
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void removedFromAncestor(RemovalType, ContainerNode&) final;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1206,7 +1206,7 @@ void HTMLMediaElement::didDetachRenderers()
     });
 }
 
-void HTMLMediaElement::didRecalcStyle(Style::Change)
+void HTMLMediaElement::didRecalcStyle(OptionSet<Style::Change>)
 {
     updateRenderer();
 }

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -806,7 +806,7 @@ private:
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;
     void didFinishInsertingNode() override;
     void removedFromAncestor(RemovalType, ContainerNode&) override;
-    void didRecalcStyle(Style::Change) override;
+    void didRecalcStyle(OptionSet<Style::Change>) override;
     bool canStartSelection() const override { return false; } 
     bool isInteractiveContent() const override;
 

--- a/Source/WebCore/html/HTMLPlugInImageElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInImageElement.cpp
@@ -149,10 +149,10 @@ bool HTMLPlugInImageElement::childShouldCreateRenderer(const Node& child) const
     return HTMLPlugInElement::childShouldCreateRenderer(child);
 }
 
-void HTMLPlugInImageElement::willRecalcStyle(Style::Change change)
+void HTMLPlugInImageElement::willRecalcStyle(OptionSet<Style::Change> change)
 {
     // Make sure style recalcs scheduled by a child shadow tree don't trigger reconstruction and cause flicker.
-    if (change == Style::Change::None && styleValidity() == Style::Validity::Valid)
+    if (!change && styleValidity() == Style::Validity::Valid)
         return;
 
     // FIXME: There shoudn't be need to force render tree reconstruction here.
@@ -161,7 +161,7 @@ void HTMLPlugInImageElement::willRecalcStyle(Style::Change change)
         invalidateStyleAndRenderersForSubtree();
 }
 
-void HTMLPlugInImageElement::didRecalcStyle(Style::Change styleChange)
+void HTMLPlugInImageElement::didRecalcStyle(OptionSet<Style::Change> styleChange)
 {
     scheduleUpdateForAfterStyleResolution();
 

--- a/Source/WebCore/html/HTMLPlugInImageElement.h
+++ b/Source/WebCore/html/HTMLPlugInImageElement.h
@@ -75,8 +75,8 @@ private:
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
     bool childShouldCreateRenderer(const Node&) const override;
-    void willRecalcStyle(Style::Change) final;
-    void didRecalcStyle(Style::Change) final;
+    void willRecalcStyle(OptionSet<Style::Change>) final;
+    void didRecalcStyle(OptionSet<Style::Change>) final;
     void didAttachRenderers() final;
     void willDetachRenderers() final;
 

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -98,7 +98,7 @@ Ref<HTMLSelectElement> HTMLSelectElement::create(Document& document)
     return adoptRef(*new HTMLSelectElement(selectTag, document, nullptr));
 }
 
-void HTMLSelectElement::didRecalcStyle(Style::Change styleChange)
+void HTMLSelectElement::didRecalcStyle(OptionSet<Style::Change> styleChange)
 {
     // Even though the options didn't necessarily change, we will call setOptionsChangedOnRenderer for its side effect
     // of recomputing the width of the element. We need to do that if the style change included a change in zoom level.

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -155,7 +155,7 @@ private:
 
     void dispatchChangeEventForMenuList();
 
-    void didRecalcStyle(Style::Change) final;
+    void didRecalcStyle(OptionSet<Style::Change>) final;
 
     void recalcListItems(bool updateSelectedStates = true, AllowStyleInvalidation = AllowStyleInvalidation::Yes) const;
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
@@ -179,7 +179,7 @@ void RenderTreeBuilder::FirstLetter::updateStyle(RenderBlock& firstLetterBlock, 
 
     ASSERT(firstLetter->isFloating() || firstLetter->isInline());
 
-    if (Style::determineChange(firstLetter->style(), *pseudoStyle) == Style::Change::Renderer) {
+    if (Style::determineChanges(firstLetter->style(), *pseudoStyle).contains(Style::Change::Renderer)) {
         // The first-letter renderer needs to be replaced. Create a new renderer of the right type.
         RenderPtr<RenderBoxModelObject> newFirstLetter;
         if (pseudoStyle->display() == DisplayType::Inline)

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -1135,7 +1135,7 @@ void Adjuster::propagateToDocumentElementAndInitialContainingBlock(Update& updat
         }
         documentElementUpdate->style->setWritingMode(writingMode);
         documentElementUpdate->style->setDirection(direction);
-        documentElementUpdate->change = std::max(documentElementUpdate->change, Change::Inherited);
+        documentElementUpdate->changes.add(Change::Inherited);
     }
 }
 

--- a/Source/WebCore/style/StyleChange.cpp
+++ b/Source/WebCore/style/StyleChange.cpp
@@ -33,13 +33,19 @@
 namespace WebCore {
 namespace Style {
 
-Change determineChange(const RenderStyle& s1, const RenderStyle& s2)
+OptionSet<Change> determineChanges(const RenderStyle& s1, const RenderStyle& s2)
 {
-    if (s1.display() != s2.display())
-        return Change::Renderer;
+    OptionSet<Change> result;
 
-    if (s1.hasPseudoStyle(PseudoId::FirstLetter) != s2.hasPseudoStyle(PseudoId::FirstLetter))
-        return Change::Renderer;
+    if (!s1.nonInheritedEqual(s2))
+        result.add(Change::NonInherited);
+    if (!s1.nonFastPathInheritedEqual(s2))
+        result.add(Change::Inherited);
+    if (!s1.fastPathInheritedEqual(s2))
+        result.add(Change::FastPathInherited);
+
+    if (!s1.descendantAffectingNonInheritedPropertiesEqual(s2))
+        result.add(Change::Inherited);
 
     // We just detach if a renderer acquires or loses a column-span, since spanning elements
     // typically won't contain much content.
@@ -50,51 +56,54 @@ Change determineChange(const RenderStyle& s1, const RenderStyle& s2)
             return false;
         // Spanning in ignored for floating and out-of-flow boxes.
         return s1.isFloating() != s2.isFloating() || s1.hasOutOfFlowPosition() != s2.hasOutOfFlowPosition();
-    }();
+    };
 
-    if (columnSpanNeedsNewRenderer)
-        return Change::Renderer;
+    auto needsRendererUpdate = [&] {
+        if (s1.display() != s2.display())
+            return true;
+        if (s1.hasPseudoStyle(PseudoId::FirstLetter) != s2.hasPseudoStyle(PseudoId::FirstLetter))
+            return true;
+        if (columnSpanNeedsNewRenderer())
+            return true;
+        if (s1.hasTextCombine() != s2.hasTextCombine())
+            return true;
+        // When text-combine property has been changed, we need to prepare a separate renderer object.
+        // When text-combine is on, we use RenderCombineText, otherwise RenderText.
+        // https://bugs.webkit.org/show_bug.cgi?id=55069
+        if (s1.hasTextCombine() != s2.hasTextCombine())
+            return true;
+        if (!s1.contentDataEquivalent(s2))
+            return true;
+        return false;
+    };
 
-    // When text-combine property has been changed, we need to prepare a separate renderer object.
-    // When text-combine is on, we use RenderCombineText, otherwise RenderText.
-    // https://bugs.webkit.org/show_bug.cgi?id=55069
-    if (s1.hasTextCombine() != s2.hasTextCombine())
-        return Change::Renderer;
-
-    if (!s1.contentDataEquivalent(s2))
-        return Change::Renderer;
+    if (needsRendererUpdate())
+        result.add(Change::Renderer);
 
     // Query container changes affect descendant style.
     if (!s1.containerTypeAndNamesEqual(s2))
-        return Change::Descendants;
+        result.add(Change::Container);
 
-    if (!s1.descendantAffectingNonInheritedPropertiesEqual(s2))
-        return Change::Inherited;
-
-    if (!s1.nonFastPathInheritedEqual(s2))
-        return Change::Inherited;
-
-    bool nonInheritedEqual = s1.nonInheritedEqual(s2);
-    if (!s1.fastPathInheritedEqual(s2))
-        return nonInheritedEqual ? Change::FastPathInherited : Change::NonInheritedAndFastPathInherited;
-
-    if (!nonInheritedEqual)
-        return Change::NonInherited;
-
-    return Change::None;
+    return result;
 }
 
 TextStream& operator<<(TextStream& ts, Change change)
 {
     switch (change) {
-    case Change::None: ts << "None"_s; break;
     case Change::NonInherited: ts << "NonInherited"_s; break;
     case Change::FastPathInherited: ts << "FastPathInherited"_s; break;
-    case Change::NonInheritedAndFastPathInherited: ts << "NonInheritedAndFastPathInherited"_s; break;
     case Change::Inherited: ts << "Inherited"_s; break;
-    case Change::Descendants: ts << "Descendants"_s; break;
+    case Change::Container: ts << "Container"_s; break;
     case Change::Renderer: ts << "Renderer"_s; break;
     }
+    return ts;
+}
+
+TextStream& operator<<(TextStream& ts, OptionSet<Change> changes)
+{
+    auto separator = ""_s;
+    for (auto change : changes)
+        ts << std::exchange(separator, ", "_s) << change;
     return ts;
 }
 

--- a/Source/WebCore/style/StyleChange.h
+++ b/Source/WebCore/style/StyleChange.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/OptionSet.h>
+
 namespace WTF {
 class TextStream;
 }
@@ -36,18 +38,19 @@ class RenderStyle;
 namespace Style {
 
 enum class Change : uint8_t {
-    None,
-    NonInherited,
-    FastPathInherited,
-    NonInheritedAndFastPathInherited,
-    Inherited,
-    Descendants,
-    Renderer
+    NonInherited = 1 << 0,
+    Inherited = 1 << 1,
+    FastPathInherited = 1 << 2,
+    Container = 1 << 3,
+    Renderer = 1 << 4
 };
 
-WEBCORE_EXPORT Change determineChange(const RenderStyle&, const RenderStyle&);
+constexpr OptionSet<Change> inheritedChanges() { return { Change::Inherited, Change::FastPathInherited }; }
+
+WEBCORE_EXPORT OptionSet<Change> determineChanges(const RenderStyle&, const RenderStyle&);
 
 WTF::TextStream& operator<<(WTF::TextStream&, Change);
+WTF::TextStream& operator<<(WTF::TextStream&, OptionSet<Change>);
 
 }
 

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -77,11 +77,11 @@ private:
     enum class LayoutInterleavingAction : uint8_t { None, SkipDescendants };
     enum class DescendantsToResolve : uint8_t { None, RebuildAllUsingExisting, ChildrenWithExplicitInherit, Children, All };
 
-    LayoutInterleavingAction updateStateForQueryContainer(Element&, const RenderStyle*, Change&, DescendantsToResolve&);
+    LayoutInterleavingAction updateStateForQueryContainer(Element&, const RenderStyle*, OptionSet<Change>&, DescendantsToResolve&);
 
     std::pair<ElementUpdate, DescendantsToResolve> resolveElement(Element&, const RenderStyle* existingStyle, ResolutionType);
 
-    ElementUpdate createAnimatedElementUpdate(ResolvedStyle&&, const Styleable&, Change, const ResolutionContext&, IsInDisplayNoneTree = IsInDisplayNoneTree::No);
+    ElementUpdate createAnimatedElementUpdate(ResolvedStyle&&, const Styleable&, OptionSet<Change>, const ResolutionContext&, IsInDisplayNoneTree = IsInDisplayNoneTree::No);
     std::unique_ptr<RenderStyle> resolveStartingStyle(const ResolvedStyle&, const Styleable&, const ResolutionContext&);
     std::unique_ptr<RenderStyle> resolveAfterChangeStyleForNonAnimated(const ResolvedStyle&, const Styleable&, const ResolutionContext&);
     std::unique_ptr<RenderStyle> resolveAgainInDifferentContext(const ResolvedStyle&, const Styleable&, const RenderStyle& parentStyle,  OptionSet<PropertyCascade::PropertyType>, std::optional<BuilderPositionTryFallback>&&, const ResolutionContext&);
@@ -109,7 +109,7 @@ private:
     struct Parent {
         Element* element;
         const RenderStyle& style;
-        Change change { Change::None };
+        OptionSet<Change> changes;
         DescendantsToResolve descendantsToResolve { DescendantsToResolve::None };
         bool didPushScope { false };
         bool resolvedFirstLineAndLetterChild { false };
@@ -117,7 +117,7 @@ private:
         IsInDisplayNoneTree isInDisplayNoneTree { IsInDisplayNoneTree::No };
 
         Parent(Document&);
-        Parent(Element&, const RenderStyle&, Change, DescendantsToResolve, IsInDisplayNoneTree);
+        Parent(Element&, const RenderStyle&, OptionSet<Change>, DescendantsToResolve, IsInDisplayNoneTree);
     };
 
     Scope& scope() { return m_scopeStack.last(); }
@@ -130,12 +130,12 @@ private:
     void pushEnclosingScope();
     void popScope();
 
-    void pushParent(Element&, const RenderStyle&, Change, DescendantsToResolve, IsInDisplayNoneTree);
+    void pushParent(Element&, const RenderStyle&, OptionSet<Change>, DescendantsToResolve, IsInDisplayNoneTree);
     void popParent();
     void popParentsToDepth(unsigned depth);
 
     DescendantsToResolve computeDescendantsToResolve(const ElementUpdate&, const RenderStyle* existingStyle, Validity) const;
-    static std::optional<ResolutionType> determineResolutionType(const Element&, const RenderStyle*, DescendantsToResolve, Change parentChange);
+    static std::optional<ResolutionType> determineResolutionType(const Element&, const RenderStyle*, DescendantsToResolve, OptionSet<Change> parentChange);
     static void resetDescendantStyleRelations(Element&, DescendantsToResolve);
 
     ResolutionContext makeResolutionContext();
@@ -145,7 +145,7 @@ private:
     const RenderStyle* parentBoxStyle() const;
     const RenderStyle* parentBoxStyleForPseudoElement(const ElementUpdate&) const;
 
-    LayoutInterleavingAction updateAnchorPositioningState(Element&, const RenderStyle*, Change);
+    LayoutInterleavingAction updateAnchorPositioningState(Element&, const RenderStyle*, OptionSet<Change>);
 
     void generatePositionOptionsIfNeeded(const ResolvedStyle&, const Styleable&, const ResolutionContext&);
     std::unique_ptr<RenderStyle> generatePositionOption(const PositionTryFallback&, const ResolvedStyle&, const Styleable&, const ResolutionContext&);
@@ -161,7 +161,7 @@ private:
     bool hasUnresolvedAnchorPosition(const Element&) const;
 
     struct QueryContainerState {
-        Change change { Change::None };
+        OptionSet<Change> changes;
         DescendantsToResolve descendantsToResolve { DescendantsToResolve::None };
         bool invalidated { false };
     };

--- a/Source/WebCore/style/StyleUpdate.h
+++ b/Source/WebCore/style/StyleUpdate.h
@@ -45,7 +45,7 @@ namespace Style {
 
 struct ElementUpdate {
     std::unique_ptr<RenderStyle> style;
-    Change change { Change::None };
+    OptionSet<Change> changes { };
     bool recompositeLayer { false };
     bool mayNeedRebuildRoot { false };
 };

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -103,13 +103,13 @@ SVGElement::~SVGElement()
     }
 }
 
-void SVGElement::willRecalcStyle(Style::Change change)
+void SVGElement::willRecalcStyle(OptionSet<Style::Change> change)
 {
     if (!m_svgRareData || styleResolutionShouldRecompositeLayer())
         return;
     // If the style changes because of a regular property change (not induced by SMIL animations themselves)
     // reset the "computed style without SMIL style properties", so the base value change gets reflected.
-    if (change > Style::Change::None || needsStyleRecalc())
+    if (change || needsStyleRecalc())
         m_svgRareData->setNeedsOverrideComputedStyleUpdate();
 }
 

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -194,7 +194,7 @@ protected:
     void updateRelativeLengthsInformation();
     void updateRelativeLengthsInformationForChild(bool hasRelativeLengths, SVGElement&);
 
-    void willRecalcStyle(Style::Change) override;
+    void willRecalcStyle(OptionSet<Style::Change>) override;
 
 private:
     virtual void clearTarget() { }

--- a/Tools/TestWebKitAPI/Tests/WebCore/RenderStyleChange.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/RenderStyleChange.cpp
@@ -42,8 +42,8 @@ TEST(RenderStyleChangeTest, None)
     RenderStyle style2 = RenderStyle::create();
     FontCascadeDescription fontDescription2;
     style1.setFontDescription(WTFMove(fontDescription2));
-    Change change = determineChange(style1, style2);
-    EXPECT_EQ(change, Change::None);
+    auto changes = determineChanges(style1, style2);
+    EXPECT_EQ(changes, OptionSet<Change> { });
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 2ba2f10dab33e9a804e8851691034f410b8bef82
<pre>
Track style changes as an OptionSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=291843">https://bugs.webkit.org/show_bug.cgi?id=291843</a>
<a href="https://rdar.apple.com/149685288">rdar://149685288</a>

Reviewed by Ryosuke Niwa.

Style changes are more naturally modeled as an OptionSet than a single-value Style::Change enum.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::onStyleChange):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resolveStyle):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::resolveComputedStyle):
(WebCore::Element::willRecalcStyle):
(WebCore::Element::didRecalcStyle):
* Source/WebCore/dom/Element.h:
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::didRecalcStyle):
* Source/WebCore/html/HTMLFormControlElement.h:
* Source/WebCore/html/HTMLFrameSetElement.cpp:
(WebCore::HTMLFrameSetElement::willRecalcStyle):
* Source/WebCore/html/HTMLFrameSetElement.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::didRecalcStyle):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLPlugInImageElement.cpp:
(WebCore::HTMLPlugInImageElement::willRecalcStyle):
(WebCore::HTMLPlugInImageElement::didRecalcStyle):
* Source/WebCore/html/HTMLPlugInImageElement.h:
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::didRecalcStyle):
* Source/WebCore/html/HTMLSelectElement.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp:
(WebCore::RenderTreeBuilder::FirstLetter::updateStyle):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::updateRebuildRoots):
(WebCore::RenderTreeUpdater::updateRenderTree):
(WebCore::RenderTreeUpdater::updateAfterDescendants):
(WebCore::RenderTreeUpdater::updateElementRenderer):
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(WebCore::RenderTreeUpdater::GeneratedContent::updatePseudoElement):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::propagateToDocumentElementAndInitialContainingBlock):
* Source/WebCore/style/StyleChange.cpp:
(WebCore::Style::determineChanges):
(WebCore::Style::operator&lt;&lt;):
(WebCore::Style::determineChange): Deleted.
* Source/WebCore/style/StyleChange.h:
(WebCore::Style::inheritedChanges):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::Parent::Parent):
(WebCore::Style::TreeResolver::computeDescendantsToResolve const):
(WebCore::Style::TreeResolver::resolveElement):
(WebCore::Style::TreeResolver::resolvePseudoElement):
(WebCore::Style::TreeResolver::resolveAncestorPseudoElement):
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):
(WebCore::Style::TreeResolver::pushParent):
(WebCore::Style::TreeResolver::determineResolutionType):
(WebCore::Style::TreeResolver::resolveComposedTree):
(WebCore::Style::TreeResolver::updateStateForQueryContainer):
(WebCore::Style::TreeResolver::updateAnchorPositioningState):
* Source/WebCore/style/StyleTreeResolver.h:
* Source/WebCore/style/StyleUpdate.h:
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::willRecalcStyle):
* Source/WebCore/svg/SVGElement.h:
* Tools/TestWebKitAPI/Tests/WebCore/RenderStyleChange.cpp:
(TestWebKitAPI::TEST(RenderStyleChangeTest, None)):

Canonical link: <a href="https://commits.webkit.org/293966@main">https://commits.webkit.org/293966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/738f59e17c4333f2f0025851383b0d4d31603faa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20083 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105568 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51019 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102472 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28557 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76472 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33525 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15622 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90719 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56828 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/15438 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8722 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50393 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107922 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20215 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85428 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27912 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84966 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21610 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29647 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7378 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21510 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27484 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32727 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27295 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30613 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28853 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->