### PR TITLE
REGRESSION(292709@main): Web content process occasionally crashes under UnifiedPDFPlugin::updateScrollingExtents() during visible content rect updates

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1234,7 +1234,10 @@ void UnifiedPDFPlugin::setPageScaleFactor(double scale, std::optional<WebCore::I
 
 void UnifiedPDFPlugin::mainFramePageScaleFactorDidChange()
 {
-    ASSERT(!handlesPageScaleFactor());
+    if (handlesPageScaleFactor()) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
     updateScrollingExtents();
 }
 
@@ -1710,6 +1713,9 @@ void UnifiedPDFPlugin::updateScrollingExtents()
 
     CheckedPtr renderer = m_element->renderer();
     if (!renderer)
+        return;
+
+    if (!m_scrollContainerLayer)
         return;
 
     EventRegion eventRegion;


### PR DESCRIPTION
#### 1c54f3b67b8e948ca5f5e4d6b5dcc4646cc27209
<pre>
REGRESSION(292709@main): Web content process occasionally crashes under UnifiedPDFPlugin::updateScrollingExtents() during visible content rect updates
<a href="https://bugs.webkit.org/show_bug.cgi?id=291868">https://bugs.webkit.org/show_bug.cgi?id=291868</a>
<a href="https://rdar.apple.com/149639054">rdar://149639054</a>

Reviewed by Wenson Hsieh and Megan Gardner.

This is a follow-up fix to 293366@main. We sometimes still see null
dereferences (of the scroll container layer) like this:

```
WebKit::UnifiedPDFPlugin::updateScrollingExtents() (WebKit)
  WebKit::PluginView::mainFramePageScaleFactorDidChange() (WebKit)
    auto WebKit::WebPage::updateVisibleContentRects(WebKit::VisibleContentRectUpdateInfo const&amp;, WTF::MonotonicTime)::$_0::operator()&lt;WebCore::IntPoint&gt;(float, WebCore::IntPoint const&amp;, bool) const (WebKit)
      WebKit::WebPage::updateVisibleContentRects(WebKit::VisibleContentRectUpdateInfo const&amp;, WTF::MonotonicTime) (WebKit)
```

In this patch, we further harden the plugin agains such crashes by null
checking the scroll container layer. This is appropriate because said
layer is not guaranteed to be well formed during certain visible content
rect updates.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::mainFramePageScaleFactorDidChange):

Drive-by: avoid calling into updateScrollingExtents() to begin with in
unsupported configurations.

(WebKit::UnifiedPDFPlugin::updateScrollingExtents):

Canonical link: <a href="https://commits.webkit.org/293943@main">https://commits.webkit.org/293943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a6857050bd57f95d4ecccf5b7859027d66e49a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100369 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10320 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105505 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50957 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76421 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33476 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15565 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90662 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56776 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15382 "Passed tests") | | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50324 "Failed to compile WebKit") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85302 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8745 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107860 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27487 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20169 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85373 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27850 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86862 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84909 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21592 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29594 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7329 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21407 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27422 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32663 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27233 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30551 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28791 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->