### PR TITLE
[scroll-animations] WPT test scroll-animations/scroll-timelines/scroll-timeline-invalidation.html has failures

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-invalidation-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Animation current time and effect local time are updated after scroller content size changes.
 PASS Animation current time and effect local time are updated after scroller size changes.
-FAIL If scroll animation resizes its scroll timeline scroller, layout reruns once per frame. assert_approx_equals: expected 28.42105263157895 +/- 0.1 but got 60.000003814697266
+PASS If scroll animation resizes its scroll timeline scroller, layout reruns once per frame.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-invalidation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-invalidation.html
@@ -123,6 +123,15 @@ promise_test(async t => {
   // makes the scroll timeline stale.
   // https://github.com/w3c/csswg-drafts/issues/8694
 
+  // runAndWaitForFrameUpdate will yield after the requestAnimationFrame callbacks
+  // have been serviced, which is prior to when stale timelines are updated.
+  // https://github.com/w3c/csswg-drafts/issues/12120
+  assert_approx_equals(timeline.currentTime.value, 60, 0.1);
+
+  // Now wait another beat such that the rest of the HTML Processing Model event loop
+  // has run and we can check whether stale timelines have been updated.
+  await new Promise(setTimeout);
+
   // With a single layout, timeline current time would be at 60%, but the
   // timeline would be stale.
   const expected_progress = 60 * maxScroll / (maxScroll + 1000);

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -38,6 +38,7 @@ namespace WebCore {
 
 class AnimationTimeline;
 class Document;
+class ScrollTimeline;
 class WeakPtrImplWithEventTargetData;
 class WebAnimation;
 
@@ -57,6 +58,7 @@ public:
     void removeTimeline(AnimationTimeline&);
     void detachFromDocument();
     void updateAnimationsAndSendEvents(ReducedResolutionSeconds);
+    void updateStaleScrollTimelines();
     void addPendingAnimation(WebAnimation&);
 
     std::optional<Seconds> currentTime();
@@ -85,6 +87,7 @@ private:
     std::unique_ptr<AcceleratedEffectStackUpdater> m_acceleratedEffectStackUpdater;
 #endif
 
+    Vector<Ref<ScrollTimeline>> m_updatedScrollTimelines;
     UncheckedKeyHashMap<FramesPerSecond, ReducedResolutionSeconds> m_animationFrameRateToLastTickTimeMap;
     WeakHashSet<AnimationTimeline> m_timelines;
     WeakHashSet<WebAnimation, WeakPtrImplWithEventTargetData> m_pendingAnimations;

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -68,6 +68,7 @@ public:
     bool isInactiveStyleOriginatedTimeline() const { return m_isInactiveStyleOriginatedTimeline; }
 
     AnimationTimeline::ShouldUpdateAnimationsAndSendEvents documentWillUpdateAnimationsAndSendEvents() override;
+    void updateCurrentTimeIfStale();
 
     AnimationTimelinesController* controller() const override;
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10464,6 +10464,12 @@ void Document::updateAnimationsAndSendEvents()
         timelinesController->updateAnimationsAndSendEvents(domWindow->frozenNowTimestamp());
 }
 
+void Document::updateStaleScrollTimelines()
+{
+    if (CheckedPtr timelinesController = this->timelinesController())
+        timelinesController->updateStaleScrollTimelines();
+}
+
 DocumentTimeline& Document::timeline()
 {
     if (!m_timeline)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1799,6 +1799,7 @@ public:
     WEBCORE_EXPORT void setConsoleMessageListener(RefPtr<StringCallback>&&); // For testing.
 
     void updateAnimationsAndSendEvents();
+    void updateStaleScrollTimelines();
     WEBCORE_EXPORT DocumentTimeline& timeline();
     DocumentTimeline* existingTimeline() const { return m_timeline.get(); }
     Vector<RefPtr<WebAnimation>> getAnimations();

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2185,6 +2185,11 @@ void Page::updateRendering()
         document.updateResizeObservations(*this);
     });
 
+    // https://drafts.csswg.org/scroll-animations-1/#event-loop
+    forEachDocument([] (Document& document) {
+        document.updateStaleScrollTimelines();
+    });
+
     runProcessingStep(RenderingUpdateStep::FocusFixup, [&] (Document& document) {
         if (RefPtr focusedElement = document.focusedElement()) {
             if (!focusedElement->isFocusable())


### PR DESCRIPTION
#### 3da5ec4d32bde7cc2bcd0f51f14c17175722ef75
<pre>
[scroll-animations] WPT test scroll-animations/scroll-timelines/scroll-timeline-invalidation.html has failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=284546">https://bugs.webkit.org/show_bug.cgi?id=284546</a>

Reviewed by Antti Koivisto.

The Scroll-driven Animations spec [0] calls for the re-computation of styles if during a page rendering
update a scroll timeline becomes &quot;stale&quot;, ie. if its current time changes during the update. This
will happen for instance if the bounds of the scroll timeline source changes during the update as
part of an animation, a requestAnimationFrame callback or a resize observer. There is a provision
that there can only be a single additional style update caused by this.

Because the spec references the HTML spec by section number and not hyperlinks, it is not perfectly
clear when exactly potentially-stale timelines should be considered for an update, but it seems from
informative notes that this happens _after_ resize observers have been serviced, which also implies
that the style and layout update has also happened. A spec issue was filed to clarify this.

As such, we call from `Page::updateRendering()` into `AnimationTimelinesController::updateStaleScrollTimelines()`
to iterate all scroll and view timelines updated during the immediate prior call to `updateAnimationsAndSendEvents()`
and call the new `ScrollTimeline::updateCurrentTimeIfStale()` method which will recompute the basic
data used to determine a scroll timeline&apos;s current time and, if the source bounds have changed, will
invalidate the targets of all associated animations and update styles once more.

This process is non-reentrant, ensuring we only update stale timelines once.

The test that was written to test this functionality did not strictly adhere to what the spec seems
to specify (see [1]) so we update it as well to check that a timeline&apos;s current time is only updated
after much of the page rendering steps have been performed, since it previously would check it within
a `requestAnimationFrame()` callback.

[0] <a href="https://drafts.csswg.org/scroll-animations-1/#event-loop">https://drafts.csswg.org/scroll-animations-1/#event-loop</a>
[1] <a href="https://github.com/w3c/csswg-drafts/issues/12120">https://github.com/w3c/csswg-drafts/issues/12120</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-invalidation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-invalidation.html:
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::updateAnimationsAndSendEvents):
(WebCore::AnimationTimelinesController::updateStaleScrollTimelines):
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::updateCurrentTimeIfStale):
* Source/WebCore/animation/ScrollTimeline.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateStaleScrollTimelines):
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateRendering):

Canonical link: <a href="https://commits.webkit.org/294121@main">https://commits.webkit.org/294121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea1755cbbf68d1752b34ceea545740160c63c0af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106008 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51460 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102912 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20832 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28997 "Build is in progress. Recent messages:OS: Sequoia (15.3), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76812 "Found 5 new test failures: imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-none/sharedworker-import-data.http.html imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-self/sharedworker-classic.https.html imported/w3c/web-platform-tests/css/css-grid/abspos/grid-positioned-items-implicit-grid-line-001.html imported/w3c/web-platform-tests/media-source/SourceBuffer-abort-updating.html imported/w3c/web-platform-tests/mediasession/mediametadata.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33848 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16018 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91111 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57164 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15832 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50837 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108363 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27989 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/28997 "Build is in progress. Recent messages:OS: Sequoia (15.3), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85777 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28352 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87313 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85321 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30030 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7760 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22015 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16409 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27924 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33208 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27735 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31053 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29293 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->