### PR TITLE
Update default alignment for position-area center tracks

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-align-justify-wm-dir.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-align-justify-wm-dir.html
@@ -22,7 +22,7 @@
     position: absolute;
     width: 10px;
     height: 10px;
-    inset: 10px;
+    inset: 10px 15px 20px 25px;
     position-anchor: --anchor;
   }
 </style>
@@ -41,10 +41,10 @@
     }, "Offsets for: " + position_area + " with writing-mode / direction: " + writing_direction);
   }
 
-  const top_left = {left:80, top:80, width:10, height:10};
-  const top_right = {left:210, top:80, width:10, height:10};
-  const bottom_left = {left:80, top:210, width:10, height:10};
-  const bottom_right = {left:210, top:210, width:10, height:10};
+  const top_left = {left:75, top:70, width:10, height:10};
+  const top_right = {left:225, top:70, width:10, height:10};
+  const bottom_left = {left:75, top:210, width:10, height:10};
+  const bottom_right = {left:225, top:210, width:10, height:10};
 
   anchored.style.writingMode = "horizontal-tb";
   anchored.style.direction = "ltr";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-align-justify.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-align-justify.html
@@ -22,7 +22,7 @@
     position: absolute;
     width: 10px;
     height: 10px;
-    inset: 10px;
+    inset: 10px 15px 20px 25px;
     position-anchor: --anchor;
   }
 </style>
@@ -46,20 +46,20 @@
   test_position_area("span-all", {left:145, top:145, width:10, height:10});
 
   // Single region spans
-  test_position_area("top left", {left:80, top:80, width:10, height:10});
-  test_position_area("top center", {left:145, top:80, width:10, height:10});
-  test_position_area("top right", {left:210, top:80, width:10, height:10});
-  test_position_area("center left", {left:80, top:145, width:10, height:10});
-  test_position_area("center center", {left:145, top:145, width:10, height:10});
-  test_position_area("center right", {left:210, top:145, width:10, height:10});
-  test_position_area("bottom left", {left:80, top:210, width:10, height:10});
-  test_position_area("bottom center", {left:145, top:210, width:10, height:10});
-  test_position_area("bottom right", {left:210, top:210, width:10, height:10});
+  test_position_area("top left", {left:75, top:70, width:10, height:10});
+  test_position_area("top center", {left:150, top:70, width:10, height:10});
+  test_position_area("top right", {left:225, top:70, width:10, height:10});
+  test_position_area("center left", {left:75, top:140, width:10, height:10});
+  test_position_area("center center", {left:150, top:140, width:10, height:10});
+  test_position_area("center right", {left:225, top:140, width:10, height:10});
+  test_position_area("bottom left", {left:75, top:210, width:10, height:10});
+  test_position_area("bottom center", {left:150, top:210, width:10, height:10});
+  test_position_area("bottom right", {left:225, top:210, width:10, height:10});
 
   // Multi-region spans
-  test_position_area("top span-left", {left:180, top:80, width:10, height:10});
-  test_position_area("top span-right", {left:110, top:80, width:10, height:10});
-  test_position_area("span-top left", {left:80, top:180, width:10, height:10});
-  test_position_area("span-bottom left", {left:80, top:110, width:10, height:10});
+  test_position_area("top span-left", {left:175, top:70, width:10, height:10});
+  test_position_area("top span-right", {left:125, top:70, width:10, height:10});
+  test_position_area("span-top left", {left:75, top:170, width:10, height:10});
+  test_position_area("span-bottom left", {left:75, top:110, width:10, height:10});
 
 </script>

--- a/Source/WebCore/rendering/style/PositionArea.cpp
+++ b/Source/WebCore/rendering/style/PositionArea.cpp
@@ -134,6 +134,7 @@ ItemPosition PositionArea::defaultAlignmentForAxis(BoxAxis physicalAxis, Writing
         alignment = ItemPosition::Start;
         break;
     case PositionAreaTrack::Center:
+        return ItemPosition::Center;
     case PositionAreaTrack::SpanAll:
         return ItemPosition::AnchorCenter;
     }


### PR DESCRIPTION
#### 32a4d430fc366048dbfa71ef229d63403fba2ac3
<pre>
Update default alignment for position-area center tracks
<a href="https://bugs.webkit.org/show_bug.cgi?id=291863">https://bugs.webkit.org/show_bug.cgi?id=291863</a>
<a href="https://rdar.apple.com/149715581">rdar://149715581</a>

Reviewed by Anne van Kesteren.

CSSWG recently changed the default alignment of the center track from
anchor-center to center, so this updates defaultAlignmentForAxis() accordingly.
See <a href="https://github.com/w3c/csswg-drafts/issues/11803">https://github.com/w3c/csswg-drafts/issues/11803</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-align-justify-wm-dir.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-align-justify.html:
* Source/WebCore/rendering/style/PositionArea.cpp:
(WebCore::PositionArea::defaultAlignmentForAxis const):

Canonical link: <a href="https://commits.webkit.org/293961@main">https://commits.webkit.org/293961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/615c4ae74ddc38ef16ef2c80d9529b0c5df83620

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20085 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10384 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105570 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51021 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102474 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28559 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/76469 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33523 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103440 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/15620 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/90722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56825 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15436 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/8725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50395 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85352 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/8804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107924 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27551 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20217 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85422 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27914 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/86922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84960 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21609 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29645 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/7381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21512 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27486 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/32736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27297 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30615 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28855 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->