### PR TITLE
[JSC][GreedyRegAlloc] buildLiveRanges can track interval end rather than interval

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -406,10 +406,10 @@ public:
         }
     }
 
-    void addClobberHigh64(Reg reg, Interval interval)
+    void addClobberHigh64(Reg reg, Point point)
     {
         ASSERT(reg.isFPR());
-        m_allocationsHigh64.insert({ Tmp(reg), interval });
+        m_allocationsHigh64.insert({ Tmp(reg), Interval(point) });
     }
 
     void evict(Tmp tmp, LiveRange& range)
@@ -750,18 +750,19 @@ private:
 
     static Point positionOfEarly(Interval interval)
     {
-        return interval.begin() & ~static_cast<Point>(1);
+        static_assert(!(pointsPerInst & (pointsPerInst - 1)));
+        return interval.begin() & ~static_cast<Point>(pointsPerInst - 1);
     }
 
     static Interval earlyInterval(Point positionOfEarly)
     {
-        ASSERT(!(positionOfEarly & 1));
+        ASSERT(!(positionOfEarly % pointsPerInst));
         return Interval(positionOfEarly);
     }
 
     static Interval lateInterval(Point positionOfEarly)
     {
-        ASSERT(!(positionOfEarly & 1));
+        ASSERT(!(positionOfEarly % pointsPerInst));
         return Interval(positionOfEarly + 1);
     }
 
@@ -900,7 +901,11 @@ private:
     {
         CompilerTimingScope timingScope("Air"_s, "GreedyRegAlloc::buildLiveRanges"_s);
         UnifiedTmpLiveness liveness(m_code);
-        TmpMap<Interval> activeIntervals(m_code);
+        TmpMap<Point> activeEnds(m_code);
+        TmpMap<Point> liveAtTailMarkers(m_code, std::numeric_limits<Point>::max());
+#if ASSERT_ENABLED
+        UnifiedTmpLiveness::LiveAtHead assertOnlyLiveAtHead = liveness.liveAtHead();
+#endif
 
         // Find non-rare blocks.
         m_fastBlocks.push(m_code[0]);
@@ -942,7 +947,7 @@ private:
         };
 
         auto isLiveAt = [&](Tmp tmp, Point point) {
-            if (activeIntervals[tmp])
+            if (activeEnds[tmp])
                 return true;
             // Tmp may have had a dead def at point (e.g. clobber).
             auto& intervals = m_map[tmp].liveRange.intervals();
@@ -972,10 +977,18 @@ private:
             });
         };
 
-        auto closeInterval = [&](Tmp tmp) {
-            ASSERT(activeIntervals[tmp] != Interval());
-            m_map[tmp].liveRange.prepend(activeIntervals[tmp]);
-            activeIntervals[tmp] = Interval();
+        auto markUse = [&](Tmp tmp, Point point) {
+            Point& end = activeEnds[tmp];
+            ASSERT(!end || point < end);
+            if (!end)
+                end = point + 1; // +1 since Interval end is not inclusive
+        };
+        auto markDef = [&](Tmp tmp, Point point)  {
+            Point end = activeEnds[tmp];
+            if (UNLIKELY(!end))
+                end = point + 1; // Dead def / clobber
+            m_map[tmp].liveRange.prepend({ point, end });
+            activeEnds[tmp] = 0;
         };
 
         // First pass: collect all the potential coalescable pairs of Tmps.
@@ -1006,6 +1019,7 @@ private:
         // prune conflicts from the coalescables.
         BasicBlock* blockAfter = nullptr;
         Vector<Tmp, 8> earlyUses, earlyDefs, lateUses, lateDefs;
+        Vector<Reg, 8> earlyClobbersHigh64, lateClobbersHigh64;
         for (size_t blockIndex = m_code.size(); blockIndex--;) {
             BasicBlock* block = m_code[blockIndex];
             if (!block)
@@ -1019,28 +1033,33 @@ private:
                 dataLog("  positionOfTail = ", positionOfTail, "\n");
             }
 
-            for (Tmp tmp : liveness.liveAtTail(block))
-                activeIntervals[tmp] |= Interval(positionOfTail); // FIXME: could just set interval start
-
+            for (Tmp tmp : liveness.liveAtTail(block)) {
+                markUse(tmp, positionOfTail);
+                liveAtTailMarkers[tmp] = positionOfTail;
+            }
             if (blockAfter) {
+                Point blockAfterPositionOfHead = this->positionOfHead(blockAfter);
                 for (Tmp tmp : liveness.liveAtHead(blockAfter)) {
-                    if (!activeIntervals[tmp].contains(positionOfTail)) {
-                        // If tmp was live at the head of the next block but no longer live, close
-                        // the current interval.
-                        ASSERT(activeIntervals[tmp].begin() == this->positionOfHead(blockAfter));
-                        closeInterval(tmp);
-                    }
+                    // FIXME: rdar://145150735, remove pinned register liveness special cases
+                    ASSERT(activeEnds[tmp] || (tmp.isReg() && !m_allAllowedRegisters.contains(tmp.reg(), IgnoreVectors)));
+                    // If tmp was live at the head of the next block but not live at the
+                    // tail of the current block, close the interval.
+                    if (liveAtTailMarkers[tmp] > positionOfTail && LIKELY(activeEnds[tmp]))
+                        markDef(tmp, blockAfterPositionOfHead);
                 }
             }
 
             for (unsigned instIndex = block->size(); instIndex--;) {
                 Inst& inst = block->at(instIndex);
                 Point positionOfEarly = positionOfHead + instIndex * pointsPerInst;
+                Point positionOfLate = positionOfEarly + 1;
 
                 lateUses.shrink(0);
                 lateDefs.shrink(0);
+                lateClobbersHigh64.shrink(0);
                 earlyUses.shrink(0);
                 earlyDefs.shrink(0);
+                earlyClobbersHigh64.shrink(0);
                 inst.forEachTmp([&](Tmp& tmp, Arg::Role role, Bank, Width) {
                     if (Arg::isLateUse(role))
                         lateUses.append(tmp);
@@ -1051,60 +1070,59 @@ private:
                     if (Arg::isEarlyDef(role))
                         earlyDefs.append(tmp);
                 });
-                for (Tmp tmp : lateUses)
-                    activeIntervals[tmp] |= lateInterval(positionOfEarly);
-                for (Tmp tmp : lateDefs) {
-                    activeIntervals[tmp] |= lateInterval(positionOfEarly);
-                    closeInterval(tmp);
-                    pruneCoalescable(inst, tmp, positionOfEarly + 1);
-                }
-                for (Tmp tmp : earlyUses)
-                    activeIntervals[tmp] |= earlyInterval(positionOfEarly);
-                for (Tmp tmp : earlyDefs) {
-                    activeIntervals[tmp] |= earlyInterval(positionOfEarly);
-                    closeInterval(tmp);
-                    pruneCoalescable(inst, tmp, positionOfEarly);
-                }
-                if (inst.kind.opcode == Patch) {
-                    auto clobberReg = [&](Reg reg, PreservedWidth preservedWidth, Interval interval) {
-                        if (preservedWidth == PreservesNothing) {
-                            Tmp tmp = Tmp(reg);
-                            bool isAlive = !!activeIntervals[tmp];
-                            activeIntervals[tmp] |= interval;
-                            if (!isAlive)
-                                closeInterval(tmp);
-                        } else {
-                            ASSERT(preservedWidth == Preserves64);
-                            ASSERT(reg.isFPR() && m_code.usesSIMD());
-                            m_regRanges[reg].addClobberHigh64(reg, interval);
-                        }
-                    };
-                    inst.extraClobberedRegs().forEachWithWidthAndPreserved(
-                        [&](Reg reg, Width, PreservedWidth preservedWidth) {
-                            clobberReg(reg, preservedWidth, lateInterval(positionOfEarly));
-                        });
+                if (UNLIKELY(inst.kind.opcode == Patch)) {
                     inst.extraEarlyClobberedRegs().forEachWithWidthAndPreserved(
                         [&](Reg reg, Width, PreservedWidth preservedWidth) {
-                            clobberReg(reg, preservedWidth, earlyInterval(positionOfEarly));
+                            ASSERT(preservedWidth == PreservesNothing || preservedWidth == Preserves64);
+                            if (preservedWidth == PreservesNothing)
+                                earlyDefs.append(Tmp(reg));
+                            else
+                                earlyClobbersHigh64.append(reg);
+                        });
+                    inst.extraClobberedRegs().forEachWithWidthAndPreserved(
+                        [&](Reg reg, Width, PreservedWidth preservedWidth) {
+                            ASSERT(preservedWidth == PreservesNothing || preservedWidth == Preserves64);
+                            if (preservedWidth == PreservesNothing)
+                                lateDefs.append(Tmp(reg));
+                            else
+                                lateClobbersHigh64.append(reg);
                         });
                 }
 
-            }
-            for (Tmp tmp : liveness.liveAtHead(block))
-                activeIntervals[tmp] |= Interval(positionOfHead);
+                for (Tmp tmp : lateUses)
+                    markUse(tmp, positionOfLate);
+                for (Tmp tmp : lateDefs) {
+                    markDef(tmp, positionOfLate);
+                    pruneCoalescable(inst, tmp, positionOfLate);
+                }
+                for (Reg reg : lateClobbersHigh64)
+                    m_regRanges[reg].addClobberHigh64(reg, positionOfLate);
 
+                for (Tmp tmp : earlyUses)
+                    markUse(tmp, positionOfEarly);
+                for (Tmp tmp : earlyDefs) {
+                    markDef(tmp, positionOfEarly);
+                    pruneCoalescable(inst, tmp, positionOfEarly);
+                }
+                for (Reg reg : earlyClobbersHigh64)
+                    m_regRanges[reg].addClobberHigh64(reg, positionOfEarly);
+            }
+#if ASSERT_ENABLED
+            m_code.forEachTmp([&](Tmp tmp) {
+                ASSERT(!!activeEnds[tmp] == assertOnlyLiveAtHead.isLiveAtHead(block, tmp));
+            });
+#endif
             blockAfter = block;
         }
         if (blockAfter) {
-            for (Tmp tmp : liveness.liveAtHead(blockAfter)) {
-                ASSERT(activeIntervals[tmp].begin() == this->positionOfHead(blockAfter));
-                closeInterval(tmp);
-            }
+            Point firstBlockPositionOfHead = this->positionOfHead(blockAfter);
+            for (Tmp tmp : liveness.liveAtHead(blockAfter))
+                markDef(tmp, firstBlockPositionOfHead);
         }
 
 #if ASSERT_ENABLED
         m_code.forEachTmp([&](Tmp tmp) {
-            ASSERT(!activeIntervals[tmp]);
+            ASSERT(!activeEnds[tmp]);
         });
 #endif
     }


### PR DESCRIPTION
#### 119ab85f69fdcd30bf83c12c957ddcec0f2781c8
<pre>
[JSC][GreedyRegAlloc] buildLiveRanges can track interval end rather than interval
<a href="https://bugs.webkit.org/show_bug.cgi?id=292104">https://bugs.webkit.org/show_bug.cgi?id=292104</a>
<a href="https://rdar.apple.com/150113046">rdar://150113046</a>

Reviewed by Yijia Huang and Yusuke Suzuki.

Rather than keeping a set of live Intervals, we can instead just
track the ends of the intervals. It&apos;s a bit cheaper to do this
bookkeeping since merging Points into an Interval requires checking
both the Interval&apos;s begin and end. But since buildLiveRanges()
processes points in decreasing order, we only need to track the
end of live intervals. Also this avoids the need to iterate the
liveAtHead for each block.

This improves readability since the bookkeeping abstraction is now in
terms of use/def rather than intervals, which is a bit more idiomatic.
Also, it removes a special case for clobbers that was required when
processing them out-of-order w.r.t. other use/defs.

Before:

total ms:  232.402 max ms:  10.764 [Air] GreedyRegAlloc::buildLiveRanges
total ms:  243.187 max ms:  11.164 [Air] GreedyRegAlloc::buildLiveRanges
total ms:  242.306 max ms:  10.915 [Air] GreedyRegAlloc::buildLiveRanges

After:

total ms:  228.547 max ms:   9.746 [Air] GreedyRegAlloc::buildLiveRanges
total ms:  221.583 max ms:  10.154 [Air] GreedyRegAlloc::buildLiveRanges
total ms:  226.871 max ms:  10.116 [Air] GreedyRegAlloc::buildLiveRanges

Canonical link: <a href="https://commits.webkit.org/294266@main">https://commits.webkit.org/294266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3129aa280200de2f542f5de0cf4b5471abdad691

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106300 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51779 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77052 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34078 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16277 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91370 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57399 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16094 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9390 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51127 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/93819 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85996 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9453 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108656 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/99761 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28280 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20882 "Found 1 new test failure: http/tests/iframe-monitor/data-url-resource.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86019 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28642 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87571 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85559 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21797 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30281 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8007 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22379 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28210 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33480 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/123387 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28022 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34354 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31342 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29580 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->