### PR TITLE
[StyleBench] Make sure we don't include pending layout work in measurements.

### DIFF
--- a/PerformanceTests/StyleBench/resources/benchmark-runner.js
+++ b/PerformanceTests/StyleBench/resources/benchmark-runner.js
@@ -126,12 +126,14 @@ BenchmarkRunner.prototype._runTest = function(suite, test, prepareReturnValue, c
     var contentWindow = self._frame.contentWindow;
     var contentDocument = self._frame.contentDocument;
 
+    // Force style resolution before running the test to ensure we don't measure stuff unrelated to the test.
+    window._unusedHeightValue = contentDocument.body.getBoundingClientRect().height;
     self._writeMark(suite.name + '.' + test.name + '-start');
 
     var startTime = now();
     test.run(prepareReturnValue, contentWindow, contentDocument);
     // Force style resolution + layout to ensure we're measuring it.
-    window._unusedHeightValue = self._frame.contentDocument.body.getBoundingClientRect().height;
+    window._unusedHeightValue = contentDocument.body.getBoundingClientRect().height;
     var endTime = now();
 
     self._writeMark(suite.name + '.' + test.name + '-sync-end');


### PR DESCRIPTION
#### db0047ab0e766393bfc2aa900555108dfeaac731
<pre>
[StyleBench] Make sure we don&apos;t include pending layout work in measurements.
<a href="https://bugs.webkit.org/show_bug.cgi?id=292091">https://bugs.webkit.org/show_bug.cgi?id=292091</a>

Reviewed by Antti Koivisto.

I&apos;m looking into a stylebench regression in Firefox due to an scheduling
change (<a href="https://bugzil.la/1961181).">https://bugzil.la/1961181).</a>

It seems that if we try to run layout / paint more often, then
stylebench improves because the test is measuring pending layout / style
work from other subtests and such.

Part of this is bug 219785 (which isn&apos;t in Firefox&apos;s tree). But it seems
worth updating layout at the beginning of the test too, to make sure
that the test measures exactly what&apos;s intended.

* PerformanceTests/StyleBench/resources/benchmark-runner.js:
(BenchmarkRunner.prototype._runTest): Update layout before the test.

Canonical link: <a href="https://commits.webkit.org/294345@main">https://commits.webkit.org/294345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f2079e22d2c8663e63359c4b7118b56d235c7db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10936 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106117 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51595 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20942 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29127 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76895 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33920 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103978 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16112 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91201 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57243 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15927 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50945 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85833 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9284 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108473 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20667 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85860 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28461 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87401 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85402 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21843 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30118 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7845 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22143 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28029 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27841 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31161 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29399 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->