### PR TITLE
Remove IsDeprecatedWeakRefSmartPointerException from CookieChangeListener

### DIFF
--- a/Source/WebCore/loader/CookieChangeListener.h
+++ b/Source/WebCore/loader/CookieChangeListener.h
@@ -25,23 +25,14 @@
 
 #pragma once
 
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Forward.h>
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class CookieChangeListener;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::CookieChangeListener> : std::true_type { };
-}
 
 namespace WebCore {
 
 struct Cookie;
 
-class CookieChangeListener : public CanMakeWeakPtr<CookieChangeListener> {
+class CookieChangeListener : public AbstractRefCountedAndCanMakeWeakPtr<CookieChangeListener> {
 public:
     virtual void cookiesAdded(const String& host, const Vector<Cookie>&) = 0;
     virtual void cookiesDeleted(const String& host, const Vector<Cookie>&) = 0;

--- a/Source/WebKit/WebProcess/WebPage/WebCookieCache.h
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieCache.h
@@ -28,14 +28,16 @@
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/CookieChangeListener.h>
 #include <WebCore/CookieJar.h>
+#include <WebCore/NetworkStorageSession.h>
 #include <WebCore/SameSiteInfo.h>
 #include <wtf/Forward.h>
 #include <wtf/HashSet.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
 #include <wtf/RefCounter.h>
 
 namespace WebCore {
 struct Cookie;
-class NetworkStorageSession;
 enum class ShouldRelaxThirdPartyCookieBlocking : bool;
 }
 
@@ -44,10 +46,17 @@ namespace WebKit {
 enum PendingCookieUpdateCounterType { };
 using PendingCookieUpdateCounter = RefCounter<PendingCookieUpdateCounterType>;
 
-class WebCookieCache final : public WebCore::CookieChangeListener {
+class WebCookieCache final : public RefCounted<WebCookieCache>, public WebCore::CookieChangeListener {
 public:
-    WebCookieCache() = default;
+    static Ref<WebCookieCache> create()
+    {
+        return adoptRef(*new WebCookieCache);
+    }
+
     virtual ~WebCookieCache();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     bool isSupported();
 
@@ -65,6 +74,8 @@ public:
     void setOptInCookiePartitioningEnabled(bool);
 
 private:
+    WebCookieCache() = default;
+
     WebCore::NetworkStorageSession& inMemoryStorageSession();
     void pruneCacheIfNecessary();
     bool cacheMayBeOutOfSync() const;

--- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
@@ -93,7 +93,7 @@ private:
     NSHTTPCookieStorage* ensurePartitionedCookieStorage();
 #endif
 
-    mutable WebCookieCache m_cache;
+    const Ref<WebCookieCache> m_cache;
     HashMap<String, WeakHashSet<WebCore::CookieChangeListener>> m_changeListeners;
 
 #if PLATFORM(COCOA)


### PR DESCRIPTION
#### 496bc364b988d838d2f2b8684f7b0af54960d252
<pre>
Remove IsDeprecatedWeakRefSmartPointerException from CookieChangeListener
<a href="https://bugs.webkit.org/show_bug.cgi?id=292108">https://bugs.webkit.org/show_bug.cgi?id=292108</a>
<a href="https://rdar.apple.com/150115987">rdar://150115987</a>

Reviewed by Chris Dumez.

Remove IsDeprecatedWeakRefSmartPointerException from CookieChangeListener

* Source/WebCore/loader/CookieChangeListener.h:
* Source/WebKit/WebProcess/WebPage/WebCookieCache.h:
* Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp:
(WebKit::WebCookieJar::WebCookieJar):
(WebKit::WebCookieJar::isEligibleForCache const):
(WebKit::WebCookieJar::cookies const):
(WebKit::WebCookieJar::setCookies):
(WebKit::WebCookieJar::allCookiesDeleted):
(WebKit::WebCookieJar::clearCache):
(WebKit::WebCookieJar::clearCacheForHost):
(WebKit::WebCookieJar::setCookieAsync const):
(WebKit::WebCookieJar::setOptInCookiePartitioningEnabled):
* Source/WebKit/WebProcess/WebPage/WebCookieJar.h:

Canonical link: <a href="https://commits.webkit.org/294325@main">https://commits.webkit.org/294325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1f26ce1f46d6555299766e945b85acb5627be47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11397 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106580 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52056 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103467 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29585 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77245 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34278 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104434 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91602 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57587 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16333 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9619 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51404 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86209 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108932 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28556 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21007 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86219 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28918 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87808 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85781 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30514 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8223 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22673 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16514 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28487 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33767 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28298 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31618 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29857 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->