### PR TITLE
[SwiftUI] WebViewRepresentable does not need to store the owning WebView

### DIFF
--- a/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
@@ -39,10 +39,10 @@ public struct WebView: View {
         self.page = page
     }
 
-    let page: WebPage
+    private let page: WebPage
 
     public var body: some View {
-        WebViewRepresentable(owner: self)
+        WebViewRepresentable(page: page)
     }
 }
 

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
@@ -26,24 +26,24 @@ internal import SwiftUI
 
 @MainActor
 struct WebViewRepresentable {
-    let owner: WebView
+    let page: WebPage
 
     func makePlatformView(context: Context) -> CocoaWebViewAdapter {
         // FIXME: Make this more robust by figuring out what happens when a WebPage moves between representables.
-        // We can't have multiple owners regardless, but we'll want to decide if it's an error, if we can handle it gracefully, and how deterministic it might even be.
+        // We can't have multiple owning pages regardless, but we'll want to decide if it's an error, if we can handle it gracefully, and how deterministic it might even be.
         // Perhaps we should keep an ownership assertion which we can tear down in something like dismantleUIView().
 
-        precondition(!owner.page.isBoundToWebView, "This web page is already bound to another web view.")
+        precondition(!page.isBoundToWebView, "This web page is already bound to another web view.")
 
         let parent = CocoaWebViewAdapter()
-        parent.webView = owner.page.backingWebView
-        owner.page.isBoundToWebView = true
+        parent.webView = page.backingWebView
+        page.isBoundToWebView = true
 
         return parent
     }
 
     func updatePlatformView(_ platformView: CocoaWebViewAdapter, context: Context) {
-        let webView = owner.page.backingWebView
+        let webView = page.backingWebView
         let environment = context.environment
 
         platformView.webView = webView
@@ -89,11 +89,11 @@ struct WebViewRepresentable {
 
 #if os(macOS) && !targetEnvironment(macCatalyst)
         if let menu = environment.webViewContextMenuContext?.menu {
-            owner.page.setMenuBuilder {
+            page.setMenuBuilder {
                 menu(.init(linkURL: $0.linkURL))
             }
         } else {
-            owner.page.setMenuBuilder(nil)
+            page.setMenuBuilder(nil)
         }
 #endif
     }
@@ -116,7 +116,7 @@ struct WebViewRepresentable {
     }
 
     static func dismantlePlatformView(_ platformView: CocoaWebViewAdapter, coordinator: WebViewCoordinator) {
-        coordinator.configuration.owner.page.isBoundToWebView = false
+        coordinator.configuration.page.isBoundToWebView = false
     }
 }
 


### PR DESCRIPTION
#### db956ad95293ef25b4a34403d45313e24b325839
<pre>
[SwiftUI] WebViewRepresentable does not need to store the owning WebView
<a href="https://bugs.webkit.org/show_bug.cgi?id=291972">https://bugs.webkit.org/show_bug.cgi?id=291972</a>
<a href="https://rdar.apple.com/149884447">rdar://149884447</a>

Reviewed by Richard Robinson.

`WebViewRepresentable` only uses the `WebPage`, store that object directly.

* Source/WebKit/_WebKit_SwiftUI/API/WebView.swift:
(WebView.body):
* Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift:
(WebViewRepresentable.makePlatformView(_:)):
(WebViewRepresentable.updatePlatformView(_:context:)):
(WebViewRepresentable.dismantlePlatformView(_:coordinator:)):

Canonical link: <a href="https://commits.webkit.org/294031@main">https://commits.webkit.org/294031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e019efe1be1e9e797fdb4e43db3801b3fca50a7c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105755 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51206 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20578 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28744 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76618 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33660 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103625 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15790 "Found 1 new test failure: fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90880 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56973 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15605 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50582 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85518 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108109 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27736 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20367 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85573 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28099 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87081 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85113 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29810 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7534 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21724 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16374 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27671 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32922 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27482 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30800 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29040 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->