### PR TITLE
REGRESSION(293851@main):[iOS MacOS Debug] ASSERTION FAILED: !layer || !layer->hasAncestor in fast/css/view-transitions-hide-under-page-background-color.html

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7852,7 +7852,3 @@ webkit.org/b/291456 fast/forms/state-restore-per-form.html [ Pass Timeout ]
 webkit.org/b/291459 imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-018.html [ Pass Failure ]
 
 webkit.org/b/291767 media/video-aspect-ratio.html [ Pass Failure ]
-
-# webkit.org/b/291904 REGRESSION(293851@main):[iOS MacOS Debug] ASSERTION FAILED: !layer || !layer->hasAncestor in fast/css/view-transitions-hide-under-page-background-color.html (flaky in EWS)
-[ Debug ] fast/css/view-transition-pseudo-element-styles-crash.html [ Skip ]
-[ Debug ] fast/css/view-transitions-hide-under-page-background-color.html [ Skip ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2141,8 +2141,4 @@ webkit.org/b/291861 [ Release x86_64 ] media/media-vp8-hiddenframes.html [ Pass 
 
 webkit.org/b/291878 [ Sequoia Release arm64 ] http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleBias.html [ Failure ]
 
-# webkit.org/b/291904 REGRESSION(293851@main):[iOS MacOS Debug] ASSERTION FAILED: !layer || !layer->hasAncestor in fast/css/view-transitions-hide-under-page-background-color.html (flaky in EWS)
-[ Sonoma Debug ] fast/css/view-transition-pseudo-element-styles-crash.html [ Skip ]
-[ Sonoma Debug ] fast/css/view-transitions-hide-under-page-background-color.html [ Skip ]
-
 webkit.org/b/291966 [ Sequoia+ Release ] http/tests/webgpu/webgpu/api/validation/render_pipeline/fragment_state.html [ Pass Timeout ]

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -681,6 +681,12 @@ void ViewTransition::setupTransitionPseudoElements()
 
     for (auto& [name, capturedElement] : m_namedElements.map())
         setupDynamicStyleSheet(name, capturedElement);
+
+    if (RefPtr documentElement = document()->documentElement())
+        documentElement->invalidateStyleInternal();
+
+    // Ensure style & render tree are up-to-date.
+    protectedDocument()->updateStyleIfNeeded();
 }
 
 ExceptionOr<void> ViewTransition::checkForViewportSizeChange()


### PR DESCRIPTION
#### 497b138d4b4de6e1ac120ac9785783f2c19cfaf1
<pre>
REGRESSION(293851@main):[iOS MacOS Debug] ASSERTION FAILED: !layer || !layer-&gt;hasAncestor in fast/css/view-transitions-hide-under-page-background-color.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=291904">https://bugs.webkit.org/show_bug.cgi?id=291904</a>
&lt;<a href="https://rdar.apple.com/149783892">rdar://149783892</a>&gt;

Reviewed by Tim Nguyen.

Ensure styles get flushed at the end of setupTransitionPseudoElements, since we
need those elements to exist for the next step. This is a repeat of 278608@main
(and fixes the same test).

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::setupTransitionPseudoElements):

Canonical link: <a href="https://commits.webkit.org/294027@main">https://commits.webkit.org/294027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/839dea5347e090fdafa43a62fe87d8c166d8f0f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105765 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51216 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102669 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20588 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28754 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/76628 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/33668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15800 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90892 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56983 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/15614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8899 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50592 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/85526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8974 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108119 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27746 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85583 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28109 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87093 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85123 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21651 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29818 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7546 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21734 "Failed to checkout and rebase branch from PR 44400") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27681 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/32932 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27492 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30810 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29050 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->