### PR TITLE
Support alternative configurations for web content restrictions

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/WebContentRestrictionsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/WebContentRestrictionsSPI.h
@@ -37,6 +37,11 @@
 + (BOOL)shouldEvaluateURLs;
 - (void)evaluateURL:(NSURL *)url withCompletion:(void (^)(BOOL shouldBlock, NSData * _Nullable blockPageRepresentation))completion onCompletionQueue:(dispatch_queue_t)queue;
 - (void)allowURL:(NSURL *)url withCompletion:(void (^)(BOOL didAllow, NSError *error))completion;
+
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+- (instancetype)initWithConfigurationAtPath:(NSString *)configurationPath;
++ (BOOL)shouldEvaluateURLsForConfigurationAtPath:(NSString *)configurationPath;
+#endif
 @end
 
 #endif // USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/loader/ContentFilter.cpp
+++ b/Source/WebCore/loader/ContentFilter.cpp
@@ -73,7 +73,10 @@ std::unique_ptr<ContentFilter> ContentFilter::create(ContentFilterClient& client
 {
     PlatformContentFilter::FilterParameters params {
 #if HAVE(WEBCONTENTRESTRICTIONS)
-        client.usesWebContentRestrictions()
+        client.usesWebContentRestrictions(),
+#endif
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+        client.webContentRestrictionsConfigurationPath(),
 #endif
     };
     auto filters = types().map([params](auto& type) {

--- a/Source/WebCore/loader/ContentFilterClient.h
+++ b/Source/WebCore/loader/ContentFilterClient.h
@@ -58,6 +58,9 @@ public:
 #if HAVE(WEBCONTENTRESTRICTIONS)
     virtual bool usesWebContentRestrictions() = 0;
 #endif
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    virtual String webContentRestrictionsConfigurationPath() const = 0;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2646,6 +2646,13 @@ bool DocumentLoader::usesWebContentRestrictions()
     return DeprecatedGlobalSettings::usesWebContentRestrictionsForFilter();
 }
 #endif
+
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+String DocumentLoader::webContentRestrictionsConfigurationPath() const
+{
+    return emptyString();
+}
+#endif
 #endif // ENABLE(CONTENT_FILTERING)
 
 #if ENABLE(CONTENT_FILTERING)

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -600,6 +600,9 @@ private:
 #if HAVE(WEBCONTENTRESTRICTIONS)
     WEBCORE_EXPORT bool usesWebContentRestrictions() final;
 #endif
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    WEBCORE_EXPORT String webContentRestrictionsConfigurationPath() const final;
+#endif
 #endif
 
     void redirectReceived(ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(ResourceRequest&&)>&&);

--- a/Source/WebCore/platform/ContentFilterUnblockHandler.h
+++ b/Source/WebCore/platform/ContentFilterUnblockHandler.h
@@ -85,6 +85,10 @@ public:
 #if HAVE(WEBCONTENTRESTRICTIONS)
     std::optional<URL> evaluatedURL() const { return m_evaluatedURL; }
 #endif
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    const String& configurationPath() const { return m_configurationPath; }
+    void setConfigurationPath(const String& path) { m_configurationPath = path; }
+#endif
 #if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
     WEBCORE_EXPORT Vector<uint8_t> webFilterEvaluatorData() const;
 #endif
@@ -102,6 +106,9 @@ private:
     UnblockRequesterFunction m_unblockRequester;
 #if HAVE(WEBCONTENTRESTRICTIONS)
     std::optional<URL> m_evaluatedURL;
+#endif
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    String m_configurationPath;
 #endif
 #if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
     RetainPtr<WebFilterEvaluator> m_webFilterEvaluator;

--- a/Source/WebCore/platform/PlatformContentFilter.h
+++ b/Source/WebCore/platform/PlatformContentFilter.h
@@ -86,6 +86,9 @@ public:
 #if HAVE(WEBCONTENTRESTRICTIONS)
         bool usesWebContentRestrictions { false };
 #endif
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+        String webContentRestrictionsConfigurationPath { };
+#endif
     };
 
 protected:

--- a/Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm
@@ -179,7 +179,12 @@ void ContentFilterUnblockHandler::requestUnblockAsync(DecisionHandlerFunction de
 {
 #if HAVE(WEBCONTENTRESTRICTIONS)
     if (m_evaluatedURL) {
-        WebCore::ParentalControlsURLFilter::singleton().allowURL(*m_evaluatedURL, [decisionHandler = WTFMove(decisionHandler)](bool didAllow) {
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+        auto& filter = WebCore::ParentalControlsURLFilter::filterWithConfigurationPath(configurationPath());
+#else
+        auto& filter = WebCore::ParentalControlsURLFilter::singleton();
+#endif
+        filter.allowURL(*m_evaluatedURL, [decisionHandler = WTFMove(decisionHandler)](bool didAllow) {
             callOnMainThread([decisionHandler = WTFMove(decisionHandler), didAllow]() {
                 RELEASE_LOG(ContentFiltering, "ParentalControlsURLFilter %" PUBLIC_LOG_STRING " the unblock request.\n", didAllow ? "allowed" : "did not allow");
                 decisionHandler(didAllow);

--- a/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
@@ -71,6 +71,9 @@ private:
     bool m_usesWebContentRestrictions { false };
     std::optional<URL> m_evaluatedURL;
 #endif
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    String m_webContentRestrictionsConfigurationPath;
+#endif
 };
     
 } // namespace WebCore

--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
@@ -33,20 +33,27 @@ namespace WebCore {
 
 class ParentalControlsURLFilter {
     WTF_MAKE_FAST_ALLOCATED;
-    friend UniqueRef<ParentalControlsURLFilter> WTF::makeUniqueRefWithoutFastMallocCheck<ParentalControlsURLFilter>();
 public:
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    static ParentalControlsURLFilter& filterWithConfigurationPath(const String&);
+#else
     static ParentalControlsURLFilter& singleton();
+#endif
 
     bool isEnabled() const;
     void isURLAllowed(const URL&, CompletionHandler<void(bool, NSData *)>&&);
     void allowURL(const URL&, CompletionHandler<void(bool)>&&);
 
 private:
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    ParentalControlsURLFilter(const String& configurationPath);
+#else
     ParentalControlsURLFilter();
+#endif
 
     RetainPtr<WCRBrowserEngineClient> m_wcrBrowserEngineClient;
 };
 
 } // namespace WebCore
 
-#endif
+#endif // HAVE(WEBCONTENTRESTRICTIONS)

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -2199,6 +2199,16 @@ bool NetworkResourceLoader::usesWebContentRestrictions()
     return protectedConnectionToWebProcess()->usesWebContentRestrictionsForFilter();
 }
 #endif
+
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+String NetworkResourceLoader::webContentRestrictionsConfigurationPath() const
+{
+    if (CheckedPtr session = protectedConnectionToWebProcess()->protectedNetworkProcess()->networkSession(sessionID()))
+        return session->webContentRestrictionsConfigurationFile();
+
+    return emptyString();
+}
+#endif
 #endif // ENABLE(CONTENT_FILTERING)
 
 void NetworkResourceLoader::useRedirectionForCurrentNavigation(WebCore::ResourceResponse&& response)

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -207,6 +207,9 @@ private:
 #if HAVE(WEBCONTENTRESTRICTIONS)
     bool usesWebContentRestrictions() final;
 #endif
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    String webContentRestrictionsConfigurationPath() const final;
+#endif
 #endif
 
     void processClearSiteDataHeader(const WebCore::ResourceResponse&, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -178,6 +178,9 @@ NetworkSession::NetworkSession(NetworkProcess& networkProcess, const NetworkSess
 #if ENABLE(CONTENT_EXTENSIONS)
     , m_resourceMonitorThrottlerDirectory(parameters.resourceMonitorThrottlerDirectory)
 #endif
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    , m_webContentRestrictionsConfigurationFile(parameters.webContentRestrictionsConfigurationFile)
+#endif
     , m_dataStoreIdentifier(parameters.dataStoreIdentifier)
 {
     if (!m_sessionID.isEphemeral()) {
@@ -225,6 +228,9 @@ NetworkSession::NetworkSession(NetworkProcess& networkProcess, const NetworkSess
 
 #if ENABLE(CONTENT_EXTENSIONS)
     SandboxExtension::consumePermanently(parameters.resourceMonitorThrottlerDirectoryExtensionHandle);
+#endif
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    SandboxExtension::consumePermanently(parameters.webContentRestrictionsConfigurationExtensionHandle);
 #endif
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -302,6 +302,10 @@ public:
     void resetResourceMonitorThrottlerForTesting();
 #endif
 
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    String webContentRestrictionsConfigurationFile() const { return m_webContentRestrictionsConfigurationFile; }
+#endif
+
     std::optional<WTF::UUID> dataStoreIdentifier() const { return m_dataStoreIdentifier; }
 
 protected:
@@ -417,6 +421,9 @@ protected:
 #if ENABLE(CONTENT_EXTENSIONS)
     RefPtr<WebCore::ResourceMonitorThrottlerHolder> m_resourceMonitorThrottler;
     String m_resourceMonitorThrottlerDirectory;
+#endif
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    String m_webContentRestrictionsConfigurationFile;
 #endif
     Markable<WTF::UUID> m_dataStoreIdentifier;
 };

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
@@ -144,6 +144,10 @@ struct NetworkSessionCreationParameters {
 #else
     bool isLegacyTLSAllowed { true };
 #endif
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    String webContentRestrictionsConfigurationFile;
+    SandboxExtension::Handle webContentRestrictionsConfigurationExtensionHandle;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
@@ -114,6 +114,10 @@ enum class WebKit::AllowsCellularAccess : bool;
     WebKit::SandboxExtensionHandle resourceMonitorThrottlerDirectoryExtensionHandle;
 #endif
     bool isLegacyTLSAllowed;
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    String webContentRestrictionsConfigurationFile;
+    WebKit::SandboxExtension::Handle webContentRestrictionsConfigurationExtensionHandle;
+#endif
 };
 
 #if USE(SOUP)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKErrorPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKErrorPrivate.h
@@ -31,6 +31,7 @@ typedef NS_ENUM(NSInteger, _WKLegacyErrorCode) {
     _WKErrorCodeCannotShowURL WK_API_AVAILABLE(macos(13.3), ios(16.4)) = 101,
     _WKErrorCodeFrameLoadInterruptedByPolicyChange WK_API_AVAILABLE(macos(10.11), ios(9.0)) = 102,
     _WKErrorCodeFrameLoadBlockedByContentBlocker WK_API_AVAILABLE(macos(13.3), ios(16.4)) = 104,
+    _WKErrorCodeFrameLoadBlockedByContentFilter WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA)) = 105,
     _WKErrorCodeFrameLoadBlockedByRestrictions WK_API_AVAILABLE(macos(10.15), ios(13.0)) = 106,
     _WKErrorCodeHTTPSUpgradeRedirectLoop WK_API_AVAILABLE(macos(14.0), ios(17.0)) = 304,
     _WKErrorCodeHTTPNavigationWithHTTPSOnly WK_API_AVAILABLE(macos(14.0), ios(17.0)) = 305,

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
@@ -104,6 +104,7 @@ WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
 @property (nonatomic) BOOL isDeclarativeWebPushEnabled WK_API_AVAILABLE(macos(14.4), ios(17.4), visionos(1.1));
 @property (nonatomic, nullable, copy) NSNumber *defaultTrackingPreventionEnabledOverride WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
 @property (nonatomic, copy, setter=_setResourceMonitorThrottlerDirectory:) NSURL *_resourceMonitorThrottlerDirectory WK_API_AVAILABLE(macos(15.0), ios(18.0));
+@property (nonatomic, nullable, copy) NSURL *webContentRestrictionsConfigurationURL WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 // Testing only.
 @property (nonatomic) BOOL allLoadsBlockedByDeviceManagementRestrictionsForTesting WK_API_AVAILABLE(macos(10.15), ios(13.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
@@ -612,6 +612,25 @@ static WebKit::UnifiedOriginStorageLevel toUnifiedOriginStorageLevel(_WKUnifiedO
     _configuration->setResourceMonitorThrottlerDirectory(url.path);
 }
 
+- (NSURL *)webContentRestrictionsConfigurationURL
+{
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    auto file = _configuration->webContentRestrictionsConfigurationFile();
+    if (!file.isEmpty())
+        return [NSURL fileURLWithPath:file.createNSString().get()];
+#endif
+
+    return nil;
+}
+
+- (void)setWebContentRestrictionsConfigurationURL:(NSURL *)url
+{
+    checkURLArgument(url);
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    _configuration->setWebContentRestrictionsConfigurationFile(url.path);
+#endif
+}
+
 - (BOOL)isDeclarativeWebPushEnabled
 {
 #if ENABLE(DECLARATIVE_WEB_PUSH)

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -407,6 +407,11 @@ bool WebFrameProxy::didHandleContentFilterUnblockNavigation(const ResourceReques
 
     RefPtr page = m_page.get();
     ASSERT(page);
+
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    m_contentFilterUnblockHandler.setConfigurationPath(page->protectedWebsiteDataStore()->configuration().webContentRestrictionsConfigurationFile());
+#endif
+
     m_contentFilterUnblockHandler.requestUnblockAsync([page](bool unblocked) {
         if (unblocked)
             page->reload({ });

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2115,6 +2115,13 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
         createHandleFromResolvedPathIfPossible(resourceMonitorThrottlerDirectory, resourceMonitorThrottlerDirectoryExtensionHandle);
 #endif
 
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    auto webContentRestrictionsConfigurationFile = m_configuration->webContentRestrictionsConfigurationFile();
+    SandboxExtension::Handle webContentRestrictionsConfigurationExtensionHandle;
+    if (!webContentRestrictionsConfigurationFile.isEmpty())
+        createHandleFromResolvedPathIfPossible(webContentRestrictionsConfigurationFile, webContentRestrictionsConfigurationExtensionHandle, SandboxExtension::Type::ReadOnly);
+#endif
+
     bool shouldIncludeLocalhostInResourceLoadStatistics = false;
     auto firstPartyWebsiteDataRemovalMode = WebCore::FirstPartyWebsiteDataRemovalMode::AllButCookies;
     WebCore::RegistrableDomain standaloneApplicationDomain;
@@ -2215,6 +2222,11 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
     networkSessionParameters.resourceMonitorThrottlerDirectoryExtensionHandle = WTFMove(resourceMonitorThrottlerDirectoryExtensionHandle);
 #endif
     networkSessionParameters.isLegacyTLSAllowed = m_configuration->legacyTLSEnabled();
+
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    networkSessionParameters.webContentRestrictionsConfigurationFile = WTFMove(webContentRestrictionsConfigurationFile);
+    networkSessionParameters.webContentRestrictionsConfigurationExtensionHandle = WTFMove(webContentRestrictionsConfigurationExtensionHandle);
+#endif
 
     parameters.networkSessionParameters = WTFMove(networkSessionParameters);
     parameters.networkSessionParameters.resourceLoadStatisticsParameters.enabled = trackingPreventionEnabled();

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
@@ -176,6 +176,9 @@ Ref<WebsiteDataStoreConfiguration> WebsiteDataStoreConfiguration::copy() const
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     copy->m_isDeclarativeWebPushEnabled = this->m_isDeclarativeWebPushEnabled;
 #endif
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    copy->m_webContentRestrictionsConfigurationFile = this->m_webContentRestrictionsConfigurationFile;
+#endif
 
     return copy;
 }

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -259,6 +259,11 @@ public:
     void setMemoryFootprintNotificationThresholds(Vector<size_t>&& thresholds) { m_memoryFootprintNotificationThresholds = WTFMove(thresholds); }
     const Vector<size_t>& memoryFootprintNotificationThresholds() { return m_memoryFootprintNotificationThresholds; }
 
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    void setWebContentRestrictionsConfigurationFile(String&& file) { m_webContentRestrictionsConfigurationFile = WTFMove(file); }
+    const String& webContentRestrictionsConfigurationFile() const { return m_webContentRestrictionsConfigurationFile; }
+#endif
+
     struct Directories {
         String applicationCacheFlatFileSubdirectoryName { "Files"_s };
         String applicationCacheDirectory;
@@ -354,6 +359,9 @@ private:
 #endif
     Vector<size_t> m_memoryFootprintNotificationThresholds;
     std::optional<bool> m_defaultTrackingPreventionEnabledOverride;
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    String m_webContentRestrictionsConfigurationFile;
+#endif
 };
 
 }

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -379,6 +379,7 @@ Tests/WebKitCocoa/WKWebViewThemeColor.mm
 Tests/WebKitCocoa/WKWebViewUnderPageBackgroundColor.mm
 Tests/WebKitCocoa/WKWebsiteDatastore.mm
 Tests/WebKitCocoa/WebContentProcessDidTerminate.mm
+Tests/WebKitCocoa/WebContentRestrictions.mm
 Tests/WebKitCocoa/WebCryptoMasterKey.mm
 Tests/WebKitCocoa/WebLocks.mm
 Tests/WebKitCocoa/WebProcessKillIDBCleanup.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -3040,6 +3040,7 @@
 		5E4B1D2C1D404C6100053621 /* WKScrollViewDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKScrollViewDelegate.mm; path = ../ios/WKScrollViewDelegate.mm; sourceTree = "<group>"; };
 		631EFFF51E7B5E8D00D2EBB8 /* Geolocation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Geolocation.mm; sourceTree = "<group>"; };
 		634910DF1E9D3FF300880309 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
+		634E44892DB770CA00793399 /* WebContentRestrictions.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebContentRestrictions.mm; sourceTree = "<group>"; };
 		6351992722275C6A00890AD3 /* NavigationAction.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NavigationAction.mm; sourceTree = "<group>"; };
 		6354F4D01F7C3AB500D89DF3 /* ApplicationManifestParser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ApplicationManifestParser.cpp; sourceTree = "<group>"; };
 		6356FB211EC4E0BA0044BF18 /* VisibleContentRect.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VisibleContentRect.mm; sourceTree = "<group>"; };
@@ -4678,6 +4679,7 @@
 				6356FB211EC4E0BA0044BF18 /* VisibleContentRect.mm */,
 				83779C371F82FEB0007CDA8A /* VisitedLinkStore.mm */,
 				830F2E0B209A6A7400D36FF1 /* WebContentProcessDidTerminate.mm */,
+				634E44892DB770CA00793399 /* WebContentRestrictions.mm */,
 				57A79856224AB34E00A7F6F1 /* WebCryptoMasterKey.mm */,
 				46061545275824B400AB613D /* WebLocks.mm */,
 				51714EB61CF8C7A4004723C4 /* WebProcessKillIDBCleanup.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebContentRestrictions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebContentRestrictions.mm
@@ -1,0 +1,245 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(CONTENT_FILTERING) && HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+
+#import "HTTPServer.h"
+#import "TestNavigationDelegate.h"
+#import <WebKit/WKErrorPrivate.h>
+#import <WebKit/WKWebView.h>
+#import <WebKit/WKWebViewPrivateForTesting.h>
+#import <WebKit/WKWebsiteDataStorePrivate.h>
+#import <WebKit/_WKWebsiteDataStoreConfiguration.h>
+
+@interface WebContentRestrictionsNavigationDelegate : TestNavigationDelegate
+@property (nonatomic) BOOL failedLoadDueToContentFilter;
+@end
+
+@implementation WebContentRestrictionsNavigationDelegate
+
+- (void)webView:(WKWebView *)webView didFailProvisionalNavigation:(WKNavigation *)navigation withError:(NSError *)error
+{
+    if ([error.domain isEqualToString:_WKLegacyErrorDomain] && error.code == _WKErrorCodeFrameLoadBlockedByContentFilter)
+        _failedLoadDueToContentFilter = YES;
+    else
+        FAIL();
+}
+
+@end
+
+#define ALLOWLIST_ENABLED_KEY @"white" @"listEnabled"
+#define SITE_ALLOWLIST_KEY @"site" @"White" @"list"
+
+static NSDictionary *permissiveConfiguration()
+{
+    return @{
+        @"restrictWeb" : @(0),
+        @"useContentFilter" : @(0),
+        @"useContentFilterOverrides" : @(0),
+        ALLOWLIST_ENABLED_KEY : @(0),
+    };
+}
+
+static NSDictionary *restrictiveConfiguration()
+{
+    return @{
+        @"restrictWeb" : @(1),
+        @"useContentFilter" : @(0),
+        @"useContentFilterOverrides" : @(0),
+        ALLOWLIST_ENABLED_KEY : @(1),
+        SITE_ALLOWLIST_KEY: @[
+            @{
+                @"address": @"webkit.org",
+                @"pageTitle": @"WebKit",
+            },
+        ],
+    };
+}
+
+TEST(WebContentRestrictions, ConfigurationFileDoesNotExist)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { "Hello."_s } },
+    });
+
+    NSURL *configurationURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:NSUUID.UUID.UUIDString]];
+    EXPECT_FALSE([NSFileManager.defaultManager fileExistsAtPath:configurationURL.path]);
+
+    RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    [dataStoreConfiguration setWebContentRestrictionsConfigurationURL:configurationURL];
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setWebsiteDataStore:dataStore.get()];
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[WebContentRestrictionsNavigationDelegate alloc] init]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]]];
+
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_FALSE([navigationDelegate failedLoadDueToContentFilter]);
+}
+
+TEST(WebContentRestrictions, ConfigurationFileIsPermissive)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { "Hello."_s } },
+    });
+
+    NSURL *configurationURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:NSUUID.UUID.UUIDString]];
+    EXPECT_TRUE([permissiveConfiguration() writeToURL:configurationURL error:nil]);
+
+    RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    [dataStoreConfiguration setWebContentRestrictionsConfigurationURL:configurationURL];
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setWebsiteDataStore:dataStore.get()];
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[WebContentRestrictionsNavigationDelegate alloc] init]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]]];
+
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_FALSE([navigationDelegate failedLoadDueToContentFilter]);
+
+    [NSFileManager.defaultManager removeItemAtURL:configurationURL error:nil];
+}
+
+TEST(WebContentRestrictions, ConfigurationFileIsRestrictive)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { "Hello."_s } },
+    });
+
+    NSURL *configurationURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:NSUUID.UUID.UUIDString]];
+    EXPECT_TRUE([restrictiveConfiguration() writeToURL:configurationURL error:nil]);
+
+    RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    [dataStoreConfiguration setWebContentRestrictionsConfigurationURL:configurationURL];
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setWebsiteDataStore:dataStore.get()];
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[WebContentRestrictionsNavigationDelegate alloc] init]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]]];
+
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_TRUE([navigationDelegate failedLoadDueToContentFilter]);
+
+    [NSFileManager.defaultManager removeItemAtURL:configurationURL error:nil];
+}
+
+TEST(WebContentRestrictions, MultipleConfigurationFiles)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/a"_s, { "Hello."_s } },
+        { "/b"_s, { "Also Hello."_s } },
+    });
+
+    NSString *urlStringA = [NSString stringWithFormat:@"http://127.0.0.1:%d/a", server.port()];
+    NSString *urlStringB = [NSString stringWithFormat:@"http://127.0.0.1:%d/b", server.port()];
+
+    RetainPtr configurationA = @{
+        @"restrictWeb" : @(1),
+        @"useContentFilter" : @(0),
+        @"useContentFilterOverrides" : @(0),
+        ALLOWLIST_ENABLED_KEY : @(1),
+        SITE_ALLOWLIST_KEY: @[
+            @{
+                @"address": urlStringA,
+                @"pageTitle": @"Page A",
+            },
+        ],
+    };
+
+    RetainPtr configurationB = @{
+        @"restrictWeb" : @(1),
+        @"useContentFilter" : @(0),
+        @"useContentFilterOverrides" : @(0),
+        ALLOWLIST_ENABLED_KEY : @(1),
+        SITE_ALLOWLIST_KEY: @[
+            @{
+                @"address": urlStringB,
+                @"pageTitle": @"Page B",
+            },
+        ],
+    };
+
+    NSURL *configurationURLA = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:NSUUID.UUID.UUIDString]];
+    NSURL *configurationURLB = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:NSUUID.UUID.UUIDString]];
+
+    EXPECT_TRUE([configurationA writeToURL:configurationURLA error:nil]);
+    EXPECT_TRUE([configurationB writeToURL:configurationURLB error:nil]);
+
+    RetainPtr dataStoreConfigurationA = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    [dataStoreConfigurationA setWebContentRestrictionsConfigurationURL:configurationURLA];
+    RetainPtr dataStoreA = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfigurationA.get()]);
+    RetainPtr webViewConfigurationA = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [webViewConfigurationA setWebsiteDataStore:dataStoreA.get()];
+    RetainPtr webViewA = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfigurationA.get()]);
+    RetainPtr navigationDelegateA = adoptNS([[WebContentRestrictionsNavigationDelegate alloc] init]);
+    [webViewA setNavigationDelegate:navigationDelegateA.get()];
+
+    RetainPtr dataStoreConfigurationB = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    [dataStoreConfigurationB setWebContentRestrictionsConfigurationURL:configurationURLB];
+    RetainPtr dataStoreB = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfigurationB.get()]);
+    RetainPtr webViewConfigurationB = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [webViewConfigurationB setWebsiteDataStore:dataStoreB.get()];
+    RetainPtr webViewB = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfigurationB.get()]);
+    RetainPtr navigationDelegateB = adoptNS([[WebContentRestrictionsNavigationDelegate alloc] init]);
+    [webViewB setNavigationDelegate:navigationDelegateB.get()];
+
+    NSURLRequest *requestA = [NSURLRequest requestWithURL:[NSURL URLWithString:urlStringA]];
+    NSURLRequest *requestB = [NSURLRequest requestWithURL:[NSURL URLWithString:urlStringB]];
+
+    [webViewA loadRequest:requestA];
+    [navigationDelegateA waitForDidFinishNavigation];
+    EXPECT_FALSE([navigationDelegateA failedLoadDueToContentFilter]);
+
+    [webViewA loadRequest:requestB];
+    [navigationDelegateA waitForDidFinishNavigation];
+    EXPECT_TRUE([navigationDelegateA failedLoadDueToContentFilter]);
+
+    [webViewB loadRequest:requestA];
+    [navigationDelegateB waitForDidFinishNavigation];
+    EXPECT_TRUE([navigationDelegateB failedLoadDueToContentFilter]);
+    [navigationDelegateB setFailedLoadDueToContentFilter:NO];
+
+    [webViewB loadRequest:requestB];
+    [navigationDelegateB waitForDidFinishNavigation];
+    EXPECT_FALSE([navigationDelegateB failedLoadDueToContentFilter]);
+
+    EXPECT_EQ([webViewA _networkProcessIdentifier], [webViewB _networkProcessIdentifier]);
+
+    [NSFileManager.defaultManager removeItemAtURL:configurationURLA error:nil];
+    [NSFileManager.defaultManager removeItemAtURL:configurationURLB error:nil];
+}
+
+#endif // ENABLE(CONTENT_FILTERING) && HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)


### PR DESCRIPTION
#### 2fe72762174e1f9efb5e71455bf41bcb82c94c83
<pre>
Support alternative configurations for web content restrictions
<a href="https://bugs.webkit.org/show_bug.cgi?id=291915">https://bugs.webkit.org/show_bug.cgi?id=291915</a>
<a href="https://rdar.apple.com/149723541">rdar://149723541</a>

Reviewed by Sihui Liu.

Make it possible for an app to direct WebContentRestrictions to a particular path
to load content restriction configurations from. This functionality is exposed on
_WKWebsiteDataStoreConfiguration, since the restriction configuration is applied to
all networking within that session. This reverses some of the singleton-ization
introduced in <a href="https://commits.webkit.org/292963@main">https://commits.webkit.org/292963@main</a>, since the ability to configure a
particular policy for web content restrictions is exposed by creating a new instance of
WCRBrowserEngineClient with a path. It&apos;s still beneficial to reuse instances of these
classes, but now there may need to be more than one in the case where one process uses
multiple configurations for different browsing contexts.

* Source/WebCore/PAL/pal/spi/cocoa/WebContentRestrictionsSPI.h:
* Source/WebCore/loader/ContentFilter.cpp:
(WebCore::ContentFilter::create):
* Source/WebCore/loader/ContentFilterClient.h:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::webContentRestrictionsConfigurationPath const):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/platform/ContentFilterUnblockHandler.h:
(WebCore::ContentFilterUnblockHandler::configurationPath const):
(WebCore::ContentFilterUnblockHandler::setConfigurationPath):
* Source/WebCore/platform/PlatformContentFilter.h:
* Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm:
(WebCore::ContentFilterUnblockHandler::requestUnblockAsync const):
* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h:
* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm:
(WebCore::ParentalControlsContentFilter::enabled const):
(WebCore::ParentalControlsContentFilter::ParentalControlsContentFilter):
(WebCore::ParentalControlsContentFilter::responseReceived):
* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h:
* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm:
(WebCore::wcrBrowserEngineClientEnabled):
(WebCore::ParentalControlsURLFilter::filterWithConfigurationPath):
(WebCore::ParentalControlsURLFilter::ParentalControlsURLFilter):
(WebCore::ParentalControlsURLFilter::singleton):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::webContentRestrictionsConfigurationPath const):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::m_dataStoreIdentifier):
* Source/WebKit/NetworkProcess/NetworkSession.h:
(WebKit::NetworkSession::webContentRestrictionsConfigurationFile const):
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h:
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKErrorPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm:
(-[_WKWebsiteDataStoreConfiguration webContentRestrictionsConfigurationURL]):
(-[_WKWebsiteDataStoreConfiguration setWebContentRestrictionsConfigurationURL:]):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::didHandleContentFilterUnblockNavigation):
    When handling a request from the web process to unblock a website, read the
    configuration path from this web view&apos;s data store, then hand it to the
    ContentFilterUnblockHandler. It didn&apos;t seem wise to make this property
    serializable / deserializable, since that could give a compromised web
    process the ability to direct the UI process to perform IO on an
    attacker-controlled path.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::parameters):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp:
(WebKit::WebsiteDataStoreConfiguration::copy const):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
(WebKit::WebsiteDataStoreConfiguration::setWebContentRestrictionsConfigurationFile):
(WebKit::WebsiteDataStoreConfiguration::webContentRestrictionsConfigurationFile const):
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebContentRestrictions.mm: Added.
(-[WebContentRestrictionsNavigationDelegate webView:didFailProvisionalNavigation:withError:]):
(permissiveConfiguration):
(restrictiveConfiguration):
(TEST(WebContentRestrictions, ConfigurationFileDoesNotExist)):
(TEST(WebContentRestrictions, ConfigurationFileIsPermissive)):
(TEST(WebContentRestrictions, ConfigurationFileIsRestrictive)):
(TEST(WebContentRestrictions, MultipleConfigurationFiles)):

Canonical link: <a href="https://commits.webkit.org/294381@main">https://commits.webkit.org/294381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bbdc879c9ae55a72332cb7072246f98875b13e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11588 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106764 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52240 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103646 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29795 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77381 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34413 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16668 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91760 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57718 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16494 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9777 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51587 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86361 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9854 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109117 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21175 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86355 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29100 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87961 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85918 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21869 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30664 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8378 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22891 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28667 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33956 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28478 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31801 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30037 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->