### PR TITLE
Stopping an ImageCapture may execute javascript on stop and ActiveDOMObject doesn't allow this

### DIFF
--- a/LayoutTests/fast/mediastream/stopping-image-capture-heap-collect-crash-expected.txt
+++ b/LayoutTests/fast/mediastream/stopping-image-capture-heap-collect-crash-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: grabFrame is stopped
+
+Harness Error (FAIL), message = Unhandled rejection: grabFrame is stopped
+
+PASS grabFrame while GC
+

--- a/LayoutTests/fast/mediastream/stopping-image-capture-heap-collect-crash.html
+++ b/LayoutTests/fast/mediastream/stopping-image-capture-heap-collect-crash.html
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script src="../../resources/gc.js"></script>
+  </head>
+  <body>
+    <script>
+      function createPeerConnectionImageCapture()
+{
+    const connection = new RTCPeerConnection();
+    const transceiver = connection.addTransceiver('video');
+    return new ImageCapture(transceiver.receiver.track);
+}
+
+promise_test(async test => {
+    const imageCapture = createPeerConnectionImageCapture();
+    imageCapture.grabFrame();
+
+    gc(); 
+    await new Promise(resolve => test.step_timeout(resolve, 100));
+}, "grabFrame while GC");
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/Modules/mediastream/ImageCapture.h
+++ b/Source/WebCore/Modules/mediastream/ImageCapture.h
@@ -67,10 +67,10 @@ private:
     void stopGrabFrameObserver();
 
     // ActiveDOMObject
-    void stop() final;
+    void stop() final { stopGrabFrameObserver(); };
 
     // MediaStreamTrackPrivateObserver
-    void trackEnded(MediaStreamTrackPrivate&) final { stopGrabFrameObserver(); }
+    void trackEnded(MediaStreamTrackPrivate&) final;
     void trackMutedChanged(MediaStreamTrackPrivate&) final { }
     void trackSettingsChanged(MediaStreamTrackPrivate&) final { }
     void trackEnabledChanged(MediaStreamTrackPrivate&) final { }
@@ -84,7 +84,6 @@ private:
 
     const Ref<MediaStreamTrack> m_track;
     RefPtr<ImageCaptureVideoFrameObserver> m_grabFrameObserver;
-    bool m_isStopped { false };
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
     const uint64_t m_logIdentifier;


### PR DESCRIPTION
#### 1c35b87779d7133c1abc1522fadb695a50d868e6
<pre>
Stopping an ImageCapture may execute javascript on stop and ActiveDOMObject doesn&apos;t allow this
<a href="https://rdar.apple.com/149686446">rdar://149686446</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292030">https://bugs.webkit.org/show_bug.cgi?id=292030</a>

Reviewed by Youenn Fablet.

This fixes the bug by having trackEnd call stop on the main thread

* LayoutTests/fast/mediastream/stopping-image-capture-heap-collect-crash-expected.txt: Added.
* LayoutTests/fast/mediastream/stopping-image-capture-heap-collect-crash.html: Added.
* Source/WebCore/Modules/mediastream/ImageCapture.cpp:
(WebCore::ImageCapture::grabFrame):
(WebCore::ImageCapture::trackEnded):
(WebCore::ImageCapture::stop): Deleted.
* Source/WebCore/Modules/mediastream/ImageCapture.h:

Canonical link: <a href="https://commits.webkit.org/294388@main">https://commits.webkit.org/294388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f2e7ea8940e854661b898901902136b543f02c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101528 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11505 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106685 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52160 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103568 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29690 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77322 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34349 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91687 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57659 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16423 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9703 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51508 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86295 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9781 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109037 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28661 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21090 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86296 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29022 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87888 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85858 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21873 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30598 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8306 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/22792 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28589 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33877 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28400 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31723 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29959 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->