### PR TITLE
Reduce unsafeness in WebCore/dom & xml

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -165,7 +165,6 @@ css/query/MediaQueryFeatures.cpp
 css/typedom/CSSStyleValueFactory.cpp
 css/typedom/ComputedStylePropertyMapReadOnly.cpp
 css/typedom/InlineStylePropertyMap.cpp
-dom/ActiveDOMObject.cpp
 dom/Attr.cpp
 dom/BoundaryPoint.cpp
 dom/CharacterData.cpp
@@ -175,9 +174,6 @@ dom/ContainerNode.cpp
 dom/ContainerNodeAlgorithms.cpp
 dom/ContentVisibilityDocumentState.cpp
 dom/CurrentScriptIncrementer.h
-dom/CustomElementReactionQueue.cpp
-dom/CustomElementRegistry.cpp
-dom/DOMImplementation.cpp
 dom/DataTransfer.cpp
 dom/DeviceMotionController.cpp
 dom/DeviceOrientationController.cpp
@@ -1003,7 +999,6 @@ workers/service/server/SWRegistrationDatabase.cpp
 workers/shared/context/SharedWorkerThreadProxy.cpp
 worklets/PaintWorkletGlobalScope.cpp
 worklets/WorkletGlobalScope.cpp
-xml/DOMParser.cpp
 xml/NativeXPathNSResolver.cpp
 xml/XMLHttpRequestProgressEventThrottle.cpp
 xml/XMLHttpRequestUpload.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1412,7 +1412,6 @@ workers/shared/SharedWorkerScriptLoader.cpp
 worklets/PaintWorkletGlobalScope.cpp
 worklets/WorkletGlobalScope.cpp
 worklets/WorkletPendingTasks.cpp
-xml/DOMParser.cpp
 xml/NativeXPathNSResolver.cpp
 xml/XMLHttpRequest.cpp
 xml/XMLHttpRequestProgressEventThrottle.cpp

--- a/Source/WebCore/dom/ActiveDOMObject.cpp
+++ b/Source/WebCore/dom/ActiveDOMObject.cpp
@@ -141,10 +141,10 @@ bool ActiveDOMObject::isAllowedToRunScript() const
 
 void ActiveDOMObject::queueTaskInEventLoop(TaskSource source, Function<void ()>&& function)
 {
-    RefPtr<ScriptExecutionContext> context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
-    context->eventLoop().queueTask(source, WTFMove(function));
+    context->checkedEventLoop()->queueTask(source, WTFMove(function));
 }
 
 class ActiveDOMObjectEventDispatchTask : public EventLoopTask {

--- a/Source/WebCore/dom/CustomElementReactionQueue.cpp
+++ b/Source/WebCore/dom/CustomElementReactionQueue.cpp
@@ -389,7 +389,7 @@ void CustomElementReactionQueue::enqueueElementOnAppropriateElementQueue(Element
     ASSERT(element.reactionQueue());
     element.setIsInCustomElementReactionQueue();
     if (!CustomElementReactionStack::s_currentProcessingStack) {
-        element.document().windowEventLoop().backupElementQueue().add(element);
+        element.protectedDocument()->windowEventLoop().backupElementQueue().add(element);
         return;
     }
 

--- a/Source/WebCore/dom/CustomElementRegistry.cpp
+++ b/Source/WebCore/dom/CustomElementRegistry.cpp
@@ -230,7 +230,7 @@ void CustomElementRegistry::addToScopedCustomElementRegistryMap(Element& element
     if (element.usesScopedCustomElementRegistryMap())
         return;
     element.setUsesScopedCustomElementRegistryMap();
-    registry.didAssociateWithDocument(element.document());
+    registry.didAssociateWithDocument(element.protectedDocument().get());
     auto result = scopedCustomElementRegistryMap().add(element, registry);
     ASSERT_UNUSED(result, result.isNewEntry);
 }

--- a/Source/WebCore/dom/DOMImplementation.cpp
+++ b/Source/WebCore/dom/DOMImplementation.cpp
@@ -103,10 +103,11 @@ static inline Ref<XMLDocument> createXMLDocument(const String& namespaceURI, con
 
 ExceptionOr<Ref<XMLDocument>> DOMImplementation::createDocument(const AtomString& namespaceURI, const AtomString& qualifiedName, DocumentType* documentType)
 {
-    Ref document = createXMLDocument(namespaceURI, m_document->protectedSettings());
+    Ref thisDocument = m_document.get();
+    Ref document = createXMLDocument(namespaceURI, thisDocument->protectedSettings());
     document->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent });
-    document->setContextDocument(m_document->contextDocument());
-    document->setSecurityOriginPolicy(m_document->securityOriginPolicy());
+    document->setContextDocument(thisDocument->contextDocument());
+    document->setSecurityOriginPolicy(thisDocument->securityOriginPolicy());
 
     RefPtr<Element> documentElement;
     if (!qualifiedName.isEmpty()) {
@@ -136,7 +137,8 @@ Ref<CSSStyleSheet> DOMImplementation::createCSSStyleSheet(const String&, const S
 
 Ref<HTMLDocument> DOMImplementation::createHTMLDocument(String&& title)
 {
-    Ref document = HTMLDocument::create(nullptr, m_document->protectedSettings(), URL(), { });
+    Ref thisDocument = m_document.get();
+    Ref document = HTMLDocument::create(nullptr, thisDocument->protectedSettings(), URL(), { });
     document->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent });
     document->open();
     document->write(nullptr, FixedVector<String> { "<!doctype html><html><head></head><body></body></html>"_s });
@@ -146,8 +148,8 @@ Ref<HTMLDocument> DOMImplementation::createHTMLDocument(String&& title)
         ASSERT(document->head());
         document->protectedHead()->appendChild(titleElement);
     }
-    document->setContextDocument(m_document->contextDocument());
-    document->setSecurityOriginPolicy(m_document->securityOriginPolicy());
+    document->setContextDocument(thisDocument->contextDocument());
+    document->setSecurityOriginPolicy(thisDocument->securityOriginPolicy());
     return document;
 }
 

--- a/Source/WebCore/xml/DOMParser.cpp
+++ b/Source/WebCore/xml/DOMParser.cpp
@@ -21,6 +21,7 @@
 
 #include "CommonAtomStrings.h"
 #include "HTMLDocument.h"
+#include "NodeInlines.h"
 #include "SVGDocument.h"
 #include "SecurityOriginPolicy.h"
 #include "TrustedType.h"
@@ -43,7 +44,7 @@ Ref<DOMParser> DOMParser::create(Document& contextDocument)
 
 ExceptionOr<Ref<Document>> DOMParser::parseFromString(Variant<RefPtr<TrustedHTML>, String>&& string, const AtomString& contentType)
 {
-    auto stringValueHolder = trustedTypeCompliantString(*m_contextDocument->scriptExecutionContext(), WTFMove(string), "DOMParser parseFromString"_s);
+    auto stringValueHolder = trustedTypeCompliantString(*protectedContextDocument()->protectedScriptExecutionContext().get(), WTFMove(string), "DOMParser parseFromString"_s);
 
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();

--- a/Source/WebCore/xml/DOMParser.h
+++ b/Source/WebCore/xml/DOMParser.h
@@ -38,6 +38,8 @@ public:
 private:
     explicit DOMParser(Document& contextDocument);
 
+    RefPtr<Document> protectedContextDocument() const { return m_contextDocument.get(); }
+
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_contextDocument;
     const Ref<const Settings> m_settings;
 };


### PR DESCRIPTION
#### 91adeac8b28caf815007f457c1eb67b531854aae
<pre>
Reduce unsafeness in WebCore/dom &amp; xml
<a href="https://bugs.webkit.org/show_bug.cgi?id=292061">https://bugs.webkit.org/show_bug.cgi?id=292061</a>

Reviewed by Ryosuke Niwa.

As per <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/294162@main">https://commits.webkit.org/294162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5bf0601c939ef4c93e4a523d3cc29713437de450

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106112 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51589 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103007 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29122 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76890 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33917 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16107 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91195 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57238 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15922 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9217 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50940 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85828 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9278 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108468 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28094 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20662 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85856 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87395 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85398 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30111 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7839 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22137 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16429 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28024 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33292 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27836 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31156 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29394 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->