### PR TITLE
Re-enable mutation events in WebKitLegacy

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5449,7 +5449,7 @@ MutationEventsEnabled:
   humanReadableName: "DOM mutation events"
   defaultValue:
     WebKitLegacy:
-      default: false
+      default: WebKit::defaultMutationEventsEnabled()
     WebKit:
       default: WebKit::defaultMutationEventsEnabled()
     WebCore:

--- a/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.h
@@ -59,6 +59,7 @@ bool defaultNeedsFrameNameFallbackToIdQuirk();
 bool defaultNeedsKeyboardEventDisambiguationQuirks();
 #endif
 
+bool defaultMutationEventsEnabled();
 bool defaultAttachmentElementEnabled();
 bool defaultShouldRestrictBaseURLSchemes();
 bool defaultAllowDisplayOfInsecureContent();

--- a/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.mm
@@ -162,6 +162,11 @@ bool defaultNeedsKeyboardEventDisambiguationQuirks()
 
 #endif // PLATFORM(MAC)
 
+bool defaultMutationEventsEnabled()
+{
+    return WTF::CocoaApplication::isAppleApplication() || !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::MutationEventsDisabledByDefault);
+}
+
 bool defaultAttachmentElementEnabled()
 {
 #if PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 388884e2151d8c1f30521beb5b060572da5b135e
<pre>
Re-enable mutation events in WebKitLegacy
<a href="https://bugs.webkit.org/show_bug.cgi?id=292049">https://bugs.webkit.org/show_bug.cgi?id=292049</a>
<a href="https://rdar.apple.com/149142781">rdar://149142781</a>

Reviewed by Anne van Kesteren.

Like 291447@main, re-enable mutation events in WebKitLegacy for Apple applications
and applications linked against an old SDK.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.h:
* Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.mm:
(WebKit::defaultMutationEventsEnabled):

Canonical link: <a href="https://commits.webkit.org/294138@main">https://commits.webkit.org/294138@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7622874bcac1f6b4648dfb5fafe7677af08f1ad6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106041 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51494 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29052 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76836 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33870 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103903 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16046 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91136 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57182 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15860 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9156 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50870 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/93563 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85775 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9219 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108398 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/99505 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28023 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20614 "Found 1 new test failure: resize-observer/contain-instrinsic-size-should-not-leak-nodes.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85801 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28386 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87336 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85339 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30054 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7785 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22052 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16416 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27954 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33221 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/123130 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27766 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34304 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31086 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29324 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->