### PR TITLE
[GTK] Fix return-stack-address warnings

### DIFF
--- a/Source/JavaScriptCore/API/glib/JSCContext.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCContext.cpp
@@ -1119,5 +1119,6 @@ JSCClass* jsc_context_register_class(JSCContext* context, const char* name, JSCC
 
     auto jscClass = jscClassCreate(context, name, parentClass, vtable, destroyFunction);
     wrapperMap(context).registerClass(jscClass.get());
-    return jscClass.get();
+    auto result = jscClass.get();
+    return result;
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitBackForwardList.cpp
@@ -97,13 +97,16 @@ static WebKitBackForwardListItem* webkitBackForwardListGetOrCreateItem(WebKitBac
 
     WebKitBackForwardListPrivate* priv = list->priv;
     GRefPtr<WebKitBackForwardListItem> listItem = priv->itemsMap.get(webListItem);
-    if (listItem)
-        return listItem.get();
+    if (listItem) {
+        auto result = listItem.get();
+        return result;
+    }
 
     listItem = webkitBackForwardListItemGetOrCreate(webListItem);
     priv->itemsMap.set(webListItem, listItem);
 
-    return listItem.get();
+    auto result = listItem.get();
+    return result;
 }
 
 static GList* webkitBackForwardListCreateList(WebKitBackForwardList* list, API::Array* backForwardItems)

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
@@ -183,7 +183,8 @@ void PageClientImpl::setCursor(const WebCore::Cursor& cursor)
     // so don't re-set the cursor if it's already set to the target value.
 #if USE(GTK4)
     GdkCursor* currentCursor = gtk_widget_get_cursor(m_viewWidget);
-    GdkCursor* newCursor = cursor.platformCursor().get();
+    auto platformCursor = cursor.platformCursor();
+    GdkCursor* newCursor = platformCursor.get();
     if (currentCursor != newCursor)
         gtk_widget_set_cursor(m_viewWidget, newCursor);
 #else


### PR DESCRIPTION
#### de39757bd31c361e1241d25efd972d3727ec3753
<pre>
[GTK] Fix return-stack-address warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=292097">https://bugs.webkit.org/show_bug.cgi?id=292097</a>

Reviewed by NOBODY (OOPS!).

* Source/JavaScriptCore/API/glib/JSCContext.cpp:
(jsc_context_register_class):
* Source/WebKit/UIProcess/API/glib/WebKitBackForwardList.cpp:
(webkitBackForwardListGetOrCreateItem):
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp:
(WebKit::PageClientImpl::setCursor):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de39757bd31c361e1241d25efd972d3727ec3753

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100983 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106129 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51607 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29139 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76906 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33931 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16125 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91212 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57254 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15940 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9236 "Found 3 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50957 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/93650 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85846 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108485 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/99592 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28111 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20678 "Found 1 new test failure: http/tests/iframe-monitor/workers/service-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85873 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28473 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87412 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85413 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30128 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7856 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22162 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28041 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33309 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/123217 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27853 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34328 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31173 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29411 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->