### PR TITLE
[WebGPU] remove some unused FIXMEs

### DIFF
--- a/Source/WebGPU/WebGPU/APIConversions.h
+++ b/Source/WebGPU/WebGPU/APIConversions.h
@@ -57,8 +57,6 @@
 
 namespace WebGPU {
 
-// FIXME: It would be cool if we didn't have to list all these overloads, but instead could do something like bridge_cast() in WTF.
-
 inline Adapter& fromAPI(WGPUAdapter adapter)
 {
     return static_cast<Adapter&>(*adapter);

--- a/Source/WebGPU/WebGPU/Adapter.mm
+++ b/Source/WebGPU/WebGPU/Adapter.mm
@@ -72,7 +72,6 @@ bool Adapter::getLimits(WGPUSupportedLimits& limits)
 
 void Adapter::getProperties(WGPUAdapterProperties& properties)
 {
-    // FIXME: What should the vendorID and deviceID be?
     properties.vendorID = 0;
     properties.deviceID = 0;
     properties.name = m_device.name.UTF8String;

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -65,8 +65,6 @@ static bool validateDescriptor(const Device& device, const WGPUBufferDescriptor&
     if (device.isLost())
         return false;
 
-    // FIXME: "If any of the bits of descriptor’s usage aren’t present in this device’s [[allowed buffer usages]] return false."
-
     if ((descriptor.usage & WGPUBufferUsage_MapRead) && (descriptor.usage & WGPUBufferUsage_MapWrite))
         return false;
 
@@ -147,7 +145,6 @@ Ref<Buffer> Device::createBuffer(const WGPUBufferDescriptor& descriptor)
         return Buffer::createInvalid(*this);
     }
 
-    // FIXME(PERFORMANCE): Consider write-combining CPU cache mode.
     // FIXME(PERFORMANCE): Consider implementing hazard tracking ourself.
     MTLStorageMode storageMode = WebGPU::storageMode(hasUnifiedMemory(), descriptor.usage, descriptor.mappedAtCreation);
     auto buffer = safeCreateBuffer(static_cast<NSUInteger>(descriptor.size), storageMode);
@@ -241,10 +238,8 @@ void Buffer::destroy()
 {
     // https://gpuweb.github.io/gpuweb/#dom-gpubuffer-destroy
 
-    if (m_state != State::Unmapped && m_state != State::Destroyed) {
-        // FIXME: ASSERT() that this call doesn't fail.
+    if (m_state != State::Unmapped && m_state != State::Destroyed)
         unmap();
-    }
 
     setState(State::Destroyed);
     for (auto commandEncoder : m_commandEncoders) {

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -2067,8 +2067,6 @@ NSString* CommandEncoder::validateFinishError() const
     if (m_debugGroupStackSize)
         return [NSString stringWithFormat:@"GPUCommandEncoder.finish: encoder stack size '%llu'", m_debugGroupStackSize];
 
-    // FIXME: "Every usage scope contained in this must satisfy the usage scope validation."
-
     return nil;
 }
 

--- a/Source/WebGPU/WebGPU/CommandsMixin.mm
+++ b/Source/WebGPU/WebGPU/CommandsMixin.mm
@@ -41,10 +41,8 @@ bool CommandsMixin::prepareTheEncoderState() const
     case EncoderState::Open:
         return true;
     case EncoderState::Locked:
-        // FIXME: "Make encoder invalid"
         return false;
     case EncoderState::Ended:
-        // FIXME: "Generate a validation error"
         return false;
     }
 }

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -606,7 +606,6 @@ bool Device::popErrorScope(CompletionHandler<void(WGPUErrorType, String&&)>&& ca
     } else
         callback(WGPUErrorType_NoError, { });
 
-    // FIXME: Make sure this is the right thing to return.
     return true;
 }
 

--- a/Source/WebGPU/WebGPU/Instance.mm
+++ b/Source/WebGPU/WebGPU/Instance.mm
@@ -154,8 +154,6 @@ void Instance::requestAdapter(const WGPURequestAdapterOptions& options, Completi
         [devices addObject:device];
 #endif
 
-    // FIXME: Deal with options.compatibleSurface.
-
     auto sortedDevices = WebGPU::sortedDevices(devices, options.powerPreference);
 
     if (options.nextInChain) {
@@ -192,7 +190,6 @@ void Instance::requestAdapter(const WGPURequestAdapterOptions& options, Completi
         return;
     }
 
-    // FIXME: this should be asynchronous
     callback(WGPURequestAdapterStatus_Success, Adapter::create(sortedDevices[0], *this, options.xrCompatible, WTFMove(*deviceCapabilities)), { });
 }
 

--- a/Source/WebGPU/WebGPU/Pipeline.h
+++ b/Source/WebGPU/WebGPU/Pipeline.h
@@ -36,7 +36,7 @@ using BufferBindingSizesForPipeline = HashMap<uint32_t, BufferBindingSizesForBin
 
 struct LibraryCreationResult {
     id<MTLLibrary> library;
-    WGSL::Reflection::EntryPointInformation entryPointInformation; // FIXME(PERFORMANCE): This is big. Don't copy this around.
+    WGSL::Reflection::EntryPointInformation entryPointInformation;
     HashMap<String, WGSL::ConstantValue> wgslConstantValues;
 };
 

--- a/Source/WebGPU/WebGPU/PipelineLayout.mm
+++ b/Source/WebGPU/WebGPU/PipelineLayout.mm
@@ -192,9 +192,7 @@ void PipelineLayout::setLabel(String&&)
 
 bool PipelineLayout::operator==(const PipelineLayout& other) const
 {
-    UNUSED_PARAM(other);
-    // FIXME: Implement this
-    return false;
+    return uniqueId() == other.uniqueId();
 }
 
 BindGroupLayout& PipelineLayout::bindGroupLayout(size_t i) const

--- a/Source/WebGPU/WebGPU/PresentationContext.h
+++ b/Source/WebGPU/WebGPU/PresentationContext.h
@@ -64,7 +64,7 @@ public:
 
     virtual void present(uint32_t);
     virtual Texture* getCurrentTexture(uint32_t);
-    virtual TextureView* getCurrentTextureView(); // FIXME: This should return a TextureView&.
+    virtual TextureView* getCurrentTextureView();
 
     virtual bool isPresentationContextIOSurface() const { return false; }
     virtual bool isPresentationContextCoreAnimation() const { return false; }

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -230,11 +230,6 @@ NSString* Queue::errorValidatingSubmit(const Vector<Ref<WebGPU::CommandBuffer>>&
             return command->lastError() ?: @"Validation failure.";
     }
 
-    // FIXME: "Every GPUQuerySet referenced in a command in any element of commandBuffers is in the available state."
-    // FIXME: "For occlusion queries, occlusionQuerySet in beginRenderPass() does not constitute a reference, while beginOcclusionQuery() does."
-
-    // There's only one queue right now, so there is no need to make sure that the command buffers are being submitted to the correct queue.
-
     return nil;
 }
 
@@ -1093,8 +1088,6 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint
     }
 
     ensureBlitCommandEncoder();
-    // FIXME(PERFORMANCE): Suballocate, so the common case doesn't need to hit the kernel.
-    // FIXME(PERFORMANCE): Should this temporary buffer really be shared?
     NSUInteger newBufferSize = dataByteSize - dataLayoutOffset;
     bool noCopy = newBufferSize >= largeBufferSize;
     auto temporaryBufferWithOffset = newTemporaryBufferWithBytes(data.subspan(dataLayoutOffset), noCopy);

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -194,9 +194,6 @@ static std::optional<MTLIndexType> indexType(WGPUIndexFormat format)
 
 bool Device::validateRenderPipeline(const WGPURenderPipelineDescriptor& descriptor)
 {
-    // FIXME: Implement this according to the description in
-    // https://gpuweb.github.io/gpuweb/#abstract-opdef-validating-gpurenderpipelinedescriptor
-
     if (descriptor.fragment) {
         const auto& fragmentDescriptor = *descriptor.fragment;
 

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -2565,11 +2565,9 @@ std::optional<MTLPixelFormat> Texture::stencilOnlyAspectMetalFormat(WGPUTextureF
     }
 }
 
-static MTLStorageMode storageMode(bool deviceHasUnifiedMemory, bool supportsNonPrivateDepthStencilTextures)
+static MTLStorageMode storageMode(bool deviceHasUnifiedMemory, bool supportsNonPrivateDepthStencilTextures, bool isDepthOrStencil)
 {
-
-    // FIXME: only perform this check if the texture is a depth/stencil texture.
-    if (!supportsNonPrivateDepthStencilTextures)
+    if (isDepthOrStencil && !supportsNonPrivateDepthStencilTextures)
         return MTLStorageModePrivate;
 
     if (deviceHasUnifiedMemory)
@@ -2650,11 +2648,9 @@ Ref<Texture> Device::createTexture(const WGPUTextureDescriptor& descriptor)
 
     textureDescriptor.sampleCount = descriptor.sampleCount;
 
-    textureDescriptor.storageMode = storageMode(hasUnifiedMemory(), baseCapabilities().supportsNonPrivateDepthStencilTextures);
+    textureDescriptor.storageMode = storageMode(hasUnifiedMemory(), baseCapabilities().supportsNonPrivateDepthStencilTextures, Texture::isDepthOrStencilFormat(descriptor.format));
 
-    // FIXME(PERFORMANCE): Consider write-combining CPU cache mode.
     // FIXME(PERFORMANCE): Consider implementing hazard tracking ourself.
-
     id<MTLTexture> texture = [m_device newTextureWithDescriptor:textureDescriptor];
 
     if (!texture) {

--- a/Source/WebGPU/WebGPU/WebGPUExt.h
+++ b/Source/WebGPU/WebGPU/WebGPUExt.h
@@ -115,7 +115,6 @@ typedef void (*WGPUProcRenderBundleSetLabel)(WGPURenderBundle renderBundle, char
 
 typedef WGPUExternalTexture (*WGPUProcDeviceImportExternalTexture)(WGPUSwapChain swapChain);
 
-// FIXME: https://github.com/webgpu-native/webgpu-headers/issues/89 is about moving this from WebGPUExt.h to WebGPU.h
 typedef WGPUTexture (*WGPUProcSwapChainGetCurrentTexture)(WGPUSwapChain swapChain);
 
 #endif  // !defined(WGPU_SKIP_PROCS)
@@ -124,7 +123,6 @@ typedef WGPUTexture (*WGPUProcSwapChainGetCurrentTexture)(WGPUSwapChain swapChai
 
 WGPU_EXPORT void wgpuRenderBundleSetLabel(WGPURenderBundle renderBundle, char const * label);
 
-// FIXME: https://github.com/webgpu-native/webgpu-headers/issues/89 is about moving this from WebGPUExt.h to WebGPU.h
 WGPU_EXPORT WGPUTexture wgpuSwapChainGetCurrentTexture(WGPUSwapChain swapChain, uint32_t frameIndex);
 
 WGPU_EXPORT WGPUExternalTexture wgpuDeviceImportExternalTexture(WGPUDevice device, const WGPUExternalTextureDescriptor* descriptor);


### PR DESCRIPTION
#### 21eafebe3f0e60e4727434cca306e16edab44f54
<pre>
[WebGPU] remove some unused FIXMEs
<a href="https://bugs.webkit.org/show_bug.cgi?id=292071">https://bugs.webkit.org/show_bug.cgi?id=292071</a>
<a href="https://rdar.apple.com/150049205">rdar://150049205</a>

Reviewed by NOBODY (OOPS!).

Remove some outdated FIXMEs.

* Source/WebGPU/WebGPU/APIConversions.h:
* Source/WebGPU/WebGPU/Adapter.mm:
(WebGPU::Adapter::getProperties):
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::validateDescriptor):
(WebGPU::Device::createBuffer):
(WebGPU::Buffer::destroy):
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::validateFinishError const):
* Source/WebGPU/WebGPU/CommandsMixin.mm:
(WebGPU::CommandsMixin::prepareTheEncoderState const):
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::popErrorScope):
* Source/WebGPU/WebGPU/Instance.mm:
(WebGPU::Instance::requestAdapter):
* Source/WebGPU/WebGPU/Pipeline.h:
* Source/WebGPU/WebGPU/PipelineLayout.h:
* Source/WebGPU/WebGPU/PipelineLayout.mm:
(WebGPU::PipelineLayout::operator== const): Deleted.
* Source/WebGPU/WebGPU/PresentationContext.h:
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::errorValidatingSubmit const):
(WebGPU::Queue::writeTexture):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::validateRenderPipeline):
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::storageMode):
(WebGPU::Device::createTexture):
* Source/WebGPU/WebGPU/WebGPUExt.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21eafebe3f0e60e4727434cca306e16edab44f54

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106326 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51805 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29334 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77066 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34094 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104185 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91394 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57413 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16121 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51153 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86016 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9477 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108682 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28306 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20843 "Found 4 new test failures: http/tests/download/anchor-download-redirect-cross-origin.html http/tests/iframe-monitor/workers/service-worker.html http/tests/security/contentSecurityPolicy/extensions/manifest-v3/script-src/manifest-v3-script-src-block-non-https-scheme.html imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-default-writing-mode-rl.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86039 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28668 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85582 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30307 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8027 "Found 1 new test failure: http/tests/webgpu/webgpu/api/validation/queue/destroyed/texture.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22405 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28236 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33507 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28048 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31368 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29606 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->