### PR TITLE
[JSC] JITWorklist: add load-based thread-pool autoscaling

### DIFF
--- a/Source/JavaScriptCore/jit/JITWorklist.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklist.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,13 +46,18 @@ JITWorklist::JITWorklist()
     , m_planEnqueued(AutomaticThreadCondition::create())
 {
     m_maximumNumberOfConcurrentCompilationsPerTier = {
-        Options::numberOfWorklistThreads(),
+        Options::numberOfBaselineCompilerThreads(),
         Options::numberOfDFGCompilerThreads(),
         Options::numberOfFTLCompilerThreads(),
     };
+    m_loadWeightsPerTier = {
+        Options::worklistBaselineLoadWeight(),
+        Options::worklistDFGLoadWeight(),
+        Options::worklistFTLLoadWeight(),
+    };
 
     Locker locker { *m_lock };
-    for (unsigned i = 0; i < Options::numberOfWorklistThreads(); ++i)
+    for (unsigned i = 0; i < Options::maxNumberOfWorklistThreads(); ++i)
         m_threads.append(*new JITWorklistThread(locker, *this));
 }
 
@@ -79,6 +84,54 @@ JITWorklist& JITWorklist::ensureGlobalWorklist()
             theGlobalJITWorklist = worklist;
         });
     return *theGlobalJITWorklist;
+}
+
+// wakeThreads wakes up compiler worker threads, if appropriate.
+//
+// There is a cost to running more worker threads. For example, there is a direct cost
+// to wake (or spawn) a thread, and additional threads lead to more synchronization
+// overhead between threads, colder CPU and software (e.g. allocator) caches, more
+// contention for cpu resources across the system, more cpu scheduler overhead, etc.
+//
+// So, it's better to have a short queue of work ready for each compiler thread rather
+// than aggressively spinning up a thread whenever there is any work pending.
+// Yet, the queues should not get too long as to increase compiler latency significantly.
+// wakeThreads applies a load-based heuristic to determine whether it's worthwhile
+// to use more compiler threads.
+//
+// The load is computed from the queue-depth of each tier scaled by a per-tier weight,
+// to model the the increasing compile latency at each tier. The heuristic wakes
+// more threads only when the capacity of the thread pool, as determined by the number
+// of threads and a desired load-factor, is exceeded.
+void JITWorklist::wakeThreads(const AbstractLocker& locker, unsigned enqueuedTier)
+{
+    unsigned targetNumThreads;
+
+    if (m_numberOfActiveThreads < Options::minNumberOfWorklistThreads()
+        && m_ongoingCompilationsPerTier[enqueuedTier] < m_maximumNumberOfConcurrentCompilationsPerTier[enqueuedTier]) {
+        targetNumThreads = m_numberOfActiveThreads + 1;
+    } else {
+        unsigned load = 0;
+        unsigned maxThreads = 0;
+        for (unsigned tier = 0; tier < static_cast<unsigned>(JITPlan::Tier::Count); tier++) {
+            unsigned plansForTier = m_ongoingCompilationsPerTier[tier] + m_queues[tier].size();
+
+            unsigned maxThreadsUsedForTier = std::min(plansForTier, m_maximumNumberOfConcurrentCompilationsPerTier[tier]);
+            maxThreads += maxThreadsUsedForTier;
+
+            unsigned loadForTier = plansForTier * m_loadWeightsPerTier[tier];
+            load += loadForTier;
+        }
+        maxThreads = std::min(maxThreads, Options::maxNumberOfWorklistThreads());
+
+        targetNumThreads = (load + Options::worklistLoadFactor() - 1) / Options::worklistLoadFactor();
+        targetNumThreads = std::min(targetNumThreads, maxThreads);
+    }
+    while (m_numberOfActiveThreads < targetNumThreads) {
+        m_planEnqueued->notifyOne(locker);
+        m_numberOfActiveThreads++;
+    }
+    ASSERT(m_numberOfActiveThreads >= 1);
 }
 
 CompilationResult JITWorklist::enqueue(Ref<JITPlan> plan)
@@ -108,12 +161,7 @@ CompilationResult JITWorklist::enqueue(Ref<JITPlan> plan)
     ASSERT(m_plans.find(plan->key()) == m_plans.end());
     m_plans.add(plan->key(), plan.copyRef());
     m_queues[tier].append(WTFMove(plan));
-
-    if (m_numberOfActiveThreads < m_threads.size()
-        && m_ongoingCompilationsPerTier[tier] < m_maximumNumberOfConcurrentCompilationsPerTier[tier]) {
-        m_planEnqueued->notifyOne(locker);
-        m_numberOfActiveThreads++;
-    }
+    wakeThreads(locker, tier);
     return CompilationDeferred;
 }
 

--- a/Source/JavaScriptCore/jit/JITWorklist.h
+++ b/Source/JavaScriptCore/jit/JITWorklist.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -88,6 +88,8 @@ public:
 private:
     JITWorklist();
 
+    void wakeThreads(const AbstractLocker&, unsigned enqueuedTier);
+
     size_t queueLength(const AbstractLocker&) const;
 
     void waitUntilAllPlansForVMAreReady(VM&);
@@ -102,6 +104,7 @@ private:
     unsigned m_numberOfActiveThreads { 0 };
     std::array<unsigned, static_cast<size_t>(JITPlan::Tier::Count)> m_ongoingCompilationsPerTier { 0, 0, 0 };
     std::array<unsigned, static_cast<size_t>(JITPlan::Tier::Count)> m_maximumNumberOfConcurrentCompilationsPerTier;
+    std::array<unsigned, static_cast<size_t>(JITPlan::Tier::Count)> m_loadWeightsPerTier;
 
     Vector<Ref<JITWorklistThread>> m_threads;
 

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -586,8 +586,17 @@ static void overrideDefaults()
 
 #if OS(DARWIN) && CPU(ARM64)
     Options::numberOfGCMarkers() = std::min<unsigned>(4, kernTCSMAwareNumberOfProcessorCores());
+
+    Options::minNumberOfWorklistThreads() = 1;
+    Options::maxNumberOfWorklistThreads() = std::min<unsigned>(3, kernTCSMAwareNumberOfProcessorCores());
+    Options::numberOfBaselineCompilerThreads() = std::min<unsigned>(3, kernTCSMAwareNumberOfProcessorCores());
     Options::numberOfDFGCompilerThreads() = std::min<unsigned>(3, kernTCSMAwareNumberOfProcessorCores());
     Options::numberOfFTLCompilerThreads() = std::min<unsigned>(3, kernTCSMAwareNumberOfProcessorCores());
+    Options::worklistLoadFactor() = 4;
+    Options::worklistBaselineLoadWeight() = 1;
+    Options::worklistDFGLoadWeight() = 2;
+    // Set the FTL load weight equal to the load-factor so that a new thread is started for each FTL plan
+    Options::worklistFTLLoadWeight() = 4;
 #endif
 
 #if OS(LINUX) && CPU(ARM)

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -275,10 +275,16 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, maxDFGNodesInBasicBlockForPreciseAnalysis, 20000, Normal, "Disable precise but costly analysis and give conservative results if the number of DFG nodes in a block exceeds this threshold"_s) \
     \
     v(Bool, useConcurrentJIT, true, Normal, "allows the DFG / FTL compilation in threads other than the executing JS thread"_s) \
-    v(Unsigned, numberOfWorklistThreads, computeNumberOfWorkerThreads(3, 2), Normal, nullptr) \
+    v(Unsigned, minNumberOfWorklistThreads, computeNumberOfWorkerThreads(3, 2), Normal, nullptr) \
+    v(Unsigned, maxNumberOfWorklistThreads, computeNumberOfWorkerThreads(3, 2), Normal, nullptr) \
+    v(Unsigned, numberOfBaselineCompilerThreads, computeNumberOfWorkerThreads(3, 2), Normal, nullptr) \
     v(Unsigned, numberOfDFGCompilerThreads, computeNumberOfWorkerThreads(3, 2) - 1, Normal, nullptr) \
     v(Unsigned, numberOfFTLCompilerThreads, computeNumberOfWorkerThreads(MAXIMUM_NUMBER_OF_FTL_COMPILER_THREADS, 2) - 1, Normal, nullptr) \
     v(Unsigned, numberOfWasmCompilerThreads, computeNumberOfWorkerThreads(INT32_MAX, 2) - 1, Normal, nullptr) \
+    v(Unsigned, worklistLoadFactor, 1, Normal, nullptr) \
+    v(Unsigned, worklistBaselineLoadWeight, 1, Normal, nullptr) \
+    v(Unsigned, worklistDFGLoadWeight, 1, Normal, nullptr) \
+    v(Unsigned, worklistFTLLoadWeight, 1, Normal, nullptr) \
     v(Int32, priorityDeltaOfDFGCompilerThreads, computePriorityDeltaOfWorkerThreads(-1, 0), Normal, nullptr) \
     v(Int32, priorityDeltaOfFTLCompilerThreads, computePriorityDeltaOfWorkerThreads(-2, 0), Normal, nullptr) \
     v(Int32, priorityDeltaOfWasmCompilerThreads, computePriorityDeltaOfWorkerThreads(-1, 0), Normal, nullptr) \


### PR DESCRIPTION
#### 6d26b6d6031c4cd6a309d38be13b5e759be949e5
<pre>
[JSC] JITWorklist: add load-based thread-pool autoscaling
<a href="https://bugs.webkit.org/show_bug.cgi?id=292014">https://bugs.webkit.org/show_bug.cgi?id=292014</a>
<a href="https://rdar.apple.com/149953531">rdar://149953531</a>

Reviewed by Mark Lam and Yusuke Suzuki.

There is a cost to using more compiler worker threads. For example,
there is a direct cost to wake (or spawn) a thread, and additional
threads lead to more synchronization overhead between threads,
colder CPU and software (e.g. allocator) caches, more contention for
cpu resources across the system, more cpu scheduler overhead, etc.

The current policy of waking a thread whenever there is a plan
available to compile (and the thread limits haven&apos;t been exceeded)
does not consider these costs.

It&apos;s better to have a short queue of work ready for each compiler
thread. Yet, the queues should not get too long as to increase compiler
latency significantly. So, apply a load-based heuristic to
determine whether it&apos;s worthwhile to use more compiler threads.

The load is computed from the queue-depth of each tier scaled by a
per-tier weight, to model the increasing compile latency at each
tier. The heuristic wakes more threads only when the capacity of the
thread pool, as determined by the number of threads and a desired
load-factor, is exceeded.

Further refinement of this model might be worthwhile to try in the
future. For example, the size or complexity of the plan could be used
to better estimate compile latency than using tier alone.

This also sets the stage for increasing the maximum size of the
thread pool on systems that have available CPU cores. With the
previous policy, adding additional cores pretty much always
hurts performance due to paying the cost of these overheads even for
workloads that do not have enough benefit of more compile throughput.
However, this commit does not change the maximum thread-pool size
since this new scale-up policy is already a win within the current limit,
and additional work may be needed to realize better scaling.

Previously, --numberOfWorklistThreads controlled both the maximum
number of compiler threads and also the limit for the number threads
that can compile baseline plans. Split this into an independent
option --numberOfBaselineCompilerThreads.

--numberOfWorklistThreads is renamed --maxNumberOfWorklistThreads
and sets the overall limit to how large the compiler thread-pool can
grow.

--minNumberOfWorklistThreads controls when this new heuristic kicks in.
Threads are woken 1 to 1 with enqueued plans up to this limit.
Setting both min and max to the same value effectively falls back
to the old policy.

--worklist{Tier}LoadWeight controls the weight used to scale the
queue-depth of each tier when computing load.

--worklistLoadFactor determines the effective capacity of the
thread-pool in units of weight.

It probably doesn&apos;t make sense to set a --worklist{Tier}LoadWeight
greater than --worklistLoadFactor since the compile of a single plan
is not multithreaded.

This change enables the new load-based policy only for ARM64 Darwin.

Canonical link: <a href="https://commits.webkit.org/294082@main">https://commits.webkit.org/294082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1240f672fc1e061fd61abafb62dbc916c844aa0a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105912 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51364 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28901 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/76738 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/33777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103782 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/15933 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57091 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15743 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9034 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50739 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/93439 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85645 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108267 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/99383 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27893 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20490 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28256 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87228 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/85246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21691 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29947 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/7676 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21897 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27828 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33084 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/123009 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27639 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34283 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30957 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29197 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->