### PR TITLE
Sync `svg/painting` from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/scripted/SVGMarkerElement-orientType-synchronization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/scripted/SVGMarkerElement-orientType-synchronization-expected.txt
@@ -1,4 +1,5 @@
 
 PASS SVGMarkerElement.orientType synchronization, setting orientType to 'auto'
 PASS SVGMarkerElement.orientType synchronization, setting orientAngle using valueInSpecifiedUnits
+PASS SVGMarkerElement.orientType synchronization, setting orientAngle using convertToSpecifiedUnits
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/scripted/SVGMarkerElement-orientType-synchronization.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/scripted/SVGMarkerElement-orientType-synchronization.html
@@ -26,4 +26,17 @@ test(function() {
   assert_equals(marker.getAttribute('orient'), '1');
   assert_equals(marker.orientType.baseVal, SVGMarkerElement.SVG_MARKER_ORIENT_ANGLE);
 }, `${document.title}, setting orientAngle using valueInSpecifiedUnits`);
+
+test(function() {
+  const marker = document.createElementNS('http://www.w3.org/2000/svg', 'marker');
+  assert_false(marker.hasAttribute('orient'));
+
+  marker.setOrientToAuto();
+  assert_equals(marker.getAttribute('orient'), 'auto');
+
+  marker.orientAngle.baseVal.convertToSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_UNSPECIFIED);
+  assert_true(marker.hasAttribute('orient'));
+  assert_equals(marker.getAttribute('orient'), '0');
+  assert_equals(marker.orientType.baseVal, SVGMarkerElement.SVG_MARKER_ORIENT_ANGLE);
+}, `${document.title}, setting orientAngle using convertToSpecifiedUnits`);
 </script>


### PR DESCRIPTION
#### 7142572a4fc6b29f206f3a9bf635893fe172a3df
<pre>
Sync `svg/painting` from WPT upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=292135">https://bugs.webkit.org/show_bug.cgi?id=292135</a>

Reviewed by Anne van Kesteren.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/5a881289df674557a02ca0b26f554f0a26b71f24">https://github.com/web-platform-tests/wpt/commit/5a881289df674557a02ca0b26f554f0a26b71f24</a>

* LayoutTests/imported/w3c/web-platform-tests/svg/painting/scripted/SVGMarkerElement-orientType-synchronization-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/painting/scripted/SVGMarkerElement-orientType-synchronization.html:

Canonical link: <a href="https://commits.webkit.org/294174@main">https://commits.webkit.org/294174@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f31229496c2c885bd61ab337b906bfe1d021453

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11036 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106217 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51697 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29227 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76984 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34012 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104078 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91292 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57332 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16020 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9318 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51045 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85926 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/9375 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108573 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28199 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20763 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85951 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28561 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87492 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85489 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21749 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30210 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7936 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22289 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28129 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27941 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31261 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29499 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->