### PR TITLE
[Viewport Clipping] [Part 3/4] Plumb the viewport anchor layer through the scrolling tree

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -539,7 +539,6 @@ page/mac/ServicesOverlayController.mm
 page/scrolling/AsyncScrollingCoordinator.cpp
 page/scrolling/ScrollAnchoringController.cpp
 page/scrolling/ScrollingCoordinator.cpp
-page/scrolling/ScrollingStateStickyNode.cpp
 page/scrolling/ScrollingTreeOverflowScrollProxyNode.cpp
 page/scrolling/ScrollingTreePositionedNode.cpp
 page/scrolling/ScrollingTreeStickyNode.cpp

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -991,6 +991,9 @@ void AsyncScrollingCoordinator::setNodeLayers(ScrollingNodeID nodeID, const Node
             frameScrollingNode->setRootContentsLayer(nodeLayers.rootContentsLayer);
         }
     }
+
+    if (RefPtr stickyNode = dynamicDowncast<ScrollingStateStickyNode>(*node))
+        stickyNode->setViewportAnchorLayer(nodeLayers.viewportAnchorLayer);
 }
 
 void AsyncScrollingCoordinator::setFrameScrollingNodeState(ScrollingNodeID nodeID, const LocalFrameView& frameView)

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -163,6 +163,7 @@ public:
         GraphicsLayer* rootContentsLayer { nullptr };
         GraphicsLayer* horizontalScrollbarLayer { nullptr };
         GraphicsLayer* verticalScrollbarLayer { nullptr };
+        GraphicsLayer* viewportAnchorLayer { nullptr };
     };
     virtual void setNodeLayers(ScrollingNodeID, const NodeLayers&) { }
 

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -256,6 +256,7 @@ enum class ScrollingStateNodeProperty : uint64_t {
     LayoutConstraintData                        = 1LLU << 2, // Same value as TotalContentsSize
     // ScrollingStateFixedNode, ScrollingStateStickyNode
     ViewportConstraints                         = 1LLU << 1, // Same value as ScrollableAreaSize, RelatedOverflowScrollingNodes and OverflowScrollingNode
+    ViewportAnchorLayer                         = 1LLU << 2, // Same value as TotalContentsSize
     // ScrollingStateOverflowScrollProxyNode
     OverflowScrollingNode                       = 1LLU << 1, // Same value as ScrollableAreaSize, ViewportConstraints and RelatedOverflowScrollingNodes
     // ScrollingStateFrameHostingNode

--- a/Source/WebCore/page/scrolling/ScrollingStateStickyNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateStickyNode.h
@@ -48,19 +48,26 @@ public:
     WEBCORE_EXPORT void updateConstraints(const StickyPositionViewportConstraints&);
     const StickyPositionViewportConstraints& viewportConstraints() const { return m_constraints; }
 
+    const LayerRepresentation& viewportAnchorLayer() const { return m_viewportAnchorLayer; }
+    WEBCORE_EXPORT void setViewportAnchorLayer(const LayerRepresentation&);
+
 private:
-    WEBCORE_EXPORT ScrollingStateStickyNode(ScrollingNodeID, Vector<Ref<ScrollingStateNode>>&&, OptionSet<ScrollingStateNodeProperty>, std::optional<PlatformLayerIdentifier>, StickyPositionViewportConstraints&&);
+    WEBCORE_EXPORT ScrollingStateStickyNode(ScrollingNodeID, Vector<Ref<ScrollingStateNode>>&&, OptionSet<ScrollingStateNodeProperty>, std::optional<PlatformLayerIdentifier>, StickyPositionViewportConstraints&&, LayerRepresentation&&);
     ScrollingStateStickyNode(ScrollingStateTree&, ScrollingNodeID);
     ScrollingStateStickyNode(const ScrollingStateStickyNode&, ScrollingStateTree&);
 
-    FloatPoint computeLayerPosition(const LayoutRect& viewportRect) const;
+    FloatPoint computeClippingLayerPosition(const LayoutRect& viewportRect) const;
+    FloatPoint computeAnchorLayerPosition(const LayoutRect& viewportRect) const;
     void reconcileLayerPositionForViewportRect(const LayoutRect& viewportRect, ScrollingLayerPositionAction) final;
     FloatSize scrollDeltaSinceLastCommit(const LayoutRect& viewportRect) const;
 
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const final;
     OptionSet<ScrollingStateNode::Property> applicableProperties() const final;
 
+    bool hasViewportClippingLayer() const;
+
     StickyPositionViewportConstraints m_constraints;
+    LayerRepresentation m_viewportAnchorLayer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp
@@ -73,6 +73,16 @@ void ScrollingTreeStickyNode::dumpProperties(TextStream& ts, OptionSet<Scrolling
         ts.dumpProperty("layer top left"_s, layerTopLeft());
 }
 
+FloatPoint ScrollingTreeStickyNode::computeClippingLayerPosition() const
+{
+    if (!hasViewportClippingLayer()) {
+        ASSERT_NOT_REACHED();
+        return { };
+    }
+
+    return computeLayerPosition();
+}
+
 FloatPoint ScrollingTreeStickyNode::computeAnchorLayerPosition() const
 {
     FloatSize offsetFromStickyAncestors;
@@ -114,7 +124,7 @@ FloatPoint ScrollingTreeStickyNode::computeAnchorLayerPosition() const
 
 FloatSize ScrollingTreeStickyNode::scrollDeltaSinceLastCommit() const
 {
-    auto layerPosition = computeAnchorLayerPosition();
+    auto layerPosition = hasViewportClippingLayer() ? computeClippingLayerPosition() : computeAnchorLayerPosition();
     return layerPosition - m_constraints.layerPositionAtLastLayout();
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h
@@ -51,10 +51,12 @@ protected:
 
     bool commitStateBeforeChildren(const ScrollingStateNode&) override;
 
+    FloatPoint computeClippingLayerPosition() const;
     FloatPoint computeAnchorLayerPosition() const;
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
 
     virtual FloatPoint layerTopLeft() const = 0;
+    virtual bool hasViewportClippingLayer() const { return false; }
     const ViewportConstraints& constraints() const final { return m_constraints; }
 
     StickyPositionViewportConstraints m_constraints;

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h
@@ -49,8 +49,10 @@ private:
     void applyLayerPositions() final WTF_REQUIRES_LOCK(scrollingTree()->treeLock());
     FloatPoint layerTopLeft() const final;
     CALayer *layer() const final { return m_layer.get(); }
+    bool hasViewportClippingLayer() const final;
 
     RetainPtr<CALayer> m_layer;
+    RetainPtr<CALayer> m_viewportAnchorLayer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -529,7 +529,7 @@ void RenderLayerBacking::updateDebugIndicators(bool showBorder, bool showRepaint
     m_graphicsLayer->setShowDebugBorder(showBorder);
     m_graphicsLayer->setShowRepaintCounter(showRepaintCounter);
 
-    // m_viewportAnchorLayer can't show layer borders becuase it's a structural layer.
+    // m_viewportAnchorLayer can't show layer borders because it's a structural layer.
 
     if (m_ancestorClippingStack) {
         for (auto& entry : m_ancestorClippingStack->stack())
@@ -3543,8 +3543,8 @@ GraphicsLayer* RenderLayerBacking::childForSuperlayersExcludingViewTransitions()
     if (m_ancestorClippingStack)
         return m_ancestorClippingStack->firstLayer();
 
-    if (m_viewportAnchorLayer)
-        return m_viewportAnchorLayer.get();
+    if (RefPtr viewportConstrainedLayer = viewportClippingOrAnchorLayer())
+        return viewportConstrainedLayer.get();
 
     if (m_contentsContainmentLayer)
         return m_contentsContainmentLayer.get();

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -109,6 +109,7 @@ public:
 
     GraphicsLayer* contentsContainmentLayer() const { return m_contentsContainmentLayer.get(); }
     GraphicsLayer* viewportAnchorLayer() const { return m_viewportAnchorLayer.get(); }
+    GraphicsLayer* viewportClippingOrAnchorLayer() const { return viewportAnchorLayer(); }
 
     GraphicsLayer* foregroundLayer() const { return m_foregroundLayer.get(); }
     GraphicsLayer* backgroundLayer() const { return m_backgroundLayer.get(); }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
@@ -229,6 +229,7 @@ header: <WebCore/ScrollingStatePositionedNode.h>
     [OptionalTupleBits] OptionSet<WebCore::ScrollingStateNodeProperty> changedProperties()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::Layer] std::optional<WebCore::PlatformLayerIdentifier> layer().layerID()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ViewportConstraints] WebCore::StickyPositionViewportConstraints viewportConstraints()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ViewportAnchorLayer] std::optional<WebCore::PlatformLayerIdentifier> viewportAnchorLayer().layerID();
 }
 
 [RefCounted] class WebCore::ScrollingStatePositionedNode {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4458,6 +4458,7 @@ header: <WebCore/ScrollingStateNode.h>
     RelatedOverflowScrollingNodes
     LayoutConstraintData
     ViewportConstraints
+    ViewportAnchorLayer
     OverflowScrollingNode
     KeyboardScrollData
     OverlayScrollbarsEnabled

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -45,6 +45,7 @@
 #import <WebCore/ScrollingStateOverflowScrollingNode.h>
 #import <WebCore/ScrollingStatePluginScrollingNode.h>
 #import <WebCore/ScrollingStatePositionedNode.h>
+#import <WebCore/ScrollingStateStickyNode.h>
 #import <WebCore/ScrollingStateTree.h>
 #import <WebCore/ScrollingTreeFrameScrollingNode.h>
 #import <WebCore/ScrollingTreeOverflowScrollProxyNode.h>
@@ -203,7 +204,13 @@ void RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers(ScrollingStateTr
         case ScrollingNodeType::FrameHosting:
         case ScrollingNodeType::PluginHosting:
         case ScrollingNodeType::Fixed:
-        case ScrollingNodeType::Sticky:
+        case ScrollingNodeType::Sticky: {
+            if (RefPtr stickyStateNode = dynamicDowncast<ScrollingStateStickyNode>(currNode)) {
+                if (stickyStateNode->hasChangedProperty(ScrollingStateNode::Property::ViewportAnchorLayer))
+                    stickyStateNode->setViewportAnchorLayer(layerTreeHost.layerForID(stickyStateNode->viewportAnchorLayer().layerID()));
+            }
+            break;
+        }
         case ScrollingNodeType::Positioned:
             break;
         }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -37,6 +37,7 @@
 #import <WebCore/ScrollingStateOverflowScrollingNode.h>
 #import <WebCore/ScrollingStatePluginScrollingNode.h>
 #import <WebCore/ScrollingStatePositionedNode.h>
+#import <WebCore/ScrollingStateStickyNode.h>
 #import <WebCore/ScrollingStateTree.h>
 #import <WebCore/ScrollingTreeFrameScrollingNode.h>
 #import <WebCore/ScrollingTreeOverflowScrollProxyNode.h>
@@ -247,7 +248,13 @@ void RemoteScrollingCoordinatorProxyMac::connectStateNodeLayers(ScrollingStateTr
         case ScrollingNodeType::FrameHosting:
         case ScrollingNodeType::PluginHosting:
         case ScrollingNodeType::Fixed:
-        case ScrollingNodeType::Sticky:
+        case ScrollingNodeType::Sticky: {
+            if (RefPtr stickyStateNode = dynamicDowncast<ScrollingStateStickyNode>(currNode)) {
+                if (stickyStateNode->hasChangedProperty(ScrollingStateNode::Property::ViewportAnchorLayer))
+                    stickyStateNode->setViewportAnchorLayer(layerTreeHost.layerForID(stickyStateNode->viewportAnchorLayer().layerID()));
+            }
+            break;
+        }
         case ScrollingNodeType::Positioned:
             break;
         }


### PR DESCRIPTION
#### 7de5d103812b0f8da9ff696e9058bc13011a6da3
<pre>
[Viewport Clipping] [Part 3/4] Plumb the viewport anchor layer through the scrolling tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=292124">https://bugs.webkit.org/show_bug.cgi?id=292124</a>
<a href="https://rdar.apple.com/150150239">rdar://150150239</a>

Reviewed by Abrar Rahman Protyasha.

Continue working towards clipping fixed and sticky elements to the viewport. In this patch, we add
plumbing for the viewport anchor layer through scrolling tree and scrolling state nodes. At the
moment, this viewport anchor layer is redundant with the scrolling tree/state node&apos;s layer; however,
in the next and final patch, we&apos;ll add a new clipping layer which will replace the anchor layer as
the scrolling node&apos;s primary layer, in the case where the fixed or sticky element is clipped to the
viewport.

See below for more details; no change in behavior yet.

* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::setNodeLayers):

Add `viewportAnchorLayer` to `NodeLayers`.

* Source/WebCore/page/scrolling/ScrollingCoordinator.h:
* Source/WebCore/page/scrolling/ScrollingStateNode.h:

Add a changed property flag corresponding to the viewport anchor layer.

* Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp:
(WebCore::ScrollingStateStickyNode::ScrollingStateStickyNode):
(WebCore::ScrollingStateStickyNode::applicableProperties const):
(WebCore::ScrollingStateStickyNode::setViewportAnchorLayer):
(WebCore::ScrollingStateStickyNode::computeAnchorLayerPosition const):

Split `computeLayerPosition` into two methods: one to compute the position of the anchor layer, and
another to compute the position of the clipping layer (to be introduced in the next patch). Note
that both of these positions are relative to the sticky node&apos;s parent layer.

(WebCore::ScrollingStateStickyNode::computeClippingLayerPosition const):

Add a new method to return the position of the (soon-to-exist) clipping layer.

(WebCore::ScrollingStateStickyNode::reconcileLayerPositionForViewportRect):

Teach this to update both the viewport anchor layer as well as the viewport clipping layer. In the
case where the clipping layer doesn&apos;t exist, we fall back to existing behavior (i.e. blitting the
anchor layer to the anchor layer position); however, if the clipping layer exists, we&apos;ll instead
blit the clipping layer and then counter-blit the anchor layer as needed.

(WebCore::ScrollingStateStickyNode::hasViewportClippingLayer const):

Add a helper method to return whether or not the scrolling node has a viewport clipping layer (i.e.
whether the primary scrolling node layer is different from the viewport anchor layer).

(WebCore::ScrollingStateStickyNode::scrollDeltaSinceLastCommit const):

Use the clipping layer here when computing scroll delta, if it exists.

(WebCore::ScrollingStateStickyNode::computeLayerPosition const): Deleted.
* Source/WebCore/page/scrolling/ScrollingStateStickyNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp:
(WebCore::ScrollingTreeStickyNode::computeClippingLayerPosition const):

Add a new method to return the position of the (soon-to-exist) clipping layer, by calling into
`ScrollingStateViewportConstrainedNode::computeLayerPosition`.

(WebCore::ScrollingTreeStickyNode::scrollDeltaSinceLastCommit const):

Match `ScrollingStateStickyNode::scrollDeltaSinceLastCommit`.

* Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h:
(WebCore::ScrollingTreeStickyNode::hasViewportClippingLayer const):
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm:
(WebCore::ScrollingTreeStickyNodeCocoa::commitStateBeforeChildren):

Set `m_viewportAnchorLayer` based on the sticky state node&apos;s viewport anchor layer representation.

(WebCore::ScrollingTreeStickyNodeCocoa::applyLayerPositions):

Match the changes in `reconcileLayerPositionForViewportRect` above, by only blitting the anchor
layer to its updated position in the case where the clipping layer doesn&apos;t exist; otherwise, blit
the containing clipping layer to match the viewport rect while scrolling, and simultaneously
counter-blit the anchor layer underneath.

(WebCore::ScrollingTreeStickyNodeCocoa::hasViewportClippingLayer const):

Add a helper method to return whether or not the scrolling node has a viewport clipping layer (i.e.
whether the primary scrolling node layer is different from the viewport anchor layer).

* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateDebugIndicators):

Drive-by fix: fix a typo in this comment.

(WebCore::RenderLayerBacking::childForSuperlayersExcludingViewTransitions const):

Use the more generic `viewportClippingOrAnchorLayer()` here, instead of returning the viewport
anchor layer. This method just returns `m_viewportAnchorLayer` right now, but once the clipping
layer is introduced, it will return the clipping layer instead (which will contain the anchor
layer).

* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::didChangePlatformLayerForLayer):

Set both the new `viewportAnchorLayer` alongside `layer` on `NodeLayers`; these are always identical
for now, but in the next patch will change such that `layer` points to the outer layer that needs to
be repositioned when the scrolling node changes, while `viewportAnchorLayer` will continue to point
to just the anchor layer.

(WebCore::RenderLayerCompositor::computeFixedViewportConstraints const):
(WebCore::RenderLayerCompositor::computeStickyViewportConstraints const):

Adopt `viewportClippingOrAnchorLayer` here, instead of just using `viewportAnchorLayer` to compute
rects for the viewport constraints.

(WebCore::RenderLayerCompositor::updateScrollingNodeForViewportConstrainedRole):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::connectStateNodeLayers):

Add Cocoa-specific logic to update scrolling state tree nodes with the viewport anchor layer, by
mapping layer ID to platform `CALayer`.

Canonical link: <a href="https://commits.webkit.org/294311@main">https://commits.webkit.org/294311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b641f3d513aa47aa4032dd39a2443d048166e1a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21053 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106541 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52017 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29546 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77220 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34260 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16486 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91577 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57562 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16307 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9589 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51365 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/86186 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9663 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108893 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28517 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20984 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86195 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87779 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85754 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21818 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30487 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8196 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22634 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28448 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33727 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28259 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31579 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29818 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->