### PR TITLE
Replace shouldSkip with standard unittest.skip

### DIFF
--- a/Tools/Scripts/webkitpy/test/main.py
+++ b/Tools/Scripts/webkitpy/test/main.py
@@ -375,12 +375,6 @@ class _Loader(unittest.TestLoader):
     test_method_prefixes = []
 
     def getTestCaseNames(self, testCaseClass):
-        should_skip_class_method = getattr(testCaseClass, "shouldSkip", None)
-        if callable(should_skip_class_method):
-            if testCaseClass.shouldSkip():
-                _log.info('Skipping tests in %s' % (testCaseClass.__name__))
-                return []
-
         def isTestMethod(attrname, testCaseClass=testCaseClass):
             if not hasattr(getattr(testCaseClass, attrname), '__call__'):
                 return False

--- a/Tools/lldb/dump_class_layout_unittest.py
+++ b/Tools/lldb/dump_class_layout_unittest.py
@@ -46,11 +46,8 @@ def destroy_cached_debug_session():
     debugger_instance = None
 
 
+@unittest.skipUnless(SystemHost.get_default().platform.is_mac(), "macOS only")
 class TestDumpClassLayout(unittest.TestCase):
-    @classmethod
-    def shouldSkip(cls):
-        return not SystemHost.get_default().platform.is_mac()
-
     @classmethod
     def setUpClass(cls):
         global debugger_instance

--- a/Tools/lldb/lldb_webkit_unittest.py
+++ b/Tools/lldb/lldb_webkit_unittest.py
@@ -82,11 +82,8 @@ class LLDBDebugSession(object):
         cls.sbProcess.Kill()
 
 
+@unittest.skipUnless(SystemHost.get_default().platform.is_mac(), "macOS only")
 class TestSummaryProviders(unittest.TestCase):
-    @classmethod
-    def shouldSkip(cls):
-        return not SystemHost.get_default().platform.is_mac()
-
     @classmethod
     def setUpClass(cls):
         global cached_debug_session


### PR DESCRIPTION
#### e693cc322ef8757b6efce4b4ccea32910d1d1afd
<pre>
Replace shouldSkip with standard unittest.skip
<a href="https://bugs.webkit.org/show_bug.cgi?id=291975">https://bugs.webkit.org/show_bug.cgi?id=291975</a>

Reviewed by Jonathan Bedard.

This gets rid of more special-cases in our code, reducing what we&apos;re
doing in unittest subclasses.

* Tools/Scripts/webkitpy/test/main.py:
(_Loader.getTestCaseNames): Remove shouldSkip support
* Tools/lldb/dump_class_layout_unittest.py:
(TestDumpClassLayout): Add unittest.skip decorator
(TestDumpClassLayout.shouldSkip): Deleted.
* Tools/lldb/lldb_webkit_unittest.py:
(TestSummaryProviders): Add unittest.skip decorator
(TestSummaryProviders.shouldSkip): Deleted.

Canonical link: <a href="https://commits.webkit.org/294203@main">https://commits.webkit.org/294203@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/baa14f80471f54123fdc1ebe16243c37e6be7dc8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105758 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51209 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102662 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28747 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76622 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33661 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103628 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15794 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90888 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56977 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/100095 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15608 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8895 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50585 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85521 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8970 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108112 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20371 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85577 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28102 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87089 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85117 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29811 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7542 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21727 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16446 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27674 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27485 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30803 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29043 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->