### PR TITLE
Relocate variant index in WTF::CompactVariant

### DIFF
--- a/Source/WTF/wtf/CompactVariant.h
+++ b/Source/WTF/wtf/CompactVariant.h
@@ -29,7 +29,7 @@
 namespace WTF {
 
 // A `CompactVariant` acts like a `Variant` with the following differences:
-// - All alternatives must be pointers, smart pointers, have size of 56 bits or fewer, or be specialized for `CompactVariantTraits`.
+// - All alternatives must be pointers, smart pointers, have size of 48 bits or fewer, or be specialized for `CompactVariantTraits`.
 // - Can only contain 254 or fewer alternatives.
 // - Has a more limited API, only offering `holds_alternative()` for type checking and `switchOn()` for value access.
 

--- a/Source/WTF/wtf/CompactVariantOperations.h
+++ b/Source/WTF/wtf/CompactVariantOperations.h
@@ -59,17 +59,25 @@ template<typename T> concept  CompactVariantAlternative =
     || CompactVariantAlternativeSmallEnough<T>
     || CompactVariantTraits<T>::hasAlternativeRepresentation;
 
+// A CompactVariant stores data by bit-packing the variant index
+// and data into a storage of type Storage (uint64_t):
+// * Bit 63-56: if pointer/smart pointer, bit 63-56 of the pointer. Useful
+//              if the architecture supports top-byte ignore, and information
+//              is stored there. Otherwise zeroes.
+// * Bit 55-48: variant index (indicates the data type of the variant)
+// * Bit 47-0 : if pointer/smart pointer, bit 48-0 of the pointer. If other
+//              types of data, the encoded data.
+// This struct provides operations on the packed storage in a CompactVariant.
 template<CompactVariantAlternative... Ts> struct CompactVariantOperations {
     using StdVariant = Variant<Ts...>;
     using Index = uint8_t;
     using Storage = uint64_t;
     static constexpr Storage movedFromDataValue = std::numeric_limits<Storage>::max();
-    static constexpr Storage totalSize = sizeof(Storage) * 8;
-    static constexpr Storage indexSize = sizeof(Index) * 8;
-    static constexpr Storage indexShift = totalSize - indexSize;
-    static constexpr Storage payloadSize = totalSize - indexSize;
-    static constexpr Storage payloadMask = (1ULL << payloadSize) - 1;
-    static_assert(payloadSize + indexSize <= totalSize);
+    static constexpr Storage indexShift = 48;
+    static constexpr Storage indexMask = 0xFFULL << indexShift;
+    static constexpr Storage payloadMask = ~indexMask;
+    static constexpr Storage topByteShift = 64 - 8;
+    static constexpr Storage topByteMask = 0xFFULL << topByteShift;
 
     static constexpr Storage encodedIndex(Index index)
     {
@@ -78,7 +86,7 @@ template<CompactVariantAlternative... Ts> struct CompactVariantOperations {
 
     static constexpr Index decodedIndex(Storage value)
     {
-        return static_cast<Index>(static_cast<uint8_t>(value >> indexShift));
+        return static_cast<Index>(static_cast<uint8_t>((value & indexMask) >> indexShift));
     }
 
     template<typename T, typename U> static constexpr Storage encodedPayload(U&& payload)
@@ -89,6 +97,17 @@ template<CompactVariantAlternative... Ts> struct CompactVariantOperations {
             data = CompactVariantTraits<T>::encode(std::forward<U>(payload));
         else
             new (NotNull, &data) T(std::forward<U>(payload));
+
+        // For data other than pointers, ensure the data doesn't overwrite the top byte.
+        // (i.e top byte should be zero)
+        // (pointers may store arbitrary data in the top byte, and that's okay due to TBI)
+        if constexpr (!CompactVariantAlternativePointer<T>)
+            RELEASE_ASSERT(!(data & topByteMask));
+
+        // Ensure the bits in the index area are zeroes.
+        // Sanity check to make sure the data doesn't overwrite the index.
+        RELEASE_ASSERT(!(data & indexMask));
+        data &= payloadMask;
 
         return data;
     }
@@ -101,6 +120,17 @@ template<CompactVariantAlternative... Ts> struct CompactVariantOperations {
             data = CompactVariantTraits<T>::encodeFromArguments(std::forward<Args>(arguments)...);
         else
             new (NotNull, &data) T(std::forward<Args>(arguments)...);
+
+        // For data other than pointers, ensure the data doesn't overwrite the top byte.
+        // (i.e top byte should be zero)
+        // (pointers may store arbitrary data in the top byte, and that's okay due to TBI)
+        if constexpr (!CompactVariantAlternativePointer<T>)
+            RELEASE_ASSERT(!(data & topByteMask));
+
+        // Ensure the bits in the index area are zeroes.
+        // Sanity check to make sure the data doesn't overwrite the index.
+        RELEASE_ASSERT(!(data & indexMask));
+        data &= payloadMask;
 
         return data;
     }

--- a/Tools/TestWebKitAPI/Tests/WTF/CompactVariant.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CompactVariant.cpp
@@ -103,6 +103,32 @@ TEST(WTF_CompactVariant, Pointers)
     );
 }
 
+#if CPU(ADDRESS64)
+TEST(WTF_CompactVariant, Pointers64)
+{
+    int testInt = 1;
+    void* testPtr = reinterpret_cast<void*>(0x2600'1234'5678'9abcULL);
+
+    CompactVariant<int*, void*> variant = &testInt;
+    EXPECT_TRUE(WTF::holdsAlternative<int*>(variant));
+    EXPECT_FALSE(WTF::holdsAlternative<void*>(variant));
+
+    WTF::switchOn(variant,
+        [&](int* const& value) { EXPECT_EQ(*value, 1); },
+        [&](void* const& value) { FAIL(); }
+    );
+
+    variant = testPtr;
+    EXPECT_FALSE(WTF::holdsAlternative<int*>(variant));
+    EXPECT_TRUE(WTF::holdsAlternative<void*>(variant));
+
+    WTF::switchOn(variant,
+        [&](int* const& value) { FAIL(); },
+        [&](void* const& value) { EXPECT_EQ(reinterpret_cast<uintptr_t>(value), 0x2600'1234'5678'9abcULL); }
+    );
+}
+#endif
+
 TEST(WTF_CompactVariant, SmartPointers)
 {
     {


### PR DESCRIPTION
#### df3e3ba21deda04897917f16f95844b5366c5a74
<pre>
Relocate variant index in WTF::CompactVariant
<a href="https://rdar.apple.com/149655111">rdar://149655111</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291989">https://bugs.webkit.org/show_bug.cgi?id=291989</a>

Reviewed by Sam Weinig, David Degazio, and Darin Adler.

Relocate the variant index bits in WTF::CompactVariant from bit
63-56 to 55-48. Some architectures support ignoring the top bits
in a pointer (ex: AArch64 Top Byte Ignore), so this allows storing
the top byte untouched for applications that store metadata there.

* Source/WTF/wtf/CompactVariant.h:
* Source/WTF/wtf/CompactVariantOperations.h:
(WTF::CompactVariantOperations::decodedIndex):
(WTF::CompactVariantOperations::encodedPayload):
(WTF::CompactVariantOperations::encodedPayloadFromArguments):
* Tools/TestWebKitAPI/Tests/WTF/CompactVariant.cpp:
(TestWebKitAPI::TEST(WTF_CompactVariant, Pointers64)):
    - Added test to ensure the top byte in a 64-bit pointer is preserved.
      This test is only built on architectures with 64-bit pointers.

Canonical link: <a href="https://commits.webkit.org/294327@main">https://commits.webkit.org/294327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c865aecdd6491a0fff3761e38657517bbb2d0d56

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106539 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52015 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103426 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29544 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77221 "Found 1 new test failure: media/video-src-blob-replay.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34259 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104393 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16481 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91576 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57563 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16302 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9588 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51363 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94055 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86180 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108891 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/99996 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28515 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20980 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86198 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28877 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87778 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85757 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21829 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30484 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8195 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22632 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28446 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33738 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/123621 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28257 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34380 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31577 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29816 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->