### PR TITLE
REGRESSION (294089@main): Extensions embedded in TestWebKitAPI.app are re-signed with the app's entitlements

### DIFF
--- a/Tools/TestRunnerShared/Scripts/install-extensions-rule.sh
+++ b/Tools/TestRunnerShared/Scripts/install-extensions-rule.sh
@@ -1,5 +1,24 @@
 set -e
 
+# Removes the `--entitlements path` argument pair from $OTHER_CODE_SIGN_FLAGS to avoid signing the
+# extension with entitlements meant for the embedding app.
+function filtered_other_code_sign_flags()
+{
+    while [[ $# -gt 0 ]]
+    do
+        case $1 in
+        --entitlements)
+            shift
+            shift
+            ;;
+        *)
+            echo "$1"
+            shift
+            ;;
+        esac
+    done
+}
+
 DESTINATION_PATH=${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/Extensions/${INPUT_FILE_NAME}
 
 mkdir -p "${DESTINATION_PATH}"
@@ -23,5 +42,5 @@ if [[ -n "${EXTENSION_POINT_ID}" ]]; then
 fi
 
 if [ -n "${CODE_SIGN_IDENTITY}" ]; then
-    xcrun codesign --force --preserve-metadata=entitlements --sign "${CODE_SIGN_IDENTITY}" ${OTHER_CODE_SIGN_FLAGS} "${DESTINATION_PATH}"
+    xcrun codesign --force --preserve-metadata=entitlements --sign "${CODE_SIGN_IDENTITY}" $(filtered_other_code_sign_flags ${OTHER_CODE_SIGN_FLAGS}) "${DESTINATION_PATH}"
 fi


### PR DESCRIPTION
#### 6f58d009e2987a6d2a76b514a7a4715259b0edf4
<pre>
REGRESSION (294089@main): Extensions embedded in TestWebKitAPI.app are re-signed with the app&apos;s entitlements
<a href="https://bugs.webkit.org/show_bug.cgi?id=292084">https://bugs.webkit.org/show_bug.cgi?id=292084</a>

Reviewed by Elliott Williams.

In 294089@main we introduced a script to generate entitlements for TestWebKitAPI.app, using
OTHER_CODE_SIGN_FLAGS to specify the generated entitlements file to the build system&apos;s codesign
invocation. Since install-extensions-rule.sh also passes $OTHER_CODE_SIGN_FLAGS to its invocation
of codesign, this had the undesired side effect of replacing embedded app extensions&apos; entitlements
with the app&apos;s entitlements.

Resolved this by teaching install-extensions-rule.sh to remove a `--entitlements path` argument
pair from $OTHER_CODE_SIGN_FLAGS before passing it to codesign. The existing codesign invocation
specifies --preserve-metadata=entitlements, which ensures the app extensions&apos; entitlements are
retained.

* Tools/TestRunnerShared/Scripts/install-extensions-rule.sh:

Canonical link: <a href="https://commits.webkit.org/294154@main">https://commits.webkit.org/294154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da1ff3351f978a639a7dd31020c7214f08c8da57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106095 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51548 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20919 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29105 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76874 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33907 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16090 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91180 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57222 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15905 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9202 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50923 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85811 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9263 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108451 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28077 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20644 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85838 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28439 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87380 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85380 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21737 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30097 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7824 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22110 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28007 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27819 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31139 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29377 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->