### PR TITLE
Avoid resuming task if session is being destroyed

### DIFF
--- a/Source/WebCore/platform/network/NetworkStorageSession.cpp
+++ b/Source/WebCore/platform/network/NetworkStorageSession.cpp
@@ -646,24 +646,24 @@ void NetworkStorageSession::setCookiesVersion(uint64_t version)
     while (!cookiesVersionChangeCallbacks.isEmpty()) {
         auto callback = cookiesVersionChangeCallbacks.takeFirst();
         if (callback.version <= m_cookiesVersion) {
-            callback.callback();
+            callback.callback(CookieVersionChangeCallback::Reason::VersionChange);
             continue;
         }
         m_cookiesVersionChangeCallbacks.append(WTFMove(callback));
     }
 }
 
-void NetworkStorageSession::addCookiesVersionChangeCallback(uint64_t version, CompletionHandler<void()>&& completionHandler)
+void NetworkStorageSession::addCookiesVersionChangeCallback(CookieVersionChangeCallback&& callback)
 {
-    ASSERT(version < m_cookiesVersion);
-    m_cookiesVersionChangeCallbacks.append({ version, WTFMove(completionHandler) });
+    ASSERT(callback.version < m_cookiesVersion);
+    m_cookiesVersionChangeCallbacks.append(WTFMove(callback));
 }
 
 void NetworkStorageSession::clearCookiesVersionChangeCallbacks()
 {
     while (!m_cookiesVersionChangeCallbacks.isEmpty()) {
         auto callback = m_cookiesVersionChangeCallbacks.takeFirst();
-        callback.callback();
+        callback.callback(CookieVersionChangeCallback::Reason::SessionClose);
     }
 }
 

--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -305,7 +305,12 @@ public:
 
     uint64_t cookiesVersion() const { return m_cookiesVersion; }
     WEBCORE_EXPORT void setCookiesVersion(uint64_t);
-    WEBCORE_EXPORT void addCookiesVersionChangeCallback(uint64_t version, CompletionHandler<void()>&&);
+    struct CookieVersionChangeCallback {
+        enum class Reason : uint8_t { VersionChange, SessionClose };
+        uint64_t version;
+        CompletionHandler<void(Reason)> callback;
+    };
+    WEBCORE_EXPORT void addCookiesVersionChangeCallback(CookieVersionChangeCallback&&);
 
 private:
 #if PLATFORM(COCOA)
@@ -392,10 +397,6 @@ private:
     mutable std::unique_ptr<CookieStorageObserver> m_cookieStorageObserver;
 #endif
     uint64_t m_cookiesVersion { 0 };
-    struct CookieVersionChangeCallback {
-        uint64_t version;
-        CompletionHandler<void()> callback;
-    };
     Deque<CookieVersionChangeCallback> m_cookiesVersionChangeCallbacks;
 
     static bool m_processMayUseCookieAPI;


### PR DESCRIPTION
#### 983a998e43efcc39ca03b7fb47cd150870091b1c
<pre>
Avoid resuming task if session is being destroyed
<a href="https://bugs.webkit.org/show_bug.cgi?id=292034">https://bugs.webkit.org/show_bug.cgi?id=292034</a>
<a href="https://rdar.apple.com/149775419">rdar://149775419</a>

Reviewed by Per Arne Vollan.

In existing implementation, CookieVersionChangeCallback can be invoked when session is destroyed; in this case, we
should not resume network data task, otherwise it might access the session and crash.

* Source/WebCore/platform/network/NetworkStorageSession.cpp:
(WebCore::NetworkStorageSession::setCookiesVersion):
(WebCore::NetworkStorageSession::addCookiesVersionChangeCallback):
(WebCore::NetworkStorageSession::clearCookiesVersionChangeCallbacks):
* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::resume):

Canonical link: <a href="https://commits.webkit.org/294115@main">https://commits.webkit.org/294115@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7facb2ad06052fb4bb29a877e7122895b816e8fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105948 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51400 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102852 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20772 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28937 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76758 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33798 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103818 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15962 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57111 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15772 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9066 "Found 6 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html imported/w3c/web-platform-tests/svg/painting/marker-005.svg imported/w3c/web-platform-tests/svg/painting/marker-006.svg media/media-source/media-source-video-renders.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50775 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85674 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9140 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108303 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27929 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20517 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-contain/contain-size-replaced-003a.html imported/w3c/web-platform-tests/media-source/mediasource-duration-boundaryconditions.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85725 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28292 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85268 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21715 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29974 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7706 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21934 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27864 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33121 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27675 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30993 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29233 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->