### PR TITLE
Keep a copy of affected players while notifying abrupt rendering stop.

### DIFF
--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.cpp
@@ -91,7 +91,8 @@ void ModelProcessModelPlayerManager::modelProcessConnectionDidClose(ModelProcess
 {
     m_modelProcessConnection = nullptr;
 
-    for (auto& entry : m_players) {
+    auto playersToNotify = m_players;
+    for (auto& entry : playersToNotify) {
         if (RefPtr player = entry.value.get())
             player->renderingAbruptlyStopped();
     }


### PR DESCRIPTION
#### e72e89897081efd608c057fe8c33f468a10bda4b
<pre>
Keep a copy of affected players while notifying abrupt rendering stop.
<a href="https://bugs.webkit.org/show_bug.cgi?id=291973">https://bugs.webkit.org/show_bug.cgi?id=291973</a>
<a href="https://rdar.apple.com/149869888">rdar://149869888</a>

Reviewed by Ada Chan.

Calling renderingAbruptlyStopped() may lead to a ModelPlayer creation
when model&apos;s auto-reload logic kicks in. Consecutively that leads to
m_players being changed while iterating over the HashMap.
Having a copy of currently affected players helps to mitigate that.

* Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.cpp:
(WebKit::ModelProcessModelPlayerManager::modelProcessConnectionDidClose):

Canonical link: <a href="https://commits.webkit.org/294071@main">https://commits.webkit.org/294071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62ca3901363efeb835a63cd3b16ab1c59fe52915

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100620 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105757 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51208 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28746 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76619 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33666 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103627 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15797 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90886 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56974 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15611 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50584 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85524 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108111 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27738 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20370 "Found 1 new test failure: fast/css/view-transitions-hide-under-page-background-color.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85576 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28101 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87087 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85116 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21686 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29815 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7540 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/21726 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27673 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32924 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27484 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30802 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29042 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->