### PR TITLE
[SaferCPP] Address issues in StyleSheetList

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -5,7 +5,6 @@ bindings/js/JSLazyEventListener.cpp
 css/CSSToLengthConversionData.h
 css/SelectorChecker.h
 css/SelectorFilter.h
-css/StyleSheetList.h
 css/calc/CSSCalcTree+CalculationValue.cpp
 css/query/MediaQueryEvaluator.h
 dom/CollectionIndexCache.h

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -27,7 +27,6 @@ css/ShorthandSerializer.cpp
 css/StyleProperties.h
 css/StyleRuleImport.h
 css/StyleSheetContents.h
-css/StyleSheetList.h
 dom/CollectionIndexCache.h
 dom/Node.cpp
 dom/Node.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -150,7 +150,6 @@ css/SelectorChecker.cpp
 css/SelectorCheckerTestFunctions.h
 css/SelectorFilter.cpp
 css/StyleAttributeMutationScope.h
-css/StyleSheetList.cpp
 css/calc/CSSCalcTree+ContainerProgressEvaluator.cpp
 css/parser/SizesAttributeParser.cpp
 css/query/MediaQueryFeatures.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -469,7 +469,6 @@ css/StyleRule.cpp
 css/StyleRuleImport.cpp
 css/StyleRuleImport.h
 css/StyleSheetContents.cpp
-css/StyleSheetList.cpp
 css/query/GenericMediaQuerySerialization.cpp
 css/query/MediaQueryFeatures.cpp
 css/typedom/CSSOMVariableReferenceValue.cpp

--- a/Source/WebCore/css/StyleSheetList.cpp
+++ b/Source/WebCore/css/StyleSheetList.cpp
@@ -48,28 +48,32 @@ StyleSheetList::~StyleSheetList() = default;
 inline const Vector<RefPtr<StyleSheet>>& StyleSheetList::styleSheets() const
 {
     if (m_document)
-        return m_document->styleScope().styleSheetsForStyleSheetList();
+        return protectedDocument()->checkedStyleScope()->styleSheetsForStyleSheetList();
     if (m_shadowRoot)
-        return m_shadowRoot->styleScope().styleSheetsForStyleSheetList();
+        return protectedShadowRoot()->checkedStyleScope()->styleSheetsForStyleSheetList();
     return m_detachedStyleSheets;
 }
+
+RefPtr<Document> StyleSheetList::protectedDocument() const { return m_document.get(); }
+
+RefPtr<ShadowRoot> StyleSheetList::protectedShadowRoot() const { return m_shadowRoot.get(); }
 
 Node* StyleSheetList::ownerNode() const
 {
     if (m_document)
         return m_document.get();
-    return m_shadowRoot;
+    return m_shadowRoot.get();
 }
 
 void StyleSheetList::detach()
 {
     if (m_document) {
         ASSERT(!m_shadowRoot);
-        m_detachedStyleSheets = m_document->styleScope().styleSheetsForStyleSheetList();
+        m_detachedStyleSheets = protectedDocument()->checkedStyleScope()->styleSheetsForStyleSheetList();
         m_document = nullptr;
     } else if (m_shadowRoot) {
         ASSERT(!m_document);
-        m_detachedStyleSheets = m_shadowRoot->styleScope().styleSheetsForStyleSheetList();
+        m_detachedStyleSheets = protectedShadowRoot()->checkedStyleScope()->styleSheetsForStyleSheetList();
         m_shadowRoot = nullptr;
     } else
         ASSERT_NOT_REACHED();
@@ -97,7 +101,7 @@ CSSStyleSheet* StyleSheetList::namedItem(const AtomString& name) const
     // ### Bad implementation because returns a single element (are IDs always unique?)
     // and doesn't look for name attribute.
     // But unicity of stylesheet ids is good practice anyway ;)
-    if (RefPtr element = dynamicDowncast<HTMLStyleElement>(m_document->getElementById(name)))
+    if (RefPtr element = dynamicDowncast<HTMLStyleElement>(protectedDocument()->getElementById(name)))
         return element->sheet();
     return nullptr;
 }

--- a/Source/WebCore/css/StyleSheetList.h
+++ b/Source/WebCore/css/StyleSheetList.h
@@ -57,9 +57,11 @@ private:
     StyleSheetList(Document&);
     StyleSheetList(ShadowRoot&);
     const Vector<RefPtr<StyleSheet>>& styleSheets() const;
+    RefPtr<Document> protectedDocument() const;
+    RefPtr<ShadowRoot> protectedShadowRoot() const;
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
-    ShadowRoot* m_shadowRoot { nullptr };
+    WeakPtr<ShadowRoot, WeakPtrImplWithEventTargetData> m_shadowRoot;
     Vector<RefPtr<StyleSheet>> m_detachedStyleSheets;
 };
 


### PR DESCRIPTION
#### 3769f65b184a217e62fb36ddd1a74246a9cf8bc0
<pre>
[SaferCPP] Address issues in StyleSheetList
<a href="https://bugs.webkit.org/show_bug.cgi?id=291967">https://bugs.webkit.org/show_bug.cgi?id=291967</a>
<a href="https://rdar.apple.com/149876360">rdar://149876360</a>

Reviewed by Geoffrey Garen.

Address Safer CPP issues identified for StyleSheetList.cpp/.h files.

* Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/css/StyleSheetList.cpp:
(WebCore::StyleSheetList::styleSheets const):
(WebCore::StyleSheetList::protectedDocument const):
(WebCore::StyleSheetList::protectedShadowRoot const):
(WebCore::StyleSheetList::ownerNode const):
(WebCore::StyleSheetList::detach):
(WebCore::StyleSheetList::namedItem const):
* Source/WebCore/css/StyleSheetList.h:

Canonical link: <a href="https://commits.webkit.org/294035@main">https://commits.webkit.org/294035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fd397de06de8d654912ab21a023ad6796080597

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10577 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105763 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51214 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102667 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28752 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76626 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33665 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15799 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90891 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56981 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15613 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8898 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50590 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85525 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8973 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108117 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20376 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85582 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28107 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87092 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85122 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21658 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29817 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7545 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21732 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27679 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32930 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27490 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30808 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29048 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->