### PR TITLE
[Screen Time Refactoring] Apps glitch due to ScreenTimeWebExtension

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -416,7 +416,7 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
     if (!PAL::isScreenTimeFrameworkAvailable())
         return;
 
-    if (_page && !_page->preferences().screenTimeEnabled())
+    if (!_page->preferences().screenTimeEnabled() || !_page->mainFrame()->url().protocolIsInHTTPFamily())
         return;
 
     _screenTimeWebpageController = adoptNS([PAL::allocSTWebpageControllerInstance() init]);
@@ -436,6 +436,7 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
         [screenTimeView setFrame:self.bounds];
         [self addSubview:screenTimeView.get()];
     }
+
     RELEASE_LOG(ScreenTime, "Screen Time controller was installed.");
 }
 
@@ -477,6 +478,7 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
         [self _installScreenTimeWebpageControllerIfNeeded];
         if (!previouslyInstalledScreenTimeWebpageController && _screenTimeWebpageController)
             [_screenTimeWebpageController setURL:[self _mainFrameURL]];
+
         if (!showsSystemScreenTimeBlockingView && _screenTimeBlurredSnapshot) {
             [_screenTimeBlurredSnapshot setHidden:NO];
             RELEASE_LOG(ScreenTime, "Screen Time has updated to use the blurred view for any blocked URL.");


### PR DESCRIPTION
#### 2302a8a6064a27a03cb9921a2131780768dab35f
<pre>
[Screen Time Refactoring] Apps glitch due to ScreenTimeWebExtension
<a href="https://bugs.webkit.org/show_bug.cgi?id=292019">https://bugs.webkit.org/show_bug.cgi?id=292019</a>
<a href="https://rdar.apple.com/149961063">rdar://149961063</a>

Reviewed by Aditya Keerthi.

Currently, we call STWebpageController&apos;s loadView and
add the subview to the WKWebView regardless of the type of URL.
Some apps may be using a WKWebView for purposes other than
displaying web content. In those cases, Screen Time
functionality is not used and we shouldn&apos;t
call STWebpageController&apos;s loadView, add the subview or
install the controller in general since it is not
needed unless we are actually loading an http/https URL.

Add an API test to ensure we only install the STWebpageController
for http/https URLs. Additionally, alter some other API tests
to request valid http/https URLs due to this change.

Rename API test URLIsPictureInPictureMacos to
URLIsPictureInPicture.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _installScreenTimeWebpageControllerIfNeeded]):
(-[WKWebView _updateScreenTimeBasedOnWindowVisibility]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm:
(testSuppressUsageRecordingWithDataStore):
(testShowsSystemScreenTimeBlockingView):
(testWebContentIsNotClickableShowingSystemScreenTimeBlockingView):
(TEST(ScreenTime, IsBlockedByScreenTimeTrue)):
(TEST(ScreenTime, IsBlockedByScreenTimeFalse)):
(TEST(ScreenTime, IsBlockedByScreenTimeMultiple)):
(TEST(ScreenTime, IsBlockedByScreenTimeKVO)):
(TEST(ScreenTime, IdentifierNil)):
(TEST(ScreenTime, IdentifierString)):
(TEST(ScreenTime, URLIsPlayingVideo)):
(TEST(ScreenTime, URLIsPictureInPicture)):
(TEST(ScreenTime, RemoveDataWithTimeInterval)):
(TEST(ScreenTime, OffscreenSystemScreenTimeBlockingView)):
(TEST(ScreenTime, OffscreenBlurredScreenTimeBlockingView)):
(TEST(ScreenTime, DoNotDonateURLsInOccludedWebView)):
(TEST(ScreenTime, CreateControllerAfterOffscreenWebViewBecomesInWindow)):
(TEST(ScreenTime, ScreenTimeControllerSetsURLWhenOffscreenWebViewBecomesInWindow)):
(TEST(ScreenTime, ScreenTimeControllerInstalledAfterRestoreFromSessionState)):
(TEST(ScreenTime, ScreenTimeControllerViewOnlyInstalledForHTTPFamily)):
(TEST(ScreenTime, URLIsPictureInPictureMacos)): Deleted.

Canonical link: <a href="https://commits.webkit.org/294226@main">https://commits.webkit.org/294226@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b17627d1d034b547176dc6ac356e31f0efc97c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101215 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/20877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/11180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/106363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/51842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103256 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21186 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29371 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/106363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/51842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104222 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/16332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/11180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/106363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/16148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/11180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/51190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/86035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/11180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108719 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/28343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/28705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/11180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/85612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/11180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/22442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16457 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/28273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/33544 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28085 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/31405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/29643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->