### PR TITLE
Use CheckedPtr for SharedTimer

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -105,7 +105,6 @@ platform/PODRedBlackTree.h
 platform/PlatformStrategies.h
 platform/Scrollbar.h
 platform/ThreadGlobalData.h
-platform/ThreadTimers.h
 platform/cocoa/TelephoneNumberDetectorCocoa.cpp
 platform/graphics/ImageBufferContextSwitcher.h
 platform/graphics/StringTruncator.cpp

--- a/Source/WebCore/platform/MainThreadSharedTimer.h
+++ b/Source/WebCore/platform/MainThreadSharedTimer.h
@@ -38,6 +38,7 @@ namespace WebCore {
 
 class MainThreadSharedTimer final : public SharedTimer {
     WTF_MAKE_TZONE_ALLOCATED(MainThreadSharedTimer);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MainThreadSharedTimer);
     friend class NeverDestroyed<MainThreadSharedTimer>;
 public:
     static MainThreadSharedTimer& singleton();

--- a/Source/WebCore/platform/SharedTimer.h
+++ b/Source/WebCore/platform/SharedTimer.h
@@ -26,6 +26,7 @@
 #ifndef SharedTimer_h
 #define SharedTimer_h
 
+#include <wtf/CheckedRef.h>
 #include <wtf/Function.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Seconds.h>
@@ -36,9 +37,10 @@ namespace WebCore {
 // Each thread has its own single instance of shared timer, which implements this interface.
 // This instance is shared by all timers in the thread.
 // Not intended to be used directly; use the Timer class instead.
-class SharedTimer {
+class SharedTimer : public CanMakeCheckedPtr<SharedTimer> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(SharedTimer);
     WTF_MAKE_NONCOPYABLE(SharedTimer);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SharedTimer);
 public:
     SharedTimer() = default;
     virtual ~SharedTimer() = default;

--- a/Source/WebCore/platform/ThreadTimers.cpp
+++ b/Source/WebCore/platform/ThreadTimers.cpp
@@ -43,6 +43,11 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ThreadTimers);
 
+inline CheckedPtr<SharedTimer> ThreadTimers::checkedSharedTimer()
+{
+    return m_sharedTimer.get();
+}
+
 // Timers are created, started and fired on the same thread, and each thread has its own ThreadTimers
 // copy to keep the heap and a set of currently firing timers.
 
@@ -56,16 +61,16 @@ ThreadTimers::ThreadTimers()
 // Also, SharedTimer can be replaced with nullptr before all timers are destroyed.
 void ThreadTimers::setSharedTimer(SharedTimer* sharedTimer)
 {
-    if (m_sharedTimer) {
-        m_sharedTimer->setFiredFunction(nullptr);
-        m_sharedTimer->stop();
+    if (CheckedPtr sharedTimer = m_sharedTimer) {
+        sharedTimer->setFiredFunction(nullptr);
+        sharedTimer->stop();
         m_pendingSharedTimerFireTime = MonotonicTime { };
     }
     
     m_sharedTimer = sharedTimer;
     
     if (sharedTimer) {
-        m_sharedTimer->setFiredFunction([] { threadGlobalData().threadTimers().sharedTimerFiredInternal(); });
+        sharedTimer->setFiredFunction([] { threadGlobalData().threadTimers().sharedTimerFiredInternal(); });
         updateSharedTimer();
     }
 }
@@ -83,7 +88,7 @@ void ThreadTimers::updateSharedTimer()
 
     if (m_firingTimers || m_timerHeap.isEmpty()) {
         m_pendingSharedTimerFireTime = MonotonicTime { };
-        m_sharedTimer->stop();
+        checkedSharedTimer()->stop();
     } else {
         MonotonicTime nextFireTime = m_timerHeap.first()->time;
         MonotonicTime currentMonotonicTime = MonotonicTime::now();
@@ -93,7 +98,7 @@ void ThreadTimers::updateSharedTimer()
                 return;
         } 
         m_pendingSharedTimerFireTime = nextFireTime;
-        m_sharedTimer->setFireInterval(std::max(nextFireTime - currentMonotonicTime, 0_s));
+        checkedSharedTimer()->setFireInterval(std::max(nextFireTime - currentMonotonicTime, 0_s));
     }
 }
 
@@ -146,8 +151,8 @@ void ThreadTimers::fireTimersInNestedEventLoop()
     // Reset the reentrancy guard so the timers can fire again.
     m_firingTimers = false;
 
-    if (m_sharedTimer) {
-        m_sharedTimer->invalidate();
+    if (CheckedPtr sharedTimer = m_sharedTimer) {
+        sharedTimer->invalidate();
         m_pendingSharedTimerFireTime = MonotonicTime { };
     }
 

--- a/Source/WebCore/platform/ThreadTimers.h
+++ b/Source/WebCore/platform/ThreadTimers.h
@@ -27,6 +27,7 @@
 #ifndef ThreadTimers_h
 #define ThreadTimers_h
 
+#include <wtf/CheckedPtr.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefCounted.h>
@@ -65,11 +66,13 @@ public:
     unsigned nextHeapInsertionCount() { return m_currentHeapInsertionOrder++; }
 
 private:
+    inline CheckedPtr<SharedTimer> checkedSharedTimer();
+
     void sharedTimerFiredInternal();
     void fireTimersInNestedEventLoopInternal();
 
     ThreadTimerHeap m_timerHeap;
-    SharedTimer* m_sharedTimer { nullptr }; // External object, can be a run loop on a worker thread. Normally set/reset by worker thread.
+    CheckedPtr<SharedTimer> m_sharedTimer; // External object, can be a run loop on a worker thread. Normally set/reset by worker thread.
     bool m_firingTimers { false };
     bool m_shouldBreakFireLoopForRenderingUpdate { false };
     unsigned m_currentHeapInsertionOrder { 0 };


### PR DESCRIPTION
#### c5c1a86c0f823abe547291692b3f5bd772799937
<pre>
Use CheckedPtr for SharedTimer
<a href="https://bugs.webkit.org/show_bug.cgi?id=292105">https://bugs.webkit.org/show_bug.cgi?id=292105</a>

Reviewed by Chris Dumez.

Use CheckedPtr&lt;SharedTimer&gt; in ThreadTimers instead of a raw pointer.

* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/platform/MainThreadSharedTimer.h:
* Source/WebCore/platform/SharedTimer.h:
* Source/WebCore/platform/ThreadTimers.cpp:
(WebCore::ThreadTimers::checkedSharedTimer):
(WebCore::ThreadTimers::setSharedTimer):
(WebCore::ThreadTimers::updateSharedTimer):
(WebCore::ThreadTimers::fireTimersInNestedEventLoop):
* Source/WebCore/platform/ThreadTimers.h:
* Source/WebCore/workers/WorkerRunLoop.cpp:
(WebCore::WorkerDedicatedRunLoop::WorkerDedicatedRunLoop):
(WebCore::RunLoopSetup::RunLoopSetup):
(WebCore::RunLoopSetup::~RunLoopSetup):

Canonical link: <a href="https://commits.webkit.org/294233@main">https://commits.webkit.org/294233@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93f7b9483bf036d2bba62e70297d92a4e05fc11e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101233 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106381 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51860 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103274 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21204 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29389 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77100 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34134 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104240 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16350 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91439 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57447 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16166 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9449 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51208 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86051 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9525 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108737 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28361 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86075 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28723 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85625 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30354 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8065 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22460 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16462 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28291 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33562 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28103 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31423 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29661 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->