### PR TITLE
Eliminate virtual function call in Node::pseudoId()

### DIFF
--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -234,10 +234,10 @@ public:
 
     bool isFormControlElement() const { return hasTypeFlag(TypeFlag::IsFormControlElement); }
 
-    bool isPseudoElement() const { return pseudoId() != PseudoId::None; }
-    bool isBeforePseudoElement() const { return pseudoId() == PseudoId::Before; }
-    bool isAfterPseudoElement() const { return pseudoId() == PseudoId::After; }
-    PseudoId pseudoId() const { return (isElementNode() && hasCustomStyleResolveCallbacks()) ? customPseudoId() : PseudoId::None; }
+    bool isPseudoElement() const { return hasStateFlag(StateFlag::IsPseudoElement); }
+    inline bool isBeforePseudoElement() const;
+    inline bool isAfterPseudoElement() const;
+    inline PseudoId pseudoId() const;
 
 #if ENABLE(VIDEO)
     virtual bool isWebVTTElement() const { return false; }
@@ -645,8 +645,9 @@ protected:
 #endif
         ContainsSelectionEndPoint = 1 << 11,
         IsSpecialInternalNode = 1 << 12, // DocumentFragment node for innerHTML/outerHTML or EditingText node.
+        IsPseudoElement = 1 << 13, // FIXME: This belongs to TypeFlag.
 
-        // 3 bits free.
+        // 2 bits free.
     };
 
     enum class ElementStateFlag : uint16_t {
@@ -778,12 +779,6 @@ protected:
     ExceptionOr<NodeVector> convertNodesOrStringsIntoNodeVector(FixedVector<NodeOrString>&&);
 
 private:
-    virtual PseudoId customPseudoId() const
-    {
-        ASSERT(hasCustomStyleResolveCallbacks());
-        return PseudoId::None;
-    }
-
     WEBCORE_EXPORT void removedLastRef();
 
     void refEventTarget() final;

--- a/Source/WebCore/dom/NodeInlines.h
+++ b/Source/WebCore/dom/NodeInlines.h
@@ -24,6 +24,7 @@
 #include "Document.h"
 #include "Element.h"
 #include "Node.h"
+#include "PseudoElement.h"
 #include "WebCoreOpaqueRoot.h"
 
 namespace WebCore {
@@ -68,6 +69,23 @@ inline Element* Node::parentElement() const
 inline RefPtr<Element> Node::protectedParentElement() const
 {
     return parentElement();
+}
+
+bool Node::isBeforePseudoElement() const
+{
+    return pseudoId() == PseudoId::Before;
+}
+
+bool Node::isAfterPseudoElement() const
+{
+    return pseudoId() == PseudoId::After;
+}
+
+PseudoId Node::pseudoId() const
+{
+    if (auto* pseudoElement = dynamicDowncast<PseudoElement>(*this))
+        return pseudoElement->pseudoId();
+    return PseudoId::None;
 }
 
 inline void Node::setTabIndexState(TabIndexState state)

--- a/Source/WebCore/dom/PseudoElement.cpp
+++ b/Source/WebCore/dom/PseudoElement.cpp
@@ -54,6 +54,7 @@ PseudoElement::PseudoElement(Element& host, PseudoId pseudoId)
     , m_pseudoId(pseudoId)
 {
     setEventTargetFlag(EventTargetFlag::IsConnected);
+    setStateFlag(StateFlag::IsPseudoElement);
     ASSERT(pseudoId == PseudoId::Before || pseudoId == PseudoId::After);
 }
 

--- a/Source/WebCore/dom/PseudoElement.h
+++ b/Source/WebCore/dom/PseudoElement.h
@@ -41,6 +41,8 @@ public:
     Element* hostElement() const { return m_hostElement.get(); }
     void clearHostElement();
 
+    PseudoId pseudoId() const { return m_pseudoId; }
+
     bool rendererIsNeeded(const RenderStyle&) override;
 
     bool canStartSelection() const override { return false; }
@@ -48,8 +50,6 @@ public:
 
 private:
     PseudoElement(Element&, PseudoId);
-
-    PseudoId customPseudoId() const override { return m_pseudoId; }
 
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_hostElement;
     PseudoId m_pseudoId;

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Element.h"
+#include "NodeInlines.h"
 #include "PseudoElement.h"
 #include "PseudoElementIdentifier.h"
 #include "RenderStyleConstants.h"


### PR DESCRIPTION
#### ca55d7b7d4af390f99edbd2bbea27b38b36bbc26
<pre>
Eliminate virtual function call in Node::pseudoId()
<a href="https://bugs.webkit.org/show_bug.cgi?id=292099">https://bugs.webkit.org/show_bug.cgi?id=292099</a>

Reviewed by Anne van Kesteren.

Devirtualize Node::pseudoId() by storing a bit for IsPseudoElement.

* Source/WebCore/dom/Node.h:
(WebCore::Node::isPseudoElement const):
(WebCore::Node::isBeforePseudoElement const): Moved to NodeInlines.h
(WebCore::Node::isAfterPseudoElement const): Ditto.
(WebCore::Node::pseudoId const): Ditto.
(WebCore::Node::customPseudoId const): Deleted.
* Source/WebCore/dom/NodeInlines.h:
(WebCore::Node::isBeforePseudoElement const):
(WebCore::Node::isAfterPseudoElement const):
(WebCore::Node::pseudoId const):
* Source/WebCore/dom/PseudoElement.cpp:
(WebCore::PseudoElement::PseudoElement):
* Source/WebCore/dom/PseudoElement.h:
* Source/WebCore/style/Styleable.h:

Canonical link: <a href="https://commits.webkit.org/294168@main">https://commits.webkit.org/294168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b06fe5a8c3618b8a666c80a6a845bf8b7b213ef6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100987 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10952 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106133 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51611 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103028 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29143 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76912 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33937 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103994 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16129 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91217 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57260 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15944 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9242 "Found 5 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html imported/w3c/web-platform-tests/svg/painting/marker-005.svg imported/w3c/web-platform-tests/svg/painting/marker-006.svg (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50961 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85850 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108489 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28115 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20684 "Found 2 new test failures: http/tests/iframe-monitor/workers/service-worker.html imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85877 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28477 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85417 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30134 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7861 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22166 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16431 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28045 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33313 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27857 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31177 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29415 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->