### PR TITLE
REGRESSION(294049@main): ASSERTION FAILED: m_cachedCurrentTime in WebCore::AnimationTimelinesController::processPendingAnimations() for animations/resume-after-page-cache.html

### DIFF
--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -1057,8 +1057,6 @@ animations/font-variations/font-style.html [ Skip ]
 
 webkit.org/b/229584 animations/fill-mode-forwards.html [ Failure Pass Timeout ]
 
-webkit.org/b/292032 animations/resume-after-page-cache.html [ Skip ] # Crash Pass
-
 # TODO Uses showModalDialog
 webkit.org/b/53675 fast/animation/request-animation-frame-during-modal.html [ Skip ]
 

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -302,7 +302,7 @@ void AnimationTimelinesController::cacheCurrentTime(ReducedResolutionSeconds new
     // We can get in a situation where the event loop will not run a task that had been enqueued.
     // If that is the case, we must clear the task group and run the callback prior to adding a
     // new task.
-    if (m_pendingAnimationsProcessingTaskCancellationGroup.hasPendingTask()) {
+    if (m_pendingAnimationsProcessingTaskCancellationGroup.hasPendingTask() && m_cachedCurrentTime) {
         m_pendingAnimationsProcessingTaskCancellationGroup.cancel();
         processPendingAnimations();
     }


### PR DESCRIPTION
#### e3d2dab9323c072cd5092855df2d0e870a82a10e
<pre>
REGRESSION(294049@main): ASSERTION FAILED: m_cachedCurrentTime in WebCore::AnimationTimelinesController::processPendingAnimations() for animations/resume-after-page-cache.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=292032">https://bugs.webkit.org/show_bug.cgi?id=292032</a>

Reviewed by Antoine Quint.

After &lt;<a href="https://commits.webkit.org/294049@main">https://commits.webkit.org/294049@main</a>&gt;, Windows port was
failing an assertion in processPendingAnimations.
processPendingAnimations should be called only if m_cachedCurrentTime
isn&apos;t nullopt.

* LayoutTests/platform/win/TestExpectations:
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::cacheCurrentTime):

Canonical link: <a href="https://commits.webkit.org/294100@main">https://commits.webkit.org/294100@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c64ec668d8f134b47af6ed8389584bb4c02518ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100817 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105954 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51406 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102858 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28943 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76765 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33803 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91062 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57118 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15779 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9071 "Found 2 new test failures: imported/w3c/web-platform-tests/svg/painting/marker-005.svg imported/w3c/web-platform-tests/svg/painting/marker-006.svg (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50782 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85680 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9145 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108309 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27935 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85728 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/content-with-child-with-transparent-background.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87264 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85271 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29981 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7711 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21940 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16401 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27870 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33127 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27681 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30999 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29239 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->