### PR TITLE
feMerge misplaces the HTML element when merging the same feMergeNode multiple times

### DIFF
--- a/LayoutTests/svg/filters/feMerge-nodes-unite-outsets-expected.html
+++ b/LayoutTests/svg/filters/feMerge-nodes-unite-outsets-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .shadow-box {
+            position: absolute;
+            top: 10px;
+            left: 10px;
+            display: inline-block;
+            width: 200px;
+            height: 200px;
+            background-color: green;
+            border: solid black 20px;
+        }
+    </style>
+</head>
+<body>
+    <div class="shadow-box"></div>
+</body>
+</html>

--- a/LayoutTests/svg/filters/feMerge-nodes-unite-outsets.html
+++ b/LayoutTests/svg/filters/feMerge-nodes-unite-outsets.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-18081" />
+    <style>
+        svg {
+            width: 0;
+            height: 0;
+        }
+        .shadow-box {
+            position: absolute;
+            top: 30px;
+            left: 30px;
+            display: inline-block;
+            width: 200px;
+            height: 200px;
+            background-color: green;
+            filter: url('#filter');
+        }
+    </style>
+</head>
+<body>
+	<svg viewBox="0 0 1440 300">
+        <defs>
+            <filter id="filter">
+                <feDropShadow dx="0" dy="0" stdDeviation="100" flood-color="black" result="drop-shadow" />
+                <feMerge>
+                    <feMergeNode in="drop-shadow"></feMergeNode>
+                    <feMergeNode in="drop-shadow"></feMergeNode>
+                    <feMergeNode in="drop-shadow"></feMergeNode>
+                    <feMergeNode in="drop-shadow"></feMergeNode>
+                    <feMergeNode in="drop-shadow"></feMergeNode>
+                    <feMergeNode in="drop-shadow"></feMergeNode>
+                    <feMergeNode in="drop-shadow"></feMergeNode>
+                    <feMergeNode in="drop-shadow"></feMergeNode>
+                    <feMergeNode in="drop-shadow"></feMergeNode>
+                    <feMergeNode in="drop-shadow"></feMergeNode>
+                    <feMergeNode in="drop-shadow"></feMergeNode>
+                    <feMergeNode in="drop-shadow"></feMergeNode>
+                    <feMergeNode in="drop-shadow"></feMergeNode>
+                    <feMergeNode in="drop-shadow"></feMergeNode>
+                    <feMergeNode in="drop-shadow"></feMergeNode>
+                </feMerge>
+            </filter>
+        </defs>
+    </svg>
+    <div class="shadow-box"></div>
+</body>
+</html>

--- a/Source/WebCore/platform/RectEdges.h
+++ b/Source/WebCore/platform/RectEdges.h
@@ -173,6 +173,23 @@ inline RectEdges<T>& operator+=(RectEdges<T>& a, const RectEdges<T>& b)
     return a;
 }
 
+template<typename T, typename F>
+inline RectEdges<T> blend(const RectEdges<T>& a, const RectEdges<T>& b, F&& functor)
+{
+    return {
+        functor(a.top(), b.top(), BoxSide::Top),
+        functor(a.right(), b.right(), BoxSide::Right),
+        functor(a.bottom(), b.bottom(), BoxSide::Bottom),
+        functor(a.left(), b.left(), BoxSide::Left)
+    };
+}
+
+template<typename T>
+inline RectEdges<T> max(const RectEdges<T>& a, const RectEdges<T>& b)
+{
+    return blend(a, b, [](const T& a, const T& b, BoxSide) { return std::max(a, b); });
+}
+
 template<typename T>
 TextStream& operator<<(TextStream& ts, const RectEdges<T>& edges)
 {

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
@@ -26,10 +26,10 @@
 #include "ElementChildIteratorInlines.h"
 #include "FilterResults.h"
 #include "GeometryUtilities.h"
+#include "SVGFilterEffectGraph.h"
 #include "SVGFilterElement.h"
-#include "SVGFilterGraph.h"
+#include "SVGFilterPrimitiveGraph.h"
 #include "SVGFilterPrimitiveStandardAttributes.h"
-#include "SourceGraphic.h"
 
 namespace WebCore {
 
@@ -80,13 +80,13 @@ SVGFilter::SVGFilter(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitTy
 {
 }
 
-static std::optional<std::tuple<SVGFilterEffectsGraph, FilterEffectGeometryMap>> buildFilterEffectsGraph(SVGFilterElement& filterElement, const SVGFilter& filter, const GraphicsContext& destinationContext)
+static std::optional<std::tuple<SVGFilterEffectGraph, FilterEffectGeometryMap>> buildFilterEffectGraph(SVGFilterElement& filterElement, const SVGFilter& filter, const GraphicsContext& destinationContext)
 {
     if (filterElement.countChildNodes() > maxCountChildNodes)
         return std::nullopt;
 
     const auto colorSpace = filterElement.colorInterpolation() == ColorInterpolation::LinearRGB ? DestinationColorSpace::LinearSRGB() : DestinationColorSpace::SRGB();
-    SVGFilterEffectsGraph graph(SourceGraphic::create(colorSpace), SourceAlpha::create(colorSpace));
+    SVGFilterEffectGraph graph(SourceGraphic::create(colorSpace), SourceAlpha::create(colorSpace));
     FilterEffectGeometryMap effectGeometryMap;
 
     for (Ref effectElement : childrenOfType<SVGFilterPrimitiveStandardAttributes>(filterElement)) {
@@ -115,11 +115,11 @@ static std::optional<std::tuple<SVGFilterEffectsGraph, FilterEffectGeometryMap>>
 
 std::optional<std::tuple<SVGFilterExpression, FilterEffectVector>> SVGFilter::buildExpression(SVGFilterElement& filterElement, const SVGFilter& filter, const GraphicsContext& destinationContext)
 {
-    auto result = buildFilterEffectsGraph(filterElement, filter, destinationContext);
+    auto result = buildFilterEffectGraph(filterElement, filter, destinationContext);
     if (!result)
         return std::nullopt;
 
-    auto& graph = std::get<SVGFilterEffectsGraph>(*result);
+    auto& graph = std::get<SVGFilterEffectGraph>(*result);
     auto& effectGeometryMap = std::get<FilterEffectGeometryMap>(*result);
 
     auto effectGeometry = [&](FilterEffect& effect) -> std::optional<FilterEffectGeometry> {
@@ -148,17 +148,17 @@ std::optional<std::tuple<SVGFilterExpression, FilterEffectVector>> SVGFilter::bu
     return { { WTFMove(expression), WTFMove(effects) } };
 }
 
-static std::optional<SVGFilterPrimitivesGraph> buildFilterPrimitivesGraph(SVGFilterElement& filterElement)
+static std::optional<SVGFilterPrimitiveGraph> buildFilterPrimitiveGraph(SVGFilterElement& filterElement)
 {
     auto countChildNodes = filterElement.countChildNodes();
     if (!countChildNodes || countChildNodes > maxCountChildNodes)
         return std::nullopt;
 
-    SVGFilterPrimitivesGraph graph;
+    SVGFilterPrimitiveGraph graph;
 
     for (Ref effectElement : childrenOfType<SVGFilterPrimitiveStandardAttributes>(filterElement)) {
         // We should not be strict about not finding the input primitives here because SourceGraphic and SourceAlpha do not have primitives.
-        auto inputs = graph.getNamedNodes(effectElement->filterEffectInputsNames()).value_or(SVGFilterPrimitivesGraph::NodeVector());
+        auto inputs = graph.getNamedNodes(effectElement->filterEffectInputsNames()).value_or(SVGFilterPrimitiveGraph::NodeVector());
         graph.addNamedNode(AtomString { effectElement->result() }, effectElement.copyRef());
         graph.setNodeInputs(effectElement, WTFMove(inputs));
     }
@@ -168,7 +168,7 @@ static std::optional<SVGFilterPrimitivesGraph> buildFilterPrimitivesGraph(SVGFil
 
 bool SVGFilter::isIdentity(SVGFilterElement& filterElement)
 {
-    auto graph = buildFilterPrimitivesGraph(filterElement);
+    auto graph = buildFilterPrimitiveGraph(filterElement);
     if (!graph)
         return false;
 
@@ -183,16 +183,45 @@ bool SVGFilter::isIdentity(SVGFilterElement& filterElement)
 
 IntOutsets SVGFilter::calculateOutsets(SVGFilterElement& filterElement, const FloatRect& targetBoundingBox)
 {
-    auto graph = buildFilterPrimitivesGraph(filterElement);
+    auto graph = buildFilterPrimitiveGraph(filterElement);
     if (!graph)
         return { };
 
-    IntOutsets outsets;
-    bool result = graph->visit([&](SVGFilterPrimitiveStandardAttributes& primitive, unsigned) {
-        outsets += primitive.outsets(targetBoundingBox, filterElement.primitiveUnits());
+    Vector<std::pair<IntOutsets, unsigned>> outsetsStack;
+
+    // Remove the outsets of the last level and return their maximum.
+    auto lastLevelOutsets([](auto& outsetsStack) -> IntOutsets {
+        IntOutsets lastLevelOutsets;
+        for (unsigned lastLevel = outsetsStack.last().second; lastLevel == outsetsStack.last().second; outsetsStack.takeLast())
+            lastLevelOutsets = max(lastLevelOutsets, outsetsStack.last().first);
+        return lastLevelOutsets;
     });
 
-    return result ? outsets : IntOutsets();
+    bool result = graph->visit([&](SVGFilterPrimitiveStandardAttributes& primitive, unsigned level) {
+        auto primitiveOutsets = primitive.outsets(targetBoundingBox, filterElement.primitiveUnits());
+        unsigned lastLevel = outsetsStack.isEmpty() ? 0 : outsetsStack.last().second;
+
+        // Expand the last outsets of this level with the maximum of the outsets of its children.
+        if (level < lastLevel) {
+            auto childrenOutsets = lastLevelOutsets(outsetsStack);
+            outsetsStack.last().first += childrenOutsets;
+        }
+
+        outsetsStack.append(std::make_pair(primitiveOutsets, level));
+    });
+
+    if (!result)
+        return IntOutsets();
+
+    ASSERT(!outsetsStack.isEmpty());
+
+    // Calculate the whole filter outsets by going back to the lastNode of the graph.
+    while (outsetsStack.size() > 1) {
+        auto childrenOutsets = lastLevelOutsets(outsetsStack);
+        outsetsStack.last().first += childrenOutsets;
+    }
+
+    return outsetsStack.takeLast().first;
 }
 
 FloatSize SVGFilter::calculateResolvedSize(const FloatSize& size, const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits)

--- a/Source/WebCore/svg/graphics/filters/SVGFilterEffectGraph.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterEffectGraph.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2022-2025 Apple Inc.  All rights reserved.
+ * Copyright (C) 2014 Google Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "SVGFilterGraph.h"
+
+namespace WebCore {
+
+class FilterEffect;
+
+class SVGFilterEffectGraph final : public SVGFilterGraph<FilterEffect> {
+public:
+    SVGFilterEffectGraph(Ref<FilterEffect>&& sourceGraphic, Ref<FilterEffect>&& sourceAlpha)
+    {
+        m_sourceNodes.add(SourceGraphic::effectName(), WTFMove(sourceGraphic));
+        m_sourceNodes.add(SourceAlpha::effectName(), WTFMove(sourceAlpha));
+
+        setNodeInputs(Ref { *this->sourceGraphic() }, NodeVector { });
+        setNodeInputs(Ref { *this->sourceAlpha() }, NodeVector { *this->sourceGraphic() });
+    }
+
+    void addNamedNode(const AtomString& name, Ref<FilterEffect>&& node) override
+    {
+        if (name.isEmpty()) {
+            m_lastNode = WTFMove(node);
+            return;
+        }
+
+        if (m_sourceNodes.contains(name))
+            return;
+
+        m_lastNode = WTFMove(node);
+        m_namedNodes.set(name, Ref { *m_lastNode });
+    }
+
+private:
+    FilterEffect* sourceGraphic() const
+    {
+        return m_sourceNodes.get(FilterEffect::sourceGraphicName());
+    }
+
+    FilterEffect* sourceAlpha() const
+    {
+        return m_sourceNodes.get(FilterEffect::sourceAlphaName());
+    }
+
+    RefPtr<FilterEffect> getNamedNode(const AtomString& name) const override
+    {
+        if (!name.isEmpty()) {
+            if (RefPtr sourceNode = m_sourceNodes.get(name))
+                return sourceNode;
+
+            if (RefPtr namedNode = m_namedNodes.get(name))
+                return namedNode;
+        }
+
+        if (m_lastNode)
+            return m_lastNode;
+
+        // Fallback to the 'sourceGraphic' input.
+        return sourceGraphic();
+    }
+
+    UncheckedKeyHashMap<AtomString, Ref<FilterEffect>> m_sourceNodes;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/svg/graphics/filters/SVGFilterGraph.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterGraph.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Apple Inc.  All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc.  All rights reserved.
  * Copyright (C) 2014 Google Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,65 +33,15 @@
 
 namespace WebCore {
 
-class FilterEffect;
-class SVGFilterPrimitiveStandardAttributes;
-
 template<typename NodeType>
 class SVGFilterGraph {
 public:
     using NodeVector = Vector<Ref<NodeType>>;
 
-    SVGFilterGraph() = default;
+    virtual ~SVGFilterGraph() = default;
 
-    SVGFilterGraph(Ref<NodeType>&& sourceGraphic, Ref<NodeType>&& sourceAlpha)
-    {
-        m_sourceNodes.add(SourceGraphic::effectName(), WTFMove(sourceGraphic));
-        m_sourceNodes.add(SourceAlpha::effectName(), WTFMove(sourceAlpha));
-
-        setNodeInputs(Ref { *this->sourceGraphic() }, NodeVector { });
-        setNodeInputs(Ref { *this->sourceAlpha() }, NodeVector { *this->sourceGraphic() });
-    }
-
-    NodeType* sourceGraphic() const
-    {
-        return m_sourceNodes.get(FilterEffect::sourceGraphicName());
-    }
-
-    NodeType* sourceAlpha() const
-    {
-        return m_sourceNodes.get(FilterEffect::sourceAlphaName());
-    }
-
-    void addNamedNode(const AtomString& id, Ref<NodeType>&& node)
-    {
-        if (id.isEmpty()) {
-            m_lastNode = WTFMove(node);
-            return;
-        }
-
-        if (m_sourceNodes.contains(id))
-            return;
-
-        m_lastNode = WTFMove(node);
-        m_namedNodes.set(id, Ref { *m_lastNode });
-    }
-
-    RefPtr<NodeType> getNamedNode(const AtomString& id) const
-    {
-        if (!id.isEmpty()) {
-            if (RefPtr sourceNode = m_sourceNodes.get(id))
-                return sourceNode;
-
-            if (RefPtr namedNode = m_namedNodes.get(id))
-                return namedNode;
-        }
-
-        if (m_lastNode)
-            return m_lastNode;
-
-        // Fallback to the 'sourceGraphic' input.
-        return sourceGraphic();
-    }
+    virtual void addNamedNode(const AtomString& id, Ref<NodeType>&&) = 0;
+    virtual RefPtr<NodeType> getNamedNode(const AtomString& id) const = 0;
 
     std::optional<NodeVector> getNamedNodes(std::span<const AtomString> names) const
     {
@@ -139,10 +89,10 @@ public:
         return visit(*lastNode, stack, 0, callback);
     }
 
-private:
-    static bool isSourceName(const AtomString& id)
+protected:
+    static bool isSourceName(const AtomString& name)
     {
-        return id == SourceGraphic::effectName() || id == SourceAlpha::effectName();
+        return name == SourceGraphic::effectName() || name == SourceAlpha::effectName();
     }
 
     template<typename Callback>
@@ -168,13 +118,9 @@ private:
         return true;
     }
 
-    UncheckedKeyHashMap<AtomString, Ref<NodeType>> m_sourceNodes;
     UncheckedKeyHashMap<AtomString, Ref<NodeType>> m_namedNodes;
     UncheckedKeyHashMap<Ref<NodeType>, NodeVector> m_nodeInputs;
     RefPtr<NodeType> m_lastNode;
 };
-
-using SVGFilterEffectsGraph = SVGFilterGraph<FilterEffect>;
-using SVGFilterPrimitivesGraph = SVGFilterGraph<SVGFilterPrimitiveStandardAttributes>;
 
 } // namespace WebCore

--- a/Source/WebCore/svg/graphics/filters/SVGFilterPrimitiveGraph.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterPrimitiveGraph.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022-2025 Apple Inc.  All rights reserved.
+ * Copyright (C) 2014 Google Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "SVGFilterGraph.h"
+
+namespace WebCore {
+
+class SVGFilterPrimitiveStandardAttributes;
+
+class SVGFilterPrimitiveGraph final : public SVGFilterGraph<SVGFilterPrimitiveStandardAttributes> {
+public:
+    SVGFilterPrimitiveGraph() = default;
+
+    void addNamedNode(const AtomString& name, Ref<SVGFilterPrimitiveStandardAttributes>&& node) override
+    {
+        if (name.isEmpty()) {
+            m_lastNode = WTFMove(node);
+            return;
+        }
+
+        m_lastNode = WTFMove(node);
+        m_namedNodes.set(name, Ref { *m_lastNode });
+    }
+
+private:
+    RefPtr<SVGFilterPrimitiveStandardAttributes> getNamedNode(const AtomString& name) const override
+    {
+        if (name.isEmpty())
+            return m_lastNode;
+
+        return m_namedNodes.get(name);
+    }
+};
+
+} // namespace WebCore


### PR DESCRIPTION
#### e2873429150ba8df42e6acf17a0ff6ac64f1a69f
<pre>
feMerge misplaces the HTML element when merging the same feMergeNode multiple times
<a href="https://bugs.webkit.org/show_bug.cgi?id=291919">https://bugs.webkit.org/show_bug.cgi?id=291919</a>
<a href="https://rdar.apple.com/149431216">rdar://149431216</a>

Reviewed by Simon Fraser.

Two bugs need to be fixed to get this scenario working:

1. Building SVGFilterPrimitiveGraph:

There are two graphs for SVGFiler. One is for the effects and the other is for
the primitives. The main difference between these two graphs is the effect graph
has entries for SourceGraphics and SourceAlpha. The primitive graph can&apos;t have
entries for these predefined effects. But there should not be an error when
handling them.

When looking for a named effect, we fall back to the lastEffect when there is no
matched named effect and it is not predefined effect. Since there is no predefined
primitives, getNamedNode() was falling back to the lastNode when the name is
SourceGraphis or SourceAlpha. This was building a wrong primitives graph.

To make fixing this simple, SVGFilterPrimitiveGraph and SVGFilterEffectGraph
should be split and should be made sub-classes of SVGFilterGraph.
Only SVGFilterEffectGraph will handle the predefined effects.

2. The outsets of the sibling primitives should be their maximum:

SVGFilter::calculateOutsets() will push the outsets of the current primitive
associated with the its level into a stack. When the graph enumeration goes up
one level, all the outsets on the lower level will be popped out of the stack
and their maximum will expand the outsets of the top of outsets stack.

* LayoutTests/svg/filters/feMerge-nodes-unite-outsets-expected.html: Added.
* LayoutTests/svg/filters/feMerge-nodes-unite-outsets.html: Added.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/RectEdges.h:
(WebCore::blend):
(WebCore::max):
* Source/WebCore/svg/graphics/filters/SVGFilter.cpp:
(WebCore::buildFilterEffectGraph):
(WebCore::SVGFilter::buildExpression):
(WebCore::buildFilterPrimitiveGraph):
(WebCore::SVGFilter::isIdentity):
(WebCore::SVGFilter::calculateOutsets):
(WebCore::buildFilterEffectsGraph): Deleted.
(WebCore::buildFilterPrimitivesGraph): Deleted.
* Source/WebCore/svg/graphics/filters/SVGFilterEffectGraph.h: Added.
(WebCore::SVGFilterEffectGraph::SVGFilterEffectGraph):
(WebCore::SVGFilterEffectGraph::sourceGraphic const):
(WebCore::SVGFilterEffectGraph::sourceAlpha const):
* Source/WebCore/svg/graphics/filters/SVGFilterGraph.h:
(WebCore::SVGFilterGraph::isSourceName):
(WebCore::SVGFilterGraph::SVGFilterGraph): Deleted.
(WebCore::SVGFilterGraph::sourceGraphic const): Deleted.
(WebCore::SVGFilterGraph::sourceAlpha const): Deleted.
(WebCore::SVGFilterGraph::addNamedNode): Deleted.
(WebCore::SVGFilterGraph::getNamedNode const): Deleted.
* Source/WebCore/svg/graphics/filters/SVGFilterPrimitiveGraph.h: Added.

Canonical link: <a href="https://commits.webkit.org/294088@main">https://commits.webkit.org/294088@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d864b4d80d3099ae5bda14f922538c4fc0b12f21

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100792 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10743 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/105929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/51381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28918 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/105929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/51381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103799 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/15951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/91040 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/105929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/15761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9049 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/50756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/85662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9123 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108284 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27910 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28273 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87242 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/85256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21694 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29962 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/7690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/21914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27845 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/33101 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27656 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30974 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29214 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->