### PR TITLE
[css-grid] Wrong 'auto' track size for a grid item

### DIFF
--- a/LayoutTests/fast/css-grid-layout/max-content-track-sizing-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/max-content-track-sizing-expected.txt
@@ -1,0 +1,11 @@
+Test that resolving minmax(auto, <fixed>) with different width properties on grid items works properly under max-content constraints
+
+grid-template-columns: minmax(auto, 15px)
+
+XXXX
+PASS
+
+grid-template-columns: minmax(auto, 30px)
+
+XXXX
+PASS

--- a/LayoutTests/fast/css-grid-layout/max-content-track-sizing.html
+++ b/LayoutTests/fast/css-grid-layout/max-content-track-sizing.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<link href="resources/grid.css" rel="stylesheet">
+<style>
+.grid {
+    display: inline-grid;
+    align-items: start;
+    justify-items: start;
+    border: 1px dotted;
+    margin-bottom: 4px;
+}
+
+.gridMinMaxAuto15px {
+    grid-template-columns: minmax(auto, 15px);
+    grid-template-rows: auto;
+}
+
+.gridMinMaxAuto30px {
+    grid-template-columns: minmax(auto, 30px);
+    grid-template-rows: auto;
+}
+
+.firstRowFirstColumn {
+    font: 10px/1 Ahem;
+    width: max-content; /* Equivalent to max-content in the original test */
+}
+
+.firstRowFirstColumn.min-content {
+    width: -moz-min-content;
+    width: -webkit-min-content;
+    width: min-content;
+}
+
+.firstRowFirstColumn.max-content {
+    width: -moz-max-content;
+    width: -webkit-max-content;
+    width: max-content;
+}
+
+.firstRowFirstColumn.fit-content {
+    width: -moz-fit-content;
+    width: -webkit-fit-content;
+    width: fit-content;
+}
+
+.firstRowFirstColumn.fill {
+    width: -moz-available;
+    width: -webkit-fill-available;
+    width: fill;
+}
+</style>
+<script src="../../resources/check-layout.js"></script>
+<body onload="checkLayout('.gridMinMaxAuto15px'); checkLayout('.gridMinMaxAuto30px')">
+
+<p>Test that resolving minmax(auto, &lt;fixed&gt;) with different width properties on grid items works properly under max-content constraints</p>
+<!-- Tests for grid-template-columns: minmax(auto, 15px) -->
+<pre>grid-template-columns: minmax(auto, 15px)</pre>
+<br>
+<div class="constrainedContainer">
+    <div class="grid gridMinMaxAuto15px" data-expected-width="42" data-expected-height="12">
+        <div class="firstRowFirstColumn max-content" data-expected-width="40" data-expected-height="10">XXXX</div>
+    </div>
+</div>
+<br>
+<!-- Tests for grid-template-columns: minmax(auto, 30px) -->
+<pre>grid-template-columns: minmax(auto, 30px)</pre>
+<br>
+<div class="constrainedContainer">
+    <div class="grid gridMinMaxAuto30px" data-expected-width="42" data-expected-height="12">
+        <div class="firstRowFirstColumn max-content" data-expected-width="40" data-expected-height="10">XXXX</div>
+    </div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -282,10 +282,20 @@ LayoutUnit GridTrackSizingAlgorithm::initialGrowthLimit(const GridTrackSize& tra
 
 bool GridTrackSizingAlgorithm::isUnderMaxContentConstraint() const
 {
-    // inline-grid sizes to its content by default, which is a max-content constraint
-    if (m_renderGrid->style().display() == DisplayType::InlineGrid)
-        return true;
-    return !availableSpace(m_direction).has_value();
+    bool noAvailableSpace = !availableSpace(m_direction).has_value();
+    // Also check if the grid has an explicit max-content size
+    if (m_direction == GridTrackSizingDirection::ForColumns) {
+        const auto& gridStyle = m_renderGrid->style();
+        // Check if width is explicitly set to max-content
+        if (gridStyle.width().isMaxContent())
+            return true;
+    } else {
+        const auto& gridStyle = m_renderGrid->style();
+        // Check if height is explicitly set to max-content
+        if (gridStyle.height().isMaxContent())
+            return true;
+    }
+    return noAvailableSpace;
 }
 
 void GridTrackSizingAlgorithm::sizeTrackToFitSingleSpanMasonryGroup(const GridSpan& span, MasonryMinMaxTrackSize& masonryIndefiniteItems, GridTrack& track)
@@ -319,9 +329,8 @@ void GridTrackSizingAlgorithm::sizeTrackToFitNonSpanningItem(const GridSpan& spa
         track.setBaseSize(std::max(track.baseSize(), m_strategy->minContentContributionForGridItem(gridItem, gridLayoutState)));
     } else if (trackSize.hasMaxContentMinTrackBreadth()) {
         track.setBaseSize(std::max(track.baseSize(), m_strategy->maxContentContributionForGridItem(gridItem, gridLayoutState)));
-    } else if (trackSize.hasAutoMinTrackBreadth()) {
+    } else if (trackSize.hasAutoMinTrackBreadth())
         track.setBaseSize(std::max(track.baseSize(), m_strategy->minContributionForGridItem(gridItem, gridLayoutState)));
-    }
 
     if (trackSize.hasMinContentMaxTrackBreadth()) {
         track.setGrowthLimit(std::max(track.growthLimit(), m_strategy->minContentContributionForGridItem(gridItem, gridLayoutState)));
@@ -331,12 +340,8 @@ void GridTrackSizingAlgorithm::sizeTrackToFitNonSpanningItem(const GridSpan& spa
             growthLimit = std::min(growthLimit, valueForLength(trackSize.fitContentTrackBreadth().length(), availableSpace().value_or(0)));
         track.setGrowthLimit(std::max(track.growthLimit(), growthLimit));
     } else if (m_direction == GridTrackSizingDirection::ForColumns && isUnderMaxContentConstraint() && trackSize.hasIntrinsicMinTrackBreadth()) {
-        // Apply this logic only for columns to preserve original row sizing behavior
-        // Allow the track to grow to max-content under a max-content constraint if:
-        // The min track sizing function is intrinsic (e.g., auto, min-content, max-content).
-        // If the max track sizing function is fixed (e.g., 40px), only allow growth if the min track sizing function is 'auto'.
+        // Allow tracks with intrinsic min sizing functions to grow to max-content under max-content constraints (columns only)
         if (!trackSize.hasMinContentMaxTrackBreadth() && (!trackSize.hasFixedMaxTrackBreadth() || trackSize.hasAutoMinTrackBreadth()))
-
             track.setGrowthLimit(std::max(track.growthLimit(), m_strategy->maxContentContributionForGridItem(gridItem, gridLayoutState)));
     }
 }

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -280,6 +280,14 @@ LayoutUnit GridTrackSizingAlgorithm::initialGrowthLimit(const GridTrackSize& tra
     return infinity;
 }
 
+bool GridTrackSizingAlgorithm::isUnderMaxContentConstraint() const
+{
+    // inline-grid sizes to its content by default, which is a max-content constraint
+    if (m_renderGrid->style().display() == DisplayType::InlineGrid)
+        return true;
+    return !availableSpace(m_direction).has_value();
+}
+
 void GridTrackSizingAlgorithm::sizeTrackToFitSingleSpanMasonryGroup(const GridSpan& span, MasonryMinMaxTrackSize& masonryIndefiniteItems, GridTrack& track)
 {
     auto trackPosition = span.startLine();
@@ -322,6 +330,14 @@ void GridTrackSizingAlgorithm::sizeTrackToFitNonSpanningItem(const GridSpan& spa
         if (trackSize.isFitContent())
             growthLimit = std::min(growthLimit, valueForLength(trackSize.fitContentTrackBreadth().length(), availableSpace().value_or(0)));
         track.setGrowthLimit(std::max(track.growthLimit(), growthLimit));
+    } else if (m_direction == GridTrackSizingDirection::ForColumns && isUnderMaxContentConstraint() && trackSize.hasIntrinsicMinTrackBreadth()) {
+        // Apply this logic only for columns to preserve original row sizing behavior
+        // Allow the track to grow to max-content under a max-content constraint if:
+        // The min track sizing function is intrinsic (e.g., auto, min-content, max-content).
+        // If the max track sizing function is fixed (e.g., 40px), only allow growth if the min track sizing function is 'auto'.
+        if (!trackSize.hasMinContentMaxTrackBreadth() && (!trackSize.hasFixedMaxTrackBreadth() || trackSize.hasAutoMinTrackBreadth()))
+
+            track.setGrowthLimit(std::max(track.growthLimit(), m_strategy->maxContentContributionForGridItem(gridItem, gridLayoutState)));
     }
 }
 

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -194,7 +194,7 @@ private:
     // Helper methods for step 2. resolveIntrinsicTrackSizes().
     void sizeTrackToFitNonSpanningItem(const GridSpan&, RenderBox& gridItem, GridTrack&, GridLayoutState&);
     void sizeTrackToFitSingleSpanMasonryGroup(const GridSpan&, MasonryMinMaxTrackSize&, GridTrack&);
-
+    bool isUnderMaxContentConstraint() const;
     bool spanningItemCrossesFlexibleSizedTracks(const GridSpan&) const;
 
     using GridItemsSpanGroupRange = std::span<GridItemWithSpan>;


### PR DESCRIPTION
#### 78184d38af9fb3351dd7aa35ea45fc640ad727d7
<pre>
[css-grid] Wrong &apos;auto&apos; track size for a grid item
with a specified &apos;width:max-content&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=216144">https://bugs.webkit.org/show_bug.cgi?id=216144</a>

Reviewed by NOBODY (OOPS!).

This patch corrects the logic determining whether a grid container is
sized under a max-content constraint. The previous implementation
assumed that inline-grid implies a max-content constraint, which is
incorrect, as atomic inlines use fit-content sizing behavior.

* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::isUnderMaxContentConstraint const):
(WebCore::GridTrackSizingAlgorithm::sizeTrackToFitNonSpanningItem):
</pre>
----------------------------------------------------------------------
#### 40c3957c5ff2c75527c788245781795cc4813f1c
<pre>
Wrong &apos;auto&apos; track size in minmax content for a grid item with a specified &apos;width:max-content&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=216144">https://bugs.webkit.org/show_bug.cgi?id=216144</a>

Reviewed by NOBODY (OOPS!).

The addition of the new condition in sizeTrackToFitNonSpanningItem allows the grid track to grow to the max-content contribution of its items if the track has an auto min track sizing function and the grid container is being sized under a min/max-content constraint. This behavior applies only when the min track sizing function is auto.

* LayoutTests/fast/css-grid-layout/max-content-track-sizing-expected.txt: Added.
* LayoutTests/fast/css-grid-layout/max-content-track-sizing.html: Added.
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::isUnderMaxContentConstraint const):
(WebCore::GridTrackSizingAlgorithm::sizeTrackToFitNonSpanningItem):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78184d38af9fb3351dd7aa35ea45fc640ad727d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21227 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106717 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52192 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103599 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21535 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29722 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77347 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-sizing/range-percent-intrinsic-size-1.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34371 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104566 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16627 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91716 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57685 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16451 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-sizing/range-percent-intrinsic-size-1.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9733 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-sizing/range-percent-intrinsic-size-1.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51539 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86321 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9810 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-sizing/range-percent-intrinsic-size-1.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109068 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28692 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21114 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-sizing/range-percent-intrinsic-size-1.html imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86320 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-sizing/range-percent-intrinsic-size-1.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29053 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87917 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85882 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30622 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8335 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-sizing/range-percent-intrinsic-size-1.html (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/22824 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28620 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33909 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28431 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31754 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29990 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->