### PR TITLE
MediaRecorder WebM Videos Play Rotated 90° Counterclockwise

### DIFF
--- a/LayoutTests/fast/mediastream/mediaStream-with-rotation-expected.txt
+++ b/LayoutTests/fast/mediastream/mediaStream-with-rotation-expected.txt
@@ -1,0 +1,4 @@
+
+PASS WebM recorder with oriented stream
+PASS MP4 recorder with oriented stream
+

--- a/LayoutTests/fast/mediastream/mediaStream-with-rotation.html
+++ b/LayoutTests/fast/mediastream/mediaStream-with-rotation.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html>
+<head>
+    <title>MediaRecorder recording video with rotation</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+    async function record(stream, mimeType)
+    {
+        const recorder = new MediaRecorder(stream, { mimeType : mimeType });
+        const promise = new Promise((resolve, reject) => {
+            recorder.ondataavailable = (e) => {
+                recorder.stop();
+                resolve(e.data);
+            };
+            setTimeout(reject, 5000);
+        });
+        recorder.start(50);
+        return promise;
+    }
+
+    async function setVideo(t, obj)
+    {
+        const video = document.createElement('video');
+        video.muted = true;
+        video.srcObject = obj;
+        const watcher = new EventWatcher(t, video, [ 'loadedmetadata' ]);
+        await watcher.wait_for([ 'loadedmetadata' ]);
+        return video.videoHeight / video.videoWidth;
+    }
+
+    promise_test(async (t) => {
+        if (window.testRunner)
+            testRunner.setMockCameraOrientation(90);
+        const stream = await navigator.mediaDevices.getUserMedia({ video : true });
+        let result1 = await setVideo(t, stream);
+
+        let blob = await record(stream, 'video/webm');
+        assert_not_equals(blob.size, 0);
+        let result2 = await setVideo(t, blob);
+
+        assert_equals(result1, result2, "Height:Width ratio identical to source");
+    }, "WebM recorder with oriented stream");
+
+    promise_test(async (t) => {
+        if (window.testRunner)
+            testRunner.setMockCameraOrientation(90);
+        const stream = await navigator.mediaDevices.getUserMedia({ video : true });
+        let result1 = await setVideo(t, stream);
+
+        let blob = await record(stream, 'video/mp4');
+        assert_not_equals(blob.size, 0);
+        let result2 = await setVideo(t, blob);
+
+        assert_equals(result1, result2, "Height:Width ratio identical to source");
+    }, "MP4 recorder with oriented stream");
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1273,6 +1273,7 @@ webkit.org/b/213699 http/wpt/mediarecorder/set-srcObject-MediaStream-Blob.html [
 webkit.org/b/213699 http/wpt/mediarecorder/MediaRecorder-audio-bitrate.html [ Pass Failure ]
 webkit.org/b/213699 http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable.html [ Crash Timeout Failure ]
 webkit.org/b/213699 http/wpt/mediarecorder/MediaRecorder-first-frame.html [ Failure Pass ]
+webkit.org/b/292271 fast/mediastream/mediaStream-with-rotation.html [ Skip ]
 
 # No support for Matroska container in GStreamer port.
 http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
@@ -120,7 +120,10 @@ std::unique_ptr<MediaRecorderPrivateAVFImpl> MediaRecorderPrivateAVFImpl::create
         recorder->checkTrackState(*selectedTracks.audioTrack);
     }
     if (selectedTracks.videoTrack) {
-        recorder->setVideoSource(&selectedTracks.videoTrack->source());
+        Ref source = selectedTracks.videoTrack->source();
+        if (recorder->shouldApplyVideoRotation())
+            source->setShouldApplyRotation();
+        recorder->setVideoSource(WTFMove(source));
         recorder->checkTrackState(*selectedTracks.videoTrack);
     }
     return recorder;

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.h
@@ -66,6 +66,8 @@ private:
     void pauseRecording(CompletionHandler<void()>&&) final;
     void resumeRecording(CompletionHandler<void()>&&) final;
 
+    bool shouldApplyVideoRotation() const { return m_encoder->shouldApplyVideoRotation(); }
+
     const Ref<MediaRecorderPrivateEncoder> m_encoder;
     RefPtr<VideoFrame> m_blackFrame;
     std::optional<CAAudioStreamDescription> m_description;

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
@@ -144,7 +144,7 @@ bool MediaRecorderPrivateEncoder::initialize(const MediaRecorderPrivateOptions& 
 {
     assertIsMainThread();
 
-    m_writer = writer.moveToUniquePtr();
+    lazyInitialize(m_writer, writer.moveToUniquePtr());
 
     ContentType mimeType(options.mimeType);
     auto containerType = mimeType.containerType();

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
@@ -75,6 +75,7 @@ public:
 
     bool hasAudio() const { return m_hasAudio; }
     bool hasVideo() const { return m_hasVideo; }
+    bool shouldApplyVideoRotation() const { return m_writer ? m_writer->shouldApplyVideoRotation() : false; }
 
 private:
     MediaRecorderPrivateEncoder(bool hasAudio, bool hasVideo);
@@ -200,7 +201,7 @@ private:
     const bool m_hasAudio { false };
     const bool m_hasVideo { false };
     const Ref<Listener> m_listener;
-    std::unique_ptr<MediaRecorderPrivateWriter> m_writer; // Always set and immutable once initialize() has been called
+    const std::unique_ptr<MediaRecorderPrivateWriter> m_writer; // Always set and immutable once initialize() has been called
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.h
@@ -64,6 +64,7 @@ public:
     using WriterPromise = NativePromise<void, Result>;
     WEBCORE_EXPORT virtual Ref<WriterPromise> writeFrames(Deque<UniqueRef<MediaSamplesBlock>>&&, const MediaTime&);
     WEBCORE_EXPORT virtual Ref<GenericPromise> close();
+    virtual bool shouldApplyVideoRotation() const { return false; }
 
 private:
     virtual Result writeFrame(const MediaSamplesBlock&) = 0;

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.h
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.h
@@ -49,6 +49,7 @@ private:
     Result writeFrame(const MediaSamplesBlock&) final;
     void forceNewSegment(const WTF::MediaTime&) final;
     Ref<GenericPromise> close(const WTF::MediaTime&) final;
+    bool shouldApplyVideoRotation() const final { return true; }
 
     const UniqueRef<MediaRecorderPrivateWriterWebMDelegate> m_delegate;
 };


### PR DESCRIPTION
#### 83051fcd6af8b80ba5b1c2ee71e8d59828820a61
<pre>
MediaRecorder WebM Videos Play Rotated 90° Counterclockwise
<a href="https://bugs.webkit.org/show_bug.cgi?id=290223">https://bugs.webkit.org/show_bug.cgi?id=290223</a>
<a href="https://rdar.apple.com/147878206">rdar://147878206</a>

Reviewed by Youenn Fablet.

WebM, unlike mp4 doesn&apos;t support metadata indicating that a video track
should be played with given rotation.
So instead we apply the rotation on the RealtimeMediaSource before encoding it
to vp8 or vp9.

Added test. We do not test on real iOS devices, manually tested on iPhone.

* LayoutTests/fast/mediastream/mediaStream-with-rotation-expected.txt: Added.
* LayoutTests/fast/mediastream/mediaStream-with-rotation.html: Added.
* LayoutTests/platform/glib/TestExpectations: Skip test on GStreamer platform, test times out.
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp:
(WebCore::MediaRecorderPrivateAVFImpl::create):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp:
(WebCore::MediaRecorderPrivateEncoder::initialize):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.h:
(WebCore::MediaRecorderPrivateWriter::shouldApplyVideoRotation const):
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.h:

Canonical link: <a href="https://commits.webkit.org/294257@main">https://commits.webkit.org/294257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41f649e60299d42d7274efe5b8f98e62cdace683

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11281 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106465 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51942 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103356 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29472 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/77165 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34199 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104322 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16417 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91510 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57512 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/16235 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9522 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51290 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/86109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108819 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28443 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86140 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28805 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87717 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/85699 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21791 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30423 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8131 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22547 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28373 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/33647 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28185 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31505 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29743 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->