### PR TITLE
[ResourceMonitor] Persistence of throttler is not working.

### DIFF
--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -172,7 +172,7 @@ WTF_EXPORT_PRIVATE String createTemporaryDirectory();
 #endif
 
 #if PLATFORM(COCOA)
-WTF_EXPORT_PRIVATE NSString *createTemporaryDirectory(NSString *directoryPrefix);
+WTF_EXPORT_PRIVATE NSString *createTemporaryDirectory(NSString *directoryPrefix = nil);
 WTF_EXPORT_PRIVATE NSString *systemDirectoryPath();
 
 // Allow reading cloud files with no local copy.

--- a/Source/WebCore/loader/ResourceMonitorPersistence.h
+++ b/Source/WebCore/loader/ResourceMonitorPersistence.h
@@ -44,7 +44,7 @@ public:
     WEBCORE_EXPORT ResourceMonitorPersistence();
     WEBCORE_EXPORT ~ResourceMonitorPersistence();
 
-    bool openDatabase(String&& path);
+    bool openDatabase(String&& directoryPath);
     bool isDatabaseOpen() const { return m_sqliteDB && m_sqliteDB->isOpen(); }
 
     void deleteAllRecords();

--- a/Source/WebCore/loader/ResourceMonitorThrottler.cpp
+++ b/Source/WebCore/loader/ResourceMonitorThrottler.cpp
@@ -38,7 +38,7 @@
 
 namespace WebCore {
 
-ResourceMonitorThrottler::ResourceMonitorThrottler(String&& path, size_t count, Seconds duration, size_t maxHosts)
+ResourceMonitorThrottler::ResourceMonitorThrottler(String&& directoryPath, size_t count, Seconds duration, size_t maxHosts)
     : m_config { count, duration, maxHosts }
 {
     ASSERT(!isMainThread());
@@ -49,7 +49,7 @@ ResourceMonitorThrottler::ResourceMonitorThrottler(String&& path, size_t count, 
     RESOURCEMONITOR_RELEASE_LOG("Opening persistence for throttler.");
     auto persistence = makeUnique<ResourceMonitorPersistence>();
 
-    if (!persistence->openDatabase(WTFMove(path))) {
+    if (!persistence->openDatabase(WTFMove(directoryPath))) {
         RESOURCEMONITOR_RELEASE_LOG("Failed to setup persistence for throttler.");
         return;
     }

--- a/Source/WebCore/loader/ResourceMonitorThrottler.h
+++ b/Source/WebCore/loader/ResourceMonitorThrottler.h
@@ -39,7 +39,7 @@ class ResourceMonitorPersistence;
 class ResourceMonitorThrottler final {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    ResourceMonitorThrottler(String&& databasePath, size_t count, Seconds duration, size_t maxHosts);
+    ResourceMonitorThrottler(String&& databaseDirectoryPath, size_t count, Seconds duration, size_t maxHosts);
     ~ResourceMonitorThrottler();
 
     void openDatabase(String&& path);

--- a/Source/WebCore/loader/ResourceMonitorThrottlerHolder.cpp
+++ b/Source/WebCore/loader/ResourceMonitorThrottlerHolder.cpp
@@ -55,24 +55,24 @@ Ref<ResourceMonitorThrottlerHolder> ResourceMonitorThrottlerHolder::create()
 
 Ref<ResourceMonitorThrottlerHolder> ResourceMonitorThrottlerHolder::create(size_t count, Seconds duration, size_t maxHosts)
 {
-    return create(SQLiteDatabase::inMemoryPath(), count, duration, maxHosts);
+    return create(emptyString(), count, duration, maxHosts);
 }
 
-Ref<ResourceMonitorThrottlerHolder> ResourceMonitorThrottlerHolder::create(const String& databasePath)
+Ref<ResourceMonitorThrottlerHolder> ResourceMonitorThrottlerHolder::create(const String& databaseDirectoryPath)
 {
-    return create(databasePath, ResourceMonitorThrottler::defaultThrottleAccessCount, ResourceMonitorThrottler::defaultThrottleDuration, ResourceMonitorThrottler::defaultMaxHosts);
+    return create(databaseDirectoryPath, ResourceMonitorThrottler::defaultThrottleAccessCount, ResourceMonitorThrottler::defaultThrottleDuration, ResourceMonitorThrottler::defaultMaxHosts);
 }
 
-Ref<ResourceMonitorThrottlerHolder> ResourceMonitorThrottlerHolder::create(const String& databasePath, size_t count, Seconds duration, size_t maxHosts)
+Ref<ResourceMonitorThrottlerHolder> ResourceMonitorThrottlerHolder::create(const String& databaseDirectoryPath, size_t count, Seconds duration, size_t maxHosts)
 {
-    return adoptRef(*new ResourceMonitorThrottlerHolder(databasePath, count, duration, maxHosts));
+    return adoptRef(*new ResourceMonitorThrottlerHolder(databaseDirectoryPath, count, duration, maxHosts));
 }
 
-ResourceMonitorThrottlerHolder::ResourceMonitorThrottlerHolder(const String& databasePath, size_t count, Seconds duration, size_t maxHosts)
+ResourceMonitorThrottlerHolder::ResourceMonitorThrottlerHolder(const String& databaseDirectoryPath, size_t count, Seconds duration, size_t maxHosts)
 {
     ASSERT(isMainThread());
 
-    sharedWorkQueueSingleton()->dispatch([weakThis = ThreadSafeWeakPtr { *this }, path = crossThreadCopy(databasePath), count, duration, maxHosts] mutable {
+    sharedWorkQueueSingleton()->dispatch([weakThis = ThreadSafeWeakPtr { *this }, path = crossThreadCopy(databaseDirectoryPath), count, duration, maxHosts] mutable {
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->m_throttler = makeUnique<ResourceMonitorThrottler>(WTFMove(path), count, duration, maxHosts);
     });

--- a/Source/WebCore/loader/ResourceMonitorThrottlerHolder.h
+++ b/Source/WebCore/loader/ResourceMonitorThrottlerHolder.h
@@ -39,8 +39,8 @@ class ResourceMonitorThrottlerHolder final : public ThreadSafeRefCountedAndCanMa
 public:
     WEBCORE_EXPORT static Ref<ResourceMonitorThrottlerHolder> create();
     WEBCORE_EXPORT static Ref<ResourceMonitorThrottlerHolder> create(size_t count, Seconds duration, size_t maxHosts);
-    WEBCORE_EXPORT static Ref<ResourceMonitorThrottlerHolder> create(const String& databasePath);
-    WEBCORE_EXPORT static Ref<ResourceMonitorThrottlerHolder> create(const String& databasePath, size_t count, Seconds duration, size_t maxHosts);
+    WEBCORE_EXPORT static Ref<ResourceMonitorThrottlerHolder> create(const String& databaseDirectoryPath);
+    WEBCORE_EXPORT static Ref<ResourceMonitorThrottlerHolder> create(const String& databaseDirectoryPath, size_t count, Seconds duration, size_t maxHosts);
 
     WEBCORE_EXPORT ~ResourceMonitorThrottlerHolder();
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2109,9 +2109,9 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
     createHandleFromResolvedPathIfPossible(hstsStorageDirectory, hstsStorageDirectoryExtensionHandle);
 
 #if ENABLE(CONTENT_EXTENSIONS)
-    auto resourceMonitorThrottlerDirectory = isPersistent() ? directories.resourceMonitorThrottlerDirectory : WebCore::SQLiteDatabase::inMemoryPath();
+    auto resourceMonitorThrottlerDirectory = isPersistent() ? directories.resourceMonitorThrottlerDirectory : emptyString();
     SandboxExtension::Handle resourceMonitorThrottlerDirectoryExtensionHandle;
-    if (isPersistent())
+    if (!resourceMonitorThrottlerDirectory.isEmpty())
         createHandleFromResolvedPathIfPossible(resourceMonitorThrottlerDirectory, resourceMonitorThrottlerDirectoryExtensionHandle);
 #endif
 
@@ -2210,6 +2210,10 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
 #if HAVE(NW_PROXY_CONFIG)
     networkSessionParameters.proxyConfigData = m_proxyConfigData;
 #endif
+#if ENABLE(CONTENT_EXTENSIONS)
+    networkSessionParameters.resourceMonitorThrottlerDirectory = WTFMove(resourceMonitorThrottlerDirectory);
+    networkSessionParameters.resourceMonitorThrottlerDirectoryExtensionHandle = WTFMove(resourceMonitorThrottlerDirectoryExtensionHandle);
+#endif
     networkSessionParameters.isLegacyTLSAllowed = m_configuration->legacyTLSEnabled();
 
     parameters.networkSessionParameters = WTFMove(networkSessionParameters);
@@ -2217,11 +2221,6 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
     platformSetNetworkParameters(parameters);
 #if PLATFORM(COCOA)
     parameters.networkSessionParameters.useNetworkLoader = useNetworkLoader();
-#endif
-
-#if ENABLE(CONTENT_EXTENSIONS)
-    networkSessionParameters.resourceMonitorThrottlerDirectory = WTFMove(resourceMonitorThrottlerDirectory);
-    networkSessionParameters.resourceMonitorThrottlerDirectoryExtensionHandle = WTFMove(resourceMonitorThrottlerDirectoryExtensionHandle);
 #endif
 
 #if PLATFORM(IOS_FAMILY)

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -224,7 +224,6 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/PublicSuffix.cpp
         Tests/WebCore/RegionTests.cpp
         Tests/WebCore/RenderStyleChange.cpp
-        Tests/WebCore/ResourceMonitor.cpp
         Tests/WebCore/SecurityOrigin.cpp
         Tests/WebCore/SharedBuffer.cpp
         Tests/WebCore/SharedBufferTest.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1299,7 +1299,7 @@
 		E5AA42F2259128AE00410A3D /* UserInterfaceIdiomUpdate.mm in Sources */ = {isa = PBXBuildFile; fileRef = E5AA42F1259128AE00410A3D /* UserInterfaceIdiomUpdate.mm */; };
 		E5AA8D1D25151CC60051CC45 /* DateInputTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E5AA8D1C25151CC60051CC45 /* DateInputTests.mm */; };
 		E720BDD72D08B42A0093E680 /* web-extension-with-parent-directory.zip in Copy Resources */ = {isa = PBXBuildFile; fileRef = E720BDD62D08B42A0093E680 /* web-extension-with-parent-directory.zip */; };
-		EB1F62972D19E07E000B3A04 /* ResourceMonitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB1F62962D19E07E000B3A04 /* ResourceMonitor.cpp */; };
+		EB1F62972D19E07E000B3A04 /* ResourceMonitor.mm in Sources */ = {isa = PBXBuildFile; fileRef = EB1F62962D19E07E000B3A04 /* ResourceMonitor.mm */; };
 		EB7067FC2CCC0E9900A94073 /* MixedContentChecker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB6836D32CC967E00073A8E5 /* MixedContentChecker.cpp */; };
 		EB9AD8C727646E7400D893A4 /* PushDatabase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB9AD8C627646E7300D893A4 /* PushDatabase.cpp */; };
 		EBA75C49275ED7C700D6D31C /* PushMessageCrypto.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EBA75C48275ED7BE00D6D31C /* PushMessageCrypto.cpp */; };
@@ -3777,7 +3777,7 @@
 		E5F67D662B637F9200CC30DE /* AdaptiveImageGlyph.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AdaptiveImageGlyph.mm; sourceTree = "<group>"; };
 		E720BDD62D08B42A0093E680 /* web-extension-with-parent-directory.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = "web-extension-with-parent-directory.zip"; sourceTree = "<group>"; };
 		EB0E04122B7C228D00EFFB94 /* ProcessInfo.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ProcessInfo.mm; sourceTree = "<group>"; };
-		EB1F62962D19E07E000B3A04 /* ResourceMonitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ResourceMonitor.cpp; sourceTree = "<group>"; };
+		EB1F62962D19E07E000B3A04 /* ResourceMonitor.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ResourceMonitor.mm; sourceTree = "<group>"; };
 		EB230D3D245E722E00C66AD1 /* IDBCheckpointWAL.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = IDBCheckpointWAL.html; sourceTree = "<group>"; };
 		EB230D3E245E726300C66AD1 /* IDBCheckpointWAL.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = IDBCheckpointWAL.mm; sourceTree = "<group>"; };
 		EB4D320727C045430081A8E4 /* TestNotificationProvider.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TestNotificationProvider.cpp; sourceTree = "<group>"; };
@@ -4889,7 +4889,6 @@
 				7B0594782CB44CF600B571AC /* RegionTests.cpp */,
 				6B4E861B2220A5520022F389 /* RegistrableDomain.cpp */,
 				D84FAD9829FAC1D0008D338F /* RenderStyleChange.cpp */,
-				EB1F62962D19E07E000B3A04 /* ResourceMonitor.cpp */,
 				F418BE141F71B7DC001970E6 /* RoundedRectTests.cpp */,
 				4181C62C255A891100AEB0FF /* RTCRtpSFrameTransformerTests.cpp */,
 				CDCFA7A91E45122F00C2433D /* SampleMap.cpp */,
@@ -6344,6 +6343,7 @@
 				41EBA9F128ABA06500953013 /* ImageRotationSessionVT.cpp */,
 				7BB62AB629BB4BAA00228CD6 /* IOSurfaceTests.mm */,
 				57F1C91025DDD51900E8F6EA /* PrivateClickMeasurementCocoa.mm */,
+				EB1F62962D19E07E000B3A04 /* ResourceMonitor.mm */,
 				1AF86FBF2CD5526B00AD337C /* ScrollbarWidthCrash.mm */,
 				5769C50A1D9B0001000847FB /* SerializedCryptoKeyWrap.mm */,
 				A17991861E1C994E00A505ED /* SharedBuffer.mm */,
@@ -7401,7 +7401,7 @@
 				D84FAD9A29FAC1D0008D338F /* RenderStyleChange.cpp in Sources */,
 				7CCE7F0E1A411AE600447C4C /* ResizeReversePaginatedWebView.cpp in Sources */,
 				7CCE7F0F1A411AE600447C4C /* ResizeWindowAfterCrash.cpp in Sources */,
-				EB1F62972D19E07E000B3A04 /* ResourceMonitor.cpp in Sources */,
+				EB1F62972D19E07E000B3A04 /* ResourceMonitor.mm in Sources */,
 				512C4C9E20EAA40D004945EA /* ResponsivenessTimerCrash.mm in Sources */,
 				83B6DE6F1EE75221001E792F /* RestoreSessionState.cpp in Sources */,
 				7CCE7F111A411AE600447C4C /* RestoreSessionStateContainingFormData.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/ResourceMonitor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/ResourceMonitor.mm
@@ -47,7 +47,7 @@ public:
 protected:
     ContinuousApproximateTime m_reference;
     RefPtr<ResourceMonitorThrottlerHolder> m_throttler;
-    String m_temporayDatabasePath;
+    String m_persistenceDirectory;
 
     void prepareThrottler(size_t count, Seconds duration, size_t maxHosts, bool withPersistence = false)
     {
@@ -104,11 +104,9 @@ protected:
 
     String& temporaryDatabasePath()
     {
-        if (m_temporayDatabasePath.isEmpty()) {
-            m_temporayDatabasePath = FileSystem::createTemporaryFile("tempDatabaseForResourceMonitorThrottler"_s);
-            FileSystem::deleteFile(m_temporayDatabasePath);
-        }
-        return m_temporayDatabasePath;
+        if (m_persistenceDirectory.isEmpty())
+            m_persistenceDirectory = FileSystem::createTemporaryDirectory(@"ResourceMonitor");
+        return m_persistenceDirectory;
     }
 };
 


### PR DESCRIPTION
#### 703ba3888bfa295209700d2116d6601bab813685
<pre>
[ResourceMonitor] Persistence of throttler is not working.
<a href="https://bugs.webkit.org/show_bug.cgi?id=291911">https://bugs.webkit.org/show_bug.cgi?id=291911</a>
<a href="https://rdar.apple.com/148348437">rdar://148348437</a>

Reviewed by Ben Nham.

There&apos;re two issues. Passing path to throttler was directory path. SQLite database file name is
required. Added. Also the timing to set networkSessionParameters is too late. The parameter is
already stored in WebsiteDataStoreParameters. Fixed.

* Source/WTF/wtf/FileSystem.h:
* Source/WebCore/loader/ResourceMonitorPersistence.cpp
(WebCore::databasePath):
(WebCore::ResourceMonitorPersistence::openDatabase):
* Source/WebCore/loader/ResourceMonitorPersistence.h:
* Source/WebCore/loader/ResourceMonitorThrottler.cpp:
(WebCore::ResourceMonitorThrottler::ResourceMonitorThrottler):
Source/WebCore/loader/ResourceMonitorThrottler.h:
* Source/WebCore/loader/ResourceMonitorThrottlerHolder.cpp:
(WebCore::ResourceMonitorThrottlerHolder::create):
(WebCore::ResourceMonitorThrottlerHolder::ResourceMonitorThrottlerHolder):
* Source/WebCore/loader/ResourceMonitorThrottlerHolder.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::parameters):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/ResourceMonitor.mm: Renamed from Tools/TestWebKitAPI/Tests/WebCore/ResourceMonitor.cpp.
(TestWebKitAPI::ResourceMonitorTest::temporaryDatabasePath):

Canonical link: <a href="https://commits.webkit.org/294151@main">https://commits.webkit.org/294151@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/562ffebe7f78226a61100d9ef32ef4ec07de8b08

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100968 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106114 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51591 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29124 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76892 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33922 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103975 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16110 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91199 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57240 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15925 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9221 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50942 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/93635 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85831 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9282 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108470 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/99577 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28096 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20664 "Found 1 new test failure: http/tests/iframe-monitor/workers/shared-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85858 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28458 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85400 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21734 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30116 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7843 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22139 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28026 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33294 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/123202 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27838 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34323 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31158 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29396 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->