### PR TITLE
Re-enable the tests fixed by 291526@main

### DIFF
--- a/LayoutTests/interaction-region/guard-crash-expected.txt
+++ b/LayoutTests/interaction-region/guard-crash-expected.txt
@@ -31,7 +31,7 @@
                               (layer bounds [x: 0 y: 0 width: 800 height: 600])
                               (layer anchorPoint [x: 0 y: 0]))))
                         (
-                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
                           (layer anchorPoint [x: 0 y: 0]))
                         (
                           (layer bounds [x: 0 y: 0 width: 0 height: 0])

--- a/LayoutTests/interaction-region/interaction-layers-culling-expected.txt
+++ b/LayoutTests/interaction-region/interaction-layers-culling-expected.txt
@@ -34,7 +34,7 @@
                               (layer position [x: 0 y: 0])
                               (layer anchorPoint [x: 0 y: 0]))))
                         (
-                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                          (layer bounds [x: 0 y: 0 width: 800 height: 86050])
                           (layer anchorPoint [x: 0 y: 0]))
                         (
                           (layer bounds [x: 0 y: 0 width: 0 height: 0])

--- a/LayoutTests/interaction-region/interaction-layers-culling-layer-type-change-expected.txt
+++ b/LayoutTests/interaction-region/interaction-layers-culling-layer-type-change-expected.txt
@@ -34,7 +34,7 @@
                               (layer position [x: 0 y: 0])
                               (layer anchorPoint [x: 0 y: 0]))))
                         (
-                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                          (layer bounds [x: 0 y: 0 width: 800 height: 713])
                           (layer anchorPoint [x: 0 y: 0])
                           (sublayers
                             (

--- a/LayoutTests/interaction-region/layer-tree-expected.txt
+++ b/LayoutTests/interaction-region/layer-tree-expected.txt
@@ -68,7 +68,7 @@
                               (layer bounds [x: 0 y: 0 width: 100 height: 100])
                               (layer position [x: 350 y: 350]))))
                         (
-                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
                           (layer anchorPoint [x: 0 y: 0])
                           (sublayers
                             (

--- a/LayoutTests/interaction-region/layer-tree-shape-reset-expected.txt
+++ b/LayoutTests/interaction-region/layer-tree-shape-reset-expected.txt
@@ -30,7 +30,7 @@
                               (layer bounds [x: 0 y: 0 width: 800 height: 600])
                               (layer anchorPoint [x: 0 y: 0]))))
                         (
-                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
                           (layer anchorPoint [x: 0 y: 0]))
                         (
                           (layer bounds [x: 0 y: 0 width: 0 height: 0])

--- a/LayoutTests/platform/visionos/TestExpectations
+++ b/LayoutTests/platform/visionos/TestExpectations
@@ -79,7 +79,6 @@ workers [ Skip ]
 fast/events/pointer [ Pass ]
 interaction-region [ Pass ]
 media/media-css-volume-locked.html [ Pass ]
-overlay-region [ Pass ]
 platform/visionos/transforms [ Pass ]
 
 imported/w3c/web-platform-tests/webxr [ Pass ]
@@ -137,21 +136,6 @@ fast/events/pointer/ios/drag-populates-pointer-events-with-movementxy-fields.htm
 fast/events/pointer/ios/tap-gives-pointerdown-pointerup.html [ Timeout ]
 
 webkit.org/b/275115 imported/w3c/web-platform-tests/webxr/getInputPose_pointer.https.html [ Skip ]
-
-# webkit.org/b/288683 REGRESSION(291033@main): Broke visionOS layout tests
-interaction-region/guard-crash.html [ Failure ]
-interaction-region/interaction-layers-culling-layer-type-change.html [ Failure ]
-interaction-region/interaction-layers-culling.html [ Failure ]
-interaction-region/layer-tree-shape-reset.html [ Failure ]
-interaction-region/layer-tree.html [ Failure ]
-platform/visionos/transforms/separated-image-downgrade-content.html [ Failure ]
-platform/visionos/transforms/separated-image-downgrade-tiled.html [ Failure ]
-platform/visionos/transforms/separated-image-downgrade.html [ Failure ]
-platform/visionos/transforms/separated-image-upgrade-tiled.html [ Failure ]
-platform/visionos/transforms/separated-image-upgrade.html [ Failure ]
-platform/visionos/transforms/separated-update.html [ Failure ]
-platform/visionos/transforms/separated-video.html [ Failure ]
-platform/visionos/transforms/separated.html [ Failure ]
 
 ### END OF Triaged failures
 ###################################################################################################

--- a/LayoutTests/platform/visionos/transforms/separated-expected.txt
+++ b/LayoutTests/platform/visionos/transforms/separated-expected.txt
@@ -34,7 +34,7 @@
                               (layer position [x: 0 y: 0])
                               (layer anchorPoint [x: 0 y: 0]))))
                         (
-                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                          (layer bounds [x: 0 y: 0 width: 800 height: 2613])
                           (layer anchorPoint [x: 0 y: 0])
                           (sublayers
                             (

--- a/LayoutTests/platform/visionos/transforms/separated-image-downgrade-content-expected.txt
+++ b/LayoutTests/platform/visionos/transforms/separated-image-downgrade-content-expected.txt
@@ -34,7 +34,7 @@
                                 (view [class: WKCompositingView]
                                   (layer bounds [x: 0 y: 0 width: 0 height: 0]))
                                 (view [class: WKCompositingView]
-                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer bounds [x: 0 y: 0 width: 3000 height: 3213])
                                   (layer anchorPoint [x: 0 y: 0])
                                   (subviews
                                     (view [class: WKCompositingView]

--- a/LayoutTests/platform/visionos/transforms/separated-image-downgrade-expected.txt
+++ b/LayoutTests/platform/visionos/transforms/separated-image-downgrade-expected.txt
@@ -34,7 +34,7 @@
                                 (view [class: WKCompositingView]
                                   (layer bounds [x: 0 y: 0 width: 0 height: 0]))
                                 (view [class: WKCompositingView]
-                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer bounds [x: 0 y: 0 width: 3000 height: 3213])
                                   (layer anchorPoint [x: 0 y: 0])
                                   (subviews
                                     (view [class: WKCompositingView]

--- a/LayoutTests/platform/visionos/transforms/separated-image-downgrade-tiled-expected.txt
+++ b/LayoutTests/platform/visionos/transforms/separated-image-downgrade-tiled-expected.txt
@@ -34,7 +34,7 @@
                                 (view [class: WKCompositingView]
                                   (layer bounds [x: 0 y: 0 width: 0 height: 0]))
                                 (view [class: WKCompositingView]
-                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer bounds [x: 0 y: 0 width: 3000 height: 3013])
                                   (layer anchorPoint [x: 0 y: 0])
                                   (subviews
                                     (view [class: WKCompositingView]

--- a/LayoutTests/platform/visionos/transforms/separated-image-upgrade-expected.txt
+++ b/LayoutTests/platform/visionos/transforms/separated-image-upgrade-expected.txt
@@ -34,7 +34,7 @@
                                 (view [class: WKCompositingView]
                                   (layer bounds [x: 0 y: 0 width: 0 height: 0]))
                                 (view [class: WKCompositingView]
-                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer bounds [x: 0 y: 0 width: 3000 height: 3213])
                                   (layer anchorPoint [x: 0 y: 0])
                                   (subviews
                                     (view [class: WKSeparatedImageView]

--- a/LayoutTests/platform/visionos/transforms/separated-image-upgrade-tiled-expected.txt
+++ b/LayoutTests/platform/visionos/transforms/separated-image-upgrade-tiled-expected.txt
@@ -34,7 +34,7 @@
                                 (view [class: WKCompositingView]
                                   (layer bounds [x: 0 y: 0 width: 0 height: 0]))
                                 (view [class: WKCompositingView]
-                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer bounds [x: 0 y: 0 width: 800 height: 600])
                                   (layer anchorPoint [x: 0 y: 0])
                                   (subviews
                                     (view [class: WKSeparatedImageView]

--- a/LayoutTests/platform/visionos/transforms/separated-update-expected.txt
+++ b/LayoutTests/platform/visionos/transforms/separated-update-expected.txt
@@ -39,7 +39,7 @@
                               (layer position [x: 0 y: 0])
                               (layer anchorPoint [x: 0 y: 0]))))
                         (
-                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                          (layer bounds [x: 0 y: 0 width: 800 height: 2813])
                           (layer anchorPoint [x: 0 y: 0])
                           (sublayers
                             (

--- a/LayoutTests/platform/visionos/transforms/separated-video-expected.txt
+++ b/LayoutTests/platform/visionos/transforms/separated-video-expected.txt
@@ -30,7 +30,7 @@
                               (layer bounds [x: 0 y: 0 width: 800 height: 600])
                               (layer anchorPoint [x: 0 y: 0]))))
                         (
-                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
                           (layer anchorPoint [x: 0 y: 0])
                           (sublayers
                             (


### PR DESCRIPTION
#### 4633cb528068dbb52f422c9eebf7216406d9f29b
<pre>
Re-enable the tests fixed by 291526@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=292056">https://bugs.webkit.org/show_bug.cgi?id=292056</a>
<a href="https://rdar.apple.com/150027210">rdar://150027210</a>

Reviewed by NOBODY (OOPS!).

Re-enable and re-baseline the tests now that the fix is in.

* LayoutTests/platform/visionos/TestExpectations:
Re-enable tests.
Fix a warning about duplicate entries for `overlay-region`.

* LayoutTests/interaction-region/guard-crash-expected.txt:
* LayoutTests/interaction-region/interaction-layers-culling-expected.txt:
* LayoutTests/interaction-region/interaction-layers-culling-layer-type-change-expected.txt:
* LayoutTests/interaction-region/layer-tree-expected.txt:
* LayoutTests/interaction-region/layer-tree-shape-reset-expected.txt:
* LayoutTests/platform/visionos/transforms/separated-expected.txt:
* LayoutTests/platform/visionos/transforms/separated-image-downgrade-content-expected.txt:
* LayoutTests/platform/visionos/transforms/separated-image-downgrade-expected.txt:
* LayoutTests/platform/visionos/transforms/separated-image-downgrade-tiled-expected.txt:
* LayoutTests/platform/visionos/transforms/separated-image-upgrade-expected.txt:
* LayoutTests/platform/visionos/transforms/separated-image-upgrade-tiled-expected.txt:
* LayoutTests/platform/visionos/transforms/separated-update-expected.txt:
* LayoutTests/platform/visionos/transforms/separated-video-expected.txt:
Re-baseline the tests.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4633cb528068dbb52f422c9eebf7216406d9f29b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101104 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106252 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51731 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29260 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77015 "Found 1 new test failure: fast/css/view-transitions-nested-transparency-layers.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34039 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104111 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16233 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91321 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57362 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16049 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9348 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51079 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85955 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108608 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28232 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20788 "Found 2 new test failures: http/tests/iframe-monitor/data-url-resource.html http/tests/iframe-monitor/iframe-unload.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85981 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28594 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87521 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85518 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30238 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7964 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22327 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28162 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27974 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31294 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29532 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->