### PR TITLE
Reduce unsafeness in FormListedElement

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -303,7 +303,6 @@ html/FTPDirectoryDocument.cpp
 html/FileInputType.cpp
 html/FormAssociatedCustomElement.cpp
 html/FormAssociatedElement.cpp
-html/FormListedElement.cpp
 html/HTMLAllCollection.cpp
 html/HTMLAnchorElement.cpp
 html/HTMLAttachmentElement.cpp

--- a/Source/WebCore/html/FormListedElement.cpp
+++ b/Source/WebCore/html/FormListedElement.cpp
@@ -143,7 +143,7 @@ void FormListedElement::formOwnerRemovedFromTree(const Node& formRoot)
 void FormListedElement::setFormInternal(RefPtr<HTMLFormElement>&& newForm)
 {
     willChangeForm();
-    if (auto* oldForm = form())
+    if (RefPtr oldForm = form())
         oldForm->unregisterFormListedElement(*this);
     FormAssociatedElement::setFormInternal(newForm.copyRef());
     if (newForm)
@@ -171,12 +171,12 @@ void FormListedElement::formWillBeDestroyed()
 
 void FormListedElement::resetFormOwner()
 {
-    RefPtr<HTMLFormElement> originalForm = form();
-    HTMLElement& element = asHTMLElement();
-    setForm(findAssociatedForm(element, originalForm.get()));
-    auto* newForm = form();
+    RefPtr originalForm = form();
+    Ref element = asHTMLElement();
+    setForm(findAssociatedForm(element.get(), originalForm.get()));
+    RefPtr newForm = form();
     if (newForm && newForm != originalForm && newForm->isConnected())
-        element.document().didAssociateFormControl(element);
+        element->protectedDocument()->didAssociateFormControl(element.get());
 }
 
 void FormListedElement::parseAttribute(const QualifiedName& name, const AtomString& value)
@@ -187,21 +187,21 @@ void FormListedElement::parseAttribute(const QualifiedName& name, const AtomStri
 
 void FormListedElement::parseFormAttribute(const AtomString& value)
 {
-    HTMLElement& element = asHTMLElement();
+    Ref element = asHTMLElement();
     if (value.isNull()) {
         // The form attribute removed. We need to reset form owner here.
         RefPtr originalForm = form();
         // Instead of calling setForm(findAssociatedForm(&element, originalForm.get())) here,
         // we effectively perform setForm(findAssociatedForm(&element, nullptr)) because
         // it's known that originalForm is obsolete and can't be used as a fallback.
-        setForm(HTMLFormElement::findClosestFormAncestor(element));
-        auto* newForm = form();
+        setForm(HTMLFormElement::findClosestFormAncestor(element.get()));
+        RefPtr newForm = form();
         if (newForm && newForm != originalForm && newForm->isConnected())
-            element.protectedDocument()->didAssociateFormControl(element);
+            element->protectedDocument()->didAssociateFormControl(element.get());
         m_formAttributeTargetObserver = nullptr;
     } else {
         resetFormOwner();
-        if (element.isConnected())
+        if (element->isConnected())
             resetFormAttributeTargetObserver();
     }
 }


### PR DESCRIPTION
#### 4c45c913532da8d271244f2f7b41795674389a49
<pre>
Reduce unsafeness in FormListedElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=292006">https://bugs.webkit.org/show_bug.cgi?id=292006</a>

Reviewed by Ryosuke Niwa.

As per <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/html/FormListedElement.cpp:
(WebCore::FormListedElement::setFormInternal):
(WebCore::FormListedElement::resetFormOwner):
(WebCore::FormListedElement::parseFormAttribute):

Canonical link: <a href="https://commits.webkit.org/294147@main">https://commits.webkit.org/294147@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50569b96c0bc1ca88166ef629edb4fe29f4da220

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106111 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/51587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20935 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29121 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/76889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/51587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103972 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/16106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/91197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/57237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/15921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/9219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/50939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/85827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/9280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/108467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28093 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/108467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28455 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/87397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/108467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/30110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/7841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/22136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16423 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28023 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33291 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27835 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31155 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29393 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->