### PR TITLE
RegExp Unicode JIT treats escaped surrogate followed by literal surrogate as surrogate pair

### DIFF
--- a/JSTests/stress/regexp-unicode-mix-escaped-and-literal-surrogates.js
+++ b/JSTests/stress/regexp-unicode-mix-escaped-and-literal-surrogates.js
@@ -1,0 +1,200 @@
+// With verbose set to false, this test is successful if there is no output.  Set verbose to true to see expected matches.
+let verbose = false;
+
+let errors = 0;
+
+function arrayToString(arr)
+{
+    let str = '';
+    arr.forEach(function(v, index) {
+        if (typeof v == "string")
+            str += "\"" + v + "\"";
+        else
+            str += v;
+
+        if (index != (arr.length - 1))
+            str += ',';
+      });
+  return str;
+}
+
+function objectToString(obj)
+{
+    let str = "";
+
+    firstEntry = true;
+
+    for (const [key, value] of Object.entries(obj)) {
+        if (!firstEntry)
+            str += ", ";
+
+        str += key + ": " + dumpValue(value);
+
+        firstEntry = false;
+    }
+
+    return "{ " + str + " }";
+}
+
+function dumpValue(v)
+{
+    if (v === null)
+        return "<null>";
+
+    if (v === undefined)
+        return "<undefined>";
+
+    if (typeof v == "string")
+        return "\"" + v + "\"";
+
+    let str = "";
+
+    if (v.length)
+        str += arrayToString(v);
+
+    if (v.groups) {
+        groupStr = objectToString(v.groups);
+
+        if (str.length) {
+            if ( groupStr.length)
+                str += ", " + groupStr;
+        } else
+            str = groupStr;
+    }
+
+    return "[ " + str + " ]";
+}
+
+function compareArray(expected, actual)
+{
+    if (expected === null && actual === null)
+        return true;
+
+    if (expected === null) {
+        print("### expected is null, actual is not null");
+        return false;
+    }
+
+    if (actual === null) {
+        print("### expected is not null, actual is null");
+        return false;
+    }
+
+    if (expected.length !== actual.length) {
+        print("### expected.length: " + expected.length + ", actual.length: " + actual.length);
+        return false;
+    }
+
+    for (var i = 0; i < expected.length; i++) {
+        if (expected[i] !== actual[i]) {
+            print("### expected[" + i + "]: \"" + expected[i] + "\" !== actual[" + i + "]: \"" + actual[i] + "\"");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function compareGroups(expected, actual)
+{
+    if (expected === null && actual === null)
+        return true;
+
+    if (expected === null) {
+        print("### expected group is null, actual group is not null");
+        return false;
+    }
+
+    if (actual === null) {
+        print("### expected group is not null, actual group is null");
+        return false;
+    }
+
+    for (const key in expected) {
+        if (expected[key] !== actual[key]) {
+            print("### expected." + key + ": " + dumpValue(expected[key]) + " !== actual." + key + ": " + dumpValue(actual[key]));
+            return false;
+        }
+    }
+
+    return true;
+}
+
+let testNumber = 0;
+
+function testRegExp(re, str, exp, groups)
+{
+    testNumber++;
+
+    if (groups)
+        exp.groups = groups;
+
+    let actual = re.exec(str);
+
+    let result = compareArray(exp, actual);;
+
+    if (exp && exp.groups) {
+        if (!compareGroups(exp.groups, actual.groups))
+            result = false;
+    }
+
+    if (result) {
+        if (verbose)
+            print(re.toString() + ".exec(" + dumpValue(str) + "), passed ", dumpValue(exp));
+    } else {
+        print(re.toString() + ".exec(" + dumpValue(str) + "), FAILED test #" + testNumber + ", Expected ", dumpValue(exp), " got ", dumpValue(actual));
+        errors++;
+    }
+}
+
+function testRegExpSyntaxError(reString, flags, expError)
+{
+    testNumber++;
+
+
+    try {
+        let re = new RegExp(reString, flags);
+        print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError + "\", but it didn't");
+        errors++;
+    } catch (e) {
+        if (e != expError)
+            print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError + "\" got \"" + e + "\"");
+        else if (verbose)
+            print("/" + reString + "/" + flags + " passed, it threw \"" + expError + "\" as expected");
+    }
+}
+
+function printErrors()
+{
+    if (errors)
+        throw "Test had " + errors + " errors";
+}
+
+// Test a escaped surrogate paired with a literal surrogate.
+testRegExp(new RegExp("\\ud800\udc00+", "u"), "\u{10000}\u{10000}", null);
+testRegExp(new RegExp("^\\ud800\udc00+", "u"), "\u{10000}\u{10000}", null);
+testRegExp(new RegExp("\\ud800\udc00+$", "u"), "\u{10000}\u{10000}", null);
+testRegExp(new RegExp("^\\ud800\udc00+$", "u"), "\u{10000}\u{10000}", null);
+testRegExp(new RegExp("\\uD83D\uDC38", "u"), "\u{1F438}", null);
+testRegExp(new RegExp("\ud800\\udc00", "u"), "\u{10000}\u{10000}", null);
+testRegExp(new RegExp("\uD83D\\uDC38", "u"), "\u{1F438}", null);
+testRegExp(new RegExp("abcdefg\\ud800\udc001234567", "u"), "abcdefg\u{10000}1234567", null);
+testRegExp(new RegExp("1234567\uD83D\\uDC38abcdefg", "u"), "1234567\u{1F438}abcdefg", null);
+
+// Test well formed pairs of escaped surrogates
+testRegExp(new RegExp("\\ud800\\udc00+", "u"), "\u{10000}\u{10000}", ["\u{10000}\u{10000}"]);
+testRegExp(new RegExp("^\\ud800\\udc00+", "u"), "\u{10000}\u{10000}", ["\u{10000}\u{10000}"]);
+testRegExp(new RegExp("\\ud800\\udc00+$", "u"), "\u{10000}\u{10000}", ["\u{10000}\u{10000}"]);
+testRegExp(new RegExp("^\\ud800\\udc00+$", "u"), "\u{10000}\u{10000}", ["\u{10000}\u{10000}"]);
+testRegExp(new RegExp("\\uD83D\\uDC38", "u"), "\u{1F438}", ["\u{1F438}"]);
+testRegExp(new RegExp("abcdefg\\ud800\\udc001234567", "u"), "abcdefg\u{10000}1234567", ["abcdefg\u{10000}1234567"]);
+testRegExp(new RegExp("1234567\\uD83D\\uDC38abcdefg", "u"), "1234567\u{1F438}abcdefg", ["1234567\u{1F438}abcdefg"]);
+
+// Test well formed pairs of literal surrogates
+testRegExp(new RegExp("\ud800\udc00+", "u"), "\u{10000}\u{10000}", ["\u{10000}\u{10000}"]);
+testRegExp(new RegExp("^\ud800\udc00+", "u"), "\u{10000}\u{10000}", ["\u{10000}\u{10000}"]);
+testRegExp(new RegExp("\ud800\udc00+$", "u"), "\u{10000}\u{10000}", ["\u{10000}\u{10000}"]);
+testRegExp(new RegExp("^\ud800\udc00+$", "u"), "\u{10000}\u{10000}", ["\u{10000}\u{10000}"]);
+testRegExp(new RegExp("\uD83D\uDC38", "u"), "\u{1F438}", ["\u{1F438}"]);
+testRegExp(new RegExp("abcdefg\ud800\udc001234567", "u"), "abcdefg\u{10000}1234567", ["abcdefg\u{10000}1234567"]);
+testRegExp(new RegExp("1234567\uD83D\uDC38abcdefg", "u"), "1234567\u{1F438}abcdefg", ["1234567\u{1F438}abcdefg"]);

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -2103,8 +2103,8 @@ class YarrGenerator final : public YarrJITInfo {
         // upper & lower case representations are converted to a character class.
         ASSERT(!op.m_term->ignoreCase() || isASCIIAlpha(firstChar) || isCanonicallyUnique(firstChar, m_canonicalMode));
 
-        if (have16BitCharacter && m_charSize == CharSize::Char16 && !U_IS_BMP(firstChar)) {
-            // The first term we are considering is a non-BMP char in a 16 bit pattern. Just try matching it and be done.
+        if (m_decodeSurrogatePairs && (!U_IS_BMP(firstChar) || U16_IS_SURROGATE(firstChar))) {
+            // The first term we are considering is a non-BMP or dangling surrogate char in unicode pattern. Just try matching it and be done.
             uint64_t charToMatch = firstChar;
 
             auto offset = op.m_checkedOffset - op.m_term->inputPosition;
@@ -2133,7 +2133,7 @@ class YarrGenerator final : public YarrJITInfo {
                 || (currTerm->type != PatternTerm::Type::PatternCharacter
                     && currTerm->type != PatternTerm::Type::CharacterClass)
                 || (m_decodeSurrogatePairs
-                    && ((currTerm->type == PatternTerm::Type::PatternCharacter && !U_IS_BMP(currTerm->patternCharacter))
+                    && ((currTerm->type == PatternTerm::Type::PatternCharacter && (!U_IS_BMP(currTerm->patternCharacter) || U16_IS_SURROGATE(currTerm->patternCharacter)))
                         || (currTerm->type == PatternTerm::Type::CharacterClass && (currTerm->characterClass->hasNonBMPCharacters()
                             || currTerm->invert())))))
                 break;


### PR DESCRIPTION
#### ab6288d351f1e0c83b9060b9583c88dd707e30cc
<pre>
RegExp Unicode JIT treats escaped surrogate followed by literal surrogate as surrogate pair
<a href="https://bugs.webkit.org/show_bug.cgi?id=290567">https://bugs.webkit.org/show_bug.cgi?id=290567</a>
<a href="https://rdar.apple.com/148548273">rdar://148548273</a>

Reviewed by Yusuke Suzuki.

This is due to the multi character optimization in JSC::Yarr::generatePatternCharacterOnce() where we match
multiple characters by loading the number of characters we are matching together and then checking that what
was loaded match the concatenation of characters.  This bypasses the normal reading of a valid surrogate pair.

The fix is to process dangling surrogates as individual characters and group together with surrounding
characters.

* JSTests/stress/regexp-unicode-mix-escaped-and-literal-surrogates.js: Added.
(arrayToString):
(objectToString):
(dumpValue):
(compareArray):
(compareGroups):
(testRegExp):
(testRegExpSyntaxError):
(printErrors):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/294066@main">https://commits.webkit.org/294066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3772fa198dfda3efc2d0ce3a5f0445f79ea0162

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100658 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20310 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105795 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51246 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20618 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28784 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76646 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33685 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103665 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15827 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90918 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57001 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15636 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8925 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50622 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/93322 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85548 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108150 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/99266 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27776 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20396 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85602 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28139 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87119 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85143 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21684 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29844 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7571 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21764 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27711 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32964 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122892 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27522 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34266 "Found 1 new JSC stress test failure: ChakraCore.yaml/ChakraCore/test/es6/ES6MathAPIs.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30840 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29080 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->