### PR TITLE
[WebDriver][BiDi] Assertion in RefCountedAndCanMakeWeakPtr<WebSocketServer> destructor

### DIFF
--- a/Source/WebDriver/WebDriverService.h
+++ b/Source/WebDriver/WebDriverService.h
@@ -176,7 +176,7 @@ private:
 
     HTTPServer m_server;
 #if ENABLE(WEBDRIVER_BIDI)
-    WebSocketServer m_bidiServer;
+    Ref<WebSocketServer> m_bidiServer;
     SessionHost::BrowserTerminatedObserver m_browserTerminatedObserver;
 #endif
     RefPtr<Session> m_session;

--- a/Source/WebDriver/WebSocketServer.cpp
+++ b/Source/WebDriver/WebSocketServer.cpp
@@ -38,9 +38,8 @@
 
 namespace WebDriver {
 
-WebSocketServer::WebSocketServer(WebSocketMessageHandler& messageHandler, WebDriverService& service)
+WebSocketServer::WebSocketServer(WebSocketMessageHandler& messageHandler)
     : m_messageHandler(messageHandler)
-    , m_service(service)
 {
 }
 
@@ -71,25 +70,14 @@ void WebSocketServer::removeConnection(const WebSocketMessageHandler::Connection
         m_connectionToSession.remove(it);
 }
 
-RefPtr<Session> WebSocketServer::session(const WebSocketMessageHandler::Connection& connection)
+String WebSocketServer::sessionID(const WebSocketMessageHandler::Connection& connection) const
 {
-    String sessionId;
-
     for (const auto& pair : m_connectionToSession) {
-        if (pair.key == connection) {
-            sessionId = pair.value;
-            break;
-        }
+        if (pair.key == connection)
+            return pair.value;
     }
 
-    if (sessionId.isNull())
-        return { };
-
-    const auto& existingSession = m_service.session();
-    if (!existingSession || (existingSession->id() != sessionId))
-        return { };
-
-    return existingSession;
+    return { };
 }
 
 std::optional<WebSocketMessageHandler::Connection> WebSocketServer::connection(const String& sessionId)

--- a/Source/WebDriver/WebSocketServer.h
+++ b/Source/WebDriver/WebSocketServer.h
@@ -106,7 +106,10 @@ private:
 
 class WebSocketServer : public RefCountedAndCanMakeWeakPtr<WebSocketServer> {
 public:
-    explicit WebSocketServer(WebSocketMessageHandler&, WebDriverService&);
+    static Ref<WebSocketServer> create(WebSocketMessageHandler& messageHandler)
+    {
+        return adoptRef(*new WebSocketServer(messageHandler));
+    }
     virtual ~WebSocketServer() = default;
 
     std::optional<String> listen(const String& host, unsigned port);
@@ -121,7 +124,7 @@ public:
     void removeStaticConnection(const WebSocketMessageHandler::Connection&);
 
     void addConnection(WebSocketMessageHandler::Connection&&, const String& sessionId);
-    RefPtr<Session> session(const WebSocketMessageHandler::Connection&);
+    String sessionID(const WebSocketMessageHandler::Connection&) const;
     std::optional<WebSocketMessageHandler::Connection> connection(const String& sessionId);
     void removeConnection(const WebSocketMessageHandler::Connection&);
 
@@ -136,9 +139,9 @@ public:
     void disconnectSession(const String& sessionId);
 
 private:
+    explicit WebSocketServer(WebSocketMessageHandler&);
 
     WebSocketMessageHandler& m_messageHandler;
-    WebDriverService& m_service;
     String m_listenerURL;
     RefPtr<WebSocketListener> m_listener;
     HashMap<WebSocketMessageHandler::Connection, String> m_connectionToSession;


### PR DESCRIPTION
#### 71b34966f4fbbb0e2c7bbf5132c4645a0ef67e90
<pre>
[WebDriver][BiDi] Assertion in RefCountedAndCanMakeWeakPtr&lt;WebSocketServer&gt; destructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=291925">https://bugs.webkit.org/show_bug.cgi?id=291925</a>

Reviewed by BJ Burg and Carlos Garcia Campos.

Make WebDriverService hold the WebSocketServer in a Ref, as the server
implements RefCountedAndCanMakeWeakPtr.

This commit also removes the member of WebSocketServer that used to hold
the WebDriverService, as it was just used in
`WebSocketServer::session(...)`. This method was changed to return the
session id associated to that connection, so we don&apos;t have to pass the
current session anymore.

Combined changes:
* Source/WebDriver/WebDriverService.cpp:
(WebDriver::WebDriverService::WebDriverService): Update server
constructor call.
(WebDriver::WebDriverService::run): Fix pointer usage.
(WebDriver::WebDriverService::acceptHandshake): Ditto and update method
call.
(WebDriver::WebDriverService::handleMessage): Ditto and cleanup.
(WebDriver::WebDriverService::newSession): Fix pointer usage.
(WebDriver::WebDriverService::createSession): Ditto.
(WebDriver::WebDriverService::deleteSession): Ditto.
(WebDriver::WebDriverService::clientDisconnected): Ditto.
(WebDriver::WebDriverService::onBrowserTerminated): Ditto.
* Source/WebDriver/WebDriverService.h: Fix m_bidiServer type.
* Source/WebDriver/WebSocketServer.cpp:
(WebDriver::WebSocketServer::WebSocketServer): Update constructor call.
(WebDriver::WebSocketServer::sessionID const): Added.
(WebDriver::WebSocketServer::session): Deleted.
* Source/WebDriver/WebSocketServer.h: Remove m_bidiService and make
  constructor private.
(WebDriver::WebSocketServer::create): Added.
* Source/WebDriver/soup/WebSocketServerSoup.cpp:
(WebDriver::WebSocketServer::disconnect): Checks and disconnect the
signal handlers.
(WebDriver::WebSocketServer::disconnectSession): Ditto.

Canonical link: <a href="https://commits.webkit.org/294135@main">https://commits.webkit.org/294135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c68bd01e0e0e62ad30036ee4f433463dd031d4e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106073 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51525 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20897 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29083 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/76860 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33888 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91159 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57207 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/15887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9181 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50901 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/85796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9242 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108429 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28054 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85824 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28417 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87359 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85365 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21729 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30079 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7804 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22084 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27985 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/33253 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27797 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31117 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29355 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->