### PR TITLE
[WebDriver][BiDi] Move Script and BrowsingContext to their own agents

### DIFF
--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -561,6 +561,8 @@ UIProcess/Authentication/WebProtectionSpace.cpp
 
 // FIXME(206266): AutomationProtocolObjects.h's "namespace Protocol" conflicts with objc/runtime.h's "typedef struct objc_object Protocol"
 UIProcess/Automation/BidiBrowserAgent.cpp @no-unify
+UIProcess/Automation/BidiBrowsingContextAgent.cpp @no-unify
+UIProcess/Automation/BidiScriptAgent.cpp @no-unify
 UIProcess/Automation/BidiUserContext.cpp @no-unify
 UIProcess/Automation/SimulatedInputDispatcher.cpp @no-unify
 UIProcess/Automation/WebAutomationSession.cpp @no-unify

--- a/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
@@ -1,0 +1,239 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Microsoft Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "BidiBrowsingContextAgent.h"
+
+#if ENABLE(WEBDRIVER_BIDI)
+
+#include "AutomationProtocolObjects.h"
+#include "Logging.h"
+#include "PageLoadState.h"
+#include "WebAutomationSession.h"
+#include "WebAutomationSessionMacros.h"
+#include "WebDriverBidiFrontendDispatchers.h"
+#include "WebDriverBidiProtocolObjects.h"
+#include "WebPageProxy.h"
+#include "WebProcessPool.h"
+
+namespace WebKit {
+
+using namespace Inspector;
+using BrowsingContext = Inspector::Protocol::BidiBrowsingContext::BrowsingContext;
+using ReadinessState = Inspector::Protocol::BidiBrowsingContext::ReadinessState;
+using PageLoadStrategy = Inspector::Protocol::Automation::PageLoadStrategy;
+using UserPromptType = Inspector::Protocol::BidiBrowsingContext::UserPromptType;
+using UserPromptHandlerType = Inspector::Protocol::BidiSession::UserPromptHandlerType;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BidiBrowsingContextAgent);
+
+BidiBrowsingContextAgent::BidiBrowsingContextAgent(WebAutomationSession& session, BackendDispatcher& backendDispatcher)
+    : m_session(session)
+    , m_browsingContextDomainDispatcher(BidiBrowsingContextBackendDispatcher::create(backendDispatcher, this))
+{
+}
+
+BidiBrowsingContextAgent::~BidiBrowsingContextAgent() = default;
+
+void BidiBrowsingContextAgent::activate(const BrowsingContext& browsingContext, CommandCallback<void>&& callback)
+{
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    RefPtr webPageProxy = session->webPageProxyForHandle(browsingContext);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!webPageProxy, WindowNotFound);
+
+    // FIXME: detect non-top level browsing contexts, returning `invalid argument`.
+    session->switchToBrowsingContext(browsingContext, emptyString(), [callback = WTFMove(callback)](CommandResult<void>&& result) {
+        if (!result) {
+            callback(makeUnexpected(result.error()));
+            return;
+        }
+
+        callback({ });
+    });
+}
+
+void BidiBrowsingContextAgent::close(const BrowsingContext& browsingContext, std::optional<bool>&& optionalPromptUnload, CommandCallback<void>&& callback)
+{
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    // FIXME: implement `promptUnload` option.
+    // FIXME: raise `invalid argument` if `browsingContext` is not a top-level traversable.
+
+    session->closeBrowsingContext(browsingContext);
+
+    callback({ });
+}
+
+static constexpr Inspector::Protocol::Automation::BrowsingContextPresentation defaultBrowsingContextPresentation = Inspector::Protocol::Automation::BrowsingContextPresentation::Tab;
+
+static Inspector::Protocol::Automation::BrowsingContextPresentation browsingContextPresentationFromCreateType(Inspector::Protocol::BidiBrowsingContext::CreateType createType)
+{
+    switch (createType) {
+    case Inspector::Protocol::BidiBrowsingContext::CreateType::Tab:
+        return Inspector::Protocol::Automation::BrowsingContextPresentation::Tab;
+    case Inspector::Protocol::BidiBrowsingContext::CreateType::Window:
+        return Inspector::Protocol::Automation::BrowsingContextPresentation::Window;
+    }
+
+    ASSERT_NOT_REACHED();
+    return defaultBrowsingContextPresentation;
+}
+
+void BidiBrowsingContextAgent::create(Inspector::Protocol::BidiBrowsingContext::CreateType createType, const BrowsingContext& optionalReferenceContext, std::optional<bool>&& optionalBackground, const String& optionalUserContext, CommandCallback<BrowsingContext>&& callback)
+{
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    // FIXME: implement `referenceContext` option.
+    // FIXME: implement `background` option.
+    // FIXME: implement `userContext` option.
+
+    session->createBrowsingContext(browsingContextPresentationFromCreateType(createType), [callback = WTFMove(callback)](CommandResultOf<BrowsingContext, Inspector::Protocol::Automation::BrowsingContextPresentation>&& result) {
+        if (!result) {
+            callback(makeUnexpected(result.error()));
+            return;
+        }
+
+        auto [resultContext, resultPresentation] = WTFMove(result.value());
+        callback(WTFMove(resultContext));
+    });
+}
+
+void BidiBrowsingContextAgent::getTree(const BrowsingContext& optionalRoot, std::optional<double>&& optionalMaxDepth, CommandCallback<Ref<JSON::ArrayOf<Protocol::BidiBrowsingContext::Info>>>&& callback)
+{
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    // FIXME: implement `root` option.
+    // FIXME: implement `maxDepth` option.
+
+    auto infos = JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>::create();
+    for (Ref process : session->protectedProcessPool()->processes()) {
+        for (Ref page : process->pages()) {
+            if (!page->isControlledByAutomation())
+                continue;
+
+            // FIXME: implement `parent` field.
+            // FIXME: implement `children` field.
+            // FIXME: implement `originalOpener` field.
+            // FIXME: implement `clientWindow` field.
+            // FIXME: implement `userContext` field.
+            infos->addItem(Inspector::Protocol::BidiBrowsingContext::Info::create()
+                .setContext(session->handleForWebPageProxy(page))
+                .setUrl(page->currentURL())
+                .setClientWindow("placeholder_window"_s)
+                .setUserContext("placeholder_context"_s)
+                .release());
+        }
+    }
+
+    callback({ { WTFMove(infos) } });
+}
+
+void BidiBrowsingContextAgent::handleUserPrompt(const BrowsingContext& browsingContext, std::optional<bool>&& optionalShouldAccept, const String&, CommandCallback<void>&& callback)
+{
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    // FIXME: implement `userText` option.
+
+    if (optionalShouldAccept && *optionalShouldAccept) {
+        callback(session->acceptCurrentJavaScriptDialog(browsingContext));
+        return;
+    }
+
+    // FIXME: this should consider the session's user prompt handler. <https://webkit.org/b/291666>
+    callback(session->dismissCurrentJavaScriptDialog(browsingContext));
+}
+
+
+// https://www.w3.org/TR/webdriver/#dfn-session-page-load-timeout
+static constexpr Seconds defaultPageLoadTimeout = 300_s;
+static constexpr ReadinessState defaultReadinessState = ReadinessState::None;
+
+static PageLoadStrategy pageLoadStrategyFromReadinessState(ReadinessState state)
+{
+    switch (state) {
+    case ReadinessState::None:
+        return PageLoadStrategy::None;
+    case ReadinessState::Interactive:
+        return PageLoadStrategy::Eager;
+    case ReadinessState::Complete:
+        return PageLoadStrategy::Normal;
+    }
+
+    ASSERT_NOT_REACHED();
+    return PageLoadStrategy::Normal;
+}
+
+void BidiBrowsingContextAgent::navigate(const BrowsingContext& browsingContext, const String& url, std::optional<ReadinessState>&& optionalReadinessState, CommandCallbackOf<String, Inspector::Protocol::BidiBrowsingContext::Navigation>&& callback)
+{
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    auto pageLoadStrategy = pageLoadStrategyFromReadinessState(optionalReadinessState.value_or(defaultReadinessState));
+    session->navigateBrowsingContext(browsingContext, url, pageLoadStrategy, defaultPageLoadTimeout.milliseconds(), [url, callback = WTFMove(callback)](CommandResult<void>&& result) {
+        if (!result) {
+            callback(makeUnexpected(result.error()));
+            return;
+        }
+
+        // FIXME: keep track of navigation IDs that we hand out.
+        callback({ { url, "placeholder_navigation"_s } });
+    });
+}
+
+void BidiBrowsingContextAgent::reload(const BrowsingContext& browsingContext, std::optional<bool>&& optionalIgnoreCache, std::optional<ReadinessState>&& optionalReadinessState, CommandCallbackOf<String, Inspector::Protocol::BidiBrowsingContext::Navigation>&& callback)
+{
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    // FIXME: implement `ignoreCache` option.
+
+    auto pageLoadStrategy = pageLoadStrategyFromReadinessState(optionalReadinessState.value_or(defaultReadinessState));
+    session->reloadBrowsingContext(browsingContext, pageLoadStrategy, defaultPageLoadTimeout.milliseconds(), [session = WTFMove(session), browsingContext, callback = WTFMove(callback)](CommandResult<void>&& result) {
+        if (!result) {
+            callback(makeUnexpected(result.error()));
+            return;
+        }
+
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+        RefPtr webPageProxy = session->webPageProxyForHandle(browsingContext);
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!webPageProxy, WindowNotFound);
+
+        // FIXME: keep track of navigation IDs that we hand out.
+        callback({ { webPageProxy->currentURL(), "placeholder_navigation"_s } });
+    });
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBDRIVER_BIDI)
+

--- a/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Microsoft Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBDRIVER_BIDI)
+
+#include "WebDriverBidiBackendDispatchers.h"
+#include <JavaScriptCore/InspectorBackendDispatcher.h>
+#include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebKit {
+
+class WebAutomationSession;
+
+class BidiBrowsingContextAgent final : public Inspector::BidiBrowsingContextBackendDispatcherHandler {
+    WTF_MAKE_TZONE_ALLOCATED(BidiBrowsingContextAgent);
+public:
+    BidiBrowsingContextAgent(WebAutomationSession&, Inspector::BackendDispatcher&);
+    ~BidiBrowsingContextAgent() override;
+
+    // Inspector::BidiBrowsingContextDispatcherHandler methods.
+    void activate(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, Inspector::CommandCallback<void>&&) override;
+    void close(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, std::optional<bool>&& optionalPromptUnload, Inspector::CommandCallback<void>&&) override;
+    void create(Inspector::Protocol::BidiBrowsingContext::CreateType, const Inspector::Protocol::BidiBrowsingContext::BrowsingContext& optionalReferenceContext, std::optional<bool>&& optionalBackground, const String& optionalUserContext, Inspector::CommandCallback<String>&&) override;
+    void getTree(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext& optionalRoot, std::optional<double>&& optionalMaxDepth, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>>>&&) override;
+    void handleUserPrompt(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, std::optional<bool>&& optionalShouldAccept, const String& userText, Inspector::CommandCallback<void>&&) override;
+    void navigate(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, const String& url, std::optional<Inspector::Protocol::BidiBrowsingContext::ReadinessState>&&, Inspector::CommandCallbackOf<String, Inspector::Protocol::BidiBrowsingContext::Navigation>&&) override;
+    void reload(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, std::optional<bool>&& optionalIgnoreCache, std::optional<Inspector::Protocol::BidiBrowsingContext::ReadinessState>&& optionalWait, Inspector::CommandCallbackOf<String, String>&&) override;
+
+private:
+    WeakPtr<WebAutomationSession> m_session;
+    Ref<Inspector::BidiBrowsingContextBackendDispatcher> m_browsingContextDomainDispatcher;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBDRIVER_BIDI)

--- a/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Microsoft Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "BidiScriptAgent.h"
+
+#if ENABLE(WEBDRIVER_BIDI)
+
+#include "AutomationProtocolObjects.h"
+#include "WebAutomationSession.h"
+#include "WebAutomationSessionMacros.h"
+#include "WebDriverBidiProtocolObjects.h"
+#include "WebPageProxy.h"
+
+namespace WebKit {
+
+using namespace Inspector;
+using BrowsingContext = Inspector::Protocol::BidiBrowsingContext::BrowsingContext;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BidiScriptAgent);
+
+BidiScriptAgent::BidiScriptAgent(WebAutomationSession& session, BackendDispatcher& backendDispatcher)
+    : m_session(session)
+    , m_scriptDomainDispatcher(BidiScriptBackendDispatcher::create(backendDispatcher, this))
+{
+}
+
+BidiScriptAgent::~BidiScriptAgent() = default;
+
+void BidiScriptAgent::callFunction(const String& functionDeclaration, bool awaitPromise, Ref<JSON::Object>&& target, RefPtr<JSON::Array>&& arguments, std::optional<Protocol::BidiScript::ResultOwnership>&&, RefPtr<JSON::Object>&& optionalSerializationOptions, RefPtr<JSON::Object>&& optionalThis, std::optional<bool>&& optionalUserActivation, CommandCallbackOf<Protocol::BidiScript::EvaluateResultType, String, RefPtr<Protocol::BidiScript::RemoteValue>, RefPtr<Protocol::BidiScript::ExceptionDetails>>&& callback)
+{
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    // FIXME: handle non-BrowsingContext obtained from `Target`.
+    std::optional<BrowsingContext> browsingContext = target->getString("context"_s);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!browsingContext, InvalidParameter);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session->webPageProxyForHandle(*browsingContext), WindowNotFound);
+
+    // FIXME: handle `awaitPromise` option.
+    // FIXME: handle `resultOwnership` option.
+    // FIXME: handle `serializationOptions` option.
+    // FIXME: handle custom `this` option.
+    // FIXME: handle `userActivation` option.
+
+    Ref<JSON::Array> argumentsArray = arguments ? arguments.releaseNonNull() : JSON::Array::create();
+
+    session->evaluateJavaScriptFunction(*browsingContext, emptyString(), functionDeclaration, WTFMove(argumentsArray), false, optionalUserActivation.value_or(false), std::nullopt, [callback = WTFMove(callback)](Inspector::CommandResult<String>&& result) {
+        auto evaluateResultType = result.has_value() ? Inspector::Protocol::BidiScript::EvaluateResultType::Success : Inspector::Protocol::BidiScript::EvaluateResultType::Exception;
+        auto resultObject = Inspector::Protocol::BidiScript::RemoteValue::create()
+            .setType(Inspector::Protocol::BidiScript::RemoteValueType::Object)
+            .release();
+
+        // FIXME: handle serializing different RemoteValue types as JSON.
+        if (result)
+            resultObject->setValue(JSON::Value::create(WTFMove(result.value())));
+
+        // FIXME: keep track of realm IDs that we hand out.
+        callback({ { evaluateResultType, "placeholder_realm"_s, WTFMove(resultObject), nullptr } });
+    });
+}
+
+void BidiScriptAgent::evaluate(const String& expression, bool awaitPromise, Ref<JSON::Object>&& target, std::optional<Protocol::BidiScript::ResultOwnership>&&, RefPtr<JSON::Object>&& optionalSerializationOptions, std::optional<bool>&& optionalUserActivation, CommandCallbackOf<Protocol::BidiScript::EvaluateResultType, String, RefPtr<Protocol::BidiScript::RemoteValue>, RefPtr<Protocol::BidiScript::ExceptionDetails>>&& callback)
+{
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    // FIXME: handle non-BrowsingContext obtained from `Target`.
+    std::optional<BrowsingContext> browsingContext = target->getString("context"_s);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!browsingContext, InvalidParameter);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session->webPageProxyForHandle(*browsingContext), WindowNotFound);
+
+    // FIXME: handle `awaitPromise` option.
+    // FIXME: handle `resultOwnership` option.
+    // FIXME: handle `serializationOptions` option.
+
+    String functionDeclaration = makeString("function() {\n return "_s, expression, "; \n}"_s);
+    session->evaluateJavaScriptFunction(*browsingContext, emptyString(), functionDeclaration, JSON::Array::create(), false, optionalUserActivation.value_or(false), std::nullopt, [callback = WTFMove(callback)](Inspector::CommandResult<String>&& result) {
+        auto evaluateResultType = result.has_value() ? Inspector::Protocol::BidiScript::EvaluateResultType::Success : Inspector::Protocol::BidiScript::EvaluateResultType::Exception;
+        auto resultObject = Inspector::Protocol::BidiScript::RemoteValue::create()
+            .setType(Inspector::Protocol::BidiScript::RemoteValueType::Object)
+            .release();
+
+        // FIXME: handle serializing different RemoteValue types as JSON here.
+        if (result)
+            resultObject->setValue(JSON::Value::create(WTFMove(result.value())));
+
+        // FIXME: keep track of realm IDs that we hand out.
+        callback({ { evaluateResultType, "placeholder_realm"_s, WTFMove(resultObject), nullptr } });
+    });
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBDRIVER_BIDI)
+

--- a/Source/WebKit/UIProcess/Automation/BidiScriptAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiScriptAgent.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Microsoft Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBDRIVER_BIDI)
+
+#include "WebDriverBidiBackendDispatchers.h"
+#include <JavaScriptCore/InspectorBackendDispatcher.h>
+#include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebKit {
+
+class WebAutomationSession;
+
+class BidiScriptAgent final : public Inspector::BidiScriptBackendDispatcherHandler {
+    WTF_MAKE_TZONE_ALLOCATED(BidiScriptAgent);
+public:
+    BidiScriptAgent(WebAutomationSession&, Inspector::BackendDispatcher&);
+    ~BidiScriptAgent() override;
+
+    // Inspector::BidiScriptBackendDispatcherHandler methods.
+    void callFunction(const String& functionDeclaration, bool awaitPromise, Ref<JSON::Object>&& target, RefPtr<JSON::Array>&& optionalArguments, std::optional<Inspector::Protocol::BidiScript::ResultOwnership>&&, RefPtr<JSON::Object>&& optionalSerializationOptions, RefPtr<JSON::Object>&& optionalThis, std::optional<bool>&& optionalUserActivation, Inspector::CommandCallbackOf<Inspector::Protocol::BidiScript::EvaluateResultType, String, RefPtr<Inspector::Protocol::BidiScript::RemoteValue>, RefPtr<Inspector::Protocol::BidiScript::ExceptionDetails>>&&) override;
+    void evaluate(const String& expression, bool awaitPromise, Ref<JSON::Object>&& target, std::optional<Inspector::Protocol::BidiScript::ResultOwnership>&&, RefPtr<JSON::Object>&& optionalSerializationOptions,  std::optional<bool>&& optionalUserActivation, Inspector::CommandCallbackOf<Inspector::Protocol::BidiScript::EvaluateResultType, String, RefPtr<Inspector::Protocol::BidiScript::RemoteValue>, RefPtr<Inspector::Protocol::BidiScript::ExceptionDetails>>&&) override;
+
+private:
+    WeakPtr<WebAutomationSession> m_session;
+    Ref<Inspector::BidiScriptBackendDispatcher> m_scriptDomainDispatcher;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBDRIVER_BIDI)

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
@@ -28,18 +28,11 @@
 
 #if ENABLE(WEBDRIVER_BIDI)
 
-// For AutomationError codes.
-#include "AutomationProtocolObjects.h"
 #include "BidiBrowserAgent.h"
+#include "BidiBrowsingContextAgent.h"
+#include "BidiScriptAgent.h"
 #include "Logging.h"
-#include "PageLoadState.h"
 #include "WebAutomationSession.h"
-#include "WebAutomationSessionMacros.h"
-#include "WebDriverBidiBackendDispatchers.h"
-#include "WebDriverBidiFrontendDispatchers.h"
-#include "WebDriverBidiProtocolObjects.h"
-#include "WebPageProxy.h"
-#include "WebProcessPool.h"
 #include <JavaScriptCore/InspectorBackendDispatcher.h>
 #include <JavaScriptCore/InspectorFrontendRouter.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -48,11 +41,6 @@
 namespace WebKit {
 
 using namespace Inspector;
-using BrowsingContext = Inspector::Protocol::BidiBrowsingContext::BrowsingContext;
-using ReadinessState = Inspector::Protocol::BidiBrowsingContext::ReadinessState;
-using PageLoadStrategy = Inspector::Protocol::Automation::PageLoadStrategy;
-using UserPromptType = Inspector::Protocol::BidiBrowsingContext::UserPromptType;
-using UserPromptHandlerType = Inspector::Protocol::BidiSession::UserPromptHandlerType;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebDriverBidiProcessor);
 
@@ -60,9 +48,9 @@ WebDriverBidiProcessor::WebDriverBidiProcessor(WebAutomationSession& session)
     : m_session(session)
     , m_frontendRouter(FrontendRouter::create())
     , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef()))
-    , m_browsingContextDomainDispatcher(BidiBrowsingContextBackendDispatcher::create(m_backendDispatcher, this))
-    , m_scriptDomainDispatcher(BidiScriptBackendDispatcher::create(m_backendDispatcher, this))
     , m_browserAgent(makeUnique<BidiBrowserAgent>(session, m_backendDispatcher))
+    , m_browsingContextAgent(makeUnique<BidiBrowsingContextAgent>(session, m_backendDispatcher))
+    , m_scriptAgent(makeUnique<BidiScriptAgent>(session, m_backendDispatcher))
     , m_browsingContextDomainNotifier(makeUnique<BidiBrowsingContextFrontendDispatcher>(m_frontendRouter))
     , m_logDomainNotifier(makeUnique<BidiLogFrontendDispatcher>(m_frontendRouter))
 {
@@ -118,274 +106,6 @@ void WebDriverBidiProcessor::sendBidiMessage(const String& message)
 void WebDriverBidiProcessor::sendMessageToFrontend(const String& message)
 {
     sendBidiMessage(message);
-}
-
-
-// MARK: Inspector::BidiBrowsingContextDispatcherHandler methods.
-
-void WebDriverBidiProcessor::activate(const BrowsingContext& browsingContext, CommandCallback<void>&& callback)
-{
-    RefPtr session = m_session.get();
-    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
-
-    RefPtr webPageProxy = session->webPageProxyForHandle(browsingContext);
-    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!webPageProxy, WindowNotFound);
-
-    // FIXME: detect non-top level browsing contexts, returning `invalid argument`.
-    session->switchToBrowsingContext(browsingContext, emptyString(), [callback = WTFMove(callback)](CommandResult<void>&& result) {
-        if (!result) {
-            callback(makeUnexpected(result.error()));
-            return;
-        }
-
-        callback({ });
-    });
-}
-
-void WebDriverBidiProcessor::close(const BrowsingContext& browsingContext, std::optional<bool>&& optionalPromptUnload, CommandCallback<void>&& callback)
-{
-    RefPtr session = m_session.get();
-    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
-
-    // FIXME: implement `promptUnload` option.
-    // FIXME: raise `invalid argument` if `browsingContext` is not a top-level traversable.
-
-    session->closeBrowsingContext(browsingContext);
-
-    callback({ });
-}
-
-static constexpr Inspector::Protocol::Automation::BrowsingContextPresentation defaultBrowsingContextPresentation = Inspector::Protocol::Automation::BrowsingContextPresentation::Tab;
-
-static Inspector::Protocol::Automation::BrowsingContextPresentation browsingContextPresentationFromCreateType(Inspector::Protocol::BidiBrowsingContext::CreateType createType)
-{
-    switch (createType) {
-    case Inspector::Protocol::BidiBrowsingContext::CreateType::Tab:
-        return Inspector::Protocol::Automation::BrowsingContextPresentation::Tab;
-    case Inspector::Protocol::BidiBrowsingContext::CreateType::Window:
-        return Inspector::Protocol::Automation::BrowsingContextPresentation::Window;
-    }
-
-    ASSERT_NOT_REACHED();
-    return defaultBrowsingContextPresentation;
-}
-
-void WebDriverBidiProcessor::create(Inspector::Protocol::BidiBrowsingContext::CreateType createType, const BrowsingContext& optionalReferenceContext, std::optional<bool>&& optionalBackground, const String& optionalUserContext, CommandCallback<BrowsingContext>&& callback)
-{
-    RefPtr session = m_session.get();
-    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
-
-    // FIXME: implement `referenceContext` option.
-    // FIXME: implement `background` option.
-    // FIXME: implement `userContext` option.
-
-    session->createBrowsingContext(browsingContextPresentationFromCreateType(createType), [callback = WTFMove(callback)](CommandResultOf<BrowsingContext, Inspector::Protocol::Automation::BrowsingContextPresentation>&& result) {
-        if (!result) {
-            callback(makeUnexpected(result.error()));
-            return;
-        }
-
-        auto [resultContext, resultPresentation] = WTFMove(result.value());
-        callback(WTFMove(resultContext));
-    });
-}
-
-void WebDriverBidiProcessor::getTree(const BrowsingContext& optionalRoot, std::optional<double>&& optionalMaxDepth, CommandCallback<Ref<JSON::ArrayOf<Protocol::BidiBrowsingContext::Info>>>&& callback)
-{
-    RefPtr session = m_session.get();
-    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
-
-    // FIXME: implement `root` option.
-    // FIXME: implement `maxDepth` option.
-
-    auto infos = JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>::create();
-    for (Ref process : session->protectedProcessPool()->processes()) {
-        for (Ref page : process->pages()) {
-            if (!page->isControlledByAutomation())
-                continue;
-
-            // FIXME: implement `parent` field.
-            // FIXME: implement `children` field.
-            // FIXME: implement `originalOpener` field.
-            // FIXME: implement `clientWindow` field.
-            // FIXME: implement `userContext` field.
-            infos->addItem(Inspector::Protocol::BidiBrowsingContext::Info::create()
-                .setContext(session->handleForWebPageProxy(page))
-                .setUrl(page->currentURL())
-                .setClientWindow("placeholder_window"_s)
-                .setUserContext("placeholder_context"_s)
-                .release());
-        }
-    }
-
-    callback({ { WTFMove(infos) } });
-}
-
-void WebDriverBidiProcessor::handleUserPrompt(const BrowsingContext& browsingContext, std::optional<bool>&& optionalShouldAccept, const String&, CommandCallback<void>&& callback)
-{
-    RefPtr session = m_session.get();
-    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
-
-    // FIXME: implement `userText` option.
-
-    if (optionalShouldAccept && *optionalShouldAccept) {
-        callback(session->acceptCurrentJavaScriptDialog(browsingContext));
-        return;
-    }
-
-    // FIXME: this should consider the session's user prompt handler. <https://webkit.org/b/291666>
-    callback(session->dismissCurrentJavaScriptDialog(browsingContext));
-}
-
-
-// https://www.w3.org/TR/webdriver/#dfn-session-page-load-timeout
-static constexpr Seconds defaultPageLoadTimeout = 300_s;
-static constexpr ReadinessState defaultReadinessState = ReadinessState::None;
-
-static PageLoadStrategy pageLoadStrategyFromReadinessState(ReadinessState state)
-{
-    switch (state) {
-    case ReadinessState::None:
-        return PageLoadStrategy::None;
-    case ReadinessState::Interactive:
-        return PageLoadStrategy::Eager;
-    case ReadinessState::Complete:
-        return PageLoadStrategy::Normal;
-    }
-
-    ASSERT_NOT_REACHED();
-    return PageLoadStrategy::Normal;
-}
-
-void WebDriverBidiProcessor::navigate(const BrowsingContext& browsingContext, const String& url, std::optional<ReadinessState>&& optionalReadinessState, CommandCallbackOf<String, Inspector::Protocol::BidiBrowsingContext::Navigation>&& callback)
-{
-    RefPtr session = m_session.get();
-    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
-
-    auto pageLoadStrategy = pageLoadStrategyFromReadinessState(optionalReadinessState.value_or(defaultReadinessState));
-    session->navigateBrowsingContext(browsingContext, url, pageLoadStrategy, defaultPageLoadTimeout.milliseconds(), [url, callback = WTFMove(callback)](CommandResult<void>&& result) {
-        if (!result) {
-            callback(makeUnexpected(result.error()));
-            return;
-        }
-
-        // FIXME: keep track of navigation IDs that we hand out.
-        callback({ { url, "placeholder_navigation"_s } });
-    });
-}
-
-void WebDriverBidiProcessor::reload(const BrowsingContext& browsingContext, std::optional<bool>&& optionalIgnoreCache, std::optional<ReadinessState>&& optionalReadinessState, CommandCallbackOf<String, Inspector::Protocol::BidiBrowsingContext::Navigation>&& callback)
-{
-    RefPtr session = m_session.get();
-    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
-
-    // FIXME: implement `ignoreCache` option.
-
-    auto pageLoadStrategy = pageLoadStrategyFromReadinessState(optionalReadinessState.value_or(defaultReadinessState));
-    session->reloadBrowsingContext(browsingContext, pageLoadStrategy, defaultPageLoadTimeout.milliseconds(), [session = WTFMove(session), browsingContext, callback = WTFMove(callback)](CommandResult<void>&& result) {
-        if (!result) {
-            callback(makeUnexpected(result.error()));
-            return;
-        }
-
-        ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
-
-        RefPtr webPageProxy = session->webPageProxyForHandle(browsingContext);
-        ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!webPageProxy, WindowNotFound);
-
-        // FIXME: keep track of navigation IDs that we hand out.
-        callback({ { webPageProxy->currentURL(), "placeholder_navigation"_s } });
-    });
-}
-
-void WebDriverBidiProcessor::userPromptOpenedOnPage(WebPageProxy& page, const UserPromptType& promptType, const UserPromptHandlerType& handlerType, const String& message, std::optional<String>&& defaultValue)
-{
-    RefPtr session = m_session.get();
-    if (!session)
-        return;
-
-    m_browsingContextDomainNotifier->userPromptOpened(session->handleForWebPageProxy(page), promptType, handlerType, message, defaultValue.value_or(emptyString()));
-}
-
-void WebDriverBidiProcessor::userPromptClosedOnPage(WebPageProxy& page, const UserPromptType& promptType, bool accepted, std::optional<String>&& userText)
-{
-    RefPtr session = m_session.get();
-    if (!session)
-        return;
-
-    m_browsingContextDomainNotifier->userPromptClosed(session->handleForWebPageProxy(page), promptType, accepted, userText.value_or(emptyString()));
-}
-
-// MARK: Log domain.
-
-void WebDriverBidiProcessor::logEntryAdded(const String& level, const String& source, const String& message, double timestamp, const String& type, const String& method)
-{
-    m_logDomainNotifier->entryAdded(level, source, message, timestamp, type, method);
-}
-
-// MARK: Inspector::BidiScriptDispatcherHandler methods.
-
-void WebDriverBidiProcessor::callFunction(const String& functionDeclaration, bool awaitPromise, Ref<JSON::Object>&& target, RefPtr<JSON::Array>&& arguments, std::optional<Protocol::BidiScript::ResultOwnership>&&, RefPtr<JSON::Object>&& optionalSerializationOptions, RefPtr<JSON::Object>&& optionalThis, std::optional<bool>&& optionalUserActivation, CommandCallbackOf<Protocol::BidiScript::EvaluateResultType, String, RefPtr<Protocol::BidiScript::RemoteValue>, RefPtr<Protocol::BidiScript::ExceptionDetails>>&& callback)
-{
-    RefPtr session = m_session.get();
-    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
-
-    // FIXME: handle non-BrowsingContext obtained from `Target`.
-    std::optional<BrowsingContext> browsingContext = target->getString("context"_s);
-    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!browsingContext, InvalidParameter);
-    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session->webPageProxyForHandle(*browsingContext), WindowNotFound);
-
-    // FIXME: handle `awaitPromise` option.
-    // FIXME: handle `resultOwnership` option.
-    // FIXME: handle `serializationOptions` option.
-    // FIXME: handle custom `this` option.
-    // FIXME: handle `userActivation` option.
-
-    Ref<JSON::Array> argumentsArray = arguments ? arguments.releaseNonNull() : JSON::Array::create();
-
-    session->evaluateJavaScriptFunction(*browsingContext, emptyString(), functionDeclaration, WTFMove(argumentsArray), false, optionalUserActivation.value_or(false), std::nullopt, [callback = WTFMove(callback)](Inspector::CommandResult<String>&& result) {
-        auto evaluateResultType = result.has_value() ? Inspector::Protocol::BidiScript::EvaluateResultType::Success : Inspector::Protocol::BidiScript::EvaluateResultType::Exception;
-        auto resultObject = Inspector::Protocol::BidiScript::RemoteValue::create()
-            .setType(Inspector::Protocol::BidiScript::RemoteValueType::Object)
-            .release();
-
-        // FIXME: handle serializing different RemoteValue types as JSON.
-        if (result)
-            resultObject->setValue(JSON::Value::create(WTFMove(result.value())));
-
-        // FIXME: keep track of realm IDs that we hand out.
-        callback({ { evaluateResultType, "placeholder_realm"_s, WTFMove(resultObject), nullptr } });
-    });
-}
-
-void WebDriverBidiProcessor::evaluate(const String& expression, bool awaitPromise, Ref<JSON::Object>&& target, std::optional<Protocol::BidiScript::ResultOwnership>&&, RefPtr<JSON::Object>&& optionalSerializationOptions, std::optional<bool>&& optionalUserActivation, CommandCallbackOf<Protocol::BidiScript::EvaluateResultType, String, RefPtr<Protocol::BidiScript::RemoteValue>, RefPtr<Protocol::BidiScript::ExceptionDetails>>&& callback)
-{
-    RefPtr session = m_session.get();
-    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
-
-    // FIXME: handle non-BrowsingContext obtained from `Target`.
-    std::optional<BrowsingContext> browsingContext = target->getString("context"_s);
-    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!browsingContext, InvalidParameter);
-    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session->webPageProxyForHandle(*browsingContext), WindowNotFound);
-
-    // FIXME: handle `awaitPromise` option.
-    // FIXME: handle `resultOwnership` option.
-    // FIXME: handle `serializationOptions` option.
-
-    String functionDeclaration = makeString("function() {\n return "_s, expression, "; \n}"_s);
-    session->evaluateJavaScriptFunction(*browsingContext, emptyString(), functionDeclaration, JSON::Array::create(), false, optionalUserActivation.value_or(false), std::nullopt, [callback = WTFMove(callback)](Inspector::CommandResult<String>&& result) {
-        auto evaluateResultType = result.has_value() ? Inspector::Protocol::BidiScript::EvaluateResultType::Success : Inspector::Protocol::BidiScript::EvaluateResultType::Exception;
-        auto resultObject = Inspector::Protocol::BidiScript::RemoteValue::create()
-            .setType(Inspector::Protocol::BidiScript::RemoteValueType::Object)
-            .release();
-
-        // FIXME: handle serializing different RemoteValue types as JSON here.
-        if (result)
-            resultObject->setValue(JSON::Value::create(WTFMove(result.value())));
-
-        // FIXME: keep track of realm IDs that we hand out.
-        callback({ { evaluateResultType, "placeholder_realm"_s, WTFMove(resultObject), nullptr } });
-    });
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
@@ -37,13 +37,12 @@
 namespace WebKit {
 
 class BidiBrowserAgent;
+class BidiBrowsingContextAgent;
+class BidiScriptAgent;
 class WebAutomationSession;
 class WebPageProxy;
 
-class WebDriverBidiProcessor final
-    : public Inspector::FrontendChannel
-    , public Inspector::BidiBrowsingContextBackendDispatcherHandler
-    , public Inspector::BidiScriptBackendDispatcherHandler {
+class WebDriverBidiProcessor final : public Inspector::FrontendChannel {
     WTF_MAKE_TZONE_ALLOCATED(WebDriverBidiProcessor);
 public:
     explicit WebDriverBidiProcessor(WebAutomationSession&);
@@ -57,23 +56,10 @@ public:
     Inspector::FrontendChannel::ConnectionType connectionType() const override { return Inspector::FrontendChannel::ConnectionType::Local; };
     void sendMessageToFrontend(const String&) override;
 
-    // Inspector::BidiBrowsingContextDispatcherHandler methods.
-    void activate(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, Inspector::CommandCallback<void>&&) override;
-    void close(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, std::optional<bool>&& optionalPromptUnload, Inspector::CommandCallback<void>&&) override;
-    void create(Inspector::Protocol::BidiBrowsingContext::CreateType, const Inspector::Protocol::BidiBrowsingContext::BrowsingContext& optionalReferenceContext, std::optional<bool>&& optionalBackground, const String& optionalUserContext, Inspector::CommandCallback<String>&&) override;
-    void getTree(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext& optionalRoot, std::optional<double>&& optionalMaxDepth, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>>>&&) override;
-    void handleUserPrompt(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, std::optional<bool>&& optionalShouldAccept, const String& userText, Inspector::CommandCallback<void>&&) override;
-    void navigate(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, const String& url, std::optional<Inspector::Protocol::BidiBrowsingContext::ReadinessState>&&, Inspector::CommandCallbackOf<String, Inspector::Protocol::BidiBrowsingContext::Navigation>&&) override;
-    void reload(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, std::optional<bool>&& optionalIgnoreCache, std::optional<Inspector::Protocol::BidiBrowsingContext::ReadinessState>&& optionalWait, Inspector::CommandCallbackOf<String, String>&&) override;
-
-    // Inspector::BidiScriptBackendDispatcherHandler methods.
-    void callFunction(const String& functionDeclaration, bool awaitPromise, Ref<JSON::Object>&& target, RefPtr<JSON::Array>&& optionalArguments, std::optional<Inspector::Protocol::BidiScript::ResultOwnership>&&, RefPtr<JSON::Object>&& optionalSerializationOptions, RefPtr<JSON::Object>&& optionalThis, std::optional<bool>&& optionalUserActivation, Inspector::CommandCallbackOf<Inspector::Protocol::BidiScript::EvaluateResultType, String, RefPtr<Inspector::Protocol::BidiScript::RemoteValue>, RefPtr<Inspector::Protocol::BidiScript::ExceptionDetails>>&&) override;
-    void evaluate(const String& expression, bool awaitPromise, Ref<JSON::Object>&& target, std::optional<Inspector::Protocol::BidiScript::ResultOwnership>&&, RefPtr<JSON::Object>&& optionalSerializationOptions,  std::optional<bool>&& optionalUserActivation, Inspector::CommandCallbackOf<Inspector::Protocol::BidiScript::EvaluateResultType, String, RefPtr<Inspector::Protocol::BidiScript::RemoteValue>, RefPtr<Inspector::Protocol::BidiScript::ExceptionDetails>>&&) override;
-
     // Event entry points called from the owning WebAutomationSession.
-    void logEntryAdded(const String& level, const String& source, const String& message, double timestamp, const String& type, const String& method);
-    void userPromptOpenedOnPage(WebPageProxy&, const Inspector::Protocol::BidiBrowsingContext::UserPromptType&, const Inspector::Protocol::BidiSession::UserPromptHandlerType&, const String& message, std::optional<String>&& defaultValue);
-    void userPromptClosedOnPage(WebPageProxy&, const Inspector::Protocol::BidiBrowsingContext::UserPromptType&, bool accepted, std::optional<String>&& userText);
+    Inspector::BidiBrowsingContextFrontendDispatcher& browsingContextDomainNotifier() const { return *m_browsingContextDomainNotifier; }
+    Inspector::BidiLogFrontendDispatcher& logDomainNotifier() const { return *m_logDomainNotifier; }
+
 private:
     Ref<Inspector::FrontendRouter> protectedFrontendRouter() const;
     Ref<Inspector::BackendDispatcher> protectedBackendDispatcher() const;
@@ -83,10 +69,9 @@ private:
     Ref<Inspector::FrontendRouter> m_frontendRouter;
     Ref<Inspector::BackendDispatcher> m_backendDispatcher;
 
-    Ref<Inspector::BidiBrowsingContextBackendDispatcher> m_browsingContextDomainDispatcher;
-    Ref<Inspector::BidiScriptBackendDispatcher> m_scriptDomainDispatcher;
-
     std::unique_ptr<BidiBrowserAgent> m_browserAgent;
+    std::unique_ptr<BidiBrowsingContextAgent> m_browsingContextAgent;
+    std::unique_ptr<BidiScriptAgent> m_scriptAgent;
     std::unique_ptr<Inspector::BidiBrowsingContextFrontendDispatcher> m_browsingContextDomainNotifier;
     std::unique_ptr<Inspector::BidiLogFrontendDispatcher> m_logDomainNotifier;
 };

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2457,6 +2457,10 @@
 		EEA52F482D70545300D578B5 /* WKStageMode.h in Headers */ = {isa = PBXBuildFile; fileRef = EE0D3CDD2D3709BE00072978 /* WKStageMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EEA52F492D7055A700D578B5 /* WKStageMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0D3CDC2D3709BE00072978 /* WKStageMode.swift */; };
 		EEFE72792D64FE5600DC6214 /* StageModeInteractionState.h in Headers */ = {isa = PBXBuildFile; fileRef = EEFE72782D64FE5600DC6214 /* StageModeInteractionState.h */; };
+		F3272B802DB997C6007B3A9A /* BidiBrowsingContextAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F3272B7D2DB997C6007B3A9A /* BidiBrowsingContextAgent.cpp */; };
+		F3272B812DB997C6007B3A9A /* BidiScriptAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F3272B7F2DB997C6007B3A9A /* BidiScriptAgent.cpp */; };
+		F3272B822DB997C6007B3A9A /* BidiBrowsingContextAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = F3272B7C2DB997C6007B3A9A /* BidiBrowsingContextAgent.h */; };
+		F3272B832DB997C6007B3A9A /* BidiScriptAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = F3272B7E2DB997C6007B3A9A /* BidiScriptAgent.h */; };
 		F3A94F012DB6F3310023CE9D /* BidiUserContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F3A94F002DB6F3310023CE9D /* BidiUserContext.cpp */; };
 		F3A94F022DB6F3310023CE9D /* BidiUserContext.h in Headers */ = {isa = PBXBuildFile; fileRef = F3A94EFF2DB6F3310023CE9D /* BidiUserContext.h */; };
 		F3EEEE592DB318270038CC1D /* BidiBrowserAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = F3EEEE572DB318270038CC1D /* BidiBrowserAgent.h */; };
@@ -8318,6 +8322,10 @@
 		EE0D3CDD2D3709BE00072978 /* WKStageMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKStageMode.h; sourceTree = "<group>"; };
 		EEFE72782D64FE5600DC6214 /* StageModeInteractionState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StageModeInteractionState.h; sourceTree = "<group>"; };
 		F036978715F4BF0500C3A80E /* WebColorPicker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebColorPicker.cpp; sourceTree = "<group>"; };
+		F3272B7C2DB997C6007B3A9A /* BidiBrowsingContextAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiBrowsingContextAgent.h; sourceTree = "<group>"; };
+		F3272B7D2DB997C6007B3A9A /* BidiBrowsingContextAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiBrowsingContextAgent.cpp; sourceTree = "<group>"; };
+		F3272B7E2DB997C6007B3A9A /* BidiScriptAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiScriptAgent.h; sourceTree = "<group>"; };
+		F3272B7F2DB997C6007B3A9A /* BidiScriptAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiScriptAgent.cpp; sourceTree = "<group>"; };
 		F3A94EFF2DB6F3310023CE9D /* BidiUserContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiUserContext.h; sourceTree = "<group>"; };
 		F3A94F002DB6F3310023CE9D /* BidiUserContext.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiUserContext.cpp; sourceTree = "<group>"; };
 		F3EEEE572DB318270038CC1D /* BidiBrowserAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiBrowserAgent.h; sourceTree = "<group>"; };
@@ -14066,6 +14074,10 @@
 				9955A6E91C7980BB00EB6A93 /* Automation.json */,
 				F3EEEE582DB318270038CC1D /* BidiBrowserAgent.cpp */,
 				F3EEEE572DB318270038CC1D /* BidiBrowserAgent.h */,
+				F3272B7D2DB997C6007B3A9A /* BidiBrowsingContextAgent.cpp */,
+				F3272B7C2DB997C6007B3A9A /* BidiBrowsingContextAgent.h */,
+				F3272B7F2DB997C6007B3A9A /* BidiScriptAgent.cpp */,
+				F3272B7E2DB997C6007B3A9A /* BidiScriptAgent.h */,
 				F3A94F002DB6F3310023CE9D /* BidiUserContext.cpp */,
 				F3A94EFF2DB6F3310023CE9D /* BidiUserContext.h */,
 				995226D5207D184600F78420 /* SimulatedInputDispatcher.cpp */,
@@ -16938,6 +16950,8 @@
 				46A2B6091E5676A600C3DEDA /* BackgroundProcessResponsivenessTimer.h in Headers */,
 				95C943912523C0D00054F3D5 /* BaseBoardSPI.h in Headers */,
 				F3EEEE592DB318270038CC1D /* BidiBrowserAgent.h in Headers */,
+				F3272B822DB997C6007B3A9A /* BidiBrowsingContextAgent.h in Headers */,
+				F3272B832DB997C6007B3A9A /* BidiScriptAgent.h in Headers */,
 				F3A94F022DB6F3310023CE9D /* BidiUserContext.h in Headers */,
 				E164A2F2191AF14E0010737D /* BlobDataFileReferenceWithSandboxExtension.h in Headers */,
 				E170876C16D6CA6900F99226 /* BlobRegistryProxy.h in Headers */,
@@ -20391,6 +20405,8 @@
 				E326E357284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm in Sources */,
 				413E5C9229B0CF7C002F4987 /* BackgroundFetchStateCocoa.mm in Sources */,
 				F3EEEE5A2DB318270038CC1D /* BidiBrowserAgent.cpp in Sources */,
+				F3272B802DB997C6007B3A9A /* BidiBrowsingContextAgent.cpp in Sources */,
+				F3272B812DB997C6007B3A9A /* BidiScriptAgent.cpp in Sources */,
 				F3A94F012DB6F3310023CE9D /* BidiUserContext.cpp in Sources */,
 				1C62747E288B4C3E00CED3A2 /* CocoaHelpers.mm in Sources */,
 				49DC1DE127E5129100C1CB36 /* CSPExtensionUtilities.mm in Sources */,


### PR DESCRIPTION
#### 40c20149343ef9301c1d713dbbdf9af18bec0d23
<pre>
[WebDriver][BiDi] Move Script and BrowsingContext to their own agents
<a href="https://bugs.webkit.org/show_bug.cgi?id=291978">https://bugs.webkit.org/show_bug.cgi?id=291978</a>

Reviewed by BJ Burg.

Extracted BrowsingContext and Script modules into separate agents - like BidiBrowserAgent -
to keep domain-specific logic out of the WebDriverBidiProcessor.

* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp: Added.
(WebKit::BidiBrowsingContextAgent::BidiBrowsingContextAgent):
(WebKit::BidiBrowsingContextAgent::activate):
(WebKit::BidiBrowsingContextAgent::close):
(WebKit::browsingContextPresentationFromCreateType):
(WebKit::BidiBrowsingContextAgent::create):
(WebKit::BidiBrowsingContextAgent::getTree):
(WebKit::BidiBrowsingContextAgent::handleUserPrompt):
(WebKit::pageLoadStrategyFromReadinessState):
(WebKit::BidiBrowsingContextAgent::navigate):
(WebKit::BidiBrowsingContextAgent::reload):
* Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.h: Copied from Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h.
* Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp: Added.
(WebKit::BidiScriptAgent::BidiScriptAgent):
(WebKit::BidiScriptAgent::callFunction):
(WebKit::BidiScriptAgent::evaluate):
* Source/WebKit/UIProcess/Automation/BidiScriptAgent.h: Added.
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp: The notifiers
are called directly from the session, which eliminates null check fo the
session that was required before.

(WebKit::WebAutomationSession::willShowJavaScriptDialog):
(WebKit::WebAutomationSession::dismissCurrentJavaScriptDialog):
(WebKit::WebAutomationSession::acceptCurrentJavaScriptDialog):
(WebKit::WebAutomationSession::logEntryAdded):
* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp:
(WebKit::WebDriverBidiProcessor::WebDriverBidiProcessor):
(WebKit::WebDriverBidiProcessor::activate): Deleted.
(WebKit::WebDriverBidiProcessor::close): Deleted.
(WebKit::browsingContextPresentationFromCreateType): Deleted.
(WebKit::WebDriverBidiProcessor::create): Deleted.
(WebKit::WebDriverBidiProcessor::getTree): Deleted.
(WebKit::WebDriverBidiProcessor::handleUserPrompt): Deleted.
(WebKit::pageLoadStrategyFromReadinessState): Deleted.
(WebKit::WebDriverBidiProcessor::navigate): Deleted.
(WebKit::WebDriverBidiProcessor::reload): Deleted.
(WebKit::WebDriverBidiProcessor::userPromptOpenedOnPage): Deleted.
(WebKit::WebDriverBidiProcessor::userPromptClosedOnPage): Deleted.
(WebKit::WebDriverBidiProcessor::logEntryAdded): Deleted.
(WebKit::WebDriverBidiProcessor::callFunction): Deleted.
(WebKit::WebDriverBidiProcessor::evaluate): Deleted.
* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/294128@main">https://commits.webkit.org/294128@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95ab5e49eaade5c44a97497d61b9ab95b312c41f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105769 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51220 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20592 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28758 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76631 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33667 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90895 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56987 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15616 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50596 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85528 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8977 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108123 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20380 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85585 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28113 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85126 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21723 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29821 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7549 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21738 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27685 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32936 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27496 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30814 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29054 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->