### PR TITLE
Add `--site-isolation` option to TestWebKitAPI

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -1932,6 +1932,11 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
     return NO;
 }
 
++ (void)_forceSiteIsolationAlwaysOnForTesting
+{
+    WebKit::WebPreferences::forceSiteIsolationAlwaysOnForTesting();
+}
+
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/WKPreferencesAdditions.mm>)
 #import <WebKitAdditions/WKPreferencesAdditions.mm>
 #endif

--- a/Source/WebKit/UIProcess/WebPreferences.cpp
+++ b/Source/WebKit/UIProcess/WebPreferences.cpp
@@ -43,6 +43,8 @@
 
 namespace WebKit {
 
+static bool forceSiteIsolationAlwaysOnForTesting;
+
 Ref<WebPreferences> WebPreferences::create(const String& identifier, const String& keyPrefix, const String& globalDebugKeyPrefix)
 {
     return adoptRef(*new WebPreferences(identifier, keyPrefix, globalDebugKeyPrefix));
@@ -63,6 +65,9 @@ WebPreferences::WebPreferences(const String& identifier, const String& keyPrefix
     , m_globalDebugKeyPrefix(globalDebugKeyPrefix)
 {
     platformInitializeStore();
+
+    if (WebKit::forceSiteIsolationAlwaysOnForTesting)
+        setSiteIsolationEnabled(true);
 }
 
 WebPreferences::WebPreferences(const WebPreferences& other)
@@ -72,11 +77,19 @@ WebPreferences::WebPreferences(const WebPreferences& other)
     , m_store(other.m_store)
 {
     platformInitializeStore();
+
+    if (WebKit::forceSiteIsolationAlwaysOnForTesting)
+        setSiteIsolationEnabled(true);
 }
 
 WebPreferences::~WebPreferences()
 {
     ASSERT(m_pages.isEmptyIgnoringNullReferences());
+}
+
+void WebPreferences::forceSiteIsolationAlwaysOnForTesting()
+{
+    WebKit::forceSiteIsolationAlwaysOnForTesting = true;
 }
 
 const Vector<RefPtr<API::Object>>& WebPreferences::experimentalFeatures()

--- a/Source/WebKit/UIProcess/WebPreferences.h
+++ b/Source/WebKit/UIProcess/WebPreferences.h
@@ -94,6 +94,8 @@ public:
     void startBatchingUpdates();
     void endBatchingUpdates();
 
+    static void forceSiteIsolationAlwaysOnForTesting();
+
 private:
     void platformInitializeStore();
 


### PR DESCRIPTION
#### bbafb05be33d6f01078d44067866ff8cf8a79b36
<pre>
Add `--site-isolation` option to TestWebKitAPI
<a href="https://rdar.apple.com/149976547">rdar://149976547</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292026">https://bugs.webkit.org/show_bug.cgi?id=292026</a>

Reviewed by Alex Christensen.

All API tests eventually need to work with site isolation on, and exploring which ones
currently fail is useful in identifying areas that need work.

This patch adds a command line option to trivially force all WKWebView&apos;s to enable site
isolation for testing and feature development.

When we get to the point where site isolation can be enabled by default globally, we
can remove (or invert!) this command line option.

* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(+[WKPreferences _forceSiteIsolationAlwaysOnForTesting]):
* Source/WebKit/UIProcess/WebPreferences.cpp:
(WebKit::WebPreferences::WebPreferences):
(WebKit::WebPreferences::forceSiteIsolationAlwaysOnForTesting):
* Source/WebKit/UIProcess/WebPreferences.h:
* Tools/TestWebKitAPI/mac/mainMac.mm:
(forceSiteIsolationForTesting):
(handleArguments):
(main):
(buildArgumentDefaults): Deleted.

Canonical link: <a href="https://commits.webkit.org/294094@main">https://commits.webkit.org/294094@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd909924bcf81c4d0fd71063f2ca2a73487bc8ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100799 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20451 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105936 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51388 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102840 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28925 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/76751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/33788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103806 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15953 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91046 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/57104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15763 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/9055 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/50763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/85664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108291 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27917 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85710 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28280 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87248 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85253 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21699 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29967 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7695 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/21921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27852 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33108 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27663 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30981 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29221 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->