### PR TITLE
REGRESSION (286644@main): style invalidation for `:has(+:popover-open)` doesn't work properly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/popover-open-with-has-sibling-selector-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/popover-open-with-has-sibling-selector-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/popover-open-with-has-sibling-selector.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/popover-open-with-has-sibling-selector.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/selectors/#selectordef-popover-open">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<style>
+    .half-square {
+        width: 100px;
+        height: 50px;
+        background-color: red;
+    }
+    #p1-sibling:not(:has(+:popover-open)) {
+        background-color: green;
+    }
+    #p2-sibling:has(+:popover-open) {
+        background-color: green;
+    }
+    [popover] {
+        visibility: hidden;
+    }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div>
+    <div id="p1-sibling" class="half-square"></div>
+    <div popover id="p1">Popover 1</div>
+</div>
+
+<div>
+    <div id="p2-sibling" class="half-square"></div>
+    <div popover id="p2">Popover 2</div>
+</div>
+
+<script>
+    addEventListener("load", async () => {
+        p1.showPopover();
+        await new Promise(r => requestAnimationFrame(r));
+        p1.hidePopover();
+        await new Promise(r => requestAnimationFrame(r));
+        p2.showPopover();
+        document.documentElement.classList.remove("reftest-wait");
+    });
+</script>
+</html>

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1251,9 +1251,7 @@ ExceptionOr<void> HTMLElement::hidePopoverInternal(FocusPreviousElement focusPre
 
     removeFromTopLayer();
 
-    std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
-    if (isConnected())
-        styleInvalidation.emplace(*this, CSSSelector::PseudoClass::PopoverOpen, false, Style::InvalidationScope::Descendants);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::PopoverOpen, false);
     popoverData()->setVisibilityState(PopoverVisibilityState::Hidden);
 
     if (fireEvents == FireEvents::Yes)

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -297,8 +297,10 @@ void Invalidator::invalidateStyleWithMatchElement(Element& element, MatchElement
             invalidateIfNeeded(*sibling, nullptr);
         break;
     case MatchElement::AnySibling:
-        for (auto& parentChild : childrenOfType<Element>(*element.parentNode()))
-            invalidateIfNeeded(parentChild, nullptr);
+        if (CheckedPtr parentNode = element.parentNode()) {
+            for (auto& parentChild : childrenOfType<Element>(*element.parentNode()))
+                invalidateIfNeeded(parentChild, nullptr);
+        }
         break;
     case MatchElement::ParentSibling:
         for (auto* sibling = element.nextElementSibling(); sibling; sibling = sibling->nextElementSibling()) {


### PR DESCRIPTION
#### 0db60d2b4123e101f8d16f925634f6226f7daaae
<pre>
REGRESSION (286644@main): style invalidation for `:has(+:popover-open)` doesn&apos;t work properly
<a href="https://bugs.webkit.org/show_bug.cgi?id=291174">https://bugs.webkit.org/show_bug.cgi?id=291174</a>
<a href="https://rdar.apple.com/148774717">rdar://148774717</a>

Reviewed by Ryosuke Niwa.

Undo behavior change that accidentally slipped in 286644@main that was missed during review.

That behavior change caused style invalidation to stop working with the sibling selector.

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/popover-open-with-has-sibling-selector-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/popover-open-with-has-sibling-selector.html: Added.
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::hidePopoverInternal):
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::Invalidator::invalidateStyleWithMatchElement):

Canonical link: <a href="https://commits.webkit.org/293967@main">https://commits.webkit.org/293967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a63a4eced19069c14dd0c91e4912dde3f5bf34d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105550 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51001 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102454 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28539 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76456 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33509 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15603 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90700 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56812 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15420 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8702 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50374 "Failed to compile WebKit") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85335 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8782 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107904 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27531 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20198 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85409 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27894 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86900 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84946 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21614 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29629 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7359 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21474 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27466 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32709 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27277 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30595 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28835 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->