### PR TITLE
[WebDriver][BiDi][WPE] Enable BidiBrowserAgentGlib.cpp for WPE

### DIFF
--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -208,6 +208,7 @@ UIProcess/API/wpe/WPEWebViewPlatform.cpp @no-unify
 
 UIProcess/Automation/libwpe/WebAutomationSessionLibWPE.cpp
 UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp
+UIProcess/Automation/glib/BidiBrowserAgentGlib.cpp @no-unify
 
 UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
 

--- a/Source/WebKit/UIProcess/Automation/BidiBrowserAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowserAgent.cpp
@@ -124,7 +124,7 @@ Inspector::CommandResult<void> BidiBrowserAgent::removeUserContext(const String&
     return { };
 }
 
-#if !PLATFORM(GTK)
+#if !USE(GLIB)
 std::unique_ptr<BidiUserContext> BidiBrowserAgent::platformCreateUserContext(String& error)
 {
     error = "User context creation is not implemented for this platform yet."_s;

--- a/Source/WebKit/UIProcess/Automation/BidiUserContext.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiUserContext.cpp
@@ -33,7 +33,7 @@
 
 namespace WebKit {
 
-#if PLATFORM(GTK)
+#if USE(GLIB)
 BidiUserContext::BidiUserContext(WebsiteDataStore& dataStore, WebProcessPool& processPool, GRefPtr<WebKitWebContext>&& context)
     : m_dataStore(dataStore)
     , m_processPool(processPool)

--- a/Source/WebKit/UIProcess/Automation/BidiUserContext.h
+++ b/Source/WebKit/UIProcess/Automation/BidiUserContext.h
@@ -32,7 +32,7 @@
 #include <wtf/Noncopyable.h>
 #include <wtf/Ref.h>
 
-#if PLATFORM(GTK)
+#if USE(GLIB)
 #include <wtf/glib/GRefPtr.h>
 typedef struct _WebKitWebContext WebKitWebContext;
 #endif
@@ -46,7 +46,7 @@ class BidiUserContext {
     WTF_MAKE_NONCOPYABLE(BidiUserContext);
     WTF_MAKE_FAST_ALLOCATED;
 public:
-#if PLATFORM(GTK)
+#if USE(GLIB)
     BidiUserContext(WebsiteDataStore&, WebProcessPool&, GRefPtr<WebKitWebContext>&&);
 #else
     BidiUserContext(WebsiteDataStore&, WebProcessPool&);
@@ -60,7 +60,7 @@ private:
 
     Ref<WebsiteDataStore> m_dataStore;
     Ref<WebProcessPool> m_processPool;
-#if PLATFORM(GTK)
+#if USE(GLIB)
     GRefPtr<WebKitWebContext> m_context;
 #endif
 };


### PR DESCRIPTION
#### 67a51a3477d4921c65b77ff6b9d1e0c75203d8a9
<pre>
[WebDriver][BiDi][WPE] Enable BidiBrowserAgentGlib.cpp for WPE
<a href="https://bugs.webkit.org/show_bug.cgi?id=292039">https://bugs.webkit.org/show_bug.cgi?id=292039</a>

Reviewed by BJ Burg.

This makes a few more user contexts tests pass, but we still need to
expose a way to allow the browser creating new browsing contexts (views)
related to a given user context (WebKitWebContext).

* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/Automation/BidiBrowserAgent.cpp:
* Source/WebKit/UIProcess/Automation/BidiUserContext.cpp:
* Source/WebKit/UIProcess/Automation/BidiUserContext.h:

Canonical link: <a href="https://commits.webkit.org/294133@main">https://commits.webkit.org/294133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b0201eed23a672262a177dcc7256639f76e72a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100809 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10760 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105946 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51398 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28935 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76756 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33795 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15959 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91058 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57109 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15769 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50781 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85670 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9141 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108301 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27927 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20515 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-table.html imported/w3c/web-platform-tests/css/css-contain/contain-size-replaced-003b.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85720 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28290 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87260 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85264 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21730 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29977 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7707 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21932 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27862 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33119 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27673 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30991 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29231 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->