### PR TITLE
[WebGPU] fast/webgpu/nocrash/fuzz-275294.html crashes in Debug

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1554,6 +1554,7 @@ webkit.org/b/261356 [ Debug ] fast/mediastream/device-change-event-2.html [ Pass
 webkit.org/b/263396 css3/color/text.html [ Skip ]
 
 # WebGPU
+fast/webgpu/nocrash/fuzz-275294.html [ Pass ]
 [ Release ] http/tests/webgpu/webgpu/api/validation/encoding/cmds/copyTextureToTexture.html
 
 # skipped due to infinite loop compute shaders normally not terminating on macOS, test must be run locally for now

--- a/Source/WebGPU/WebGPU/Sampler.mm
+++ b/Source/WebGPU/WebGPU/Sampler.mm
@@ -295,14 +295,8 @@ id<MTLSamplerState> Sampler::samplerState() const
             return false;
         });
     }
-    if (cachedSamplerStates->size() >= maxArgumentBufferSamplerCount) {
-        if (!lastAccessedKeys->size())
-            return nil;
-        auto& firstKey = *lastAccessedKeys->begin();
-        cachedSamplerStates->remove(firstKey);
-        retainedSamplerStates->remove(firstKey);
-        lastAccessedKeys->removeFirst();
-    }
+    if (cachedSamplerStates->size() >= maxArgumentBufferSamplerCount)
+        return nil;
 
     samplerState = [device newSamplerStateWithDescriptor:createMetalDescriptorFromDescriptor(m_descriptor)];
     if (!samplerState)


### PR DESCRIPTION
#### 4573a8d1036488907303ea3065fcfedc1ebb7523
<pre>
[WebGPU] fast/webgpu/nocrash/fuzz-275294.html crashes in Debug
<a href="https://bugs.webkit.org/show_bug.cgi?id=292020">https://bugs.webkit.org/show_bug.cgi?id=292020</a>
<a href="https://rdar.apple.com/149971001">rdar://149971001</a>

Reviewed by Tadeu Zagallo.

When there are no slots in the cache, because for instance a
compute shader running an infinite loop is using 2000 samplers,
we should return nil instead of removing elements from the global
cache.

Removing elements doesn&apos;t resolve the lifetime of the MTLSamplerState
object that is cached by the MTLCommandBuffer which is still executing
an infinte loop, for instance.

* LayoutTests/fast/webgpu/nocrash/fuzz-275294-expected.txt:
Update expectations.
* LayoutTests/platform/mac-wk2/TestExpectations:
Set to Pass

* Source/WebGPU/WebGPU/Sampler.mm:
(WebGPU::Sampler::samplerState const):
Correct cache.

Canonical link: <a href="https://commits.webkit.org/294328@main">https://commits.webkit.org/294328@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70fd1aac801cd774d9ca826d9ddc1d6910ae78e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21131 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106618 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52094 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29624 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77273 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34303 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16541 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91634 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57615 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16362 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9653 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51442 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86230 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9725 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108970 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28594 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21028 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86242 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28956 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87841 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85808 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21830 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30543 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8255 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22712 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28525 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33805 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28336 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31656 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29895 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->