### PR TITLE
Add LIFETIME_BOUND to more functions that return WTF::StringView from their input parameters

### DIFF
--- a/Source/WTF/wtf/text/StringBuilder.h
+++ b/Source/WTF/wtf/text/StringBuilder.h
@@ -81,7 +81,7 @@ public:
     bool isEmpty() const { return !m_length; }
     unsigned length() const;
 
-    operator StringView() const;
+    operator StringView() const LIFETIME_BOUND;
     UChar operator[](unsigned i) const;
 
     bool is8Bit() const;

--- a/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 
 enum class ApplicationCacheParserMode { Explicit, Fallback, OnlineAllowlist, Unknown };
 
-static StringView manifestPath(const URL& manifestURL)
+static StringView manifestPath(const URL& manifestURL LIFETIME_BOUND)
 {
     auto manifestPath = manifestURL.path();
     ASSERT(manifestPath[0] == '/');

--- a/Source/WebCore/platform/network/RFC8941.cpp
+++ b/Source/WebCore/platform/network/RFC8941.cpp
@@ -46,7 +46,7 @@ template<typename CharacterType> constexpr bool isEndOfKey(CharacterType charact
 }
 
 // Parsing a key (https://datatracker.ietf.org/doc/html/rfc8941#section-4.2.3.3).
-template<typename CharType> static StringView parseKey(StringParsingBuffer<CharType>& buffer)
+template<typename CharType> static StringView parseKey(StringParsingBuffer<CharType>& buffer LIFETIME_BOUND)
 {
     if (buffer.atEnd() || !isASCIILower(*buffer))
         return { };


### PR DESCRIPTION
#### aab018b874e6592f6e2db9b74df66eb3ca8c0d92
<pre>
Add LIFETIME_BOUND to more functions that return WTF::StringView from their input parameters
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=291881">https://bugs.webkit.org/show_bug.cgi?id=291881</a>&gt;
&lt;<a href="https://rdar.apple.com/149734109">rdar://149734109</a>&gt;

Reviewed by Geoffrey Garen.

* Source/WTF/wtf/text/StringBuilder.h:
(WTF::StringBuilder::operator StringView):
- Add LIFETIME_BOUND to method declaration since it returns a StringView
  to a data member.
* Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp:
(WebCore::manifestPath):
- Add LIFETIME_BOUND to parameter since the StringView returned points
  to data from the parameter object.
* Source/WebCore/platform/network/RFC8941.cpp:
(RFC8941::parseKey):
- Ditto.

Canonical link: <a href="https://commits.webkit.org/293952@main">https://commits.webkit.org/293952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52ebe0157d4e57c851cf7ee899d1e9aa1fa44e26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105536 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50988 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102441 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28526 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76446 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33501 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15593 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90692 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56802 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15410 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8694 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50358 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/93062 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85325 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107891 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/99008 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27518 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20188 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85401 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27881 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86892 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84938 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29619 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7351 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21446 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16337 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27453 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32694 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122634 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27264 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34212 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30582 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28822 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->