### PR TITLE
FontCache::forCurrentThread(): Avoid some unsafe unchecked reference to FontCache

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -136,9 +136,6 @@ contentextensions/ContentExtensionsBackend.cpp
 css/CSSComputedStyleDeclaration.cpp
 css/CSSCustomPropertyValue.cpp
 css/CSSFontFace.cpp
-css/CSSFontFaceSet.cpp
-css/CSSFontFaceSource.cpp
-css/CSSFontSelector.cpp
 css/CSSImageValue.cpp
 css/CSSStyleProperties.cpp
 css/CSSStyleSheet.cpp
@@ -272,7 +269,6 @@ editing/VisibleSelection.cpp
 editing/VisibleUnits.cpp
 editing/cocoa/AutofillElements.cpp
 editing/cocoa/EditorCocoa.mm
-editing/cocoa/FontAttributeChangesCocoa.mm
 editing/cocoa/HTMLConverter.mm
 editing/cocoa/WebContentReaderCocoa.mm
 editing/mac/EditorMac.mm
@@ -579,7 +575,6 @@ page/PerformanceMonitor.cpp
 page/PointerCaptureController.cpp
 page/PointerLockController.cpp
 page/PrintContext.cpp
-page/ProcessWarming.cpp
 page/Quirks.cpp
 page/RemoteFrame.cpp
 page/ResizeObservation.cpp
@@ -620,12 +615,7 @@ platform/cocoa/LowPowerModeNotifier.mm
 platform/cocoa/VideoPresentationModelVideoElement.mm
 platform/cocoa/WebAVPlayerLayer.mm
 platform/graphics/ComplexTextController.cpp
-platform/graphics/FontCache.cpp
-platform/graphics/FontCascade.cpp
 platform/graphics/FontCascade.h
-platform/graphics/FontCascadeFonts.cpp
-platform/graphics/FontPlatformData.cpp
-platform/graphics/SystemFallbackFontCache.cpp
 platform/graphics/WidthIterator.cpp
 platform/graphics/ca/GraphicsLayerCA.cpp
 platform/graphics/ca/PlatformCALayer.mm
@@ -634,7 +624,6 @@ platform/graphics/ca/TileCoverageMap.cpp
 platform/graphics/ca/TileGrid.cpp
 platform/graphics/ca/cocoa/WebTiledBackingLayer.mm
 platform/graphics/cg/CGSubimageCacheWithTimer.cpp
-platform/graphics/cocoa/FontFamilySpecificationCoreText.cpp
 platform/graphics/coretext/ComplexTextControllerCoreText.mm
 platform/ios/PlaybackSessionInterfaceIOS.mm
 platform/ios/WebAVPlayerController.mm

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -398,7 +398,6 @@ platform/Widget.cpp
 platform/animation/AcceleratedEffect.cpp
 platform/cocoa/VideoPresentationModelVideoElement.mm
 platform/graphics/FontCache.cpp
-platform/graphics/FontCascadeFonts.cpp
 platform/graphics/GraphicsLayer.cpp
 platform/graphics/SystemFallbackFontCache.cpp
 platform/graphics/ca/GraphicsLayerCA.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -91,7 +91,6 @@ platform/Timer.h
 platform/cocoa/NetworkExtensionContentFilter.mm
 platform/encryptedmedia/CDMProxy.cpp
 platform/encryptedmedia/clearkey/CDMClearKey.cpp
-platform/graphics/FontCascadeFonts.cpp
 platform/graphics/ShadowBlur.cpp
 platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -720,7 +720,7 @@ RefPtr<Font> CSSFontFace::font(const FontDescription& fontDescription, bool synt
         case CSSFontFaceSource::Status::Pending:
         case CSSFontFaceSource::Status::Loading: {
             Font::Visibility visibility = WebCore::visibility(status(), fontLoadTiming());
-            return Font::create(FontCache::forCurrentThread().lastResortFallbackFont(fontDescription)->platformData(), Font::Origin::Local, Font::IsInterstitial::Yes, visibility);
+            return Font::create(FontCache::forCurrentThread()->lastResortFallbackFont(fontDescription)->platformData(), Font::Origin::Local, Font::IsInterstitial::Yes, visibility);
         }
         case CSSFontFaceSource::Status::Success: {
             FontCreationContext fontCreationContext { m_featureSettings, m_fontSelectionCapabilities, fontPaletteValues, fontFeatureValues, m_sizeAdjust };

--- a/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -121,7 +121,7 @@ void CSSFontFaceSet::ensureLocalFontFacesForFamilyRegistered(const AtomString& f
     if (!owningFontSelector->scriptExecutionContext())
         return;
     auto allowUserInstalledFonts = owningFontSelector->protectedScriptExecutionContext()->settingsValues().shouldAllowUserInstalledFonts ? AllowUserInstalledFonts::Yes : AllowUserInstalledFonts::No;
-    auto capabilities = FontCache::forCurrentThread().getFontSelectionCapabilitiesInFamily(familyName, allowUserInstalledFonts);
+    auto capabilities = FontCache::forCurrentThread()->getFontSelectionCapabilitiesInFamily(familyName, allowUserInstalledFonts);
     if (capabilities.isEmpty())
         return;
 

--- a/Source/WebCore/css/CSSFontFaceSource.cpp
+++ b/Source/WebCore/css/CSSFontFaceSource.cpp
@@ -185,7 +185,7 @@ void CSSFontFaceSource::load(Document* document)
             fontDescription.setOneFamily(m_fontFaceName);
             fontDescription.setComputedSize(1);
             fontDescription.setShouldAllowUserInstalledFonts(protectedCSSFontFace()->allowUserInstalledFonts());
-            success = FontCache::forCurrentThread().fontForFamily(fontDescription, m_fontFaceName, { }, FontLookupOptions::ExactFamilyNameMatch);
+            success = FontCache::forCurrentThread()->fontForFamily(fontDescription, m_fontFaceName, { }, FontLookupOptions::ExactFamilyNameMatch);
             if (document && document->settings().webAPIStatisticsEnabled())
                 ResourceLoadObserver::shared().logFontLoad(*document, m_fontFaceName.string(), success);
         }
@@ -213,7 +213,7 @@ RefPtr<Font> CSSFontFaceSource::font(const FontDescription& fontDescription, boo
             options.add(FontLookupOptions::DisallowBoldSynthesis);
         if (!syntheticItalic)
             options.add(FontLookupOptions::DisallowObliqueSynthesis);
-        return FontCache::forCurrentThread().fontForFamily(fontDescription, m_fontFaceName, fontCreationContext, options);
+        return FontCache::forCurrentThread()->fontForFamily(fontDescription, m_fontFaceName, fontCreationContext, options);
     }
 
     if (m_fontRequest) {

--- a/Source/WebCore/css/CSSFontSelector.cpp
+++ b/Source/WebCore/css/CSSFontSelector.cpp
@@ -89,7 +89,7 @@ CSSFontSelector::CSSFontSelector(ScriptExecutionContext& context)
         });
     }
 
-    FontCache::forCurrentThread().addClient(*this);
+    FontCache::forCurrentThread()->addClient(*this);
     m_cssFontFaceSet->addFontModifiedObserver(m_fontModifiedObserver);
     LOG(Fonts, "CSSFontSelector %p ctor", this);
 }
@@ -405,7 +405,7 @@ FontRanges CSSFontSelector::fontRangesForFamily(const FontDescription& fontDescr
     if (!resolveGenericFamilyFirst)
         resolveAndAssignGenericFamily();
 
-    auto font = FontCache::forCurrentThread().fontForFamily(*fontDescriptionForLookup, familyForLookup, { { }, { }, fontPaletteValues, fontFeatureValues, 1.0 });
+    auto font = FontCache::forCurrentThread()->fontForFamily(*fontDescriptionForLookup, familyForLookup, { { }, { }, fontPaletteValues, fontFeatureValues, 1.0 });
     if (document && document->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logFontLoad(*document, familyForLookup.string(), !!font);
     return { FontRanges { WTFMove(font) }, isGenericFontFamily };
@@ -436,7 +436,7 @@ RefPtr<Font> CSSFontSelector::fallbackFontAt(const FontDescription& fontDescript
     if (!m_context->settingsValues().fontFallbackPrefersPictographs)
         return nullptr;
     auto& pictographFontFamily = m_context->settingsValues().fontGenericFamilies.pictographFontFamily();
-    auto font = FontCache::forCurrentThread().fontForFamily(fontDescription, pictographFontFamily);
+    auto font = FontCache::forCurrentThread()->fontForFamily(fontDescription, pictographFontFamily);
     if (auto* document = dynamicDowncast<Document>(m_context.get()); document && document->settingsValues().webAPIStatisticsEnabled)
         ResourceLoadObserver::shared().logFontLoad(*document, pictographFontFamily, !!font);
 

--- a/Source/WebCore/editing/cocoa/FontAttributeChangesCocoa.mm
+++ b/Source/WebCore/editing/cocoa/FontAttributeChangesCocoa.mm
@@ -51,7 +51,7 @@ const String& FontChanges::platformFontFamilyNameForCSS() const
     FontDescription description;
     description.setIsItalic(m_italic.value_or(false));
     description.setWeight(FontSelectionValue { m_bold.value_or(false) ? 900 : 500 });
-    if (auto font = FontCache::forCurrentThread().fontForFamily(description, m_fontFamily))
+    if (auto font = FontCache::forCurrentThread()->fontForFamily(description, m_fontFamily))
         fontNameFromDescription = adoptCF(CTFontCopyPostScriptName(font->getCTFont()));
 
     if (fontNameFromDescription && CFStringCompare(cfFontName.get(), fontNameFromDescription.get(), 0) == kCFCompareEqualTo)

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -938,7 +938,7 @@ Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<String>>> InspectorCSSAgent
 {
     auto fontFamilyNames = JSON::ArrayOf<String>::create();
 
-    Vector<String> systemFontFamilies = FontCache::forCurrentThread().systemFontFamilies();
+    Vector<String> systemFontFamilies = FontCache::forCurrentThread()->systemFontFamilies();
     for (const auto& familyName : systemFontFamilies)
         fontFamilyNames->addItem(familyName);
 

--- a/Source/WebCore/page/ProcessWarming.cpp
+++ b/Source/WebCore/page/ProcessWarming.cpp
@@ -89,12 +89,12 @@ void ProcessWarming::prewarmGlobally()
 
 WebCore::PrewarmInformation ProcessWarming::collectPrewarmInformation()
 {
-    return { FontCache::forCurrentThread().collectPrewarmInformation() };
+    return { FontCache::forCurrentThread()->collectPrewarmInformation() };
 }
 
 void ProcessWarming::prewarmWithInformation(PrewarmInformation&& prewarmInfo)
 {
-    FontCache::forCurrentThread().prewarm(WTFMove(prewarmInfo.fontCache));
+    FontCache::forCurrentThread()->prewarm(WTFMove(prewarmInfo.fontCache));
 }
 
 }

--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -98,7 +98,7 @@ Font::Font(const FontPlatformData& platformData, Origin origin, IsInterstitial i
     platformCharWidthInit();
 #if ENABLE(OPENTYPE_VERTICAL)
     if (platformData.orientation() == FontOrientation::Vertical && orientationFallback == IsOrientationFallback::No) {
-        m_verticalData = FontCache::forCurrentThread().verticalData(platformData);
+        m_verticalData = FontCache::forCurrentThread()->verticalData(platformData);
         m_hasVerticalGlyphs = m_verticalData.get() && m_verticalData->hasVerticalMetrics();
     }
 #endif

--- a/Source/WebCore/platform/graphics/FontCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCache.cpp
@@ -134,7 +134,7 @@ struct FontCache::FontDataCaches {
 #endif
 };
 
-FontCache& FontCache::forCurrentThread()
+CheckedRef<FontCache> FontCache::forCurrentThread()
 {
     return threadGlobalData().fontCache();
 }
@@ -423,7 +423,7 @@ static void dispatchToAllFontCaches(F function)
 {
     ASSERT(isMainThread());
 
-    function(FontCache::forCurrentThread());
+    function(FontCache::forCurrentThread().get());
 
     for (auto& thread : WorkerOrWorkletThread::workerOrWorkletThreads()) {
         thread.runLoop().postTask([function](ScriptExecutionContext&) {

--- a/Source/WebCore/platform/graphics/FontCache.h
+++ b/Source/WebCore/platform/graphics/FontCache.h
@@ -120,7 +120,7 @@ class FontCache : public CanMakeCheckedPtr<FontCache> {
     WTF_MAKE_NONCOPYABLE(FontCache);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FontCache);
 public:
-    WEBCORE_EXPORT static FontCache& forCurrentThread();
+    WEBCORE_EXPORT static CheckedRef<FontCache> forCurrentThread();
     static FontCache* forCurrentThreadIfExists();
     static FontCache* forCurrentThreadIfNotDestroyed();
 

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -138,7 +138,7 @@ bool FontCascade::isCurrent(const FontSelector& fontSelector) const
 {
     if (!m_fonts)
         return false;
-    if (m_fonts->generation() != FontCache::forCurrentThread().generation())
+    if (m_fonts->generation() != FontCache::forCurrentThread()->generation())
         return false;
     if (fontSelectorVersion() != fontSelector.version())
         return false;
@@ -161,7 +161,7 @@ void FontCascade::updateFonts(Ref<FontCascadeFonts>&& fonts) const
 void FontCascade::update(RefPtr<FontSelector>&& fontSelector) const
 {
     m_fontSelector = WTFMove(fontSelector);
-    FontCache::forCurrentThread().updateFontCascade(*this);
+    FontCache::forCurrentThread()->updateFontCascade(*this);
 }
 
 GlyphBuffer FontCascade::layoutText(CodePath codePathToUse, const TextRun& run, unsigned from, unsigned to, ForTextEmphasisOrNot forTextEmphasis) const
@@ -1304,7 +1304,7 @@ bool FontCascade::isLoadingCustomFonts() const
 
 bool FontCascade::computeUseBackslashAsYenSymbol() const
 {
-    return FontCache::forCurrentThread().useBackslashAsYenSignForFamily(m_fontDescription.firstFamily());
+    return FontCache::forCurrentThread()->useBackslashAsYenSignForFamily(m_fontDescription.firstFamily());
 }
 
 enum class GlyphUnderlineType : uint8_t {

--- a/Source/WebCore/platform/graphics/FontCascadeCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.cpp
@@ -67,7 +67,7 @@ bool operator==(const FontFamilyName& a, const FontFamilyName& b)
 
 FontCascadeCache& FontCascadeCache::forCurrentThread()
 {
-    return FontCache::forCurrentThread().fontCascadeCache();
+    return FontCache::forCurrentThread()->fontCascadeCache();
 }
 
 void FontCascadeCache::invalidate()

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -105,7 +105,7 @@ DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FontCascadeFonts);
 
 FontCascadeFonts::FontCascadeFonts()
     : m_cachedPrimaryFont(nullptr)
-    , m_generation(FontCache::forCurrentThread().generation())
+    , m_generation(FontCache::forCurrentThread()->generation())
 {
 #if ASSERT_ENABLED
     if (!isMainThread())
@@ -115,10 +115,10 @@ FontCascadeFonts::FontCascadeFonts()
 
 FontCascadeFonts::FontCascadeFonts(const FontPlatformData& platformData)
     : m_cachedPrimaryFont(nullptr)
-    , m_generation(FontCache::forCurrentThread().generation())
+    , m_generation(FontCache::forCurrentThread()->generation())
     , m_isForPlatformFont(true)
 {
-    m_realizedFallbackRanges.append(FontRanges(FontCache::forCurrentThread().fontForPlatformData(platformData)));
+    m_realizedFallbackRanges.append(FontRanges(FontCache::forCurrentThread()->fontForPlatformData(platformData)));
 }
 
 FontCascadeFonts::~FontCascadeFonts() = default;
@@ -162,7 +162,7 @@ static FontRanges realizeNextFallback(const FontCascadeDescription& description,
 {
     ASSERT(index < description.effectiveFamilyCount());
 
-    auto& fontCache = FontCache::forCurrentThread();
+    CheckedRef fontCache = FontCache::forCurrentThread();
     while (index < description.effectiveFamilyCount()) {
         auto visitor = WTF::makeVisitor([&, fontSelector = RefPtr { fontSelector }](const AtomString& family) -> FontRanges {
             if (family.isNull())
@@ -172,7 +172,7 @@ static FontRanges realizeNextFallback(const FontCascadeDescription& description,
                 if (!ranges.isNull())
                     return ranges;
             }
-            if (auto font = fontCache.fontForFamily(description, family))
+            if (auto font = fontCache->fontForFamily(description, family))
                 return FontRanges(WTFMove(font));
             return FontRanges();
         }, [&](const FontFamilyPlatformSpecification& fontFamilySpecification) -> FontRanges {
@@ -187,7 +187,7 @@ static FontRanges realizeNextFallback(const FontCascadeDescription& description,
     // For example on OS X, we know to map any families containing the words Arabic, Pashto, or Urdu to the
     // Geeza Pro font.
     for (auto& family : description.families()) {
-        if (auto font = fontCache.similarFont(description, family))
+        if (auto font = fontCache->similarFont(description, family))
             return FontRanges(WTFMove(font));
     }
     return { };
@@ -199,7 +199,7 @@ const FontRanges& FontCascadeFonts::realizeFallbackRangesAt(const FontCascadeDes
         return m_realizedFallbackRanges[index];
 
     ASSERT(index == m_realizedFallbackRanges.size());
-    ASSERT(FontCache::forCurrentThread().generation() == m_generation);
+    ASSERT(FontCache::forCurrentThread()->generation() == m_generation);
 
     m_realizedFallbackRanges.append(FontRanges());
     auto& fontRanges = m_realizedFallbackRanges.last();
@@ -209,7 +209,7 @@ const FontRanges& FontCascadeFonts::realizeFallbackRangesAt(const FontCascadeDes
         if (fontRanges.isNull() && fontSelector)
             fontRanges = fontSelector->fontRangesForFamily(description, familyNamesData->at(FamilyNamesIndex::StandardFamily));
         if (fontRanges.isNull())
-            fontRanges = FontRanges(FontCache::forCurrentThread().lastResortFallbackFont(description));
+            fontRanges = FontRanges(FontCache::forCurrentThread()->lastResortFallbackFont(description));
         return fontRanges;
     }
 

--- a/Source/WebCore/platform/graphics/FontPlatformData.cpp
+++ b/Source/WebCore/platform/graphics/FontPlatformData.cpp
@@ -103,7 +103,7 @@ void FontPlatformData::updateSizeWithFontSizeAdjust(const FontSizeAdjust& fontSi
         return;
     }
 
-    auto tmpFont = FontCache::forCurrentThread().fontForPlatformData(*this);
+    auto tmpFont = FontCache::forCurrentThread()->fontForPlatformData(*this);
     auto adjustedFontSize = Style::adjustedFontSize(computedSize, fontSizeAdjust, tmpFont->fontMetrics());
 
     if (adjustedFontSize == size())

--- a/Source/WebCore/platform/graphics/SystemFallbackFontCache.cpp
+++ b/Source/WebCore/platform/graphics/SystemFallbackFontCache.cpp
@@ -41,7 +41,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(SystemFallbackFontCache);
 
 SystemFallbackFontCache& SystemFallbackFontCache::forCurrentThread()
 {
-    return FontCache::forCurrentThread().systemFallbackFontCache();
+    return FontCache::forCurrentThread()->systemFallbackFontCache();
 }
 
 SystemFallbackFontCache* SystemFallbackFontCache::forCurrentThreadIfExists()
@@ -79,7 +79,7 @@ RefPtr<Font> SystemFallbackFontCache::systemFallbackFontForCharacterCluster(cons
             break;
         }
 
-        RefPtr fallbackFont = FontCache::forCurrentThread().systemFallbackForCharacterCluster(description, *font, isForPlatformFont, FontCache::PreferColoredFont::No, stringBuilder);
+        RefPtr fallbackFont = FontCache::forCurrentThread()->systemFallbackForCharacterCluster(description, *font, isForPlatformFont, FontCache::PreferColoredFont::No, stringBuilder);
         if (fallbackFont)
             fallbackFont->setIsUsedInSystemFallbackFontCache();
         return fallbackFont.get();

--- a/Source/WebCore/platform/graphics/cairo/FontCairoHarfbuzzNG.cpp
+++ b/Source/WebCore/platform/graphics/cairo/FontCairoHarfbuzzNG.cpp
@@ -134,7 +134,7 @@ RefPtr<const Font> FontCascade::fontForCombiningCharacterSequence(StringView str
     }
 
     const auto& originalFont = fallbackRangesAt(0).fontForFirstRange();
-    if (auto systemFallback = FontCache::forCurrentThread().systemFallbackForCharacterCluster(m_fontDescription, originalFont, IsForPlatformFont::No, preferColoredFont ? FontCache::PreferColoredFont::Yes : FontCache::PreferColoredFont::No, normalizedString.view)) {
+    if (auto systemFallback = FontCache::forCurrentThread()->systemFallbackForCharacterCluster(m_fontDescription, originalFont, IsForPlatformFont::No, preferColoredFont ? FontCache::PreferColoredFont::Yes : FontCache::PreferColoredFont::No, normalizedString.view)) {
         if (systemFallback->canRenderCombiningCharacterSequence(normalizedString.view) && (!preferColoredFont || systemFallback->platformData().isColorBitmapFont()))
             return systemFallback.get();
 

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -166,7 +166,7 @@ RefPtr<Font> FontCache::similarFont(const FontDescription& description, const St
 
 static void fontCacheRegisteredFontsChangedNotificationCallback(CFNotificationCenterRef, void* observer, CFStringRef, const void *, CFDictionaryRef)
 {
-    ASSERT_UNUSED(observer, isMainThread() && observer == &FontCache::forCurrentThread());
+    ASSERT_UNUSED(observer, isMainThread() && observer == FontCache::forCurrentThread().ptr());
 
     ensureOnMainThread([] {
         FontCache::invalidateAllFontCaches();
@@ -975,7 +975,7 @@ void FontCache::prewarmGlobally()
 
     FontCache::PrewarmInformation prewarmInfo;
     prewarmInfo.seenFamilies = WTFMove(families);
-    FontCache::forCurrentThread().prewarm(WTFMove(prewarmInfo));
+    FontCache::forCurrentThread()->prewarm(WTFMove(prewarmInfo));
 #endif
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreText.cpp
@@ -63,7 +63,7 @@ FontRanges FontFamilySpecificationCoreText::fontRanges(const FontDescription& fo
         return platformData;
     });
 
-    return FontRanges(FontCache::forCurrentThread().fontForPlatformData(originalPlatformData));
+    return FontRanges(FontCache::forCurrentThread()->fontForPlatformData(originalPlatformData));
 }
 
 }

--- a/Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreTextCache.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreTextCache.cpp
@@ -35,7 +35,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(FontFamilySpecificationCoreTextCache);
 
 FontFamilySpecificationCoreTextCache& FontFamilySpecificationCoreTextCache::forCurrentThread()
 {
-    return FontCache::forCurrentThread().fontFamilySpecificationCoreTextCache();
+    return FontCache::forCurrentThread()->fontFamilySpecificationCoreTextCache();
 }
 
 void FontFamilySpecificationCoreTextCache::clear()

--- a/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
@@ -38,7 +38,7 @@ namespace WebCore {
 
 SystemFontDatabaseCoreText& SystemFontDatabaseCoreText::forCurrentThread()
 {
-    return FontCache::forCurrentThread().systemFontDatabaseCoreText();
+    return FontCache::forCurrentThread()->systemFontDatabaseCoreText();
 }
 
 SystemFontDatabase& SystemFontDatabase::singleton()

--- a/Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm
+++ b/Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm
@@ -274,7 +274,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
                         continue;
                     }
                     FontPlatformData runFontPlatformData(runCTFont, CTFontGetSize(runCTFont));
-                    runFont = FontCache::forCurrentThread().fontForPlatformData(runFontPlatformData).ptr();
+                    runFont = FontCache::forCurrentThread()->fontForPlatformData(runFontPlatformData).ptr();
                 }
                 if (m_fallbackFonts && runFont != m_fontCascade.primaryFont().ptr())
                     m_fallbackFonts->add(*runFont);

--- a/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
@@ -101,7 +101,7 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
 
 RefPtr<FontCustomPlatformData> FontCustomPlatformData::create(SharedBuffer& buffer, const String& itemInCollection)
 {
-    sk_sp<SkTypeface> typeface = FontCache::forCurrentThread().fontManager().makeFromData(buffer.createSkData());
+    sk_sp<SkTypeface> typeface = FontCache::forCurrentThread()->fontManager().makeFromData(buffer.createSkData());
     if (!typeface)
         return nullptr;
 

--- a/Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp
@@ -171,7 +171,7 @@ FontPlatformData FontPlatformData::create(const Attributes& data, const FontCust
         sk_sp<SkTypeface> typeface = custom->m_typeface;
         return { WTFMove(typeface), data.m_size, data.m_syntheticBold, data.m_syntheticOblique, data.m_orientation, data.m_widthVariant, data.m_textRenderingMode, WTFMove(features), custom };
     }
-    sk_sp<SkTypeface> typeface = FontCache::forCurrentThread().fontManager().matchFamilyStyle(data.m_familyName.c_str(), data.m_style);
+    sk_sp<SkTypeface> typeface = FontCache::forCurrentThread()->fontManager().matchFamilyStyle(data.m_familyName.c_str(), data.m_style);
     return { WTFMove(typeface), data.m_size, data.m_syntheticBold, data.m_syntheticOblique, data.m_orientation, data.m_widthVariant, data.m_textRenderingMode, WTFMove(features) };
 }
 

--- a/Source/WebCore/platform/graphics/skia/SkiaHarfBuzzFont.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaHarfBuzzFont.cpp
@@ -39,7 +39,7 @@ namespace WebCore {
 
 Ref<SkiaHarfBuzzFont> SkiaHarfBuzzFont::getOrCreate(SkTypeface& typeface)
 {
-    return FontCache::forCurrentThread().harfBuzzFontCache().font(typeface);
+    return FontCache::forCurrentThread()->harfBuzzFontCache().font(typeface);
 }
 
 static hb_font_funcs_t* harfBuzzFontFunctions()
@@ -140,7 +140,7 @@ SkiaHarfBuzzFont::SkiaHarfBuzzFont(SkTypeface& typeface)
 
 SkiaHarfBuzzFont::~SkiaHarfBuzzFont()
 {
-    FontCache::forCurrentThread().harfBuzzFontCache().remove(m_uniqueID);
+    FontCache::forCurrentThread()->harfBuzzFontCache().remove(m_uniqueID);
 }
 
 static inline hb_position_t skScalarToHarfBuzzPosition(SkScalar value)

--- a/Source/WebKitLegacy/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -84,7 +84,6 @@ mac/DOM/DOMTreeWalker.mm
 mac/DOM/DOMXPathExpression.mm
 mac/DOM/DOMXPathResult.mm
 mac/DOM/WebDOMOperations.mm
-mac/Misc/WebCoreStatistics.mm
 mac/Misc/WebElementDictionary.mm
 mac/Misc/WebNSPasteboardExtras.mm
 mac/Misc/WebSharingServicePickerController.mm

--- a/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
@@ -139,17 +139,17 @@ static RetainPtr<NSCountedSet> createNSCountedSet(const HashCountedSet<ASCIILite
 
 + (size_t)cachedFontDataCount
 {
-    return FontCache::forCurrentThread().fontCount();
+    return FontCache::forCurrentThread()->fontCount();
 }
 
 + (size_t)cachedFontDataInactiveCount
 {
-    return FontCache::forCurrentThread().inactiveFontCount();
+    return FontCache::forCurrentThread()->inactiveFontCount();
 }
 
 + (void)purgeInactiveFontData
 {
-    FontCache::forCurrentThread().purgeInactiveFontData();
+    FontCache::forCurrentThread()->purgeInactiveFontData();
 }
 
 + (size_t)glyphPageCount


### PR DESCRIPTION
#### 4dd0136e96991368db4273115b61e0d0cbac563f
<pre>
FontCache::forCurrentThread(): Avoid some unsafe unchecked reference to FontCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=291876">https://bugs.webkit.org/show_bug.cgi?id=291876</a>
<a href="https://rdar.apple.com/149725020">rdar://149725020</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::CSSFontFace::font):
* Source/WebCore/css/CSSFontFaceSet.cpp:
(WebCore::CSSFontFaceSet::ensureLocalFontFacesForFamilyRegistered):
* Source/WebCore/css/CSSFontFaceSource.cpp:
(WebCore::CSSFontFaceSource::load):
(WebCore::CSSFontFaceSource::font):
* Source/WebCore/css/CSSFontSelector.cpp:
(WebCore::m_version):
(WebCore::CSSFontSelector::fontRangesForFamily):
(WebCore::CSSFontSelector::fallbackFontAt):
* Source/WebCore/editing/cocoa/FontAttributeChangesCocoa.mm:
(WebCore::FontChanges::platformFontFamilyNameForCSS const):
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::getSupportedSystemFontFamilyNames):
* Source/WebCore/page/ProcessWarming.cpp:
(WebCore::ProcessWarming::collectPrewarmInformation):
(WebCore::ProcessWarming::prewarmWithInformation):
* Source/WebCore/platform/graphics/Font.cpp:
(WebCore::m_shouldNotBeUsedForArabic):
* Source/WebCore/platform/graphics/FontCache.cpp:
(WebCore::FontCache::forCurrentThread):
(WebCore::dispatchToAllFontCaches):
* Source/WebCore/platform/graphics/FontCache.h:
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::isCurrent const):
(WebCore::FontCascade::update const):
(WebCore::FontCascade::computeUseBackslashAsYenSymbol const):
* Source/WebCore/platform/graphics/FontCascadeCache.cpp:
(WebCore::FontCascadeCache::forCurrentThread):
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::FontCascadeFonts::FontCascadeFonts):
(WebCore::realizeNextFallback):
(WebCore::FontCascadeFonts::realizeFallbackRangesAt):
* Source/WebCore/platform/graphics/FontPlatformData.cpp:
(WebCore::FontPlatformData::updateSizeWithFontSizeAdjust):
* Source/WebCore/platform/graphics/SystemFallbackFontCache.cpp:
(WebCore::SystemFallbackFontCache::forCurrentThread):
(WebCore::SystemFallbackFontCache::systemFallbackFontForCharacterCluster):
* Source/WebCore/platform/graphics/cairo/FontCairoHarfbuzzNG.cpp:
(WebCore::FontCascade::fontForCombiningCharacterSequence const):
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::fontCacheRegisteredFontsChangedNotificationCallback):
(WebCore::FontCache::prewarmGlobally):
* Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreText.cpp:
(WebCore::FontFamilySpecificationCoreText::fontRanges const):
* Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreTextCache.cpp:
(WebCore::FontFamilySpecificationCoreTextCache::forCurrentThread):
* Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp:
(WebCore::SystemFontDatabaseCoreText::forCurrentThread):
* Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm:
(WebCore::ComplexTextController::collectComplexTextRunsForCharacters):
* Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp:
(WebCore::FontCustomPlatformData::create):
* Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp:
(WebCore::FontPlatformData::create):
* Source/WebCore/platform/graphics/skia/SkiaHarfBuzzFont.cpp:
(WebCore::SkiaHarfBuzzFont::getOrCreate):
(WebCore::SkiaHarfBuzzFont::~SkiaHarfBuzzFont):
* Source/WebKitLegacy/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm:
(+[WebCoreStatistics cachedFontDataCount]):
(+[WebCoreStatistics cachedFontDataInactiveCount]):
(+[WebCoreStatistics purgeInactiveFontData]):

Canonical link: <a href="https://commits.webkit.org/293971@main">https://commits.webkit.org/293971@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/130177e97963b43588c27ee97ed2a2269a5126a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10387 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105573 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51024 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102477 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20395 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28562 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76474 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33528 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103443 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90724 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56830 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15441 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8727 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50399 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85357 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8806 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107927 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27554 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20219 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85425 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27917 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86924 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84963 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21616 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29650 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7383 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21517 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27489 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32735 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27300 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30618 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28858 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->