### PR TITLE
[JSC] Use `constexpr` over `const` Where Applicable

### DIFF
--- a/Source/JavaScriptCore/API/JSClassRef.cpp
+++ b/Source/JavaScriptCore/API/JSClassRef.cpp
@@ -35,7 +35,7 @@ using namespace JSC;
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
-const JSClassDefinition kJSClassDefinitionEmpty = { 0, 0, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr };
+constexpr JSClassDefinition kJSClassDefinitionEmpty = { 0, 0, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr };
 
 OpaqueJSClass::OpaqueJSClass(const JSClassDefinition* definition, OpaqueJSClass* protoClass) 
     : parentClass(definition->parentClass)

--- a/Source/JavaScriptCore/API/tests/CompareAndSwapTest.cpp
+++ b/Source/JavaScriptCore/API/tests/CompareAndSwapTest.cpp
@@ -98,7 +98,7 @@ static void setBitThreadFunc(void* p)
 void testCompareAndSwap()
 {
     Bitmap bitmap;
-    const int numThreads = 5;
+    constexpr int numThreads = 5;
     RefPtr<Thread> threads[numThreads];
     Data data[numThreads];
 

--- a/Source/JavaScriptCore/assembler/ARM64Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64Assembler.h
@@ -1835,8 +1835,8 @@ public:
     ALWAYS_INLINE void umaxv(FPRegisterID vd, FPRegisterID vn)
     {
         static_assert(destSize == 8 || destSize == 16 || destSize == 32);
-        const unsigned Q = 1;
-        const unsigned size = destSize == 8 ? 0 : destSize == 16 ? 1 : 2;
+        constexpr unsigned Q = 1;
+        constexpr unsigned size = destSize == 8 ? 0 : destSize == 16 ? 1 : 2;
         insn(0b00101110001100001010100000000000 | (Q << 30) | (size << 22)| (vn << 5) | vd);
     }
 
@@ -1844,8 +1844,8 @@ public:
     ALWAYS_INLINE void uminv(FPRegisterID vd, FPRegisterID vn)
     {
         static_assert(destSize == 8 || destSize == 16 || destSize == 32);
-        const unsigned Q = 1;
-        const unsigned size = destSize == 8 ? 0 : destSize == 16 ? 1 : 2;
+        constexpr unsigned Q = 1;
+        constexpr unsigned size = destSize == 8 ? 0 : destSize == 16 ? 1 : 2;
         insn(0b00101110001100011010100000000000 | (Q << 30) | (size << 22)| (vn << 5) | vd);
     }
 
@@ -2105,16 +2105,16 @@ public:
 
     ALWAYS_INLINE void tbl(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm)
     {
-        const unsigned len = 0;
-        const unsigned Q = 1;
+        constexpr unsigned len = 0;
+        constexpr unsigned Q = 1;
         insn(0b00001110000000000000000000000000 | (Q << 30) | (vm << 16) | (len << 13) | (vn << 5) | vd);
     }
 
     ALWAYS_INLINE void tbl2(FPRegisterID vd, FPRegisterID vn, FPRegisterID vn2, FPRegisterID vm)
     {
         RELEASE_ASSERT(vn2, vn2 == vn + 1);
-        const unsigned len = 1;
-        const unsigned Q = 1;
+        constexpr unsigned len = 1;
+        constexpr unsigned Q = 1;
         insn(0b00001110000000000000000000000000 | (Q << 30) | (vm << 16) | (len << 13) | (vn << 5) | vd);
     }
 
@@ -4233,7 +4233,7 @@ protected:
     {
         ASSERT(imm3 < 5);
         // The only allocated values for opt is 0.
-        const int opt = 0;
+        constexpr int opt = 0;
         return (0x0b200000 | sf << 31 | op << 30 | S << 29 | opt << 22 | xOrZr(rm) << 16 | option << 13 | (imm3 & 0x7) << 10 | xOrSp(rn) << 5 | xOrZrOrSp(S, rd));
     }
 
@@ -4253,7 +4253,7 @@ protected:
 
     ALWAYS_INLINE static int addSubtractWithCarry(Datasize sf, AddOp op, SetFlags S, RegisterID rm, RegisterID rn, RegisterID rd)
     {
-        const int opcode2 = 0;
+        constexpr int opcode2 = 0;
         return (0x1a000000 | sf << 31 | op << 30 | S << 29 | xOrZr(rm) << 16 | opcode2 << 10 | xOrZr(rn) << 5 | xOrZr(rd));
     }
 
@@ -4277,8 +4277,8 @@ protected:
         ASSERT(imm19 == (imm19 << 13) >> 13);
         ASSERT(!(cond & ~15));
         // The only allocated values for o1 & o0 are 0.
-        const int o1 = 0;
-        const int o0 = 0;
+        constexpr int o1 = 0;
+        constexpr int o0 = 0;
         return (0x54000000 | o1 << 24 | (imm19 & 0x7ffff) << 5 | o0 << 4 | cond);
     }
 
@@ -4286,18 +4286,18 @@ protected:
     {
         ASSERT(!(imm5 & ~0x1f));
         ASSERT(nzcv < 16);
-        const int S = 1;
-        const int o2 = 0;
-        const int o3 = 0;
+        constexpr int S = 1;
+        constexpr int o2 = 0;
+        constexpr int o3 = 0;
         return (0x1a400800 | sf << 31 | op << 30 | S << 29 | (imm5 & 0x1f) << 16 | cond << 12 | o2 << 10 | xOrZr(rn) << 5 | o3 << 4 | nzcv);
     }
 
     ALWAYS_INLINE static int conditionalCompareRegister(Datasize sf, AddOp op, RegisterID rm, Condition cond, RegisterID rn, int nzcv)
     {
         ASSERT(nzcv < 16);
-        const int S = 1;
-        const int o2 = 0;
-        const int o3 = 0;
+        constexpr int S = 1;
+        constexpr int o2 = 0;
+        constexpr int o3 = 0;
         return (0x1a400000 | sf << 31 | op << 30 | S << 29 | xOrZr(rm) << 16 | cond << 12 | o2 << 10 | xOrZr(rn) << 5 | o3 << 4 | nzcv);
     }
 
@@ -4305,20 +4305,20 @@ protected:
     // 'op2' means increment
     ALWAYS_INLINE static int conditionalSelect(Datasize sf, bool op, RegisterID rm, Condition cond, bool op2, RegisterID rn, RegisterID rd)
     {
-        const int S = 0;
+        constexpr int S = 0;
         return (0x1a800000 | sf << 31 | op << 30 | S << 29 | xOrZr(rm) << 16 | cond << 12 | op2 << 10 | xOrZr(rn) << 5 | xOrZr(rd));
     }
 
     ALWAYS_INLINE static int dataProcessing1Source(Datasize sf, DataOp1Source opcode, RegisterID rn, RegisterID rd)
     {
-        const int S = 0;
-        const int opcode2 = 0;
+        constexpr int S = 0;
+        constexpr int opcode2 = 0;
         return (0x5ac00000 | sf << 31 | S << 29 | opcode2 << 16 | opcode << 10 | xOrZr(rn) << 5 | xOrZr(rd));
     }
 
     ALWAYS_INLINE static int dataProcessing2Source(Datasize sf, RegisterID rm, DataOp2Source opcode, RegisterID rn, RegisterID rd)
     {
-        const int S = 0;
+        constexpr int S = 0;
         return (0x1ac00000 | sf << 31 | S << 29 | xOrZr(rm) << 16 | opcode << 10 | xOrZr(rn) << 5 | xOrZr(rd));
     }
 
@@ -4333,7 +4333,7 @@ protected:
     ALWAYS_INLINE static int excepnGeneration(ExcepnOp opc, uint16_t imm16, int LL)
     {
         ASSERT((opc == ExcepnOp_BREAKPOINT || opc == ExcepnOp_HALT) ? !LL : (LL && (LL < 4)));
-        const int op2 = 0;
+        constexpr int op2 = 0;
         return (0xd4000000 | opc << 21 | imm16 << 5 | op2 << 2 | LL);
     }
     ALWAYS_INLINE static int excepnGenerationImmMask()
@@ -4345,46 +4345,46 @@ protected:
     ALWAYS_INLINE static int extract(Datasize sf, RegisterID rm, int imms, RegisterID rn, RegisterID rd)
     {
         ASSERT(imms < (sf ? 64 : 32));
-        const int op21 = 0;
+        constexpr int op21 = 0;
         const int N = sf;
-        const int o0 = 0;
+        constexpr int o0 = 0;
         return (0x13800000 | sf << 31 | op21 << 29 | N << 22 | o0 << 21 | xOrZr(rm) << 16 | imms << 10 | xOrZr(rn) << 5 | xOrZr(rd));
     }
 
     ALWAYS_INLINE static int floatingPointCompare(Datasize type, FPRegisterID rm, FPRegisterID rn, FPCmpOp opcode2)
     {
-        const int M = 0;
-        const int S = 0;
-        const int op = 0;
+        constexpr int M = 0;
+        constexpr int S = 0;
+        constexpr int op = 0;
         return (0x1e202000 | M << 31 | S << 29 | type << 22 | rm << 16 | op << 14 | rn << 5 | opcode2);
     }
 
     ALWAYS_INLINE static int floatingPointConditionalCompare(Datasize type, FPRegisterID rm, Condition cond, FPRegisterID rn, FPCondCmpOp op, int nzcv)
     {
         ASSERT(nzcv < 16);
-        const int M = 0;
-        const int S = 0;
+        constexpr int M = 0;
+        constexpr int S = 0;
         return (0x1e200400 | M << 31 | S << 29 | type << 22 | rm << 16 | cond << 12 | rn << 5 | op << 4 | nzcv);
     }
 
     ALWAYS_INLINE static int floatingPointConditionalSelect(Datasize type, FPRegisterID rm, Condition cond, FPRegisterID rn, FPRegisterID rd)
     {
-        const int M = 0;
-        const int S = 0;
+        constexpr int M = 0;
+        constexpr int S = 0;
         return (0x1e200c00 | M << 31 | S << 29 | type << 22 | rm << 16 | cond << 12 | rn << 5 | rd);
     }
 
     ALWAYS_INLINE static int floatingPointImmediate(Datasize type, int imm8, FPRegisterID rd)
     {
-        const int M = 0;
-        const int S = 0;
-        const int imm5 = 0;
+        constexpr int M = 0;
+        constexpr int S = 0;
+        constexpr int imm5 = 0;
         return (0x1e201000 | M << 31 | S << 29 | type << 22 | (imm8 & 0xff) << 13 | imm5 << 5 | rd);
     }
 
     ALWAYS_INLINE static int floatingPointIntegerConversions(Datasize sf, Datasize type, FPIntConvOp rmodeOpcode, FPRegisterID rn, FPRegisterID rd)
     {
-        const int S = 0;
+        constexpr int S = 0;
         return (0x1e200000 | sf << 31 | S << 29 | type << 22 | rmodeOpcode << 16 | rn << 5 | rd);
     }
 
@@ -4400,15 +4400,15 @@ protected:
 
     ALWAYS_INLINE static int floatingPointDataProcessing1Source(Datasize type, FPDataOp1Source opcode, FPRegisterID rn, FPRegisterID rd)
     {
-        const int M = 0;
-        const int S = 0;
+        constexpr int M = 0;
+        constexpr int S = 0;
         return (0x1e204000 | M << 31 | S << 29 | type << 22 | opcode << 15 | rn << 5 | rd);
     }
 
     ALWAYS_INLINE static int floatingPointDataProcessing2Source(Datasize type, FPRegisterID rm, FPDataOp2Source opcode, FPRegisterID rn, FPRegisterID rd)
     {
-        const int M = 0;
-        const int S = 0;
+        constexpr int M = 0;
+        constexpr int S = 0;
         return (0x1e200800 | M << 31 | S << 29 | type << 22 | rm << 16 | opcode << 12 | rn << 5 | rd);
     }
 
@@ -4421,15 +4421,15 @@ protected:
     // 'o1' means negate
     ALWAYS_INLINE static int floatingPointDataProcessing3Source(Datasize type, bool o1, FPRegisterID rm, AddOp o2, FPRegisterID ra, FPRegisterID rn, FPRegisterID rd)
     {
-        const int M = 0;
-        const int S = 0;
+        constexpr int M = 0;
+        constexpr int S = 0;
         return (0x1f000000 | M << 31 | S << 29 | type << 22 | o1 << 21 | rm << 16 | o2 << 15 | ra << 10 | rn << 5 | rd);
     }
 
     ALWAYS_INLINE static int floatingPointDataProcessing4Source(Datasize type, FPDataOp4Source opcode, FPRegisterID rn, FPRegisterID rd)
     {
-        const int M = 0;
-        const int S = 0;
+        constexpr int M = 0;
+        constexpr int S = 0;
         return (0b0'0'0'11110'00'10100'00'10000'00000'00000 | M << 31 | S << 29 | type << 22 | opcode << 15 | rn << 5 | rd);
     }
 
@@ -4658,9 +4658,9 @@ protected:
     ALWAYS_INLINE static int unconditionalBranchRegister(BranchType opc, RegisterID rn)
     {
         // The only allocated values for op2 is 0x1f, for op3 & op4 are 0.
-        const int op2 = 0x1f;
-        const int op3 = 0;
-        const int op4 = 0;
+        constexpr int op2 = 0x1f;
+        constexpr int op3 = 0;
+        constexpr int op4 = 0;
         return (0xd6000000 | opc << 21 | op2 << 16 | op3 << 10 | xOrZr(rn) << 5 | op4);
     }
     

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
@@ -3413,7 +3413,7 @@ public:
     template<PtrTag tag>
     static CodeLocationLabel<tag> startOfBranchPtrWithPatchOnRegister(CodeLocationDataLabelPtr<tag> label)
     {
-        const unsigned twoWordOpSize = 4;
+        constexpr unsigned twoWordOpSize = 4;
         return label.labelAtOffset(-twoWordOpSize * 2);
     }
     

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -4895,8 +4895,8 @@ public:
     Call threadSafePatchableNearCall()
     {
         padBeforePatch();
-        const size_t nearCallOpcodeSize = 1;
-        const size_t nearCallRelativeLocationSize = sizeof(int32_t);
+        constexpr size_t nearCallOpcodeSize = 1;
+        constexpr size_t nearCallRelativeLocationSize = sizeof(int32_t);
         // We want to make sure the 32-bit near call immediate is 32-bit aligned.
         size_t codeSize = m_assembler.codeSize();
         size_t alignedSize = WTF::roundUpToMultipleOf<nearCallRelativeLocationSize>(codeSize + nearCallOpcodeSize);
@@ -4909,8 +4909,8 @@ public:
 
     Call threadSafePatchableNearTailCall()
     {
-        const size_t nearCallOpcodeSize = 1;
-        const size_t nearCallRelativeLocationSize = sizeof(int32_t);
+        constexpr size_t nearCallOpcodeSize = 1;
+        constexpr size_t nearCallRelativeLocationSize = sizeof(int32_t);
         // We want to make sure the 32-bit near call immediate is 32-bit aligned.
         size_t codeSize = m_assembler.codeSize();
         size_t alignedSize = WTF::roundUpToMultipleOf<nearCallRelativeLocationSize>(codeSize + nearCallOpcodeSize);
@@ -9065,10 +9065,10 @@ public:
     template<PtrTag tag>
     static CodeLocationLabel<tag> startOfBranchPtrWithPatchOnRegister(CodeLocationDataLabelPtr<tag> label)
     {
-        const int rexBytes = 1;
-        const int opcodeBytes = 1;
-        const int immediateBytes = 8;
-        const int totalBytes = rexBytes + opcodeBytes + immediateBytes;
+        constexpr int rexBytes = 1;
+        constexpr int opcodeBytes = 1;
+        constexpr int immediateBytes = 8;
+        constexpr int totalBytes = rexBytes + opcodeBytes + immediateBytes;
         ASSERT(totalBytes >= maxJumpReplacementSize());
         return label.labelAtOffset(-totalBytes);
     }
@@ -9076,10 +9076,10 @@ public:
     template<PtrTag tag>
     static CodeLocationLabel<tag> startOfBranch32WithPatchOnRegister(CodeLocationDataLabel32<tag> label)
     {
-        const int rexBytes = 1;
-        const int opcodeBytes = 1;
-        const int immediateBytes = 4;
-        const int totalBytes = rexBytes + opcodeBytes + immediateBytes;
+        constexpr int rexBytes = 1;
+        constexpr int opcodeBytes = 1;
+        constexpr int immediateBytes = 4;
+        constexpr int totalBytes = rexBytes + opcodeBytes + immediateBytes;
         ASSERT(totalBytes >= maxJumpReplacementSize());
         return label.labelAtOffset(-totalBytes);
     }

--- a/Source/JavaScriptCore/assembler/testmasm.cpp
+++ b/Source/JavaScriptCore/assembler/testmasm.cpp
@@ -345,9 +345,9 @@ void testBranchTruncateDoubleToInt32(double val, int32_t expected)
 {
     const uint64_t valAsUInt = std::bit_cast<uint64_t>(val);
 #if CPU(BIG_ENDIAN)
-    const bool isBigEndian = true;
+    constexpr bool isBigEndian = true;
 #else
-    const bool isBigEndian = false;
+    constexpr bool isBigEndian = false;
 #endif
     CHECK_EQ(compileAndRun<int>([&] (CCallHelpers& jit) {
         emitFunctionPrologue(jit);

--- a/Source/JavaScriptCore/b3/B3LowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerMacros.cpp
@@ -723,8 +723,8 @@ private:
         // shift off the uninteresting bits. On the other hand, it's not clear that this would
         // actually be any better than what we have done here and it's not clear that it would be
         // better than a binary switch.
-        const unsigned minCasesForTable = 7;
-        const unsigned densityLimit = 4;
+        constexpr unsigned minCasesForTable = 7;
+        constexpr unsigned densityLimit = 4;
         if (end - start >= minCasesForTable) {
             int64_t firstValue = cases[start].caseValue();
             int64_t lastValue = cases[end - 1].caseValue();
@@ -819,7 +819,7 @@ private:
         // See comments in jit/BinarySwitch.cpp for a justification of this algorithm. The only
         // thing we do differently is that we don't use randomness.
 
-        const unsigned leafThreshold = 3;
+        constexpr unsigned leafThreshold = 3;
 
         unsigned size = end - start;
 

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackByLinearScan.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackByLinearScan.cpp
@@ -54,8 +54,8 @@ namespace {
 bool verbose() { return Options::airLinearScanVerbose(); }
 
 // Phase constants we use for the PhaseInsertionSet.
-const unsigned firstPhase = 0;
-const unsigned secondPhase = 1;
+constexpr unsigned firstPhase = 0;
+constexpr unsigned secondPhase = 1;
 
 typedef Range<size_t> Interval;
 

--- a/Source/JavaScriptCore/b3/air/AirLogRegisterPressure.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLogRegisterPressure.cpp
@@ -37,8 +37,8 @@ namespace JSC { namespace B3 { namespace Air {
 
 void logRegisterPressure(Code& code)
 {
-    const unsigned totalColumns = 200;
-    const unsigned registerColumns = 100;
+    constexpr unsigned totalColumns = 200;
+    constexpr unsigned registerColumns = 100;
     
     RegLiveness liveness(code);
 

--- a/Source/JavaScriptCore/b3/testb3_5.cpp
+++ b/Source/JavaScriptCore/b3/testb3_5.cpp
@@ -2185,7 +2185,7 @@ void testCallFunctionWithHellaArguments2()
 
 static void preCommitStackMemory(void* stackLimit)
 {
-    const int pageSize = 4096;
+    constexpr int pageSize = 4096;
     for (volatile char* p = reinterpret_cast<char*>(&stackLimit); p > stackLimit; p -= pageSize) {
         char ch = *p;
         *p = ch;

--- a/Source/JavaScriptCore/bytecode/SuperSampler.cpp
+++ b/Source/JavaScriptCore/bytecode/SuperSampler.cpp
@@ -49,8 +49,8 @@ void initializeSuperSampler()
     Thread::create(
         "JSC Super Sampler"_s,
         [] () {
-            const int sleepQuantum = 3;
-            const int printingPeriod = 3000;
+            constexpr int sleepQuantum = 3;
+            constexpr int printingPeriod = 3000;
             for (;;) {
                 for (int ms = 0; ms < printingPeriod; ms += sleepQuantum) {
                     if (g_superSamplerEnabled) {

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -7497,7 +7497,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
             auto bytecode = currentInstruction->as<OpStrcat>();
             int startOperand = bytecode.m_src.offset();
             int numOperands = bytecode.m_count;
-            const unsigned maxArguments = 3;
+            constexpr unsigned maxArguments = 3;
             Node* operands[AdjacencyList::Size];
             unsigned indexInOperands = 0;
             for (unsigned i = 0; i < AdjacencyList::Size; ++i)

--- a/Source/JavaScriptCore/dfg/DFGCFGSimplificationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCFGSimplificationPhase.cpp
@@ -49,7 +49,7 @@ public:
     
     bool run()
     {
-        const bool extremeLogging = false;
+        constexpr bool extremeLogging = false;
 
         bool outerChanged = false;
         bool innerChanged;

--- a/Source/JavaScriptCore/dfg/DFGCSEPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCSEPhase.cpp
@@ -199,7 +199,7 @@ public:
                 + m_fallbackStackMap.size()));
 
 #if ASSERT_ENABLED
-        const bool verifyClobber = false;
+        constexpr bool verifyClobber = false;
         if (verifyClobber) {
             for (auto& pair : m_debugImpureData)
                 ASSERT(!!get(pair.key));

--- a/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
@@ -43,7 +43,7 @@ namespace {
 namespace DFGIntegerRangeOptimizationPhaseInternal {
 static constexpr bool verbose = false;
 }
-const unsigned giveUpThreshold = 50;
+constexpr unsigned giveUpThreshold = 50;
 
 int64_t clampedSumImpl() { return 0; }
 

--- a/Source/JavaScriptCore/dfg/DFGSSAConversionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSSAConversionPhase.cpp
@@ -98,7 +98,7 @@ public:
 
             RELEASE_ASSERT(entrySwitchData->cases[0] == m_graph.block(0)); // We strongly assume the normal call entrypoint is the first item in the list.
 
-            const bool exitOK = false;
+            constexpr bool exitOK = false;
             NodeOrigin origin { CodeOrigin(BytecodeIndex(0)), CodeOrigin(BytecodeIndex(0)), exitOK };
             newRoot->appendNode(
                 m_graph, SpecNone, EntrySwitch, origin, OpInfo(entrySwitchData));

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -18056,7 +18056,7 @@ IGNORE_CLANG_WARNINGS_END
     // stores value at every 64-bits word between base+begin*8 and base+end*8
     void splatWords(LValue base, LValue begin, LValue end, LValue value, const AbstractHeap& heap)
     {
-        const uint64_t unrollingLimit = 10;
+        constexpr uint64_t unrollingLimit = 10;
         if (begin->hasInt() && end->hasInt()) {
             uint64_t beginConst = static_cast<uint64_t>(begin->asInt());
             uint64_t endConst = static_cast<uint64_t>(end->asInt());

--- a/Source/JavaScriptCore/inspector/remote/socket/posix/RemoteInspectorSocketPOSIX.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/posix/RemoteInspectorSocketPOSIX.cpp
@@ -78,7 +78,7 @@ std::optional<PlatformSocketType> listen(const char* addressStr, uint16_t port)
         return std::nullopt;
     }
 
-    const int enabled = 1;
+    constexpr int enabled = 1;
     int error = setsockopt(fdListen, SOL_SOCKET, SO_REUSEADDR, &enabled, sizeof(enabled));
     if (error < 0) {
         LOG_ERROR("setsockopt() SO_REUSEADDR, errno = %d", errno);

--- a/Source/JavaScriptCore/jit/BinarySwitch.cpp
+++ b/Source/JavaScriptCore/jit/BinarySwitch.cpp
@@ -177,7 +177,7 @@ void BinarySwitch::build(unsigned start, bool hardStart, unsigned end)
     // when combined with some input will always produce pathologically good or pathologically bad
     // performance.
     
-    const unsigned leafThreshold = 3;
+    constexpr unsigned leafThreshold = 3;
     
     if (size <= leafThreshold) {
         if (BinarySwitchInternal::verbose)

--- a/Source/JavaScriptCore/jit/JITCall.cpp
+++ b/Source/JavaScriptCore/jit/JITCall.cpp
@@ -516,7 +516,7 @@ void JIT::emit_op_iterator_next(const JSInstruction* instruction)
         ScratchRegisterAllocator scratchAllocator(usedRegisters);
         GPRReg scratch1 = scratchAllocator.allocateScratchGPR();
         GPRReg scratch2 = scratchAllocator.allocateScratchGPR();
-        const bool shouldCheckMasqueradesAsUndefined = false;
+        constexpr bool shouldCheckMasqueradesAsUndefined = false;
         JumpList iterationDone = branchIfTruthy(vm(), resultJSR, scratch1, scratch2, fpRegT0, fpRegT1, shouldCheckMasqueradesAsUndefined, CCallHelpers::LazyBaselineGlobalObject);
 
         emitGetVirtualRegister(bytecode.m_value, baseJSR);

--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -1597,7 +1597,7 @@ ALWAYS_INLINE auto Lexer<T>::parseBinary() -> std::optional<NumberParseResult>
 
     // Optimization: most binary values fit into 4 bytes.
     uint32_t binaryValue = 0;
-    const unsigned maximumDigits = 32;
+    constexpr unsigned maximumDigits = 32;
     int digit = maximumDigits - 1;
     // Temporary buffer for the digits. Makes easier
     // to reconstruct the input characters when needed.
@@ -1653,7 +1653,7 @@ ALWAYS_INLINE auto Lexer<T>::parseOctal() -> std::optional<NumberParseResult>
 
     // Optimization: most octal values fit into 4 bytes.
     uint32_t octalValue = 0;
-    const unsigned maximumDigits = 10;
+    constexpr unsigned maximumDigits = 10;
     int digit = maximumDigits - 1;
     // Temporary buffer for the digits. Makes easier
     // to reconstruct the input characters when needed.
@@ -1712,7 +1712,7 @@ ALWAYS_INLINE auto Lexer<T>::parseDecimal() -> std::optional<NumberParseResult>
     // Since parseOctal may be executed before parseDecimal,
     // the m_buffer8 may hold ascii digits.
     if (!m_buffer8.size()) {
-        const unsigned maximumDigits = 10;
+        constexpr unsigned maximumDigits = 10;
         int digit = maximumDigits - 1;
         // Temporary buffer for the digits. Makes easier
         // to reconstruct the input characters when needed.

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -402,7 +402,7 @@ bool Parser<LexerType>::allowAutomaticSemicolon()
 template <typename LexerType>
 template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseSourceElements(TreeBuilder& context, SourceElementsMode mode)
 {
-    const unsigned lengthOfUseStrictLiteral = 12; // "use strict".length
+    constexpr unsigned lengthOfUseStrictLiteral = 12; // "use strict".length
     TreeSourceElements sourceElements = context.createSourceElements();
     const Identifier* directive = nullptr;
     unsigned directiveLiteralLength = 0;

--- a/Source/JavaScriptCore/parser/ParserArena.h
+++ b/Source/JavaScriptCore/parser/ParserArena.h
@@ -58,7 +58,7 @@ namespace JSC {
         const Identifier& makePrivateIdentifier(VM&, ASCIILiteral, unsigned);
 
     public:
-        static const int MaximumCachableCharacter = 128;
+        static constexpr int MaximumCachableCharacter = 128;
         typedef SegmentedVector<Identifier, 64> IdentifierVector;
         void clear()
         {
@@ -197,7 +197,7 @@ namespace JSC {
         }
 
     private:
-        static const size_t freeablePoolSize = 8000;
+        static constexpr size_t freeablePoolSize = 8000;
 
         static size_t alignSize(size_t size)
         {

--- a/Source/JavaScriptCore/parser/ParserModes.h
+++ b/Source/JavaScriptCore/parser/ParserModes.h
@@ -327,45 +327,45 @@ inline bool functionNameScopeIsDynamic(bool usesEval, bool isStrictMode)
 
 typedef uint8_t LexicallyScopedFeatures;
 
-const LexicallyScopedFeatures NoLexicallyScopedFeatures                     = 0;
-const LexicallyScopedFeatures StrictModeLexicallyScopedFeature         = 1 << 0;
-const LexicallyScopedFeatures TaintedByWithScopeLexicallyScopedFeature = 1 << 1;
+constexpr LexicallyScopedFeatures NoLexicallyScopedFeatures                     = 0;
+constexpr LexicallyScopedFeatures StrictModeLexicallyScopedFeature         = 1 << 0;
+constexpr LexicallyScopedFeatures TaintedByWithScopeLexicallyScopedFeature = 1 << 1;
 
-const LexicallyScopedFeatures AllLexicallyScopedFeatures = NoLexicallyScopedFeatures | StrictModeLexicallyScopedFeature | TaintedByWithScopeLexicallyScopedFeature;
+constexpr LexicallyScopedFeatures AllLexicallyScopedFeatures = NoLexicallyScopedFeatures | StrictModeLexicallyScopedFeature | TaintedByWithScopeLexicallyScopedFeature;
 static constexpr unsigned bitWidthOfLexicallyScopedFeatures = 2;
 static_assert(AllLexicallyScopedFeatures <= (1 << bitWidthOfLexicallyScopedFeatures) - 1, "LexicallyScopedFeatures must be 2bits");
 
 typedef uint16_t CodeFeatures;
 
-const CodeFeatures NoFeatures =                         0;
-const CodeFeatures EvalFeature =                   1 << 0;
-const CodeFeatures ArgumentsFeature =              1 << 1;
-const CodeFeatures WithFeature =                   1 << 2;
-const CodeFeatures ThisFeature =                   1 << 3;
-const CodeFeatures NonSimpleParameterListFeature = 1 << 4;
-const CodeFeatures ShadowsArgumentsFeature =       1 << 5;
-const CodeFeatures ArrowFunctionFeature =          1 << 6;
-const CodeFeatures AwaitFeature =                  1 << 7;
-const CodeFeatures SuperCallFeature =              1 << 8;
-const CodeFeatures SuperPropertyFeature =          1 << 9;
-const CodeFeatures NewTargetFeature =              1 << 10;
-const CodeFeatures NoEvalCacheFeature =            1 << 11;
-const CodeFeatures ImportMetaFeature =             1 << 12;
+constexpr CodeFeatures NoFeatures =                         0;
+constexpr CodeFeatures EvalFeature =                   1 << 0;
+constexpr CodeFeatures ArgumentsFeature =              1 << 1;
+constexpr CodeFeatures WithFeature =                   1 << 2;
+constexpr CodeFeatures ThisFeature =                   1 << 3;
+constexpr CodeFeatures NonSimpleParameterListFeature = 1 << 4;
+constexpr CodeFeatures ShadowsArgumentsFeature =       1 << 5;
+constexpr CodeFeatures ArrowFunctionFeature =          1 << 6;
+constexpr CodeFeatures AwaitFeature =                  1 << 7;
+constexpr CodeFeatures SuperCallFeature =              1 << 8;
+constexpr CodeFeatures SuperPropertyFeature =          1 << 9;
+constexpr CodeFeatures NewTargetFeature =              1 << 10;
+constexpr CodeFeatures NoEvalCacheFeature =            1 << 11;
+constexpr CodeFeatures ImportMetaFeature =             1 << 12;
 
-const CodeFeatures AllFeatures = EvalFeature | ArgumentsFeature | WithFeature | ThisFeature | NonSimpleParameterListFeature | ShadowsArgumentsFeature | ArrowFunctionFeature | AwaitFeature | SuperCallFeature | SuperPropertyFeature | NewTargetFeature | NoEvalCacheFeature | ImportMetaFeature;
+constexpr CodeFeatures AllFeatures = EvalFeature | ArgumentsFeature | WithFeature | ThisFeature | NonSimpleParameterListFeature | ShadowsArgumentsFeature | ArrowFunctionFeature | AwaitFeature | SuperCallFeature | SuperPropertyFeature | NewTargetFeature | NoEvalCacheFeature | ImportMetaFeature;
 static constexpr unsigned bitWidthOfCodeFeatures = 14;
 static_assert(AllFeatures <= (1 << bitWidthOfCodeFeatures) - 1, "CodeFeatures must fit within 14 bits");
 
 typedef uint8_t InnerArrowFunctionCodeFeatures;
     
-const InnerArrowFunctionCodeFeatures NoInnerArrowFunctionFeatures =                0;
-const InnerArrowFunctionCodeFeatures EvalInnerArrowFunctionFeature =          1 << 0;
-const InnerArrowFunctionCodeFeatures ArgumentsInnerArrowFunctionFeature =     1 << 1;
-const InnerArrowFunctionCodeFeatures ThisInnerArrowFunctionFeature =          1 << 2;
-const InnerArrowFunctionCodeFeatures SuperCallInnerArrowFunctionFeature =     1 << 3;
-const InnerArrowFunctionCodeFeatures SuperPropertyInnerArrowFunctionFeature = 1 << 4;
-const InnerArrowFunctionCodeFeatures NewTargetInnerArrowFunctionFeature =     1 << 5;
+constexpr InnerArrowFunctionCodeFeatures NoInnerArrowFunctionFeatures =                0;
+constexpr InnerArrowFunctionCodeFeatures EvalInnerArrowFunctionFeature =          1 << 0;
+constexpr InnerArrowFunctionCodeFeatures ArgumentsInnerArrowFunctionFeature =     1 << 1;
+constexpr InnerArrowFunctionCodeFeatures ThisInnerArrowFunctionFeature =          1 << 2;
+constexpr InnerArrowFunctionCodeFeatures SuperCallInnerArrowFunctionFeature =     1 << 3;
+constexpr InnerArrowFunctionCodeFeatures SuperPropertyInnerArrowFunctionFeature = 1 << 4;
+constexpr InnerArrowFunctionCodeFeatures NewTargetInnerArrowFunctionFeature =     1 << 5;
     
-const InnerArrowFunctionCodeFeatures AllInnerArrowFunctionCodeFeatures = EvalInnerArrowFunctionFeature | ArgumentsInnerArrowFunctionFeature | ThisInnerArrowFunctionFeature | SuperCallInnerArrowFunctionFeature | SuperPropertyInnerArrowFunctionFeature | NewTargetInnerArrowFunctionFeature;
+constexpr InnerArrowFunctionCodeFeatures AllInnerArrowFunctionCodeFeatures = EvalInnerArrowFunctionFeature | ArgumentsInnerArrowFunctionFeature | ThisInnerArrowFunctionFeature | SuperCallInnerArrowFunctionFeature | SuperPropertyInnerArrowFunctionFeature | NewTargetInnerArrowFunctionFeature;
 static_assert(AllInnerArrowFunctionCodeFeatures <= 0b111111, "InnerArrowFunctionCodeFeatures must be 6bits");
 } // namespace JSC

--- a/Source/JavaScriptCore/parser/SourceProvider.h
+++ b/Source/JavaScriptCore/parser/SourceProvider.h
@@ -60,7 +60,7 @@ class UnlinkedFunctionCodeBlock;
 
     class SourceProvider : public RefCounted<SourceProvider> {
     public:
-        static const intptr_t nullID = 1;
+        static constexpr intptr_t nullID = 1;
         
         JS_EXPORT_PRIVATE SourceProvider(const SourceOrigin&, String&& sourceURL, String&& preRedirectURL, SourceTaintedOrigin, const TextPosition& startPosition, SourceProviderSourceType);
 

--- a/Source/JavaScriptCore/runtime/ArrayConventions.h
+++ b/Source/JavaScriptCore/runtime/ArrayConventions.h
@@ -126,7 +126,7 @@ JS_EXPORT_PRIVATE void clearArrayMemset(double* base, unsigned count);
 ALWAYS_INLINE void clearArray(WriteBarrier<Unknown>* base, unsigned count)
 {
 #if USE(JSVALUE64)
-    const unsigned minCountForMemset = 100;
+    constexpr unsigned minCountForMemset = 100;
     if (count >= minCountForMemset) {
         clearArrayMemset(base, count);
         return;
@@ -140,7 +140,7 @@ ALWAYS_INLINE void clearArray(WriteBarrier<Unknown>* base, unsigned count)
 ALWAYS_INLINE void clearArray(double* base, unsigned count)
 {
 #if USE(JSVALUE64)
-    const unsigned minCountForMemset = 100;
+    constexpr unsigned minCountForMemset = 100;
     if (count >= minCountForMemset) {
         clearArrayMemset(base, count);
         return;

--- a/Source/JavaScriptCore/runtime/AssertInvariants.cpp
+++ b/Source/JavaScriptCore/runtime/AssertInvariants.cpp
@@ -41,12 +41,12 @@ void assertInvariants()
     // prepared to change LowLevelInterpreter.asm as well!!
     {
 #if USE(JSVALUE64)
-        const ptrdiff_t CallFrameHeaderSlots = 5;
+        constexpr ptrdiff_t CallFrameHeaderSlots = 5;
 #else // USE(JSVALUE64) // i.e. 32-bit version
-        const ptrdiff_t CallFrameHeaderSlots = 4;
+        constexpr ptrdiff_t CallFrameHeaderSlots = 4;
 #endif
-        const ptrdiff_t MachineRegisterSize = sizeof(CPURegister);
-        const ptrdiff_t SlotSize = 8;
+        constexpr ptrdiff_t MachineRegisterSize = sizeof(CPURegister);
+        constexpr ptrdiff_t SlotSize = 8;
 
         static_assert(sizeof(Register) == SlotSize);
         static_assert(CallFrame::headerSizeInRegisters == CallFrameHeaderSlots);

--- a/Source/JavaScriptCore/runtime/ConfigFile.cpp
+++ b/Source/JavaScriptCore/runtime/ConfigFile.cpp
@@ -46,7 +46,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 
-static const size_t s_processNameMax = 128;
+static constexpr size_t s_processNameMax = 128;
 char ConfigFile::s_processName[s_processNameMax + 1] = { 0 };
 char ConfigFile::s_parentProcessName[s_processNameMax + 1] = { 0 };
 

--- a/Source/JavaScriptCore/runtime/ConfigFile.h
+++ b/Source/JavaScriptCore/runtime/ConfigFile.h
@@ -41,11 +41,11 @@ private:
     void canonicalizePaths();
 
 #if OS(WINDOWS)
-    static const size_t s_maxPathLength = 260; // Windows value for "MAX_PATH"
+    static constexpr size_t s_maxPathLength = 260; // Windows value for "MAX_PATH"
 #elif defined(PATH_MAX)
-    static const size_t s_maxPathLength = PATH_MAX;
+    static constexpr size_t s_maxPathLength = PATH_MAX;
 #else
-    static const size_t s_maxPathLength = 4095;
+    static constexpr size_t s_maxPathLength = 4095;
 #endif
 
     static char s_processName[];

--- a/Source/JavaScriptCore/runtime/DateInstanceCache.h
+++ b/Source/JavaScriptCore/runtime/DateInstanceCache.h
@@ -76,7 +76,7 @@ public:
     }
 
 private:
-    static const size_t cacheSize = 16;
+    static constexpr size_t cacheSize = 16;
 
     struct CacheEntry {
         double key;

--- a/Source/JavaScriptCore/runtime/DatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/DatePrototype.cpp
@@ -299,13 +299,13 @@ void DatePrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToString, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    const bool asUTCVariant = false;
+    constexpr bool asUTCVariant = false;
     return formateDateInstance(globalObject, callFrame, DateTimeFormatDateAndTime, asUTCVariant);
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToUTCString, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    const bool asUTCVariant = true;
+    constexpr bool asUTCVariant = true;
     return formateDateInstance(globalObject, callFrame, DateTimeFormatDateAndTime, asUTCVariant);
 }
 
@@ -353,13 +353,13 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToISOString, (JSGlobalObject* globalObject
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToDateString, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    const bool asUTCVariant = false;
+    constexpr bool asUTCVariant = false;
     return formateDateInstance(globalObject, callFrame, DateTimeFormatDate, asUTCVariant);
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToTimeString, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    const bool asUTCVariant = false;
+    constexpr bool asUTCVariant = false;
     return formateDateInstance(globalObject, callFrame, DateTimeFormatTime, asUTCVariant);
 }
 

--- a/Source/JavaScriptCore/runtime/ErrorConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorConstructor.cpp
@@ -122,7 +122,7 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorCaptureStackTrace, (JSGlobalObject* glo
 
     Vector<StackFrame> stackTrace;
     // skip this function.
-    const size_t framesToSkip = 1;
+    constexpr size_t framesToSkip = 1;
 
     vm.interpreter.getStackTrace(object, stackTrace, framesToSkip, globalObject->stackTraceLimit().value_or(0), caller);
 

--- a/Source/JavaScriptCore/runtime/IndexingType.h
+++ b/Source/JavaScriptCore/runtime/IndexingType.h
@@ -61,57 +61,57 @@ namespace JSC {
 typedef uint8_t IndexingType;
 
 // Flags for testing the presence of capabilities.
-static const IndexingType IsArray                  = 0x01;
+static constexpr IndexingType IsArray                  = 0x01;
 
 // The shape of the indexed property storage.
-static const IndexingType NoIndexingShape                 = 0x00;
-static const IndexingType UndecidedShape                  = 0x02; // Only useful for arrays.
-static const IndexingType Int32Shape                      = 0x04;
-static const IndexingType DoubleShape                     = 0x06;
-static const IndexingType ContiguousShape                 = 0x08;
-static const IndexingType ArrayStorageShape               = 0x0A;
-static const IndexingType SlowPutArrayStorageShape        = 0x0C;
+static constexpr IndexingType NoIndexingShape                 = 0x00;
+static constexpr IndexingType UndecidedShape                  = 0x02; // Only useful for arrays.
+static constexpr IndexingType Int32Shape                      = 0x04;
+static constexpr IndexingType DoubleShape                     = 0x06;
+static constexpr IndexingType ContiguousShape                 = 0x08;
+static constexpr IndexingType ArrayStorageShape               = 0x0A;
+static constexpr IndexingType SlowPutArrayStorageShape        = 0x0C;
 
-static const IndexingType IndexingShapeMask               = 0x0E;
-static const IndexingType IndexingShapeShift              = 1;
-static const IndexingType NumberOfIndexingShapes          = 7;
-static const IndexingType IndexingTypeMask                = IndexingShapeMask | IsArray;
+static constexpr IndexingType IndexingShapeMask               = 0x0E;
+static constexpr IndexingType IndexingShapeShift              = 1;
+static constexpr IndexingType NumberOfIndexingShapes          = 7;
+static constexpr IndexingType IndexingTypeMask                = IndexingShapeMask | IsArray;
 
 // Whether or not the butterfly is copy on write. If it is copy on write then the butterfly is actually a JSImmutableButterfly. This should only ever be set if there are no named properties.
-static const IndexingType CopyOnWrite                      = 0x10;
-static const IndexingType IndexingShapeAndWritabilityMask  = CopyOnWrite | IndexingShapeMask;
-static const IndexingType IndexingModeMask                 = CopyOnWrite | IndexingTypeMask;
-static const IndexingType NumberOfCopyOnWriteIndexingModes = 3; // We only have copy on write for int32, double, and contiguous shapes.
-static const IndexingType NumberOfArrayIndexingModes       = NumberOfIndexingShapes + NumberOfCopyOnWriteIndexingModes;
+static constexpr IndexingType CopyOnWrite                      = 0x10;
+static constexpr IndexingType IndexingShapeAndWritabilityMask  = CopyOnWrite | IndexingShapeMask;
+static constexpr IndexingType IndexingModeMask                 = CopyOnWrite | IndexingTypeMask;
+static constexpr IndexingType NumberOfCopyOnWriteIndexingModes = 3; // We only have copy on write for int32, double, and contiguous shapes.
+static constexpr IndexingType NumberOfArrayIndexingModes       = NumberOfIndexingShapes + NumberOfCopyOnWriteIndexingModes;
 
 // Additional flags for tracking the history of the type. These are usually
 // masked off unless you ask for them directly.
 // FIXME: We only seem to use MayHaveIndexedAccessors for checking if the prototype chain may intercept indexed properties. We should probably be able to compute that same information via (indexingShape != SlowPutArrayStorageShape || classInfo().getOwnPropertySlotByIndex != JSObject::getOwnPropertySlotByIndex || globalObject().isHavingABadTime()) since we will already get the structure in order to do the prototype chain walk.
 // See: https://bugs.webkit.org/show_bug.cgi?id=209757
-static const IndexingType MayHaveIndexedAccessors         = 0x20;
+static constexpr IndexingType MayHaveIndexedAccessors         = 0x20;
 
 // The IndexingType field of JSCells is stolen for locks and remembering if the object has been a
 // prototype.
-static const IndexingType IndexingTypeLockIsHeld          = 0x40;
-static const IndexingType IndexingTypeLockHasParked       = 0x80;
+static constexpr IndexingType IndexingTypeLockIsHeld          = 0x40;
+static constexpr IndexingType IndexingTypeLockHasParked       = 0x80;
 
 // List of acceptable array types.
-static const IndexingType NonArray                        = 0x0;
-static const IndexingType NonArrayWithInt32               = Int32Shape;
-static const IndexingType NonArrayWithDouble              = DoubleShape;
-static const IndexingType NonArrayWithContiguous          = ContiguousShape;
-static const IndexingType NonArrayWithArrayStorage        = ArrayStorageShape;
-static const IndexingType NonArrayWithSlowPutArrayStorage = SlowPutArrayStorageShape;
-static const IndexingType ArrayClass                      = IsArray; // I'd want to call this "Array" but this would lead to disastrous namespace pollution.
-static const IndexingType ArrayWithUndecided              = IsArray | UndecidedShape;
-static const IndexingType ArrayWithInt32                  = IsArray | Int32Shape;
-static const IndexingType ArrayWithDouble                 = IsArray | DoubleShape;
-static const IndexingType ArrayWithContiguous             = IsArray | ContiguousShape;
-static const IndexingType ArrayWithArrayStorage           = IsArray | ArrayStorageShape;
-static const IndexingType ArrayWithSlowPutArrayStorage    = IsArray | SlowPutArrayStorageShape;
-static const IndexingType CopyOnWriteArrayWithInt32       = IsArray | Int32Shape | CopyOnWrite;
-static const IndexingType CopyOnWriteArrayWithDouble      = IsArray | DoubleShape | CopyOnWrite;
-static const IndexingType CopyOnWriteArrayWithContiguous  = IsArray | ContiguousShape | CopyOnWrite;
+static constexpr IndexingType NonArray                        = 0x0;
+static constexpr IndexingType NonArrayWithInt32               = Int32Shape;
+static constexpr IndexingType NonArrayWithDouble              = DoubleShape;
+static constexpr IndexingType NonArrayWithContiguous          = ContiguousShape;
+static constexpr IndexingType NonArrayWithArrayStorage        = ArrayStorageShape;
+static constexpr IndexingType NonArrayWithSlowPutArrayStorage = SlowPutArrayStorageShape;
+static constexpr IndexingType ArrayClass                      = IsArray; // I'd want to call this "Array" but this would lead to disastrous namespace pollution.
+static constexpr IndexingType ArrayWithUndecided              = IsArray | UndecidedShape;
+static constexpr IndexingType ArrayWithInt32                  = IsArray | Int32Shape;
+static constexpr IndexingType ArrayWithDouble                 = IsArray | DoubleShape;
+static constexpr IndexingType ArrayWithContiguous             = IsArray | ContiguousShape;
+static constexpr IndexingType ArrayWithArrayStorage           = IsArray | ArrayStorageShape;
+static constexpr IndexingType ArrayWithSlowPutArrayStorage    = IsArray | SlowPutArrayStorageShape;
+static constexpr IndexingType CopyOnWriteArrayWithInt32       = IsArray | Int32Shape | CopyOnWrite;
+static constexpr IndexingType CopyOnWriteArrayWithDouble      = IsArray | DoubleShape | CopyOnWrite;
+static constexpr IndexingType CopyOnWriteArrayWithContiguous  = IsArray | ContiguousShape | CopyOnWrite;
 
 #define ALL_BLANK_INDEXING_TYPES \
     NonArray:                    \
@@ -243,10 +243,10 @@ IndexingType leastUpperBoundOfIndexingTypeAndValue(IndexingType, JSValue);
 void dumpIndexingType(PrintStream&, IndexingType);
 MAKE_PRINT_ADAPTOR(IndexingTypeDump, IndexingType, dumpIndexingType);
 
-static const IndexingType AllWritableArrayTypes    = IndexingShapeMask | IsArray;
-static const IndexingType AllArrayTypes            = AllWritableArrayTypes | CopyOnWrite;
-static const IndexingType AllWritableArrayTypesAndHistory = AllWritableArrayTypes | MayHaveIndexedAccessors;
-static const IndexingType AllArrayTypesAndHistory  = AllArrayTypes | MayHaveIndexedAccessors;
+static constexpr IndexingType AllWritableArrayTypes    = IndexingShapeMask | IsArray;
+static constexpr IndexingType AllArrayTypes            = AllWritableArrayTypes | CopyOnWrite;
+static constexpr IndexingType AllWritableArrayTypesAndHistory = AllWritableArrayTypes | MayHaveIndexedAccessors;
+static constexpr IndexingType AllArrayTypesAndHistory  = AllArrayTypes | MayHaveIndexedAccessors;
 
 typedef LockAlgorithm<IndexingType, IndexingTypeLockIsHeld, IndexingTypeLockHasParked> IndexingTypeLockAlgorithm;
 

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -345,7 +345,7 @@ bool JSArray::unshiftCountSlowCase(const AbstractLocker&, VM& vm, DeferGC&, bool
         newStorageCapacity = currentCapacity;
         allocatedNewStorage = false;
     } else {
-        const unsigned preCapacity = 0;
+        constexpr unsigned preCapacity = 0;
         Butterfly* newButterfly = Butterfly::tryCreateUninitialized(vm, this, preCapacity, propertyCapacity, true, ArrayStorage::sizeFor(desiredCapacity));
         if (!newButterfly)
             return false;

--- a/Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.h
+++ b/Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.h
@@ -29,7 +29,7 @@
 
 namespace JSC {
 
-const static uint8_t JSAsyncFromSyncIteratorNumberOfInternalFields = 2;
+static constexpr uint8_t JSAsyncFromSyncIteratorNumberOfInternalFields = 2;
 
 class JSAsyncFromSyncIterator final : public JSInternalFieldObjectImpl<JSAsyncFromSyncIteratorNumberOfInternalFields> {
 public:

--- a/Source/JavaScriptCore/runtime/JSBigInt.cpp
+++ b/Source/JavaScriptCore/runtime/JSBigInt.cpp
@@ -2782,7 +2782,7 @@ JSBigInt::ComparisonResult JSBigInt::compareToDouble(BigIntImpl x, double y)
     //
     uint64_t mantissa = doubleBits & 0x000FFFFFFFFFFFFF;
     mantissa |= 0x0010000000000000;
-    const int mantissaTopBit = 52; // 0-indexed.
+    constexpr int mantissaTopBit = 52; // 0-indexed.
 
     // 0-indexed position of {x}'s most significant bit within the {msd}.
     int msdTopBit = digitBits - 1 - msdLeadingZeros;

--- a/Source/JavaScriptCore/runtime/JSCJSValue.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.h
@@ -381,9 +381,9 @@ public:
 
     // Constants used for Int52. Int52 isn't part of JSValue right now, but JSValues may be
     // converted to Int52s and back again.
-    static constexpr const unsigned numberOfInt52Bits = 52;
-    static constexpr const int64_t notInt52 = static_cast<int64_t>(1) << numberOfInt52Bits;
-    static constexpr const unsigned int52ShiftAmount = 12;
+    static constexpr unsigned numberOfInt52Bits = 52;
+    static constexpr int64_t notInt52 = static_cast<int64_t>(1) << numberOfInt52Bits;
+    static constexpr unsigned int52ShiftAmount = 12;
     
     static constexpr ptrdiff_t offsetOfPayload() { return OBJECT_OFFSETOF(JSValue, u.asBits.payload); }
     static constexpr ptrdiff_t offsetOfTag() { return OBJECT_OFFSETOF(JSValue, u.asBits.tag); }

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -233,7 +233,7 @@ static JSValue decode(JSGlobalObject* globalObject, JSValue argument, const WTF:
     });
 }
 
-static const int SizeOfInfinity = 8;
+static constexpr int SizeOfInfinity = 8;
 
 template <typename CharType>
 static bool isInfinity(std::span<const CharType> data)

--- a/Source/JavaScriptCore/runtime/JSMapIterator.h
+++ b/Source/JavaScriptCore/runtime/JSMapIterator.h
@@ -31,7 +31,7 @@
 
 namespace JSC {
 
-const static uint8_t JSMapIteratorNumberOFInternalFields = 4;
+static constexpr uint8_t JSMapIteratorNumberOFInternalFields = 4;
 
 class JSMapIterator final : public JSInternalFieldObjectImpl<JSMapIteratorNumberOFInternalFields> {
 public:

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -1788,7 +1788,7 @@ void JSObject::convertFromCopyOnWrite(VM& vm)
     ASSERT(isCopyOnWrite(indexingMode()));
     ASSERT(structure()->indexingMode() == indexingMode());
 
-    const bool hasIndexingHeader = true;
+    constexpr bool hasIndexingHeader = true;
     Butterfly* oldButterfly = butterfly();
     size_t propertyCapacity = 0;
     unsigned newVectorLength = Butterfly::optimalContiguousVectorLength(propertyCapacity, std::min(oldButterfly->vectorLength() * 2, MAX_STORAGE_VECTOR_LENGTH));

--- a/Source/JavaScriptCore/runtime/JSRegExpStringIterator.h
+++ b/Source/JavaScriptCore/runtime/JSRegExpStringIterator.h
@@ -29,7 +29,7 @@
 
 namespace JSC {
 
-const static uint8_t JSRegExpStringIteratorNumberOfInternalFields = 5;
+static constexpr uint8_t JSRegExpStringIteratorNumberOfInternalFields = 5;
 
 class JSRegExpStringIterator final : public JSInternalFieldObjectImpl<JSRegExpStringIteratorNumberOfInternalFields> {
 public:

--- a/Source/JavaScriptCore/runtime/JSSetIterator.h
+++ b/Source/JavaScriptCore/runtime/JSSetIterator.h
@@ -31,7 +31,7 @@
 
 namespace JSC {
 
-const static uint8_t JSSetIteratorNumberOFInternalFields = 4;
+static constexpr uint8_t JSSetIteratorNumberOFInternalFields = 4;
 
 class JSSetIterator final : public JSInternalFieldObjectImpl<JSSetIteratorNumberOFInternalFields> {
 public:

--- a/Source/JavaScriptCore/runtime/JSWrapForValidIterator.h
+++ b/Source/JavaScriptCore/runtime/JSWrapForValidIterator.h
@@ -29,7 +29,7 @@
 
 namespace JSC {
 
-const static uint8_t JSWrapForValidIteratorNumberOfInternalFields = 2;
+static constexpr uint8_t JSWrapForValidIteratorNumberOfInternalFields = 2;
 
 class JSWrapForValidIterator final : public JSInternalFieldObjectImpl<JSWrapForValidIteratorNumberOfInternalFields> {
 

--- a/Source/JavaScriptCore/runtime/LazyProperty.h
+++ b/Source/JavaScriptCore/runtime/LazyProperty.h
@@ -111,8 +111,8 @@ private:
     template<typename Func>
     static ElementType* callFunc(const Initializer&);
     
-    static const uintptr_t lazyTag = 1;
-    static const uintptr_t initializingTag = 2;
+    static constexpr uintptr_t lazyTag = 1;
+    static constexpr uintptr_t initializingTag = 2;
     
     uintptr_t m_pointer { 0 };
 };

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -1115,7 +1115,7 @@ TokenType LiteralParser<CharType, reviverMode>::Lexer::lexNumber(LiteralParserTo
     }
 
     // ('.' [0-9]+)?
-    const int NumberOfDigitsForSafeInt32 = 9;  // The numbers from -99999999 to 999999999 are always in range of Int32.
+    constexpr int NumberOfDigitsForSafeInt32 = 9; // The numbers from -99999999 to 999999999 are always in range of Int32.
     if (m_ptr < m_end && *m_ptr == '.') {
         ++m_ptr;
         // [0-9]+

--- a/Source/JavaScriptCore/runtime/NumericStrings.h
+++ b/Source/JavaScriptCore/runtime/NumericStrings.h
@@ -36,7 +36,7 @@ class SmallStrings;
 
 class NumericStrings {
 public:
-    static const size_t cacheSize = 1024;
+    static constexpr size_t cacheSize = 1024;
 
     template<typename T>
     struct CacheEntry {

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -1164,7 +1164,7 @@ bool Options::setOptions(const char* optionsStr)
 
         char* valueBegin = p;
         bool hasStringValue = false;
-        const int minStringLength = 2; // The min is an empty string i.e. 2 double quotes.
+        constexpr int minStringLength = 2; // The min is an empty string i.e. 2 double quotes.
         if ((p + minStringLength < end) && (*p == '"')) {
             p = strstr(p + 1, "\"");
             if (!p) {

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -61,8 +61,8 @@ namespace JSC {
 static double sNumTotalStackTraces = 0;
 static double sNumTotalWalks = 0;
 static double sNumFailedWalks = 0;
-static const uint32_t sNumWalkReportingFrequency = 50;
-static const double sWalkErrorPercentage = .05;
+static constexpr uint32_t sNumWalkReportingFrequency = 50;
+static constexpr double sWalkErrorPercentage = .05;
 static constexpr bool sReportStatsOnlyWhenTheyreAboveThreshold = false;
 static constexpr bool sReportStats = false;
 

--- a/Source/JavaScriptCore/runtime/SymbolTable.h
+++ b/Source/JavaScriptCore/runtime/SymbolTable.h
@@ -323,16 +323,16 @@ public:
     }
     
 private:
-    static const intptr_t SlimFlag = 0x1;
-    static const intptr_t ReadOnlyFlag = 0x2;
-    static const intptr_t DontEnumFlag = 0x4;
-    static const intptr_t NotNullFlag = 0x8;
-    static const intptr_t KindBitsMask = 0x30;
-    static const intptr_t ScopeKindBits = 0x00;
-    static const intptr_t UnwatchableScopeKindBits = 0x10;
-    static const intptr_t StackKindBits = 0x20;
-    static const intptr_t DirectArgumentKindBits = 0x30;
-    static const intptr_t FlagBits = 6;
+    static constexpr intptr_t SlimFlag = 0x1;
+    static constexpr intptr_t ReadOnlyFlag = 0x2;
+    static constexpr intptr_t DontEnumFlag = 0x4;
+    static constexpr intptr_t NotNullFlag = 0x8;
+    static constexpr intptr_t KindBitsMask = 0x30;
+    static constexpr intptr_t ScopeKindBits = 0x00;
+    static constexpr intptr_t UnwatchableScopeKindBits = 0x10;
+    static constexpr intptr_t StackKindBits = 0x20;
+    static constexpr intptr_t DirectArgumentKindBits = 0x30;
+    static constexpr intptr_t FlagBits = 6;
     
     class FatEntry {
         WTF_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(SymbolTableEntryFatEntry);

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1028,7 +1028,7 @@ size_t VM::updateSoftReservedZoneSize(size_t softReservedZoneSize)
 
 static void preCommitStackMemory(void* stackLimit)
 {
-    const int pageSize = 4096;
+    constexpr int pageSize = 4096;
     for (volatile char* p = reinterpret_cast<char*>(&stackLimit); p > stackLimit; p -= pageSize) {
         char ch = *p;
         *p = ch;

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -2305,7 +2305,7 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(functionCrash, NO_RETURN_DUE_TO_CRASH, 
     auto scope = DECLARE_CATCH_SCOPE(vm);
     if (callFrame->argumentCount()) {
         dataLogLn("Dumping ", callFrame->argumentCount(), " values before crashing:");
-        const bool addLineFeed = true;
+        constexpr bool addLineFeed = true;
         doPrint(globalObject, callFrame, addLineFeed);
         if (scope.exception()) {
             JSValue value = scope.exception()->value();
@@ -2798,7 +2798,7 @@ JSC_DEFINE_HOST_FUNCTION(functionDumpBytecodeFor, (JSGlobalObject* globalObject,
 JSC_DEFINE_HOST_FUNCTION(functionDataLog, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     DollarVMAssertScope assertScope;
-    const bool addLineFeed = false;
+    constexpr bool addLineFeed = false;
     return doPrint(globalObject, callFrame, addLineFeed);
 }
 
@@ -2807,7 +2807,7 @@ JSC_DEFINE_HOST_FUNCTION(functionDataLog, (JSGlobalObject* globalObject, CallFra
 JSC_DEFINE_HOST_FUNCTION(functionPrint, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     DollarVMAssertScope assertScope;
-    const bool addLineFeed = true;
+    constexpr bool addLineFeed = true;
     return doPrint(globalObject, callFrame, addLineFeed);
 }
 

--- a/Source/JavaScriptCore/tools/TieredMMapArray.h
+++ b/Source/JavaScriptCore/tools/TieredMMapArray.h
@@ -35,7 +35,7 @@ namespace JSC {
 // holding the fast malloc heap lock).
 template<typename T>
 class TieredMMapArray {
-    static const size_t entriesPerBlock = 4096;
+    static constexpr size_t entriesPerBlock = 4096;
 
 public:
     TieredMMapArray()

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -4404,7 +4404,7 @@ void BBQJIT::emitIndirectTailCall(const char* opcode, const Value& callee, GPRRe
     ASSERT(arguments.size() == callInfo.params.size());
 
     ArgumentList resolvedArguments;
-    const unsigned calleeArgument = 1;
+    constexpr unsigned calleeArgument = 1;
     resolvedArguments.reserveInitialCapacity(arguments.size() + calleeArgument + isX86() * 2);
     Vector<Location, 8> parameterLocations;
     parameterLocations.reserveInitialCapacity(arguments.size() + calleeArgument + isX86() * 2);

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -2876,7 +2876,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallIndirect(unsigned tableI
 {
     const FunctionSignature& signature = *originalSignature.expand().as<FunctionSignature>();
     if (callType == CallType::TailCall) {
-        const unsigned callIndex = 1;
+        constexpr unsigned callIndex = 1;
         changeStackSize(-signature.argumentCount() - callIndex);
         m_metadata->setTailCallClobbersInstance();
 
@@ -2904,7 +2904,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallIndirect(unsigned tableI
 
     auto& callConvention = cachedCallInformationFor(signature);
     results.appendUsingFunctor(signature.returnCount(), [](unsigned) { return Value { }; });
-    const unsigned callIndex = 1;
+    constexpr unsigned callIndex = 1;
     changeStackSize(signature.returnCount() - signature.argumentCount() - callIndex);
 
     IPInt::CallIndirectMetadata functionIndexMetadata {
@@ -2928,7 +2928,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallRef(const TypeDefinition
 {
     const FunctionSignature& signature = *originalSignature.expand().as<FunctionSignature>();
     if (callType == CallType::TailCall) {
-        const unsigned callIndex = 1;
+        constexpr unsigned callIndex = 1;
         changeStackSize(-signature.argumentCount() - callIndex);
         m_metadata->setTailCallClobbersInstance();
 
@@ -2955,7 +2955,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallRef(const TypeDefinition
 
     auto& callConvention = cachedCallInformationFor(signature);
     results.appendUsingFunctor(signature.returnCount(), [](unsigned) { return Value { }; });
-    const unsigned callRef = 1;
+    constexpr unsigned callRef = 1;
     changeStackSize(signature.returnCount() - signature.argumentCount() - callRef);
 
     IPInt::CallRefMetadata callMetadata {

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -5996,7 +5996,7 @@ void OMGIRGenerator::emitChecksForModOrDiv(B3::Opcode operation, Value* left, Va
 
 auto OMGIRGenerator::addI32DivS(ExpressionType leftVar, ExpressionType rightVar, ExpressionType& result) -> PartialResult
 {
-    const B3::Opcode op = Div;
+    constexpr B3::Opcode op = Div;
     Value* left = get(leftVar);
     Value* right = get(rightVar);
     emitChecksForModOrDiv(op, left, right);
@@ -6006,7 +6006,7 @@ auto OMGIRGenerator::addI32DivS(ExpressionType leftVar, ExpressionType rightVar,
 
 auto OMGIRGenerator::addI32RemS(ExpressionType leftVar, ExpressionType rightVar, ExpressionType& result) -> PartialResult
 {
-    const B3::Opcode op = Mod;
+    constexpr B3::Opcode op = Mod;
     Value* left = get(leftVar);
     Value* right = get(rightVar);
     emitChecksForModOrDiv(op, left, right);
@@ -6016,7 +6016,7 @@ auto OMGIRGenerator::addI32RemS(ExpressionType leftVar, ExpressionType rightVar,
 
 auto OMGIRGenerator::addI32DivU(ExpressionType leftVar, ExpressionType rightVar, ExpressionType& result) -> PartialResult
 {
-    const B3::Opcode op = UDiv;
+    constexpr B3::Opcode op = UDiv;
     Value* left = get(leftVar);
     Value* right = get(rightVar);
     emitChecksForModOrDiv(op, left, right);
@@ -6026,7 +6026,7 @@ auto OMGIRGenerator::addI32DivU(ExpressionType leftVar, ExpressionType rightVar,
 
 auto OMGIRGenerator::addI32RemU(ExpressionType leftVar, ExpressionType rightVar, ExpressionType& result) -> PartialResult
 {
-    const B3::Opcode op = UMod;
+    constexpr B3::Opcode op = UMod;
     Value* left = get(leftVar);
     Value* right = get(rightVar);
     emitChecksForModOrDiv(op, left, right);
@@ -6036,7 +6036,7 @@ auto OMGIRGenerator::addI32RemU(ExpressionType leftVar, ExpressionType rightVar,
 
 auto OMGIRGenerator::addI64DivS(ExpressionType leftVar, ExpressionType rightVar, ExpressionType& result) -> PartialResult
 {
-    const B3::Opcode op = Div;
+    constexpr B3::Opcode op = Div;
     Value* left = get(leftVar);
     Value* right = get(rightVar);
     emitChecksForModOrDiv(op, left, right);
@@ -6046,7 +6046,7 @@ auto OMGIRGenerator::addI64DivS(ExpressionType leftVar, ExpressionType rightVar,
 
 auto OMGIRGenerator::addI64RemS(ExpressionType leftVar, ExpressionType rightVar, ExpressionType& result) -> PartialResult
 {
-    const B3::Opcode op = Mod;
+    constexpr B3::Opcode op = Mod;
     Value* left = get(leftVar);
     Value* right = get(rightVar);
     emitChecksForModOrDiv(op, left, right);
@@ -6056,7 +6056,7 @@ auto OMGIRGenerator::addI64RemS(ExpressionType leftVar, ExpressionType rightVar,
 
 auto OMGIRGenerator::addI64DivU(ExpressionType leftVar, ExpressionType rightVar, ExpressionType& result) -> PartialResult
 {
-    const B3::Opcode op = UDiv;
+    constexpr B3::Opcode op = UDiv;
     Value* left = get(leftVar);
     Value* right = get(rightVar);
     emitChecksForModOrDiv(op, left, right);
@@ -6066,7 +6066,7 @@ auto OMGIRGenerator::addI64DivU(ExpressionType leftVar, ExpressionType rightVar,
 
 auto OMGIRGenerator::addI64RemU(ExpressionType leftVar, ExpressionType rightVar, ExpressionType& result) -> PartialResult
 {
-    const B3::Opcode op = UMod;
+    constexpr B3::Opcode op = UMod;
     Value* left = get(leftVar);
     Value* right = get(rightVar);
     emitChecksForModOrDiv(op, left, right);

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -6417,7 +6417,7 @@ void OMGIRGenerator::emitChecksForModOrDiv(B3::Opcode operation, Value* left, Va
 
 auto OMGIRGenerator::addI32DivS(ExpressionType leftVar, ExpressionType rightVar, ExpressionType& result) -> PartialResult
 {
-    const B3::Opcode op = Div;
+    constexpr B3::Opcode op = Div;
     Value* left = get(leftVar);
     Value* right = get(rightVar);
     emitChecksForModOrDiv(op, left, right);
@@ -6427,7 +6427,7 @@ auto OMGIRGenerator::addI32DivS(ExpressionType leftVar, ExpressionType rightVar,
 
 auto OMGIRGenerator::addI32RemS(ExpressionType leftVar, ExpressionType rightVar, ExpressionType& result) -> PartialResult
 {
-    const B3::Opcode op = Mod;
+    constexpr B3::Opcode op = Mod;
     Value* left = get(leftVar);
     Value* right = get(rightVar);
     emitChecksForModOrDiv(op, left, right);
@@ -6437,7 +6437,7 @@ auto OMGIRGenerator::addI32RemS(ExpressionType leftVar, ExpressionType rightVar,
 
 auto OMGIRGenerator::addI32DivU(ExpressionType leftVar, ExpressionType rightVar, ExpressionType& result) -> PartialResult
 {
-    const B3::Opcode op = UDiv;
+    constexpr B3::Opcode op = UDiv;
     Value* left = get(leftVar);
     Value* right = get(rightVar);
     emitChecksForModOrDiv(op, left, right);
@@ -6447,7 +6447,7 @@ auto OMGIRGenerator::addI32DivU(ExpressionType leftVar, ExpressionType rightVar,
 
 auto OMGIRGenerator::addI32RemU(ExpressionType leftVar, ExpressionType rightVar, ExpressionType& result) -> PartialResult
 {
-    const B3::Opcode op = UMod;
+    constexpr B3::Opcode op = UMod;
     Value* left = get(leftVar);
     Value* right = get(rightVar);
     emitChecksForModOrDiv(op, left, right);
@@ -6457,7 +6457,7 @@ auto OMGIRGenerator::addI32RemU(ExpressionType leftVar, ExpressionType rightVar,
 
 auto OMGIRGenerator::addI64DivS(ExpressionType leftVar, ExpressionType rightVar, ExpressionType& result) -> PartialResult
 {
-    const B3::Opcode op = Div;
+    constexpr B3::Opcode op = Div;
     Value* left = get(leftVar);
     Value* right = get(rightVar);
     emitChecksForModOrDiv(op, left, right);
@@ -6467,7 +6467,7 @@ auto OMGIRGenerator::addI64DivS(ExpressionType leftVar, ExpressionType rightVar,
 
 auto OMGIRGenerator::addI64RemS(ExpressionType leftVar, ExpressionType rightVar, ExpressionType& result) -> PartialResult
 {
-    const B3::Opcode op = Mod;
+    constexpr B3::Opcode op = Mod;
     Value* left = get(leftVar);
     Value* right = get(rightVar);
     emitChecksForModOrDiv(op, left, right);
@@ -6477,7 +6477,7 @@ auto OMGIRGenerator::addI64RemS(ExpressionType leftVar, ExpressionType rightVar,
 
 auto OMGIRGenerator::addI64DivU(ExpressionType leftVar, ExpressionType rightVar, ExpressionType& result) -> PartialResult
 {
-    const B3::Opcode op = UDiv;
+    constexpr B3::Opcode op = UDiv;
     Value* left = get(leftVar);
     Value* right = get(rightVar);
     emitChecksForModOrDiv(op, left, right);
@@ -6487,7 +6487,7 @@ auto OMGIRGenerator::addI64DivU(ExpressionType leftVar, ExpressionType rightVar,
 
 auto OMGIRGenerator::addI64RemU(ExpressionType leftVar, ExpressionType rightVar, ExpressionType& result) -> PartialResult
 {
-    const B3::Opcode op = UMod;
+    constexpr B3::Opcode op = UMod;
     Value* left = get(leftVar);
     Value* right = get(rightVar);
     emitChecksForModOrDiv(op, left, right);

--- a/Source/JavaScriptCore/wasm/WasmThunks.cpp
+++ b/Source/JavaScriptCore/wasm/WasmThunks.cpp
@@ -228,7 +228,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> triggerOMGEntryTierUpThunkGeneratorImpl(co
 
     jit.emitFunctionPrologue();
 
-    const unsigned extraPaddingBytes = 0;
+    constexpr unsigned extraPaddingBytes = 0;
     auto registersToSpill = RegisterSetBuilder::registersToSaveForCCall(isSIMDContext ? RegisterSetBuilder::allRegisters() : RegisterSetBuilder::allScalarRegisters()).buildWithLowerBits();
     unsigned numberOfStackBytesUsedForRegisterPreservation = ScratchRegisterAllocator::preserveRegistersToStackForCall(jit, registersToSpill, extraPaddingBytes);
 

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -844,7 +844,7 @@ public:
     bool cleanup();
 
     // Type definitions are uniqued and, for call_indirect, validated at runtime. Tables can create invalid TypeIndex values which cause call_indirect to fail. We use 0 as the invalidIndex so that the codegen can easily test for it and trap, and we add a token invalid entry in TypeInformation.
-    static const constexpr TypeIndex invalidIndex = 0;
+    static constexpr TypeIndex invalidIndex = 0;
 
 private:
     // Returns the TypeIndex of a potentially unowned (other than TypeInformation::m_typeSet) TypeDefinition.

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -465,7 +465,7 @@ public:
 
         void dump(PrintStream& out) const
         {
-            const unsigned maxPrintLen = 50;
+            constexpr unsigned maxPrintLen = 50;
 
             out.print(sizeof(CharType) == 1 ? "8bit" : "16bit", " len: ", length, " \"");
             unsigned printLen = std::min(length, maxPrintLen);
@@ -546,7 +546,7 @@ public:
         if (characterClass->m_anyCharacter)
             return true;
 
-        const size_t thresholdForBinarySearch = 6;
+        constexpr size_t thresholdForBinarySearch = 6;
 
         if (!isASCII(ch)) {
             if (characterClass->m_matchesUnicode.size()) {


### PR DESCRIPTION
#### f73be03bc7f7d7f2b5b19e683ca988ddc49cf18a
<pre>
[JSC] Use `constexpr` over `const` Where Applicable
<a href="https://bugs.webkit.org/show_bug.cgi?id=292112">https://bugs.webkit.org/show_bug.cgi?id=292112</a>

Reviewed by NOBODY (OOPS!).

Use `constexpr` over `const` for compile time evaluation if applicable

* Source/JavaScriptCore/API/JSClassRef.cpp:
* Source/JavaScriptCore/API/tests/CompareAndSwapTest.cpp:
(testCompareAndSwap):
* Source/JavaScriptCore/assembler/ARM64Assembler.h:
* Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h:
(JSC::MacroAssemblerARMv7::startOfBranchPtrWithPatchOnRegister):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::threadSafePatchableNearCall):
(JSC::MacroAssemblerX86_64::threadSafePatchableNearTailCall):
(JSC::MacroAssemblerX86_64::startOfBranchPtrWithPatchOnRegister):
(JSC::MacroAssemblerX86_64::startOfBranch32WithPatchOnRegister):
* Source/JavaScriptCore/assembler/testmasm.cpp:
(JSC::testBranchTruncateDoubleToInt32):
* Source/JavaScriptCore/b3/B3LowerMacros.cpp:
* Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackByLinearScan.cpp:
* Source/JavaScriptCore/b3/air/AirLogRegisterPressure.cpp:
(JSC::B3::Air::logRegisterPressure):
* Source/JavaScriptCore/b3/testb3_5.cpp:
(preCommitStackMemory):
* Source/JavaScriptCore/bytecode/SuperSampler.cpp:
(JSC::initializeSuperSampler):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::parseBlock):
* Source/JavaScriptCore/dfg/DFGCFGSimplificationPhase.cpp:
(JSC::DFG::CFGSimplificationPhase::run):
* Source/JavaScriptCore/dfg/DFGCSEPhase.cpp:
* Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSSAConversionPhase.cpp:
(JSC::DFG::SSAConversionPhase::run):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/inspector/remote/socket/posix/RemoteInspectorSocketPOSIX.cpp:
(Inspector::Socket::listen):
* Source/JavaScriptCore/jit/BinarySwitch.cpp:
(JSC::BinarySwitch::build):
* Source/JavaScriptCore/jit/JITCall.cpp:
(JSC::JIT::emit_op_iterator_next):
* Source/JavaScriptCore/parser/Lexer.cpp:
(JSC::Lexer&lt;T&gt;::parseBinary):
(JSC::Lexer&lt;T&gt;::parseOctal):
(JSC::Lexer&lt;T&gt;::parseDecimal):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseSourceElements):
* Source/JavaScriptCore/parser/ParserArena.h:
* Source/JavaScriptCore/parser/ParserModes.h:
* Source/JavaScriptCore/parser/SourceProvider.h:
* Source/JavaScriptCore/runtime/ArrayConventions.h:
(JSC::clearArray):
* Source/JavaScriptCore/runtime/AssertInvariants.cpp:
(JSC::assertInvariants):
* Source/JavaScriptCore/runtime/ConfigFile.cpp:
* Source/JavaScriptCore/runtime/ConfigFile.h:
* Source/JavaScriptCore/runtime/DateInstanceCache.h:
* Source/JavaScriptCore/runtime/DatePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ErrorConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IndexingType.h:
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::unshiftCountSlowCase):
* Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.h:
* Source/JavaScriptCore/runtime/JSBigInt.cpp:
(JSC::JSBigInt::compareToDouble):
* Source/JavaScriptCore/runtime/JSCJSValue.h:
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
* Source/JavaScriptCore/runtime/JSMapIterator.h:
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::convertFromCopyOnWrite):
* Source/JavaScriptCore/runtime/JSRegExpStringIterator.h:
* Source/JavaScriptCore/runtime/JSSetIterator.h:
* Source/JavaScriptCore/runtime/JSWrapForValidIterator.h:
* Source/JavaScriptCore/runtime/LazyProperty.h:
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::reviverMode&gt;::Lexer::lexNumber):
* Source/JavaScriptCore/runtime/NumericStrings.h:
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::setOptions):
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
* Source/JavaScriptCore/runtime/SymbolTable.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::preCommitStackMemory):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/tools/TieredMMapArray.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitIndirectTailCall):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::addCallIndirect):
(JSC::Wasm::IPIntGenerator::addCallRef):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addI32DivS):
(JSC::Wasm::OMGIRGenerator::addI32RemS):
(JSC::Wasm::OMGIRGenerator::addI32DivU):
(JSC::Wasm::OMGIRGenerator::addI32RemU):
(JSC::Wasm::OMGIRGenerator::addI64DivS):
(JSC::Wasm::OMGIRGenerator::addI64RemS):
(JSC::Wasm::OMGIRGenerator::addI64DivU):
(JSC::Wasm::OMGIRGenerator::addI64RemU):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::addI32DivS):
(JSC::Wasm::OMGIRGenerator::addI32RemS):
(JSC::Wasm::OMGIRGenerator::addI32DivU):
(JSC::Wasm::OMGIRGenerator::addI32RemU):
(JSC::Wasm::OMGIRGenerator::addI64DivS):
(JSC::Wasm::OMGIRGenerator::addI64RemS):
(JSC::Wasm::OMGIRGenerator::addI64DivU):
(JSC::Wasm::OMGIRGenerator::addI64RemU):
* Source/JavaScriptCore/wasm/WasmThunks.cpp:
(JSC::Wasm::triggerOMGEntryTierUpThunkGeneratorImpl):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::InputStream::dump const):
(JSC::Yarr::Interpreter::testCharacterClass):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f73be03bc7f7d7f2b5b19e683ca988ddc49cf18a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101549 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106706 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52182 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103589 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29711 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77341 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34370 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104556 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16617 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91708 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57679 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16439 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9725 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51529 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94221 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86311 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9802 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109058 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100159 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28682 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21107 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86313 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29043 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85875 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30616 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8327 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/22814 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28610 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33899 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/123783 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28421 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34405 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31744 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29980 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->