### PR TITLE
Remove duplicate `color-inherit-link-visited.html` from WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/color-inherit-link-visited-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/color-inherit-link-visited-expected.html
@@ -1,8 +1,0 @@
-<svg width="100" height="100" fill="green" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:html="http://www.w3.org/1999/xhtml">
-  <html:link rel="help" href="https://developer.mozilla.org/en-US/docs/Web/CSS/Privacy_and_the_:visited_selector"/>
-  <html:link rel="match" href="color-inherit-link-visited-ref.svg"/>
-  <html:meta name="assert" content="Tests that color is correctly inherited in the presence of visited link"/>
-  <a xlink:href="">
-    <rect width="100" height="100"></rect>
-  </a>
-</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/color-inherit-link-visited-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/color-inherit-link-visited-ref.html
@@ -1,8 +1,0 @@
-<svg width="100" height="100" fill="green" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:html="http://www.w3.org/1999/xhtml">
-  <html:link rel="help" href="https://developer.mozilla.org/en-US/docs/Web/CSS/Privacy_and_the_:visited_selector"/>
-  <html:link rel="match" href="color-inherit-link-visited-ref.svg"/>
-  <html:meta name="assert" content="Tests that color is correctly inherited in the presence of visited link"/>
-  <a xlink:href="">
-    <rect width="100" height="100" fill="green"></rect>
-  </a>
-</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/color-inherit-link-visited.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/color-inherit-link-visited.html
@@ -1,8 +1,0 @@
-<svg width="100" height="100" fill="green" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:html="http://www.w3.org/1999/xhtml">
-  <html:link rel="help" href="https://developer.mozilla.org/en-US/docs/Web/CSS/Privacy_and_the_:visited_selector"/>
-  <html:link rel="match" href="color-inherit-link-visited-ref.svg"/>
-  <html:meta name="assert" content="Tests that color is correctly inherited in the presence of visited link"/>
-  <a xlink:href="">
-    <rect width="100" height="100"></rect>
-  </a>
-</svg>


### PR DESCRIPTION
#### cd00079da4fc583c1a5bdfa5112b4f9348afef65
<pre>
Remove duplicate `color-inherit-link-visited.html` from WPT

<a href="https://bugs.webkit.org/show_bug.cgi?id=291998">https://bugs.webkit.org/show_bug.cgi?id=291998</a>
<a href="https://rdar.apple.com/149916497">rdar://149916497</a>

Reviewed by Tim Nguyen.

This patch removes `svg/color-inherit-link-visited.html` test since it was
moved to `svg/styling` path upstream [1] and we synced it in 293912@main:

[1] <a href="https://github.com/web-platform-tests/wpt/commit/3b5f52f7793a33e593631cfe597dc180db231fb1">https://github.com/web-platform-tests/wpt/commit/3b5f52f7793a33e593631cfe597dc180db231fb1</a>

New path: svg/styling/color-inherit-link-visited.svg

* LayoutTests/imported/w3c/web-platform-tests/svg/color-inherit-link-visited-expected.html: Removed.
* LayoutTests/imported/w3c/web-platform-tests/svg/color-inherit-link-visited-ref.html: Removed.
* LayoutTests/imported/w3c/web-platform-tests/svg/color-inherit-link-visited.html: Removed.

Canonical link: <a href="https://commits.webkit.org/294051@main">https://commits.webkit.org/294051@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/110f40cda4d88f5168e6af81494857229d858d78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20351 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105836 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51287 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20659 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28825 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76677 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33711 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90957 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57031 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15672 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8965 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50663 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85574 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9040 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108191 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27817 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20420 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85634 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28180 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87159 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85174 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21673 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29878 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7607 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21805 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27752 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27563 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30881 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29121 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->