### PR TITLE
RTCRtpScriptTransform cannot be reused

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-encoded-transform.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-encoded-transform.https-expected.txt
@@ -1,5 +1,6 @@
 
 
+PASS Receiver and sender read, try to reuse transforms.
 PASS Receiver and sender read, modifiy and write video frames.
 PASS Receiver and sender read, modifiy and write audio frames.
 PASS Sender reads frames but doesn't write them back. Receiver doesn't receive any frames.

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-encoded-transform.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-encoded-transform.https.html
@@ -12,6 +12,31 @@
 <body>
 <video id="video" autoplay controls playsinline></video>
 <script>
+promise_test(async (test) => {
+    const worker = new Worker('RTCRtpScriptTransform-encoded-transform-worker.js');
+    let sender, receiver;
+    const senderTransform = new RTCRtpScriptTransform(worker, {name:'sender'});
+    const receiverTransform = new RTCRtpScriptTransform(worker, {name:'receiver'});
+
+    const pc = new RTCPeerConnection();
+    const transceiver1 = pc.addTransceiver("audio");
+    const transceiver2 = pc.addTransceiver("audio");
+
+    transceiver1.sender.transform = senderTransform;
+    transceiver1.receiver.transform = receiverTransform;
+
+    transceiver1.sender.transform = senderTransform;
+    transceiver1.receiver.transform = receiverTransform;
+
+    assert_throws_dom("InvalidStateError", () => transceiver2.sender.transform = senderTransform, "set a used transform 1");
+    assert_throws_dom("InvalidStateError", () => transceiver2.receiver.transform = receiverTransform, "set a used transform 2");
+
+    transceiver1.sender.transform = null;
+    transceiver1.receiver.transform = null;
+
+    assert_throws_dom("InvalidStateError", () => transceiver2.sender.transform = senderTransform, "set a used transform 3");
+    assert_throws_dom("InvalidStateError", () => transceiver2.receiver.transform = receiverTransform, "set a used transform 4");
+}, "Receiver and sender read, try to reuse transforms.");
 
 promise_test(async (test) => {
     const worker = new Worker('RTCRtpScriptTransform-encoded-transform-worker.js');

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp
@@ -132,8 +132,6 @@ bool RTCRtpScriptTransform::setupTransformer(Ref<RTCRtpTransformBackend>&& backe
 
 void RTCRtpScriptTransform::clear(RTCRtpScriptTransformer::ClearCallback clearCallback)
 {
-    m_isAttached = false;
-
     Locker locker { m_transformerLock };
     m_isTransformerInitialized = false;
     m_worker->postTaskToWorkerGlobalScope([transformer = WTFMove(m_transformer), clearCallback](auto&) mutable {


### PR DESCRIPTION
#### 2042d35832ac3563c7a92f28fb76f652d5bd3c1e
<pre>
RTCRtpScriptTransform cannot be reused
<a href="https://rdar.apple.com/150032266">rdar://150032266</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292060">https://bugs.webkit.org/show_bug.cgi?id=292060</a>

Reviewed by Jean-Yves Avenard.

As per spec, a transform cannot be reused once it is used by a sender or receiver.
This was implemented correctly for a transform that was in use by a sender and a receiver.
But this was not implemented for a transform that was no longer in use.
We update the WPT test according <a href="https://github.com/web-platform-tests/wpt/pull/52174/">https://github.com/web-platform-tests/wpt/pull/52174/</a>

* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-encoded-transform.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-encoded-transform.https.html:
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp:
(WebCore::RTCRtpScriptTransform::clear):

Canonical link: <a href="https://commits.webkit.org/294182@main">https://commits.webkit.org/294182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba490f236c28208d1c229fa4404047348523a650

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101057 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106203 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51683 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103098 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76971 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34000 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104064 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91283 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57319 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16006 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9309 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51031 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85912 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9366 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108559 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28185 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20750 "Found 2 new test failures: http/tests/iframe-monitor/iframe-unload.html http/tests/iframe-monitor/workers/service-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85940 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28547 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87483 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85478 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21755 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30197 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7927 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22270 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28115 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33383 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27927 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31247 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29485 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->