### PR TITLE
Gamepad events are not sent for WKWebView clients linked before visionOS 2.0

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -135,6 +135,7 @@ enum class SDKAlignedBehavior {
     DispatchFocusEventBeforeNotifyingClient,
     EnableTrustedTypesByDefault,
     BlobFileAccessEnforcement,
+    SupportGameControllerEventInteractionAPI,
 
     NumberOfBehaviors
 };

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -238,6 +238,7 @@ static SDKAlignedBehaviors computeSDKAlignedBehaviors()
         disableBehavior(SDKAlignedBehavior::UseCFNetworkNetworkLoader);
         disableBehavior(SDKAlignedBehavior::BlocksConnectionsToAddressWithOnlyZeros);
         disableBehavior(SDKAlignedBehavior::BlockCrossOriginRedirectDownloads);
+        disableBehavior(SDKAlignedBehavior::SupportGameControllerEventInteractionAPI);
     }
 
     disableAdditionalSDKAlignedBehaviors(behaviors);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -425,6 +425,7 @@ struct PerWebProcessState {
 #endif
 
 #if ENABLE(GAMEPAD)
+    BOOL _gamepadsRecentlyAccessed;
     RetainPtr<id> _gamepadsRecentlyAccessedState;
 #endif
 


### PR DESCRIPTION
#### 9e05b9fe98cc19b5901813fbb73d79db2b1c79f8
<pre>
Gamepad events are not sent for WKWebView clients linked before visionOS 2.0
<a href="https://bugs.webkit.org/show_bug.cgi?id=291929">https://bugs.webkit.org/show_bug.cgi?id=291929</a>
<a href="https://rdar.apple.com/148680538">rdar://148680538</a>

Reviewed by Brady Eidson.

Game controllers can be used to interact with system UI on visionOS
starting with visionOS 2.0, and apps can choose to receive
controller events through the Game Controller framework
instead of the UIResponder chain by adding the GCEventInteraction
to the views:
<a href="https://developer.apple.com/documentation/gamecontroller/gceventinteraction">https://developer.apple.com/documentation/gamecontroller/gceventinteraction</a>

That means for WKWebView to be able to process controller events through
the Game Controller framework, it&apos;s up to the app embedding the WKWebView to
add the GCEventInteraction to it first. For WKWebView clients linked before
visionOS 2.0, WebKit will automatically add that interaction if there&apos;s
recent Gamepad API access while a physical game controller is connected.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm:
(WTF::computeSDKAlignedBehaviors):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _setGamepadsRecentlyAccessed:]):
For web view client configured to explicitly ask for user consent for
gamepad data (Safari), notify the UI delegate about the new gamepad
access state.
(-[WKWebView _gamepadsConnectedStateChanged]):
Ditto for gamepad connection state.
(-[WKWebView _gamepadAccessRequiresExplicitConsent]):
(-[WKWebView _supportsGameControllerEventInteractionAPI]):
(-[WKWebView _tryUpdatingGamepadsAccessStateForImplicitConsentCase]):
For apps linked before visionOS 2.0, allow Game Controller events
if there&apos;s recent Gamepad API access and a controller is connected.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:

Canonical link: <a href="https://commits.webkit.org/294217@main">https://commits.webkit.org/294217@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86e0dc8b5ed344076180a7b26544156c3c469e60

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105650 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51101 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20473 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28639 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76577 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33579 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15759 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90796 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56896 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15517 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8799 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50477 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/93177 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85429 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8878 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108004 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/99121 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27631 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20327 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85491 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27994 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86996 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85029 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21774 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29723 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7451 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21597 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27566 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32816 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122747 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27377 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34235 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30695 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28935 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->