### PR TITLE
Remove the bitwise packing and unpacking operations from Color

### DIFF
--- a/Source/WebCore/platform/graphics/Color.h
+++ b/Source/WebCore/platform/graphics/Color.h
@@ -111,7 +111,7 @@ public:
     bool isSemantic() const;
     bool usesColorFunctionSerialization() const;
 
-    ColorSpace colorSpace() const;
+    ColorSpace colorSpace() const { return m_colorSpace; }
     WEBCORE_EXPORT std::optional<ColorDataForIPC> data() const;
 
     bool isOpaque() const { return isOutOfLine() ? asOutOfLine().resolvedAlpha() == 1.0 : asInline().resolved().alpha == 255; }
@@ -253,7 +253,7 @@ private:
     };
     static OptionSet<FlagsIncludingPrivate> toFlagsIncludingPrivate(OptionSet<Flags> flags) { return OptionSet<FlagsIncludingPrivate>::fromRaw(flags.toRaw()); }
 
-    OptionSet<FlagsIncludingPrivate> flags() const;
+    OptionSet<FlagsIncludingPrivate> flags() const { return OptionSet<FlagsIncludingPrivate>::fromRaw(m_flags); }
     bool isOutOfLine() const;
     bool isInline() const;
 
@@ -266,32 +266,26 @@ private:
     const OutOfLineComponents& asOutOfLine() const;
     Ref<OutOfLineComponents> protectedAsOutOfLine() const;
 
-#if CPU(ADDRESS64)
-    static constexpr unsigned maxNumberOfBitsInPointer = 48;
-#else
-    static constexpr unsigned maxNumberOfBitsInPointer = 32;
-#endif
-    static constexpr uint64_t colorValueMask = (1ULL << maxNumberOfBitsInPointer) - 1;
-    static constexpr uint64_t flagsSize = sizeof(FlagsIncludingPrivate) * 8;
-    static constexpr uint64_t flagsShift = maxNumberOfBitsInPointer;
-    static constexpr uint64_t colorSpaceSize = sizeof(ColorSpace) * 8;
-    static constexpr uint64_t colorSpaceShift = flagsShift + flagsSize;
-    static_assert(flagsSize + colorSpaceSize + maxNumberOfBitsInPointer <= 64);
-
-    static uint64_t encodedFlags(OptionSet<FlagsIncludingPrivate>);
-    static uint64_t encodedColorSpace(ColorSpace);
-    static uint64_t encodedInlineColor(SRGBA<uint8_t>);
-    static uint64_t encodedPackedInlineColor(PackedColor::RGBA);
-    static uint64_t encodedOutOfLineComponents(Ref<OutOfLineComponents>&&);
-
-    static OptionSet<FlagsIncludingPrivate> decodedFlags(uint64_t);
-    static ColorSpace decodedColorSpace(uint64_t);
-    static SRGBA<uint8_t> decodedInlineColor(uint64_t);
-    static PackedColor::RGBA decodedPackedInlineColor(uint64_t);
-    static OutOfLineComponents& decodedOutOfLineComponents(uint64_t);
-
     static constexpr uint64_t invalidColorAndFlags = 0;
-    uint64_t m_colorAndFlags { invalidColorAndFlags };
+
+#pragma pack(push)
+#pragma pack(1)
+    union {
+        uint64_t m_colorAndFlags { invalidColorAndFlags };
+        struct {
+            union {
+                uint32_t m_inlineColor;
+#if CPU(ADDRESS64)
+                uint64_t m_outOfLineComponentsAddress : 48;
+#else
+                uint32_t m_outOfLineComponentsAddress;
+#endif
+            };
+            uint8_t m_flags;
+            ColorSpace m_colorSpace;
+        };
+    };
+#pragma pack(pop)
 };
 
 inline void add(Hasher& hasher, const Color& color)
@@ -385,12 +379,12 @@ inline Color::Color(Ref<OutOfLineComponents>&& outOfLineComponents, ColorSpace c
 
 inline Color::Color(WTF::HashTableEmptyValueType)
 {
-    m_colorAndFlags = encodedFlags({ FlagsIncludingPrivate::HashTableEmptyValue });
+    m_flags = static_cast<uint8_t>(FlagsIncludingPrivate::HashTableEmptyValue);
 }
 
 inline Color::Color(WTF::HashTableDeletedValueType)
 {
-    m_colorAndFlags = encodedFlags({ FlagsIncludingPrivate::HashTableDeletedValue });
+    m_flags = static_cast<uint8_t>(FlagsIncludingPrivate::HashTableDeletedValue);
 }
 
 inline Color::Color(const Color& other)
@@ -464,11 +458,6 @@ inline bool Color::usesColorFunctionSerialization() const
     return flags().contains(FlagsIncludingPrivate::UseColorFunctionSerialization);
 }
 
-inline ColorSpace Color::colorSpace() const
-{
-    return decodedColorSpace(m_colorAndFlags);
-}
-
 template<typename Functor> decltype(auto) Color::callOnUnderlyingType(Functor&& functor) const
 {
     if (isOutOfLine())
@@ -510,11 +499,6 @@ inline Color Color::colorWithAlpha(std::optional<float> alpha) const
     return alpha ? colorWithAlpha(alpha.value()) : *this;
 }
 
-inline OptionSet<Color::FlagsIncludingPrivate> Color::flags() const
-{
-    return decodedFlags(m_colorAndFlags);
-}
-
 inline bool Color::isOutOfLine() const
 {
     return flags().contains(FlagsIncludingPrivate::OutOfLine);
@@ -528,13 +512,13 @@ inline bool Color::isInline() const
 inline const Color::OutOfLineComponents& Color::asOutOfLine() const
 {
     ASSERT(isOutOfLine());
-    return decodedOutOfLineComponents(m_colorAndFlags);
+    return *std::bit_cast<OutOfLineComponents*>(m_outOfLineComponentsAddress);
 }
 
 inline Ref<Color::OutOfLineComponents> Color::protectedAsOutOfLine() const
 {
     ASSERT(isOutOfLine());
-    return decodedOutOfLineComponents(m_colorAndFlags);
+    return *std::bit_cast<OutOfLineComponents*>(m_outOfLineComponentsAddress);
 }
 
 inline SRGBA<uint8_t> Color::asInline() const
@@ -546,7 +530,7 @@ inline SRGBA<uint8_t> Color::asInline() const
 inline PackedColor::RGBA Color::asPackedInline() const
 {
     ASSERT(isInline());
-    return decodedPackedInlineColor(m_colorAndFlags);
+    return PackedColor::RGBA { m_inlineColor };
 }
 
 inline std::optional<PackedColor::RGBA> Color::tryGetAsPackedInline() const
@@ -563,75 +547,23 @@ inline std::optional<SRGBA<uint8_t>> Color::tryGetAsSRGBABytes() const
     return std::nullopt;
 }
 
-inline uint64_t Color::encodedFlags(OptionSet<FlagsIncludingPrivate> flags)
-{
-    return static_cast<uint64_t>(flags.toRaw()) << flagsShift;
-}
-
-inline uint64_t Color::encodedColorSpace(ColorSpace colorSpace)
-{
-    return static_cast<uint64_t>(colorSpace) << colorSpaceShift;
-}
-
-inline uint64_t Color::encodedInlineColor(SRGBA<uint8_t> color)
-{
-    return encodedPackedInlineColor(PackedColor::RGBA { color });
-}
-
-inline uint64_t Color::encodedPackedInlineColor(PackedColor::RGBA color)
-{
-    return color.value;
-}
-
-inline uint64_t Color::encodedOutOfLineComponents(Ref<OutOfLineComponents>&& outOfLineComponents)
-{
-#if CPU(ADDRESS64)
-    return std::bit_cast<uint64_t>(&outOfLineComponents.leakRef());
-#else
-    return std::bit_cast<uint32_t>(&outOfLineComponents.leakRef());
-#endif
-}
-
-inline OptionSet<Color::FlagsIncludingPrivate> Color::decodedFlags(uint64_t value)
-{
-    return OptionSet<Color::FlagsIncludingPrivate>::fromRaw(static_cast<uint8_t>(value >> flagsShift));
-}
-
-inline ColorSpace Color::decodedColorSpace(uint64_t value)
-{
-    return static_cast<ColorSpace>(static_cast<uint8_t>(value >> colorSpaceShift));
-}
-
-inline SRGBA<uint8_t> Color::decodedInlineColor(uint64_t value)
-{
-    return asSRGBA(decodedPackedInlineColor(value));
-}
-
-inline PackedColor::RGBA Color::decodedPackedInlineColor(uint64_t value)
-{
-    return PackedColor::RGBA { static_cast<uint32_t>(value & colorValueMask) };
-}
-
-inline Color::OutOfLineComponents& Color::decodedOutOfLineComponents(uint64_t value)
-{
-#if CPU(ADDRESS64)
-    return *std::bit_cast<OutOfLineComponents*>(value & colorValueMask);
-#else
-    return *std::bit_cast<OutOfLineComponents*>(static_cast<uint32_t>(value & colorValueMask));
-#endif
-}
-
 inline void Color::setColor(SRGBA<uint8_t> color, OptionSet<FlagsIncludingPrivate> flags)
 {
-    flags.add({ FlagsIncludingPrivate::Valid });
-    m_colorAndFlags = encodedInlineColor(color) | encodedColorSpace(ColorSpace::SRGB) | encodedFlags(flags);
+    m_inlineColor = PackedColor::RGBA { color }.value;
+    m_flags = flags.toRaw() | static_cast<uint8_t>(FlagsIncludingPrivate::Valid);
+    m_colorSpace = ColorSpace::SRGB;
     ASSERT(isInline());
 }
 
 inline void Color::setOutOfLineComponents(Ref<OutOfLineComponents>&& color, ColorSpace colorSpace, OptionSet<FlagsIncludingPrivate> flags)
 {
-    flags.add({ FlagsIncludingPrivate::Valid, FlagsIncludingPrivate::OutOfLine });
-    m_colorAndFlags = encodedOutOfLineComponents(WTFMove(color)) | encodedColorSpace(colorSpace) | encodedFlags(flags);
+#if CPU(ADDRESS64)
+    m_outOfLineComponentsAddress = std::bit_cast<uint64_t>(&color.leakRef());
+#else
+    m_outOfLineComponentsAddress = std::bit_cast<uint32_t>(&color.leakRef());
+#endif
+    m_flags = flags.toRaw() | static_cast<uint8_t>(FlagsIncludingPrivate::Valid) | static_cast<uint8_t>(FlagsIncludingPrivate::OutOfLine);
+    m_colorSpace = colorSpace;
     ASSERT(isOutOfLine());
 }
 


### PR DESCRIPTION
#### c74aecf287bd98503ce2e53106837e55a51c9192
<pre>
Remove the bitwise packing and unpacking operations from Color
<a href="https://bugs.webkit.org/show_bug.cgi?id=292113">https://bugs.webkit.org/show_bug.cgi?id=292113</a>
<a href="https://rdar.apple.com/150121409">rdar://150121409</a>

Reviewed by NOBODY (OOPS!).

The Color class has one single member which is 64 bits. These bits should include
a set of flags and ColorSpace. Based on the flags the reset of the bits may have
either four bytes for RGBA color or a 48-bit address to a Ref pointer. The Ref
pointer points to a class which holds four float of an out-of-line  color components.

To split the 64-bits member to these three fields, bitwise-mask and  bitwise-shift
operations and casting operations are used. This makes reading the code difficult.
It is hard to see or remember the layout of these 64 bits. It is also hard to read
the values of the fields directly in the debugger.

To fix this, anonymous union can be used to describe the layout the of the bits
clearly. It should also allow deleting the cumbersome bitwise operations entirely.

* Source/WebCore/platform/graphics/Color.h:
(WebCore::Color::colorSpace const):
(WebCore::Color::flags const):
(WebCore::Color::Color):
(WebCore::Color::asOutOfLine const):
(WebCore::Color::protectedAsOutOfLine const):
(WebCore::Color::asPackedInline const):
(WebCore::Color::setColor):
(WebCore::Color::setOutOfLineComponents):
(WebCore::Color::encodedFlags): Deleted.
(WebCore::Color::encodedColorSpace): Deleted.
(WebCore::Color::encodedInlineColor): Deleted.
(WebCore::Color::encodedPackedInlineColor): Deleted.
(WebCore::Color::encodedOutOfLineComponents): Deleted.
(WebCore::Color::decodedFlags): Deleted.
(WebCore::Color::decodedColorSpace): Deleted.
(WebCore::Color::decodedInlineColor): Deleted.
(WebCore::Color::decodedPackedInlineColor): Deleted.
(WebCore::Color::decodedOutOfLineComponents): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c74aecf287bd98503ce2e53106837e55a51c9192

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20681 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106165 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51645 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103060 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20990 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29175 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76935 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33980 "Found 60 new test failures: animations/3d/animate-to-transform-perpective-to-none.html animations/3d/change-transform-in-end-event.html animations/3d/full-rotation-animation.html animations/3d/replace-filling-transform.html animations/3d/state-at-end-event-transform.html animations/3d/transform-origin-vs-functions.html animations/3d/transform-perspective.html animations/CSSKeyframesRule-name-null.html animations/CSSKeyframesRule-parameters.html animations/added-while-suspended.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104026 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16156 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91244 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57283 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15971 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9269 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50993 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85877 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108521 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28147 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20714 "Found 4 new test failures: http/tests/iframe-monitor/data-url-resource.html http/wpt/screen-wake-lock/sticky-permission-after-transient-activation.html imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page.html pdf/pdf-in-embed-rounded-border.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85903 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28509 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87444 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85442 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30162 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7888 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22206 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28077 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33345 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27889 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31209 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29447 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->