### PR TITLE
declarativeNetRequest: 'allowAllRequests' doesn't work

### DIFF
--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
@@ -248,7 +248,8 @@ ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForLoad(
         else if (auto* page = frame->page())
             mainDocumentURL = page->mainFrameURL();
     }
-    if (currentDocument)
+
+    if (currentDocument && currentDocument->url().isValid())
         frameURL = currentDocument->url();
     else
         frameURL = url;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -120,7 +120,7 @@ static NSString * const sessionStorageAllowedInContentScriptsKey = @"SessionStor
 static constexpr NSInteger currentBackgroundContentListenerStateVersion = 3;
 
 // Update this value when any changes are made to the rule translation logic in _WKWebExtensionDeclarativeNetRequestRule.
-static constexpr NSInteger currentDeclarativeNetRequestRuleTranslatorVersion = 4;
+static constexpr NSInteger currentDeclarativeNetRequestRuleTranslatorVersion = 5;
 
 @interface _WKWebExtensionContextDelegate : NSObject <WKNavigationDelegate, WKUIDelegate> {
     WeakPtr<WebKit::WebExtensionContext> _webExtensionContext;


### PR DESCRIPTION
#### 2de894785a2f3bbcf02128b5e7d19e715313d791
<pre>
declarativeNetRequest: &apos;allowAllRequests&apos; doesn&apos;t work
<a href="https://bugs.webkit.org/show_bug.cgi?id=291872">https://bugs.webkit.org/show_bug.cgi?id=291872</a>
<a href="https://rdar.apple.com/72203692">rdar://72203692</a>

Reviewed by Timothy Hatcher.

This patch fixes our implementation of allowAllRequests dNR rules.

Google&apos;s description of allowAllRequests is:

    Allow all requests within a frame hierarchy, including the frame request itself.
    <a href="https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest#type-RuleActionType">https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest#type-RuleActionType</a>

To do this, we have to create WebKit content blocking rules that are shaped
like:

{
  action: {
    type: ignore-previous-rules
  },
  trigger: {
    url-filter: .*

    if-frame-url: foo.com   // Based on the urlFilter, regexFilter, or
                            // requestDomains

    load-context: top-frame // or child-frame, just depending on resourceType in
                            // the dNR rule.
  }
}

All other rule conditions have to be thrown away; otherwise, we wouldn&apos;t have a
way to convert it into a valid WebKit content blocking rule.

* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForLoad):
Only use the current document&apos;s URL if it&apos;s valid. I was seeing if-frame-url
rules fail due to an empty frame URL in the resource load info.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
Update the dNR translation version.

* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm:
(-[_WKWebExtensionDeclarativeNetRequestRule ruleInWebKitFormat]):
(-[_WKWebExtensionDeclarativeNetRequestRule _convertRulesWithModifiedCondition:webKitActionType:chromeActionType:]):
(-[_WKWebExtensionDeclarativeNetRequestRule _webKitRuleWithWebKitActionType:chromeActionType:condition:]):
Update the translation rules as described in the summary.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithAllowAllRequests)):
Wrote new tests to validate the fix.

Canonical link: <a href="https://commits.webkit.org/294041@main">https://commits.webkit.org/294041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef8037f3a440b7fc863561391ac774c2ca9aec03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20251 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10550 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105736 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51187 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102640 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28725 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76608 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33646 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103606 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15776 "Found 1 new test failure: fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90867 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56964 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15591 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8873 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50563 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85506 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8949 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108090 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27717 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20357 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85566 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28080 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87068 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85105 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29794 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7521 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21705 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16376 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27652 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32903 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27463 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30781 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29021 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->