### PR TITLE
Unreviewed, reverting 294084@main (40e8bb366e26)

### DIFF
--- a/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.cpp
+++ b/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.cpp
@@ -174,8 +174,6 @@ SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMBufferQueueGetBuffer
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMBufferQueueGetCallbacksForUnsortedSampleBuffers, const CMBufferCallbacks*, (), (), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMBufferQueueGetFirstPresentationTimeStamp, CMTime, (CMBufferQueueRef queue), (queue), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMBufferQueueGetEndPresentationTimeStamp, CMTime, (CMBufferQueueRef queue), (queue), PAL_EXPORT)
-SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMBufferQueueGetMaxPresentationTimeStamp, CMTime, (CMBufferQueueRef queue), (queue), PAL_EXPORT)
-
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMBufferQueueInstallTrigger, OSStatus, (CMBufferQueueRef queue, CMBufferQueueTriggerCallback callback, void* refcon, CMBufferQueueTriggerCondition condition, CMTime time, CMBufferQueueTriggerToken* triggerTokenOut), (queue, callback, refcon, condition, time, triggerTokenOut), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMBufferQueueRemoveTrigger, OSStatus, (CMBufferQueueRef queue, CMBufferQueueTriggerToken triggerToken), (queue, triggerToken), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMBufferQueueInstallTriggerWithIntegerThreshold, OSStatus, (CMBufferQueueRef queue, CMBufferQueueTriggerCallback triggerCallback, void* triggerRefcon, CMBufferQueueTriggerCondition triggerCondition, CMItemCount triggerThreshold, CMBufferQueueTriggerToken* triggerTokenOut), (queue, triggerCallback, triggerRefcon, triggerCondition, triggerThreshold, triggerTokenOut), PAL_EXPORT)

--- a/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h
+++ b/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h
@@ -287,8 +287,6 @@ SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMBufferQueueGetCallbacksForUnsort
 #define CMBufferQueueGetCallbacksForUnsortedSampleBuffers softLink_CoreMedia_CMBufferQueueGetCallbacksForUnsortedSampleBuffers
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMBufferQueueGetEndPresentationTimeStamp, CMTime, (CMBufferQueueRef queue), (queue))
 #define CMBufferQueueGetEndPresentationTimeStamp softLink_CoreMedia_CMBufferQueueGetEndPresentationTimeStamp
-SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMBufferQueueGetMaxPresentationTimeStamp, CMTime, (CMBufferQueueRef queue), (queue))
-#define CMBufferQueueGetMaxPresentationTimeStamp softLink_CoreMedia_CMBufferQueueGetMaxPresentationTimeStamp
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMBufferQueueInstallTrigger, OSStatus, (CMBufferQueueRef queue, CMBufferQueueTriggerCallback callback, void* refcon, CMBufferQueueTriggerCondition condition, CMTime time, CMBufferQueueTriggerToken* triggerTokenOut), (queue, callback, refcon, condition, time, triggerTokenOut))
 #define CMBufferQueueInstallTrigger softLink_CoreMedia_CMBufferQueueInstallTrigger
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMBufferQueueRemoveTrigger, OSStatus, (CMBufferQueueRef queue, CMBufferQueueTriggerToken triggerToken), (queue, triggerToken))

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -230,28 +230,6 @@ CMTime VideoMediaSampleRenderer::nextDecodedSampleEndTime() const
     return data.presentationTime;
 }
 
-CMTime VideoMediaSampleRenderer::lastDecodedSampleTime() const
-{
-    return PAL::CMBufferQueueGetMaxPresentationTimeStamp(m_decodedSampleQueue.get());
-}
-
-bool VideoMediaSampleRenderer::hasIncomingOutOfOrderFrame(const CMTime& time) const
-{
-    assertIsCurrent(dispatcher().get());
-
-    size_t forwardIndex = 0;
-    // The maximum queue depth possible for out of order frames with either H264 or HEVC is 16, limit looking ahead of 16 frames.
-    for (auto it = m_compressedSampleQueue.begin(); it != m_compressedSampleQueue.end() && forwardIndex < 16; ++forwardIndex, ++it) {
-        const auto& [sample, flushId] = *it;
-        if (flushId != m_flushId)
-            return false;
-        auto presentationTime = PAL::CMSampleBufferGetPresentationTimeStamp(sample.get());
-        if (PAL::CMTimeCompare(presentationTime, time) < 0)
-            return true;
-    }
-    return false;
-}
-
 void VideoMediaSampleRenderer::enqueueDecodedSample(RetainPtr<CMSampleBufferRef>&& sample)
 {
     ASSERT(sample);
@@ -341,7 +319,7 @@ void VideoMediaSampleRenderer::setTimebase(RetainPtr<CMTimebaseRef>&& timebase)
     auto timerSource = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatchQueue()));
     dispatch_source_set_event_handler(timerSource.get(), [weakThis = ThreadSafeWeakPtr { *this }] {
         if (RefPtr protectedThis = weakThis.get())
-            protectedThis->purgeDecodedSampleQueue(protectedThis->m_flushId);
+            protectedThis->purgeDecodedSampleQueueAndDisplay(protectedThis->m_flushId);
     });
     dispatch_activate(timerSource.get());
     PAL::CMTimebaseAddTimerDispatchSource(timebase.get(), timerSource.get());
@@ -352,7 +330,7 @@ void VideoMediaSampleRenderer::setTimebase(RetainPtr<CMTimebaseRef>&& timebase)
                 if (!timebase)
                     return;
                 if (PAL::CMTimebaseGetRate(timebase.get()))
-                    protectedThis->purgeDecodedSampleQueue(protectedThis->m_flushId);
+                    protectedThis->purgeDecodedSampleQueueAndDisplay(protectedThis->m_flushId);
             }
         });
     }, timebase.get());
@@ -416,11 +394,8 @@ void VideoMediaSampleRenderer::enqueueSample(const MediaSample& sample)
         return;
     }
 
-    bool hasOutOfOrderFrames = m_highestPresentationTime.isValid() && sample.presentationTime() < m_highestPresentationTime;
-    if (!hasOutOfOrderFrames)
-        m_highestPresentationTime = sample.presentationTime();
     ++m_compressedSampleQueueSize;
-    dispatcher()->dispatch([weakThis = ThreadSafeWeakPtr { *this }, sample = RetainPtr { cmSampleBuffer }, flushId = m_flushId.load(), hasOutOfOrderFrames]() mutable {
+    dispatcher()->dispatch([weakThis = ThreadSafeWeakPtr { *this }, sample = RetainPtr { cmSampleBuffer }, flushId = m_flushId.load()]() mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -433,9 +408,13 @@ void VideoMediaSampleRenderer::enqueueSample(const MediaSample& sample)
             return;
         }
         protectedThis->m_compressedSampleQueue.append({ WTFMove(sample), flushId });
-        protectedThis->m_hasOutOfOrderFrames = hasOutOfOrderFrames;
         protectedThis->decodeNextSampleIfNeeded();
     });
+}
+
+size_t VideoMediaSampleRenderer::maximumDecodedSampleCount(const WebCoreDecompressionSession& decompressionSession) const
+{
+    return decompressionSession.isHardwareAccelerated() ? 3 : 10;
 }
 
 void VideoMediaSampleRenderer::decodeNextSampleIfNeeded()
@@ -450,16 +429,9 @@ void VideoMediaSampleRenderer::decodeNextSampleIfNeeded()
     if (m_compressedSampleQueue.isEmpty())
         return;
 
-    if (RetainPtr timebase = this->timebase()) {
-        auto currentTime = PAL::CMTimebaseGetTime(timebase.get());
-        auto aheadTime = PAL::CMTimeAdd(currentTime, PAL::toCMTime(s_decodeAhead));
-        auto endTime = lastDecodedSampleTime();
-        if (CMTIME_IS_VALID(endTime) && PAL::CMTimeCompare(endTime, aheadTime) > 0 && decodedSamplesCount() >= 3) {
-            if (!m_hasOutOfOrderFrames || !hasIncomingOutOfOrderFrame(endTime))
-                return;
-            RELEASE_LOG_DEBUG(Media, "Out of order frames detected, forcing extra decode");
-        }
-    }
+    if (decodedSamplesCount() > maximumDecodedSampleCount(*decompressionSession))
+        return;
+
     auto [sample, flushId] = m_compressedSampleQueue.takeFirst();
     m_compressedSampleQueueSize = m_compressedSampleQueue.size();
     maybeBecomeReadyForMoreMediaData();
@@ -480,8 +452,6 @@ void VideoMediaSampleRenderer::decodeNextSampleIfNeeded()
     auto decodePromise = decompressionSession->decodeSample(sample.get(), displaying);
     m_isDecodingSample = true;
     decodePromise->whenSettled(dispatcher(), [weakThis = ThreadSafeWeakPtr { *this }, this, displaying, flushId = flushId, startTime = MonotonicTime::now()](auto&& result) {
-        assertIsCurrent(dispatcher().get());
-
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -489,7 +459,7 @@ void VideoMediaSampleRenderer::decodeNextSampleIfNeeded()
         if (LOG_CHANNEL(MediaPerformance).level >= WTFLogLevel::Debug) {
             auto now = MonotonicTime::now();
             m_frameRateMonitor.update();
-            RELEASE_LOG_DEBUG(MediaPerformance, "VideoMediaSampleRenderer decoding rate:%0.1fHz rolling:%0.1f decoder rate:%0.1fHz compressed queue:%u decoded queue:%zu bframes:%d", 1.0f / Seconds { now - std::exchange(m_timeSinceLastDecode, now) }.value(), m_frameRateMonitor.observedFrameRate(), 1.0f / Seconds { now - startTime }.value(), m_compressedSampleQueueSize.load(), decodedSamplesCount(), m_hasOutOfOrderFrames);
+            RELEASE_LOG_DEBUG(MediaPerformance, "VideoMediaSampleRenderer decoding rate:%0.1fHz rolling:%0.1f decoder rate:%0.1fHz compressed queue:%u decoded queue:%zu", 1.0f / Seconds { now - std::exchange(m_timeSinceLastDecode, now) }.value(), m_frameRateMonitor.observedFrameRate(), 1.0f / Seconds { now - startTime }.value(), m_compressedSampleQueueSize.load(), decodedSamplesCount());
         }
         assertIsCurrent(dispatcher().get());
 
@@ -600,10 +570,9 @@ void VideoMediaSampleRenderer::decodedFrameAvailable(RetainPtr<CMSampleBufferRef
 
     if (auto timebase = this->timebase()) {
         enqueueDecodedSample(WTFMove(sample));
-        maybeReschedulePurge(flushId);
+        maybeReschedulePurgeAndDisplay(flushId);
     } else
         maybeQueueFrameForDisplay(PAL::kCMTimeInvalid, sample.get(), flushId);
-    [rendererOrDisplayLayer() enqueueSampleBuffer:sample.get()];
 }
 
 VideoMediaSampleRenderer::DecodedFrameResult VideoMediaSampleRenderer::maybeQueueFrameForDisplay(const CMTime& currentTime, CMSampleBufferRef sample, FlushId flushId)
@@ -635,6 +604,7 @@ VideoMediaSampleRenderer::DecodedFrameResult VideoMediaSampleRenderer::maybeQueu
     }
 
     ++m_presentedVideoFrames;
+    [rendererOrDisplayLayer() enqueueSampleBuffer:sample];
     m_isDisplayingSample = true;
     m_forceLateSampleToBeDisplayed = false;
 
@@ -650,7 +620,6 @@ void VideoMediaSampleRenderer::flushCompressedSampleQueue()
     ++m_flushId;
     m_compressedSampleQueueSize = 0;
     m_gotDecodingError = false;
-    m_highestPresentationTime = MediaTime::invalidTime();
 }
 
 void VideoMediaSampleRenderer::flushDecodedSampleQueue()
@@ -663,15 +632,14 @@ void VideoMediaSampleRenderer::flushDecodedSampleQueue()
     m_lastDisplayedSample.reset();
     m_lastDisplayedTime.reset();
     m_isDisplayingSample = false;
-    m_hasOutOfOrderFrames = false;
 }
 
 void VideoMediaSampleRenderer::cancelTimer()
 {
-    schedulePurgeAtTime(PAL::kCMTimeInvalid);
+    schedulePurgeAndDisplayAtTime(PAL::kCMTimeInvalid);
 }
 
-void VideoMediaSampleRenderer::purgeDecodedSampleQueue(FlushId flushId)
+void VideoMediaSampleRenderer::purgeDecodedSampleQueueAndDisplay(FlushId flushId)
 {
     assertIsCurrent(dispatcher().get());
 
@@ -689,13 +657,13 @@ void VideoMediaSampleRenderer::purgeDecodedSampleQueue(FlushId flushId)
     if (timebase) {
         CMTime currentTime = PAL::CMTimebaseGetTime(timebase.get());
 
-        samplesPurged = purgeDecodedSampleQueueUntilTime(currentTime);
+        samplesPurged = purgeDecodedSampleQueue(currentTime);
         if (RetainPtr nextSample = nextDecodedSample()) {
             auto result = maybeQueueFrameForDisplay(currentTime, nextSample.get(), flushId);
+            auto presentationTime = PAL::CMSampleBufferGetOutputPresentationTimeStamp(nextSample.get());
+            auto presentationEndTime = nextDecodedSampleEndTime();
 #if !LOG_DISABLED
             if (LOG_CHANNEL(Media).level >= WTFLogLevel::Debug) {
-                auto presentationTime = PAL::CMSampleBufferGetOutputPresentationTimeStamp(nextSample.get());
-                auto presentationEndTime = nextDecodedSampleEndTime();
                 auto resultLiteral = [](DecodedFrameResult result) {
                     switch (result) {
                     case DecodedFrameResult::TooEarly: return "tooEarly"_s;
@@ -706,9 +674,11 @@ void VideoMediaSampleRenderer::purgeDecodedSampleQueue(FlushId flushId)
                 }(result);
                 LOG(Media, "maybeQueueFrameForDisplay: currentTime:%f start:%f end:%f result:%s", PAL::CMTimeGetSeconds(currentTime), PAL::CMTimeGetSeconds(presentationTime), PAL::CMTimeGetSeconds(presentationEndTime), resultLiteral.characters());
             }
-#else
-            UNUSED_VARIABLE(result);
 #endif
+            if (result == DecodedFrameResult::TooEarly)
+                [rendererOrDisplayLayer() expectMinimumUpcomingSampleBufferPresentationTime:presentationTime];
+            else if (CMTIME_IS_VALID(presentationEndTime))
+                [rendererOrDisplayLayer() expectMinimumUpcomingSampleBufferPresentationTime:presentationEndTime];
         }
     }
     if (samplesPurged) {
@@ -717,7 +687,7 @@ void VideoMediaSampleRenderer::purgeDecodedSampleQueue(FlushId flushId)
     }
 }
 
-bool VideoMediaSampleRenderer::purgeDecodedSampleQueueUntilTime(const CMTime& currentTime)
+bool VideoMediaSampleRenderer::purgeDecodedSampleQueue(const CMTime& currentTime)
 {
     assertIsCurrent(dispatcher().get());
 
@@ -738,7 +708,7 @@ bool VideoMediaSampleRenderer::purgeDecodedSampleQueueUntilTime(const CMTime& cu
 
         if (m_lastDisplayedSample && PAL::CMTimeCompare(*m_lastDisplayedSample, presentationTime) < 0) {
             ++m_droppedVideoFrames; // This frame was never displayed.
-            LOG(Media, "purgeDecodedSampleQueueUntilTime: currentTime:%f start:%f end:%f result:tooLate scheduled:%f (dropped:%u)", PAL::CMTimeGetSeconds(currentTime), PAL::CMTimeGetSeconds(presentationTime), PAL::CMTimeGetSeconds(presentationEndTime), PAL::CMTimeGetSeconds(m_nextScheduledPurge.value_or(PAL::kCMTimePositiveInfinity)), m_droppedVideoFrames.load());
+            LOG(Media, "purgeDecodedSampleQueue: currentTime:%f start:%f end:%f result:tooLate scheduled:%f (dropped:%u)", PAL::CMTimeGetSeconds(currentTime), PAL::CMTimeGetSeconds(presentationTime), PAL::CMTimeGetSeconds(presentationEndTime), PAL::CMTimeGetSeconds(m_nextScheduledPurge.value_or(PAL::kCMTimePositiveInfinity)), m_droppedVideoFrames.load());
         }
 
         RetainPtr sampleToBePurged = adoptCF(PAL::CMBufferQueueDequeueAndRetain(m_decodedSampleQueue.get()));
@@ -749,12 +719,12 @@ bool VideoMediaSampleRenderer::purgeDecodedSampleQueueUntilTime(const CMTime& cu
     if (!CMTIME_IS_VALID(nextPurgeTime))
         return samplesPurged;
 
-    schedulePurgeAtTime(nextPurgeTime);
+    schedulePurgeAndDisplayAtTime(nextPurgeTime);
 
     return samplesPurged;
 }
 
-void VideoMediaSampleRenderer::schedulePurgeAtTime(const CMTime& nextPurgeTime)
+void VideoMediaSampleRenderer::schedulePurgeAndDisplayAtTime(const CMTime& nextPurgeTime)
 {
     auto [timebase, timerSource] = timebaseAndTimerSource();
     if (!timebase)
@@ -768,7 +738,7 @@ void VideoMediaSampleRenderer::schedulePurgeAtTime(const CMTime& nextPurgeTime)
     }
 }
 
-void VideoMediaSampleRenderer::maybeReschedulePurge(FlushId flushId)
+void VideoMediaSampleRenderer::maybeReschedulePurgeAndDisplay(FlushId flushId)
 {
     assertIsCurrent(dispatcher().get());
 
@@ -779,10 +749,10 @@ void VideoMediaSampleRenderer::maybeReschedulePurge(FlushId flushId)
         return;
 
     if ((m_nextScheduledPurge && CMTIME_IS_POSITIVE_INFINITY(*m_nextScheduledPurge)) || CMTIME_IS_POSITIVE_INFINITY(presentationEndTime)) {
-        purgeDecodedSampleQueue(flushId);
+        purgeDecodedSampleQueueAndDisplay(flushId);
         return;
     }
-    schedulePurgeAtTime(presentationEndTime);
+    schedulePurgeAndDisplayAtTime(presentationEndTime);
 }
 
 void VideoMediaSampleRenderer::flush()
@@ -915,7 +885,7 @@ auto VideoMediaSampleRenderer::copyDisplayedPixelBuffer() -> DisplayedPixelBuffe
             return;
 
         m_forceLateSampleToBeDisplayed = true;
-        purgeDecodedSampleQueue(m_flushId);
+        purgeDecodedSampleQueueAndDisplay(m_flushId);
 
         auto nextSample = nextDecodedSample();
         if (!nextSample)


### PR DESCRIPTION
#### 0cda807030ef962455766f8edfee57b4fdaddb5b
<pre>
Unreviewed, reverting 294084@main (40e8bb366e26)
<a href="https://bugs.webkit.org/show_bug.cgi?id=292063">https://bugs.webkit.org/show_bug.cgi?id=292063</a>
<a href="https://rdar.apple.com/150036104">rdar://150036104</a>

REGRESSION(294084@main): ASSERTION FAILED: :VideoMediaSampleRenderer::decodeNextSampleIfNeeded

Reverted change:

    Decoding should continue until we have set time ahead.
    <a href="https://bugs.webkit.org/show_bug.cgi?id=291894">https://bugs.webkit.org/show_bug.cgi?id=291894</a>
    <a href="https://rdar.apple.com/149756577">rdar://149756577</a>
    294084@main (40e8bb366e26)

Canonical link: <a href="https://commits.webkit.org/294109@main">https://commits.webkit.org/294109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d32e44f2b54c5eeceddaadab5f48ee6e88cf04a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10825 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/106011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51463 "Failed to checkout and rebase branch from PR 44519") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102915 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29000 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/106011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/51463 "Failed to checkout and rebase branch from PR 44519") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103881 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/16021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/91115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/106011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/15833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/9129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50840 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/85731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/9198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/108366 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27992 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/108366 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28355 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/87317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/108366 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/30034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/7764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22020 "Failed to checkout and rebase branch from PR 44519") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16403 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27927 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33185 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27738 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31056 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29296 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->