### PR TITLE
[macOS] Add stylesheet for vector-based controls

### DIFF
--- a/Source/WebCore/style/UserAgentStyle.cpp
+++ b/Source/WebCore/style/UserAgentStyle.cpp
@@ -96,6 +96,9 @@ StyleSheetContents* UserAgentStyle::imageControlsStyleSheet;
 #if ENABLE(ATTACHMENT_ELEMENT)
 StyleSheetContents* UserAgentStyle::attachmentStyleSheet;
 #endif
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+StyleSheetContents* UserAgentStyle::vectorControlsStyleSheet;
+#endif
 
 static const MQ::MediaQueryEvaluator& screenEval()
 {
@@ -243,6 +246,17 @@ void UserAgentStyle::ensureDefaultStyleSheetsForElement(const Element& element)
         addToDefaultStyle(*viewTransitionsStyleSheet);
         addUserAgentKeyframes(*viewTransitionsStyleSheet);
     }
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+#if PLATFORM(MAC)
+    auto needsVectorControlStyles = element.document().settings().vectorBasedControlsOnMacEnabled();
+#else
+    auto needsVectorControlStyles = element.document().settings().macStyleControlsOnCatalyst();
+#endif
+    if (needsVectorControlStyles && !vectorControlsStyleSheet) {
+        vectorControlsStyleSheet = parseUASheet(StringImpl::createWithoutCopying(vectorControlsUserAgentStyleSheet));
+        addToDefaultStyle(*vectorControlsStyleSheet);
+    }
+#endif
 
     ASSERT(defaultStyle->features().idsInRules.isEmpty());
 }

--- a/Source/WebCore/style/UserAgentStyle.h
+++ b/Source/WebCore/style/UserAgentStyle.h
@@ -57,6 +57,9 @@ public:
 #if ENABLE(ATTACHMENT_ELEMENT)
     static StyleSheetContents* attachmentStyleSheet;
 #endif
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    static StyleSheetContents* vectorControlsStyleSheet;
+#endif
 
     static void initDefaultStyleSheet();
     static void ensureDefaultStyleSheetsForElement(const Element&);


### PR DESCRIPTION
#### dafc76d3bf7c7834f76251d3ef51be6ca42f403e
<pre>
[macOS] Add stylesheet for vector-based controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=291855">https://bugs.webkit.org/show_bug.cgi?id=291855</a>
<a href="https://rdar.apple.com/149705355">rdar://149705355</a>

Reviewed by Abrar Rahman Protyasha and Megan Gardner.

Add support for a stylesheet for vector-based controls to resolve
a few minor layout bugs.

* Source/WebCore/style/UserAgentStyle.cpp:
(WebCore::Style::UserAgentStyle::ensureDefaultStyleSheetsForElement):
* Source/WebCore/style/UserAgentStyle.h:

Canonical link: <a href="https://commits.webkit.org/293988@main">https://commits.webkit.org/293988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff3ca1b671bb85f25e290727fa2ec0eddcfd08c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20014 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10313 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105498 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50950 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102403 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28488 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76416 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33471 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103369 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90658 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56771 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15377 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8659 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50317 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85299 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107853 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27480 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20159 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85368 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27843 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86858 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84904 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21627 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29590 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7326 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21400 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27415 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32656 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27226 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30544 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28784 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->