### PR TITLE
Use Frame::documentSecurityOrigin in more places

### DIFF
--- a/Source/WebCore/page/Location.cpp
+++ b/Source/WebCore/page/Location.cpp
@@ -128,12 +128,12 @@ String Location::origin() const
 Ref<DOMStringList> Location::ancestorOrigins() const
 {
     auto origins = DOMStringList::create();
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return origins;
-    for (auto* ancestor = frame->tree().parent(); ancestor; ancestor = ancestor->tree().parent()) {
-        if (auto* localAncestor = dynamicDowncast<LocalFrame>(ancestor))
-            origins->append(localAncestor->document()->securityOrigin().toString());
+    for (RefPtr ancestor = frame->tree().parent(); ancestor; ancestor = ancestor->tree().parent()) {
+        if (RefPtr origin = ancestor->frameDocumentSecurityOrigin())
+            origins->append(origin->toString());
     }
     return origins;
 }

--- a/Source/WebCore/workers/service/ServiceWorkerClientData.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerClientData.cpp
@@ -70,14 +70,14 @@ ServiceWorkerClientData ServiceWorkerClientData::isolatedCopy() &&
 
 ServiceWorkerClientData ServiceWorkerClientData::from(ScriptExecutionContext& context)
 {
-    if (auto* document = dynamicDowncast<Document>(context)) {
+    if (RefPtr document = dynamicDowncast<Document>(context)) {
         auto lastNavigationWasAppInitiated = document->loader() && document->loader()->lastNavigationWasAppInitiated() ? LastNavigationWasAppInitiated::Yes : LastNavigationWasAppInitiated::No;
 
         Vector<String> ancestorOrigins;
-        if (auto* frame = document->frame()) {
-            for (auto* ancestor = frame->tree().parent(); ancestor; ancestor = ancestor->tree().parent()) {
-                if (auto* ancestorFrame = dynamicDowncast<LocalFrame>(ancestor))
-                    ancestorOrigins.append(ancestorFrame->document()->securityOrigin().toString());
+        if (RefPtr frame = document->frame()) {
+            for (RefPtr ancestor = frame->tree().parent(); ancestor; ancestor = ancestor->tree().parent()) {
+                if (RefPtr origin = ancestor->frameDocumentSecurityOrigin())
+                    ancestorOrigins.append(origin->toString());
             }
         }
 


### PR DESCRIPTION
#### f6b9a849914bfbc627c0949db5668cb4770a854a
<pre>
Use Frame::documentSecurityOrigin in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=291875">https://bugs.webkit.org/show_bug.cgi?id=291875</a>
<a href="https://rdar.apple.com/119230392">rdar://119230392</a>

Reviewed by Charlie Wolfe.

This allows us to eliminate behavior differences from enabling site isolation.
Frame::documentSecurityOrigin returns the same thing as what it replaces with
site isolation off, but with it on it returns the frame&apos;s security origin even
if it is in another process.  This was already introduced for CSP purposes, and
now we use it for ServiceWorkerClientData and Location.ancestorOrigins which is
used on some credit card entry iframes.

* Source/WebCore/page/Location.cpp:
(WebCore::Location::ancestorOrigins const):
* Source/WebCore/workers/service/ServiceWorkerClientData.cpp:
(WebCore::ServiceWorkerClientData::from):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, IframeWithCSPHeaderForFrameAncestors)):

Canonical link: <a href="https://commits.webkit.org/293944@main">https://commits.webkit.org/293944@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecb840d6a4b73e2daddb9e788737a76b1455b6e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20038 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105522 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50974 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102427 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76432 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33487 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103393 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15581 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90680 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56787 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15402 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8681 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50342 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/85314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8762 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107877 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27504 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20178 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85385 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27867 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84922 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29612 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/7340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21424 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16335 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27439 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32680 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27250 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30568 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28808 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->