### PR TITLE
[Viewport Clipping] [Part 2/4] Add a common base class for ScrollingTree{Sticky|Fixed}Node

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1824,6 +1824,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/scrolling/ScrollingTreeScrollingNode.h
     page/scrolling/ScrollingTreeScrollingNodeDelegate.h
     page/scrolling/ScrollingTreeStickyNode.h
+    page/scrolling/ScrollingTreeViewportConstrainedNode.h
     page/scrolling/ThreadedScrollingTree.h
 
     page/text-extraction/TextExtraction.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -540,7 +540,6 @@ page/scrolling/AsyncScrollingCoordinator.cpp
 page/scrolling/ScrollAnchoringController.cpp
 page/scrolling/ScrollingCoordinator.cpp
 page/scrolling/ScrollingStateStickyNode.cpp
-page/scrolling/ScrollingTreeFixedNode.cpp
 page/scrolling/ScrollingTreeOverflowScrollProxyNode.cpp
 page/scrolling/ScrollingTreePositionedNode.cpp
 page/scrolling/ScrollingTreeStickyNode.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2255,6 +2255,7 @@ page/scrolling/ScrollingTreePositionedNode.cpp
 page/scrolling/ScrollingTreeScrollingNode.cpp
 page/scrolling/ScrollingTreeScrollingNodeDelegate.cpp
 page/scrolling/ScrollingTreeStickyNode.cpp
+page/scrolling/ScrollingTreeViewportConstrainedNode.cpp
 page/scrolling/ThreadedScrollingCoordinator.cpp
 page/scrolling/ThreadedScrollingTree.cpp
 page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp

--- a/Source/WebCore/page/scrolling/ScrollingTreeFixedNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFixedNode.cpp
@@ -44,9 +44,8 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreeFixedNode);
 
 ScrollingTreeFixedNode::ScrollingTreeFixedNode(ScrollingTree& scrollingTree, ScrollingNodeID nodeID)
-    : ScrollingTreeNode(scrollingTree, ScrollingNodeType::Fixed, nodeID)
+    : ScrollingTreeViewportConstrainedNode(scrollingTree, ScrollingNodeType::Fixed, nodeID)
 {
-    scrollingTree.fixedOrStickyNodeAdded(*this);
 }
 
 ScrollingTreeFixedNode::~ScrollingTreeFixedNode() = default;
@@ -61,55 +60,6 @@ bool ScrollingTreeFixedNode::commitStateBeforeChildren(const ScrollingStateNode&
         m_constraints = fixedStateNode->viewportConstraints();
 
     return true;
-}
-
-FloatPoint ScrollingTreeFixedNode::computeLayerPosition() const
-{
-    FloatSize overflowScrollDelta;
-    ScrollingTreeStickyNode* lastStickyNode = nullptr;
-    for (RefPtr ancestor = parent(); ancestor; ancestor = ancestor->parent()) {
-        if (auto* scrollingNode = dynamicDowncast<ScrollingTreeFrameScrollingNode>(*ancestor)) {
-            // Fixed nodes are positioned relative to the containing frame scrolling node.
-            // We bail out after finding one.
-            auto layoutViewport = scrollingNode->layoutViewport();
-            return m_constraints.viewportRelativeLayerPosition(layoutViewport) - overflowScrollDelta;
-        }
-
-        if (auto* overflowNode = dynamicDowncast<ScrollingTreeOverflowScrollingNode>(*ancestor)) {
-            // To keep the layer still during async scrolling we adjust by how much the position has changed since layout.
-            overflowScrollDelta -= overflowNode->scrollDeltaSinceLastCommit();
-            continue;
-        }
-
-        if (auto* overflowNode = dynamicDowncast<ScrollingTreeOverflowScrollProxyNode>(*ancestor)) {
-            // To keep the layer still during async scrolling we adjust by how much the position has changed since layout.
-            overflowScrollDelta -= overflowNode->scrollDeltaSinceLastCommit();
-            continue;
-        }
-
-        if (auto* positioningAncestor = dynamicDowncast<ScrollingTreePositionedNode>(*ancestor)) {
-            // See if sticky node already handled this positioning node.
-            // FIXME: Include positioning node information to sticky/fixed node to avoid these tests.
-            if (lastStickyNode && lastStickyNode->layer() == positioningAncestor->layer())
-                continue;
-            if (positioningAncestor->layer() != layer())
-                overflowScrollDelta -= positioningAncestor->scrollDeltaSinceLastCommit();
-            continue;
-        }
-
-        if (auto* stickyNode = dynamicDowncast<ScrollingTreeStickyNode>(*ancestor)) {
-            overflowScrollDelta += stickyNode->scrollDeltaSinceLastCommit();
-            lastStickyNode = stickyNode;
-            continue;
-        }
-
-        if (is<ScrollingTreeFixedNode>(*ancestor)) {
-            // The ancestor fixed node has already applied the needed corrections to say put.
-            return m_constraints.layerPositionAtLastLayout() - overflowScrollDelta;
-        }
-    }
-    ASSERT_NOT_REACHED();
-    return FloatPoint();
 }
 
 void ScrollingTreeFixedNode::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const

--- a/Source/WebCore/page/scrolling/ScrollingTreeFixedNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFixedNode.h
@@ -31,13 +31,14 @@
 #include "ScrollingPlatformLayer.h"
 #include "ScrollingTree.h"
 #include "ScrollingTreeNode.h"
+#include "ScrollingTreeViewportConstrainedNode.h"
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class FixedPositionViewportConstraints;
 
-class ScrollingTreeFixedNode : public ScrollingTreeNode {
+class ScrollingTreeFixedNode : public ScrollingTreeViewportConstrainedNode {
     WTF_MAKE_TZONE_ALLOCATED(ScrollingTreeFixedNode);
 public:
     virtual ~ScrollingTreeFixedNode();
@@ -45,9 +46,7 @@ public:
 protected:
     ScrollingTreeFixedNode(ScrollingTree&, ScrollingNodeID);
 
-    virtual ScrollingPlatformLayer* layer() const = 0;
-
-    FloatPoint computeLayerPosition() const;
+    const ViewportConstraints& constraints() const final { return m_constraints; }
 
     bool commitStateBeforeChildren(const ScrollingStateNode&) override;
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;

--- a/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp
@@ -46,9 +46,8 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreeStickyNode);
 
 ScrollingTreeStickyNode::ScrollingTreeStickyNode(ScrollingTree& scrollingTree, ScrollingNodeID nodeID)
-    : ScrollingTreeNode(scrollingTree, ScrollingNodeType::Sticky, nodeID)
+    : ScrollingTreeViewportConstrainedNode(scrollingTree, ScrollingNodeType::Sticky, nodeID)
 {
-    scrollingTree.fixedOrStickyNodeAdded(*this);
 }
 
 ScrollingTreeStickyNode::~ScrollingTreeStickyNode() = default;
@@ -74,7 +73,7 @@ void ScrollingTreeStickyNode::dumpProperties(TextStream& ts, OptionSet<Scrolling
         ts.dumpProperty("layer top left"_s, layerTopLeft());
 }
 
-FloatPoint ScrollingTreeStickyNode::computeLayerPosition() const
+FloatPoint ScrollingTreeStickyNode::computeAnchorLayerPosition() const
 {
     FloatSize offsetFromStickyAncestors;
     auto computeLayerPositionForScrollingNode = [&](ScrollingTreeNode& scrollingNode) {
@@ -115,7 +114,7 @@ FloatPoint ScrollingTreeStickyNode::computeLayerPosition() const
 
 FloatSize ScrollingTreeStickyNode::scrollDeltaSinceLastCommit() const
 {
-    auto layerPosition = computeLayerPosition();
+    auto layerPosition = computeAnchorLayerPosition();
     return layerPosition - m_constraints.layerPositionAtLastLayout();
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h
@@ -33,28 +33,29 @@
 #include "ScrollingConstraints.h"
 #include "ScrollingPlatformLayer.h"
 #include "ScrollingTreeNode.h"
+#include "ScrollingTreeViewportConstrainedNode.h"
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
-class ScrollingTreeStickyNode : public ScrollingTreeNode {
+class ScrollingTreeStickyNode : public ScrollingTreeViewportConstrainedNode {
     WTF_MAKE_TZONE_ALLOCATED(ScrollingTreeStickyNode);
 public:
     virtual ~ScrollingTreeStickyNode();
 
     FloatSize scrollDeltaSinceLastCommit() const;
 
-    virtual ScrollingPlatformLayer* layer() const = 0;
-
 protected:
     ScrollingTreeStickyNode(ScrollingTree&, ScrollingNodeID);
 
     bool commitStateBeforeChildren(const ScrollingStateNode&) override;
-    FloatPoint computeLayerPosition() const;
+
+    FloatPoint computeAnchorLayerPosition() const;
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
 
     virtual FloatPoint layerTopLeft() const = 0;
+    const ViewportConstraints& constraints() const final { return m_constraints; }
 
     StickyPositionViewportConstraints m_constraints;
 };

--- a/Source/WebCore/page/scrolling/ScrollingTreeViewportConstrainedNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeViewportConstrainedNode.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ScrollingTreeViewportConstrainedNode.h"
+
+#if ENABLE(ASYNC_SCROLLING)
+
+#include "ScrollingConstraints.h"
+#include "ScrollingStateStickyNode.h"
+#include "ScrollingTree.h"
+#include "ScrollingTreeFixedNode.h"
+#include "ScrollingTreeFrameScrollingNode.h"
+#include "ScrollingTreeOverflowScrollProxyNode.h"
+#include "ScrollingTreeOverflowScrollingNode.h"
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreeViewportConstrainedNode);
+
+ScrollingTreeViewportConstrainedNode::ScrollingTreeViewportConstrainedNode(ScrollingTree& scrollingTree, ScrollingNodeType nodeType, ScrollingNodeID nodeID)
+    : ScrollingTreeNode(scrollingTree, nodeType, nodeID)
+{
+    scrollingTree.fixedOrStickyNodeAdded(*this);
+}
+
+ScrollingTreeViewportConstrainedNode::~ScrollingTreeViewportConstrainedNode() = default;
+
+FloatPoint ScrollingTreeViewportConstrainedNode::computeLayerPosition() const
+{
+    FloatSize overflowScrollDelta;
+    RefPtr<ScrollingTreeStickyNode> lastStickyNode;
+    for (RefPtr ancestor = parent(); ancestor; ancestor = ancestor->parent()) {
+        if (RefPtr scrollingNode = dynamicDowncast<ScrollingTreeFrameScrollingNode>(*ancestor)) {
+            // Fixed nodes are positioned relative to the containing frame scrolling node.
+            // We bail out after finding one.
+            auto layoutViewport = scrollingNode->layoutViewport();
+            return constraints().viewportRelativeLayerPosition(layoutViewport) - overflowScrollDelta;
+        }
+
+        if (RefPtr overflowNode = dynamicDowncast<ScrollingTreeOverflowScrollingNode>(*ancestor)) {
+            // To keep the layer still during async scrolling we adjust by how much the position has changed since layout.
+            overflowScrollDelta -= overflowNode->scrollDeltaSinceLastCommit();
+            continue;
+        }
+
+        if (RefPtr overflowNode = dynamicDowncast<ScrollingTreeOverflowScrollProxyNode>(*ancestor)) {
+            // To keep the layer still during async scrolling we adjust by how much the position has changed since layout.
+            overflowScrollDelta -= overflowNode->scrollDeltaSinceLastCommit();
+            continue;
+        }
+
+        if (RefPtr positioningAncestor = dynamicDowncast<ScrollingTreePositionedNode>(*ancestor)) {
+            // See if sticky node already handled this positioning node.
+            // FIXME: Include positioning node information to sticky/fixed node to avoid these tests.
+            if (lastStickyNode && lastStickyNode->layer() == positioningAncestor->layer())
+                continue;
+            if (positioningAncestor->layer() != layer())
+                overflowScrollDelta -= positioningAncestor->scrollDeltaSinceLastCommit();
+            continue;
+        }
+
+        if (RefPtr stickyNode = dynamicDowncast<ScrollingTreeStickyNode>(*ancestor)) {
+            overflowScrollDelta += stickyNode->scrollDeltaSinceLastCommit();
+            lastStickyNode = stickyNode;
+            continue;
+        }
+
+        if (is<ScrollingTreeFixedNode>(*ancestor)) {
+            // The ancestor fixed node has already applied the needed corrections to say put.
+            return constraints().layerPositionAtLastLayout() - overflowScrollDelta;
+        }
+    }
+    ASSERT_NOT_REACHED();
+    return { };
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/page/scrolling/ScrollingTreeViewportConstrainedNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeViewportConstrainedNode.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(ASYNC_SCROLLING)
+
+#include "ScrollingPlatformLayer.h"
+#include "ScrollingTreeNode.h"
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class ViewportConstraints;
+
+class ScrollingTreeViewportConstrainedNode : public ScrollingTreeNode {
+    WTF_MAKE_TZONE_ALLOCATED(ScrollingTreeViewportConstrainedNode);
+protected:
+    ScrollingTreeViewportConstrainedNode(ScrollingTree&, ScrollingNodeType, ScrollingNodeID);
+
+    virtual ~ScrollingTreeViewportConstrainedNode();
+    virtual const ViewportConstraints& constraints() const = 0;
+    virtual ScrollingPlatformLayer* layer() const = 0;
+
+    FloatPoint computeLayerPosition() const;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h
@@ -45,7 +45,7 @@ public:
 private:
     ScrollingTreeFixedNodeCocoa(ScrollingTree&, ScrollingNodeID);
 
-    CALayer* layer() const final { return m_layer.get(); }
+    CALayer *layer() const final { return m_layer.get(); }
 
     bool commitStateBeforeChildren(const ScrollingStateNode&) final;
     void applyLayerPositions() final WTF_REQUIRES_LOCK(scrollingTree()->treeLock());

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h
@@ -48,7 +48,7 @@ private:
     bool commitStateBeforeChildren(const ScrollingStateNode&) final;
     void applyLayerPositions() final WTF_REQUIRES_LOCK(scrollingTree()->treeLock());
     FloatPoint layerTopLeft() const final;
-    CALayer* layer() const final { return m_layer.get(); }
+    CALayer *layer() const final { return m_layer.get(); }
 
     RetainPtr<CALayer> m_layer;
 };

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm
@@ -60,7 +60,7 @@ bool ScrollingTreeStickyNodeCocoa::commitStateBeforeChildren(const ScrollingStat
 
 void ScrollingTreeStickyNodeCocoa::applyLayerPositions()
 {
-    auto layerPosition = computeLayerPosition();
+    auto layerPosition = computeAnchorLayerPosition();
 
     LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeStickyNodeCocoa " << scrollingNodeID() << " constrainingRectAtLastLayout " << m_constraints.constrainingRectAtLastLayout() << " last layer pos " << m_constraints.layerPositionAtLastLayout() << " layerPosition " << layerPosition);
 

--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeStickyNodeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeStickyNodeCoordinated.cpp
@@ -62,7 +62,7 @@ bool ScrollingTreeStickyNodeCoordinated::commitStateBeforeChildren(const Scrolli
 
 void ScrollingTreeStickyNodeCoordinated::applyLayerPositions()
 {
-    auto layerPosition = computeLayerPosition();
+    auto layerPosition = computeAnchorLayerPosition();
 
     LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeStickyNodeCoordinated " << scrollingNodeID() << " constrainingRectAtLastLayout " << m_constraints.constrainingRectAtLastLayout() << " last layer pos " << m_constraints.layerPositionAtLastLayout() << " layerPosition " << layerPosition);
 


### PR DESCRIPTION
#### 57a561ae10fa118c6f17ecfdf593be67f986061e
<pre>
[Viewport Clipping] [Part 2/4] Add a common base class for ScrollingTree{Sticky|Fixed}Node
<a href="https://bugs.webkit.org/show_bug.cgi?id=292109">https://bugs.webkit.org/show_bug.cgi?id=292109</a>
<a href="https://rdar.apple.com/150116251">rdar://150116251</a>

Reviewed by Abrar Rahman Protyasha.

In preparation for a configuration where viewport-constrained objects in the mainframe are clipped
to the layout viewport rect, we introduce a base class — `ScrollingTreeViewportConstrainedNode` —
from which `ScrollingTreeStickyNode` and `ScrollingTreeFixedNode` both derive. See below for more
details.

* Source/WebCore/Headers.cmake:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Add the new files.

* Source/WebCore/page/scrolling/ScrollingTreeFixedNode.cpp:
(WebCore::ScrollingTreeFixedNode::ScrollingTreeFixedNode):
(WebCore::ScrollingTreeFixedNode::computeLayerPosition const): Deleted.

Move this method into `ScrollingTreeViewportConstrainedNode` (see below).

* Source/WebCore/page/scrolling/ScrollingTreeFixedNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp:
(WebCore::ScrollingTreeStickyNode::ScrollingTreeStickyNode):
(WebCore::ScrollingTreeStickyNode::computeAnchorLayerPosition const):

Rename the existing method `computeLayerPosition` to `computeAnchorLayerPosition`. This seems
unnecessary at the moment, but will become important once the clipping layer is introduced, since
the position of the clipping layer needs to be computed separately from the position of the anchor
layer.

Namely, for a viewport-clipped sticky node that does not yet intersect with the constraining rect
(and therefore behaves as relative instead of fixed), we need to blit the clipping layer so it
matches the viewport rect while scrolling, and simultaneously counter-blit the anchor layer
underneath such that the sticky contents (visually) scroll with the rest of the page. Once the
constraining rect is reached and the sticky node behaves like a fixed-position node, only the
clipping layer continues blitting, while the anchor node offset becomes constant.

(WebCore::ScrollingTreeStickyNode::scrollDeltaSinceLastCommit const):
(WebCore::ScrollingTreeStickyNode::computeLayerPosition const): Deleted.
* Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeViewportConstrainedNode.cpp: Copied from Source/WebCore/page/scrolling/ScrollingTreeFixedNode.cpp.
(WebCore::ScrollingTreeViewportConstrainedNode::ScrollingTreeViewportConstrainedNode):

Consolidate logic to call `fixedOrStickyNodeAdded` when creating a viewport-constrained node.

(WebCore::ScrollingTreeViewportConstrainedNode::computeLayerPosition const):

Move this logic into `ScrollingTreeViewportConstrainedNode`, where it can be used for both sticky
and fixed nodes.

* Source/WebCore/page/scrolling/ScrollingTreeViewportConstrainedNode.h: Copied from Source/WebCore/page/scrolling/ScrollingTreeFixedNode.h.
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm:
(WebCore::ScrollingTreeStickyNodeCocoa::applyLayerPositions):
* Source/WebCore/page/scrolling/coordinated/ScrollingTreeStickyNodeCoordinated.cpp:
(WebCore::ScrollingTreeStickyNodeCoordinated::applyLayerPositions):

Canonical link: <a href="https://commits.webkit.org/294285@main">https://commits.webkit.org/294285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/603ae2bd7d1b31cb4ed9749a8f6b19bf9ec2bb3a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20996 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106485 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51961 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103375 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29491 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77177 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34215 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104341 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16433 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91524 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57524 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16252 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9536 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51309 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86142 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9610 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108838 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28462 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20943 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86152 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28824 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87731 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85712 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21807 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30440 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8145 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22573 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28392 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33666 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28204 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31524 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29762 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->