### PR TITLE
Unreviewed, reverting 292314@main

### DIFF
--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -233,6 +233,17 @@ private:
     std::optional<LayoutUnit> m_overridingHeight;
 };
 
+static void updateFlexItemDirtyBitsBeforeLayout(bool relayoutFlexItem, RenderBox& flexItem)
+{
+    if (flexItem.isOutOfFlowPositioned())
+        return;
+
+    // FIXME: Technically percentage height objects only need a relayout if their percentage isn't going to be turned into
+    // an auto value. Add a method to determine this, so that we can avoid the relayout.
+    if (relayoutFlexItem || flexItem.hasRelativeLogicalHeight())
+        flexItem.setChildNeedsLayout(MarkOnlyThis);
+}
+
 void RenderFlexibleBox::computeChildIntrinsicLogicalWidths(RenderBox& flexBoxChild, LayoutUnit& minPreferredLogicalWidth, LayoutUnit& maxPreferredLogicalWidth) const
 {
     // Children excluded from normal layout are handled here too (e.g. legend when fieldset is set to flex).
@@ -333,24 +344,16 @@ void RenderFlexibleBox::styleDidChange(StyleDifference diff, const RenderStyle* 
     if (!oldStyle || diff != StyleDifference::Layout)
         return;
 
-    auto& newStyle = style();
     auto oldStyleAlignItemsIsStretch = oldStyle->resolvedAlignItems(selfAlignmentNormalBehavior()).position() == ItemPosition::Stretch;
-    auto logicalHeightIsDifferent = oldStyle->logicalHeight() != newStyle.logicalHeight();
     for (auto& flexItem : childrenOfType<RenderBox>(*this)) {
-        if (logicalHeightIsDifferent)
-            removePercentLogicalHeightFlexItemsFromIntrinsicLogicalHeightCache();
-
         // Flex items that were previously stretching need to be relayed out so we
         // can compute new available cross axis space. This is only necessary for
         // stretching since other alignment values don't change the size of the
         // box.
         if (oldStyleAlignItemsIsStretch) {
             ItemPosition previousAlignment = flexItem.style().resolvedAlignSelf(oldStyle, selfAlignmentNormalBehavior()).position();
-            if (previousAlignment == ItemPosition::Stretch && previousAlignment != flexItem.style().resolvedAlignSelf(&newStyle, selfAlignmentNormalBehavior()).position()) {
+            if (previousAlignment == ItemPosition::Stretch && previousAlignment != flexItem.style().resolvedAlignSelf(&style(), selfAlignmentNormalBehavior()).position())
                 flexItem.setChildNeedsLayout(MarkOnlyThis);
-                if (auto* renderFlexibleBox = dynamicDowncast<RenderFlexibleBox>(flexItem))
-                    renderFlexibleBox->setNoLongerStretching();
-            }
         }
     }
 }
@@ -395,9 +398,6 @@ void RenderFlexibleBox::layoutBlock(RelayoutChildren relayoutChildren, LayoutUni
     }
 
     LayoutRepainter repainter(*this);
-
-    if (m_flexLayoutDamage.contains(Damage::NoLongerStretching))
-        removePercentLogicalHeightFlexItemsFromIntrinsicLogicalHeightCache();
 
     resetLogicalHeightBeforeLayoutIfNeeded();
     m_relaidOutFlexItems.clear();
@@ -470,8 +470,6 @@ void RenderFlexibleBox::layoutBlock(RelayoutChildren relayoutChildren, LayoutUni
     clearNeedsLayout();
     
     m_inLayout = oldInLayout;
-
-    ASSERT(m_flexLayoutDamage.isEmpty());
 }
 
 void RenderFlexibleBox::appendFlexItemFrameRects(FlexItemFrameRects& flexItemFrameRects)
@@ -613,13 +611,6 @@ void RenderFlexibleBox::clearCachedFlexItemIntrinsicContentLogicalHeight(const R
     if (flexItem.isRenderReplaced())
         return; // Replaced elements know their intrinsic height already, so nothing to do.
     m_intrinsicContentLogicalHeights.remove(flexItem);
-}
-
-void RenderFlexibleBox::removePercentLogicalHeightFlexItemsFromIntrinsicLogicalHeightCache()
-{
-    m_intrinsicContentLogicalHeights.removeIf([](auto& keyValue) {
-        return keyValue.key->hasRelativeLogicalHeight();
-    });
 }
 
 LayoutUnit RenderFlexibleBox::flexItemIntrinsicLogicalHeight(RenderBox& flexItem) const
@@ -2291,22 +2282,7 @@ void RenderFlexibleBox::layoutAndPlaceFlexItems(LayoutUnit& crossAxisOffset, Fle
             // So, redo it here.
             forceFlexItemRelayout = true;
         }
-
-        auto shouldRelayoutRelativeLogicalHeightFlexItem = [&] {
-            if (!flexItem.hasRelativeLogicalHeight())
-                return false;
-            // If we do not have a definite logical height constraint, then the flex item's
-            // percentage logical height will behave as auto. If that is the case we may
-            // have a previously cached logical height that will end up being used
-            // through crossAxisIntrinsicExtentForFlexItem.
-            if (mainAxisIsFlexItemInlineAxis(flexItem))
-                return hasDefiniteLogicalHeight() || !m_intrinsicContentLogicalHeights.contains(flexItem);
-            return true;
-        };
-
-        if (forceFlexItemRelayout || shouldRelayoutRelativeLogicalHeightFlexItem())
-            flexItem.setChildNeedsLayout(MarkOnlyThis);
-
+        updateFlexItemDirtyBitsBeforeLayout(forceFlexItemRelayout, flexItem);
         if (!flexItem.needsLayout())
             flexItem.markForPaginationRelayoutIfNeeded();
         if (flexItem.needsLayout())
@@ -2319,9 +2295,10 @@ void RenderFlexibleBox::layoutAndPlaceFlexItems(LayoutUnit& crossAxisOffset, Fle
 
         updateAutoMarginsInMainAxis(flexItem, autoMarginOffset);
 
+        LayoutUnit flexItemCrossAxisMarginBoxExtent;
+
         auto alignment = alignmentForFlexItem(flexItem);
-        bool isFlexItemBaselineAligned = (alignment == ItemPosition::Baseline || alignment == ItemPosition::LastBaseline) && !hasAutoMarginsInCrossAxis(flexItem);
-        if (isFlexItemBaselineAligned) {
+        if ((alignment == ItemPosition::Baseline || alignment == ItemPosition::LastBaseline) && !hasAutoMarginsInCrossAxis(flexItem)) {
             LayoutUnit ascent = marginBoxAscentForFlexItem(flexItem);
             LayoutUnit descent = (crossAxisMarginExtentForFlexItem(flexItem) + crossAxisExtentForFlexItem(flexItem)) - ascent;
             maxDescent = std::max(maxDescent, descent);
@@ -2333,17 +2310,14 @@ void RenderFlexibleBox::layoutAndPlaceFlexItems(LayoutUnit& crossAxisOffset, Fle
 
             if (alignment == ItemPosition::Baseline) {
                 maxAscent =  std::max(maxAscent, ascent);
+                flexItemCrossAxisMarginBoxExtent = maxAscent + maxDescent;
             } else {
                 lastBaselineMaxAscent = std::max(lastBaselineMaxAscent, ascent);
+                flexItemCrossAxisMarginBoxExtent = lastBaselineMaxAscent + maxDescent;
             }
-        }
 
-        auto flexItemCrossAxisMarginBoxExtent = [&] {
-            if (isFlexItemBaselineAligned)
-                return alignment == ItemPosition::Baseline ? maxAscent + maxDescent : lastBaselineMaxAscent + maxDescent;
-            return crossAxisIntrinsicExtentForFlexItem(flexItem) + crossAxisMarginExtentForFlexItem(flexItem);
-        }();
-
+        } else
+            flexItemCrossAxisMarginBoxExtent = crossAxisIntrinsicExtentForFlexItem(flexItem) + crossAxisMarginExtentForFlexItem(flexItem);
 
         if (!isColumnFlow())
             setLogicalHeight(std::max(logicalHeight(), crossAxisOffset + flowAwareBorderAfter() + flowAwarePaddingAfter() + flexItemCrossAxisMarginBoxExtent + crossAxisScrollbarExtent()));
@@ -2824,17 +2798,6 @@ const RenderBox* RenderFlexibleBox::flexItemForLastBaseline() const
     }
     // Logically first (but visually last) item on logically last (but visually first) line.
     return firstBaselineCandidateOnLine(m_orderIterator, ItemPosition::LastBaseline, m_numberOfFlexItemsOnFirstLine);
-}
-
-void RenderFlexibleBox::clearNeedsLayout()
-{
-    m_flexLayoutDamage = { };
-    RenderObject::clearNeedsLayout();
-}
-
-void RenderFlexibleBox::setNoLongerStretching()
-{
-    m_flexLayoutDamage.add(Damage::NoLongerStretching);
 }
 
 }

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -52,8 +52,6 @@ public:
 
     using Direction = FlowDirection;
 
-    enum class Damage : uint8_t { NoLongerStretching = 1 << 0 };
-
     ASCIILiteral renderName() const override;
 
     bool canDropAnonymousBlockChild() const final { return false; }
@@ -108,7 +106,6 @@ public:
     LayoutUnit cachedFlexItemIntrinsicContentLogicalHeight(const RenderBox& flexItem) const;
     void setCachedFlexItemIntrinsicContentLogicalHeight(const RenderBox& flexItem, LayoutUnit);
     void clearCachedFlexItemIntrinsicContentLogicalHeight(const RenderBox& flexItem);
-    void removePercentLogicalHeightFlexItemsFromIntrinsicLogicalHeightCache();
 
     LayoutUnit staticMainAxisPositionForPositionedFlexItem(const RenderBox&);
     LayoutUnit staticCrossAxisPositionForPositionedFlexItem(const RenderBox&);
@@ -128,9 +125,6 @@ public:
     bool isComputingFlexBaseSizes() const { return m_isComputingFlexBaseSizes; }
 
     static std::optional<TextDirection> leftRightAxisDirectionFromStyle(const RenderStyle&);
-
-    void clearNeedsLayout();
-    void setNoLongerStretching();
 
     bool hasModernLayout() const { return m_hasFlexFormattingContextLayout && *m_hasFlexFormattingContextLayout; }
 
@@ -313,8 +307,6 @@ private:
     bool m_shouldResetFlexItemLogicalHeightBeforeLayout { false };
     bool m_isComputingFlexBaseSizes { false };
     std::optional<bool> m_hasFlexFormattingContextLayout;
-
-    OptionSet<Damage> m_flexLayoutDamage;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -35,7 +35,6 @@
 #include "LayoutRepainter.h"
 #include "RenderChildIterator.h"
 #include "RenderElementInlines.h"
-#include "RenderFlexibleBox.h"
 #include "RenderLayer.h"
 #include "RenderLayoutState.h"
 #include "RenderTreeBuilder.h"
@@ -155,13 +154,12 @@ void RenderGrid::styleDidChange(StyleDifference diff, const RenderStyle* oldStyl
         for (auto& gridItem : childrenOfType<RenderBox>(*this)) {
             if (gridItem.isOutOfFlowPositioned())
                 continue;
-            if (selfAlignmentChangedToStretch(GridTrackSizingDirection::ForColumns, *oldStyle, newStyle, gridItem) || selfAlignmentChangedToStretch(GridTrackSizingDirection::ForRows, *oldStyle, newStyle, gridItem))
-                gridItem.setNeedsLayout();
 
-            if (selfAlignmentChangedFromStretch(GridTrackSizingDirection::ForColumns, *oldStyle, newStyle, gridItem) || selfAlignmentChangedFromStretch(GridTrackSizingDirection::ForRows, *oldStyle, newStyle, gridItem)) {
+            if (selfAlignmentChangedToStretch(GridTrackSizingDirection::ForColumns, *oldStyle, newStyle, gridItem)
+                || selfAlignmentChangedFromStretch(GridTrackSizingDirection::ForColumns, *oldStyle, newStyle, gridItem)
+                || selfAlignmentChangedToStretch(GridTrackSizingDirection::ForRows, *oldStyle, newStyle, gridItem)
+                || selfAlignmentChangedFromStretch(GridTrackSizingDirection::ForRows, *oldStyle, newStyle, gridItem)) {
                 gridItem.setNeedsLayout();
-                if (auto* renderFleixbleBox = dynamicDowncast<RenderFlexibleBox>(gridItem))
-                    renderFleixbleBox->setNoLongerStretching();
             }
         }
     }


### PR DESCRIPTION
#### e08abc5a0fe04edfbdc28084302dcbe67d212acc
<pre>
Unreviewed, reverting 292314@main
<a href="https://rdar.apple.com/149102629">rdar://149102629</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291928">https://bugs.webkit.org/show_bug.cgi?id=291928</a>

Caused unbounded content growth when scrolling on homedepot.com.

* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::updateFlexItemDirtyBitsBeforeLayout):
(WebCore::RenderFlexibleBox::styleDidChange):
(WebCore::RenderFlexibleBox::layoutBlock):
(WebCore::RenderFlexibleBox::layoutAndPlaceFlexItems):
(WebCore::RenderFlexibleBox::removePercentLogicalHeightFlexItemsFromIntrinsicLogicalHeightCache): Deleted.
(WebCore::RenderFlexibleBox::clearNeedsLayout): Deleted.
(WebCore::RenderFlexibleBox::setNoLongerStretching): Deleted.
* Source/WebCore/rendering/RenderFlexibleBox.h:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::styleDidChange):

Canonical link: <a href="https://commits.webkit.org/294011@main">https://commits.webkit.org/294011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fc9473d2304993fe853aea8d9de132f41e8d8b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100579 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105716 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51167 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102620 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20539 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28705 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/76590 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/33634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103586 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/15756 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90850 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56946 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15572 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8855 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50543 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/85486 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108070 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27697 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20338 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85545 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28060 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87050 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85083 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21642 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29777 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7504 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21685 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27632 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/32882 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27443 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30761 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29001 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->