### PR TITLE
Sync `svg/linking` from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noopener-policy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noopener-policy-expected.txt
@@ -1,0 +1,3 @@
+
+PASS No Opener policy attribute on svg anchor element is applied
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noopener-policy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noopener-policy.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
+<link rel="help" href="https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement">
+<title> Rel attribute with noopener value </title>
+<svg>
+  <a id="test" href="resources/a.rel-noopener-policy-target.html" rel="noopener"></a>
+  <script>
+    var anchorElement = document.getElementById('test');
+
+    // Simulate a click event
+    var event = new MouseEvent('click', {
+      view: window,
+      bubbles: true,
+      cancelable: true
+    });
+
+    // Dispatch the event to the anchor element
+    anchorElement.dispatchEvent(event);
+  </script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noreferrer-policy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noreferrer-policy-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL No Referrer policy attribute on svg anchor element is applied assert_equals: expected "http://localhost:8800/svg/linking/scripted/a.rel-noreferrer-policy.html" but got ""
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noreferrer-policy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noreferrer-policy.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
+<link rel="help" href="https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement">
+<title> Rel attribute with noreferrer value </title>
+<svg>
+  <a id="test" href="resources/a.rel-noreferrer-policy-target.html" rel="noreferrer"></a>
+  <script>
+    var anchorElement = document.getElementById('test');
+
+    // Simulate a click event
+    var event = new MouseEvent('click', {
+      view: window,
+      bubbles: true,
+      cancelable: true
+    });
+
+    // Dispatch the event to the anchor element
+    anchorElement.dispatchEvent(event);
+  </script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/resources/a.rel-noopener-policy-target.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/resources/a.rel-noopener-policy-target.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
+<link rel="help" href="https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement">
+<script>
+  test(function () {
+    assert_equals(true,window.opener == null);
+  }, "No Opener policy attribute on svg anchor element is applied");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/resources/a.rel-noreferrer-policy-target.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/resources/a.rel-noreferrer-policy-target.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
+<link rel="help" href="https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement">
+<script>
+  test(function () {
+    assert_equals("", document.referrer);
+  }, "No Referrer policy attribute on svg anchor element is applied");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/resources/w3c-import.log
@@ -15,3 +15,5 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/resources/a-download-click.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/resources/a.rel-noopener-policy-target.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/resources/a.rel-noreferrer-policy-target.html

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/w3c-import.log
@@ -16,6 +16,8 @@ None
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a-download-click.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-getter-01.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noopener-policy.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noreferrer-policy.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-setter-01.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/href-animate-element.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/href-mpath-element.html

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noreferrer-policy-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noreferrer-policy-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL No Referrer policy attribute on svg anchor element is applied assert_equals: expected "http://web-platform.test:8800/svg/linking/scripted/a.rel-noreferrer-policy.html" but got ""
+


### PR DESCRIPTION
#### e5fab78ccfd9712ece396b4edd27b65eebe63410
<pre>
Sync `svg/linking` from WPT upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=291961">https://bugs.webkit.org/show_bug.cgi?id=291961</a>
<a href="https://rdar.apple.com/149869263">rdar://149869263</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/c4588f656804c4b872684483dca0f839b92059d3">https://github.com/web-platform-tests/wpt/commit/c4588f656804c4b872684483dca0f839b92059d3</a>

* LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/resources/a.rel-noreferrer-policy-target.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/resources/a.rel-noopener-policy-target.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noreferrer-policy.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noreferrer-policy-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noopener-policy.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noopener-policy-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noreferrer-policy-expected.txt:

Canonical link: <a href="https://commits.webkit.org/294042@main">https://commits.webkit.org/294042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c960306a18c9d75f584ba3a0ba813bd1ccad846c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105780 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51231 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28769 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76640 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33675 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103650 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90904 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56995 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15626 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8911 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50607 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85537 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8986 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108135 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27761 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20387 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85592 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87105 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85133 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21663 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29832 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7557 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21749 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27696 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27507 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30825 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29065 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->