### PR TITLE
[JSC] Integrate Int52 result into MultiGetByVal

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2982,7 +2982,9 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         if (node->hasDoubleResult()) {
             // We say SpecFullDouble since it will involve Float16 / Float32 / Float64 TypedArrays.
             setNonCellTypeForNode(node, SpecFullDouble);
-        } else
+        } else if (node->hasInt52Result())
+            setNonCellTypeForNode(node, SpecInt52Any);
+        else
             makeHeapTopForNode(node);
         break;
     }

--- a/Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.h
+++ b/Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.h
@@ -31,7 +31,7 @@ namespace JSC { namespace DFG {
 
 class Graph;
 
-// Tries to eliminate DoubleRep(ValueRep) roundtrips.
+// Tries to eliminate DoubleRep(ValueRep) / Int52Rep(ValueRep) roundtrips.
 
 bool performValueRepReduction(Graph&);
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -2270,7 +2270,7 @@ private:
 
         case DoubleRepAnyIntUse: {
             bool canIgnoreNegativeZero = bytecodeCanIgnoreNegativeZero(m_node->arithNodeFlags());
-            LValue result = doubleToStrictInt52(Int52Overflow, m_node->child1(), lowDouble(m_node->child1()), canIgnoreNegativeZero);
+            LValue result = doubleToStrictInt52(Int52Overflow, m_node->child1().node(), lowDouble(m_node->child1()), canIgnoreNegativeZero);
             m_interpreter.filter(m_node->child1(), SpecAnyIntAsDouble);
             setStrictInt52(result);
             return;
@@ -2278,7 +2278,7 @@ private:
 
         case DoubleRepRealUse: {
             bool canIgnoreNegativeZero = bytecodeCanIgnoreNegativeZero(m_node->arithNodeFlags());
-            LValue result = doubleToStrictInt52(Int52Overflow, m_node->child1(), lowDouble(m_node->child1()), canIgnoreNegativeZero);
+            LValue result = doubleToStrictInt52(Int52Overflow, m_node->child1().node(), lowDouble(m_node->child1()), canIgnoreNegativeZero);
             m_interpreter.filter(m_node->child1(), SpecDoubleReal);
             setStrictInt52(result);
             return;
@@ -6599,29 +6599,49 @@ IGNORE_CLANG_WARNINGS_END
                     LValue isHole = nullptr;
                     LValue result = nullptr;
                     if (expectedType == ArrayWithDouble) {
-                        LValue doubleResult = m_out.loadDouble(baseIndexWithProvenValue(heap, butterfly, index, indexEdge));
-                        isHole = m_out.doubleNotEqualOrUnordered(doubleResult, doubleResult);
-                        if (m_node->hasDoubleResult())
-                            result = doubleResult;
-                        else
-                            result = boxDouble(doubleResult);
+                        result = m_out.loadDouble(baseIndexWithProvenValue(heap, butterfly, index, indexEdge));
+                        isHole = m_out.doubleNotEqualOrUnordered(result, result);
                     } else {
                         result = m_out.load64(baseIndexWithProvenValue(heap, butterfly, index, indexEdge));
                         isHole = m_out.isZero64(result);
                     }
-                    if (arrayMode.isInBoundsSaneChain()) {
-                        if (m_node->hasDoubleResult())
-                            result = m_out.select(isHole, m_out.constDouble(std::bit_cast<int64_t>(PNaN)), result);
+
+                    LValue finalResult = nullptr;
+                    if (m_node->hasDoubleResult()) {
+                        ASSERT(result->type() == Double);
+                        finalResult = result;
+                    } else if (m_node->hasInt52Result()) {
+                        if (result->type() == Double) {
+                            bool canIgnoreNegativeZero = false;
+                            finalResult = doubleToStrictInt52(Int52Overflow, m_node, result, canIgnoreNegativeZero);
+                        } else {
+                            ASSERT(expectedType == ArrayWithInt32);
+                            finalResult = m_out.signExt32To64(unboxInt32(result));
+                        }
+                    } else {
+                        if (result->type() == Double)
+                            finalResult = boxDouble(result);
                         else
-                            result = m_out.select(isHole, m_out.constInt64(JSValue::encode(jsUndefined())), result);
+                            finalResult = result;
+                    }
+
+                    if (arrayMode.isInBoundsSaneChain()) {
+                        ASSERT(!m_node->hasInt52Result());
+                        if (m_node->hasDoubleResult()) {
+                            ASSERT(result->type() == Double);
+                            finalResult = m_out.select(isHole, m_out.constDouble(std::bit_cast<int64_t>(PNaN)), finalResult);
+                        } else
+                            finalResult = m_out.select(isHole, m_out.constInt64(JSValue::encode(jsUndefined())), finalResult);
                     } else
                         speculate(LoadFromHole, noValue(), nullptr, isHole);
-                    results.append(m_out.anchor(result));
+
+                    results.append(m_out.anchor(finalResult));
                     m_out.jump(continuation);
                     return;
                 }
 
                 ASSERT(!m_node->hasDoubleResult());
+                ASSERT(!m_node->hasInt52Result());
                 LBasicBlock fastCase = m_out.newBlock();
                 LBasicBlock slowCase = m_out.newBlock();
 
@@ -6720,19 +6740,30 @@ IGNORE_CLANG_WARNINGS_END
                 LValue unboxedResult = loadValue();
                 if (isInt(type)) {
                     ASSERT(!m_node->hasDoubleResult()); // Right now, it is yes. We extend later.
-                    auto speculateOrAdjust = [&](LValue result) {
-                        if (elementSize(type) < 4 || isSigned(type))
-                            return boxInt32(result);
 
-                        if (m_node->shouldSpeculateInt32()) {
-                            speculate(Overflow, noValue(), nullptr, m_out.lessThan(result, m_out.int32Zero));
-                            return boxInt32(result);
-                        }
+                    if (m_node->hasInt52Result()) {
+                        LValue result = nullptr;
+                        if (isSigned(type))
+                            result = m_out.signExt32To64(unboxedResult);
+                        else
+                            result = m_out.zeroExt(unboxedResult, Int64);
+                        results.append(m_out.anchor(result));
+                    } else {
+                        auto speculateOrAdjust = [&](LValue result) {
+                            if (elementSize(type) < 4 || isSigned(type))
+                                return boxInt32(result);
 
-                        return boxDouble(m_out.unsignedToDouble(result));
-                    };
-                    results.append(m_out.anchor(speculateOrAdjust(unboxedResult)));
+                            if (m_node->shouldSpeculateInt32()) {
+                                speculate(Overflow, noValue(), nullptr, m_out.lessThan(result, m_out.int32Zero));
+                                return boxInt32(result);
+                            }
+
+                            return boxDouble(m_out.unsignedToDouble(result));
+                        };
+                        results.append(m_out.anchor(speculateOrAdjust(unboxedResult)));
+                    }
                 } else {
+                    ASSERT(!m_node->hasInt52Result()); // Right now, it is yes. We extend later.
                     if (m_node->hasDoubleResult())
                         results.append(m_out.anchor(unboxedResult));
                     else
@@ -6818,6 +6849,8 @@ IGNORE_CLANG_WARNINGS_END
         m_out.appendTo(continuation, lastNext);
         if (m_node->hasDoubleResult())
             setDouble(m_out.phi(Double, results));
+        else if (m_node->hasInt52Result())
+            setStrictInt52(m_out.phi(Int64, results));
         else
             setJSValue(m_out.phi(Int64, results));
     }
@@ -22313,7 +22346,7 @@ IGNORE_CLANG_WARNINGS_END
         m_out.appendTo(doubleCase, continuation);
         speculate(BadType, jsValueValue(boxedValue), edge.node(), isNotNumber(boxedValue, provenType(edge) & ~SpecInt32Only));
         LValue doubleValue = unboxDouble(boxedValue);
-        ValueFromBlock doubleToInt52 = m_out.anchor(doubleToStrictInt52(BadType, edge, doubleValue, canIgnoreNegativeZero));
+        ValueFromBlock doubleToInt52 = m_out.anchor(doubleToStrictInt52(BadType, edge.node(), doubleValue, canIgnoreNegativeZero));
         m_out.jump(continuation);
 
         m_out.appendTo(continuation, lastNext);
@@ -22324,19 +22357,19 @@ IGNORE_CLANG_WARNINGS_END
         return m_out.phi(Int64, intToInt52, doubleToInt52);
     }
 
-    LValue doubleToStrictInt52(ExitKind exitKind, Edge edge, LValue value, bool canIgnoreNegativeZero)
+    LValue doubleToStrictInt52(ExitKind exitKind, Node* node, LValue value, bool canIgnoreNegativeZero)
     {
         LValue integerValue = m_out.doubleToInt64(value);
         LValue integerValueConvertedToDouble = tryDoubleToInt64AsDouble(value);
         if (!integerValueConvertedToDouble)
             integerValueConvertedToDouble = m_out.intToDouble(integerValue);
         LValue valueNotConvertibleToInteger = m_out.doubleNotEqualOrUnordered(value, integerValueConvertedToDouble);
-        speculate(exitKind, doubleValue(value), edge.node(), valueNotConvertibleToInteger);
+        speculate(exitKind, doubleValue(value), node, valueNotConvertibleToInteger);
 
         auto speculateInt52Range = [&](LValue integerValue) {
             LValue added = m_out.add(m_out.constInt64(0xfff8000000000000ULL), integerValue);
             LValue shifted = m_out.lShr(added, m_out.constInt32(52));
-            speculate(exitKind, doubleValue(value), edge.node(), m_out.belowOrEqual(shifted, m_out.constInt64(4094)));
+            speculate(exitKind, doubleValue(value), node, m_out.belowOrEqual(shifted, m_out.constInt64(4094)));
         };
 
         if (canIgnoreNegativeZero) {
@@ -22351,7 +22384,7 @@ IGNORE_CLANG_WARNINGS_END
 
         LBasicBlock lastNext = m_out.appendTo(valueIsZero, valueIsNotZero);
         LValue doubleBitcastToInt64 = m_out.bitCast(value, Int64);
-        speculate(exitKind, doubleValue(value), edge.node(), m_out.testNonZero64(doubleBitcastToInt64, m_out.constInt64(1ULL << 63)));
+        speculate(exitKind, doubleValue(value), node, m_out.testNonZero64(doubleBitcastToInt64, m_out.constInt64(1ULL << 63)));
         m_out.jump(continuation);
 
         m_out.appendTo(valueIsNotZero, continuation);
@@ -23514,7 +23547,7 @@ IGNORE_CLANG_WARNINGS_END
             return;
 
         constexpr bool canIgnoreNegativeZero = false;
-        doubleToStrictInt52(BadType, edge, lowDouble(edge), canIgnoreNegativeZero);
+        doubleToStrictInt52(BadType, edge.node(), lowDouble(edge), canIgnoreNegativeZero);
         m_interpreter.filter(edge, SpecAnyIntAsDouble);
     }
 


### PR DESCRIPTION
#### bf340ec206a1119d12e10dace602e3edf35d31a5
<pre>
[JSC] Integrate Int52 result into MultiGetByVal
<a href="https://bugs.webkit.org/show_bug.cgi?id=291958">https://bugs.webkit.org/show_bug.cgi?id=291958</a>
<a href="https://rdar.apple.com/149857634">rdar://149857634</a>

Reviewed by Yijia Huang.

When MultiGetByVal is emitted with DoubleArray | Uint32Array for
example, the result is considered as JSValue. Then we need to box and
unbox values while we already know that the result is used under the
context of Int52.

In this patch, we attempt to put Int52Result flag to MultiGetByVal. Then
it will generate Int52 result directly when it is specified. To find the
beneficial case, we extend ValueRep reduction phase to detect
MultiGetByVal nodes which is only used under Int52 context. Then we
attach Int52Result flag to that node and FTL will generate a code which
directly generates Int52 results.

* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp:
(JSC::DFG::ValueRepReductionPhase::run):
(JSC::DFG::ValueRepReductionPhase::convertValueRepsToUnboxed):
(JSC::DFG::ValueRepReductionPhase::convertValueRepsToDouble): Deleted.
* Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.h:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileInt52Rep):
(JSC::FTL::DFG::LowerDFGToB3::compileMultiGetByVal):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Canonical link: <a href="https://commits.webkit.org/294067@main">https://commits.webkit.org/294067@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f94fc9d87ffe82c7e6bf6b4b59b7d02717767968

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10651 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105837 "Hash f94fc9d8 for PR 44419 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51288 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28826 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/105837 "Hash f94fc9d8 for PR 44419 does not build (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33713 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103707 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90958 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/105837 "Hash f94fc9d8 for PR 44419 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15673 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8966 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50664 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/93364 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85575 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108192 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/99308 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27818 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20421 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85635 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28181 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87160 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85175 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29880 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7608 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21806 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16383 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27753 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33006 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122934 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27564 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34273 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30882 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29122 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->