### PR TITLE
[InteractionRegions] Cache the results of createRasterShape to improve performance

### DIFF
--- a/Source/WebCore/page/InteractionRegion.h
+++ b/Source/WebCore/page/InteractionRegion.h
@@ -66,6 +66,8 @@ struct InteractionRegion {
     String text { };
 #endif
 
+    static void clearCache();
+
     WEBCORE_EXPORT ~InteractionRegion();
 };
 

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -73,6 +73,10 @@
 #include <wtf/spi/darwin/OSVariantSPI.h>
 #endif
 
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+#include "InteractionRegion.h"
+#endif
+
 namespace WebCore {
 
 static void releaseNoncriticalMemory(MaintainMemoryCache maintainMemoryCache)
@@ -104,6 +108,9 @@ static void releaseNoncriticalMemory(MaintainMemoryCache maintainMemoryCache)
     HTMLNameCache::clear();
     ImmutableStyleProperties::clearDeduplicationMap();
     SVGPathElement::clearCache();
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    InteractionRegion::clearCache();
+#endif
 }
 
 static void releaseCriticalMemory(Synchronous synchronous, MaintainBackForwardCache maintainBackForwardCache, MaintainMemoryCache maintainMemoryCache)


### PR DESCRIPTION
#### f9cf548a81c4039848780f314705cc5f63898980
<pre>
[InteractionRegions] Cache the results of createRasterShape to improve performance
<a href="https://bugs.webkit.org/show_bug.cgi?id=292066">https://bugs.webkit.org/show_bug.cgi?id=292066</a>
&lt;<a href="https://rdar.apple.com/133094903">rdar://133094903</a>&gt;

Reviewed by Simon Fraser.

Introduce a singleton cache to limit the amount of
`LayoutShape::createRasterShape` calls.

* Source/WebCore/page/InteractionRegion.h:
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::InteractionRegionPathCache::singleton):
(WebCore::InteractionRegionPathCache::get):
(WebCore::InteractionRegionPathCache::add):
(WebCore::InteractionRegionPathCache::clear):
(WebCore::InteractionRegion::clearCache):
Add the new Cache class, backed by a WeakHashMap.
Key the entries on the Image and its FloatSize.
(WebCore::interactionRegionForRenderedRegion):
Check the cache before calling `createRasterShape`.

* Source/WebCore/page/MemoryRelease.cpp:
(WebCore::releaseNoncriticalMemory):
Clear the InteractionRegion cache as part of the non
critical memory release.

Canonical link: <a href="https://commits.webkit.org/294163@main">https://commits.webkit.org/294163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c006ef3d2c3256dc6866d98b0d8113f9942d119c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100995 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106141 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51619 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103036 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29151 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76916 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33946 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16136 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91224 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57264 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15951 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9249 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50969 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85857 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108497 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28123 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20723 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85884 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87424 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85423 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21742 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30139 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7868 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22175 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28053 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33321 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27865 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31185 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29423 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->