### PR TITLE
[iOS] Select-multiple controls may be sized incorrectly

### DIFF
--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
@@ -915,6 +915,14 @@ static NSString *optionCellReuseIdentifier = @"WKSelectPickerTableViewCell";
     RetainPtr<UIBarButtonItem> _nextButton;
 }
 
+#if ENABLE(SELECT_MULTIPLE_ADJUSTMENTS)
+#import <WebKitAdditions/WKSelectPickerTableViewControllerAdditions.mm>
+#else
+- (void)performAdjustmentsIfNeeded
+{
+}
+#endif
+
 - (id)initWithView:(WKContentView *)view
 {
     if (!(self = [super initWithStyle:UITableViewStyleGrouped]))
@@ -946,6 +954,8 @@ static NSString *optionCellReuseIdentifier = @"WKSelectPickerTableViewCell";
         if (option.isGroup)
             _numberOfSections++;
     }
+
+    [self performAdjustmentsIfNeeded];
 
     return self;
 }

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPopover.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPopover.mm
@@ -376,6 +376,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     RetainPtr<WKSelectTableViewController> _tableViewController;
 }
 
+#if ENABLE(SELECT_MULTIPLE_ADJUSTMENTS)
+#import <WebKitAdditions/WKSelectPopoverAdditions.mm>
+#else
+- (void)performAdjustmentsIfNeeded
+{
+}
+#endif
+
 - (instancetype)initWithView:(WKContentView *)view hasGroups:(BOOL)hasGroups
 {
     if (!(self = [super initWithView:view]))
@@ -397,6 +405,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     self.popoverController = adoptNS([[UIPopoverController alloc] initWithContentViewController:popoverViewController.get()]).get();
 ALLOW_DEPRECATED_DECLARATIONS_END
+
+    [self performAdjustmentsIfNeeded];
 
     return self;
 }


### PR DESCRIPTION
#### a8666542ed180f6549bcfe94f7173c74edfb65aa
<pre>
[iOS] Select-multiple controls may be sized incorrectly
<a href="https://bugs.webkit.org/show_bug.cgi?id=291909">https://bugs.webkit.org/show_bug.cgi?id=291909</a>
<a href="https://rdar.apple.com/149792964">rdar://149792964</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

Call new method `performAdjustmentsIfNeeded` to resolve an
issue where the views used for select-multiple controls
could be sized incorrectly.

* Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm:
(-[WKSelectPickerTableViewController performAdjustmentsIfNeeded]):
(-[WKSelectPickerTableViewController initWithView:]):
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPopover.mm:
(-[WKSelectPopover performAdjustmentsIfNeeded]):
(-[WKSelectPopover initWithView:hasGroups:]):

Canonical link: <a href="https://commits.webkit.org/293995@main">https://commits.webkit.org/293995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e18343b77a99b1539d0603bf24ce68a08ca74052

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105589 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51040 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28578 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76489 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33543 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90741 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56844 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15463 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50416 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85379 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8823 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107943 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20236 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85441 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27933 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86941 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84979 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21631 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29669 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7400 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21535 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27505 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32755 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27316 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30634 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28874 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->