### PR TITLE
Re-land 293913@main (Support JSVALUE32_64 in WasmIPIntSlowPaths)

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -348,8 +348,8 @@ end
 
 macro operationCallMayThrow(fn)
     loadp Wasm::IPIntCallee::m_bytecode[ws0], t0
-    negq t0
-    addq PC, t0
+    negp t0
+    addp PC, t0
     storei t0, CallSiteIndex[cfr]
 
     move wasmInstance, a0
@@ -360,7 +360,7 @@ macro operationCallMayThrow(fn)
         push PL, IB
     end
     fn()
-    bqneq r0, 1, .continuation
+    bpneq r0, (constexpr JSC::IPInt::SlowPathExceptionTag), .continuation
     storei r1, ArgumentCountIncludingThis + PayloadOffset[cfr]
     jmp _wasm_throw_from_slow_path_trampoline
 .continuation:

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -844,7 +844,7 @@ instructionLabel(_table_get)
 
     operationCallMayThrow(macro() cCall3(_ipint_extern_table_get) end)
 
-    pushQuad(t0)
+    pushQuad(r1)
 
     loadb IPInt::Const32Metadata::instructionLength[MC], t0
 
@@ -2816,16 +2816,12 @@ instructionLabel(_i64_reinterpret_f64)
     nextIPIntInstruction()
 
 instructionLabel(_f32_reinterpret_i32)
-    pushInt32(t0)
-    fi2f t0, ft0
-    popFloat32(ft0)
+    # nop because of stack layout
     advancePC(1)
     nextIPIntInstruction()
 
 instructionLabel(_f64_reinterpret_i64)
-    pushInt64(t0)
-    fq2d t0, ft0
-    popFloat64(ft0)
+    # nop because of stack layout
     advancePC(1)
     nextIPIntInstruction()
 
@@ -2904,7 +2900,7 @@ instructionLabel(_ref_func)
     move wasmInstance, a0
     loadi IPInt::Const32Metadata::value[MC], a1
     operationCall(macro() cCall2(_ipint_extern_ref_func) end)
-    pushQuad(t0)
+    pushQuad(r1)
     loadb IPInt::Const32Metadata::instructionLength[MC], t0
     advancePC(t0)
     advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
@@ -3623,7 +3619,7 @@ instructionLabel(_i64_trunc_sat_f32_s)
     nextIPIntInstruction()
 
 .ipint_i64_trunc_sat_f32_s_outOfBoundsTruncSatMinOrNaN:
-    bfeq ft0, ft0, .ipint_i64_trunc_sat_f32_s_outOfBoundsTruncSatMax
+    bfeq ft0, ft0, .ipint_i64_trunc_sat_f32_s_outOfBoundsTruncSatMin
     move 0, t0
     pushInt64(t0)
 
@@ -3634,6 +3630,15 @@ instructionLabel(_i64_trunc_sat_f32_s)
 
 .ipint_i64_trunc_sat_f32_s_outOfBoundsTruncSatMax:
     move (constexpr INT64_MAX), t0
+    pushInt64(t0)
+
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    nextIPIntInstruction()
+
+.ipint_i64_trunc_sat_f32_s_outOfBoundsTruncSatMin:
+    move (constexpr INT64_MIN), t0
     pushInt64(t0)
 
     loadb IPInt::InstructionLengthMetadata::length[MC], t0

--- a/Source/JavaScriptCore/llint/LLIntOffsetsExtractor.cpp
+++ b/Source/JavaScriptCore/llint/LLIntOffsetsExtractor.cpp
@@ -74,6 +74,7 @@
 #include "WasmCallingConvention.h"
 #include "WasmFunctionCodeBlockGenerator.h"
 #include "WasmIPIntGenerator.h"
+#include "WasmIPIntSlowPaths.h"
 #include "Watchdog.h"
 #include "WebAssemblyFunction.h"
 #include <stdio.h>

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include "CommonSlowPaths.h"
+#include "JSCJSValue.h"
 #include "WasmExceptionType.h"
 #include "WasmIPIntGenerator.h"
 #include "WasmTypeDefinition.h"
@@ -38,6 +39,12 @@ namespace JSC {
 class JSWebAssemblyInstance;
 
 namespace IPInt {
+
+#if USE(JSVALUE64)
+static constexpr uintptr_t SlowPathExceptionTag = 1;
+#elif USE(JSVALUE32_64)
+static constexpr uintptr_t SlowPathExceptionTag = JSValue::InvalidTag;
+#endif
 
 #define WASM_IPINT_EXTERN_CPP_DECL(name, ...) \
     extern "C" UGPRPair SYSV_ABI ipint_extern_##name(JSWebAssemblyInstance* instance, __VA_ARGS__)


### PR DESCRIPTION
#### 57d3a9af82a0686179ee2672d4cb2c053efe4f36
<pre>
Re-land 293913@main (Support JSVALUE32_64 in WasmIPIntSlowPaths)
<a href="https://bugs.webkit.org/show_bug.cgi?id=291905">https://bugs.webkit.org/show_bug.cgi?id=291905</a>
<a href="https://rdar.apple.com/149779888">rdar://149779888</a>

Reviewed by Yusuke Suzuki and Justin Michaud.

This fixes a small issue in the original commit where `t1` was
used instead of `r1` on x86_64, meaning that we wouldn&apos;t fetch
the correct return value from an operation.

Original commit by Max Rottenkolber:
We return from IPInt slow path operations as follows:

 - when we return an exception:
   + on 64 bit: r0(SlowPathExceptionTag=1) r1(exception)
   + on 32 bit: r0(SlowPathExceptionTag=InvalidTag) r1(exception)
 - when we return a JSValue
   + on 64 bit: r0(EncodedJSValue) r1(0)
   + on 32 bit: r0(EncodedJSValue/Tag) r1(EncodedJSValue/Payload)

Also fixes some floating point instructions I came across by chance
in InPlaceInterpreter64.asm

* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/llint/LLIntOffsetsExtractor.cpp:
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL_1P):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h:

Canonical link: <a href="https://commits.webkit.org/293913@main">https://commits.webkit.org/293913@main</a>

* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/llint/LLIntOffsetsExtractor.cpp:
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL_1P):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h:

Canonical link: <a href="https://commits.webkit.org/293981@main">https://commits.webkit.org/293981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79f73aaca58e75764a28c50f97cce2a42d8879d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20094 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105579 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51030 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28568 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76481 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33534 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103449 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15630 "Found 1 new test failure: fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90730 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56837 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15446 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8733 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50405 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/93106 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85363 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8812 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107933 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/99050 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27560 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20226 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85433 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27923 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84971 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21620 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29657 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7389 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21525 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27495 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32745 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122676 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27306 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34219 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30624 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28864 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->