### PR TITLE
TestWebKitAPI.app fails to launch in iOS Simulator

### DIFF
--- a/Tools/TestWebKitAPI/Scripts/process-entitlements.sh
+++ b/Tools/TestWebKitAPI/Scripts/process-entitlements.sh
@@ -73,6 +73,12 @@ function process_ios_family_testwebkitapi_entitlements()
     plistbuddy Add :com.apple.private.xpc.launchd.job-manager string TestWebKitAPI
     plistbuddy Add :com.apple.CommCenter.fine-grained array
     plistbuddy Add :com.apple.CommCenter.fine-grained:0 string public-cellular-plan
+
+    if [[ "${PRODUCT_BUNDLE_IDENTIFIER}" == org.webkit.TestWebKitAPI ]]
+    then
+        plistbuddy Add :com.apple.developer.web-browser bool YES
+        plistbuddy Add :com.apple.developer.web-browser-engine.host bool YES
+    fi
 }
 
 plistbuddy Clear dict


### PR DESCRIPTION
#### b84ab3c3dcf1e2adaedb89d2501c920fe337290b
<pre>
TestWebKitAPI.app fails to launch in iOS Simulator
<a href="https://bugs.webkit.org/show_bug.cgi?id=292046">https://bugs.webkit.org/show_bug.cgi?id=292046</a>
<a href="https://rdar.apple.com/150002097">rdar://150002097</a>

Reviewed by Abrar Rahman Protyasha.

Since TestWebKitAPI.app embeds its WebContent, Networking, and GPU extensions (see 291094@main), it
will fail to run on iOS devices and simulators without com.apple.developer.web-browser and
com.apple.developer.web-browser-engine.host entitlements. Resolved this by adding said entitlements
to TestWebKitAPI.app (but not TestWebKitAPI; note that the command-line tool runs tests that assume
the binary does *not* have these entitlements).

* Tools/TestWebKitAPI/Scripts/process-entitlements.sh:

Canonical link: <a href="https://commits.webkit.org/294097@main">https://commits.webkit.org/294097@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9aaa71dcd03ecf68d6e721616000db088c81f390

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10774 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105960 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51412 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102864 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28949 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/76773 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33810 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15974 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91067 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57122 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15784 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/9076 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50788 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85685 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108315 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27941 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85732 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28304 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87269 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85275 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21703 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29986 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7716 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21948 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27876 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27687 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31005 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29245 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->