### PR TITLE
Web Inspector: Resizing a docked Web Inspector does not follow the cursor smoothly

### DIFF
--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -900,7 +900,8 @@ void WebInspectorUIProxy::platformSetAttachedWindowHeight(unsigned height)
     if (!m_isAttached)
         return;
 
-    inspectedViewFrameDidChange(height);
+    NSEdgeInsets webViewInsets = [m_inspectorViewController webView].safeAreaInsets;
+    inspectedViewFrameDidChange(height + webViewInsets.top + webViewInsets.bottom);
 }
 
 void WebInspectorUIProxy::platformSetAttachedWindowWidth(unsigned width)
@@ -908,7 +909,8 @@ void WebInspectorUIProxy::platformSetAttachedWindowWidth(unsigned width)
     if (!m_isAttached)
         return;
 
-    inspectedViewFrameDidChange(width);
+    NSEdgeInsets webViewInsets = [m_inspectorViewController webView].safeAreaInsets;
+    inspectedViewFrameDidChange(width + webViewInsets.left + webViewInsets.right);
 }
 
 void WebInspectorUIProxy::platformSetSheetRect(const FloatRect& rect)


### PR DESCRIPTION
#### fdb9aa79b9b44ebdf93d3f0932752aa63a59a326
<pre>
Web Inspector: Resizing a docked Web Inspector does not follow the cursor smoothly
<a href="https://rdar.apple.com/148762897">rdar://148762897</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292042">https://bugs.webkit.org/show_bug.cgi?id=292042</a>

Reviewed by Devin Rousso.

This is a combination of two issues:

1. If the WKInspectorWKWebView has safeAreaInsets set and therefore
   _obscuredContentInsets configured, adjusting its dimensions does not
   take that into account. Assuming there is a left inset configured
   to be X and the new docked inspector width requested by the frontend
   is W, the frontend is not aware of the extra X pixels needed when
   rendering the WKInspectorWKWebView (because the frontend lives inside
   that web view), which then needs to be (W + X) pixels wide instead.

2. The setAttachedWindowHeight/Width commands in the backend take an
   `unsigned int` as the new dimension&apos;s type, but the frontend computes
   in floating point (JavaScript&apos;s Number), which always gets rounded
   down when the new dimension gets passed in and coerced to an int.
   This makes the new view just slightly smaller than required over
   the course of dragging.

* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(WebKit::WebInspectorUIProxy::platformSetAttachedWindowHeight):
(WebKit::WebInspectorUIProxy::platformSetAttachedWindowWidth):
   - Fix issue #1.

* Source/WebInspectorUI/UserInterface/Base/Main.js:
   - Fix issue #2.
   - Adding the rounding on resulting dimension alone was sufficient to
     fix the &quot;always-shrinking&quot; bug. However, resizing still didn&apos;t feel
     completely smooth; the inspector wouldn&apos;t shrink by itself, but
     it still felt like having some lag following the moving cursor.
     I took a simpler approach to compute the delta, where we use the
     original dimension as the standard instead of the last frame,
     which turns out to be extremely smooth and exactly what we wanted.

Tested the fix manually on various inspector zoom factors from 60% to
240%, combined with or without an _obscuredContentInsets applied on the
WKInspectorWKWebView.

Canonical link: <a href="https://commits.webkit.org/294123@main">https://commits.webkit.org/294123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2dfdb9c8ac55397de5f21ef917115dac6849d180

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106044 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51496 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29054 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/76841 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33874 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91137 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57187 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15861 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9157 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50872 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/85776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9220 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108400 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28025 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28388 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87337 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85342 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21718 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30058 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/7786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22054 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27956 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33224 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27768 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31088 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29326 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->