### PR TITLE
[WPE] WPEPlatform: remove error parameter from wpe_display_get_keymap

### DIFF
--- a/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp
+++ b/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp
@@ -222,11 +222,7 @@ static void doKeyStrokeEvent(WebPageProxy &page, bool pressed, uint32_t keyVal, 
     auto* view = page.wpeView();
     auto* display = wpe_view_get_display(view);
     GUniqueOutPtr<GError> error;
-    auto* keymap = WPE_KEYMAP(wpe_display_get_keymap(display, &error.outPtr()));
-    if (error) {
-        LOG(Automation, "WebAutomationSession::doKeyStrokeEvent: Failed to get keymap: %s. Ignoring event.", error->message);
-        return;
-    }
+    auto* keymap = WPE_KEYMAP(wpe_display_get_keymap(display));
 
     GUniqueOutPtr<WPEKeymapEntry> entries;
     guint entriesCount;

--- a/Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp
@@ -196,10 +196,7 @@ OptionSet<WebCore::PlatformEvent::Modifier> WebPageProxy::currentStateOfModifier
     if (!view)
         return { };
 
-    auto* keymap = wpe_display_get_keymap(wpe_view_get_display(view), nullptr);
-    if (!keymap)
-        return { };
-
+    auto* keymap = wpe_display_get_keymap(wpe_view_get_display(view));
     OptionSet<WebCore::PlatformEvent::Modifier> modifiers;
     auto wpeModifiers = wpe_keymap_get_modifiers(keymap);
     if (wpeModifiers & WPE_MODIFIER_KEYBOARD_CONTROL)

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
@@ -364,28 +364,28 @@ gpointer wpe_display_get_egl_display(WPEDisplay* display, GError** error)
 /**
  * wpe_display_get_keymap:
  * @display: a #WPEDisplay
- * @error: return location for error or %NULL to ignore
  *
  * Get the #WPEKeymap of @display
  *
  * As a fallback, a #WPEKeymapXKB for the pc105 "US" layout is returned if the actual display
  * implementation does not provide a keymap itself.
  *
- * Returns: (transfer none): a #WPEKeymap or %NULL in case of error
+ * Returns: (transfer none): a #WPEKeymap
  */
-WPEKeymap* wpe_display_get_keymap(WPEDisplay* display, GError** error)
+WPEKeymap* wpe_display_get_keymap(WPEDisplay* display)
 {
     g_return_val_if_fail(WPE_IS_DISPLAY(display), nullptr);
 
-    auto* wpeDisplayClass = WPE_DISPLAY_GET_CLASS(display);
-    if (!wpeDisplayClass->get_keymap) {
-        auto* priv = display->priv;
+    auto* priv = display->priv;
+    if (!priv->keymap) {
+        auto* wpeDisplayClass = WPE_DISPLAY_GET_CLASS(display);
+        if (wpeDisplayClass->get_keymap)
+            priv->keymap = wpeDisplayClass->get_keymap(display);
+
         if (!priv->keymap)
             priv->keymap = adoptGRef(wpe_keymap_xkb_new());
-        return priv->keymap.get();
     }
-
-    return wpeDisplayClass->get_keymap(display, error);
+    return priv->keymap.get();
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
@@ -62,8 +62,7 @@ struct _WPEDisplayClass
     WPEView                *(* create_view)                   (WPEDisplay *display);
     gpointer                (* get_egl_display)               (WPEDisplay *display,
                                                                GError    **error);
-    WPEKeymap              *(* get_keymap)                    (WPEDisplay *display,
-                                                               GError    **error);
+    WPEKeymap              *(* get_keymap)                    (WPEDisplay *display);
     WPEBufferDMABufFormats *(* get_preferred_dma_buf_formats) (WPEDisplay *display);
     guint                   (* get_n_screens)                 (WPEDisplay *display);
     WPEScreen              *(* get_screen)                    (WPEDisplay *display,
@@ -100,8 +99,7 @@ WPE_API gboolean                 wpe_display_connect                       (WPED
                                                                             GError    **error);
 WPE_API gpointer                 wpe_display_get_egl_display               (WPEDisplay *display,
                                                                             GError    **error);
-WPE_API WPEKeymap               *wpe_display_get_keymap                    (WPEDisplay *display,
-                                                                            GError    **error);
+WPE_API WPEKeymap               *wpe_display_get_keymap                    (WPEDisplay *display);
 WPE_API WPEBufferDMABufFormats  *wpe_display_get_preferred_dma_buf_formats (WPEDisplay *display);
 WPE_API guint                    wpe_display_get_n_screens                 (WPEDisplay *display);
 WPE_API WPEScreen               *wpe_display_get_screen                    (WPEDisplay *display,

--- a/Source/WebKit/WPEPlatform/wpe/WPEKeymap.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEKeymap.cpp
@@ -43,7 +43,7 @@ static void wpe_keymap_class_init(WPEKeymapClass*)
 
 /**
  * wpe_keymap_get_entries_for_keycode:
- * @keymap: a #WPEKaymap
+ * @keymap: a #WPEKeymap
  * @keyval: a keyval
  * @entries: (out): return location for array of #WPEKeymapEntry
  * @n_entries: (out): return location for length of @entries
@@ -63,7 +63,7 @@ gboolean wpe_keymap_get_entries_for_keyval(WPEKeymap* keymap, guint keyval, WPEK
 
 /**
  * wpe_keymap_translate_keyboard_state:
- * @keymap: a #WPEKaymap
+ * @keymap: a #WPEKeymap
  * @keycode: a hardware keycode
  * @modifiers: a #WPEModifiers
  * @group: active keyboard group
@@ -86,7 +86,7 @@ gboolean wpe_keymap_translate_keyboard_state(WPEKeymap* keymap, guint keycode, W
 
 /**
  * wpe_keymap_get_modifiers:
- * @keymap: a #WPEKaymap
+ * @keymap: a #WPEKeymap
  *
  * Get the modifiers state of @keymap
  *

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
@@ -470,15 +470,10 @@ static gpointer wpeDisplayWaylandGetEGLDisplay(WPEDisplay* display, GError** err
     return nullptr;
 }
 
-static WPEKeymap* wpeDisplayWaylandGetKeymap(WPEDisplay* display, GError** error)
+static WPEKeymap* wpeDisplayWaylandGetKeymap(WPEDisplay* display)
 {
     auto* priv = WPE_DISPLAY_WAYLAND(display)->priv;
-    if (!priv->wlSeat) {
-        g_set_error_literal(error, WPE_DISPLAY_ERROR, WPE_DISPLAY_ERROR_NOT_SUPPORTED, "Operation not supported");
-        return nullptr;
-    }
-
-    return priv->wlSeat->keymap();
+    return priv->wlSeat ? priv->wlSeat->keymap() : nullptr;
 }
 
 static WPEBufferDMABufFormats* wpeDisplayWaylandGetPreferredDMABufFormats(WPEDisplay* display)

--- a/Tools/TestWebKitAPI/wpe/mock-platform/WPEDisplayMock.cpp
+++ b/Tools/TestWebKitAPI/wpe/mock-platform/WPEDisplayMock.cpp
@@ -61,7 +61,7 @@ static gpointer wpeDisplayMockGetEGLDisplay(WPEDisplay* display, GError** error)
     return nullptr;
 }
 
-static WPEKeymap* wpeDisplayMockGetKeymap(WPEDisplay* display, GError** error)
+static WPEKeymap* wpeDisplayMockGetKeymap(WPEDisplay* display)
 {
     return nullptr;
 }

--- a/Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.cpp
@@ -266,12 +266,12 @@ void EventSenderProxyClientWPE::keyDown(WKStringRef keyRef, double time, WKEvent
     auto keyval = wpeKeyvalForKeyRef(keyRef, location, modifiers);
     auto* view = WKViewGetView(m_testController.mainWebView()->platformView());
     unsigned keycode = 0;
-    if (auto* keymap = wpe_display_get_keymap(wpe_view_get_display(view), nullptr)) {
-        GUniqueOutPtr<WPEKeymapEntry> entries;
-        guint entriesCount;
-        if (wpe_keymap_get_entries_for_keyval(keymap, keyval, &entries.outPtr(), &entriesCount))
-            keycode = entries.get()[0].keycode;
-    }
+    auto* keymap = wpe_display_get_keymap(wpe_view_get_display(view));
+    GUniqueOutPtr<WPEKeymapEntry> entries;
+    guint entriesCount;
+    if (wpe_keymap_get_entries_for_keyval(keymap, keyval, &entries.outPtr(), &entriesCount))
+        keycode = entries.get()[0].keycode;
+
     auto* event = wpe_event_keyboard_new(WPE_EVENT_KEYBOARD_KEY_DOWN, view, WPE_INPUT_SOURCE_KEYBOARD, secToMsTimestamp(time), static_cast<WPEModifiers>(modifiers), keycode, keyval);
     wpe_view_event(view, event);
     wpe_event_unref(event);


### PR DESCRIPTION
#### d17a7c5952dbe4c9affb61ad7249c4cd6d1deb61
<pre>
[WPE] WPEPlatform: remove error parameter from wpe_display_get_keymap
<a href="https://bugs.webkit.org/show_bug.cgi?id=292162">https://bugs.webkit.org/show_bug.cgi?id=292162</a>

Reviewed by Michael Catanzaro.

Since we always have a working fallback there&apos;s no reason to make it fail.

* Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp:
(WebKit::doKeyStrokeEvent):
* Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp:
(WebKit::WebPageProxy::currentStateOfModifierKeys):
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp:
(wpe_display_get_keymap):
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.h:
* Source/WebKit/WPEPlatform/wpe/WPEKeymap.cpp:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp:
(wpeDisplayWaylandGetKeymap):
* Tools/TestWebKitAPI/wpe/mock-platform/WPEDisplayMock.cpp:
(wpeDisplayMockGetKeymap):
* Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.cpp:
(WTR::EventSenderProxyClientWPE::keyDown):

Canonical link: <a href="https://commits.webkit.org/294239@main">https://commits.webkit.org/294239@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/782baba584370b74ffbce1a5ea4c6a184996b977

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11046 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106227 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51708 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29237 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76992 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34021 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104088 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16215 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91302 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57340 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16031 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9329 "Found 6 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html imported/w3c/web-platform-tests/svg/painting/marker-005.svg imported/w3c/web-platform-tests/svg/painting/marker-006.svg media/media-source/media-source-video-renders.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51055 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85939 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9385 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108583 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28209 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20769 "Found 3 new test failures: http/tests/iframe-monitor/data-url-resource.html http/tests/iframe-monitor/iframe-unload.html http/tests/iframe-monitor/workers/service-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85961 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28571 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87502 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85499 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30219 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7946 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22300 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16466 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28139 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33407 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27951 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31271 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29509 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->