### PR TITLE
Decoding should continue until we have set time ahead.

### DIFF
--- a/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.cpp
+++ b/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.cpp
@@ -174,6 +174,8 @@ SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMBufferQueueGetBuffer
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMBufferQueueGetCallbacksForUnsortedSampleBuffers, const CMBufferCallbacks*, (), (), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMBufferQueueGetFirstPresentationTimeStamp, CMTime, (CMBufferQueueRef queue), (queue), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMBufferQueueGetEndPresentationTimeStamp, CMTime, (CMBufferQueueRef queue), (queue), PAL_EXPORT)
+SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMBufferQueueGetMaxPresentationTimeStamp, CMTime, (CMBufferQueueRef queue), (queue), PAL_EXPORT)
+
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMBufferQueueInstallTrigger, OSStatus, (CMBufferQueueRef queue, CMBufferQueueTriggerCallback callback, void* refcon, CMBufferQueueTriggerCondition condition, CMTime time, CMBufferQueueTriggerToken* triggerTokenOut), (queue, callback, refcon, condition, time, triggerTokenOut), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMBufferQueueRemoveTrigger, OSStatus, (CMBufferQueueRef queue, CMBufferQueueTriggerToken triggerToken), (queue, triggerToken), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMBufferQueueInstallTriggerWithIntegerThreshold, OSStatus, (CMBufferQueueRef queue, CMBufferQueueTriggerCallback triggerCallback, void* triggerRefcon, CMBufferQueueTriggerCondition triggerCondition, CMItemCount triggerThreshold, CMBufferQueueTriggerToken* triggerTokenOut), (queue, triggerCallback, triggerRefcon, triggerCondition, triggerThreshold, triggerTokenOut), PAL_EXPORT)

--- a/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h
+++ b/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h
@@ -287,6 +287,8 @@ SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMBufferQueueGetCallbacksForUnsort
 #define CMBufferQueueGetCallbacksForUnsortedSampleBuffers softLink_CoreMedia_CMBufferQueueGetCallbacksForUnsortedSampleBuffers
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMBufferQueueGetEndPresentationTimeStamp, CMTime, (CMBufferQueueRef queue), (queue))
 #define CMBufferQueueGetEndPresentationTimeStamp softLink_CoreMedia_CMBufferQueueGetEndPresentationTimeStamp
+SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMBufferQueueGetMaxPresentationTimeStamp, CMTime, (CMBufferQueueRef queue), (queue))
+#define CMBufferQueueGetMaxPresentationTimeStamp softLink_CoreMedia_CMBufferQueueGetMaxPresentationTimeStamp
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMBufferQueueInstallTrigger, OSStatus, (CMBufferQueueRef queue, CMBufferQueueTriggerCallback callback, void* refcon, CMBufferQueueTriggerCondition condition, CMTime time, CMBufferQueueTriggerToken* triggerTokenOut), (queue, callback, refcon, condition, time, triggerTokenOut))
 #define CMBufferQueueInstallTrigger softLink_CoreMedia_CMBufferQueueInstallTrigger
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMBufferQueueRemoveTrigger, OSStatus, (CMBufferQueueRef queue, CMBufferQueueTriggerToken triggerToken), (queue, triggerToken))

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -126,15 +126,16 @@ private:
     void flushCompressedSampleQueue();
     void flushDecodedSampleQueue();
     void cancelTimer();
-    void purgeDecodedSampleQueueAndDisplay(FlushId);
-    bool purgeDecodedSampleQueue(const CMTime&);
-    void schedulePurgeAndDisplayAtTime(const CMTime&);
-    void maybeReschedulePurgeAndDisplay(FlushId);
+    void purgeDecodedSampleQueue(FlushId);
+    bool purgeDecodedSampleQueueUntilTime(const CMTime&);
+    void schedulePurgeAtTime(const CMTime&);
+    void maybeReschedulePurge(FlushId);
     void enqueueDecodedSample(RetainPtr<CMSampleBufferRef>&&);
     size_t decodedSamplesCount() const;
     RetainPtr<CMSampleBufferRef> nextDecodedSample() const;
     CMTime nextDecodedSampleEndTime() const;
-    size_t maximumDecodedSampleCount(const WebCoreDecompressionSession&) const;
+    CMTime lastDecodedSampleTime() const;
+    bool hasIncomingOutOfOrderFrame(const CMTime&) const;
 
     void assignResourceOwner(CMSampleBufferRef);
     bool areSamplesQueuesReadyForMoreMediaData(size_t waterMark) const;
@@ -162,6 +163,7 @@ private:
     std::atomic<FlushId> m_flushId { 0 };
     Deque<std::pair<RetainPtr<CMSampleBufferRef>, FlushId>> m_compressedSampleQueue WTF_GUARDED_BY_CAPABILITY(dispatcher().get());
     std::atomic<uint32_t> m_compressedSampleQueueSize { 0 };
+    static constexpr MediaTime s_decodeAhead { 133, 1000 };
     RetainPtr<CMBufferQueueRef> m_decodedSampleQueue; // created on the main thread, immutable after creation.
     RefPtr<WebCoreDecompressionSession> m_decompressionSession WTF_GUARDED_BY_LOCK(m_lock);
     std::atomic<bool> m_isUsingDecompressionSession { false };
@@ -177,6 +179,10 @@ private:
     std::optional<uint32_t> m_currentCodec;
     std::atomic<bool> m_gotDecodingError { false };
     bool m_needsFlushing WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
+
+    // B-Frame tracker.
+    MediaTime m_highestPresentationTime WTF_GUARDED_BY_CAPABILITY(mainThread) { MediaTime::invalidTime() };
+    bool m_hasOutOfOrderFrames WTF_GUARDED_BY_CAPABILITY(dispatcher().get()) { false };
 
     // Playback Statistics
     std::atomic<unsigned> m_totalVideoFrames { 0 };

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -230,6 +230,28 @@ CMTime VideoMediaSampleRenderer::nextDecodedSampleEndTime() const
     return data.presentationTime;
 }
 
+CMTime VideoMediaSampleRenderer::lastDecodedSampleTime() const
+{
+    return PAL::CMBufferQueueGetMaxPresentationTimeStamp(m_decodedSampleQueue.get());
+}
+
+bool VideoMediaSampleRenderer::hasIncomingOutOfOrderFrame(const CMTime& time) const
+{
+    assertIsCurrent(dispatcher().get());
+
+    size_t forwardIndex = 0;
+    // The maximum queue depth possible for out of order frames with either H264 or HEVC is 16, limit looking ahead of 16 frames.
+    for (auto it = m_compressedSampleQueue.begin(); it != m_compressedSampleQueue.end() && forwardIndex < 16; ++forwardIndex, ++it) {
+        const auto& [sample, flushId] = *it;
+        if (flushId != m_flushId)
+            return false;
+        auto presentationTime = PAL::CMSampleBufferGetPresentationTimeStamp(sample.get());
+        if (PAL::CMTimeCompare(presentationTime, time) < 0)
+            return true;
+    }
+    return false;
+}
+
 void VideoMediaSampleRenderer::enqueueDecodedSample(RetainPtr<CMSampleBufferRef>&& sample)
 {
     ASSERT(sample);
@@ -319,7 +341,7 @@ void VideoMediaSampleRenderer::setTimebase(RetainPtr<CMTimebaseRef>&& timebase)
     auto timerSource = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatchQueue()));
     dispatch_source_set_event_handler(timerSource.get(), [weakThis = ThreadSafeWeakPtr { *this }] {
         if (RefPtr protectedThis = weakThis.get())
-            protectedThis->purgeDecodedSampleQueueAndDisplay(protectedThis->m_flushId);
+            protectedThis->purgeDecodedSampleQueue(protectedThis->m_flushId);
     });
     dispatch_activate(timerSource.get());
     PAL::CMTimebaseAddTimerDispatchSource(timebase.get(), timerSource.get());
@@ -330,7 +352,7 @@ void VideoMediaSampleRenderer::setTimebase(RetainPtr<CMTimebaseRef>&& timebase)
                 if (!timebase)
                     return;
                 if (PAL::CMTimebaseGetRate(timebase.get()))
-                    protectedThis->purgeDecodedSampleQueueAndDisplay(protectedThis->m_flushId);
+                    protectedThis->purgeDecodedSampleQueue(protectedThis->m_flushId);
             }
         });
     }, timebase.get());
@@ -394,8 +416,11 @@ void VideoMediaSampleRenderer::enqueueSample(const MediaSample& sample)
         return;
     }
 
+    bool hasOutOfOrderFrames = m_highestPresentationTime.isValid() && sample.presentationTime() < m_highestPresentationTime;
+    if (!hasOutOfOrderFrames)
+        m_highestPresentationTime = sample.presentationTime();
     ++m_compressedSampleQueueSize;
-    dispatcher()->dispatch([weakThis = ThreadSafeWeakPtr { *this }, sample = RetainPtr { cmSampleBuffer }, flushId = m_flushId.load()]() mutable {
+    dispatcher()->dispatch([weakThis = ThreadSafeWeakPtr { *this }, sample = RetainPtr { cmSampleBuffer }, flushId = m_flushId.load(), hasOutOfOrderFrames]() mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -408,13 +433,9 @@ void VideoMediaSampleRenderer::enqueueSample(const MediaSample& sample)
             return;
         }
         protectedThis->m_compressedSampleQueue.append({ WTFMove(sample), flushId });
+        protectedThis->m_hasOutOfOrderFrames = hasOutOfOrderFrames;
         protectedThis->decodeNextSampleIfNeeded();
     });
-}
-
-size_t VideoMediaSampleRenderer::maximumDecodedSampleCount(const WebCoreDecompressionSession& decompressionSession) const
-{
-    return decompressionSession.isHardwareAccelerated() ? 3 : 10;
 }
 
 void VideoMediaSampleRenderer::decodeNextSampleIfNeeded()
@@ -429,9 +450,16 @@ void VideoMediaSampleRenderer::decodeNextSampleIfNeeded()
     if (m_compressedSampleQueue.isEmpty())
         return;
 
-    if (decodedSamplesCount() > maximumDecodedSampleCount(*decompressionSession))
-        return;
-
+    if (RetainPtr timebase = this->timebase()) {
+        auto currentTime = PAL::CMTimebaseGetTime(timebase.get());
+        auto aheadTime = PAL::CMTimeAdd(currentTime, PAL::toCMTime(s_decodeAhead));
+        auto endTime = lastDecodedSampleTime();
+        if (CMTIME_IS_VALID(endTime) && PAL::CMTimeCompare(endTime, aheadTime) > 0 && decodedSamplesCount() >= 3) {
+            if (!m_hasOutOfOrderFrames || !hasIncomingOutOfOrderFrame(endTime))
+                return;
+            RELEASE_LOG_DEBUG(Media, "Out of order frames detected, forcing extra decode");
+        }
+    }
     auto [sample, flushId] = m_compressedSampleQueue.takeFirst();
     m_compressedSampleQueueSize = m_compressedSampleQueue.size();
     maybeBecomeReadyForMoreMediaData();
@@ -456,12 +484,13 @@ void VideoMediaSampleRenderer::decodeNextSampleIfNeeded()
         if (!protectedThis)
             return;
 
+        assertIsCurrent(dispatcher().get());
+
         if (LOG_CHANNEL(MediaPerformance).level >= WTFLogLevel::Debug) {
             auto now = MonotonicTime::now();
             m_frameRateMonitor.update();
-            RELEASE_LOG_DEBUG(MediaPerformance, "VideoMediaSampleRenderer decoding rate:%0.1fHz rolling:%0.1f decoder rate:%0.1fHz compressed queue:%u decoded queue:%zu", 1.0f / Seconds { now - std::exchange(m_timeSinceLastDecode, now) }.value(), m_frameRateMonitor.observedFrameRate(), 1.0f / Seconds { now - startTime }.value(), m_compressedSampleQueueSize.load(), decodedSamplesCount());
+            RELEASE_LOG_DEBUG(MediaPerformance, "VideoMediaSampleRenderer decoding rate:%0.1fHz rolling:%0.1f decoder rate:%0.1fHz compressed queue:%u decoded queue:%zu bframes:%d", 1.0f / Seconds { now - std::exchange(m_timeSinceLastDecode, now) }.value(), m_frameRateMonitor.observedFrameRate(), 1.0f / Seconds { now - startTime }.value(), m_compressedSampleQueueSize.load(), decodedSamplesCount(), m_hasOutOfOrderFrames);
         }
-        assertIsCurrent(dispatcher().get());
 
         m_isDecodingSample = false;
 
@@ -570,9 +599,10 @@ void VideoMediaSampleRenderer::decodedFrameAvailable(RetainPtr<CMSampleBufferRef
 
     if (auto timebase = this->timebase()) {
         enqueueDecodedSample(WTFMove(sample));
-        maybeReschedulePurgeAndDisplay(flushId);
+        maybeReschedulePurge(flushId);
     } else
         maybeQueueFrameForDisplay(PAL::kCMTimeInvalid, sample.get(), flushId);
+    [rendererOrDisplayLayer() enqueueSampleBuffer:sample.get()];
 }
 
 VideoMediaSampleRenderer::DecodedFrameResult VideoMediaSampleRenderer::maybeQueueFrameForDisplay(const CMTime& currentTime, CMSampleBufferRef sample, FlushId flushId)
@@ -604,7 +634,6 @@ VideoMediaSampleRenderer::DecodedFrameResult VideoMediaSampleRenderer::maybeQueu
     }
 
     ++m_presentedVideoFrames;
-    [rendererOrDisplayLayer() enqueueSampleBuffer:sample];
     m_isDisplayingSample = true;
     m_forceLateSampleToBeDisplayed = false;
 
@@ -620,6 +649,7 @@ void VideoMediaSampleRenderer::flushCompressedSampleQueue()
     ++m_flushId;
     m_compressedSampleQueueSize = 0;
     m_gotDecodingError = false;
+    m_highestPresentationTime = MediaTime::invalidTime();
 }
 
 void VideoMediaSampleRenderer::flushDecodedSampleQueue()
@@ -632,14 +662,15 @@ void VideoMediaSampleRenderer::flushDecodedSampleQueue()
     m_lastDisplayedSample.reset();
     m_lastDisplayedTime.reset();
     m_isDisplayingSample = false;
+    m_hasOutOfOrderFrames = false;
 }
 
 void VideoMediaSampleRenderer::cancelTimer()
 {
-    schedulePurgeAndDisplayAtTime(PAL::kCMTimeInvalid);
+    schedulePurgeAtTime(PAL::kCMTimeInvalid);
 }
 
-void VideoMediaSampleRenderer::purgeDecodedSampleQueueAndDisplay(FlushId flushId)
+void VideoMediaSampleRenderer::purgeDecodedSampleQueue(FlushId flushId)
 {
     assertIsCurrent(dispatcher().get());
 
@@ -657,13 +688,13 @@ void VideoMediaSampleRenderer::purgeDecodedSampleQueueAndDisplay(FlushId flushId
     if (timebase) {
         CMTime currentTime = PAL::CMTimebaseGetTime(timebase.get());
 
-        samplesPurged = purgeDecodedSampleQueue(currentTime);
+        samplesPurged = purgeDecodedSampleQueueUntilTime(currentTime);
         if (RetainPtr nextSample = nextDecodedSample()) {
             auto result = maybeQueueFrameForDisplay(currentTime, nextSample.get(), flushId);
-            auto presentationTime = PAL::CMSampleBufferGetOutputPresentationTimeStamp(nextSample.get());
-            auto presentationEndTime = nextDecodedSampleEndTime();
 #if !LOG_DISABLED
             if (LOG_CHANNEL(Media).level >= WTFLogLevel::Debug) {
+                auto presentationTime = PAL::CMSampleBufferGetOutputPresentationTimeStamp(nextSample.get());
+                auto presentationEndTime = nextDecodedSampleEndTime();
                 auto resultLiteral = [](DecodedFrameResult result) {
                     switch (result) {
                     case DecodedFrameResult::TooEarly: return "tooEarly"_s;
@@ -674,11 +705,9 @@ void VideoMediaSampleRenderer::purgeDecodedSampleQueueAndDisplay(FlushId flushId
                 }(result);
                 LOG(Media, "maybeQueueFrameForDisplay: currentTime:%f start:%f end:%f result:%s", PAL::CMTimeGetSeconds(currentTime), PAL::CMTimeGetSeconds(presentationTime), PAL::CMTimeGetSeconds(presentationEndTime), resultLiteral.characters());
             }
+#else
+            UNUSED_VARIABLE(result);
 #endif
-            if (result == DecodedFrameResult::TooEarly)
-                [rendererOrDisplayLayer() expectMinimumUpcomingSampleBufferPresentationTime:presentationTime];
-            else if (CMTIME_IS_VALID(presentationEndTime))
-                [rendererOrDisplayLayer() expectMinimumUpcomingSampleBufferPresentationTime:presentationEndTime];
         }
     }
     if (samplesPurged) {
@@ -687,7 +716,7 @@ void VideoMediaSampleRenderer::purgeDecodedSampleQueueAndDisplay(FlushId flushId
     }
 }
 
-bool VideoMediaSampleRenderer::purgeDecodedSampleQueue(const CMTime& currentTime)
+bool VideoMediaSampleRenderer::purgeDecodedSampleQueueUntilTime(const CMTime& currentTime)
 {
     assertIsCurrent(dispatcher().get());
 
@@ -708,7 +737,7 @@ bool VideoMediaSampleRenderer::purgeDecodedSampleQueue(const CMTime& currentTime
 
         if (m_lastDisplayedSample && PAL::CMTimeCompare(*m_lastDisplayedSample, presentationTime) < 0) {
             ++m_droppedVideoFrames; // This frame was never displayed.
-            LOG(Media, "purgeDecodedSampleQueue: currentTime:%f start:%f end:%f result:tooLate scheduled:%f (dropped:%u)", PAL::CMTimeGetSeconds(currentTime), PAL::CMTimeGetSeconds(presentationTime), PAL::CMTimeGetSeconds(presentationEndTime), PAL::CMTimeGetSeconds(m_nextScheduledPurge.value_or(PAL::kCMTimePositiveInfinity)), m_droppedVideoFrames.load());
+            LOG(Media, "purgeDecodedSampleQueueUntilTime: currentTime:%f start:%f end:%f result:tooLate scheduled:%f (dropped:%u)", PAL::CMTimeGetSeconds(currentTime), PAL::CMTimeGetSeconds(presentationTime), PAL::CMTimeGetSeconds(presentationEndTime), PAL::CMTimeGetSeconds(m_nextScheduledPurge.value_or(PAL::kCMTimePositiveInfinity)), m_droppedVideoFrames.load());
         }
 
         RetainPtr sampleToBePurged = adoptCF(PAL::CMBufferQueueDequeueAndRetain(m_decodedSampleQueue.get()));
@@ -719,12 +748,12 @@ bool VideoMediaSampleRenderer::purgeDecodedSampleQueue(const CMTime& currentTime
     if (!CMTIME_IS_VALID(nextPurgeTime))
         return samplesPurged;
 
-    schedulePurgeAndDisplayAtTime(nextPurgeTime);
+    schedulePurgeAtTime(nextPurgeTime);
 
     return samplesPurged;
 }
 
-void VideoMediaSampleRenderer::schedulePurgeAndDisplayAtTime(const CMTime& nextPurgeTime)
+void VideoMediaSampleRenderer::schedulePurgeAtTime(const CMTime& nextPurgeTime)
 {
     auto [timebase, timerSource] = timebaseAndTimerSource();
     if (!timebase)
@@ -738,7 +767,7 @@ void VideoMediaSampleRenderer::schedulePurgeAndDisplayAtTime(const CMTime& nextP
     }
 }
 
-void VideoMediaSampleRenderer::maybeReschedulePurgeAndDisplay(FlushId flushId)
+void VideoMediaSampleRenderer::maybeReschedulePurge(FlushId flushId)
 {
     assertIsCurrent(dispatcher().get());
 
@@ -749,10 +778,10 @@ void VideoMediaSampleRenderer::maybeReschedulePurgeAndDisplay(FlushId flushId)
         return;
 
     if ((m_nextScheduledPurge && CMTIME_IS_POSITIVE_INFINITY(*m_nextScheduledPurge)) || CMTIME_IS_POSITIVE_INFINITY(presentationEndTime)) {
-        purgeDecodedSampleQueueAndDisplay(flushId);
+        purgeDecodedSampleQueue(flushId);
         return;
     }
-    schedulePurgeAndDisplayAtTime(presentationEndTime);
+    schedulePurgeAtTime(presentationEndTime);
 }
 
 void VideoMediaSampleRenderer::flush()
@@ -885,7 +914,7 @@ auto VideoMediaSampleRenderer::copyDisplayedPixelBuffer() -> DisplayedPixelBuffe
             return;
 
         m_forceLateSampleToBeDisplayed = true;
-        purgeDecodedSampleQueueAndDisplay(m_flushId);
+        purgeDecodedSampleQueue(m_flushId);
 
         auto nextSample = nextDecodedSample();
         if (!nextSample)


### PR DESCRIPTION
#### 5ea7a3e8bb2642b63db04940f99093c73997f9cf
<pre>
Decoding should continue until we have set time ahead.
<a href="https://bugs.webkit.org/show_bug.cgi?id=291894">https://bugs.webkit.org/show_bug.cgi?id=291894</a>
<a href="https://rdar.apple.com/149756577">rdar://149756577</a>

Reviewed by Jer Noble.

In 293860@main we decoded 3 or 10 frames ahead of currentTime depending on the
video decoder being hardware accelerated.
We now use a time (133ms) base instead, similar to what CoreMedia does but with
a minimum of 3 frames.
Additionally, we immediately enqueue the decoded video frame in the
AVSampleBufferDisplayLayer or AVSampleBufferVideoRenderer as soon as
it is available, letting it handle frame re-ordering as needed.
The time accuracy required for requestVideoFrameCallback and readbacks
is now only approximated so that we can preserve smoother video delivery
under heavy load.
The requirement for accurate timers as such is reduced and when the purge
task is enqueued become less important as it is no longer responsible for
ensuring that the next frame is displayed on time.
In order to ensure that frames are re-ordered accurately, the decode ahead
limit is ignored if B-frame are found in the incoming compressed samples queue.

Dropped frame calculation continues to be based on our own internal timers
rather than what the AVSampleBufferDisplayLayer did or did not drop due to:
1- We don&apos;t have an accurate way to properly determine if it did.
2- Dropped frames report is used by web sites to determine if the user
machine is under heavy load and reduce or increase the content resolution
accordingly. This goal is achieved as scheduling our purge tasks are more
likely to be impacted by heavy usage.

Covered by existing tests.

* Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.cpp:
* Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h:
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::lastDecodedSampleTime const):
(WebCore::VideoMediaSampleRenderer::hasIncomingOutOfOrderFrame const):
(WebCore::VideoMediaSampleRenderer::setTimebase):
(WebCore::VideoMediaSampleRenderer::decodeNextSampleIfNeeded):
(WebCore::VideoMediaSampleRenderer::decodedFrameAvailable):
(WebCore::VideoMediaSampleRenderer::maybeQueueFrameForDisplay):
(WebCore::VideoMediaSampleRenderer::cancelTimer):
(WebCore::VideoMediaSampleRenderer::purgeDecodedSampleQueue):
(WebCore::VideoMediaSampleRenderer::purgeDecodedSampleQueueUntilTime):
(WebCore::VideoMediaSampleRenderer::schedulePurgeAtTime):
(WebCore::VideoMediaSampleRenderer::maybeReschedulePurge):
(WebCore::VideoMediaSampleRenderer::copyDisplayedPixelBuffer):
(WebCore::VideoMediaSampleRenderer::maximumDecodedSampleCount const): Deleted.
(WebCore::VideoMediaSampleRenderer::purgeDecodedSampleQueueAndDisplay): Deleted.
(WebCore::VideoMediaSampleRenderer::schedulePurgeAndDisplayAtTime): Deleted.
(WebCore::VideoMediaSampleRenderer::maybeReschedulePurgeAndDisplay): Deleted.

Canonical link: <a href="https://commits.webkit.org/294144@main">https://commits.webkit.org/294144@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d13506f4cb18c2b7724e15ca9b9c3ade1ffdbcbd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106097 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51550 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102992 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29107 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76876 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33910 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103958 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16092 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91181 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57224 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15907 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/9203 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50925 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/85813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9264 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108453 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28079 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85842 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28441 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87381 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85384 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21731 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30099 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7825 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22115 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28009 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33277 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27821 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31141 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29379 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->