### PR TITLE
ImageCapture.grabFrame should not wait for canvas change

### DIFF
--- a/LayoutTests/fast/mediastream/image-capture-grabFrame-canvas-expected.txt
+++ b/LayoutTests/fast/mediastream/image-capture-grabFrame-canvas-expected.txt
@@ -1,0 +1,3 @@
+
+PASS grabFrame on canvas track
+

--- a/LayoutTests/fast/mediastream/image-capture-grabFrame-canvas.html
+++ b/LayoutTests/fast/mediastream/image-capture-grabFrame-canvas.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8'>
+    <title>ImageCapture grabFrame for canvas capture</title>
+    <script src='../../resources/testharness.js'></script>
+    <script src='../../resources/testharnessreport.js'></script>
+</head>
+<body>
+    <canvas id=canvas width=100 height=100></canvas>
+    <script>
+promise_test(async (test) => {
+    const stream = canvas.captureStream(30);
+    const context = canvas.getContext('2d');
+    context.fillStyle = "red";
+    context.fillRect(0, 0, canvas.width, canvas.height);
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    const imageCapture = new ImageCapture(stream.getVideoTracks()[0]);
+
+    const image = await imageCapture.grabFrame();
+    context.drawImage(image, 0, 0, canvas.width, canvas.height);
+
+    const data = context.getImageData(0, 0, canvas.width, canvas.height).data;
+    for (let i = 0; i < canvas.width * canvas.height; i = i + 4) {
+         assert_equals(data[0], 255, "r");
+         assert_equals(data[1], 0, "g");
+         assert_equals(data[2], 0, "b");
+         assert_equals(data[3], 255, "r");
+    }
+}, "grabFrame on canvas track");
+    </script>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
@@ -47,6 +47,8 @@ public:
     HTMLCanvasElement& canvas() { return m_canvas.get(); }
     void requestFrame() { static_cast<Source&>(source()).requestFrame(); }
 
+    RefPtr<VideoFrame> grabFrame();
+
     RefPtr<MediaStreamTrack> clone() final;
 
 private:
@@ -56,6 +58,7 @@ private:
         
         void requestFrame() { m_shouldEmitFrame = true; }
         std::optional<double> frameRequestRate() const { return m_frameRequestRate; }
+        RefPtr<VideoFrame> grabFrame();
 
         WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 


### PR DESCRIPTION
#### b9174b433c1dac5b08c54d7d8c88476d30ee4e6e
<pre>
ImageCapture.grabFrame should not wait for canvas change
<a href="https://rdar.apple.com/149857572">rdar://149857572</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291957">https://bugs.webkit.org/show_bug.cgi?id=291957</a>

Reviewed by Jean-Yves Avenard.

The specification is saying to gather data from track and create an ImageBitmap.
For sources which have regular video frames like cameras, our strategy is to wait for the next video frame.

For canvas tracks though, there might be no video frames as the canvas might not have been changed recently.
We implement a special case for canvas by reusing the way canvas capture sources create a VideoFrame.
We then reuse the same conversion to ImageBuffer as other sources.

* LayoutTests/fast/mediastream/image-capture-grabFrame-canvas-expected.txt: Added.
* LayoutTests/fast/mediastream/image-capture-grabFrame-canvas.html: Added.
* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp:
(WebCore::CanvasCaptureMediaStreamTrack::grabFrame):
(WebCore::CanvasCaptureMediaStreamTrack::Source::grabFrame):
(WebCore::CanvasCaptureMediaStreamTrack::Source::captureCanvas):
* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/ImageCapture.cpp:
(WebCore::createImageCaptureException):
(WebCore::createImageBitmapOrException):
(WebCore::ImageCaptureVideoFrameObserver::processVideoFrame):
(WebCore::ImageCapture::grabFrame):

Canonical link: <a href="https://commits.webkit.org/294322@main">https://commits.webkit.org/294322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44cfadda91c2806da8b9abb9ce9765e0670b4cf5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101099 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11064 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106247 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51726 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103140 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29255 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77012 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34038 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104106 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16232 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91318 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57359 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16048 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9345 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51074 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85954 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108603 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28227 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20786 "Found 2 new test failures: http/tests/iframe-monitor/iframe-unload.html http/tests/iframe-monitor/workers/service-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85979 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28589 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85515 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21828 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30236 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7961 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22322 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28157 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33425 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27969 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31289 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29527 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->