### PR TITLE
Sync `svg/types` from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement-padding-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement-padding-expected.txt
@@ -1,0 +1,6 @@
+
+FAIL getScreenCTM with padding-left and rotation assert_equals: expected 50 but got -50
+FAIL getScreenCTM with padding-top and rotation assert_equals: expected 50 but got -50
+FAIL getScreenCTM with padding-right and rotation assert_equals: expected 62 but got -62
+FAIL getScreenCTM with padding-left, rotation and content-box assert_equals: expected 62 but got -62
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement-padding.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement-padding.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <title>SVGGraphicsElement with padding</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGGraphicsElement"/>
+  </metadata>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+
+  <foreignObject width="100px" height="100px">
+    <svg id="svg" width="100px" height="100px">
+      <circle cx="50" cy="0" r="44"
+            fill="blue"></circle>
+    </svg>
+  </foreignObject>
+
+  <script><![CDATA[
+    test(function() {
+        let svg = document.getElementById("svg");
+        svg.setAttribute("style", "padding-left: 12px; transform: rotate(180deg);");
+        let ctm = svg.getScreenCTM();
+        let pt = DOMPoint.fromPoint({x: 50, y: 50});
+        let transformedPoint = pt.matrixTransform(ctm.inverse());
+        svg.removeAttribute("style");
+        assert_equals(transformedPoint.x, pt.x);
+        assert_equals(transformedPoint.y, pt.y);
+    }, 'getScreenCTM with padding-left and rotation');
+
+    test(function() {
+        let svg = document.getElementById("svg");
+        svg.setAttribute("style", "padding-top: 12px; transform: rotate(180deg);");
+        let ctm = svg.getScreenCTM();
+        let pt = DOMPoint.fromPoint({x: 50, y: 50});
+        let transformedPoint = pt.matrixTransform(ctm.inverse());
+        svg.removeAttribute("style");
+        assert_equals(transformedPoint.x, pt.x);
+        assert_equals(transformedPoint.y, pt.y);
+    }, 'getScreenCTM with padding-top and rotation');
+
+    test(function() {
+        let svg = document.getElementById("svg");
+        svg.setAttribute("style", "padding-right: 12px; transform: rotate(180deg);");
+        let ctm = svg.getScreenCTM();
+        let pt = DOMPoint.fromPoint({x: 50, y: 50});
+        let transformedPoint = pt.matrixTransform(ctm.inverse());
+        svg.removeAttribute("style");
+        assert_equals(transformedPoint.x, pt.x + 12);
+        assert_equals(transformedPoint.y, pt.y);
+    }, 'getScreenCTM with padding-right and rotation');
+
+    test(function() {
+        let svg = document.getElementById("svg");
+        svg.setAttribute("style", "padding-left: 12px; transform: rotate(180deg); transform-box: content-box");
+        let ctm = svg.getScreenCTM();
+        let pt = DOMPoint.fromPoint({x: 50, y: 50});
+        let transformedPoint = pt.matrixTransform(ctm.inverse());
+        svg.removeAttribute("style");
+        assert_equals(transformedPoint.x, pt.x + 12);
+        assert_equals(transformedPoint.y, pt.y);
+    }, 'getScreenCTM with padding-left, rotation and content-box');
+
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/w3c-import.log
@@ -51,6 +51,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.isPointInStroke-01.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.isPointInStroke-02.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement-clone.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement-padding.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-01.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-02.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-03.html


### PR DESCRIPTION
#### 32f8ae903270fc634f0b3e7c97650a3a417388f9
<pre>
Sync `svg/types` from WPT upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=292114">https://bugs.webkit.org/show_bug.cgi?id=292114</a>
<a href="https://rdar.apple.com/150129551">rdar://150129551</a>

Reviewed by Simon Fraser.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/cae0369c7e2b6b4c6568843f73c7e1a5a3aae9b8">https://github.com/web-platform-tests/wpt/commit/cae0369c7e2b6b4c6568843f73c7e1a5a3aae9b8</a>

* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement-padding.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement-padding-expected.txt:

Canonical link: <a href="https://commits.webkit.org/294165@main">https://commits.webkit.org/294165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a507de74b48c4bb671ee27a1d0b8258b8aedee1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106169 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51649 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76939 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33966 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91247 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57287 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15978 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9272 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50997 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85884 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9330 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108525 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28151 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20718 "Found 1 new test failure: http/tests/iframe-monitor/workers/shared-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85907 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28513 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87447 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85446 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21745 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30166 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7891 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22210 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28081 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27893 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31213 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29451 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->