### PR TITLE
[GStreamer][MediaStream] Crash on https://mozilla.github.io/webrtc-landing/gum_test.html

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.h
@@ -64,6 +64,7 @@ protected:
     bool canResizeVideoFrames() const final { return true; }
     void generatePresets() final;
     void setSizeFrameRateAndZoom(const VideoPresetConstraints&) final;
+    void applyFrameRateAndZoomWithPreset(double, double, std::optional<VideoPreset>&&) final;
 
     mutable std::optional<RealtimeMediaSourceCapabilities> m_capabilities;
     mutable std::optional<RealtimeMediaSourceSettings> m_currentSettings;
@@ -75,6 +76,8 @@ private:
 
     RefPtr<GStreamerVideoCapturer> m_capturer;
     CaptureDevice::DeviceType m_deviceType;
+
+    std::optional<VideoPreset> m_currentPreset;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 1177dcf7f087d0abfe193bdf3d94ddb07ce6d2dd
<pre>
[GStreamer][MediaStream] Crash on <a href="https://mozilla.github.io/webrtc-landing/gum_test.html">https://mozilla.github.io/webrtc-landing/gum_test.html</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291837">https://bugs.webkit.org/show_bug.cgi?id=291837</a>

Reviewed by Xabier Rodriguez-Calvar.

The crash was happening due to a division by zero, the intrinsic size being set to 0x0. By
implementing applyFrameRateAndZoomWithPreset() the intrinsic size is now set and the framerate
applied to the capturer, although desktop capture currently doesn&apos;t support this, but that&apos;s a
separate issue.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp:
(WebCore::GStreamerVideoCaptureSource::settingsDidChange):
(WebCore::GStreamerVideoCaptureSource::sourceCapsChanged):
(WebCore::GStreamerVideoCaptureSource::generatePresets):
(WebCore::GStreamerVideoCaptureSource::applyFrameRateAndZoomWithPreset):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.h:

Canonical link: <a href="https://commits.webkit.org/294171@main">https://commits.webkit.org/294171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e2a5839501a637f69957e6696b7e7ef36a2312a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106176 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51656 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103071 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21001 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29186 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76946 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33974 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16167 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91255 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57294 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15982 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-contain/contain-size-021.html imported/w3c/web-platform-tests/mathml/presentation-markup/direction/direction-006.html imported/w3c/web-platform-tests/resource-timing/idlharness.any.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9280 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51004 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85888 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9338 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108532 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28158 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20726 "Found 1 new test failure: http/tests/iframe-monitor/data-url-resource.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85914 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28520 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85452 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21747 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30173 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7899 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22225 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28088 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33356 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27900 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31220 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29458 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->