### PR TITLE
[Yarr] Improve reading of Surrogate Pairs in Unicode Regular Expressions

### DIFF
--- a/JSTests/microbenchmarks/regexp-non-bmp-matching.js
+++ b/JSTests/microbenchmarks/regexp-non-bmp-matching.js
@@ -1,0 +1,203 @@
+// With verbose set to false, this test is successful if there is no output.  Set verbose to true to see expected matches.
+let verbose = false;
+
+function arrayToString(arr)
+{
+    let str = '';
+    arr.forEach(function(v, index) {
+        if (typeof v == "string")
+            str += "\"" + v + "\"";
+        else
+            str += v;
+
+        if (index != (arr.length - 1))
+            str += ',';
+      });
+  return str;
+}
+
+function objectToString(obj)
+{
+    let str = "";
+
+    firstEntry = true;
+
+    for (const [key, value] of Object.entries(obj)) {
+        if (!firstEntry)
+            str += ", ";
+
+        str += key + ": " + dumpValue(value);
+
+        firstEntry = false;
+    }
+
+    return "{ " + str + " }";
+}
+
+function dumpValue(v)
+{
+    if (v === null)
+        return "<null>";
+
+    if (v === undefined)
+        return "<undefined>";
+
+    if (typeof v == "string")
+        return "\"" + v + "\"";
+
+    let str = "";
+
+    if (v.length)
+        str += arrayToString(v);
+
+    if (v.groups) {
+        groupStr = objectToString(v.groups);
+
+        if (str.length) {
+            if ( groupStr.length)
+                str += ", " + groupStr;
+        } else
+            str = groupStr;
+    }
+
+    return "[ " + str + " ]";
+}
+
+function compareArray(expected, actual)
+{
+    if (expected === null && actual === null)
+        return true;
+
+    if (expected === null) {
+        print("### expected is null, actual is not null");
+        return false;
+    }
+
+    if (actual === null) {
+        print("### expected is not null, actual is null");
+        return false;
+    }
+
+    if (expected.length !== actual.length) {
+        print("### expected.length: " + expected.length + ", actual.length: " + actual.length);
+        return false;
+    }
+
+    for (var i = 0; i < expected.length; i++) {
+        if (expected[i] !== actual[i]) {
+            print("### expected[" + i + "]: \"" + expected[i] + "\" !== actual[" + i + "]: \"" + actual[i] + "\"");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function compareGroups(expected, actual)
+{
+    if (expected === null && actual === null)
+        return true;
+
+    if (expected === null) {
+        print("### expected group is null, actual group is not null");
+        return false;
+    }
+
+    if (actual === null) {
+        print("### expected group is not null, actual group is null");
+        return false;
+    }
+
+    for (const key in expected) {
+        if (expected[key] !== actual[key]) {
+            print("### expected." + key + ": " + dumpValue(expected[key]) + " !== actual." + key + ": " + dumpValue(actual[key]));
+            return false;
+        }
+    }
+
+    return true;
+}
+
+let testNumber = 0;
+
+function testRegExp(re, str, exp, groups)
+{
+    testNumber++;
+
+    if (groups)
+        exp.groups = groups;
+
+    let actual = re.exec(str);
+
+    let result = compareArray(exp, actual);;
+
+    if (exp && exp.groups) {
+        if (!compareGroups(exp.groups, actual.groups))
+            result = false;
+    }
+
+    if (result) {
+        if (verbose)
+            print(re.toString() + ".exec(" + dumpValue(str) + "), passed ", dumpValue(exp));
+    } else
+        print(re.toString() + ".exec(" + dumpValue(str) + "), FAILED test #" + testNumber + ", Expected ", dumpValue(exp), " got ", dumpValue(actual));
+}
+
+function testRegExpSyntaxError(reString, flags, expError)
+{
+    testNumber++;
+
+
+    try {
+        let re = new RegExp(reString, flags);
+        print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError + "\", but it didn't");
+    } catch (e) {
+        if (e != expError)
+            print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError + "\" got \"" + e + "\"");
+        else if (verbose)
+            print("/" + reString + "/" + flags + " passed, it threw \"" + expError + "\" as expected");
+    }
+}
+
+let re1 = /[\u{1f0a1}-\u{1f0ae}]{5}/u;
+
+let stringsThatMatch1 = [
+    "\u{1f0ae}\u{1f0a1}\u{1f0a2}\u{1f0a3}\u{1f0a4}",
+    "\u{1f0a1}\u{1f0a2}\u{1f0a3}\u{1f0a4}\u{1f0a5}",
+    "\u{1f0a3}\u{1f0a3}\u{1f0a4}\u{1f0a5}\u{1f0a6}",
+    "\u{1f0a3}\u{1f0a4}\u{1f0a5}\u{1f0a6}\u{1f0a7}",
+    "\u{1f0a3}\u{1f0a5}\u{1f0a6}\u{1f0a7}\u{1f0a8}",
+    "\u{1f0a1}\u{1f0a3}\u{1f0a5}\u{1f0a7}\u{1f0a9}",
+    "\u{1f0aa}\u{1f0a6}\u{1f0a4}\u{1f0a2}\u{1f0a8}",
+    "\u{1f0aa}\u{1f0ae}\u{1f0ad}\u{1f0a1}\u{1f0a3}"];
+
+for (i = 0; i < 500000; i++) {
+    let str = stringsThatMatch1[i % stringsThatMatch1.length];
+
+    testRegExp(re1, str, [str]);
+}
+
+
+let re2 = /(?:[\u{1f0a1}\u{1f0b1}\u{1f0d1}\u{1f0c1}]{2,4})|(?:[\u{1f0ae}\u{1f0be}\u{1f0de}\u{1f0ce}]{2,4})/u;
+
+let stringsAndMatch2 = [
+    ["\u{1f0a1}\u{1f0b1}\u{1f0d2}\u{1f0a3}\u{1f0a4}", "\u{1f0a1}\u{1f0b1}"],
+    ["\u{1f0b1}\u{1f0ae}\u{1f0be}\u{1f0ce}\u{1f0d1}", "\u{1f0ae}\u{1f0be}\u{1f0ce}"],
+    ["\u{1f0c1}\u{1f0b1}\u{1f0d1}\u{1f0a3}\u{1f0a4}", "\u{1f0c1}\u{1f0b1}\u{1f0d1}"],
+    ["\u{1f0b1}\u{1f0ae}\u{1f0be}\u{1f0c1}\u{1f0d1}", "\u{1f0ae}\u{1f0be}"],
+    ["\u{1f0a1}\u{1f0b3}\u{1f0d2}\u{1f0ae}\u{1f0ae}", "\u{1f0ae}\u{1f0ae}"],
+    ["\u{1f0b1}\u{1f0ae}\u{1f0be}\u{1f0ce}\u{1f0d1}", "\u{1f0ae}\u{1f0be}\u{1f0ce}"],
+    ["\u{1f0c1}\u{1f0b1}\u{1f0d1}\u{1f0a1}\u{1f0a4}", "\u{1f0c1}\u{1f0b1}\u{1f0d1}\u{1f0a1}"],
+    ["\u{1f0b1}\u{1f0ae}\u{1f0be}\u{1f0de}\u{1f0ce}", "\u{1f0ae}\u{1f0be}\u{1f0de}\u{1f0ce}"]
+];
+
+for (i = 0; i < 500000; i++) {
+    let strAndMatch = stringsAndMatch2[i % stringsAndMatch2.length];
+    let str = strAndMatch[0];
+    let match = strAndMatch[1];
+
+    testRegExp(re2, str, [match]);
+}
+
+
+//  |(?:[\u{1f0ad}\u{1f0bd}\u{1f0dd}\u{1f0cd}]{2,4})|(?:[\u{1f0ab}\u{1f0bb}\u{1f0db}\u{1f0cb}]{2,4})|(?:[\u{1f0aa}\u{1f0ba}\u{1f0da}\u{1f0ca}]{2,4})|(?:[\u{1f0a9}\u{1f0b9}\u{1f0d9}\u{1f0c9}]{2,4})|(?:[\u{1f0a8}\u{1f0b8}\u{1f0d8}\u{1f0c8}]{2,4})|(?:[\u{1f0a7}\u{1f0b7}\u{1f0d7}\u{1f0c7}]{2,4})|(?:[\u{1f0a6}\u{1f0b6}\u{1f0d6}\u{1f0c6}]{2,4})|(?:[\u{1f0a5}\u{1f0b5}\u{1f0d5}\u{1f0c5}]{2,4})|(?:[\u{1f0a4}\u{1f0b4}\u{1f0d4}\u{1f0c4}]{2,4})|(?:[\u{1f0a3}\u{1f0b3}\u{1f0d3}\u{1f0c3}]{2,4})|(?:[\u{1f0a2}\u{1f0b2}\u{1f0d2}\u{1f0c2}]{2,4})", "u");

--- a/Source/JavaScriptCore/jit/JITThunks.cpp
+++ b/Source/JavaScriptCore/jit/JITThunks.cpp
@@ -55,7 +55,6 @@ void JITThunks::initialize(VM& vm)
 #define JSC_DEFINE_COMMON_JIT_THUNK(name, func) \
     m_commonThunks[static_cast<unsigned>(CommonJITThunkID::name)] = func(vm);
 JSC_FOR_EACH_COMMON_THUNK(JSC_DEFINE_COMMON_JIT_THUNK)
-JSC_FOR_EACH_YARR_JIT_BACKREFERENCES_THUNK(JSC_DEFINE_COMMON_JIT_THUNK)
 #undef JSC_DEFINE_COMMON_JIT_THUNK
 }
 

--- a/Source/JavaScriptCore/jit/JITThunks.h
+++ b/Source/JavaScriptCore/jit/JITThunks.h
@@ -139,22 +139,14 @@ class NativeExecutable;
     macro(CheckPrivateBrandHandler, checkPrivateBrandHandler) \
     macro(SetPrivateBrandHandler, setPrivateBrandHandler) \
 
-#if ENABLE(YARR_JIT_BACKREFERENCES_FOR_16BIT_EXPRS)
-#define JSC_FOR_EACH_YARR_JIT_BACKREFERENCES_THUNK(macro) \
-    macro(AreCanonicallyEquivalent, Yarr::areCanonicallyEquivalentThunkGenerator)
-#else
-#define JSC_FOR_EACH_YARR_JIT_BACKREFERENCES_THUNK(macro)
-#endif
-
 enum class CommonJITThunkID : uint8_t {
 #define JSC_DEFINE_COMMON_JIT_THUNK_ID(name, func) name,
 JSC_FOR_EACH_COMMON_THUNK(JSC_DEFINE_COMMON_JIT_THUNK_ID)
-JSC_FOR_EACH_YARR_JIT_BACKREFERENCES_THUNK(JSC_DEFINE_COMMON_JIT_THUNK_ID)
 #undef JSC_DEFINE_COMMON_JIT_THUNK_ID
 };
 
 #define JSC_COUNT_COMMON_JIT_THUNK_ID(name, func) + 1
-static constexpr unsigned numberOfCommonThunkIDs = 0 JSC_FOR_EACH_COMMON_THUNK(JSC_COUNT_COMMON_JIT_THUNK_ID) JSC_FOR_EACH_YARR_JIT_BACKREFERENCES_THUNK(JSC_COUNT_COMMON_JIT_THUNK_ID);
+static constexpr unsigned numberOfCommonThunkIDs = 0 JSC_FOR_EACH_COMMON_THUNK(JSC_COUNT_COMMON_JIT_THUNK_ID);
 #undef JSC_COUNT_COMMON_JIT_THUNK_ID
 
 class JITThunks final : private WeakHandleOwner {

--- a/Source/JavaScriptCore/yarr/YarrJIT.h
+++ b/Source/JavaScriptCore/yarr/YarrJIT.h
@@ -451,10 +451,6 @@ class YarrJITRegisters;
 void jitCompileInlinedTest(StackCheck*, StringView, OptionSet<Yarr::Flags>, CharSize, VM*, YarrBoyerMooreData&, CCallHelpers&, YarrJITRegisters&);
 #endif
 
-#if ENABLE(YARR_JIT_BACKREFERENCES_FOR_16BIT_EXPRS)
-MacroAssemblerCodeRef<JITThunkPtrTag> areCanonicallyEquivalentThunkGenerator(VM&);
-#endif
-
 } } // namespace JSC::Yarr
 
 #endif

--- a/Source/JavaScriptCore/yarr/YarrJITRegisters.h
+++ b/Source/JavaScriptCore/yarr/YarrJITRegisters.h
@@ -33,8 +33,12 @@ namespace JSC {
 
 namespace Yarr {
 
+enum class YarrRegisters { DefaultRegisters, AllocatedRegisters };
+
 struct YarrJITDefaultRegisters {
 public:
+    static constexpr YarrRegisters registersAssignments = YarrRegisters::DefaultRegisters;
+
 #if CPU(ARM_THUMB2)
     static constexpr GPRReg input = ARMRegisters::r0;
     static constexpr GPRReg index = ARMRegisters::r1;
@@ -77,15 +81,13 @@ public:
     static constexpr GPRReg firstCharacterAdditionalReadSize { InvalidGPRReg };
 #endif
 
-    static constexpr GPRReg leadingSurrogateTag = ARM64Registers::x13;
-    static constexpr GPRReg trailingSurrogateTag = ARM64Registers::x14;
+#define HAVE_YARR_SURROGATE_REGISTERS 1
+    static constexpr GPRReg surrogateTagMask = ARM64Registers::x13;
+    static constexpr GPRReg surrogatePairTags = ARM64Registers::x14;
     static constexpr GPRReg endOfStringAddress = ARM64Registers::x15;
 
     static constexpr GPRReg returnRegister = ARM64Registers::x0;
     static constexpr GPRReg returnRegister2 = ARM64Registers::x1;
-
-    static constexpr MacroAssembler::TrustedImm32 supplementaryPlanesBase = MacroAssembler::TrustedImm32(0x10000);
-    static constexpr MacroAssembler::TrustedImm32 surrogateTagMask = MacroAssembler::TrustedImm32(0xfffffc00);
 #elif CPU(X86_64)
     // Argument registers
     static constexpr GPRReg input = X86Registers::edi;
@@ -110,10 +112,8 @@ public:
     static constexpr GPRReg returnRegister = X86Registers::eax;
     static constexpr GPRReg returnRegister2 = X86Registers::edx;
 
-    static constexpr MacroAssembler::TrustedImm32 supplementaryPlanesBase = MacroAssembler::TrustedImm32(0x10000);
-    static constexpr MacroAssembler::TrustedImm32 leadingSurrogateTag = MacroAssembler::TrustedImm32(0xd800);
-    static constexpr MacroAssembler::TrustedImm32 trailingSurrogateTag = MacroAssembler::TrustedImm32(0xdc00);
-    static constexpr MacroAssembler::TrustedImm32 surrogateTagMask = MacroAssembler::TrustedImm32(0xfffffc00);
+    static constexpr MacroAssembler::TrustedImm32 surrogateTagMask = MacroAssembler::TrustedImm32(0xdc00dc00);
+    static constexpr MacroAssembler::TrustedImm32 surrogatePairTags = MacroAssembler::TrustedImm32(0xdc00d800);
 #elif CPU(RISCV64)
     // Argument registers
     static constexpr GPRReg input = RISCV64Registers::x10;
@@ -137,10 +137,8 @@ public:
     static constexpr GPRReg returnRegister = RISCV64Registers::x10;
     static constexpr GPRReg returnRegister2 = RISCV64Registers::x11;
 
-    static constexpr MacroAssembler::TrustedImm32 supplementaryPlanesBase = MacroAssembler::TrustedImm32(0x10000);
-    static constexpr MacroAssembler::TrustedImm32 leadingSurrogateTag = MacroAssembler::TrustedImm32(0xd800);
-    static constexpr MacroAssembler::TrustedImm32 trailingSurrogateTag = MacroAssembler::TrustedImm32(0xdc00);
-    static constexpr MacroAssembler::TrustedImm32 surrogateTagMask = MacroAssembler::TrustedImm32(0xfffffc00);
+    static constexpr MacroAssembler::TrustedImm32 surrogateTagMask = MacroAssembler::TrustedImm32(0xdc00dc00);
+    static constexpr MacroAssembler::TrustedImm32 surrogatePairTags = MacroAssembler::TrustedImm32(0xdc00d800);
 #endif
 };
 
@@ -196,13 +194,9 @@ public:
     GPRReg unicodeAndSubpatternIdTemp { InvalidGPRReg };
     GPRReg endOfStringAddress { InvalidGPRReg };
     GPRReg firstCharacterAdditionalReadSize { InvalidGPRReg };
-
-    const MacroAssembler::TrustedImm32 supplementaryPlanesBase = MacroAssembler::TrustedImm32(0x10000);
-    const MacroAssembler::TrustedImm32 leadingSurrogateTag = MacroAssembler::TrustedImm32(0xd800);
-    const MacroAssembler::TrustedImm32 trailingSurrogateTag = MacroAssembler::TrustedImm32(0xdc00);
-    const MacroAssembler::TrustedImm32 surrogateTagMask = MacroAssembler::TrustedImm32(0xfffffc00);
 };
 #endif
+
 
 } } // namespace JSC::Yarr
 


### PR DESCRIPTION
#### aaee2a6f166a1cda4ee3876c665bceb8a7988d3f
<pre>
[Yarr] Improve reading of Surrogate Pairs in Unicode Regular Expressions
<a href="https://bugs.webkit.org/show_bug.cgi?id=291923">https://bugs.webkit.org/show_bug.cgi?id=291923</a>
<a href="https://rdar.apple.com/149811541">rdar://149811541</a>

Reviewed by Daniel Liu.

Restructured the read possible surrogate pairs helper Yarr::tryReadUnicodeCharImpl() to try to read two
characters at once, then check to see if those two characters are well formed surrogate pair and then
return the resulting non-BMP codepoint.  If they are a surrogate pair, we return either the first single
character or an error if we happened to read in a trailing surrogate that was preceded by a leading
surrogate.

Turned the helper into an on demand thunk to reduce the amount of JIT&apos;ed code when we have more than one
unicode enabled RegExp&apos;s.  Also made the areCanonicallyEquivalentThunk an on demand thunk.

Added the set flags variant of the ARM64 AND instruction as it appears that setting the flags as part
of the AND operation may be slightly more performant than doing a separate compare to zero.

Added a new micro benchmark, regexp-non-bmp-matching.js, to verify the performance improvement.
This change improves that benchmark by about 2%.

                                Baseline          TuneReadUnicode

regexp-non-bmp-matching     38.6839+-0.2168   ^   37.9023+-0.1007    ^ definitely 1.0206x faster

&lt;geometric&gt;                 38.6839+-0.2168   ^   37.9023+-0.1007    ^ definitely 1.0206x faster

* JSTests/microbenchmarks/regexp-non-bmp-matching.js: Added.
(arrayToString):
(objectToString):
(dumpValue):
(compareArray):
(compareGroups):
(testRegExp):
(testRegExpSyntaxError):
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::add32AndSetFlags):
(JSC::MacroAssemblerARM64::add64AndSetFlags):
(JSC::MacroAssemblerARM64::and32AndSetFlags):
* Source/JavaScriptCore/jit/JITThunks.cpp:
(JSC::JITThunks::initialize):
* Source/JavaScriptCore/jit/JITThunks.h:
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::tryReadUnicodeCharImpl):
(JSC::Yarr::tryReadUnicodeCharThunkGenerator):
(JSC::Yarr::tryReadUnicodeCharIncForNonBMPThunkGenerator):
(JSC::Yarr::areCanonicallyEquivalentThunkGenerator):
* Source/JavaScriptCore/yarr/YarrJIT.h:
* Source/JavaScriptCore/yarr/YarrJITRegisters.h:

Canonical link: <a href="https://commits.webkit.org/294046@main">https://commits.webkit.org/294046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff627238109f9e54a6a9a5e17382957224c439de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105773 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51224 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76637 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33672 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15810 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90903 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56992 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15622 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-contain/contain-size-021.html imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-fixed-ancestor-iframe.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8910 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50600 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/93300 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85534 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8985 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108128 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/99244 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27754 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20383 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85595 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28117 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87104 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85136 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21667 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29828 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7556 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21742 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27689 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32940 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122870 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27500 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34261 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30818 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29058 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->