### PR TITLE
TestWebKitAPI.WebKit.MouseMoveOverElementWithClosedWebView crashes under certain configurations with a nil event monitor

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
@@ -1039,6 +1039,43 @@ TEST(WebKit, MouseMoveOverElement)
 
 static BlockPtr<NSEvent*(NSEvent*)> gEventMonitorHandler;
 
+@interface TestLocalEventObserver : NSObject {
+    NSEventMask _mask;
+    id _block;
+    BOOL _isAdditive;
+}
++ (void)initialize;
+- (instancetype)initMatchingEvents:(NSEventMask)mask handler:(NSEvent *(^)(NSEvent *))block;
+- (void)invalidate;
+- (void)dealloc;
+- (void)recomputeObserverMask;
+@end
+
+@implementation TestLocalEventObserver
++ (void)initialize
+{
+}
+
+- (instancetype)initMatchingEvents:(NSEventMask)mask handler:(NSEvent *(^)(NSEvent *))block
+{
+    self = [super init];
+    return self;
+}
+
+- (void)dealloc
+{
+    [super dealloc];
+}
+
+- (void)invalidate
+{
+}
+
+- (void)recomputeObserverMask
+{
+}
+@end
+
 @interface TestEventMonitor : NSObject
 
 + (id)addLocalMonitorForEventsMatchingMask:(NSEventMask)mask handler:(NSEvent* (^)(NSEvent *event))block;
@@ -1050,7 +1087,7 @@ static BlockPtr<NSEvent*(NSEvent*)> gEventMonitorHandler;
 + (id)addLocalMonitorForEventsMatchingMask:(NSEventMask)mask handler:(NSEvent* (^)(NSEvent *event))block
 {
     gEventMonitorHandler = makeBlockPtr(block);
-    return nil;
+    return adoptNS([[TestLocalEventObserver alloc] initMatchingEvents:mask handler:block]).leakRef();
 }
 
 @end


### PR DESCRIPTION
#### 1dc90b44951e4239933a3cc21907a7661ca18bf6
<pre>
TestWebKitAPI.WebKit.MouseMoveOverElementWithClosedWebView crashes under certain configurations with a nil event monitor
<a href="https://bugs.webkit.org/show_bug.cgi?id=291981">https://bugs.webkit.org/show_bug.cgi?id=291981</a>
<a href="https://rdar.apple.com/149895830">rdar://149895830</a>

Reviewed by Wenson Hsieh.

Under certain configurations, we can get to a state where swizzling out
addLocalMonitorForEventsMatchingMask:handler: to return a nil handler
messes up underlying AppKit bookkeeping, causing a TestWebKitAPI crash.

This patch addresses the crash by instead providing a mock event monitor
with enough of an interface to not get destructively in the way of the
system&apos;s underlying bookkeeping.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:
(+[TestLocalEventObserver initialize]):
(-[TestLocalEventObserver initMatchingEvents:handler:]):
(-[TestLocalEventObserver dealloc]):
(-[TestLocalEventObserver invalidate]):
(-[TestLocalEventObserver recomputeObserverMask]):
(+[TestEventMonitor addLocalMonitorForEventsMatchingMask:handler:]):

Canonical link: <a href="https://commits.webkit.org/294075@main">https://commits.webkit.org/294075@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9b43d51fe62253c7f95ee58ba983e9b31785adc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105850 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51301 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102754 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20673 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28839 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76685 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33723 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15874 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90967 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57039 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15683 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8975 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50677 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85584 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9050 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108205 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20433 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85644 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28194 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85184 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21688 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29890 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7617 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21825 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27766 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27577 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30895 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29135 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->