### PR TITLE
Starting opportunistically deleting GlyphDisplayListCache entries.

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -105,6 +105,7 @@
 #include "GCReachableRef.h"
 #include "GPUCanvasContext.h"
 #include "GenericCachedHTMLCollection.h"
+#include "GlyphDisplayListCache.h"
 #include "GraphicsTypes.h"
 #include "HTMLAllCollection.h"
 #include "HTMLAnchorElement.h"
@@ -3475,6 +3476,8 @@ void Document::destroyRenderTree()
 
     if (RefPtr documentElement = m_documentElement)
         RenderTreeUpdater::tearDownRenderers(*documentElement);
+
+    GlyphDisplayListCache::singleton().performOpportunisticCleanup();
 
     clearChildNeedsStyleRecalc();
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -84,6 +84,7 @@
 #include "FrameSelection.h"
 #include "FrameTree.h"
 #include "GeolocationController.h"
+#include "GlyphDisplayListCache.h"
 #include "HTMLElement.h"
 #include "HTMLImageElement.h"
 #include "HTMLMediaElement.h"
@@ -5158,6 +5159,9 @@ void Page::performOpportunisticallyScheduledTasks(MonotonicTime deadline)
     OptionSet<JSC::VM::SchedulerOptions> options;
     if (m_opportunisticTaskScheduler->hasImminentlyScheduledWork())
         options.add(JSC::VM::SchedulerOptions::HasImminentlyScheduledWork);
+
+    GlyphDisplayListCache::singleton().performOpportunisticCleanup();
+
     commonVM().performOpportunisticallyScheduledTasks(deadline, options);
 
     deleteRemovedNodes();

--- a/Source/WebCore/rendering/GlyphDisplayListCache.cpp
+++ b/Source/WebCore/rendering/GlyphDisplayListCache.cpp
@@ -39,6 +39,8 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(GlyphDisplayListCacheEntry);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(GlyphDisplayListCache);
 
+static constexpr unsigned s_maxDisplayListsForOpportunisticDeletion = 300;
+
 struct GlyphDisplayListCacheKey {
     GlyphDisplayListCacheKey(const TextRun& textRun, const FontCascade& font, const GraphicsContext& context)
         : textRun(textRun)
@@ -85,6 +87,13 @@ void GlyphDisplayListCache::clear()
 {
     m_entriesForLayoutRun.clear();
     m_entries.clear();
+    m_entriesForOpportunisticDeletion.clear();
+}
+
+void GlyphDisplayListCache::clearEntriesForOpportunisticCleanup()
+{
+    static constexpr size_t s_entriesToClear = 100;
+    m_entriesForOpportunisticDeletion.remove(0, std::min(s_entriesToClear, m_entriesForOpportunisticDeletion.size()));
 }
 
 unsigned GlyphDisplayListCache::size() const
@@ -170,7 +179,10 @@ RefPtr<const DisplayList::DisplayList> GlyphDisplayListCache::getIfExists(const 
 
 void GlyphDisplayListCache::remove(const void* run)
 {
-    m_entriesForLayoutRun.remove(run);
+    if (RefPtr glyphDisplayListCacheEntry = m_entriesForLayoutRun.take(run); glyphDisplayListCacheEntry && m_entriesForOpportunisticDeletion.size() < s_maxDisplayListsForOpportunisticDeletion) {
+        m_entries.remove(*glyphDisplayListCacheEntry);
+        m_entriesForOpportunisticDeletion.append(WTFMove(glyphDisplayListCacheEntry));
+    }
 }
 
 bool GlyphDisplayListCache::canShareDisplayList(const DisplayList::DisplayList& displayList)

--- a/Source/WebCore/rendering/GlyphDisplayListCache.h
+++ b/Source/WebCore/rendering/GlyphDisplayListCache.h
@@ -119,6 +119,9 @@ public:
 
     void clear();
     unsigned size() const;
+    void clearEntriesForOpportunisticCleanup();
+
+    void performOpportunisticCleanup() { clearEntriesForOpportunisticCleanup(); }
 
     void setForceUseGlyphDisplayListForTesting(bool flag)
     {
@@ -136,6 +139,7 @@ private:
 
     UncheckedKeyHashMap<const void*, Ref<GlyphDisplayListCacheEntry>> m_entriesForLayoutRun;
     UncheckedKeyHashSet<SingleThreadWeakRef<GlyphDisplayListCacheEntry>> m_entries;
+    Vector<RefPtr<GlyphDisplayListCacheEntry>> m_entriesForOpportunisticDeletion;
     bool m_forceUseGlyphDisplayListForTesting { false };
 };
 


### PR DESCRIPTION
#### 971f7f8c0c945950d2c44b75f2474fc1a797a18d
<pre>
Starting opportunistically deleting GlyphDisplayListCache entries.
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Removing entries from the GlyphDisplayListCache and destroying them can
be expensive in that it appears in traces for benchmarks when destroying
line layout. To avoid doing this work on the critical path, we can use
the OpportunisticTaskScheduler to destroy these objects at a later point
during idle time.

To accomplish this, patch, whenever we remove an entry from the cache, we
will append it to a list that will be opportunistically cleaned up. In
order to decrease the likelihood of increasing the memory footprint, we
place a maximum limit on the number of items that can be included in
this list. After looking at some benchmarks locally, I decided to use 300
items as this maximum. OTS will then come and do a bit of cleanup by
removing min(entries.size(), 100) before moving onto other tasks. This
is to avoid hogging all of the time and allow other code aware of the
OTS deadline to execute.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/971f7f8c0c945950d2c44b75f2474fc1a797a18d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103202 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13197 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108371 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53845 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23213 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31378 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78445 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35382 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106208 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17997 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93105 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58778 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17837 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11147 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53200 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87646 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110748 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30340 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22365 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87445 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89304 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87078 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31930 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9637 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24663 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30267 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35588 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30075 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33402 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31637 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->