### PR TITLE
GoogleTest assertions should support CG/NSPoint

### DIFF
--- a/Tools/TestWebKitAPI/cocoa/TestCocoa.h
+++ b/Tools/TestWebKitAPI/cocoa/TestCocoa.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,6 +51,8 @@ void instantiateUIApplicationIfNeeded(Class customApplicationClass = nil);
 
 #if USE(CG)
 
+std::ostream& operator<<(std::ostream&, const CGPoint&);
+bool operator==(const CGPoint&, const CGPoint&);
 std::ostream& operator<<(std::ostream&, const CGRect&);
 bool operator==(const CGRect&, const CGRect&);
 
@@ -61,6 +63,8 @@ constexpr CGFloat blueColorComponents[4] = { 0, 0, 1, 1 };
 
 #if PLATFORM(MAC) && !defined(NSGEOMETRY_TYPES_SAME_AS_CGGEOMETRY_TYPES)
 
+std::ostream& operator<<(std::ostream&, const NSPoint&);
+bool operator==(const NSPoint&, const NSPoint&);
 std::ostream& operator<<(std::ostream&, const NSRect&);
 bool operator==(const NSRect&, const NSRect&);
 

--- a/Tools/TestWebKitAPI/cocoa/TestCocoa.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,10 +33,26 @@
 template<typename T>
 static inline std::ostream& ostreamRectCommon(std::ostream& os, const T& rect)
 {
-    return os << "(origin = (x = " << rect.origin.x << ", y = " << rect.origin.y << "), size = (width = " << rect.size.width << ", height = " << rect.size.height << "))";
+    return os << "(origin = " << rect.origin << ", size = (width = " << rect.size.width << ", height = " << rect.size.height << "))";
+}
+
+template<typename T>
+static inline std::ostream& ostreamPointCommon(std::ostream& os, const T& point)
+{
+    return os << "(x = " << point.x << ", y = " << point.y << ")";
 }
 
 #if USE(CG)
+
+std::ostream& operator<<(std::ostream& os, const CGPoint& point)
+{
+    return ostreamPointCommon(os, point);
+}
+
+bool operator==(const CGPoint& a, const CGPoint& b)
+{
+    return CGPointEqualToPoint(a, b);
+}
 
 std::ostream& operator<<(std::ostream& os, const CGRect& rect)
 {
@@ -51,6 +67,16 @@ bool operator==(const CGRect& a, const CGRect& b)
 #endif
 
 #if PLATFORM(MAC) && !defined(NSGEOMETRY_TYPES_SAME_AS_CGGEOMETRY_TYPES)
+
+std::ostream& operator<<(std::ostream& os, const NSPoint& point)
+{
+    return ostreamPointCommon(os, point);
+}
+
+bool operator==(const NSPoint& a, const NSPoint& b)
+{
+    return NSEqualPoints(a, b);
+}
 
 std::ostream& operator<<(std::ostream& os, const NSRect& rect)
 {


### PR DESCRIPTION
#### 225688243abae7adebbcd13b6537481cdec8c5f3
<pre>
GoogleTest assertions should support CG/NSPoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=291893">https://bugs.webkit.org/show_bug.cgi?id=291893</a>
<a href="https://rdar.apple.com/149753246">rdar://149753246</a>

Reviewed by Aditya Keerthi.

This patch provides operator== and operator&lt;&lt; overloads for CGPoint and
NSPoint so that these types can be used with EXPECT_EQ() and other
GoogleTest assertions.

Following this patch, an assertion like this:

    EXPECT_EQ(CGPointMake(1, 2), CGPointMake(3, 4));

will produce output like this when it fails:

    Expected equality of these values:
      CGPointMake(1, 2)
        Which is: (x = 1, y = 2)
      CGPointMake(3, 4)
        Which is: (x = 3, y = 4)

* Tools/TestWebKitAPI/cocoa/TestCocoa.h:
* Tools/TestWebKitAPI/cocoa/TestCocoa.mm:
(ostreamRectCommon):
  Make slightly succint now that operator&lt;&lt;(..., CG/NSPoint) is a thing.
(ostreamPointCommon):
(operator&lt;&lt;):
(operator==):

Canonical link: <a href="https://commits.webkit.org/293960@main">https://commits.webkit.org/293960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d6618a5d63301dc28fa7ae58c26d7618c832464

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10367 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105553 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51004 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102457 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20374 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28542 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76459 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33512 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15606 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90705 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56815 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15423 "Found 60 new test failures: imported/w3c/web-platform-tests/css/css-contain/contain-size-021.html imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-003.html imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-007.html imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-012.html imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-022.html imported/w3c/web-platform-tests/fetch/api/abort/request.any.serviceworker.html imported/w3c/web-platform-tests/fetch/api/basic/accept-header.any.html imported/w3c/web-platform-tests/fetch/api/basic/error-after-response.any.sharedworker.html imported/w3c/web-platform-tests/fetch/api/basic/header-value-combining.any.sharedworker.html imported/w3c/web-platform-tests/fetch/api/basic/header-value-null-byte.any.sharedworker.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8707 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50377 "Failed to compile WebKit") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85338 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8787 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107907 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27534 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20201 "Found 1 new test failure: fast/css/view-transitions-hide-under-page-background-color.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85412 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27897 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86905 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84949 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21611 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29633 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7364 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21485 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27469 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27280 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30598 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28838 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->