### PR TITLE
[Viewport Clipping] [Part 1/4] Refactor {Sticky|Fixed}PositionViewportConstraints to support adding a viewport-sized clip layer

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingConstraints.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingConstraints.cpp
@@ -40,7 +40,7 @@ AbsolutePositionConstraints::AbsolutePositionConstraints(const FloatSize& alignm
 {
 }
 
-FloatPoint FixedPositionViewportConstraints::layerPositionForViewportRect(const FloatRect& viewportRect) const
+FloatPoint ViewportConstraints::viewportRelativeLayerPosition(const FloatRect& viewportRect) const
 {
     FloatSize offset;
 
@@ -104,10 +104,10 @@ FloatSize StickyPositionViewportConstraints::computeStickyOffset(const FloatRect
     return boxRect.location() - m_stickyBoxRect.location();
 }
 
-FloatPoint StickyPositionViewportConstraints::layerPositionForConstrainingRect(const FloatRect& constrainingRect) const
+FloatPoint StickyPositionViewportConstraints::anchorLayerPositionForConstrainingRect(const FloatRect& constrainingRect) const
 {
     FloatSize offset = computeStickyOffset(constrainingRect);
-    return m_layerPositionAtLastLayout + offset - m_stickyOffsetAtLastLayout;
+    return (m_layerPositionAtLastLayout + m_anchorLayerOffsetAtLastLayout) + offset - m_stickyOffsetAtLastLayout;
 }
 
 TextStream& operator<<(TextStream& ts, ScrollPositioningBehavior behavior)
@@ -138,7 +138,9 @@ TextStream& operator<<(TextStream& ts, const FixedPositionViewportConstraints& c
 TextStream& operator<<(TextStream& ts, const StickyPositionViewportConstraints& constraints)
 {
     ts.dumpProperty("sticky-position-at-last-layout"_s, constraints.stickyOffsetAtLastLayout());
+    ts.dumpProperty("viewport-rect-at-last-layout"_s, constraints.viewportRectAtLastLayout());
     ts.dumpProperty("layer-position-at-last-layout"_s, constraints.layerPositionAtLastLayout());
+    ts.dumpProperty("anchor-layer-offset-at-last-layout"_s, constraints.anchorLayerOffsetAtLastLayout());
 
     ts.dumpProperty("sticky-box-rect"_s, constraints.stickyBoxRect());
     ts.dumpProperty("containing-block-rect"_s, constraints.containingBlockRect());

--- a/Source/WebCore/page/scrolling/ScrollingConstraints.h
+++ b/Source/WebCore/page/scrolling/ScrollingConstraints.h
@@ -80,6 +80,14 @@ public:
     FloatSize alignmentOffset() const { return m_alignmentOffset; }
     void setAlignmentOffset(FloatSize offset) { m_alignmentOffset = offset; }
 
+    WEBCORE_EXPORT FloatPoint viewportRelativeLayerPosition(const FloatRect& viewportRect) const;
+
+    const FloatRect& viewportRectAtLastLayout() const { return m_viewportRectAtLastLayout; }
+    void setViewportRectAtLastLayout(const FloatRect& rect) { m_viewportRectAtLastLayout = rect; }
+
+    const FloatPoint& layerPositionAtLastLayout() const { return m_layerPositionAtLastLayout; }
+    void setLayerPositionAtLastLayout(FloatPoint position) { m_layerPositionAtLastLayout = position; }
+
     friend bool operator==(const ViewportConstraints&, const ViewportConstraints&) = default;
 
 protected:
@@ -87,13 +95,17 @@ protected:
         : m_anchorEdges(0)
     { }
 
-    ViewportConstraints(FloatSize&& alignmentOffset, AnchorEdges&& anchorEdges)
+    ViewportConstraints(FloatSize&& alignmentOffset, AnchorEdges&& anchorEdges, FloatRect&& viewportRectAtLastLayout, FloatPoint&& layerPositionAtLastLayout)
         : m_alignmentOffset(WTFMove(alignmentOffset))
         , m_anchorEdges(WTFMove(anchorEdges))
+        , m_viewportRectAtLastLayout(WTFMove(viewportRectAtLastLayout))
+        , m_layerPositionAtLastLayout(WTFMove(layerPositionAtLastLayout))
     { }
 
     FloatSize m_alignmentOffset;
     AnchorEdges m_anchorEdges;
+    FloatRect m_viewportRectAtLastLayout;
+    FloatPoint m_layerPositionAtLastLayout;
 };
 
 class FixedPositionViewportConstraints : public ViewportConstraints {
@@ -103,26 +115,12 @@ public:
     { }
 
     FixedPositionViewportConstraints(FloatSize&& alignmentOffset, AnchorEdges&& anchorEdges, FloatRect&& viewportRectAtLastLayout, FloatPoint&& layerPositionAtLastLayout)
-        : ViewportConstraints(WTFMove(alignmentOffset), WTFMove(anchorEdges))
-        , m_viewportRectAtLastLayout(WTFMove(viewportRectAtLastLayout))
-        , m_layerPositionAtLastLayout(WTFMove(layerPositionAtLastLayout))
-    { }
-    
-    WEBCORE_EXPORT FloatPoint layerPositionForViewportRect(const FloatRect& viewportRect) const;
-
-    const FloatRect& viewportRectAtLastLayout() const { return m_viewportRectAtLastLayout; }
-    void setViewportRectAtLastLayout(const FloatRect& rect) { m_viewportRectAtLastLayout = rect; }
-
-    const FloatPoint& layerPositionAtLastLayout() const { return m_layerPositionAtLastLayout; }
-    void setLayerPositionAtLastLayout(FloatPoint position) { m_layerPositionAtLastLayout = position; }
-
-    friend bool operator==(const FixedPositionViewportConstraints&, const FixedPositionViewportConstraints&) = default;
+        : ViewportConstraints { WTFMove(alignmentOffset), WTFMove(anchorEdges), WTFMove(viewportRectAtLastLayout), WTFMove(layerPositionAtLastLayout) }
+    {
+    }
 
 private:
     ConstraintType constraintType() const override { return FixedPositionConstraint; };
-
-    FloatRect m_viewportRectAtLastLayout;
-    FloatPoint m_layerPositionAtLastLayout;
 };
 
 class StickyPositionViewportConstraints : public ViewportConstraints {
@@ -134,8 +132,8 @@ public:
         , m_bottomOffset(0)
     { }
 
-    StickyPositionViewportConstraints(FloatSize&& alignmentOffset, AnchorEdges&& anchorEdges, float leftOffset, float rightOffset, float topOffset, float bottomOffset, FloatRect&& constrainingRectAtLastLayout, FloatRect&& containingBlockRect, FloatRect&& stickyBoxRect, FloatSize&& stickyOffsetAtLastLayout, FloatPoint&& layerPositionAtLastLayout)
-        : ViewportConstraints(WTFMove(alignmentOffset), WTFMove(anchorEdges))
+    StickyPositionViewportConstraints(FloatSize&& alignmentOffset, AnchorEdges&& anchorEdges, float leftOffset, float rightOffset, float topOffset, float bottomOffset, FloatRect&& constrainingRectAtLastLayout, FloatRect&& containingBlockRect, FloatRect&& stickyBoxRect, FloatSize&& stickyOffsetAtLastLayout, FloatSize&& anchorLayerOffsetAtLastLayout, FloatRect&& viewportRectAtLastLayout, FloatPoint&& layerPositionAtLastLayout)
+        : ViewportConstraints { WTFMove(alignmentOffset), WTFMove(anchorEdges), WTFMove(viewportRectAtLastLayout), WTFMove(layerPositionAtLastLayout) }
         , m_leftOffset(leftOffset)
         , m_rightOffset(rightOffset)
         , m_topOffset(topOffset)
@@ -144,18 +142,18 @@ public:
         , m_containingBlockRect(WTFMove(containingBlockRect))
         , m_stickyBoxRect(WTFMove(stickyBoxRect))
         , m_stickyOffsetAtLastLayout(WTFMove(stickyOffsetAtLastLayout))
-        , m_layerPositionAtLastLayout(WTFMove(layerPositionAtLastLayout))
+        , m_anchorLayerOffsetAtLastLayout(WTFMove(anchorLayerOffsetAtLastLayout))
     { }
 
     FloatSize computeStickyOffset(const FloatRect& constrainingRect) const;
 
+    const FloatSize& anchorLayerOffsetAtLastLayout() const { return m_anchorLayerOffsetAtLastLayout; }
+    void setAnchorLayerOffsetAtLastLayout(FloatSize offset) { m_anchorLayerOffsetAtLastLayout = offset; }
+
     const FloatSize stickyOffsetAtLastLayout() const { return m_stickyOffsetAtLastLayout; }
     void setStickyOffsetAtLastLayout(FloatSize offset) { m_stickyOffsetAtLastLayout = offset; }
 
-    WEBCORE_EXPORT FloatPoint layerPositionForConstrainingRect(const FloatRect& constrainingRect) const;
-
-    const FloatPoint& layerPositionAtLastLayout() const { return m_layerPositionAtLastLayout; }
-    void setLayerPositionAtLastLayout(FloatPoint position) { m_layerPositionAtLastLayout = position; }
+    WEBCORE_EXPORT FloatPoint anchorLayerPositionForConstrainingRect(const FloatRect& constrainingRect) const;
 
     float leftOffset() const { return m_leftOffset; }
     float rightOffset() const { return m_rightOffset; }
@@ -193,7 +191,7 @@ private:
     FloatRect m_containingBlockRect;
     FloatRect m_stickyBoxRect;
     FloatSize m_stickyOffsetAtLastLayout;
-    FloatPoint m_layerPositionAtLastLayout;
+    FloatSize m_anchorLayerOffsetAtLastLayout;
 };
 
 

--- a/Source/WebCore/page/scrolling/ScrollingStateFixedNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateFixedNode.cpp
@@ -84,7 +84,7 @@ void ScrollingStateFixedNode::updateConstraints(const FixedPositionViewportConst
 
 void ScrollingStateFixedNode::reconcileLayerPositionForViewportRect(const LayoutRect& viewportRect, ScrollingLayerPositionAction action)
 {
-    FloatPoint position = m_constraints.layerPositionForViewportRect(viewportRect);
+    auto position = m_constraints.viewportRelativeLayerPosition(viewportRect);
     if (layer().representsGraphicsLayer()) {
         RefPtr graphicsLayer = static_cast<GraphicsLayer*>(layer());
         ASSERT(graphicsLayer);

--- a/Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp
@@ -99,7 +99,7 @@ FloatPoint ScrollingStateStickyNode::computeLayerPosition(const LayoutRect& view
             constrainingRect = FloatRect(overflowScrollingNode->scrollPosition(), m_constraints.constrainingRectAtLastLayout().size());
 
         constrainingRect.move(offsetFromStickyAncestors);
-        return m_constraints.layerPositionForConstrainingRect(constrainingRect);
+        return m_constraints.anchorLayerPositionForConstrainingRect(constrainingRect);
     };
 
     for (auto ancestor = parent(); ancestor; ancestor = ancestor->parent()) {

--- a/Source/WebCore/page/scrolling/ScrollingTreeFixedNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFixedNode.cpp
@@ -72,7 +72,7 @@ FloatPoint ScrollingTreeFixedNode::computeLayerPosition() const
             // Fixed nodes are positioned relative to the containing frame scrolling node.
             // We bail out after finding one.
             auto layoutViewport = scrollingNode->layoutViewport();
-            return m_constraints.layerPositionForViewportRect(layoutViewport) - overflowScrollDelta;
+            return m_constraints.viewportRelativeLayerPosition(layoutViewport) - overflowScrollDelta;
         }
 
         if (auto* overflowNode = dynamicDowncast<ScrollingTreeOverflowScrollingNode>(*ancestor)) {

--- a/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp
@@ -86,7 +86,7 @@ FloatPoint ScrollingTreeStickyNode::computeLayerPosition() const
             constrainingRect.move(overflowScrollingNode->scrollDeltaSinceLastCommit());
         }
         constrainingRect.move(-offsetFromStickyAncestors);
-        return m_constraints.layerPositionForConstrainingRect(constrainingRect);
+        return m_constraints.anchorLayerPositionForConstrainingRect(constrainingRect);
     };
 
     for (RefPtr ancestor = parent(); ancestor; ancestor = ancestor->parent()) {

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -5327,6 +5327,7 @@ StickyPositionViewportConstraints RenderLayerCompositor::computeStickyViewportCo
     StickyPositionViewportConstraints constraints;
     renderer.computeStickyPositionConstraints(constraints, renderer.constrainingRectForStickyPosition());
 
+    constraints.setViewportRectAtLastLayout(m_renderView.protectedFrameView()->rectForFixedPositionLayout());
     constraints.setLayerPositionAtLastLayout(anchorLayer->position());
     constraints.setStickyOffsetAtLastLayout(renderer.stickyPositionOffset());
     constraints.setAlignmentOffset(anchorLayer->pixelAlignmentOffset());

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7276,6 +7276,8 @@ header: <WebCore/ScrollingConstraints.h>
     WebCore::FloatRect containingBlockRect();
     WebCore::FloatRect stickyBoxRect();
     WebCore::FloatSize stickyOffsetAtLastLayout();
+    WebCore::FloatSize anchorLayerOffsetAtLastLayout();
+    WebCore::FloatRect viewportRectAtLastLayout();
     WebCore::FloatPoint layerPositionAtLastLayout();
 };
 

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebFixedPositionContent.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebFixedPositionContent.mm
@@ -113,7 +113,7 @@ WebFixedPositionContentData::~WebFixedPositionContentData()
         case ViewportConstraints::FixedPositionConstraint: {
             auto& fixedConstraints = downcast<FixedPositionViewportConstraints>(constraints);
 
-            FloatPoint layerPosition = fixedConstraints.layerPositionForViewportRect(positionedObjectsRect);
+            auto layerPosition = fixedConstraints.viewportRelativeLayerPosition(positionedObjectsRect);
             
             CGRect layerBounds = [layer bounds];
             CGPoint anchorPoint = [layer anchorPoint];
@@ -125,7 +125,7 @@ WebFixedPositionContentData::~WebFixedPositionContentData()
         case ViewportConstraints::StickyPositionConstraint: {
             auto& stickyConstraints = downcast<StickyPositionViewportConstraints>(constraints);
 
-            FloatPoint layerPosition = stickyConstraints.layerPositionForConstrainingRect(positionedObjectsRect);
+            FloatPoint layerPosition = stickyConstraints.anchorLayerPositionForConstrainingRect(positionedObjectsRect);
 
             CGRect layerBounds = [layer bounds];
             CGPoint anchorPoint = [layer anchorPoint];
@@ -151,7 +151,7 @@ WebFixedPositionContentData::~WebFixedPositionContentData()
             const StickyPositionViewportConstraints& stickyConstraints = static_cast<const StickyPositionViewportConstraints&>(*(constraintData->m_viewportConstraints.get()));
             FloatRect constrainingRectAtLastLayout = stickyConstraints.constrainingRectAtLastLayout();
             FloatRect scrolledConstrainingRect = FloatRect(scrollPosition.x, scrollPosition.y, constrainingRectAtLastLayout.width(), constrainingRectAtLastLayout.height());
-            FloatPoint layerPosition = stickyConstraints.layerPositionForConstrainingRect(scrolledConstrainingRect);
+            FloatPoint layerPosition = stickyConstraints.anchorLayerPositionForConstrainingRect(scrolledConstrainingRect);
 
             CGRect layerBounds = [layer bounds];
             CGPoint anchorPoint = [layer anchorPoint];


### PR DESCRIPTION
#### ab202ed2ed76dfdfb62e74c77f8647d24f247a18
<pre>
[Viewport Clipping] [Part 1/4] Refactor {Sticky|Fixed}PositionViewportConstraints to support adding a viewport-sized clip layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=292107">https://bugs.webkit.org/show_bug.cgi?id=292107</a>
<a href="https://rdar.apple.com/150115392">rdar://150115392</a>

Reviewed by Abrar Rahman Protyasha.

In preparation for supporting a configuration where sticky and fixed elements in the main frame are
clipped to the bounds of the layout viewport, we refactor `StickyPositionViewportConstraints` and
`FixedPositionViewportConstraints`; see comments below for more details.

No change in behavior yet.

* Source/WebCore/page/scrolling/ScrollingConstraints.cpp:
(WebCore::ViewportConstraints::viewportRelativeLayerPosition const):

Move `layerPositionForViewportRect` from `FixedPositionViewportConstraints` → `ViewportConstraints`,
so that we can use it for `StickyPositionViewportConstraints` as well. In doing so, we also move the
member variables `m_viewportRectAtLastLayout` and `m_layerPositionAtLastLayout` into the base
`ViewportConstraints` class.

Additionally, rename `layerPositionForViewportRect` to `viewportRelativeLayerPosition` to clarify
that this refers to the layer whose position is adjusted when scrolling, in relation to the new
viewport rect.

(WebCore::StickyPositionViewportConstraints::anchorLayerPositionForConstrainingRect const):
(WebCore::operator&lt;&lt;):
(WebCore::FixedPositionViewportConstraints::layerPositionForViewportRect const): Deleted.

Move this into `ViewportConstraints` (see above).

(WebCore::StickyPositionViewportConstraints::layerPositionForConstrainingRect const): Deleted.

Add `anchor` in front of this method name (see above).

* Source/WebCore/page/scrolling/ScrollingConstraints.h:
(WebCore::ViewportConstraints::viewportRectAtLastLayout const):
(WebCore::ViewportConstraints::setViewportRectAtLastLayout):
(WebCore::ViewportConstraints::layerPositionAtLastLayout const):
(WebCore::ViewportConstraints::setLayerPositionAtLastLayout):

Add getters/setters for `layerPositionAtLastLayout` and `viewportRectAtLastLayout`, which are now
both on the base `ViewportConstraints`.

(WebCore::ViewportConstraints::ViewportConstraints):
(WebCore::FixedPositionViewportConstraints::FixedPositionViewportConstraints):
(WebCore::StickyPositionViewportConstraints::StickyPositionViewportConstraints):
(WebCore::StickyPositionViewportConstraints::m_anchorLayerOffsetAtLastLayout):
(WebCore::StickyPositionViewportConstraints::anchorLayerOffsetAtLastLayout const):

Add a new member, `m_anchorLayerOffsetAtLastLayout`, along with getters and setters. This represents
the offset (at the time of the last layout) from the anchor layer and its parent layer — either the
parent of the sticky node or the clipping layer.

This is effectively unused at the moment, since it&apos;s always `(0, 0)`, but will be set in a future
patch once the notion of `viewportClippingLayer` for fixed/sticky layers exists.

(WebCore::StickyPositionViewportConstraints::setAnchorLayerOffsetAtLastLayout):
(WebCore::FixedPositionViewportConstraints::viewportRectAtLastLayout const): Deleted.
(WebCore::FixedPositionViewportConstraints::setViewportRectAtLastLayout): Deleted.
(WebCore::FixedPositionViewportConstraints::layerPositionAtLastLayout const): Deleted.
(WebCore::FixedPositionViewportConstraints::setLayerPositionAtLastLayout): Deleted.
(WebCore::StickyPositionViewportConstraints::layerPositionAtLastLayout const): Deleted.
(WebCore::StickyPositionViewportConstraints::setLayerPositionAtLastLayout): Deleted.

Remove this redundant getter/setter and member variable, now that `layerPositionAtLastLayout` is in
the base class.

* Source/WebCore/page/scrolling/ScrollingStateFixedNode.cpp:
(WebCore::ScrollingStateFixedNode::reconcileLayerPositionForViewportRect):
* Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp:
(WebCore::ScrollingStateStickyNode::computeLayerPosition const):
* Source/WebCore/page/scrolling/ScrollingTreeFixedNode.cpp:
(WebCore::ScrollingTreeFixedNode::computeLayerPosition const):
* Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp:
(WebCore::ScrollingTreeStickyNode::computeLayerPosition const):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::computeStickyViewportConstraints const):

Set the new `viewportRectAtLastLayout` on sticky constraints. Note that we skip setting the new
`anchorLayerOffsetAtLastLayout` for now, because the clipping layer hasn&apos;t been introduced yet.

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Add serialization for the two new members on `StickyPositionViewportConstraints`. Note that the
serialization of `FixedPositionViewportConstraints` is unchanged here because all the same members
still exist — they&apos;re just on `ViewportConstraints` now.

* Source/WebKitLegacy/ios/WebCoreSupport/WebFixedPositionContent.mm:
(-[WebFixedPositionContent scrollOrZoomChanged:]):
(-[WebFixedPositionContent overflowScrollPositionForLayer:changedTo:]):

Canonical link: <a href="https://commits.webkit.org/294230@main">https://commits.webkit.org/294230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0583b748e51325542eaf6b300e93b05719515deb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101209 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20871 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106357 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51836 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103250 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29365 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/77086 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34119 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104216 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91423 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57433 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16155 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9433 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51184 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/86041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9507 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108713 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28337 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86059 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28699 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87626 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85609 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21780 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30341 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8049 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22436 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28267 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33538 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28079 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31399 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29637 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->