### PR TITLE
[WGSL] Adjust arena allocation size

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTBuilder.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTBuilder.cpp
@@ -27,7 +27,6 @@
 #include "ASTBuilder.h"
 
 #include "ASTNode.h"
-#include <wtf/FixedVector.h>
 
 namespace WGSL::AST {
 
@@ -47,8 +46,8 @@ Builder::~Builder()
 
 void Builder::allocateArena()
 {
-    m_arenas.append(FixedVector<uint8_t>(arenaSize));
-    m_arena = m_arenas.last().mutableSpan();
+    m_arenas.append(Arena::create(arenaSize));
+    m_arena = m_arenas.last()->span();
 
 #if ASAN_ENABLED
     __asan_poison_memory_region(m_arena.data(), m_arena.size());

--- a/Source/WebGPU/WGSL/AST/ASTBuilder.h
+++ b/Source/WebGPU/WGSL/AST/ASTBuilder.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/EmbeddedFixedVector.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Nonmovable.h>
@@ -52,8 +53,10 @@ class Node;
 class Builder {
     WTF_MAKE_NONCOPYABLE(Builder);
 
+    using Arena = EmbeddedFixedVector<uint8_t>;
+
 public:
-    static constexpr size_t arenaSize = 0x4000;
+    static constexpr size_t arenaSize = 0x4000 - sizeof(Arena);
 
     Builder() = default;
     Builder(Builder&&);
@@ -102,7 +105,7 @@ private:
 
     std::span<uint8_t> m_arena { };
     uint8_t* m_arenaEnd { nullptr };
-    Vector<FixedVector<uint8_t>> m_arenas;
+    Vector<UniqueRef<Arena>> m_arenas;
     Vector<Node*> m_nodes;
 };
 


### PR DESCRIPTION
#### f9fd1ca52fae88f0a3bf4ba7abbadc306da4d841
<pre>
[WGSL] Adjust arena allocation size
<a href="https://bugs.webkit.org/show_bug.cgi?id=291965">https://bugs.webkit.org/show_bug.cgi?id=291965</a>
<a href="https://rdar.apple.com/149873577">rdar://149873577</a>

Reviewed by Mike Wyrzykowski.

The arenas were allocated with a full page size, but it didn&apos;t account for the
fact that the FixedVector allocated a 4-byte size on top of the payload. To
fix that we switch from FixedVector to EmbeddedFixedVector so we can calculate
the size of the payload so that the total allocation size matches the page size.

* Source/WebGPU/WGSL/AST/ASTBuilder.cpp:
(WGSL::AST::Builder::allocateArena):
* Source/WebGPU/WGSL/AST/ASTBuilder.h:

Canonical link: <a href="https://commits.webkit.org/294054@main">https://commits.webkit.org/294054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28be5bbc3d274d0dc0bd9092906dc0b1cc919a13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10662 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105848 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51299 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28837 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/76683 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33720 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103718 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/15876 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/90969 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57037 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15685 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50675 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85587 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9052 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108203 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20429 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85643 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28192 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87171 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85183 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21674 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29888 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7619 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21823 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27764 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33017 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27575 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30893 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29133 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->