### PR TITLE
Reduce unsafe lambdas in ControlMac & PasteboardCustomData

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UnretainedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLambdaCapturesCheckerExpectations
@@ -2,7 +2,5 @@ accessibility/mac/WebAccessibilityObjectWrapperMac.mm
 platform/cocoa/SharedVideoFrameInfo.mm
 platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
 platform/graphics/cv/VideoFrameCV.mm
-platform/graphics/mac/controls/ControlMac.mm
-platform/mac/PlatformPasteboardMac.mm
 platform/mac/WebCoreObjCExtras.mm
 platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm

--- a/Source/WebCore/platform/PasteboardCustomData.cpp
+++ b/Source/WebCore/platform/PasteboardCustomData.cpp
@@ -246,13 +246,13 @@ String PasteboardCustomData::readStringInCustomData(const String& type) const
     return { };
 }
 
-void PasteboardCustomData::forEachType(Function<void(const String&)>&& function) const
+void PasteboardCustomData::forEachType(NOESCAPE const Function<void(const String&)>& function) const
 {
     for (auto& entry : m_data)
         function(entry.type);
 }
 
-void PasteboardCustomData::forEachPlatformString(Function<void(const String& type, const String& data)>&& function) const
+void PasteboardCustomData::forEachPlatformString(NOESCAPE const Function<void(const String& type, const String& data)>& function) const
 {
     for (auto& entry : m_data) {
         if (!std::holds_alternative<String>(entry.platformData))
@@ -264,7 +264,7 @@ void PasteboardCustomData::forEachPlatformString(Function<void(const String& typ
     }
 }
 
-void PasteboardCustomData::forEachCustomString(Function<void(const String& type, const String& data)>&& function) const
+void PasteboardCustomData::forEachCustomString(NOESCAPE const Function<void(const String& type, const String& data)>& function) const
 {
     for (auto& entry : m_data) {
         if (!entry.customData.isNull())
@@ -272,7 +272,7 @@ void PasteboardCustomData::forEachCustomString(Function<void(const String& type,
     }
 }
 
-void PasteboardCustomData::forEachPlatformStringOrBuffer(Function<void(const String& type, const Variant<String, Ref<SharedBuffer>>& data)>&& function) const
+void PasteboardCustomData::forEachPlatformStringOrBuffer(NOESCAPE const Function<void(const String& type, const Variant<String, Ref<SharedBuffer>>& data)>& function) const
 {
     for (auto& entry : m_data) {
         auto& data = entry.platformData;

--- a/Source/WebCore/platform/PasteboardCustomData.h
+++ b/Source/WebCore/platform/PasteboardCustomData.h
@@ -83,10 +83,10 @@ public:
     static ASCIILiteral wpeType() { return "org.wpewebkit.WebKit.custom-pasteboard-data"_s; }
 #endif
 
-    void forEachType(Function<void(const String&)>&&) const;
-    void forEachPlatformString(Function<void(const String& type, const String& data)>&&) const;
-    void forEachPlatformStringOrBuffer(Function<void(const String& type, const Variant<String, Ref<SharedBuffer>>& data)>&&) const;
-    void forEachCustomString(Function<void(const String& type, const String& data)>&&) const;
+    void forEachType(NOESCAPE const Function<void(const String&)>&) const;
+    void forEachPlatformString(NOESCAPE const Function<void(const String& type, const String& data)>&) const;
+    void forEachPlatformStringOrBuffer(NOESCAPE const Function<void(const String& type, const Variant<String, Ref<SharedBuffer>>& data)>&) const;
+    void forEachCustomString(NOESCAPE const Function<void(const String& type, const String& data)>&) const;
 
     bool hasData() const;
     bool hasSameOriginCustomData() const;

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
@@ -221,7 +221,7 @@ static void applyViewlessCellSettings(float deviceScaleFactor, const ControlStyl
         [cell _setFallbackSemanticContext:NSViewSemanticContextForm];
 }
 
-static void performDrawingWithUnflippedContext(GraphicsContext& context, const FloatRect& rect, Function<void(const FloatRect&)>&& draw)
+static void performDrawingWithUnflippedContext(GraphicsContext& context, const FloatRect& rect, NOESCAPE const Function<void(const FloatRect&)>& draw)
 {
     auto adjustedRect = rect;
 


### PR DESCRIPTION
#### 34926f2429825d900716fe37280839f6c100d44a
<pre>
Reduce unsafe lambdas in ControlMac &amp; PasteboardCustomData
<a href="https://bugs.webkit.org/show_bug.cgi?id=292115">https://bugs.webkit.org/show_bug.cgi?id=292115</a>

Reviewed by Ryosuke Niwa.

As per <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#annotate-noescape-when-a-function-uses-a-lambda-synchronously">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#annotate-noescape-when-a-function-uses-a-lambda-synchronously</a>

Canonical link: <a href="https://commits.webkit.org/294195@main">https://commits.webkit.org/294195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2867905efe03e9b48e8a23d66199187a0fadee9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106202 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51682 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103097 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76972 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34001 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104063 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16195 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91280 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57320 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16010 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9306 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51030 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85916 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9363 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108558 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28184 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20754 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85939 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28546 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87480 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85477 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30196 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7924 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22269 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16441 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28114 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33382 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27926 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31246 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29484 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->