### PR TITLE
[WGSL] Add ASAN poisoning for allocated arenas

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTBuilder.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTBuilder.cpp
@@ -49,6 +49,10 @@ void Builder::allocateArena()
 {
     m_arenas.append(FixedVector<uint8_t>(arenaSize));
     m_arena = m_arenas.last().mutableSpan();
+
+#if ASAN_ENABLED
+    __asan_poison_memory_region(m_arena.data(), m_arena.size());
+#endif
 }
 
 auto Builder::saveCurrentState() -> State

--- a/Source/WebGPU/WGSL/AST/ASTBuilder.h
+++ b/Source/WebGPU/WGSL/AST/ASTBuilder.h
@@ -68,6 +68,11 @@ public:
         if (UNLIKELY(m_arena.size() < alignedSize))
             allocateArena();
 
+#if ASAN_ENABLED
+        RELEASE_ASSERT(__asan_address_is_poisoned(m_arena.data()));
+        __asan_unpoison_memory_region(m_arena.data(), size);
+#endif
+
         auto* node = new (m_arena.data()) T(std::forward<Arguments>(arguments)...);
         skip(m_arena, alignedSize);
         m_nodes.append(node);


### PR DESCRIPTION
#### 2c67a0929b35d968633d62ee2f0623722f3af94d
<pre>
[WGSL] Add ASAN poisoning for allocated arenas
<a href="https://bugs.webkit.org/show_bug.cgi?id=291963">https://bugs.webkit.org/show_bug.cgi?id=291963</a>
<a href="https://rdar.apple.com/149872251">rdar://149872251</a>

Reviewed by Mike Wyrzykowski.

Instrument the arena allocator to help catch any potential
OOB accesses into the arenas.

* Source/WebGPU/WGSL/AST/ASTBuilder.cpp:
(WGSL::AST::Builder::allocateArena):
* Source/WebGPU/WGSL/AST/ASTBuilder.h:
(WGSL::AST::Builder::construct):

Canonical link: <a href="https://commits.webkit.org/294048@main">https://commits.webkit.org/294048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1dacff457f37ed8543a642e11a9bf558c4c1db86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10544 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105730 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51181 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20553 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76604 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33645 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15765 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90857 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56960 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15580 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50557 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85494 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108084 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27711 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20350 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85556 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28074 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87057 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85094 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21669 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29787 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7511 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21699 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27646 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32897 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27457 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30775 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29015 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->