### PR TITLE
Nullptr crash in URLPatternUtilities::URLPatternComponent::createComponentMatchResult

### DIFF
--- a/LayoutTests/fast/url/invalid-url-pattern-context-crash-expected.txt
+++ b/LayoutTests/fast/url/invalid-url-pattern-context-crash-expected.txt
@@ -1,0 +1,5 @@
+This test passes if WebKit does not crash.
+
+
+PASS URLPattern with stopped document
+

--- a/LayoutTests/fast/url/invalid-url-pattern-context-crash.html
+++ b/LayoutTests/fast/url/invalid-url-pattern-context-crash.html
@@ -1,0 +1,21 @@
+<html>
+<head>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+    <iframe id=testFrame src="/"></iframe>
+    <script>
+        promise_test(async test => {
+            const contentWindow = testFrame.contentWindow;
+            const FrameURLPattern = contentWindow.URLPattern;
+
+            testFrame.remove();
+
+            const result = (new FrameURLPattern()).exec();
+            assert_equals(result, null);
+        }, "URLPattern with stopped document");
+    </script>
+    <p>This test passes if WebKit does not crash.</p>
+</body>
+</html>

--- a/Source/WebCore/Modules/url-pattern/URLPattern.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.cpp
@@ -440,42 +440,46 @@ ExceptionOr<std::optional<URLPatternResult>> URLPattern::match(ScriptExecutionCo
     auto protocolExecResult = m_protocolComponent.componentExec(context, protocol);
     if (protocolExecResult.isNull() || protocolExecResult.isUndefined())
         return { std::nullopt };
-    result.protocol = m_protocolComponent.createComponentMatchResult(context, WTFMove(protocol), protocolExecResult);
+
+    auto* globalObject = context.globalObject();
+    if (!globalObject)
+        return  { std::nullopt };
+    result.protocol = m_protocolComponent.createComponentMatchResult(globalObject, WTFMove(protocol), protocolExecResult);
 
     auto usernameExecResult = m_usernameComponent.componentExec(context, username);
     if (usernameExecResult.isNull() || usernameExecResult.isUndefined())
         return { std::nullopt };
-    result.username = m_usernameComponent.createComponentMatchResult(context, WTFMove(username), usernameExecResult);
+    result.username = m_usernameComponent.createComponentMatchResult(globalObject, WTFMove(username), usernameExecResult);
 
     auto passwordExecResult = m_passwordComponent.componentExec(context, password);
     if (passwordExecResult.isNull() || passwordExecResult.isUndefined())
         return { std::nullopt };
-    result.password = m_passwordComponent.createComponentMatchResult(context, WTFMove(password), passwordExecResult);
+    result.password = m_passwordComponent.createComponentMatchResult(globalObject, WTFMove(password), passwordExecResult);
 
     auto hostnameExecResult = m_hostnameComponent.componentExec(context, hostname);
     if (hostnameExecResult.isNull() || hostnameExecResult.isUndefined())
         return { std::nullopt };
-    result.hostname = m_hostnameComponent.createComponentMatchResult(context, WTFMove(hostname), hostnameExecResult);
+    result.hostname = m_hostnameComponent.createComponentMatchResult(globalObject, WTFMove(hostname), hostnameExecResult);
 
     auto pathnameExecResult = m_pathnameComponent.componentExec(context, pathname);
     if (pathnameExecResult.isNull() || pathnameExecResult.isUndefined())
         return { std::nullopt };
-    result.pathname = m_pathnameComponent.createComponentMatchResult(context, WTFMove(pathname), pathnameExecResult);
+    result.pathname = m_pathnameComponent.createComponentMatchResult(globalObject, WTFMove(pathname), pathnameExecResult);
 
     auto portExecResult = m_portComponent.componentExec(context, port);
     if (portExecResult.isNull() || portExecResult.isUndefined())
         return { std::nullopt };
-    result.port = m_portComponent.createComponentMatchResult(context, WTFMove(port), portExecResult);
+    result.port = m_portComponent.createComponentMatchResult(globalObject, WTFMove(port), portExecResult);
 
     auto searchExecResult = m_searchComponent.componentExec(context, search);
     if (searchExecResult.isNull() || searchExecResult.isUndefined())
         return { std::nullopt };
-    result.search = m_searchComponent.createComponentMatchResult(context, WTFMove(search), searchExecResult);
+    result.search = m_searchComponent.createComponentMatchResult(globalObject, WTFMove(search), searchExecResult);
 
     auto hashExecResult = m_hashComponent.componentExec(context, hash);
     if (hashExecResult.isNull() || hashExecResult.isUndefined())
         return { std::nullopt };
-    result.hash = m_hashComponent.createComponentMatchResult(context, WTFMove(hash), hashExecResult);
+    result.hash = m_hashComponent.createComponentMatchResult(globalObject, WTFMove(hash), hashExecResult);
 
     return { result };
 }

--- a/Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp
@@ -106,11 +106,10 @@ JSC::JSValue URLPatternComponent::componentExec(ScriptExecutionContext& context,
 }
 
 // https://urlpattern.spec.whatwg.org/#create-a-component-match-result
-URLPatternComponentResult URLPatternComponent::createComponentMatchResult(ScriptExecutionContext& context, String&& input, const JSC::JSValue& execResult) const
+URLPatternComponentResult URLPatternComponent::createComponentMatchResult(JSC::JSGlobalObject* globalObject, String&& input, const JSC::JSValue& execResult) const
 {
     URLPatternComponentResult::GroupsRecord groups;
 
-    auto globalObject = context.globalObject();
     Ref vm = globalObject->vm();
 
     auto length = execResult.get(globalObject, vm->propertyNames->length).toIntegerOrInfinity(globalObject);

--- a/Source/WebCore/Modules/url-pattern/URLPatternComponent.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternComponent.h
@@ -51,7 +51,7 @@ public:
     bool hasRegexGroupsFromPartList() const { return m_hasRegexGroupsFromPartList; }
     bool matchSpecialSchemeProtocol(ScriptExecutionContext&) const;
     JSC::JSValue componentExec(ScriptExecutionContext&, StringView) const;
-    URLPatternComponentResult createComponentMatchResult(ScriptExecutionContext&, String&& input, const JSC::JSValue& execResult) const;
+    URLPatternComponentResult createComponentMatchResult(JSC::JSGlobalObject*, String&& input, const JSC::JSValue& execResult) const;
     URLPatternComponent() = default;
 
 private:


### PR DESCRIPTION
#### 20ebe20f75010b63e78b719250a9b9a5e9333140
<pre>
Nullptr crash in URLPatternUtilities::URLPatternComponent::createComponentMatchResult
<a href="https://bugs.webkit.org/show_bug.cgi?id=291924">https://bugs.webkit.org/show_bug.cgi?id=291924</a>
<a href="https://rdar.apple.com/149686034">rdar://149686034</a>

Reviewed by Youenn Fablet.

Added a check for null global object context in case it is broken or detached.

* LayoutTests/fast/url/invalid-url-pattern-context-crash-expected.txt: Added.
* LayoutTests/fast/url/invalid-url-pattern-context-crash.html: Added.
* Source/WebCore/Modules/url-pattern/URLPattern.cpp:
(WebCore::URLPattern::match const):
* Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp:
(WebCore::URLPatternUtilities::URLPatternComponent::createComponentMatchResult const):
* Source/WebCore/Modules/url-pattern/URLPatternComponent.h:

Canonical link: <a href="https://commits.webkit.org/294350@main">https://commits.webkit.org/294350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ad2571e2de1a6be625cbba4848c2b9705147bd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106507 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51983 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103394 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29510 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77198 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34233 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104360 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91548 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57539 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16273 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9558 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51331 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86154 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108857 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28481 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20956 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86173 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28843 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87750 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85729 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30455 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8167 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/22596 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16522 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28411 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33693 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28223 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31543 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29784 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->