### PR TITLE
about:blank appears in back/forward cache after a declarativeNetRequest redirect

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -360,6 +360,7 @@ public:
     const ContentExtensionEnablement& contentExtensionEnablement() const { return m_contentExtensionEnablement; }
     void setContentExtensionEnablement(ContentExtensionEnablement&& enablement) { m_contentExtensionEnablement = WTFMove(enablement); }
 
+    bool hasActiveContentRuleListActions() const { return !m_activeContentRuleListActionPatterns.isEmpty(); }
     bool allowsActiveContentRuleListActionsForURL(const String& contentRuleListIdentifier, const URL&) const;
     WEBCORE_EXPORT void setActiveContentRuleListActionPatterns(const HashMap<String, Vector<String>>&);
 

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1202,10 +1202,7 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
                 return makeUnexpected(ResourceError { errorDomainWebKitInternal, 0, url, "Resource blocked by content blocker"_s, ResourceError::Type::AccessControl });
             }
             if (type == CachedResource::Type::MainResource && RegistrableDomain { resourceRequest.url() } != originalDomain) {
-                // This needs to happen after DocumentLoader::loadMainResource stops or it will cancel this new load.
-                RunLoop::protectedMain()->dispatch([frame, url = resourceRequest.url()] {
-                    frame->loader().load(FrameLoadRequest { frame, { url } });
-                });
+                frame->loader().load(FrameLoadRequest { frame, { resourceRequest.url() } });
                 return makeUnexpected(ResourceError { errorDomainWebKitInternal, 0, url, "Loading in a new process"_s, ResourceError::Type::Cancellation });
             }
         }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
@@ -1266,7 +1266,7 @@ TEST_F(WKContentRuleListStoreTest, MainResourceCrossOriginRedirectFromLoadedPage
 {
     using namespace TestWebKitAPI;
     HTTPServer server({
-        { "/example"_s, { "<script>alert('original page loaded')</script>"_s } },
+        { "/example"_s, { "<script>addEventListener('pageshow', () => { alert('original page loaded') });</script>"_s } },
         { "/after_redirect"_s, { "<script>alert('loaded replacement successfully: ' + window.location.href)</script>"_s } }
     }, HTTPServer::Protocol::HttpsProxy);
 
@@ -1294,7 +1294,8 @@ TEST_F(WKContentRuleListStoreTest, MainResourceCrossOriginRedirectFromLoadedPage
     EXPECT_WK_STREQ([webView _test_waitForAlert], "original page loaded");
     [webView evaluateJavaScript:@"window.location = 'https://webkit.org/before_redirect'" completionHandler:nil];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "loaded replacement successfully: https://apple.com/after_redirect");
-    // FIXME: <rdar://149306346> going back should arrive back at the original page.
+    [webView goBack];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "original page loaded");
 }
 
 TEST_F(WKContentRuleListStoreTest, NullPatternSet)


### PR DESCRIPTION
#### 35b37af60e645aa9c67a1fdd55126aee51a40b13
<pre>
about:blank appears in back/forward cache after a declarativeNetRequest redirect
<a href="https://bugs.webkit.org/show_bug.cgi?id=291860">https://bugs.webkit.org/show_bug.cgi?id=291860</a>
<a href="https://rdar.apple.com/149306346">rdar://149306346</a>

Reviewed by Alex Christensen.

Remove the code added in <a href="https://bugs.webkit.org/show_bug.cgi?id=291556">https://bugs.webkit.org/show_bug.cgi?id=291556</a> that caused about:blank
to appear in the back/forward cache after redirects. This change also introduces a different fix
that 291556 was trying to resolve, which is to apply the DNR rules for requests before we decide the
policy for the navigation. This will allow us to update the request with the redirected URL earlier
in the pipeline and allow cross-site redirects to work.

* Source/WebCore/loader/PolicyChecker.cpp:
(WebCore::PolicyChecker::checkNavigationPolicy):
Only attempt to apply the rules if we have set the activeContentRuleListPatterns.
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm:
(TEST_F(WKContentRuleListStoreTest,
MainResourceCrossOriginRedirectFromLoadedPageWithoutActivePatterns)):
Add a check to ensure that navigating back doesn&apos;t land on about:blank.
Change the structure of the alert on the original page that&apos;s loaded to ensure it reappears when we
test the backward navigation.

Canonical link: <a href="https://commits.webkit.org/293974@main">https://commits.webkit.org/293974@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9cd0d12e598a32fa71b2313ef56b556951fe49a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105592 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/51043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102496 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20414 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28581 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/76492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/51043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103462 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/15645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/90742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/56847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/15462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/8745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/50419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/85378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/8824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107946 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27573 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27936 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/86942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/84980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/29670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/7401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/21538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16349 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27508 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/32758 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/27319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/30637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28877 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->