### PR TITLE
[MSE] Assertion in WebKit::RemoteMediaSourceProxy::addSourceBuffer

### DIFF
--- a/LayoutTests/ipc/invalid-addSourceBuffer-to-GPU-process-crash-expected.txt
+++ b/LayoutTests/ipc/invalid-addSourceBuffer-to-GPU-process-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/invalid-addSourceBuffer-to-GPU-process-crash.html
+++ b/LayoutTests/ipc/invalid-addSourceBuffer-to-GPU-process-crash.html
@@ -1,0 +1,26 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<p>This test passes if WebKit does not crash.</p>
+<script>
+    if (window.testRunner) {
+      testRunner.dumpAsText();
+      testRunner.waitUntilDone();
+      setTimeout(() => {
+          testRunner.notifyDone();
+      }, 100);
+    }
+</script>
+<script type="module">
+  if (window.IPC) {
+    import('./coreipc.js').then(({ CoreIPC }) => {
+      var o73='';
+      var o75='';
+      var o77='';
+      CoreIPC.GPU.RemoteMediaPlayerManagerProxy.CreateMediaPlayer(0,{identifier:393216,clientIdentifier:393217,remoteEngineIdentifier:6,proxyConfiguration:{referrer:'',userAgent:o73,sourceApplicationIdentifier:'',networkInterfaceName:'',audioOutputDeviceId:'',mediaContentTypesRequiringHardwareSupport:[{raw:o73,typeWasInferredFromExtension:false},{raw:'',typeWasInferredFromExtension:false},{raw:'',typeWasInferredFromExtension:true},{raw:'',typeWasInferredFromExtension:false},{raw:'',typeWasInferredFromExtension:false},{raw:'',typeWasInferredFromExtension:true},{raw:'',typeWasInferredFromExtension:false},{raw:'',typeWasInferredFromExtension:false}],allowedMediaContainerTypes:{},allowedMediaCodecTypes:{optionalValue:['','','',o75,o73,o73,'']},allowedMediaVideoCodecIDs:{optionalValue:[{value:124},{value:655366},{value:121},{value:720918},{value:125},{value:4},{value:45},{value:115}]},allowedMediaAudioCodecIDs:{optionalValue:[{value:557939},{value:81},{value:20971541},{value:5},{value:40},{value:15},{value:110},{value:3589472272},{value:17}]},allowedMediaCaptionFormatTypes:{},playerContentBoxRect:{m_location:{x:{rawValue:68},y:{rawValue:35}},m_size:{width:{rawValue:106},height:{rawValue:0}}},preferredAudioCharacteristics:['A','',''],outOfBandTrackData:[],documentSecurityOrigin:{data:{variantType:'WebCore::SecurityOriginData::Tuple',variant:{protocol:'',host:'',port:{}}}},presentationSize:{width:4,height:65},videoLayerSize:{width:40,height:86},logIdentifier:238,shouldUsePersistentCache:false,isVideo:false,renderingCanBeAccelerated:false,prefersSandboxedParsing:false,shouldDisableHDR:false}});
+      var o83=393216;
+      CoreIPC.GPU.RemoteMediaPlayerProxy.LoadMediaSource(o83,{url:{string:o77},options:{contentType:{raw:'A',typeWasInferredFromExtension:true},requiresRemotePlayback:true,supportsLimitedMatroska:false},mediaSourceIdentifier:393218});
+      var o86=393218;
+      CoreIPC.GPU.RemoteMediaSourceProxy.AddSourceBuffer(o86,{contentType:{raw:'image/heif',typeWasInferredFromExtension:false},configuration:{textTracksEnabled:false}});
+      CoreIPC.GPU.RemoteMediaPlayerManagerProxy.DeleteMediaPlayer(0,{identifier:393216});
+    });
+}
+</script>

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -397,8 +397,6 @@ const MediaPlayerFactory* MediaPlayer::mediaEngine(MediaPlayerEnums::MediaEngine
     if (currentIndex == notFound) {
 #if PLATFORM(IOS_FAMILY_SIMULATOR)
         ASSERT(identifier == MediaPlayerEnums::MediaEngineIdentifier::AVFoundationMSE);
-#else
-        ASSERT_NOT_REACHED();
 #endif
         return nullptr;
     }

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
@@ -123,11 +123,14 @@ void RemoteMediaSourceProxy::failedToCreateRenderer(RendererType)
 void RemoteMediaSourceProxy::addSourceBuffer(const WebCore::ContentType& contentType, const WebCore::MediaSourceConfiguration& configuration, AddSourceBufferCallback&& callback)
 {
     RefPtr connection = connectionToWebProcess();
-    if (!m_remoteMediaPlayerProxy || !connection)
+    RefPtr mediaSourcePrivate = this->mediaSourcePrivate();
+    if (!m_remoteMediaPlayerProxy || !connection || !mediaSourcePrivate) {
+        callback(MediaSourcePrivate::AddStatus::NotSupported, { });
         return;
+    }
 
     RefPtr<SourceBufferPrivate> sourceBufferPrivate;
-    MediaSourcePrivate::AddStatus status = mediaSourcePrivate()->addSourceBuffer(contentType, configuration, sourceBufferPrivate);
+    MediaSourcePrivate::AddStatus status = mediaSourcePrivate->addSourceBuffer(contentType, configuration, sourceBufferPrivate);
 
     std::optional<RemoteSourceBufferIdentifier> remoteSourceIdentifier;
     if (status == MediaSourcePrivate::AddStatus::Ok) {


### PR DESCRIPTION
#### 7bd7bbbe097cfa549fbdaa60357c2d3a4c9cb6ba
<pre>
[MSE] Assertion in WebKit::RemoteMediaSourceProxy::addSourceBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=291932">https://bugs.webkit.org/show_bug.cgi?id=291932</a>
<a href="https://rdar.apple.com/149290374">rdar://149290374</a>

Reviewed by Youenn Fablet.

The completion handler given to RemoteMediaSourceProxy::addSourceBuffer
wasn&apos;t always called.
Ensure the completion handler is called when the RemoteMediaSourceProxy is
in a bad state, including when RemoteMediaSourceProxy::setPrivateAndOpen wasn&apos;t called.

Add crash test.
* LayoutTests/ipc/invalid-addSourceBuffer-to-GPU-process-crash-expected.txt: Added.
* LayoutTests/ipc/invalid-addSourceBuffer-to-GPU-process-crash.html: Added.
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp:
(WebKit::RemoteMediaSourceProxy::addSourceBuffer):

Canonical link: <a href="https://commits.webkit.org/294043@main">https://commits.webkit.org/294043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83edb0357b3de3d0de0f5a278f2b2a1f6f206ff1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10611 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105797 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51248 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102701 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28786 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76649 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33689 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103667 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15829 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90920 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57004 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15638 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8927 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50624 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85550 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108152 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27778 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20398 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85604 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28141 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87121 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85145 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21664 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29847 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7573 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21766 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27713 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32966 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27524 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30842 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29082 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->