### PR TITLE
Sync `svg/coordinate-systems` from WPT upstream

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2254,6 +2254,7 @@ imported/w3c/web-platform-tests/svg/extensibility/foreignObject/isolation-with-h
 imported/w3c/web-platform-tests/svg/extensibility/foreignObject/isolation-with-svg.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/display-none-mask.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/coordinate-systems/viewBox-baseVal-change-invalid.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/svg/coordinate-systems/viewBox-synthesized-in-img-001.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/shapes/rect-03.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/shapes/rect-04.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-002.svg [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -10740,6 +10740,7 @@
         "web-platform-tests/svg/coordinate-systems/support/viewBox-change-repaint-001-ref.html",
         "web-platform-tests/svg/coordinate-systems/support/viewBox-scaling-text-001-ref.html",
         "web-platform-tests/svg/coordinate-systems/support/views.svg",
+        "web-platform-tests/svg/coordinate-systems/viewBox-synthesized-in-img-001-ref.html",
         "web-platform-tests/svg/crashtests/support/used.svg",
         "web-platform-tests/svg/embedded/image-embedding-svg-with-near-integral-width-ref.html",
         "web-platform-tests/svg/embedded/reference/green-rect-100x100.svg",

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/viewBox-synthesized-in-img-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/viewBox-synthesized-in-img-001-ref.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference Case</title>
+<link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
+<style>
+  div.img-mockup {
+    border: 1px solid black;
+    margin: 2px;
+    vertical-align: top;
+    display: inline-block;
+  }
+</style>
+<body>
+<script>
+  // This is the <rect> width and height in the testcase's data URI.
+  const RECT_SIZE = 6;
+  // This is the <rect> x/y position in the testcase's data URI.
+  const RECT_POS = 2;
+
+  // Determines the scale factor that we expect to apply to our SVG in a given
+  // axis, based on the specified size (width or height) of the SVG element and
+  // the img element in that axis, and based on whether we expect a viewBox to
+  // be synthesized at all.
+  function getExpectedScaleInAxis(svgSize, imgSize, shouldSynthesizeViewBox) {
+    if (shouldSynthesizeViewBox && svgSize == 10) {
+      // We'll be synthesizing a viewBox, and it'll be scaling our SVG content
+      // in this axis to fit the image size, so we need to scale up the size
+      // that we'll use for our mockup.
+      return imgSize / svgSize;
+    }
+    // Otherwise, we expect to render the SVG content at a 1.0 scale in this
+    // axis.
+    return 1.0;
+  }
+  function makeRectMockup(svgWidth, svgHeight,
+                          imgWidth, imgHeight) {
+    let fakeRect = document.createElement("div");
+    fakeRect.style.backgroundColor = "blue";
+
+    // Size/position the rect based on the scale that we expect the SVG
+    // content to be rendered at in each axis.  To inform that expectation,
+    // first decide whether we expect a synthesized viewBox: we expect
+    // the testcase's SVG-as-an-image document to synthesize a viewBox from
+    // the width and/or height *unless* that viewBox would be empty
+    // (zero-sized) in some axis.
+    let shouldSynthesizeViewBox = svgWidth != 0 && svgHeight != 0;
+
+    // Now compute the expected scale in each axis using a helper function:
+    let horizScale = getExpectedScaleInAxis(svgWidth, imgWidth,
+                                            shouldSynthesizeViewBox);
+    let vertScale = getExpectedScaleInAxis(svgHeight, imgHeight,
+                                           shouldSynthesizeViewBox);
+
+    fakeRect.style.width = `${RECT_SIZE * horizScale}px`;
+    fakeRect.style.height = `${RECT_SIZE * vertScale}px`;
+    fakeRect.style.marginLeft = `${RECT_POS * horizScale}px`;
+    fakeRect.style.marginTop = `${RECT_POS * vertScale}px`;
+    return fakeRect;
+  }
+
+  // To make the logic simpler, we just use 0 here for all of the testcase's
+  // sizes that we expect to behave like 0 (e.g. 0%, -5, -5%).
+  const SVG_SIZE_VALS_TO_TEST = [ null, 0, 0, 0, 0, 10 ];
+  const IMG_SIZE_VALS_TO_TEST = [ 20, 30 ];
+
+  function go() {
+    // We group our elements into rows with a particular number of items,
+    // to make sure things fit nicely/predictably into the WPT viewport:
+    const NUM_ELEMS_PER_ROW = 12;
+    let elemIdx = 0;
+    let container;
+
+    for (iw of IMG_SIZE_VALS_TO_TEST) {
+      for (ih of IMG_SIZE_VALS_TO_TEST) {
+        for (sw of SVG_SIZE_VALS_TO_TEST) {
+          for (sh of SVG_SIZE_VALS_TO_TEST) {
+            // Generate a new container element at the start and every N elems:
+            if (elemIdx % NUM_ELEMS_PER_ROW == 0) {
+              container = document.createElement("div");
+              document.body.appendChild(container);
+            }
+            elemIdx++;
+
+            // Mockup for the img element:
+            const fakeImg = document.createElement("div");
+            fakeImg.classList.add("img-mockup");
+            fakeImg.style.width = `${iw}px`;
+            fakeImg.style.height = `${ih}px`;
+
+            // Add the mockup for the blue rect inside of the img:
+            fakeImg.appendChild(makeRectMockup(sw, sh, iw, ih));
+
+            container.appendChild(fakeImg);
+          }
+        }
+      }
+    }
+  }
+  go();
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/viewBox-synthesized-in-img-001.tentative-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/viewBox-synthesized-in-img-001.tentative-expected.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference Case</title>
+<link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
+<style>
+  div.img-mockup {
+    border: 1px solid black;
+    margin: 2px;
+    vertical-align: top;
+    display: inline-block;
+  }
+</style>
+<body>
+<script>
+  // This is the <rect> width and height in the testcase's data URI.
+  const RECT_SIZE = 6;
+  // This is the <rect> x/y position in the testcase's data URI.
+  const RECT_POS = 2;
+
+  // Determines the scale factor that we expect to apply to our SVG in a given
+  // axis, based on the specified size (width or height) of the SVG element and
+  // the img element in that axis, and based on whether we expect a viewBox to
+  // be synthesized at all.
+  function getExpectedScaleInAxis(svgSize, imgSize, shouldSynthesizeViewBox) {
+    if (shouldSynthesizeViewBox && svgSize == 10) {
+      // We'll be synthesizing a viewBox, and it'll be scaling our SVG content
+      // in this axis to fit the image size, so we need to scale up the size
+      // that we'll use for our mockup.
+      return imgSize / svgSize;
+    }
+    // Otherwise, we expect to render the SVG content at a 1.0 scale in this
+    // axis.
+    return 1.0;
+  }
+  function makeRectMockup(svgWidth, svgHeight,
+                          imgWidth, imgHeight) {
+    let fakeRect = document.createElement("div");
+    fakeRect.style.backgroundColor = "blue";
+
+    // Size/position the rect based on the scale that we expect the SVG
+    // content to be rendered at in each axis.  To inform that expectation,
+    // first decide whether we expect a synthesized viewBox: we expect
+    // the testcase's SVG-as-an-image document to synthesize a viewBox from
+    // the width and/or height *unless* that viewBox would be empty
+    // (zero-sized) in some axis.
+    let shouldSynthesizeViewBox = svgWidth != 0 && svgHeight != 0;
+
+    // Now compute the expected scale in each axis using a helper function:
+    let horizScale = getExpectedScaleInAxis(svgWidth, imgWidth,
+                                            shouldSynthesizeViewBox);
+    let vertScale = getExpectedScaleInAxis(svgHeight, imgHeight,
+                                           shouldSynthesizeViewBox);
+
+    fakeRect.style.width = `${RECT_SIZE * horizScale}px`;
+    fakeRect.style.height = `${RECT_SIZE * vertScale}px`;
+    fakeRect.style.marginLeft = `${RECT_POS * horizScale}px`;
+    fakeRect.style.marginTop = `${RECT_POS * vertScale}px`;
+    return fakeRect;
+  }
+
+  // To make the logic simpler, we just use 0 here for all of the testcase's
+  // sizes that we expect to behave like 0 (e.g. 0%, -5, -5%).
+  const SVG_SIZE_VALS_TO_TEST = [ null, 0, 0, 0, 0, 10 ];
+  const IMG_SIZE_VALS_TO_TEST = [ 20, 30 ];
+
+  function go() {
+    // We group our elements into rows with a particular number of items,
+    // to make sure things fit nicely/predictably into the WPT viewport:
+    const NUM_ELEMS_PER_ROW = 12;
+    let elemIdx = 0;
+    let container;
+
+    for (iw of IMG_SIZE_VALS_TO_TEST) {
+      for (ih of IMG_SIZE_VALS_TO_TEST) {
+        for (sw of SVG_SIZE_VALS_TO_TEST) {
+          for (sh of SVG_SIZE_VALS_TO_TEST) {
+            // Generate a new container element at the start and every N elems:
+            if (elemIdx % NUM_ELEMS_PER_ROW == 0) {
+              container = document.createElement("div");
+              document.body.appendChild(container);
+            }
+            elemIdx++;
+
+            // Mockup for the img element:
+            const fakeImg = document.createElement("div");
+            fakeImg.classList.add("img-mockup");
+            fakeImg.style.width = `${iw}px`;
+            fakeImg.style.height = `${ih}px`;
+
+            // Add the mockup for the blue rect inside of the img:
+            fakeImg.appendChild(makeRectMockup(sw, sh, iw, ih));
+
+            container.appendChild(fakeImg);
+          }
+        }
+      }
+    }
+  }
+  go();
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/viewBox-synthesized-in-img-001.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/viewBox-synthesized-in-img-001.tentative.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<meta name="timeout" content="long">
+<title>Testcase for SVG viewBox synthesis when SVG is used as an image</title>
+<link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
+<link rel="help" href="https://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1916030">
+<link rel="match" href="viewBox-synthesized-in-img-001-ref.html">
+<style>
+  img {
+    border: 1px solid black;
+    margin: 2px;
+    vertical-align: top;
+  }
+</style>
+<body>
+<script>
+  function makeDataURI(width, height) {
+    let uri = "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'";
+    if (width != "") {
+      uri += ` width='${width}'`;
+    }
+    if (height != "") {
+      uri += ` height='${height}'`;
+    }
+    uri += "><rect fill='blue' x='2' y='2' height='6' width='6'/></svg>";
+    return uri;
+  }
+
+  // Note: negative numbers here are equivalent to 0, for the purposes of
+  // what we're testing here. We test both for robustness.
+  const SVG_SIZE_VALS_TO_TEST = [ "", "0", "0%", "-5", "-5%", "10" ];
+  const IMG_SIZE_VALS_TO_TEST = [ "20", "30" ];
+  function go() {
+    // We group our elements into rows with a particular number of items,
+    // to make sure things fit nicely/predictably into the WPT viewport:
+    const NUM_ELEMS_PER_ROW = 12;
+    let elemIdx = 0;
+    let container;
+
+    for (iw of IMG_SIZE_VALS_TO_TEST) {
+      for (ih of IMG_SIZE_VALS_TO_TEST) {
+        for (sw of SVG_SIZE_VALS_TO_TEST) {
+          for (sh of SVG_SIZE_VALS_TO_TEST) {
+            // Generate a new container element at the start and every N elems:
+            if (elemIdx % NUM_ELEMS_PER_ROW == 0) {
+              container = document.createElement("div");
+              document.body.appendChild(container);
+            }
+            elemIdx++;
+
+            const img = document.createElement("img");
+            img.setAttribute("width", iw);
+            img.setAttribute("height", ih);
+
+            const dataURI = makeDataURI(sw, sh);
+            img.setAttribute("src", dataURI);
+
+            container.appendChild(img);
+          }
+        }
+      }
+    }
+  }
+  go();
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/w3c-import.log
@@ -35,3 +35,6 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/viewBox-change-repaint-001.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/viewBox-scaling-text-001-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/viewBox-scaling-text-001.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/viewBox-synthesized-in-img-001-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/viewBox-synthesized-in-img-001.tentative-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/viewBox-synthesized-in-img-001.tentative.html

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -5666,6 +5666,9 @@
     "imported/w3c/web-platform-tests/svg/animations/svglengthlist-animation-3.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/svg/coordinate-systems/viewBox-synthesized-in-img-001.tentative.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/svg/interact/scripted/async-01.svg": [
         "slow"
     ],


### PR DESCRIPTION
#### 5f06b97609166992cc0495a4e9fc26be2fffaf70
<pre>
Sync `svg/coordinate-systems` from WPT upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=292133">https://bugs.webkit.org/show_bug.cgi?id=292133</a>

Reviewed by Anne van Kesteren.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/5a881289df674557a02ca0b26f554f0a26b71f24">https://github.com/web-platform-tests/wpt/commit/5a881289df674557a02ca0b26f554f0a26b71f24</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/w3c-import.log:
* LayoutTests/tests-options.json:
* LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/viewBox-synthesized-in-img-001.tentative-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/viewBox-synthesized-in-img-001.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/viewBox-synthesized-in-img-001-ref.html:

Canonical link: <a href="https://commits.webkit.org/294173@main">https://commits.webkit.org/294173@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdbcd3d8fb9abe34542816f3338764db5c249ea6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20731 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106215 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51695 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76981 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34010 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104076 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16203 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91290 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57329 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16018 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9316 "Found 6 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html imported/w3c/web-platform-tests/svg/painting/marker-005.svg imported/w3c/web-platform-tests/svg/painting/marker-006.svg media/media-source/media-source-video-renders.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51043 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85924 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9373 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108571 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28197 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20761 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85950 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28559 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87490 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85488 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21750 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30208 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7934 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22287 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28127 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27939 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31259 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29497 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->