### PR TITLE
AX: Fix for accessibility/password-selected-text-range.html in ITM.

### DIFF
--- a/LayoutTests/accessibility-isolated-tree/TestExpectations
+++ b/LayoutTests/accessibility-isolated-tree/TestExpectations
@@ -19,9 +19,6 @@ accessibility/mac/set-value-editable-types.html [ Failure ]
 accessibility/mac/setting-attributes-is-asynchronous.html [ Failure ]
 accessibility/mac/attributed-string/attributed-string-has-completion-annotation.html [ Failure ]
 
-# Times out because we never update AXPropertyName::SelectedTextRange.
-accessibility/password-selected-text-range.html [ Timeout ]
-
 # Fails because we don't compute node-only AX objects as ignored when they're within a display:none container.
 # This causes us to fail to call AXIsolatedTree::addUnconnectedNode in AXObjectCache::addRelation, meaning
 # we never create an isolated object for #menu-item-one, causing ariaLabelledByElementAtIndex(0) to return null.

--- a/LayoutTests/accessibility/mac/input-replacevalue-userinfo-expected.txt
+++ b/LayoutTests/accessibility/mac/input-replacevalue-userinfo-expected.txt
@@ -1,19 +1,24 @@
+This tests that the value change notifications user info data are correct when replacing the contents of an input field.
 
-This tests value change notifications user info data when replacing the contents of an input field.
+Regular text field:
+globalExpectedDeletion: a
+globalExpectedInsertion: b
+PASS: globalUserInfo['AXTextStateChangeType'] === AXTextStateChangeTypeEdit
+PASS: values.length === 2
+PASS: values[0]['AXTextEditType'] === AXTextEditTypeDelete
+PASS: values[0]['AXTextChangeValue'] === globalExpectedDeletion
+PASS: values[1]['AXTextEditType'] === AXTextEditTypeInsert
+PASS: values[1]['AXTextChangeValue'] === globalExpectedInsertion
+Password field:
+globalExpectedDeletion: •
+globalExpectedInsertion: •
+PASS: globalUserInfo['AXTextStateChangeType'] === AXTextStateChangeTypeEdit
+PASS: values.length === 2
+PASS: values[0]['AXTextEditType'] === AXTextEditTypeDelete
+PASS: values[0]['AXTextChangeValue'] === globalExpectedDeletion
+PASS: values[1]['AXTextEditType'] === AXTextEditTypeInsert
+PASS: values[1]['AXTextChangeValue'] === globalExpectedInsertion
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
-PASS addedNotification is true
-PASS results[resultIndex]["AXTextStateChangeType"] is AXTextStateChangeTypeEdit
-PASS results[resultIndex]["AXTextChangeValues"][0]["AXTextChangeValue"] is "0"
-PASS results[resultIndex]["AXTextChangeValues"][0]["AXTextEditType"] is AXTextEditTypeDelete
-PASS results[resultIndex]["AXTextStateChangeType"] is AXTextStateChangeTypeEdit
-PASS results[resultIndex]["AXTextChangeValues"][1]["AXTextChangeValue"] is "1"
-PASS results[resultIndex]["AXTextChangeValues"][1]["AXTextEditType"] is AXTextEditTypeInsert
-PASS results[resultIndex]["AXTextStateChangeType"] is AXTextStateChangeTypeEdit
-PASS results[resultIndex]["AXTextChangeValues"][0]["AXTextChangeValue"] is " "
-PASS results[resultIndex]["AXTextChangeValues"][0]["AXTextEditType"] is AXTextEditTypeInsert
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/mac/input-replacevalue-userinfo.html
+++ b/LayoutTests/accessibility/mac/input-replacevalue-userinfo.html
@@ -1,81 +1,70 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-    <script src="../../resources/js-test.js"></script>
-    <script src="../../editing/editing.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="../../editing/editing.js"></script>
 </head>
-<body id="body">
+<body>
 
-    <input type="password" id="securevaluetest">
+<input type="text" id="field" value="a">
+<input type="password" id="secure-field" value="a">
 
-    <input type="text" id="valuetest">
+<script>
+var output = "This tests that the value change notifications user info data are correct when replacing the contents of an input field.\n\n";
 
-    <p id="description"></p>
-    <div id="console"></div>
-    <div id="notifications"></div>
+const AXTextStateChangeTypeEdit = 1;
+const AXTextEditTypeDelete = 1;
+const AXTextEditTypeInsert = AXTextEditTypeDelete + 1;
 
-    <script>
+var globalUserInfo = null;
+function notificationCallback(notification, userInfo) {
+    if (notification == "AXValueChanged")
+        globalUserInfo = userInfo;
+}
 
-        description("This tests value change notifications user info data when replacing the contents of an input field.");
+async function testField(id, newValue, expectedDeletion, expectedInsertion) {
+    // Assign the expected values to their corresponding globals so that they can be used in expect().
+    globalExpectedDeletion = expectedDeletion;
+    globalExpectedInsertion = expectedInsertion;
+    output += `globalExpectedDeletion: ${globalExpectedDeletion}\n`;
+    output += `globalExpectedInsertion: ${globalExpectedInsertion}\n`;
 
-        var AXTextStateChangeTypeEdit = 1;
+    globalUserInfo = null;
+    document.getElementById(id).value = newValue;
+    await waitFor(() => { return globalUserInfo; });
+    // The userInfo for a replacement edit operation consists of a dictionary with the type AXTextStateChangeTypeEdit and an array of 2 elements describing the deletion and the insertion.
+    output += expect("globalUserInfo['AXTextStateChangeType']", "AXTextStateChangeTypeEdit");
+    values = globalUserInfo['AXTextChangeValues'];
+    output += expect("values.length", "2");
+    // Each array element is in turn a dictionary with the EditType, deletion or insertion, and the text being deleted or inserted.
+    output += expect("values[0]['AXTextEditType']", "AXTextEditTypeDelete");
+    output += expect("values[0]['AXTextChangeValue']", "globalExpectedDeletion");
+    output += expect("values[1]['AXTextEditType']", "AXTextEditTypeInsert");
+    output += expect("values[1]['AXTextChangeValue']", "globalExpectedInsertion");
+}
 
-        var AXTextEditTypeDelete = 1;
-        var AXTextEditTypeInsert = AXTextEditTypeDelete + 1;
+if (window.accessibilityController) {
+    jsTestIsAsync = true;
+    accessibilityController.enableEnhancedAccessibility(true);
 
-        var webArea = 0;
-        var count = 0;
-        var results = [];
-        var resultIndex = 0;
-        function notificationCallback(notification, userInfo) {
-            if (notification == "AXValueChanged") {
-                count++;
-                results.push(userInfo);
-                if (count == 2) {
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+    webArea.addNotificationListener(notificationCallback);
 
-                    shouldBe("results[resultIndex][\"AXTextStateChangeType\"]", "AXTextStateChangeTypeEdit");
-                    shouldBe("results[resultIndex][\"AXTextChangeValues\"][0][\"AXTextChangeValue\"]", "\"0\"");
-                    shouldBe("results[resultIndex][\"AXTextChangeValues\"][0][\"AXTextEditType\"]", "AXTextEditTypeDelete");
-                    shouldBe("results[resultIndex][\"AXTextStateChangeType\"]", "AXTextStateChangeTypeEdit");
-                    shouldBe("results[resultIndex][\"AXTextChangeValues\"][1][\"AXTextChangeValue\"]", "\"1\"");
-                    shouldBe("results[resultIndex][\"AXTextChangeValues\"][1][\"AXTextEditType\"]", "AXTextEditTypeInsert");
+    var globalExpectedDeletion, globalExpectedInsertion;
+    setTimeout(async () => {
+        output += "Regular text field:\n";
+        await testField("field", "b", "a", "b");
 
-                    // Password notifications will be insert only and the value string will be whitespace
-                    resultIndex++;
-                    shouldBe("results[resultIndex][\"AXTextStateChangeType\"]", "AXTextStateChangeTypeEdit");
-                    shouldBe("results[resultIndex][\"AXTextChangeValues\"][0][\"AXTextChangeValue\"]", "\" \"");
-                    shouldBe("results[resultIndex][\"AXTextChangeValues\"][0][\"AXTextEditType\"]", "AXTextEditTypeInsert");
+        output += "Password field:\n";
+        // Notification userInfo should come with masking characters (bullet = \u2022) regardless the inner or new value.
+        await testField("secure-field", "b", "\u2022", "\u2022");
 
-                    webArea.removeNotificationListener();
-                    finishJSTest();
-                }
-            }
-        }
-
-        function setvalue() {
-            document.getElementById("valuetest").value = "1";
-        }
-
-        function setsecurevalue() {
-            document.getElementById("securevaluetest").value = "1";
-        }
-
-        document.getElementById("valuetest").value = "0";
-        document.getElementById("securevaluetest").value = "0";
-
-        if (window.accessibilityController) {
-            jsTestIsAsync = true;
-
-            accessibilityController.enableEnhancedAccessibility(true);
-
-            webArea = accessibilityController.rootElement.childAtIndex(0);
-            var addedNotification = webArea.addNotificationListener(notificationCallback);
-            shouldBe("addedNotification", "true");
-
-            setvalue();
-
-            setsecurevalue();
-        }
-    </script>
+        webArea.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
 </body>
 </html>

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -138,6 +138,15 @@ struct AXTreeData {
     String isolatedTree;
 };
 
+#if PLATFORM(COCOA)
+struct AXTextChangeContext {
+    AXTextStateChangeIntent intent;
+    String deletedText;
+    String insertedText;
+    VisibleSelection selection;
+};
+#endif // PLATFORM(COCOA)
+
 class AccessibilityReplacedText {
 public:
     AccessibilityReplacedText() = default;
@@ -272,7 +281,7 @@ enum class AXLoadingEvent : uint8_t {
 };
 
 #if !PLATFORM(COCOA)
-enum class AXTextChange : uint8_t { Inserted, Deleted, AttributesChanged };
+enum class AXTextChange : uint8_t { Inserted, Deleted, Replaced, AttributesChanged };
 #endif
 
 enum class PostTarget { Element, ObservableParent };
@@ -383,6 +392,7 @@ public:
     void onPopoverToggle(const HTMLElement&);
     void onScrollbarFrameRectChange(const Scrollbar&);
     void onSelectedChanged(Element&);
+    void onSelectedTextChanged(const VisiblePositionRange&, AccessibilityObject* = nullptr);
     void onSlottedContentChange(const HTMLSlotElement&);
     void onStyleChange(Element&, OptionSet<Style::Change>, const RenderStyle* oldStyle, const RenderStyle* newStyle);
     void onStyleChange(RenderText&, StyleDifference, const RenderStyle* oldStyle, const RenderStyle& newStyle);
@@ -409,7 +419,6 @@ public:
     void onRendererCreated(Element&);
 #if PLATFORM(MAC)
     void onDocumentRenderTreeCreation(const Document&);
-    void onSelectedTextChanged(const VisiblePositionRange&);
 #endif
 #if ENABLE(AX_THREAD_TEXT_APIS)
     void onTextRunsChanged(const RenderObject&);
@@ -731,8 +740,10 @@ private:
 
     void postTextStateChangeNotification(AccessibilityObject*, const AXTextStateChangeIntent&, const VisibleSelection&);
 
-    bool enqueuePasswordValueChangeNotification(AccessibilityObject&);
-    void passwordNotificationPostTimerFired();
+#if PLATFORM(COCOA)
+    bool enqueuePasswordNotification(AccessibilityObject&, AXTextChangeContext&&);
+    void passwordNotificationTimerFired();
+#endif
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     void selectedTextRangeTimerFired();
@@ -844,10 +855,11 @@ private:
     Timer m_notificationPostTimer;
     Vector<std::pair<Ref<AccessibilityObject>, AXNotification>> m_notificationsToPost;
 
-    Timer m_passwordNotificationPostTimer;
+#if PLATFORM(COCOA)
+    Timer m_passwordNotificationTimer;
+    Vector<std::pair<Ref<AccessibilityObject>, AXTextChangeContext>> m_passwordNotifications;
+#endif
 
-    ListHashSet<Ref<AccessibilityObject>> m_passwordNotificationsToPost;
-    
     Timer m_liveRegionChangedPostTimer;
     ListHashSet<Ref<AccessibilityObject>> m_changedLiveRegions;
 

--- a/Source/WebCore/accessibility/AXTextStateChangeIntent.h
+++ b/Source/WebCore/accessibility/AXTextStateChangeIntent.h
@@ -43,6 +43,7 @@ enum AXTextEditType {
     AXTextEditTypeDictation, // Insert via dictation
     AXTextEditTypeCut, // Delete via Cut
     AXTextEditTypePaste, // Insert via Paste
+    AXTextEditTypeReplace, // A deletion + insertion that should be notified as an atomic operation.
     AXTextEditTypeAttributesChange // Change font, style, alignment, color, etc.
 };
 
@@ -77,7 +78,7 @@ struct AXTextStateChangeIntent {
     AXTextStateChangeType type;
     union {
         AXTextSelection selection;
-        AXTextEditType change;
+        AXTextEditType editType;
     };
 
     AXTextStateChangeIntent(AXTextStateChangeType type = AXTextStateChangeTypeUnknown, AXTextSelection selection = AXTextSelection())
@@ -85,9 +86,9 @@ struct AXTextStateChangeIntent {
         , selection(selection)
     { }
 
-    AXTextStateChangeIntent(AXTextEditType change)
+    AXTextStateChangeIntent(AXTextEditType editType)
         : type(AXTextStateChangeTypeEdit)
-        , change(change)
+        , editType(editType)
     { }
 };
 

--- a/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
@@ -184,6 +184,10 @@ void AXObjectCache::postTextStateChangePlatformNotification(AccessibilityObject*
     case AXTextEditTypeAttributesChange:
         wrapper->textAttributesChanged();
         break;
+    case AXTextEditTypeReplace:
+        // Should call postTextReplacementPlatformNotification instead.
+        ASSERT_NOT_REACHED();
+        break;
     case AXTextEditTypeUnknown:
         break;
     }

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -139,6 +139,8 @@ static AXTextEditType platformEditTypeForWebCoreEditType(WebCore::AXTextEditType
         return kAXTextEditTypeCut;
     case WebCore::AXTextEditTypePaste:
         return kAXTextEditTypePaste;
+    case WebCore::AXTextEditTypeReplace:
+        return kAXTextEditTypeUnknown; // Does not exist in platform enum.
     case WebCore::AXTextEditTypeAttributesChange:
         return kAXTextEditTypeAttributesChange;
     }
@@ -1073,33 +1075,6 @@ std::optional<SimpleRange> rangeForTextMarkerRange(AXObjectCache* cache, AXTextM
     CharacterOffset startCharacterOffset = characterOffsetForTextMarker(cache, startTextMarker.get());
     CharacterOffset endCharacterOffset = characterOffsetForTextMarker(cache, endTextMarker.get());
     return cache->rangeForUnorderedCharacterOffsets(startCharacterOffset, endCharacterOffset);
-}
-
-void AXObjectCache::onSelectedTextChanged(const VisiblePositionRange& selection)
-{
-#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    if (auto tree = AXIsolatedTree::treeForPageID(m_pageID)) {
-        if (selection.isNull())
-            tree->setSelectedTextMarkerRange({ });
-        else {
-            auto startPosition = selection.start.deepEquivalent();
-            auto endPosition = selection.end.deepEquivalent();
-
-            if (startPosition.isNull() || endPosition.isNull())
-                tree->setSelectedTextMarkerRange({ });
-            else {
-                if (auto* startObject = get(startPosition.anchorNode()))
-                    createIsolatedObjectIfNeeded(*startObject);
-                if (auto* endObject = get(endPosition.anchorNode()))
-                    createIsolatedObjectIfNeeded(*endObject);
-
-                tree->setSelectedTextMarkerRange({ selection });
-            }
-        }
-    }
-#else
-    UNUSED_PARAM(selection);
-#endif
 }
 
 }


### PR DESCRIPTION
#### fc5dad73c18c845cf725213118e9de41a1691eb8
<pre>
AX: Fix for accessibility/password-selected-text-range.html in ITM.
<a href="https://bugs.webkit.org/show_bug.cgi?id=292031">https://bugs.webkit.org/show_bug.cgi?id=292031</a>
&lt;<a href="https://rdar.apple.com/problem/149980238">rdar://problem/149980238</a>&gt;

Reviewed by Tyler Wilcock.

SelectedTextChanged notifications need to be exposed for secure text fields since AX clients depend on these notifications to retrieve the correct selection range. This is one of the problems that is causing issues with entering passwords on the web with some assistive technologies.

To expose the SelectedTextchanged notifications, this patch adds a mechanism of queueing text changes that keeps all the necessary data, encapsulated in the AXTextChangeContext struct.
These changes also required changing the input-replacevalue-userinfo.html since we now expose more accurate values for the password fields. this prompted a complete re-write of this test to bring it to our current standards and correct several issues with the test itself.

* LayoutTests/accessibility-isolated-tree/TestExpectations:
* LayoutTests/accessibility/mac/input-replacevalue-userinfo-expected.txt:
* LayoutTests/accessibility/mac/input-replacevalue-userinfo.html:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::AXObjectCache):
(WebCore::AXObjectCache::showIntent):
(WebCore::AXObjectCache::postTextStateChangeNotification):
(WebCore::AXObjectCache::postTextReplacementNotification):
(WebCore::AXObjectCache::postTextReplacementNotificationForTextControl):
(WebCore::secureContext):
(WebCore::AXObjectCache::enqueuePasswordNotification):
(WebCore::AXObjectCache::passwordNotificationTimerFired):
(WebCore::AXObjectCache::onSelectedTextChanged):
(WebCore::AXObjectCache::textChangeForEditType):
(WebCore::AXObjectCache::passwordNotificationPostTimerFired): Deleted.
(WebCore::AXObjectCache::enqueuePasswordValueChangeNotification): Deleted.
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AXTextStateChangeIntent.h:
(WebCore::AXTextStateChangeIntent::AXTextStateChangeIntent):
* Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp:
(WebCore::AXObjectCache::postTextStateChangePlatformNotification):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(platformEditTypeForWebCoreEditType):
(WebCore::AXObjectCache::onSelectedTextChanged): Deleted.

Canonical link: <a href="https://commits.webkit.org/294435@main">https://commits.webkit.org/294435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39d1afa38543da1f8c0e94f052ccb18fc68a1bde

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11777 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106951 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52427 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29966 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77510 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34530 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104800 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16820 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91921 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57848 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16646 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9939 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51778 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/86501 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10016 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109308 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28926 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21304 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86489 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29287 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88122 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86060 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21905 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30812 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8532 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23096 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28854 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34144 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28665 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31988 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30224 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->