### PR TITLE
[SaferCpp] InjectedBundle*Handle.cpp

### DIFF
--- a/Source/WebCore/html/HTMLTableCellElement.cpp
+++ b/Source/WebCore/html/HTMLTableCellElement.cpp
@@ -215,4 +215,9 @@ HTMLTableCellElement* HTMLTableCellElement::cellAbove() const
     return downcast<HTMLTableCellElement>(cellAboveRenderer->element());
 }
 
+RefPtr<HTMLTableCellElement> HTMLTableCellElement::protectedCellAbove() const
+{
+    return cellAbove();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLTableCellElement.h
+++ b/Source/WebCore/html/HTMLTableCellElement.h
@@ -61,6 +61,7 @@ public:
     WEBCORE_EXPORT void setScope(const AtomString&);
 
     WEBCORE_EXPORT HTMLTableCellElement* cellAbove() const;
+    WEBCORE_EXPORT RefPtr<HTMLTableCellElement> protectedCellAbove() const;
 
 private:
     HTMLTableCellElement(const QualifiedName&, Document&);

--- a/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -42,8 +42,6 @@ WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
 WebProcess/FullScreen/WebFullScreenManager.cpp
 WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
 WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
-WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
-WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp
 WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
 WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp
 WebProcess/Network/WebLoaderStrategy.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -143,8 +143,6 @@ WebProcess/InjectedBundle/API/mac/WKDOMText.mm
 WebProcess/InjectedBundle/API/mac/WKDOMTextIterator.mm
 WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm
 WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
-WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
-WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp
 WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
 WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
 WebProcess/InjectedBundle/InjectedBundlePageUIClient.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -13,9 +13,6 @@ WebProcess/InjectedBundle/API/c/WKBundle.cpp
 WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
 WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
 WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
-WebProcess/InjectedBundle/DOM/InjectedBundleCSSStyleDeclarationHandle.cpp
-WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
-WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp
 WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
 WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
 WebProcess/InjectedBundle/InjectedBundlePageContextMenuClient.cpp

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleCSSStyleDeclarationHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleCSSStyleDeclarationHandle.cpp
@@ -46,8 +46,8 @@ static DOMStyleDeclarationHandleCache& domStyleDeclarationHandleCache()
 
 RefPtr<InjectedBundleCSSStyleDeclarationHandle> InjectedBundleCSSStyleDeclarationHandle::getOrCreate(JSContextRef, JSObjectRef object)
 {
-    CSSStyleDeclaration* cssStyleDeclaration = JSCSSStyleDeclaration::toWrapped(toJS(object)->vm(), toJS(object));
-    return getOrCreate(cssStyleDeclaration);
+    RefPtr cssStyleDeclaration = JSCSSStyleDeclaration::toWrapped(toJS(object)->vm(), toJS(object));
+    return getOrCreate(cssStyleDeclaration.get());
 }
 
 RefPtr<InjectedBundleCSSStyleDeclarationHandle> InjectedBundleCSSStyleDeclarationHandle::getOrCreate(CSSStyleDeclaration* styleDeclaration)

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
@@ -75,8 +75,8 @@ static DOMNodeHandleCache& domNodeHandleCache()
 
 RefPtr<InjectedBundleNodeHandle> InjectedBundleNodeHandle::getOrCreate(JSContextRef, JSObjectRef object)
 {
-    Node* node = JSNode::toWrapped(toJS(object)->vm(), toJS(object));
-    return getOrCreate(node);
+    RefPtr node = JSNode::toWrapped(toJS(object)->vm(), toJS(object));
+    return getOrCreate(node.get());
 }
 
 RefPtr<InjectedBundleNodeHandle> InjectedBundleNodeHandle::getOrCreate(Node* node)
@@ -89,12 +89,12 @@ RefPtr<InjectedBundleNodeHandle> InjectedBundleNodeHandle::getOrCreate(Node* nod
 
 Ref<InjectedBundleNodeHandle> InjectedBundleNodeHandle::getOrCreate(Node& node)
 {
-    if (auto existingHandle = domNodeHandleCache().get(node))
+    if (RefPtr existingHandle = domNodeHandleCache().get(node))
         return Ref<InjectedBundleNodeHandle>(*existingHandle);
 
     auto nodeHandle = InjectedBundleNodeHandle::create(node);
-    if (nodeHandle->coreNode())
-        domNodeHandleCache().add(*nodeHandle->coreNode(), nodeHandle.get());
+    if (RefPtr node = nodeHandle->coreNode())
+        domNodeHandleCache().add(*node, nodeHandle.get());
     return nodeHandle;
 }
 
@@ -113,11 +113,16 @@ InjectedBundleNodeHandle::InjectedBundleNodeHandle(Node& node)
 
 InjectedBundleNodeHandle::~InjectedBundleNodeHandle()
 {
-    if (m_node)
-        domNodeHandleCache().remove(*m_node);
+    if (RefPtr node = m_node)
+        domNodeHandleCache().remove(*node);
 }
 
 Node* InjectedBundleNodeHandle::coreNode()
+{
+    return m_node.get();
+}
+
+RefPtr<Node> InjectedBundleNodeHandle::protectedCoreNode()
 {
     return m_node.get();
 }
@@ -127,7 +132,7 @@ RefPtr<InjectedBundleNodeHandle> InjectedBundleNodeHandle::document()
     if (!m_node)
         return nullptr;
 
-    return getOrCreate(m_node->document());
+    return getOrCreate(m_node->protectedDocument());
 }
 
 // Additional DOM Operations
@@ -147,7 +152,7 @@ IntRect InjectedBundleNodeHandle::absoluteBoundingRect(bool* isReplaced)
     if (!m_node)
         return { };
 
-    return m_node->pixelSnappedAbsoluteBoundingRect(isReplaced);
+    return protectedCoreNode()->pixelSnappedAbsoluteBoundingRect(isReplaced);
 }
 
 static RefPtr<WebImage> imageForRect(LocalFrameView* frameView, const IntRect& paintingRect, const std::optional<float>& bitmapWidth, SnapshotOptions options)
@@ -205,17 +210,17 @@ RefPtr<WebImage> InjectedBundleNodeHandle::renderedImage(SnapshotOptions options
     if (!m_node)
         return nullptr;
 
-    auto* frame = m_node->document().frame();
+    RefPtr frame = m_node->document().frame();
     if (!frame)
         return nullptr;
 
-    auto* frameView = frame->view();
+    RefPtr frameView = frame->view();
     if (!frameView)
         return nullptr;
 
-    m_node->document().updateLayout();
+    m_node->protectedDocument()->updateLayout();
 
-    RenderObject* renderer = m_node->renderer();
+    CheckedPtr renderer = m_node->renderer();
     if (!renderer)
         return nullptr;
 
@@ -228,7 +233,7 @@ RefPtr<WebImage> InjectedBundleNodeHandle::renderedImage(SnapshotOptions options
     }
 
     frameView->setNodeToDraw(m_node.get());
-    auto image = imageForRect(frameView, paintingRect, bitmapWidth, options);
+    RefPtr image = imageForRect(frameView.get(), paintingRect, bitmapWidth, options);
     frameView->setNodeToDraw(0);
 
     return image;
@@ -375,7 +380,7 @@ IntRect InjectedBundleNodeHandle::htmlInputElementAutoFillButtonBounds()
     if (!input)
         return IntRect();
 
-    auto autoFillButton = input->autoFillButtonElement();
+    RefPtr autoFillButton = input->autoFillButtonElement();
     if (!autoFillButton)
         return IntRect();
 
@@ -427,7 +432,7 @@ RefPtr<InjectedBundleNodeHandle> InjectedBundleNodeHandle::htmlTableCellElementC
     if (!tableCell)
         return nullptr;
 
-    return getOrCreate(tableCell->cellAbove());
+    return getOrCreate(tableCell->protectedCellAbove().get());
 }
 
 RefPtr<WebFrame> InjectedBundleNodeHandle::documentFrame()
@@ -436,7 +441,7 @@ RefPtr<WebFrame> InjectedBundleNodeHandle::documentFrame()
     if (!document)
         return nullptr;
 
-    auto* frame = document->frame();
+    RefPtr frame = document->frame();
     if (!frame)
         return nullptr;
 
@@ -445,11 +450,11 @@ RefPtr<WebFrame> InjectedBundleNodeHandle::documentFrame()
 
 RefPtr<WebFrame> InjectedBundleNodeHandle::htmlIFrameElementContentFrame()
 {
-    auto* iframeElement = dynamicDowncast<HTMLIFrameElement>(m_node.get());
+    RefPtr iframeElement = dynamicDowncast<HTMLIFrameElement>(m_node.get());
     if (!iframeElement)
         return nullptr;
 
-    auto* frame = iframeElement->contentFrame();
+    RefPtr frame = iframeElement->contentFrame();
     if (!frame)
         return nullptr;
 
@@ -459,8 +464,8 @@ RefPtr<WebFrame> InjectedBundleNodeHandle::htmlIFrameElementContentFrame()
 void InjectedBundleNodeHandle::stop()
 {
     // Invalidate handles to nodes inside documents that are about to be destroyed in order to prevent leaks.
-    if (m_node) {
-        domNodeHandleCache().remove(*m_node);
+    if (RefPtr node = m_node) {
+        domNodeHandleCache().remove(*node);
         m_node = nullptr;
     }
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h
@@ -55,6 +55,7 @@ public:
     virtual ~InjectedBundleNodeHandle();
 
     WebCore::Node* coreNode();
+    RefPtr<WebCore::Node> protectedCoreNode();
 
     // Convenience DOM Operations
     RefPtr<InjectedBundleNodeHandle> document();

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp
@@ -39,6 +39,7 @@
 #include <WebCore/JSRange.h>
 #include <WebCore/LocalFrame.h>
 #include <WebCore/LocalFrameView.h>
+#include <WebCore/NodeInlines.h>
 #include <WebCore/Page.h>
 #include <WebCore/Range.h>
 #include <WebCore/RenderView.h>
@@ -67,7 +68,8 @@ static DOMRangeHandleCache& domRangeHandleCache()
 
 RefPtr<InjectedBundleRangeHandle> InjectedBundleRangeHandle::getOrCreate(JSContextRef context, JSObjectRef object)
 {
-    return getOrCreate(JSRange::toWrapped(toJS(context)->vm(), toJS(object)));
+    RefPtr wrapped = JSRange::toWrapped(toJS(context)->vm(), toJS(object));
+    return getOrCreate(wrapped.get());
 }
 
 RefPtr<InjectedBundleRangeHandle> InjectedBundleRangeHandle::getOrCreate(WebCore::Range* range)
@@ -105,16 +107,16 @@ Ref<WebCore::Range> InjectedBundleRangeHandle::protectedCoreRange() const
 
 Ref<InjectedBundleNodeHandle> InjectedBundleRangeHandle::document()
 {
-    return InjectedBundleNodeHandle::getOrCreate(m_range->startContainer().document());
+    return InjectedBundleNodeHandle::getOrCreate(m_range->startContainer().protectedDocument());
 }
 
 WebCore::IntRect InjectedBundleRangeHandle::boundingRectInWindowCoordinates() const
 {
     auto range = makeSimpleRange(m_range);
-    auto frame = range.start.document().frame();
+    RefPtr frame = range.start.document().frame();
     if (!frame)
         return { };
-    auto view = frame->view();
+    RefPtr view = frame->view();
     if (!view)
         return { };
     return view->contentsToWindow(enclosingIntRect(unionRectIgnoringZeroRects(RenderObject::absoluteBorderAndTextRects(range))));
@@ -130,7 +132,7 @@ RefPtr<WebImage> InjectedBundleRangeHandle::renderedImage(SnapshotOptions option
     if (!frame)
         return nullptr;
 
-    auto frameView = frame->view();
+    RefPtr frameView = frame->view();
     if (!frameView)
         return nullptr;
 


### PR DESCRIPTION
#### 3d8fd44714d76d420d677fb5f55ed3434b4e819d
<pre>
[SaferCpp] InjectedBundle*Handle.cpp
<a href="https://rdar.apple.com/149529249">rdar://149529249</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291730">https://bugs.webkit.org/show_bug.cgi?id=291730</a>

Reviewed by Rupin Mittal.

* Source/WebCore/html/HTMLTableCellElement.cpp:
(WebCore::HTMLTableCellElement::protectedCellAbove const):
* Source/WebCore/html/HTMLTableCellElement.h:
* Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp:
(WebKit::InjectedBundleNodeHandle::getOrCreate):
(WebKit::InjectedBundleNodeHandle::~InjectedBundleNodeHandle):
(WebKit::InjectedBundleNodeHandle::protectedCoreNode):
(WebKit::InjectedBundleNodeHandle::document):
(WebKit::InjectedBundleNodeHandle::absoluteBoundingRect):
(WebKit::InjectedBundleNodeHandle::renderedImage):
(WebKit::InjectedBundleNodeHandle::htmlTableCellElementCellAbove):
(WebKit::InjectedBundleNodeHandle::documentFrame):
(WebKit::InjectedBundleNodeHandle::htmlIFrameElementContentFrame):
(WebKit::InjectedBundleNodeHandle::stop):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h:
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp:
(WebKit::InjectedBundleRangeHandle::getOrCreate):
(WebKit::InjectedBundleRangeHandle::document):
(WebKit::InjectedBundleRangeHandle::boundingRectInWindowCoordinates const):
(WebKit::InjectedBundleRangeHandle::renderedImage):

Canonical link: <a href="https://commits.webkit.org/294032@main">https://commits.webkit.org/294032@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab0cd6d66ddf4c256e5210fe70f4686b078c2d19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100619 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105756 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51207 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102660 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20579 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28745 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76621 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33662 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103626 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90885 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56976 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15612 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8892 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50583 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85520 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8967 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108110 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27737 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20373 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85575 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28100 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87086 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85115 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21654 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29813 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7539 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21725 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27672 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32923 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27483 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30801 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29041 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->