### PR TITLE
[iOS][WebContent] Remove HAVE_SANDBOX_STATE_FLAGS guard in sandbox

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -189,12 +189,8 @@
     )
 
     (allow sysctl-read (sysctl-name "kern.bootsessionuuid"))
-#if HAVE(SANDBOX_STATE_FLAGS)
     (with-filter (require-not (webcontent-process-launched))
         (allow sysctl-read (sysctl-name "kern.boottime")))
-#else
-    (allow sysctl-read (sysctl-name "kern.boottime"))
-#endif
 
     (mobile-preferences-read
         "com.apple.Metal" ;; <rdar://problem/25535471>
@@ -673,12 +669,8 @@
 (deny sysctl-read (with no-report)
     (sysctl-name "vm.task_no_footprint_for_debug"))
 
-#if HAVE(SANDBOX_STATE_FLAGS)
 (with-filter (require-not (webcontent-process-launched))
     (allow sysctl-read (sysctl-name "vm.malloc_ranges"))) ;; <rdar://problem/105161083>
-#else
-(allow sysctl-read (sysctl-name "vm.malloc_ranges")) ;; <rdar://problem/105161083>
-#endif
 
 (allow iokit-get-properties
     (iokit-property "AAPL,DisplayPipe")
@@ -849,7 +841,7 @@
 
 #if ENABLE(WEBCONTENT_GPU_SANDBOX_EXTENSIONS_BLOCKING)
 (deny iokit-open-service (with no-report))
-#elif HAVE(SANDBOX_STATE_FLAGS)
+#else
 (with-filter (state-flag "BlockIOKitInWebContentSandbox")
     (deny iokit-open-service)
     (deny iokit-open-user-client (with telemetry-backtrace)
@@ -1056,12 +1048,8 @@
     (syscall-unix-in-use-after-launch)
     (syscall-unix-in-use-after-launch-blocked-in-lockdown-mode))
 
-#if HAVE(SANDBOX_STATE_FLAGS)
 (with-filter (require-not (webcontent-process-launched))
     (allow syscall-unix (syscall-unix-only-in-use-during-launch)))
-#else
-(allow syscall-unix (syscall-unix-only-in-use-during-launch))
-#endif
 
 (allow syscall-unix
     (syscall-unix-rarely-in-use)
@@ -1171,14 +1159,6 @@
 (define-once (mach-bootstrap-message-numbers-post-launch)
     (message-number 206 207 711 712 800 804 904))
 
-(define (allow-mach-bootstrap-with-filter)
-    (allow mach-bootstrap
-        (apply-message-filter
-            (deny mach-message-send (with telemetry))
-            (allow mach-message-send
-                (mach-bootstrap-message-numbers)))))
-
-#if HAVE(SANDBOX_STATE_FLAGS)
 (allow mach-bootstrap
     (apply-message-filter
         (deny mach-message-send (with no-report))
@@ -1190,9 +1170,6 @@
 #endif
         (with-filter (require-not (webcontent-process-launched))
             (allow mach-message-send (mach-bootstrap-message-numbers)))))
-#else
-(allow-mach-bootstrap-with-filter)
-#endif
 
 (define (syscall-mach-only-in-use-during-launch)
     (machtrap-number
@@ -1255,7 +1232,6 @@
 (when (defined? 'MSC_mach_msg2_trap)
     (allow syscall-mach (machtrap-number MSC_mach_msg2_trap)))
 
-#if HAVE(SANDBOX_STATE_FLAGS)
 (with-filter (require-not (webcontent-process-launched))
     (allow syscall-mach
         (syscall-mach-only-in-use-during-launch)))
@@ -1264,7 +1240,6 @@
         (with telemetry)
         (with message "Mach syscall used after launch")
         (syscall-mach-only-in-use-during-launch)))
-#endif
 
 (with-filter (lockdown-mode)
     (deny syscall-mach (with telemetry) (with message "Lockdown mode")
@@ -1372,7 +1347,6 @@
     (kernel-mig-routine-in-use-watchos))
 #endif
 
-#if HAVE(SANDBOX_STATE_FLAGS)
 (with-filter (require-not (webcontent-process-launched))
     (allow syscall-mig
         (kernel-mig-routine-only-in-use-during-launch)))
@@ -1386,7 +1360,6 @@
 #else
 (with-filter (require-not (state-flag "BlockIOKitInWebContentSandbox"))
     (allow syscall-mig (kernel-mig-routines-iokit-service)))
-#endif
 #endif
 
 #if HAVE(HARDENED_MACH_EXCEPTIONS)


### PR DESCRIPTION
#### b70d6c650e4aa56688cfa2ffe395a85508c5fe28
<pre>
[iOS][WebContent] Remove HAVE_SANDBOX_STATE_FLAGS guard in sandbox
<a href="https://bugs.webkit.org/show_bug.cgi?id=291970">https://bugs.webkit.org/show_bug.cgi?id=291970</a>
<a href="https://rdar.apple.com/149878158">rdar://149878158</a>

Reviewed by Sihui Liu.

Remove HAVE_SANDBOX_STATE_FLAGS guard in the WebContent sandbox on iOS, since it is always 1.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:

Canonical link: <a href="https://commits.webkit.org/294697@main">https://commits.webkit.org/294697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d14134f33bc3ade2ff4e4259134ac0deb182e6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106962 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52438 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29978 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77514 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34537 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104811 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91928 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57852 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16652 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51789 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86507 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10023 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109319 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28937 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21314 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86493 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88129 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86064 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30824 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8539 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23108 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16674 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28865 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34155 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28676 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31999 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30235 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->