### PR TITLE
Remove IsDeprecatedWeakRefSmartPointerException from WebCore/css

### DIFF
--- a/Source/WebCore/css/CSSFontFace.h
+++ b/Source/WebCore/css/CSSFontFace.h
@@ -39,15 +39,6 @@
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
-class CSSFontFaceClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::CSSFontFaceClient> : std::true_type { };
-}
-
-namespace WebCore {
 
 class CSSFontFaceClient;
 class CSSFontFaceSource;

--- a/Source/WebCore/css/CSSFontFaceSet.h
+++ b/Source/WebCore/css/CSSFontFaceSet.h
@@ -26,20 +26,12 @@
 #pragma once
 
 #include "CSSFontFace.h"
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/Observer.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/StringHash.h>
-
-namespace WebCore {
-struct FontEventClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::FontEventClient> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -49,7 +41,7 @@ class FontFaceSet;
 
 template<typename> class ExceptionOr;
 
-struct FontEventClient : public CanMakeWeakPtr<FontEventClient> {
+struct FontEventClient : public AbstractRefCountedAndCanMakeWeakPtr<FontEventClient> {
     virtual ~FontEventClient() = default;
     virtual void faceFinished(CSSFontFace&, CSSFontFace::Status) = 0;
     virtual void startedLoading() = 0;

--- a/Source/WebCore/css/parser/CSSParserObserverWrapper.h
+++ b/Source/WebCore/css/parser/CSSParserObserverWrapper.h
@@ -30,25 +30,17 @@
 #pragma once
 
 #include "CSSParserObserver.h"
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Vector.h>
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class CSSParserObserverWrapper;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::CSSParserObserverWrapper> : std::true_type { };
-}
 
 namespace WebCore {
 
-class CSSParserObserverWrapper : public CanMakeWeakPtr<CSSParserObserverWrapper> {
+class CSSParserObserverWrapper : public RefCountedAndCanMakeWeakPtr<CSSParserObserverWrapper> {
 public:
-    explicit CSSParserObserverWrapper(CSSParserObserver& observer)
-        : m_observer(observer)
-    { }
+    static Ref<CSSParserObserverWrapper> create(CSSParserObserver& observer)
+    {
+        return adoptRef(*new CSSParserObserverWrapper(observer));
+    }
 
     unsigned startOffset(const CSSParserTokenRange&);
     unsigned previousTokenStartOffset(const CSSParserTokenRange&);
@@ -71,6 +63,10 @@ public:
     }
 
 private:
+    explicit CSSParserObserverWrapper(CSSParserObserver& observer)
+        : m_observer(observer)
+    { }
+
     CSSParserObserver& m_observer;
     Vector<unsigned> m_tokenOffsets;
     CSSParserToken* m_firstParserToken;


### PR DESCRIPTION
#### e39d426a02eea499dd5d78a0052cdc8a5a17818f
<pre>
Remove IsDeprecatedWeakRefSmartPointerException from WebCore/css
<a href="https://bugs.webkit.org/show_bug.cgi?id=292106">https://bugs.webkit.org/show_bug.cgi?id=292106</a>
<a href="https://rdar.apple.com/150115307">rdar://150115307</a>

Reviewed by Chris Dumez.

Remove IsDeprecatedWeakRefSmartPointerException from WebCore/css

* Source/WebCore/css/CSSFontFace.h:
* Source/WebCore/css/CSSFontFaceSet.h:
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::parseDeclarationListForInspector):
(WebCore::CSSParser::parseStyleSheetForInspector):
(WebCore::CSSParser::consumeImportRule):
(WebCore::CSSParser::consumeMediaRule):
(WebCore::CSSParser::consumeSupportsRule):
(WebCore::CSSParser::consumeFontFaceRule):
(WebCore::CSSParser::consumeFontFeatureValuesRuleBlock):
(WebCore::CSSParser::consumeFontFeatureValuesRule):
(WebCore::CSSParser::consumeFontPaletteValuesRule):
(WebCore::CSSParser::consumeKeyframesRule):
(WebCore::CSSParser::consumePageRule):
(WebCore::CSSParser::consumeCounterStyleRule):
(WebCore::CSSParser::consumeViewTransitionRule):
(WebCore::CSSParser::consumePositionTryRule):
(WebCore::CSSParser::consumeScopeRule):
(WebCore::CSSParser::consumeStartingStyleRule):
(WebCore::CSSParser::consumeLayerRule):
(WebCore::CSSParser::consumeContainerRule):
(WebCore::CSSParser::consumeKeyframeStyleRule):
(WebCore::CSSParser::consumeStyleRule):
(WebCore::CSSParser::consumeBlockContent):
(WebCore::CSSParser::consumeDeclaration):
* Source/WebCore/css/parser/CSSParserObserverWrapper.h:
(WebCore::CSSParserObserverWrapper::create):
(WebCore::CSSParserObserverWrapper::CSSParserObserverWrapper):

Canonical link: <a href="https://commits.webkit.org/294291@main">https://commits.webkit.org/294291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6c2008a657b3998dcc16722345dfdb2bdd5526a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101147 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11112 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106295 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51774 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103188 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29303 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77047 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34076 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16278 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91363 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57394 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16096 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9384 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51122 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85997 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9446 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108651 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28275 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20821 "Found 1 new test failure: http/tests/iframe-monitor/iframe-unload.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86018 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28637 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87564 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85557 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30278 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8001 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22374 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16496 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28205 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33475 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28017 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31337 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->