### PR TITLE
Client id mismatch after Cross-Origin-Opener-Policy Header

### DIFF
--- a/LayoutTests/http/tests/workers/service/resultingClientId-worker.js
+++ b/LayoutTests/http/tests/workers/service/resultingClientId-worker.js
@@ -1,0 +1,28 @@
+onmessage = e => {
+    if (e.data === "getClientId") {
+        e.source.postMessage(self.clientId);
+        return;
+    }
+    e.source.postMessage(self.resultingClientId);
+};
+
+onfetch = e => {
+    self.clientId = e.clientId;
+    if (e.resultingClientId)
+        self.resultingClientId = e.resultingClientId;
+
+    const text = `<html><body><script>
+        onload = async () => {
+            await fetch("/");
+            history.back();
+        };
+        </script></body></html>`;
+    const headers = [
+       ["Cache-Control", "no-cache, no-store, must-revalidate, max-age=0"],
+       ["Content-Type", "text/html"],
+    ];
+    if (e.request.url.includes("with-coop"))
+        headers.push(["Cross-Origin-Opener-Policy", "same-origin"]);
+
+    e.respondWith(new Response(text, { headers }));
+}

--- a/LayoutTests/http/tests/workers/service/resultingClientId.https-expected.txt
+++ b/LayoutTests/http/tests/workers/service/resultingClientId.https-expected.txt
@@ -1,0 +1,2 @@
+PASS without coop
+PASS with coop

--- a/LayoutTests/http/tests/workers/service/resultingClientId.https.html
+++ b/LayoutTests/http/tests/workers/service/resultingClientId.https.html
@@ -1,0 +1,69 @@
+<!doctype html><!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<html>
+<head>
+</head>
+<body>
+<div id=logDiv></div>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function waitForState(worker, state)
+{
+    if (!worker || worker.state == undefined)
+        return Promise.reject(new Error('wait_for_state must be passed a ServiceWorker'));
+
+    if (worker.state === state)
+        return Promise.resolve(state);
+
+    return new Promise(function(resolve) {
+      worker.addEventListener('statechange', function() {
+          if (worker.state === state)
+            resolve(state);
+        });
+    });
+}
+
+var activeWorker;
+async function setup()
+{
+    let registration = await navigator.serviceWorker.register("resultingClientId-worker.js", { scope : "resources" });
+    if (!registration.installing) {
+        registration.unregister();
+        registration = await navigator.serviceWorker.register("resultingClientId-worker.js", { scope : "resources" });
+    }
+    activeWorker = registration.installing;
+    await waitForState(activeWorker, "activating");
+}
+
+async function checkIds()
+{
+    activeWorker.postMessage("getResultingClientId");
+    const resultingClientId = await new Promise(resolve => navigator.serviceWorker.onmessage = event => resolve(event.data));
+
+    activeWorker.postMessage("getClientId");
+    const clientId = await new Promise(resolve => navigator.serviceWorker.onmessage = (event) => resolve(event.data));
+
+    if (!self.step) {
+        self.step = 1;
+        self.withoutCoopResult = clientId === resultingClientId ? "PASS without coop" : "ids are not matching without coop: " + clientId + " vs. " + resultingClientId;
+        window.location = "resources/with-coop";
+        return;
+    }
+
+    logDiv.innerHTML += self.withoutCoopResult + "<br>";
+    logDiv.innerHTML += clientId === resultingClientId ? "PASS with coop" : "FAILED with coop, ids are not matching " + clientId + " vs. " + resultingClientId;
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+setup().then(async () => {
+    self.step = 0;
+    window.addEventListener("pageshow", checkIds);
+    window.location = "resources/without-coop";
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2744,6 +2744,14 @@ void DocumentLoader::whenDocumentIsCreated(Function<void(Document*)>&& callback)
     m_whenDocumentIsCreatedCallback = WTFMove(callback);
 }
 
+void DocumentLoader::setNewResultingClientId(ScriptExecutionContextIdentifier identifier)
+{
+    if (scriptExecutionContextIdentifierToLoaderMap().remove(*m_resultingClientId)) {
+        m_resultingClientId = identifier;
+        scriptExecutionContextIdentifierToLoaderMap().add(identifier, this);
+    }
+}
+
 } // namespace WebCore
 
 #undef PAGE_ID

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -543,6 +543,8 @@ public:
     bool navigationCanTriggerCrossDocumentViewTransition(Document& oldDocument, bool fromBackForwardCache);
     WEBCORE_EXPORT void whenDocumentIsCreated(Function<void(Document*)>&&);
 
+    WEBCORE_EXPORT void setNewResultingClientId(ScriptExecutionContextIdentifier);
+
 protected:
     WEBCORE_EXPORT DocumentLoader(const ResourceRequest&, const SubstituteData&);
 

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -1197,12 +1197,23 @@ void SWServer::registerServiceWorkerClient(ClientOrigin&& clientOrigin, ServiceW
 
     auto addResult = m_visibleClientIdToInternalClientIdMap.add(data.identifier.object().toString(), clientIdentifier);
     if (!addResult.isNewEntry) {
-        ASSERT(m_visibleClientIdToInternalClientIdMap.get(data.identifier.object().toString()) == clientIdentifier);
-        ASSERT(m_clientsById.contains(clientIdentifier));
-        if (data.isFocused)
-            data.focusOrder = ++m_focusOrder;
-        m_clientsById.set(clientIdentifier, makeUniqueRef<ServiceWorkerClientData>(WTFMove(data)));
-        return;
+        if (addResult.iterator->value.processIdentifier() != clientIdentifier.processIdentifier()) {
+            // The client is being process-swapped, we clear the hash maps so that they get properly populated.
+            auto previousIdentifier = addResult.iterator->value;
+            m_clientsById.remove(previousIdentifier);
+            m_clientsToBeCreatedById.remove(previousIdentifier);
+            m_clientToControllingRegistration.remove(previousIdentifier);
+            m_clientIdentifiersPerOrigin.ensure(clientOrigin, [] {
+                return Clients { };
+            }).iterator->value.identifiers.remove(previousIdentifier);
+        } else {
+            ASSERT(m_visibleClientIdToInternalClientIdMap.get(data.identifier.object().toString()) == clientIdentifier);
+            ASSERT(m_clientsById.contains(clientIdentifier));
+            if (data.isFocused)
+                data.focusOrder = ++m_focusOrder;
+            m_clientsById.set(clientIdentifier, makeUniqueRef<ServiceWorkerClientData>(WTFMove(data)));
+            return;
+        }
     }
 
     ASSERT(!m_clientsById.contains(clientIdentifier));
@@ -1265,6 +1276,10 @@ std::optional<SWServer::GatheredClientData> SWServer::gatherClientData(const Cli
 
 void SWServer::unregisterServiceWorkerClient(const ClientOrigin& clientOrigin, ScriptExecutionContextIdentifier clientIdentifier)
 {
+    auto clientIterator = m_clientsById.find(clientIdentifier);
+    if (clientIterator != m_clientsById.end() && clientIterator->value->identifier.processIdentifier() != clientIdentifier.processIdentifier())
+        return;
+
     auto clientRegistrableDomain = clientOrigin.clientRegistrableDomain();
     auto appInitiatedValueBefore = clientIsAppInitiatedForRegistrableDomain(clientOrigin.clientRegistrableDomain());
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -666,7 +666,9 @@ void NetworkResourceLoader::transferToNewWebProcess(NetworkConnectionToWebProces
     m_parameters.webPageID = parameters.webPageID;
     m_parameters.webFrameID = parameters.webFrameID;
     m_parameters.options.clientIdentifier = parameters.options.clientIdentifier;
-    m_parameters.options.resultingClientIdentifier = parameters.options.resultingClientIdentifier;
+
+    if (parameters.options.resultingClientIdentifier && m_parameters.options.resultingClientIdentifier)
+        send(Messages::WebResourceLoader::UpdateResultingClientIdentifier { *parameters.options.resultingClientIdentifier, *m_parameters.options.resultingClientIdentifier });
 
     ASSERT(m_responseCompletionHandler || m_cacheEntryWaitingForContinueDidReceiveResponse || m_serviceWorkerFetchTask);
     if (m_serviceWorkerRegistration) {

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
@@ -311,6 +311,12 @@ void WebResourceLoader::serviceWorkerDidNotHandle()
     coreLoader->didFail(error);
 }
 
+void WebResourceLoader::updateResultingClientIdentifier(WTF::UUID currentIdentifier, WTF::UUID newIdentifier)
+{
+    if (RefPtr loader = DocumentLoader::fromScriptExecutionContextIdentifier({ currentIdentifier, Process::identifier() }))
+        loader->setNewResultingClientId({ newIdentifier, Process::identifier() });
+}
+
 void WebResourceLoader::didFailResourceLoad(const ResourceError& error)
 {
     RefPtr coreLoader = m_coreLoader;

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.h
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.h
@@ -93,6 +93,8 @@ private:
     void didFailResourceLoad(const WebCore::ResourceError&);
     void didFailServiceWorkerLoad(const WebCore::ResourceError&);
     void serviceWorkerDidNotHandle();
+    void updateResultingClientIdentifier(WTF::UUID currentIdentifier, WTF::UUID newIdentifier);
+
     void didBlockAuthenticationChallenge();
     void setWorkerStart(MonotonicTime value) { m_workerStart = value; }
 

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.messages.in
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.messages.in
@@ -34,6 +34,7 @@ messages -> WebResourceLoader {
     DidFailResourceLoad(WebCore::ResourceError error)
     DidFailServiceWorkerLoad(WebCore::ResourceError error)
     ServiceWorkerDidNotHandle()
+    UpdateResultingClientIdentifier(WTF::UUID currentIdentifier, WTF::UUID newIdentifier);
     DidBlockAuthenticationChallenge()
 
     StopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied(WebCore::ResourceResponse response)


### PR DESCRIPTION
#### dfeb33f0ac4c4f96cf0e09aca2ae8ffe0fd0ca1a
<pre>
Client id mismatch after Cross-Origin-Opener-Policy Header
<a href="https://rdar.apple.com/problem/149370100">rdar://problem/149370100</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291315">https://bugs.webkit.org/show_bug.cgi?id=291315</a>

Reviewed by Brady Eidson.

Before the patch, in case of process swapping, we would create a new DocumentLoader in the final process.
This would mean a new ScriptExecutionContextIdentifier and so a new clientId that is not is the same as the inital DocumentLoader
that triggered the request sent to the service worker.

To fix this, when process swap happens in NetworkResourceLoader::transferToNewWebProcess, we tell the new DocumentLoader that it
should reuse the initial DocumentLoader ScriptExecutionContextIdentifier (with the right process identifier).

We update NetworkResourceLoader, WebResourceLoader and DocumentLoader accordingly.
We then have to deal in SWServer with ScriptExecutionContextIdentifier that have the same UUID but not the same process identifier.

* LayoutTests/http/tests/workers/service/resultingClientId-worker.js: Added.
* LayoutTests/http/tests/workers/service/resultingClientId.https-expected.txt: Added.
* LayoutTests/http/tests/workers/service/resultingClientId.https.html: Added.
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::setNewResultingClientId):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::registerServiceWorkerClient):
(WebCore::SWServer::unregisterServiceWorkerClient):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::transferToNewWebProcess):
* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:
(WebKit::WebResourceLoader::updateResultingClientIdentifier):
* Source/WebKit/WebProcess/Network/WebResourceLoader.h:
* Source/WebKit/WebProcess/Network/WebResourceLoader.messages.in:

Canonical link: <a href="https://commits.webkit.org/294061@main">https://commits.webkit.org/294061@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37fbad6eeb521d30f6dd842aee515e81495b8ba2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105863 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51314 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102767 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28852 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76698 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33737 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103733 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15890 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90982 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57051 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15699 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8990 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50690 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85601 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108218 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27844 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20446 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85657 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28207 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87184 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85198 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21679 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29904 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7632 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21838 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27779 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33034 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27590 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30908 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29148 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->