### PR TITLE
Validate NSData non-null before adding to NSMutableArray in CoreIPCSecTrust

### DIFF
--- a/Source/WebKit/Shared/cf/CoreIPCSecTrust.mm
+++ b/Source/WebKit/Shared/cf/CoreIPCSecTrust.mm
@@ -566,8 +566,14 @@ static RetainPtr<NSDictionary> createPolicyDictionary(const CoreIPCSecTrustData:
             },
             [&] (const CoreIPCSecTrustData::PolicyArrayOfData& a) {
                 RetainPtr array = adoptNS([[NSMutableArray alloc] initWithCapacity:a.size()]);
-                for (const auto& d : a)
-                    [array addObject:d.toID().get()];
+                for (const auto& d : a) {
+                    if (RetainPtr nsD = d.toID())
+                        [array addObject:d.toID().get()];
+                    else {
+                        RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrustData had an null value in policy dictionary");
+                        ASSERT_NOT_REACHED();
+                    }
+                }
                 value = array;
             },
             [&] (const CoreIPCSecTrustData::PolicyArrayOfArrayContainingDateOrNumbers& a) {
@@ -605,8 +611,14 @@ static void addToDictFromOptionalDataHelper(const std::optional<Vector<CoreIPCDa
     if (!opt)
         return;
     RetainPtr array = adoptNS([[NSMutableArray alloc] initWithCapacity:opt->size()]);
-    for (const CoreIPCData& d : *opt)
-        [array addObject:d.toID().get()];
+    for (const CoreIPCData& d : *opt) {
+        if (RetainPtr nsD = d.toID())
+            [array addObject:nsD.get()];
+        else {
+            RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrustData had an null value in data helper");
+            ASSERT_NOT_REACHED();
+        }
+    }
     [dict.get() setObject:array.get() forKey:key];
 }
 
@@ -659,15 +671,27 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     if (!m_data->certificates.isEmpty()) {
         RetainPtr certificates = adoptNS([[NSMutableArray alloc] initWithCapacity:m_data->certificates.size()]);
-        for (const CoreIPCData& cert : m_data->certificates)
-            [certificates addObject:cert.toID().get()];
+        for (const CoreIPCData& cert : m_data->certificates) {
+            if (RetainPtr nsCert = cert.toID())
+                [certificates addObject:nsCert.get()];
+            else {
+                RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrustData had an null value in certificates");
+                ASSERT_NOT_REACHED();
+            }
+        }
         [dict setObject:certificates.get() forKey:@"certificates"];
     }
 
     if (!m_data->chain.isEmpty()) {
         RetainPtr chain = adoptNS([[NSMutableArray alloc] initWithCapacity:m_data->chain.size()]);
-        for (const CoreIPCData& cert : m_data->chain)
-            [chain addObject:cert.toID().get()];
+        for (const CoreIPCData& cert : m_data->chain) {
+            if (RetainPtr nsCert = cert.toID())
+                [chain addObject:nsCert.get()];
+            else {
+                RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrustData had an null value in chain");
+                ASSERT_NOT_REACHED();
+            }
+        }
         [dict setObject:chain.get() forKey:@"chain"];
     }
 


### PR DESCRIPTION
#### dfe85c799d21dec85150f17810016f9e3337770f
<pre>
Validate NSData non-null before adding to NSMutableArray in CoreIPCSecTrust
<a href="https://rdar.apple.com/149212916">rdar://149212916</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292045">https://bugs.webkit.org/show_bug.cgi?id=292045</a>

Reviewed by Brent Fulgham and Jonathan Bedard.

We should validate that we aren&apos;t adding a NULL to an NSMutableArray as
it causes a crash.

* Source/WebKit/Shared/cf/CoreIPCSecTrust.mm:
(WebKit::createPolicyDictionary):
(WebKit::addToDictFromOptionalDataHelper):
(WebKit::CoreIPCSecTrust::createSecTrust const):

Canonical link: <a href="https://commits.webkit.org/294210@main">https://commits.webkit.org/294210@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0c781fa136908f19a917f8acdceb62d481ebc18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100821 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105958 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51410 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28947 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76767 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33805 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15972 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91065 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57120 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15782 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50786 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85683 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9148 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108313 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27939 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85730 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28302 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87267 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85273 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21768 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29984 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7714 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21945 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27874 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33131 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27685 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31003 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29243 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->