### PR TITLE
REGRESSION(294049@main): scroll-animations/css/animation-range-visual-test.html` hits `ASSERT(repaintContainer->isComposited())` under `RenderObject::repaintUsingContainer().

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7906,8 +7906,6 @@ fast/forms/color/input-color-swatch-overlay-appearance.html [ Skip ]
 
 webkit.org/b/288831 [ Debug ] fast/css/shadow-box-recursion-depth.html [ Pass Timeout ]
 
-webkit.org/b/291974 imported/w3c/web-platform-tests/scroll-animations/css/animation-range-visual-test.html [ Skip ]
-
 imported/w3c/web-platform-tests/css/cssom/adoptedstylesheets-adopt-link.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/cssom/adoptedstylesheets-adopt-style-subresource.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/cssom/adoptedstylesheets-adopt-style.tentative.html [ ImageOnlyFailure ]

--- a/LayoutTests/compositing/repaint-container-assertion-when-removing-layer.html
+++ b/LayoutTests/compositing/repaint-container-assertion-when-removing-layer.html
@@ -1,21 +1,30 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<script src="../resources/ui-helper.js"></script>
 <script>
-  if (window.testRunner)
+  if (window.testRunner) {
     testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+ }
 </script>
 </head>
 <body>
-<div id=outer style="will-change: opacity; width: 200px; height: 200px;">
+<div id=outer style="will-change: opacity; opacity: 0.5; width: 200px; height: 200px;">
   <div id=inner style="opacity: 0.5; width: 100px; height: 100px; background:blue"></div>
 </div>
 </body>
 <div>PASS if no crash or assert in debug mode.</div>
 <script>
-  outer.style.willChange = "";
-  getComputedStyle(outer);
-  inner.style.transform = "translateZ(0px)";
-</script>
+window.addEventListener('load', async () => {
+    await UIHelper.renderingUpdate();
 
+    outer.style.willChange = "";
+    outer.style.opacity = "1.0";
+    getComputedStyle(outer);
+    inner.style.transform = "translateZ(0px)";
+    if (window.testRunner)
+        testRunner.notifyDone();
+ }, false);
+</script>
 </html>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2122,12 +2122,6 @@ webkit.org/b/291878 [ Sequoia Release arm64 ] http/tests/webgpu/webgpu/shader/va
 
 webkit.org/b/291966 [ Sequoia+ Release ] http/tests/webgpu/webgpu/api/validation/render_pipeline/fragment_state.html [ Pass Timeout ]
 
-# webkit.org/b/292016 REGRESSION(294049@main): [macOS Debug] ASSERTION FAILED: repaintContainer->isComposited() (flaky in EWS)
-[ Debug ] imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-frame-size-changed.html [ Pass Crash ]
-[ Debug ] imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-default-quirks-mode.html [ Pass Crash ]
-[ Debug ] imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-default.html [ Pass Crash ]
-[ Debug ] imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-inline-orientation.html [ Pass Crash ]
-
 # webkit.org/b/292111 REGRESSION ( 294024@main): [ MacOS iOS WK2 Debug ] ASSERTION FAILED: bytecodeCanIgnoreNegativeZero(node->arithNodeFlags())
 [ Sonoma+ Debug ] imported/w3c/web-platform-tests/webcodecs/video-encoder-rescaling.https.any.html?av1 [ Skip ]
 [ Sonoma+ Debug ] imported/w3c/web-platform-tests/webcodecs/video-encoder-rescaling.https.any.html?h264_annexb [ Skip ]

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -567,6 +567,8 @@ void RenderLayer::removeOnlyThisLayer()
         removeChild(*current);
         m_parent->addChild(*current, nextSib);
         current->setRepaintStatus(RepaintStatus::NeedsFullRepaint);
+        if (isComposited())
+            current->computeRepaintRectsIncludingDescendants();
         current = next;
     }
 


### PR DESCRIPTION
#### 62a02c8c5d58aa668ea06379593b65c94b860179
<pre>
REGRESSION(294049@main): scroll-animations/css/animation-range-visual-test.html` hits `ASSERT(repaintContainer-&gt;isComposited())` under `RenderObject::repaintUsingContainer().
<a href="https://bugs.webkit.org/show_bug.cgi?id=292016">https://bugs.webkit.org/show_bug.cgi?id=292016</a>
&lt;<a href="https://rdar.apple.com/149959000">rdar://149959000</a>&gt;

Reviewed by Simon Fraser.

When removing a RenderLayer entirely, update the cached repaint container on all
children at the same time they get marked as needing a full repaint.

Fix the existing test to actually catch this bug by waiting for a rendering
update so that the container is composited before removing its layer.

* LayoutTests/compositing/repaint-container-assertion-when-removing-layer.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::removeOnlyThisLayer):

Canonical link: <a href="https://commits.webkit.org/294290@main">https://commits.webkit.org/294290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71a30c2e52493172292a3211e53bfa2def2b3aea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11193 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106376 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51855 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29384 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77092 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34127 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104235 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16344 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91435 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57439 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16160 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9445 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51203 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86045 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108732 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28356 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20866 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86070 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87643 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85620 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21811 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30349 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8061 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22455 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28286 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33557 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28098 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31418 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29656 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->