### PR TITLE
[WebGPU] executeCommandsInBuffers is limited to 0x4000 commands

### DIFF
--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -555,8 +555,7 @@ RenderBundleEncoder::FinalizeRenderCommand RenderBundleEncoder::finalizeRenderCo
 {
     m_currentCommand = nil;
 
-    constexpr auto approximateCommandSize = 512;
-    static const auto maxCommandCount = std::max<uint32_t>(100000, m_device->limits().maxBufferSize / approximateCommandSize);
+    constexpr auto maxCommandCount = 0x4000;
     if (isValid() && m_currentCommandIndex >= maxCommandCount && !m_requiresCommandReplay && !m_indirectCommandBuffer)
         endCurrentICB();
 
@@ -891,7 +890,7 @@ void RenderBundleEncoder::endCurrentICB()
     auto commandCount = m_currentCommandIndex;
     m_currentCommandIndex = 0;
     RELEASE_ASSERT(!commandCount || !!m_icbDescriptor);
-    auto cleanup = [&] {
+    auto cleanup = [&] (bool resetPipeline) {
         m_indirectCommandBuffer = nil;
         m_currentCommand = nil;
         m_currentPipelineState = nil;
@@ -899,10 +898,12 @@ void RenderBundleEncoder::endCurrentICB()
         m_dynamicOffsetsVertexBuffer = nil;
         m_minVertexCountForDrawCommand.clear();
         m_resources = [NSMapTable strongToStrongObjectsMapTable];
+        if (RefPtr pipeline = m_pipeline; resetPipeline && m_pipeline)
+            setPipeline(*pipeline);
     };
     if (!m_icbDescriptor.commandTypes && !m_requiresCommandReplay) {
         m_recordedCommands.clear();
-        cleanup();
+        cleanup(false);
         return;
     }
 
@@ -964,7 +965,7 @@ void RenderBundleEncoder::endCurrentICB()
     m_recordedCommands = std::exchange(recordedCommands, { });
     m_currentCommandIndex = commandCount - completedDraws;
     [m_icbArray addObject:makeRenderBundleICBWithResources(m_indirectCommandBuffer, m_resources, m_currentPipelineState, m_depthStencilState, m_cullMode, m_frontFace, m_depthClipMode, m_depthBias, m_depthBiasSlopeScale, m_depthBiasClamp, m_dynamicOffsetsFragmentBuffer, m_pipeline.get(), device.get(), m_minVertexCountForDrawCommand)];
-    cleanup();
+    cleanup(true);
 }
 
 bool RenderBundleEncoder::validToEncodeCommand() const
@@ -991,7 +992,7 @@ Ref<RenderBundle> RenderBundleEncoder::finish(const WGPURenderBundleDescriptor& 
         return RenderBundle::createInvalid(device, m_lastErrorString);
     }
 
-    m_requiresCommandReplay = m_requiresCommandReplay ?: (!m_currentCommandIndex);
+    m_requiresCommandReplay = m_requiresCommandReplay ?: (!m_currentCommandIndex && !m_icbArray.count);
     resetIndexBuffer();
 
     auto createRenderBundle = ^{


### PR DESCRIPTION
#### 2fba8e8ec8f30c24fee05ac5ae28659aaac2b5af
<pre>
[WebGPU] executeCommandsInBuffers is limited to 0x4000 commands
<a href="https://bugs.webkit.org/show_bug.cgi?id=291988">https://bugs.webkit.org/show_bug.cgi?id=291988</a>
radar://149901893

Reviewed by Tadeu Zagallo.

The documentation <a href="https://developer.apple.com/documentation/metal/mtlrendercommandencoder/2967439-executecommandsinbuffer">https://developer.apple.com/documentation/metal/mtlrendercommandencoder/2967439-executecommandsinbuffer</a> says
&quot;The length property of that structure needs to be less than or equal to 0x4000 (16,384).&quot;

Ensure that is the case.

* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::finalizeRenderCommand):

Canonical link: <a href="https://commits.webkit.org/294086@main">https://commits.webkit.org/294086@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/906921fa72df0bd4858e10a5af1bc310c4a86ac0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105900 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51352 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28889 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76727 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33768 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91014 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57080 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15732 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50727 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85634 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9097 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108255 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27881 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20480 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85687 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28244 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87216 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85230 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21695 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29936 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7664 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21885 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27816 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33072 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27627 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30945 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29185 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->