### PR TITLE
Update Internals::touchEventRectsForEvent to use new touch event region codepath

### DIFF
--- a/LayoutTests/fast/events/touch/ios/touch-event-regions/active-passive-nesting.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions/active-passive-nesting.html
@@ -28,9 +28,23 @@
         }
     </style>
     <script src="resources/touch-regions-helper.js"></script>
+    <script src="../../../../../resources/ui-helper.js"></script>
+
     <script>
-        if (window.testRunner)
+        if (window.testRunner) {
             testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+
+        async function getRegions() {
+            await UIHelper.ensurePresentationUpdate();
+            dumpRegions();
+            testRunner.notifyDone();
+        }
+
+
+        window.addEventListener('load', getRegions, false);
 
         function doTest()
         {
@@ -44,7 +58,7 @@
                 element.addEventListener('touchstart', function(e) { }, { 'passive': true });
             }
             
-            dumpRegions();
+            getRegions();
         }
 
         window.addEventListener('load', doTest, false);

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions/columns.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions/columns.html
@@ -15,11 +15,20 @@
         }
     </style>
     <script src="resources/touch-regions-helper.js"></script>
+    <script src="../../../../../resources/ui-helper.js"></script>
     <script>
-        if (window.testRunner)
-            testRunner.dumpAsText();
+        async function getRegions() {
+            await UIHelper.ensurePresentationUpdate();
+            dumpRegions();
+            testRunner.notifyDone();
+        }
 
-        window.addEventListener('load', dumpRegions, false);
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        window.addEventListener('load', getRegions, false);
     </script>
 </head>
 <body>

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions/complex.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions/complex.html
@@ -43,11 +43,20 @@
         }
     </style>
     <script src="resources/touch-regions-helper.js"></script>
+    <script src="../../../../../resources/ui-helper.js"></script>
     <script>
-        if (window.testRunner)
-            testRunner.dumpAsText();
+        async function getRegions() {
+            await UIHelper.ensurePresentationUpdate();
+            dumpRegions();
+            testRunner.notifyDone();
+        }
 
-        window.addEventListener('load', dumpRegions, false);
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        window.addEventListener('load', getRegions, false);
     </script>
 </head>
 <body>

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions/document.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions/document.html
@@ -4,11 +4,20 @@
 <head>
     <meta name="viewport" content="initial-scale=1.0">
     <script src="resources/touch-regions-helper.js"></script>
-    <script>
-        if (window.testRunner)
-            testRunner.dumpAsText();
+    <script src="../../../../../resources/ui-helper.js"></script>
 
-        window.addEventListener('load', dumpRegions, false);
+    <script>
+        async function getRegions() {
+            await UIHelper.ensurePresentationUpdate();
+            dumpRegions();
+            testRunner.notifyDone();
+        }
+
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+        window.addEventListener('load', getRegions, false);
     </script>
 </head>
 <body>

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions/iframes.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions/iframes.html
@@ -12,11 +12,20 @@
         }
     </style>
     <script src="resources/touch-regions-helper.js"></script>
+    <script src="../../../../../resources/ui-helper.js"></script>
     <script>
-        if (window.testRunner)
-            testRunner.dumpAsText();
+        async function getRegions() {
+            await UIHelper.ensurePresentationUpdate();
+            dumpRegions();
+            testRunner.notifyDone();
+        }
 
-        window.addEventListener('load', dumpRegions, false);
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        window.addEventListener('load', getRegions, false);
     </script>
 </head>
 <body>

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions/overflow.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions/overflow.html
@@ -23,11 +23,20 @@
         }
     </style>
     <script src="resources/touch-regions-helper.js"></script>
+    <script src="../../../../../resources/ui-helper.js"></script>
     <script>
-        if (window.testRunner)
-            testRunner.dumpAsText();
+        async function getRegions() {
+            await UIHelper.ensurePresentationUpdate();
+            dumpRegions();
+            testRunner.notifyDone();
+        }
 
-        window.addEventListener('load', dumpRegions, false);
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        window.addEventListener('load', getRegions, false);
     </script>
 </head>
 <body>

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions/range-sliders.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions/range-sliders.html
@@ -4,11 +4,20 @@
 <head>
     <meta name="viewport" content="initial-scale=1.0">
     <script src="resources/touch-regions-helper.js"></script>
+    <script src="../../../../../resources/ui-helper.js"></script>
     <script>
-        if (window.testRunner)
-            testRunner.dumpAsText();
+        async function getRegions() {
+            await UIHelper.ensurePresentationUpdate();
+            dumpRegions();
+            testRunner.notifyDone();
+        }
 
-        window.addEventListener('load', dumpRegions, false);
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        window.addEventListener('load', getRegions, false);
     </script>
 </head>
 <body>

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions/scrolled-overflow.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions/scrolled-overflow.html
@@ -19,13 +19,22 @@
         }
     </style>
     <script src="resources/touch-regions-helper.js"></script>
+    <script src="../../../../../resources/ui-helper.js"></script>
     <script>
-        if (window.testRunner)
+        async function getRegions() {
+            await UIHelper.ensurePresentationUpdate();
+            dumpRegions();
+            testRunner.notifyDone();
+        }
+
+        if (window.testRunner) {
             testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
 
         window.addEventListener('load', () => {
             scroller.scrollTo(0, 200);
-            dumpRegions();
+            getRegions();
         }, false);
     </script>
 </head>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6043,6 +6043,16 @@ void Document::updateEventRegions()
     }
 }
 
+Vector<EventTrackingRegions> Document::touchEventRegionsForTesting() const
+{
+    if (CheckedPtr view = renderView()) {
+        if (view->usesCompositing())
+            return view->compositor().touchEventRegionsForTesting();
+    }
+    return { };
+}
+
+
 void Document::scheduleDeferredAXObjectCacheUpdate()
 {
     if (m_scheduledDeferredAXObjectCacheUpdate)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -293,9 +293,7 @@ struct SecurityPolicyViolationEventInit;
 struct StartViewTransitionOptions;
 struct ViewTransitionParams;
 
-#if ENABLE(TOUCH_EVENTS)
 struct EventTrackingRegions;
-#endif
 
 #if USE(SYSTEM_PREVIEW)
 struct SystemPreviewInfo;
@@ -1361,6 +1359,7 @@ public:
 
     void updateAccessibilityObjectRegions();
     void updateEventRegions();
+    Vector<EventTrackingRegions> touchEventRegionsForTesting() const;
 
     void invalidateRenderingDependentRegions();
     void invalidateEventRegionsForFrame(HTMLFrameOwnerElement&);

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -168,6 +168,10 @@ public:
     void clearInteractionRegions();
 #endif
 
+#if ENABLE(TOUCH_EVENT_REGIONS)
+    EventTrackingRegions touchEventListenerRegions() const { return m_touchEventListenerRegion; }
+#endif
+
 private:
     friend struct IPC::ArgumentCoder<EventRegion, void>;
 #if ENABLE(TOUCH_ACTION_REGIONS)

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -4397,6 +4397,16 @@ void RenderLayer::collectEventRegionForFragments(const LayerFragments& layerFrag
     }
 }
 
+EventTrackingRegions RenderLayer::touchEventRegionsForTesting() const
+{
+    EventTrackingRegions region;
+#if ENABLE(TOUCH_EVENT_REGIONS)
+    if (auto* backing = this->backing())
+        return backing->graphicsLayer()->eventRegion().touchEventListenerRegions();
+#endif
+    return region;
+}
+
 void RenderLayer::collectAccessibilityRegionsForFragments(const LayerFragments& layerFragments, GraphicsContext& context, const LayerPaintingInfo& localPaintingInfo, OptionSet<PaintBehavior> paintBehavior)
 {
     ASSERT(is<AccessibilityRegionContext>(localPaintingInfo.regionContext));

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -956,6 +956,8 @@ public:
     enum class EventRegionInvalidationReason { Paint, SettingDidChange, Style, NonCompositedFrame };
     bool invalidateEventRegion(EventRegionInvalidationReason);
 
+    EventTrackingRegions touchEventRegionsForTesting() const;
+
     String debugDescription() const;
 
     bool setIsOpportunisticStackingContext(bool);

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1003,6 +1003,21 @@ void RenderLayerCompositor::updateEventRegions()
     m_renderView.setNeedsEventRegionUpdateForNonCompositedFrame(false);
 }
 
+Vector<EventTrackingRegions> RenderLayerCompositor::touchEventRegionsForTesting() const
+{
+    Vector<EventTrackingRegions> eventRegions;
+    Vector<CheckedPtr<RenderLayer>> layers = { m_renderView.layer() };
+    while (!layers.isEmpty()) {
+        if (CheckedPtr layer = layers.takeLast()) {
+            eventRegions.append(layer->touchEventRegionsForTesting());
+            for (auto* childLayer = layer->firstChild(); childLayer; childLayer = childLayer->nextSibling())
+                layers.append(childLayer);
+        }
+
+    }
+    return eventRegions;
+}
+
 static std::optional<ScrollingNodeID> frameHostingNodeForFrame(LocalFrame& frame)
 {
     if (!frame.document() || !frame.view())

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -209,6 +209,7 @@ public:
     // Update event regions, which only needs to happen once per rendering update.
     void updateEventRegions();
     void updateEventRegionsRecursive(RenderLayer&);
+    Vector<EventTrackingRegions> touchEventRegionsForTesting() const;
 
     struct RequiresCompositingData {
         LayoutUpToDate layoutUpToDate { LayoutUpToDate::Yes };


### PR DESCRIPTION
#### 1ed025da72085637dbf40591545f4d29301c3234
<pre>
Update Internals::touchEventRectsForEvent to use new touch event region codepath
<a href="https://bugs.webkit.org/show_bug.cgi?id=291986">https://bugs.webkit.org/show_bug.cgi?id=291986</a>
<a href="https://rdar.apple.com/149900530">rdar://149900530</a>

Reviewed by NOBODY (OOPS!).

Update Internals::touchEventRectsForEvent to get the touch event regions from the relevant layers
rather than through the scrolling coordinator.

* LayoutTests/fast/events/touch/ios/touch-event-regions/document.html:
* Source/WTF/wtf/PlatformEnableCocoa.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::getEventRegions):
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::touchEventRectsForEventForTesting):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::setEventRegion):
* Source/WebCore/rendering/EventRegion.h:
(WebCore::EventRegion::touchEventListenerRegion const):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::paintObject):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::getEventRegion):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::getEventRegions):
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::touchEventRectsForEvent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ed025da72085637dbf40591545f4d29301c3234

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20858 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11161 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106344 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51823 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77079 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34112 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104203 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16323 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91414 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57426 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16140 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9425 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51171 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86028 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9498 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108700 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28324 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20850 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86048 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28686 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87617 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85594 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30325 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8043 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22423 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28254 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33525 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28066 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31386 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29624 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->