### PR TITLE
[JSC] Add LIFETIME_BOUND to GCOwnedDataScope

### DIFF
--- a/Source/JavaScriptCore/heap/GCOwnedDataScope.h
+++ b/Source/JavaScriptCore/heap/GCOwnedDataScope.h
@@ -78,19 +78,19 @@ public:
 
     ~GCOwnedDataScope() { ensureStillAliveHere(owner); }
 
-    operator const T() const { return data; }
-    operator T() { return data; }
+    operator const T() const LIFETIME_BOUND { return data; }
+    operator T() LIFETIME_BOUND { return data; }
 
-    std::remove_reference_t<T>* operator->() requires (!std::is_pointer_v<T>) { return &data; }
-    const std::remove_reference_t<T>* operator->() const requires (!std::is_pointer_v<T>) { return &data; }
+    std::remove_reference_t<T>* operator->() LIFETIME_BOUND requires (!std::is_pointer_v<T>) { return &data; }
+    const std::remove_reference_t<T>* operator->() const LIFETIME_BOUND requires (!std::is_pointer_v<T>) { return &data; }
 
-    T operator->() requires (std::is_pointer_v<T>) { return data; }
-    const T operator->() const requires (std::is_pointer_v<T>) { return data; }
+    T operator->() LIFETIME_BOUND requires (std::is_pointer_v<T>) { return data; }
+    const T operator->() const LIFETIME_BOUND requires (std::is_pointer_v<T>) { return data; }
 
-    auto operator[](unsigned index) const { return data[index]; }
+    auto operator[](unsigned index) const LIFETIME_BOUND { return data[index]; }
 
     // Convenience conversion for String -> StringView
-    operator StringView() const requires (std::is_same_v<std::decay_t<T>, String>) { return data; }
+    operator StringView() const LIFETIME_BOUND requires (std::is_same_v<std::decay_t<T>, String>) { return data; }
 
     const JSCell* owner { nullptr };
     SUPPRESS_UNCOUNTED_MEMBER T data { };

--- a/Source/JavaScriptCore/runtime/InternalFunction.cpp
+++ b/Source/JavaScriptCore/runtime/InternalFunction.cpp
@@ -79,9 +79,14 @@ DEFINE_VISIT_CHILDREN_WITH_MODIFIER(JS_EXPORT_PRIVATE, InternalFunction);
 
 String InternalFunction::name()
 {
-    const String& name = m_originalName->tryGetValue();
+#if ASSERT_ENABLED
+    auto gcOwnedData = m_originalName->tryGetValue();
+    const String& name = gcOwnedData;
     ASSERT(name); // m_originalName was built from a String, and hence, there is no rope to resolve.
     return name;
+#else
+    return m_originalName->tryGetValue();
+#endif
 }
 
 String InternalFunction::displayName(VM& vm)

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp
@@ -60,7 +60,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayConstructorFromBase64, (JSGlobalObject* globa
             if (UNLIKELY(!alphabetString))
                 return throwVMTypeError(globalObject, scope, "Uint8Array.fromBase64 requires that alphabet be \"base64\" or \"base64url\""_s);
 
-            StringView alphabetStringView = alphabetString->view(globalObject);
+            auto alphabetStringView = alphabetString->view(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
             if (alphabetStringView == "base64url"_s)
                 alphabet = WTF::Alphabet::Base64URL;
@@ -75,7 +75,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayConstructorFromBase64, (JSGlobalObject* globa
             if (UNLIKELY(!lastChunkHandlingString))
                 return throwVMTypeError(globalObject, scope, "Uint8Array.fromBase64 requires that lastChunkHandling be \"loose\", \"strict\", or \"stop-before-partial\""_s);
 
-            StringView lastChunkHandlingStringView = lastChunkHandlingString->view(globalObject);
+            auto lastChunkHandlingStringView = lastChunkHandlingString->view(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
             if (lastChunkHandlingStringView == "strict"_s)
                 lastChunkHandling = WTF::LastChunkHandling::Strict;
@@ -86,7 +86,8 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayConstructorFromBase64, (JSGlobalObject* globa
         }
     }
 
-    StringView view = jsString->view(globalObject);
+    auto gcOwnedData = jsString->view(globalObject);
+    StringView view = gcOwnedData;
     RETURN_IF_EXCEPTION(scope, { });
 
     Vector<uint8_t, 128> output;
@@ -220,7 +221,8 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayConstructorFromHex, (JSGlobalObject* globalOb
     if (UNLIKELY(jsString->length() % 2))
         return JSValue::encode(throwSyntaxError(globalObject, scope, "Uint8Array.fromHex requires a string of even length"_s));
 
-    StringView view = jsString->view(globalObject);
+    auto gcOwnedData = jsString->view(globalObject);
+    StringView view = gcOwnedData;
     RETURN_IF_EXCEPTION(scope, { });
 
     size_t count = static_cast<size_t>(view.length() / 2);

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp
@@ -66,7 +66,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeSetFromBase64, (JSGlobalObject* glob
             if (UNLIKELY(!alphabetString))
                 return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.setFromBase64 requires that alphabet be \"base64\" or \"base64url\""_s);
 
-            StringView alphabetStringView = alphabetString->view(globalObject);
+            auto alphabetStringView = alphabetString->view(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
             if (alphabetStringView == "base64url"_s)
                 alphabet = WTF::Alphabet::Base64URL;
@@ -81,7 +81,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeSetFromBase64, (JSGlobalObject* glob
             if (UNLIKELY(!lastChunkHandlingString))
                 return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.setFromBase64 requires that lastChunkHandling be \"loose\", \"strict\", or \"stop-before-partial\""_s);
 
-            StringView lastChunkHandlingStringView = lastChunkHandlingString->view(globalObject);
+            auto lastChunkHandlingStringView = lastChunkHandlingString->view(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
             if (lastChunkHandlingStringView == "strict"_s)
                 lastChunkHandling = WTF::LastChunkHandling::Strict;
@@ -96,7 +96,8 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeSetFromBase64, (JSGlobalObject* glob
     if (UNLIKELY(isIntegerIndexedObjectOutOfBounds(uint8Array, byteLengthGetter)))
         return throwVMTypeError(globalObject, scope, typedArrayBufferHasBeenDetachedErrorMessage);
 
-    StringView view = jsString->view(globalObject);
+    auto gcOwnedData = jsString->view(globalObject);
+    StringView view = gcOwnedData;
     RETURN_IF_EXCEPTION(scope, { });
 
     auto [shouldThrowError, readLength, writeLength] = fromBase64(view, std::span { uint8Array->typedVector(), uint8Array->length() }, alphabet, lastChunkHandling);
@@ -130,7 +131,8 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeSetFromHex, (JSGlobalObject* globalO
     if (UNLIKELY(jsString->length() % 2))
         return JSValue::encode(throwSyntaxError(globalObject, scope, "Uint8Array.prototype.setFromHex requires a string of even length"_s));
 
-    StringView view = jsString->view(globalObject);
+    auto gcOwnedData = jsString->view(globalObject);
+    StringView view = gcOwnedData;
     RETURN_IF_EXCEPTION(scope, { });
 
     uint8_t* data = uint8Array->typedVector();
@@ -177,7 +179,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeToBase64, (JSGlobalObject* globalObj
             if (UNLIKELY(!alphabetString))
                 return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.toBase64 requires that alphabet be \"base64\" or \"base64url\""_s);
 
-            StringView alphabetStringView = alphabetString->view(globalObject);
+            auto alphabetStringView = alphabetString->view(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
             if (alphabetStringView == "base64url"_s)
                 options.add(Base64EncodeOption::URL);


### PR DESCRIPTION
#### 8c414d85218e71a6e44d48056d526ae855abcbf6
<pre>
[JSC] Add LIFETIME_BOUND to GCOwnedDataScope
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=291918">https://bugs.webkit.org/show_bug.cgi?id=291918</a>&gt;
&lt;<a href="https://rdar.apple.com/149808413">rdar://149808413</a>&gt;

Reviewed by Yusuke Suzuki and Keith Miller.

* Source/JavaScriptCore/heap/GCOwnedDataScope.h:
- Add LIFETIME_BOUND attribute to methods.
* Source/JavaScriptCore/runtime/InternalFunction.cpp:
(JSC::InternalFunction::name):
- Add fast path for non-Debug builds.
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION(uint8ArrayConstructorFromBase64), (...)):
(JSC::JSC_DEFINE_HOST_FUNCTION(uint8ArrayConstructorFromHex), (...)):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeSetFromBase64, (...)):
(JSC::JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeSetFromHex, (...)):
(JSC::JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeToBase64, (...)):
- Fix compiler warnings after adding LIFETIME_BOUND attribute.

Canonical link: <a href="https://commits.webkit.org/293990@main">https://commits.webkit.org/293990@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c33a7ed1351ea374e0049e7890a3fe4a12dda699

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20131 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105616 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51067 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28605 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76512 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33561 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103486 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15668 "Found 1 new test failure: fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90766 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56869 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15485 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8769 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50443 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/93143 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85399 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8848 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107970 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/99087 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27597 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20256 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85464 "Found 6 new test failures: imported/w3c/web-platform-tests/custom-elements/reactions/customized-builtins/HTMLMediaElement.html imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-self.https.sub.html imported/w3c/web-platform-tests/mixed-content/gen/top.meta/unset/worklet-paint.https.html imported/w3c/web-platform-tests/service-workers/idlharness.https.any.worker.html imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic.http-rp/upgrade/fetch.https.html imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?h264_annexb (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27960 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86966 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85002 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29692 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7424 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21562 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16355 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27532 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32782 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122713 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27343 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34229 "Found 1 new JSC stress test failure: ChakraCore.yaml/ChakraCore/test/es6/ES6MathAPIs.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30661 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28901 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->