### PR TITLE
[JSC] Remove __DARWIN_UNIX03 check

### DIFF
--- a/Source/JavaScriptCore/runtime/MachineContext.h
+++ b/Source/JavaScriptCore/runtime/MachineContext.h
@@ -88,7 +88,6 @@ void* llintInstructionPointer(const mcontext_t&);
 static inline void*& stackPointerImpl(PlatformRegisters& regs)
 {
 #if OS(DARWIN)
-#if __DARWIN_UNIX03
 
 #if CPU(X86_64)
     return reinterpret_cast<void*&>(regs.__rsp);
@@ -99,16 +98,6 @@ static inline void*& stackPointerImpl(PlatformRegisters& regs)
 #else
 #error Unknown Architecture
 #endif
-
-#else // !__DARWIN_UNIX03
-
-#if CPU(X86_64)
-    return reinterpret_cast<void*&>(regs.rsp);
-#else
-#error Unknown Architecture
-#endif
-
-#endif // __DARWIN_UNIX03
 
 #elif OS(WINDOWS)
 
@@ -228,8 +217,6 @@ static inline void*& framePointerImpl(PlatformRegisters& regs)
 {
 #if OS(DARWIN)
 
-#if __DARWIN_UNIX03
-
 #if CPU(X86_64)
     return reinterpret_cast<void*&>(regs.__rbp);
 #elif CPU(ARM64)
@@ -237,16 +224,6 @@ static inline void*& framePointerImpl(PlatformRegisters& regs)
 #else
 #error Unknown Architecture
 #endif
-
-#else // !__DARWIN_UNIX03
-
-#if CPU(X86_64)
-    return reinterpret_cast<void*&>(regs.rsp);
-#else
-#error Unknown Architecture
-#endif
-
-#endif // __DARWIN_UNIX03
 
 #elif OS(WINDOWS)
 
@@ -367,7 +344,6 @@ inline T framePointer(const mcontext_t& machineContext)
 static inline void*& instructionPointerImpl(PlatformRegisters& regs)
 {
 #if OS(DARWIN)
-#if __DARWIN_UNIX03
 
 #if CPU(X86_64)
     return reinterpret_cast<void*&>(regs.__rip);
@@ -376,15 +352,6 @@ static inline void*& instructionPointerImpl(PlatformRegisters& regs)
 #else
 #error Unknown Architecture
 #endif
-
-#else // !__DARWIN_UNIX03
-#if CPU(X86_64)
-    return reinterpret_cast<void*&>(regs.rip);
-#else
-#error Unknown Architecture
-#endif
-
-#endif // __DARWIN_UNIX03
 
 #elif OS(WINDOWS)
 
@@ -535,7 +502,7 @@ inline CodePtr<PlatformRegistersPCPtrTag> instructionPointer(const mcontext_t& m
 
 #if OS(WINDOWS) || HAVE(MACHINE_CONTEXT)
 
-#if OS(DARWIN) && __DARWIN_UNIX03 && CPU(ARM64)
+#if OS(DARWIN) && CPU(ARM64)
 
 inline CodePtr<PlatformRegistersLRPtrTag> linkRegister(const PlatformRegisters& regs)
 {
@@ -546,7 +513,7 @@ inline CodePtr<PlatformRegistersLRPtrTag> linkRegister(const PlatformRegisters& 
 #endif
     return CodePtr<PlatformRegistersLRPtrTag>(value);
 }
-#endif // OS(DARWIN) && __DARWIN_UNIX03 && CPU(ARM64)
+#endif // OS(DARWIN) && CPU(ARM64)
 
 #if HAVE(MACHINE_CONTEXT)
 template<> void*& argumentPointer<1>(mcontext_t&);
@@ -556,7 +523,6 @@ template<>
 inline void*& argumentPointer<1>(PlatformRegisters& regs)
 {
 #if OS(DARWIN)
-#if __DARWIN_UNIX03
 
 #if CPU(X86_64)
     return reinterpret_cast<void*&>(regs.__rsi);
@@ -567,16 +533,6 @@ inline void*& argumentPointer<1>(PlatformRegisters& regs)
 #else
 #error Unknown Architecture
 #endif
-
-#else // !__DARWIN_UNIX03
-
-#if CPU(X86_64)
-    return reinterpret_cast<void*&>(regs.rsi);
-#else
-#error Unknown Architecture
-#endif
-
-#endif // __DARWIN_UNIX03
 
 #elif OS(WINDOWS)
 
@@ -598,7 +554,6 @@ inline void*& argumentPointer<1>(PlatformRegisters& regs)
 inline void* wasmInstancePointer(const PlatformRegisters& regs)
 {
 #if OS(DARWIN)
-#if __DARWIN_UNIX03
 
 #if CPU(X86_64)
     return reinterpret_cast<void*>(regs.__rbx);
@@ -607,16 +562,6 @@ inline void* wasmInstancePointer(const PlatformRegisters& regs)
 #else
 #error Unknown Architecture
 #endif
-
-#else // !__DARWIN_UNIX03
-
-#if CPU(X86_64)
-    return reinterpret_cast<void*>(regs.rbx);
-#else
-#error Unknown Architecture
-#endif
-
-#endif // __DARWIN_UNIX03
 
 #elif OS(WINDOWS)
 
@@ -779,7 +724,6 @@ inline void*& llintInstructionPointer(PlatformRegisters& regs)
 {
     // LLInt uses regT4 as PC.
 #if OS(DARWIN)
-#if __DARWIN_UNIX03
 
 #if CPU(X86_64)
     static_assert(LLInt::LLIntPC == X86Registers::r8, "Wrong LLInt PC.");
@@ -790,16 +734,6 @@ inline void*& llintInstructionPointer(PlatformRegisters& regs)
 #else
 #error Unknown Architecture
 #endif
-
-#else // !__DARWIN_UNIX03
-#if CPU(X86_64)
-    static_assert(LLInt::LLIntPC == X86Registers::r8, "Wrong LLInt PC.");
-    return reinterpret_cast<void*&>(regs.r8);
-#else
-#error Unknown Architecture
-#endif
-
-#endif // __DARWIN_UNIX03
 
 #elif OS(WINDOWS)
 


### PR DESCRIPTION
#### eac2ebe92d5efe9ab7a11bbbed103e913a8d92af
<pre>
[JSC] Remove __DARWIN_UNIX03 check
<a href="https://bugs.webkit.org/show_bug.cgi?id=292088">https://bugs.webkit.org/show_bug.cgi?id=292088</a>
<a href="https://rdar.apple.com/150084193">rdar://150084193</a>

Reviewed by Mark Lam.

__DARWIN_UNIX03 is always one at this point (it is off on very old
macOS with x64). We remove __DARWIN_UNIX03 checks.

* Source/JavaScriptCore/runtime/MachineContext.h:
(JSC::MachineContext::stackPointerImpl):
(JSC::MachineContext::framePointerImpl):
(JSC::MachineContext::instructionPointerImpl):
(JSC::MachineContext::argumentPointer&lt;1&gt;):
(JSC::MachineContext::wasmInstancePointer):
(JSC::MachineContext::llintInstructionPointer):

Canonical link: <a href="https://commits.webkit.org/294150@main">https://commits.webkit.org/294150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c7183267cd0fec2a0918c1b5e0529cb26ad4106

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106105 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51588 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29115 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76880 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33915 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103966 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16099 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91190 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57228 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15914 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9212 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50933 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/93626 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85820 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9273 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108461 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/99568 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28087 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20655 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85847 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28449 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87390 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85389 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30105 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7834 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22130 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16425 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28017 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33285 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/123193 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27829 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34319 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31149 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29387 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->