### PR TITLE
[JSC] Add script to compare inlining output between builds for regression analysis

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -1771,6 +1771,8 @@ void ByteCodeParser::inlineCall(Node* callTargetNode, Operand result, CallVarian
     CodeBlock* codeBlock = callee.functionExecutable()->baselineCodeBlockFor(specializationKind);
     insertChecks(codeBlock);
 
+    dataLogLnIf(Options::printEachDFGFTLInlineCall(), "[InlineCall] JITType: ", m_graph.m_plan.jitType(), " | Callee: ", codeBlock->inferredNameWithHash(), " -> Caller: ", m_graph.m_codeBlock->inferredNameWithHash());
+
     // FIXME: Don't flush constants!
 
     // arityFixupCount and numberOfStackPaddingSlots are different. While arityFixupCount does not consider about stack alignment,

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -169,6 +169,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, verboseFTLCompilation, false, Normal, nullptr) \
     v(Bool, logCompilationChanges, false, Normal, nullptr) \
     v(Bool, printEachOSRExit, false, Normal, nullptr) \
+    v(Bool, printEachDFGFTLInlineCall, false, Normal, nullptr) \
     v(Bool, useJITAsserts, ASSERT_ENABLED, Normal, nullptr) \
     v(Bool, validateDoesGC, ASSERT_ENABLED, Normal, nullptr) \
     v(Bool, validateGraph, false, Normal, nullptr) \

--- a/Tools/Scripts/compare-inlining
+++ b/Tools/Scripts/compare-inlining
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3 -u
+
+# Copyright (C) 2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer. 
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution. 
+# 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+#     its contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission. 
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import subprocess
+import argparse
+import os
+import shlex
+
+# Usage Examples:
+# ./Tools/Scripts/compare-inlining -v -a <BUILD_A_PATH> -b <BUILD_B_PATH> --test <SINGLE_TEST_PATH> --filter FTL
+# ./Tools/Scripts/compare-inlining -v -a <BUILD_A_PATH> -b <BUILD_B_PATH> --test "-e \"testList='crypto'\" cli.js" --cwd <BENCHMARK_WORKING_DIR> --filter FTL
+
+def run_jsc_and_capture(verbose, build_path, jsc_args, cwd):
+    jsc_binary = os.path.join(build_path, "jsc")
+    env = os.environ.copy()
+    env["DYLD_FRAMEWORK_PATH"] = build_path
+
+    required_options = [
+        "--alwaysComputeHash=1",
+        "--useConcurrentJIT=0",
+        "--printEachDFGFTLInlineCall=1"
+    ]
+
+    command = [jsc_binary] + jsc_args + required_options
+
+    if verbose:
+        def human_friendly_quote(arg):
+            if " " in arg or "'" in arg or '"' in arg:
+                return f'"{arg}"'
+            return arg
+
+        print("\nRunning command:")
+        print("  cwd:", cwd)
+        print("  cmd:", " ".join(human_friendly_quote(arg) for arg in command))
+        print("  env:")
+        for key, value in sorted(env.items()):
+            if key in ["DYLD_FRAMEWORK_PATH"] or key.startswith("JSC") or key.startswith("WEBKIT"):
+                print(f"    {key}={value}")
+
+    try:
+        result = subprocess.run(
+            command,
+            env=env,
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=True
+        )
+
+        if verbose:
+            print("Command completed successfully.")
+        return result.stdout.splitlines()
+
+    except subprocess.CalledProcessError as e:
+        print("Command failed with return code:", e.returncode)
+        print("Output:")
+        print(e.stdout)
+        return []
+
+def extract_inline_lines(lines, filter_type=None):
+    result = set()
+    for line in lines:
+        line = line.strip()
+        if "[InlineCall]" not in line:
+            continue
+        if filter_type:
+            prefix = f"[InlineCall] JITType: {filter_type} "
+            if not line.startswith(prefix):
+                continue
+        result.add(line)
+    return result
+
+def compare_sets(set_a, set_b):
+    removed = sorted(set_a - set_b)
+    added = sorted(set_b - set_a)
+    return removed, added
+
+def main():
+    parser = argparse.ArgumentParser(description="Compare JIT inlining output between two JSC builds.")
+    parser.add_argument('-a', '--build-a', required=True, help="Path to build A")
+    parser.add_argument('-b', '--build-b', required=True, help="Path to build B")
+    parser.add_argument('--test', required=True, help="Test file or CLI args (quoted)")
+    parser.add_argument('--cwd', default='.', help="Working directory (default: current directory)")
+    parser.add_argument('-v', '--verbose', action='store_true', help="Enable verbose output")
+    parser.add_argument('--filter', choices=['FTL', 'DFG', 'Baseline', 'LLInt', 'Host', 'None'], help="Only compare inlining entries with this JITType")
+
+    args = parser.parse_args()
+    jsc_args = shlex.split(args.test)
+
+    print("Running build A...")
+    output_a = run_jsc_and_capture(args.verbose, args.build_a, jsc_args, args.cwd)
+    set_a = extract_inline_lines(output_a, args.filter)
+
+    print("Running build B...")
+    output_b = run_jsc_and_capture(args.verbose, args.build_b, jsc_args, args.cwd)
+    set_b = extract_inline_lines(output_b, args.filter)
+
+    if args.verbose:
+        print("\nInline logs from Build A:")
+        for line in sorted(set_a):
+            print("  A:", line)
+        print("\nInline logs from Build B:")
+        for line in sorted(set_b):
+            print("  B:", line)
+
+    removed, added = compare_sets(set_a, set_b)
+
+    print("\nInlining REMOVED from A to B:")
+    if removed:
+        for line in removed:
+            print("  -", line)
+    else:
+        print("  None")
+
+    print("\nInlining ADDED from A to B:")
+    if added:
+        for line in added:
+            print("  +", line)
+    else:
+        print("  None")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#### ed802fc9d1dfb05f12a8c6ca765956ef5088ee44
<pre>
[JSC] Add script to compare inlining output between builds for regression analysis
<a href="https://bugs.webkit.org/show_bug.cgi?id=291922">https://bugs.webkit.org/show_bug.cgi?id=291922</a>
<a href="https://rdar.apple.com/149810861">rdar://149810861</a>

Reviewed by Yusuke Suzuki.

Adds a Python script at Tools/Scripts/compare-inlining to assist in identifying
the root cause of performance regressions or progressions by comparing DFG/FTL
inlining behavior across JavaScriptCore builds.

The script:
- Runs a specified test file or CLI-based test on two JSC builds
- Extracts inlining logs tagged with [InlineCall]
- Supports filtering by JITType (e.g., FTL, DFG)
- Compares inlining entries between builds to detect additions/removals
- Provides a verbose mode to print command-line invocation, environment, and full logs

This tool is useful for quickly spotting changes in inlining decisions that may
explain performance shifts observed in benchmarks.

Example usage:
  compare-inlining -a &lt;BUILD_A&gt; -b &lt;BUILD_B&gt; --test &lt;TEST&gt; --cwd &lt;DIR&gt; --filter FTL -v

Example out:

Running build A...
Running build B...

Inlining REMOVED from A to B:
  None

Inlining ADDED from A to B:
  + [InlineCall] JITType: FTL | Callee: am3#Bmw15u -&gt; Caller: bnpMultiplyTo#D7LNcs
  + [InlineCall] JITType: FTL | Callee: am3#Bmw15u -&gt; Caller: bnpSquareTo#DKK350
  ...

* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::inlineCall):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Tools/Scripts/compare-inlining: Added.
(run_jsc_and_capture):
(run_jsc_and_capture.human_friendly_quote):
(extract_inline_lines):
(compare_sets):
(main):

Canonical link: <a href="https://commits.webkit.org/294015@main">https://commits.webkit.org/294015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34eee76798d6c7f7d4187aff5218cc8b3a602502

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100581 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20233 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105718 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51169 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102622 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28707 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/76597 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33636 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103588 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/15758 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90856 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56953 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15574 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8861 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50545 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/93245 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85488 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8938 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108072 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/99189 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27699 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20341 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28062 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87056 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85097 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21644 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29779 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7510 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21687 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27634 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32884 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122815 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27445 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34252 "Found 1 new JSC stress test failure: ChakraCore.yaml/ChakraCore/test/es6/ES6MathAPIs.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30763 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29003 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->