### PR TITLE
Sync `svg/shapes` from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -10886,6 +10886,8 @@
         "web-platform-tests/svg/shapes/reftests/pathlength-001-ref.svg",
         "web-platform-tests/svg/shapes/reftests/pathlength-002-ref.svg",
         "web-platform-tests/svg/shapes/reftests/pathlength-003-ref.svg",
+        "web-platform-tests/svg/shapes/reftests/pathlength-004-ref.svg",
+        "web-platform-tests/svg/shapes/reftests/pathlength-005-ref.html",
         "web-platform-tests/svg/shapes/reftests/reference/empty.svg",
         "web-platform-tests/svg/struct/reftests/reference/green-100x100.html",
         "web-platform-tests/svg/struct/reftests/reference/green-100x100.svg",

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-004-ref.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-004-ref.svg
@@ -1,0 +1,15 @@
+<svg id="svg-root"
+  width="100%" height="100%" viewBox="0 0 480 360"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <g id="testmeta">
+    <title>Test of 'pathLength' on shapes.</title>
+  </g>
+
+  <g id="test-reference" style="fill:none;stroke:black;stroke-width:5">
+    <path d="m  20,140 200,0 0,200 -200,0 z" style="stroke-dasharray:50" />
+    <path d="m 260,140 200,0 0,200 -200,0 z" style="stroke-dasharray:0.25" pathLength="4"/>
+  </g>
+
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-004a-expected.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-004a-expected.svg
@@ -1,0 +1,15 @@
+<svg id="svg-root"
+  width="100%" height="100%" viewBox="0 0 480 360"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <g id="testmeta">
+    <title>Test of 'pathLength' on shapes.</title>
+  </g>
+
+  <g id="test-reference" style="fill:none;stroke:black;stroke-width:5">
+    <path d="m  20,140 200,0 0,200 -200,0 z" style="stroke-dasharray:50" />
+    <path d="m 260,140 200,0 0,200 -200,0 z" style="stroke-dasharray:0.25" pathLength="4"/>
+  </g>
+
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-004a.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-004a.svg
@@ -1,0 +1,18 @@
+<svg id="svg-root"
+  width="100%" height="100%" viewBox="0 0 480 360"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <g id="testmeta">
+    <title>Test of 'pathLength' on shapes.</title>
+    <html:link rel="help"
+          href="https://www.w3.org/TR/SVG2/shapes.html#PolylineElement"/>
+    <html:link rel="match"  href="pathlength-004-ref.svg" />
+  </g>
+
+  <g id="test-body-content" style="fill:none;stroke:black;stroke-width:5px">
+    <polygon points="20,140, 220,140, 220,340 20,340" style="stroke-dasharray:50"/>
+    <polygon points="260,140, 460,140, 460,340 260,340" style="stroke-dasharray:0.25" pathLength="4"/>
+  </g>
+
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-004b-expected.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-004b-expected.svg
@@ -1,0 +1,15 @@
+<svg id="svg-root"
+  width="100%" height="100%" viewBox="0 0 480 360"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <g id="testmeta">
+    <title>Test of 'pathLength' on shapes.</title>
+  </g>
+
+  <g id="test-reference" style="fill:none;stroke:black;stroke-width:5">
+    <path d="m  20,140 200,0 0,200 -200,0 z" style="stroke-dasharray:50" />
+    <path d="m 260,140 200,0 0,200 -200,0 z" style="stroke-dasharray:0.25" pathLength="4"/>
+  </g>
+
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-004b.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-004b.svg
@@ -1,0 +1,25 @@
+<svg id="svg-root"
+  width="100%" height="100%" viewBox="0 0 480 360"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml" class="reftest-wait">
+  <script href="/common/rendering-utils.js"/>
+  <script href="/common/reftest-wait.js"/>
+  <g id="testmeta">
+    <title>Test of 'pathLength' on shapes.</title>
+    <html:link rel="help"
+          href="https://www.w3.org/TR/SVG2/shapes.html#PolylineElement"/>
+    <html:link rel="match"  href="pathlength-004-ref.svg" />
+  </g>
+
+  <g id="test-body-content" style="fill:none;stroke:black;stroke-width:5px">
+    <polygon points="20,140, 220,140, 220,340 20,340" style="stroke-dasharray:50"/>
+    <polygon id="polygon" points="260,140, 460,140, 460,340 260,340" style="stroke-dasharray:0.25"/>
+  </g>
+  <script>
+    waitForAtLeastOneFrame().then(() => {
+      document.getElementById("polygon").setAttribute("pathLength", "4");
+      takeScreenshot();
+    });
+  </script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-005-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-005-expected.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<svg width="100" height="100" viewBox="-20 -20 40 40" style="fill:none;">
+  <circle r="18" pathlength="100" stroke="green" stroke-width="1" stroke-dasharray="50,50"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-005-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-005-ref.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<svg width="100" height="100" viewBox="-20 -20 40 40" style="fill:none;">
+  <circle r="18" pathlength="100" stroke="green" stroke-width="1" stroke-dasharray="50,50"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-005.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<title>Test of 'pathLength' on shapes with zoom.</title>
+<link rel="help"
+      href="https://www.w3.org/TR/SVG2/shapes.html#CircleElement">
+<link rel="match"  href="pathlength-005-ref.html">
+
+<svg id="test-body-content" width="400" viewBox="-20 -20 40 40" style="fill:none;zoom: 0.25;">
+  <circle r="18" pathlength="100" stroke="green" stroke-width="1" stroke-dasharray="50,50"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/w3c-import.log
@@ -25,5 +25,13 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-003-expected.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-003-ref.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-003.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-004-ref.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-004a-expected.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-004a.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-004b-expected.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-004b.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-005-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-005-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-005.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/polygon-with-filtered-marker-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/polygon-with-filtered-marker.html


### PR DESCRIPTION
#### aefb093c5dbeb0a2c56f9f10a440e6a74f8ce6f5
<pre>
Sync `svg/shapes` from WPT upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=291982">https://bugs.webkit.org/show_bug.cgi?id=291982</a>
<a href="https://rdar.apple.com/149897912">rdar://149897912</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/a09cf15dff82d741996db438e5804f1c04f46d3b">https://github.com/web-platform-tests/wpt/commit/a09cf15dff82d741996db438e5804f1c04f46d3b</a>

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-005.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-005-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-005-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-004b.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-004b-expected.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-004a.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-004a-expected.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-004-ref.svg:

Canonical link: <a href="https://commits.webkit.org/294052@main">https://commits.webkit.org/294052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/453407d14a84667886f249b3ee272872d38b3082

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100645 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105782 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51233 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28771 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76641 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33674 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15816 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90910 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56996 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15628 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8917 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50609 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85539 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8992 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108137 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27763 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20391 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85593 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28126 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85134 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21671 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29838 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7563 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21751 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27698 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27509 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30827 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->