### PR TITLE
Remove use of `webkitConvertPointFromNodeToPage` from `GradientSlider.js`

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/GradientSlider.js
+++ b/Source/WebInspectorUI/UserInterface/Views/GradientSlider.js
@@ -391,9 +391,9 @@ WI.GradientSliderKnob = class GradientSliderKnob extends WI.Object
         if (!this._detaching && Math.abs(event.pageY - this._startMouseY) > 50) {
             this._detaching = this.delegate && typeof this.delegate.knobCanDetach === "function" && this.delegate.knobCanDetach(this);
             if (this._detaching && this.delegate && typeof this.delegate.knobWillDetach === "function") {
-                var translationFromParentToBody = window.webkitConvertPointFromNodeToPage(this.element.parentNode, new WebKitPoint(0, 0));
-                this._startMouseX -= translationFromParentToBody.x;
-                this._startMouseY -= translationFromParentToBody.y;
+                let parentRect = this.element.parentNode.getBoundingClientRect();
+                this._startMouseX -= parentRect.left;
+                this._startMouseY -= parentRect.top;
                 document.body.appendChild(this.element);
                 this.delegate.knobWillDetach(this);
             }


### PR DESCRIPTION
#### b26bed85494f15c23aba6d8edc8619bcbd8129d8
<pre>
Remove use of `webkitConvertPointFromNodeToPage` from `GradientSlider.js`
<a href="https://bugs.webkit.org/show_bug.cgi?id=273934">https://bugs.webkit.org/show_bug.cgi?id=273934</a>

<a href="https://rdar.apple.com/128188982">rdar://128188982</a>

Reviewed by Devin Rousso.

This patch remove usage of non-standard &apos;webkitConvertPointFromNodeToPage&apos;
and replace it with &apos;getBoundingClientRect&apos; and left/top.

I tested this manually and ensured that the &apos;slider&apos; knobs pre and post-patch
works same for linear/radial/conic gradients with multiple color stops.

* Source/WebInspectorUI/UserInterface/Views/GradientSlider.js:
(WI.GradientSliderKnob.prototype._handleMousemove):

Canonical link: <a href="https://commits.webkit.org/294187@main">https://commits.webkit.org/294187@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51a8d14389f20be9b578df63fe070435fd8563c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20684 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106168 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51648 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29178 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76937 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33969 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57285 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15973 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9274 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50996 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85879 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9332 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108524 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28150 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20717 "Found 1 new test failure: http/tests/iframe-monitor/iframe-unload.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85911 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28512 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85444 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21758 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30164 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7893 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22209 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28080 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33348 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27892 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31212 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29450 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->