### PR TITLE
[WebDriver][BiDi] Implement the browser.removeUserContext command

### DIFF
--- a/Source/WebKit/UIProcess/Automation/BidiUserContext.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiUserContext.cpp
@@ -28,8 +28,10 @@
 
 #if ENABLE(WEBDRIVER_BIDI)
 
+#include "WebPageProxy.h"
 #include "WebProcessPool.h"
 #include "WebsiteDataStore.h"
+#include <wtf/Vector.h>
 
 namespace WebKit {
 
@@ -49,6 +51,18 @@ BidiUserContext::BidiUserContext(WebsiteDataStore& dataStore, WebProcessPool& pr
 #endif // PLATFORM(GTK)
 
 BidiUserContext::~BidiUserContext() = default;
+
+Vector<Ref<WebPageProxy>> BidiUserContext::allPages() const
+{
+    Vector<Ref<WebPageProxy>> pages;
+    for (Ref process : m_processPool->processes()) {
+        for (Ref page : process->pages()) {
+            if (page->websiteDataStore() == m_dataStore.get())
+                pages.append(WTFMove(page));
+        }
+    }
+    return pages;
+}
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/Automation/BidiUserContext.h
+++ b/Source/WebKit/UIProcess/Automation/BidiUserContext.h
@@ -39,6 +39,7 @@ typedef struct _WebKitWebContext WebKitWebContext;
 
 namespace WebKit {
 
+class WebPageProxy;
 class WebProcessPool;
 class WebsiteDataStore;
 
@@ -55,6 +56,8 @@ public:
 
     WebsiteDataStore& dataStore() const { return m_dataStore.get(); }
     WebProcessPool& processPool() const { return m_processPool.get(); }
+
+    Vector<Ref<WebPageProxy>> allPages() const;
 
 private:
 

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -68,6 +68,7 @@
 #endif
 
 #if ENABLE(WEBDRIVER_BIDI)
+#include "BidiBrowserAgent.h"
 #include "WebDriverBidiProcessor.h"
 #endif
 
@@ -934,6 +935,13 @@ void WebAutomationSession::wheelEventsFlushedForPage(const WebPageProxy& page)
 #endif
 }
 
+#if ENABLE(WEBDRIVER_BIDI)
+void WebAutomationSession::didCreatePage(WebPageProxy& page)
+{
+    m_bidiProcessor->browserAgent().didCreatePage(page);
+}
+#endif
+
 void WebAutomationSession::willClosePage(const WebPageProxy& page)
 {
     String handle = handleForWebPageProxy(page);
@@ -958,6 +966,10 @@ void WebAutomationSession::willClosePage(const WebPageProxy& page)
     // Then tell the input dispatcher to cancel so timers are stopped, and let it go out of scope.
     if (auto inputDispatcher = m_inputDispatchersByPage.take(page.identifier()))
         inputDispatcher->cancel();
+#endif
+
+#if ENABLE(WEBDRIVER_BIDI)
+    m_bidiProcessor->browserAgent().willClosePage(page);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -163,6 +163,9 @@ public:
     void keyboardEventsFlushedForPage(const WebPageProxy&);
     void mouseEventsFlushedForPage(const WebPageProxy&);
     void wheelEventsFlushedForPage(const WebPageProxy&);
+#if ENABLE(WEBDRIVER_BIDI)
+    void didCreatePage(WebPageProxy&);
+#endif
     void willClosePage(const WebPageProxy&);
     void handleRunOpenPanel(const WebPageProxy&, const WebFrameProxy&, const API::OpenPanelParameters&, WebOpenPanelResultListenerProxy&);
     void willShowJavaScriptDialog(WebPageProxy&, const String& message, std::optional<String>&& defaultValue);

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
@@ -51,6 +51,8 @@ public:
     void processBidiMessage(const String&);
     void sendBidiMessage(const String&);
 
+    BidiBrowserAgent& browserAgent() const { return *m_browserAgent; }
+
     // Inspector::FrontendChannel methods. Domain events sent via WebDriverBidi domain notifiers are packaged up
     // by FrontendRouter and are then sent back out-of-process via WebAutomationSession::sendBidiMessage().
     Inspector::FrontendChannel::ConnectionType connectionType() const override { return Inspector::FrontendChannel::ConnectionType::Local; };

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiBrowser.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiBrowser.json
@@ -54,6 +54,7 @@
             "name": "removeUserContext",
             "description": "Closes a user context and all navigables in it without running beforeunload handlers.",
             "spec": "https://w3c.github.io/webdriver-bidi/#command-browser-removeUserContext",
+            "async": true,
             "parameters": [
                 { "name": "userContext", "$ref": "BidiBrowser.UserContext", "description": "User context id." }
             ]

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -914,6 +914,13 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
 #endif
     m_inspectorController->init();
 
+#if ENABLE(WEBDRIVER_BIDI)
+    if (m_controlledByAutomation) {
+        if (RefPtr automationSession = m_configuration->processPool().automationSession())
+            automationSession->didCreatePage(*this);
+    }
+#endif
+
 #if ENABLE(IPC_TESTING_API)
     if (m_preferences->ipcTestingAPIEnabled() && m_preferences->ignoreInvalidMessageWhenIPCTestingAPIEnabled())
         process.setIgnoreInvalidMessageForTesting();


### PR DESCRIPTION
#### 75d2c8aeeeb139793f6e1a4d873d4f4e038d06e8
<pre>
[WebDriver][BiDi] Implement the browser.removeUserContext command
<a href="https://bugs.webkit.org/show_bug.cgi?id=288108">https://bugs.webkit.org/show_bug.cgi?id=288108</a>

Reviewed by BJ Burg.

Close existing pages when user context is being removed and wait
for them to actually close before responding to the command.
If new WebPageProxy is created while its user context is being
removed, the page is closed immediately.

* Source/WebKit/UIProcess/Automation/BidiBrowserAgent.cpp:
(WebKit::BidiBrowserAgent::BidiUserContextDeletionRecord::BidiUserContextDeletionRecord):
(WebKit::BidiBrowserAgent::didCreatePage):
(WebKit::BidiBrowserAgent::willClosePage):
(WebKit::BidiBrowserAgent::close):
(WebKit::BidiBrowserAgent::createUserContext):
(WebKit::BidiBrowserAgent::getUserContexts):
(WebKit::BidiBrowserAgent::removeUserContext):
* Source/WebKit/UIProcess/Automation/BidiBrowserAgent.h:
* Source/WebKit/UIProcess/Automation/BidiUserContext.cpp:
(WebKit::BidiUserContext::allPages const):
* Source/WebKit/UIProcess/Automation/BidiUserContext.h:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::didCreatePage):
(WebKit::WebAutomationSession::willClosePage):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h:
* Source/WebKit/UIProcess/Automation/protocol/BidiBrowser.json:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::m_pageForTesting):

Canonical link: <a href="https://commits.webkit.org/294938@main">https://commits.webkit.org/294938@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c25eaac968586ef5472abe1679648f606e252465

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101238 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20900 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11203 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106386 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51865 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29394 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77098 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34141 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104245 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16354 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91440 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57445 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16170 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51213 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86055 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9526 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108742 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28366 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20874 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86077 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28728 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85627 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22231 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30359 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8066 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22465 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28296 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33567 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28108 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31428 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29666 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->