### PR TITLE
WebExtensionCommand::setActivationKey should generate an upper case activation key on iOS

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
@@ -102,7 +102,7 @@ void WebExtensionCommand::dispatchChangedEventSoonIfNeeded()
     }).get());
 }
 
-bool WebExtensionCommand::setActivationKey(String activationKey)
+bool WebExtensionCommand::setActivationKey(String activationKey, SuppressEvents suppressEvents)
 {
     if (activationKey.isEmpty()) {
         m_activationKey = nullString();
@@ -132,9 +132,14 @@ bool WebExtensionCommand::setActivationKey(String activationKey)
     if ([activationKey.createNSString() rangeOfCharacterFromSet:notAllowedCharacterSet].location != NSNotFound)
         return false;
 
-    dispatchChangedEventSoonIfNeeded();
+    if (suppressEvents == SuppressEvents::No)
+        dispatchChangedEventSoonIfNeeded();
 
+#if PLATFORM(IOS_FAMILY)
+    m_activationKey = activationKey.convertToASCIIUppercase();
+#else
     m_activationKey = activationKey.convertToASCIILowercase();
+#endif
 
     return true;
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.cpp
@@ -38,9 +38,9 @@ WebExtensionCommand::WebExtensionCommand(WebExtensionContext& extensionContext, 
     : m_extensionContext(extensionContext)
     , m_identifier(data.identifier)
     , m_description(data.description)
-    , m_activationKey(data.activationKey)
     , m_modifierFlags(data.modifierFlags)
 {
+    setActivationKey(data.activationKey, SuppressEvents::Yes);
 }
 
 bool WebExtensionCommand::operator==(const WebExtensionCommand& other) const

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h
@@ -76,6 +76,8 @@ public:
 
     using ModifierFlags = WebExtension::ModifierFlags;
 
+    enum class SuppressEvents : bool { No, Yes };
+
     bool operator==(const WebExtensionCommand&) const;
 
     WebExtensionCommandParameters parameters() const;
@@ -88,7 +90,7 @@ public:
     const String& description() const { return m_description; }
 
     const String& activationKey() const { return m_modifierFlags ? m_activationKey : nullString(); }
-    bool setActivationKey(String);
+    bool setActivationKey(String, SuppressEvents = SuppressEvents::No);
 
     OptionSet<ModifierFlags> modifierFlags() const { return !m_activationKey.isEmpty() ? m_modifierFlags : OptionSet<ModifierFlags> { }; }
     void setModifierFlags(OptionSet<ModifierFlags> modifierFlags) { dispatchChangedEventSoonIfNeeded(); m_modifierFlags = modifierFlags; }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm
@@ -766,18 +766,20 @@ TEST(WKWebExtensionContext, CommandsParsing)
             testCommand = command;
 
             EXPECT_NS_EQUAL(command.title, @"Send A Thing");
-            EXPECT_NS_EQUAL(command.activationKey, @"u");
 #if PLATFORM(MAC)
+            EXPECT_NS_EQUAL(command.activationKey, @"u");
             EXPECT_EQ(command.modifierFlags, NSEventModifierFlagOption | NSEventModifierFlagShift);
 #else
+            EXPECT_NS_EQUAL(command.activationKey, @"U");
             EXPECT_EQ(command.modifierFlags, UIKeyModifierAlternate | UIKeyModifierShift);
 #endif
         } else if ([command.identifier isEqualToString:@"do-another-thing"]) {
             EXPECT_NS_EQUAL(command.title, @"Find A Thing");
-            EXPECT_NS_EQUAL(command.activationKey, @"y");
 #if PLATFORM(MAC)
+            EXPECT_NS_EQUAL(command.activationKey, @"y");
             EXPECT_EQ(command.modifierFlags, NSEventModifierFlagCommand | NSEventModifierFlagShift);
 #else
+            EXPECT_NS_EQUAL(command.activationKey, @"Y");
             EXPECT_EQ(command.modifierFlags, UIKeyModifierCommand | UIKeyModifierShift);
 #endif
         } else if ([command.identifier isEqualToString:@"special-command"]) {
@@ -825,10 +827,11 @@ TEST(WKWebExtensionContext, CommandsParsing)
 
     testCommand.activationKey = @"M";
 
-    EXPECT_NS_EQUAL(testCommand.activationKey, @"m");
 #if PLATFORM(MAC)
+    EXPECT_NS_EQUAL(testCommand.activationKey, @"m");
     EXPECT_EQ(testCommand.modifierFlags, NSEventModifierFlagOption | NSEventModifierFlagShift);
 #else
+    EXPECT_NS_EQUAL(testCommand.activationKey, @"M");
     EXPECT_EQ(testCommand.modifierFlags, UIKeyModifierAlternate | UIKeyModifierShift);
 #endif
 
@@ -843,10 +846,11 @@ TEST(WKWebExtensionContext, CommandsParsing)
     testCommand.modifierFlags = UIKeyModifierCommand | UIKeyModifierShift;
 #endif
 
-    EXPECT_NS_EQUAL(testCommand.activationKey, @"m");
 #if PLATFORM(MAC)
+    EXPECT_NS_EQUAL(testCommand.activationKey, @"m");
     EXPECT_EQ(testCommand.modifierFlags, NSEventModifierFlagCommand | NSEventModifierFlagShift);
 #else
+    EXPECT_NS_EQUAL(testCommand.activationKey, @"M");
     EXPECT_EQ(testCommand.modifierFlags, UIKeyModifierCommand | UIKeyModifierShift);
 #endif
 
@@ -855,7 +859,11 @@ TEST(WKWebExtensionContext, CommandsParsing)
     } @catch (NSException *exception) {
         EXPECT_NS_EQUAL(exception.name, NSInternalInconsistencyException);
     } @finally {
+#if PLATFORM(MAC)
         EXPECT_NS_EQUAL(testCommand.activationKey, @"m");
+#else
+        EXPECT_NS_EQUAL(testCommand.activationKey, @"M");
+#endif
     }
 
     @try {


### PR DESCRIPTION
#### 13ba825e9fdb925286196161cf3e9e78190c4bcd
<pre>
WebExtensionCommand::setActivationKey should generate an upper case activation key on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=291858">https://bugs.webkit.org/show_bug.cgi?id=291858</a>
<a href="https://rdar.apple.com/149522241">rdar://149522241</a>

Reviewed by Timothy Hatcher.

This matches the platform standard on iOS. On macOS, if the activation key is a capital letter,
that is considered an implicit shift modifier. However, that is not the case on iOS, and the platform
standard is to specify a capital letter as the UIKeyCommand&apos;s input.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm:
(WebKit::WebExtensionCommand::setActivationKey):
* Source/WebKit/UIProcess/Extensions/WebExtensionCommand.cpp:
(WebKit::WebExtensionCommand::WebExtensionCommand):
* Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h:

Canonical link: <a href="https://commits.webkit.org/293959@main">https://commits.webkit.org/293959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f1bc0290fb1d8a751de0381c8cd561f52cb381a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105564 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51015 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76467 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33520 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103434 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15619 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90714 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56823 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15435 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8716 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50389 "Failed to compile WebKit") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85351 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8796 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107918 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27545 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20212 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85420 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27908 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86914 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84957 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21607 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29642 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7373 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21503 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27480 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/32723 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27291 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30609 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28849 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->