### PR TITLE
Refactor support for text alignment options in Mail compose.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3367,6 +3367,26 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKCONTENTVIEW)
 
 #undef FORWARD_ACTION_TO_WKCONTENTVIEW
 
+- (IBAction)_alignCenter:(id)sender
+{
+    [self alignCenter:sender];
+}
+
+- (IBAction)_alignJustified:(id)sender
+{
+    [self alignJustified:sender];
+}
+
+- (IBAction)_alignLeft:(id)sender
+{
+    [self alignLeft:sender];
+}
+
+- (IBAction)_alignRight:(id)sender
+{
+    [self alignRight:sender];
+}
+
 - (UIView *)inputAccessoryView
 {
     return [_contentView inputAccessoryViewForWebView];

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -138,6 +138,11 @@ enum class TapHandlingResult : uint8_t;
 - (void)replace:(id)sender;
 - (void)_translate:(id)sender;
 
+- (IBAction)alignCenter:(id)sender;
+- (IBAction)alignJustified:(id)sender;
+- (IBAction)alignLeft:(id)sender;
+- (IBAction)alignRight:(id)sender;
+
 #if HAVE(UIFINDINTERACTION)
 - (void)find:(id)sender;
 - (void)findNext:(id)sender;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -226,13 +226,13 @@ typedef std::pair<WebKit::InteractionInformationRequest, InteractionInformationC
     M(pasteAndMatchStyle) \
     M(makeTextWritingDirectionNatural) \
     M(makeTextWritingDirectionLeftToRight) \
-    M(makeTextWritingDirectionRightToLeft)
+    M(makeTextWritingDirectionRightToLeft) \
+    M(alignCenter) \
+    M(alignJustified) \
+    M(alignLeft) \
+    M(alignRight)
 
 #define FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(M) \
-    M(_alignCenter) \
-    M(_alignJustified) \
-    M(_alignLeft) \
-    M(_alignRight) \
     M(_indent) \
     M(_outdent) \
     M(_toggleStrikeThrough) \

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -4708,6 +4708,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     // FIXME: Some of the following checks should be removed once internal clients move to the underscore-prefixed versions.
     if (action == @selector(toggleBoldface:) || action == @selector(toggleItalics:) || action == @selector(toggleUnderline:) || action == @selector(_toggleStrikeThrough:)
         || action == @selector(_alignLeft:) || action == @selector(_alignRight:) || action == @selector(_alignCenter:) || action == @selector(_alignJustified:)
+        || action == @selector(alignLeft:) || action == @selector(alignRight:) || action == @selector(alignCenter:) || action == @selector(alignJustified:)
         || action == @selector(_setTextColor:sender:) || action == @selector(_setFont:sender:) || action == @selector(_setFontSize:sender:)
         || action == @selector(_insertOrderedList:) || action == @selector(_insertUnorderedList:) || action == @selector(_insertNestedOrderedList:) || action == @selector(_insertNestedUnorderedList:)
         || action == @selector(_increaseListLevel:) || action == @selector(_decreaseListLevel:) || action == @selector(_changeListType:) || action == @selector(_indent:) || action == @selector(_outdent:)


### PR DESCRIPTION
#### 9d9c2ca3d33d524d768117cc85d83a7287037b3c
<pre>
Refactor support for text alignment options in Mail compose.
<a href="https://bugs.webkit.org/show_bug.cgi?id=291873">https://bugs.webkit.org/show_bug.cgi?id=291873</a>
<a href="https://rdar.apple.com/148599632">rdar://148599632</a>

Reviewed by Wenson Hsieh.

Just moving some bits around.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _alignCenter:]):
(-[WKWebView _alignJustified:]):
(-[WKWebView _alignLeft:]):
(-[WKWebView _alignRight:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:

Canonical link: <a href="https://commits.webkit.org/293963@main">https://commits.webkit.org/293963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e0ec96580ffeceb8fce99dbb955d9abfec2eb04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10349 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105534 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50986 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20356 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28524 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76442 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33498 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103405 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90690 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56797 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15407 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50355 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85321 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8772 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107889 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20186 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85396 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86890 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84934 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21612 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29617 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7349 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21439 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27451 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32692 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27262 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30580 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28820 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->