### PR TITLE
Free up three bits in Node::StateFlag / Node::ElementStateFlag

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -916,7 +916,7 @@ void Document::removedLastRef()
     }
 
 #if ASSERT_ENABLED
-    setStateFlag(StateFlag::DeletionHasBegun);
+    m_deletionHasBegun = true;
 #endif
     delete this;
 }

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -452,7 +452,7 @@ public:
             m_refCountAndParentBit = s_refCountIncrement;
 
 #if ASSERT_ENABLED
-            setStateFlag(StateFlag::DeletionHasBegun);
+            m_deletionHasBegun = true;
 #endif
             delete this;
         }

--- a/Source/WebCore/dom/DocumentFragment.cpp
+++ b/Source/WebCore/dom/DocumentFragment.cpp
@@ -52,8 +52,7 @@ Ref<DocumentFragment> DocumentFragment::create(Document& document)
 
 Ref<DocumentFragment> DocumentFragment::createForInnerOuterHTML(Document& document)
 {
-    auto node = adoptRef(*new DocumentFragment(document));
-    node->setStateFlag(StateFlag::IsSpecialInternalNode);
+    auto node = adoptRef(*new DocumentFragment(document, { TypeFlag::IsPseudoElementOrSpecialInternalNode }));
     ASSERT(node->isDocumentFragmentForInnerOuterHTML());
     return node;
 }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -301,7 +301,7 @@ Element::~Element()
     ASSERT(!beforePseudoElement());
     ASSERT(!afterPseudoElement());
 
-    if (UNLIKELY(hasElementStateFlag(ElementStateFlag::HasElementIdentifier)))
+    if (UNLIKELY(hasStateFlag(StateFlag::HasElementIdentifier)))
         elementIdentifiersMap().remove(*this);
     else
         ASSERT(!elementIdentifiersMap().contains(*this));
@@ -2692,7 +2692,7 @@ void Element::invalidateForQueryContainerSizeChange()
 {
     // FIXME: Ideally we would just recompute things that are actually affected by containers queries within the subtree.
     Node::invalidateStyle(Style::Validity::SubtreeInvalid);
-    setElementStateFlag(ElementStateFlag::NeedsUpdateQueryContainerDependentStyle);
+    setStateFlag(StateFlag::NeedsUpdateQueryContainerDependentStyle);
 }
 
 void Element::invalidateForAnchorRectChange()
@@ -2714,12 +2714,12 @@ void Element::invalidateForResumingAnchorPositionedElementResolution()
 
 bool Element::needsUpdateQueryContainerDependentStyle() const
 {
-    return hasElementStateFlag(ElementStateFlag::NeedsUpdateQueryContainerDependentStyle);
+    return hasStateFlag(StateFlag::NeedsUpdateQueryContainerDependentStyle);
 }
 
 void Element::clearNeedsUpdateQueryContainerDependentStyle()
 {
-    clearElementStateFlag(ElementStateFlag::NeedsUpdateQueryContainerDependentStyle);
+    clearStateFlag(StateFlag::NeedsUpdateQueryContainerDependentStyle);
 }
 
 void Element::invalidateEventListenerRegions()
@@ -4965,9 +4965,9 @@ void Element::setFullscreenFlag(bool flag)
 {
     Style::PseudoClassChangeInvalidation styleInvalidation(*this, { { CSSSelector::PseudoClass::Fullscreen, flag }, { CSSSelector::PseudoClass::Modal, flag } });
     if (flag)
-        setElementStateFlag(ElementStateFlag::IsFullscreen);
+        setStateFlag(StateFlag::IsFullscreen);
     else
-        clearElementStateFlag(ElementStateFlag::IsFullscreen);
+        clearStateFlag(StateFlag::IsFullscreen);
 }
 
 #endif
@@ -5990,7 +5990,7 @@ Vector<RefPtr<WebAnimation>> Element::getAnimations(std::optional<GetAnimationsO
 ElementIdentifier Element::identifier() const
 {
     return elementIdentifiersMap().ensure(const_cast<Element&>(*this), [&] {
-        setElementStateFlag(ElementStateFlag::HasElementIdentifier);
+        setStateFlag(StateFlag::HasElementIdentifier);
         return ElementIdentifier::generate();
     }).iterator->value;
 }

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -667,7 +667,7 @@ public:
     void removeFromTopLayer();
 
 #if ENABLE(FULLSCREEN_API)
-    bool hasFullscreenFlag() const { return hasElementStateFlag(ElementStateFlag::IsFullscreen); }
+    bool hasFullscreenFlag() const { return hasStateFlag(StateFlag::IsFullscreen); }
     void setFullscreenFlag(bool);
     WEBCORE_EXPORT void webkitRequestFullscreen();
     virtual void requestFullscreen(FullscreenOptions&&, RefPtr<DeferredPromise>&&);
@@ -1003,8 +1003,8 @@ private:
     bool hasLanguageAttribute() const { return hasLangAttr() || hasXMLLangAttr(); }
     bool hasLangAttrKnownToMatchDocumentElement() const { return hasLanguageAttribute() && effectiveLangKnownToMatchDocumentElement(); }
 
-    bool hasEverHadSmoothScroll() const { return hasElementStateFlag(ElementStateFlag::EverHadSmoothScroll); }
-    void setHasEverHadSmoothScroll(bool value) { return setElementStateFlag(ElementStateFlag::EverHadSmoothScroll, value); }
+    bool hasEverHadSmoothScroll() const { return hasStateFlag(StateFlag::EverHadSmoothScroll); }
+    void setHasEverHadSmoothScroll(bool value) { return setStateFlag(StateFlag::EverHadSmoothScroll, value); }
 
     void parentOrShadowHostNode() const = delete; // Call parentNode() instead.
 

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -117,11 +117,11 @@ public:
 #if ASSERT_ENABLED
     bool inRemovedLastRefFunction;
     bool adoptionIsRequired;
+    bool deletionHasBegun;
 #endif
     uint32_t refCountAndParentBit;
     uint32_t nodeFlags;
-    uint16_t elementStateFlags;
-    uint16_t styleBitfields;
+    uint32_t stateFlags;
     void* parentNode;
     void* treeScope;
     void* previous;
@@ -2915,7 +2915,7 @@ void Node::removedLastRef()
         svgElement->detachAllProperties();
 
 #if ASSERT_ENABLED
-    setStateFlag(StateFlag::DeletionHasBegun);
+    m_deletionHasBegun = true;
 #endif
     delete this;
 }

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -232,9 +232,9 @@ public:
     bool isSVGUnknownElement() const { return isSVGElement() && isUnknownElement(); }
     bool isMathMLUnknownElement() const { return isMathMLElement() && isUnknownElement(); }
 
-    bool isFormControlElement() const { return hasTypeFlag(TypeFlag::IsFormControlElement); }
+    bool isFormControlElement() const { return isElementNode() && hasTypeFlag(TypeFlag::IsShadowRootOrFormControlElement); }
 
-    bool isPseudoElement() const { return hasStateFlag(StateFlag::IsPseudoElement); }
+    bool isPseudoElement() const { return isElementNode() && hasTypeFlag(TypeFlag::IsPseudoElementOrSpecialInternalNode); }
     inline bool isBeforePseudoElement() const;
     inline bool isAfterPseudoElement() const;
     inline PseudoId pseudoId() const;
@@ -248,9 +248,9 @@ public:
     virtual bool isPluginElement() const { return false; }
 
     bool isDocumentNode() const { return nodeType() == DOCUMENT_NODE; }
-    bool isTreeScope() const { return isDocumentNode() || hasTypeFlag(TypeFlag::IsShadowRoot); }
+    bool isTreeScope() const { return isDocumentNode() || isShadowRoot(); }
     bool isDocumentFragment() const { return nodeType() == DOCUMENT_FRAGMENT_NODE; }
-    bool isShadowRoot() const { return hasTypeFlag(TypeFlag::IsShadowRoot); }
+    bool isShadowRoot() const { return isDocumentFragment() && hasTypeFlag(TypeFlag::IsShadowRootOrFormControlElement); }
     bool isUserAgentShadowRoot() const; // Defined in ShadowRoot.h
 
     bool hasCustomStyleResolveCallbacks() const { return hasTypeFlag(TypeFlag::HasCustomStyleResolveCallbacks); }
@@ -261,8 +261,8 @@ public:
     bool hasShadowRootContainingSlots() const { return hasEventTargetFlag(EventTargetFlag::HasShadowRootContainingSlots); }
     void setHasShadowRootContainingSlots(bool flag) { setEventTargetFlag(EventTargetFlag::HasShadowRootContainingSlots, flag); }
 
-    bool needsSVGRendererUpdate() const { return hasElementStateFlag(ElementStateFlag::NeedsSVGRendererUpdate); }
-    void setNeedsSVGRendererUpdate(bool flag) { setElementStateFlag(ElementStateFlag::NeedsSVGRendererUpdate, flag); }
+    bool needsSVGRendererUpdate() const { return hasStateFlag(StateFlag::NeedsSVGRendererUpdate); }
+    void setNeedsSVGRendererUpdate(bool flag) { setStateFlag(StateFlag::NeedsSVGRendererUpdate, flag); }
 
     // If this node is in a shadow tree, returns its shadow host. Otherwise, returns null.
     WEBCORE_EXPORT Element* shadowHost() const;
@@ -289,17 +289,17 @@ public:
     bool isPrecustomizedCustomElement() const { return customElementState() == CustomElementState::FailedOrPrecustomized && !isUnknownElement(); }
     bool isPrecustomizedOrDefinedCustomElement() const { return isPrecustomizedCustomElement() || isDefinedCustomElement(); }
 
-    bool isInCustomElementReactionQueue() const { return hasElementStateFlag(ElementStateFlag::IsInCustomElementReactionQueue); }
-    void setIsInCustomElementReactionQueue() { setElementStateFlag(ElementStateFlag::IsInCustomElementReactionQueue); }
-    void clearIsInCustomElementReactionQueue() { clearElementStateFlag(ElementStateFlag::IsInCustomElementReactionQueue); }
+    bool isInCustomElementReactionQueue() const { return hasStateFlag(StateFlag::IsInCustomElementReactionQueue); }
+    void setIsInCustomElementReactionQueue() { setStateFlag(StateFlag::IsInCustomElementReactionQueue); }
+    void clearIsInCustomElementReactionQueue() { clearStateFlag(StateFlag::IsInCustomElementReactionQueue); }
 
-    bool usesNullCustomElementRegistry() const { return hasElementStateFlag(ElementStateFlag::UsesNullCustomElementRegistry); }
-    void setUsesNullCustomElementRegistry() const { setElementStateFlag(ElementStateFlag::UsesNullCustomElementRegistry); }
-    void clearUsesNullCustomElementRegistry() const { clearElementStateFlag(ElementStateFlag::UsesNullCustomElementRegistry); }
+    bool usesNullCustomElementRegistry() const { return hasStateFlag(StateFlag::UsesNullCustomElementRegistry); }
+    void setUsesNullCustomElementRegistry() const { setStateFlag(StateFlag::UsesNullCustomElementRegistry); }
+    void clearUsesNullCustomElementRegistry() const { clearStateFlag(StateFlag::UsesNullCustomElementRegistry); }
 
-    bool usesScopedCustomElementRegistryMap() const { return hasElementStateFlag(ElementStateFlag::UsesScopedCustomElementRegistryMap); }
-    void setUsesScopedCustomElementRegistryMap() { setElementStateFlag(ElementStateFlag::UsesScopedCustomElementRegistryMap); }
-    void clearUsesScopedCustomElementRegistryMap() { clearElementStateFlag(ElementStateFlag::UsesScopedCustomElementRegistryMap); }
+    bool usesScopedCustomElementRegistryMap() const { return hasStateFlag(StateFlag::UsesScopedCustomElementRegistryMap); }
+    void setUsesScopedCustomElementRegistryMap() { setStateFlag(StateFlag::UsesScopedCustomElementRegistryMap); }
+    void clearUsesScopedCustomElementRegistryMap() { clearStateFlag(StateFlag::UsesScopedCustomElementRegistryMap); }
 
     // Returns null, a child of ShadowRoot, or a legacy shadow root.
     Node* nonBoundaryShadowTreeRootNode();
@@ -357,8 +357,8 @@ public:
     virtual void notifyLoadedSheetAndAllCriticalSubresources(bool /* error loading subresource */) { }
     virtual void startLoadingDynamicSheet() { ASSERT_NOT_REACHED(); }
 
-    bool isUserActionElement() const { return hasElementStateFlag(ElementStateFlag::IsUserActionElement); }
-    void setUserActionElement(bool flag) { setElementStateFlag(ElementStateFlag::IsUserActionElement, flag); }
+    bool isUserActionElement() const { return hasStateFlag(StateFlag::IsUserActionElement); }
+    void setUserActionElement(bool flag) { setStateFlag(StateFlag::IsUserActionElement, flag); }
 
     bool inRenderedDocument() const;
     bool needsStyleRecalc() const { return styleValidity() != Style::Validity::Valid || hasInvalidRenderer(); }
@@ -366,9 +366,9 @@ public:
     bool hasInvalidRenderer() const { return hasStateFlag(StateFlag::HasInvalidRenderer); }
     bool styleResolutionShouldRecompositeLayer() const { return hasStateFlag(StateFlag::StyleResolutionShouldRecompositeLayer); }
     bool childNeedsStyleRecalc() const { return hasStyleFlag(NodeStyleFlag::DescendantNeedsStyleResolution); }
-    bool isEditingText() const { return isTextNode() && hasStateFlag(StateFlag::IsSpecialInternalNode); }
+    bool isEditingText() const { return isTextNode() && hasTypeFlag(TypeFlag::IsPseudoElementOrSpecialInternalNode); }
 
-    bool isDocumentFragmentForInnerOuterHTML() const { return isDocumentFragment() && hasStateFlag(StateFlag::IsSpecialInternalNode); }
+    bool isDocumentFragmentForInnerOuterHTML() const { return isDocumentFragment() && hasTypeFlag(TypeFlag::IsPseudoElementOrSpecialInternalNode); }
 
     bool hasHeldBackChildrenChanged() const { return hasStateFlag(StateFlag::HasHeldBackChildrenChanged); }
     void setHasHeldBackChildrenChanged() { setStateFlag(StateFlag::HasHeldBackChildrenChanged); }
@@ -555,11 +555,6 @@ public:
     unsigned refCount() const;
     void applyRefDuringDestructionCheck() const;
 
-#if ASSERT_ENABLED
-    mutable bool m_inRemovedLastRefFunction { false };
-    bool m_adoptionIsRequired { true };
-#endif
-
     void relaxAdoptionRequirement()
     {
 #if ASSERT_ENABLED
@@ -594,14 +589,13 @@ public:
     static auto flagIsText() { return enumToUnderlyingType(TypeFlag::IsText); }
     static auto flagIsContainer() { return enumToUnderlyingType(TypeFlag::IsContainerNode); }
     static auto flagIsElement() { return enumToUnderlyingType(TypeFlag::IsElement); }
-    static auto flagIsShadowRoot() { return enumToUnderlyingType(TypeFlag::IsShadowRoot); }
     static auto flagIsHTML() { return enumToUnderlyingType(TypeFlag::IsHTMLElement); }
     static auto flagIsLink() { return enumToUnderlyingType(StateFlag::IsLink); }
     static auto flagIsParsingChildren() { return enumToUnderlyingType(StateFlag::IsParsingChildren); }
 #endif // ENABLE(JIT)
 
 #if ASSERT_ENABLED
-    bool deletionHasBegun() const { return hasStateFlag(StateFlag::DeletionHasBegun); }
+    bool deletionHasBegun() const { return m_deletionHasBegun; }
 #endif
 
     bool containsSelectionEndPoint() const { return hasStateFlag(StateFlag::ContainsSelectionEndPoint); }
@@ -616,9 +610,9 @@ protected:
         IsHTMLElement = 1 << 4,
         IsSVGElement = 1 << 5,
         IsMathMLElement = 1 << 6,
-        IsShadowRoot = 1 << 7,
+        IsShadowRootOrFormControlElement = 1 << 7,
         IsUnknownElement = 1 << 8,
-        IsFormControlElement = 1 << 9,
+        IsPseudoElementOrSpecialInternalNode = 1 << 9,
         HasCustomStyleResolveCallbacks = 1 << 10,
         HasDidMoveToNewDocument = 1 << 11,
     };
@@ -629,7 +623,7 @@ protected:
     // Don't bother masking with (1 << typeFlagBitCount) - 1 since OptionSet tolerates the upper 4-bits being used for other purposes.
     bool hasTypeFlag(TypeFlag flag) const { return OptionSet<TypeFlag>::fromRaw(m_typeBitFields).contains(flag); }
 
-    enum class StateFlag : uint16_t {
+    enum class StateFlag : uint32_t {
         IsLink = 1 << 0,
         IsParsingChildren = 1 << 1,
         SelfOrPrecedingNodesAffectDirAuto = 1 << 2,
@@ -640,29 +634,19 @@ protected:
         ContainsOnlyASCIIWhitespace = 1 << 7, // Only used on CharacterData.
         ContainsOnlyASCIIWhitespaceIsValid = 1 << 8, // Only used on CharacterData.
         HasHeldBackChildrenChanged = 1 << 9,
-#if ASSERT_ENABLED
-        DeletionHasBegun = 1 << 10,
-#endif
-        ContainsSelectionEndPoint = 1 << 11,
-        IsSpecialInternalNode = 1 << 12, // DocumentFragment node for innerHTML/outerHTML or EditingText node.
-        IsPseudoElement = 1 << 13, // FIXME: This belongs to TypeFlag.
-
-        // 2 bits free.
-    };
-
-    enum class ElementStateFlag : uint16_t {
-        HasElementIdentifier = 1 << 0,
-        IsUserActionElement = 1 << 1,
-        IsInCustomElementReactionQueue = 1 << 2,
-        NeedsSVGRendererUpdate = 1 << 3,
-        NeedsUpdateQueryContainerDependentStyle = 1 << 4,
-        EverHadSmoothScroll = 1 << 5,
+        ContainsSelectionEndPoint = 1 << 10,
+        HasElementIdentifier = 1 << 11,
+        IsUserActionElement = 1 << 12,
+        IsInCustomElementReactionQueue = 1 << 13,
+        UsesNullCustomElementRegistry = 1 << 14,
+        UsesScopedCustomElementRegistryMap = 1 << 15,
+        NeedsSVGRendererUpdate = 1 << 16,
+        NeedsUpdateQueryContainerDependentStyle = 1 << 17,
+        EverHadSmoothScroll = 1 << 18,
 #if ENABLE(FULLSCREEN_API)
-        IsFullscreen = 1 << 6,
+        IsFullscreen = 1 << 19,
 #endif
-        UsesNullCustomElementRegistry = 1 << 7,
-        UsesScopedCustomElementRegistryMap = 1 << 8,
-        // 7-bits free.
+        // 12 bits free.
     };
 
     enum class TabIndexState : uint8_t {
@@ -690,10 +674,6 @@ protected:
     bool hasStateFlag(StateFlag flag) const { return m_stateFlags.contains(flag); }
     void setStateFlag(StateFlag flag, bool value = true) const { m_stateFlags.set(flag, value); }
     void clearStateFlag(StateFlag flag) const { setStateFlag(flag, false); }
-
-    bool hasElementStateFlag(ElementStateFlag flag) const { return m_elementStateFlags.contains(flag); }
-    inline void setElementStateFlag(ElementStateFlag, bool value = true) const;
-    void clearElementStateFlag(ElementStateFlag flag) const { setElementStateFlag(flag, false); }
 
     RareDataBitFields rareDataBitfields() const { return std::bit_cast<RareDataBitFields>(m_rareDataWithBitfields.type()); }
     void setRareDataBitfields(RareDataBitFields bitfields) { m_rareDataWithBitfields.setType(std::bit_cast<uint16_t>(bitfields)); }
@@ -799,12 +779,19 @@ private:
     void moveNodeToNewDocumentSlowCase(Document& oldDocument, Document& newDocument);
 
     WEBCORE_EXPORT void notifyInspectorOfRendererChange();
-    
+
+#if ASSERT_ENABLED
+    mutable bool m_inRemovedLastRefFunction { false };
+    bool m_adoptionIsRequired { true };
+    bool m_deletionHasBegun { false };
+
+    friend void adopted(Node*);
+#endif
+
     mutable uint32_t m_refCountAndParentBit { s_refCountIncrement };
     const uint16_t m_typeBitFields;
-    mutable OptionSet<StateFlag> m_stateFlags;
-    mutable OptionSet<ElementStateFlag> m_elementStateFlags;
     mutable StyleBitfields m_styleBitfields;
+    mutable OptionSet<StateFlag> m_stateFlags;
 
     CheckedPtr<ContainerNode> m_parentNode;
     TreeScope* m_treeScope { nullptr };
@@ -900,11 +887,6 @@ inline ContainerNode* Node::parentNodeGuaranteedHostFree() const
 {
     ASSERT(!isShadowRoot());
     return parentNode();
-}
-
-inline void Node::setElementStateFlag(ElementStateFlag flag, bool value) const
-{
-    m_elementStateFlags.set(flag, value);
 }
 
 ALWAYS_INLINE void Node::setStyleFlag(NodeStyleFlag flag)

--- a/Source/WebCore/dom/PseudoElement.cpp
+++ b/Source/WebCore/dom/PseudoElement.cpp
@@ -49,12 +49,11 @@ const QualifiedName& pseudoElementTagName()
 }
 
 PseudoElement::PseudoElement(Element& host, PseudoId pseudoId)
-    : Element(pseudoElementTagName(), host.document(), TypeFlag::HasCustomStyleResolveCallbacks)
+    : Element(pseudoElementTagName(), host.document(), { TypeFlag::HasCustomStyleResolveCallbacks, TypeFlag::IsPseudoElementOrSpecialInternalNode })
     , m_hostElement(host)
     , m_pseudoId(pseudoId)
 {
     setEventTargetFlag(EventTargetFlag::IsConnected);
-    setStateFlag(StateFlag::IsPseudoElement);
     ASSERT(pseudoId == PseudoId::Before || pseudoId == PseudoId::After);
 }
 

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -70,7 +70,7 @@ static_assert(sizeof(WeakPtr<Element, WeakPtrImplWithEventTargetData>) == sizeof
 #endif
 
 ShadowRoot::ShadowRoot(Document& document, ShadowRootMode mode, SlotAssignmentMode assignmentMode, DelegatesFocus delegatesFocus, Clonable clonable, Serializable serializable, AvailableToElementInternals availableToElementInternals, RefPtr<CustomElementRegistry>&& registry, ScopedCustomElementRegistry scopedRegistry, const AtomString& referenceTarget)
-    : DocumentFragment(document, TypeFlag::IsShadowRoot)
+    : DocumentFragment(document, TypeFlag::IsShadowRootOrFormControlElement)
     , TreeScope(*this, document, WTFMove(registry))
     , m_delegatesFocus(delegatesFocus == DelegatesFocus::Yes)
     , m_isClonable(clonable == Clonable::Yes)
@@ -89,7 +89,7 @@ ShadowRoot::ShadowRoot(Document& document, ShadowRootMode mode, SlotAssignmentMo
 
 
 ShadowRoot::ShadowRoot(Document& document, std::unique_ptr<SlotAssignment>&& slotAssignment)
-    : DocumentFragment(document, TypeFlag::IsShadowRoot)
+    : DocumentFragment(document, TypeFlag::IsShadowRootOrFormControlElement)
     , TreeScope(*this, document, nullptr)
     , m_mode(ShadowRootMode::UserAgent)
     , m_styleScope(makeUnique<Style::Scope>(*this))

--- a/Source/WebCore/dom/Text.cpp
+++ b/Source/WebCore/dom/Text.cpp
@@ -46,8 +46,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(Text);
 
 Ref<Text> Text::createEditingText(Document& document, String&& data)
 {
-    auto node = adoptRef(*new Text(document, WTFMove(data), TEXT_NODE, { }));
-    node->setStateFlag(StateFlag::IsSpecialInternalNode);
+    auto node = adoptRef(*new Text(document, WTFMove(data), TEXT_NODE, { TypeFlag::IsPseudoElementOrSpecialInternalNode }));
     ASSERT(node->isEditingText());
     return node;
 }

--- a/Source/WebCore/domjit/DOMJITHelpers.h
+++ b/Source/WebCore/domjit/DOMJITHelpers.h
@@ -177,17 +177,6 @@ inline CCallHelpers::Jump branchTestIsElementFlagOnNode(MacroAssembler& jit, CCa
     return jit.branchTest16(condition, CCallHelpers::Address(nodeAddress, Node::typeFlagsMemoryOffset()), CCallHelpers::TrustedImm32(Node::flagIsElement()));
 }
 
-inline CCallHelpers::Jump branchTestIsShadowRootFlagOnNode(MacroAssembler& jit, CCallHelpers::ResultCondition condition, GPRReg nodeAddress)
-{
-    return jit.branchTest16(condition, CCallHelpers::Address(nodeAddress, Node::typeFlagsMemoryOffset()), CCallHelpers::TrustedImm32(Node::flagIsShadowRoot()));
-}
-
-inline CCallHelpers::Jump branchTestIsElementOrShadowRootFlagOnNode(MacroAssembler& jit, CCallHelpers::ResultCondition condition, GPRReg nodeAddress)
-{
-    return jit.branchTest16(condition, CCallHelpers::Address(nodeAddress, Node::typeFlagsMemoryOffset()),
-        CCallHelpers::TrustedImm32(Node::flagIsShadowRoot() | Node::flagIsElement()));
-}
-
 inline CCallHelpers::Jump branchTestIsHTMLFlagOnNode(MacroAssembler& jit, CCallHelpers::ResultCondition condition, GPRReg nodeAddress)
 {
     return jit.branchTest16(condition, CCallHelpers::Address(nodeAddress, Node::typeFlagsMemoryOffset()), CCallHelpers::TrustedImm32(Node::flagIsHTML()));

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -60,7 +60,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(HTMLFormControlElement);
 using namespace HTMLNames;
 
 HTMLFormControlElement::HTMLFormControlElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
-    : HTMLElement(tagName, document, { TypeFlag::IsFormControlElement, TypeFlag::HasCustomStyleResolveCallbacks, TypeFlag::HasDidMoveToNewDocument } )
+    : HTMLElement(tagName, document, { TypeFlag::IsShadowRootOrFormControlElement, TypeFlag::HasCustomStyleResolveCallbacks, TypeFlag::HasDidMoveToNewDocument } )
     , ValidatedFormListedElement(form)
     , m_isRequired(false)
     , m_valueMatchesRenderer(false)


### PR DESCRIPTION
#### 7b29d177b63b208975414df5582923bcc419f19f
<pre>
Free up three bits in Node::StateFlag / Node::ElementStateFlag
<a href="https://bugs.webkit.org/show_bug.cgi?id=292174">https://bugs.webkit.org/show_bug.cgi?id=292174</a>

Reviewed by Anne van Kesteren.

This PR merges Node::StateFlag and Node::ElementStateFlag and free up 3 bits by
moving two bits to Node::TypeFlag and overloading them with mutually exclusive bits
in Node::TypeFlag.

It also convert StateFlag::DeletionHasBegun to its own boolean m_deletionHasBegun
since it&apos;s only useful in debug builds to free up another bit in Node::StateFlag.

In addition, this PR removes two unused functions in DOM JIT:
branchTestIsShadowRootFlagOnNode and branchTestIsElementOrShadowRootFlagOnNode.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::removedLastRef):
* Source/WebCore/dom/Document.h:
(WebCore::Document::decrementReferencingNodeCount):
* Source/WebCore/dom/DocumentFragment.cpp:
(WebCore::DocumentFragment::createForInnerOuterHTML):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::~Element):
(WebCore::Element::invalidateForQueryContainerSizeChange):
(WebCore::Element::needsUpdateQueryContainerDependentStyle const):
(WebCore::Element::clearNeedsUpdateQueryContainerDependentStyle):
(WebCore::Element::setFullscreenFlag):
(WebCore::Element::identifier const):
* Source/WebCore/dom/Element.h:
(WebCore::Element::hasFullscreenFlag const):
(WebCore::Element::hasEverHadSmoothScroll const):
(WebCore::Element::setHasEverHadSmoothScroll):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::removedLastRef):
* Source/WebCore/dom/Node.h:
(WebCore::Node::isFormControlElement const):
(WebCore::Node::isPseudoElement const):
(WebCore::Node::isTreeScope const):
(WebCore::Node::isShadowRoot const):
(WebCore::Node::needsSVGRendererUpdate const):
(WebCore::Node::setNeedsSVGRendererUpdate):
(WebCore::Node::isInCustomElementReactionQueue const):
(WebCore::Node::setIsInCustomElementReactionQueue):
(WebCore::Node::clearIsInCustomElementReactionQueue):
(WebCore::Node::usesNullCustomElementRegistry const):
(WebCore::Node::setUsesNullCustomElementRegistry const):
(WebCore::Node::clearUsesNullCustomElementRegistry const):
(WebCore::Node::usesScopedCustomElementRegistryMap const):
(WebCore::Node::setUsesScopedCustomElementRegistryMap):
(WebCore::Node::clearUsesScopedCustomElementRegistryMap):
(WebCore::Node::isUserActionElement const):
(WebCore::Node::setUserActionElement):
(WebCore::Node::isEditingText const):
(WebCore::Node::isDocumentFragmentForInnerOuterHTML const):
(WebCore::Node::flagIsElement):
(WebCore::Node::deletionHasBegun const):
(WebCore::Node::flagIsShadowRoot): Deleted.
(WebCore::Node::hasElementStateFlag const): Deleted.
(WebCore::Node::clearElementStateFlag const): Deleted.
(WebCore::Node::setElementStateFlag const): Deleted.
* Source/WebCore/dom/PseudoElement.cpp:
(WebCore::PseudoElement::PseudoElement):
(WebCore::m_pseudoId):
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::ShadowRoot):
* Source/WebCore/dom/Text.cpp:
(WebCore::Text::createEditingText):
* Source/WebCore/domjit/DOMJITHelpers.h:
(WebCore::DOMJIT::branchTestIsShadowRootFlagOnNode): Deleted.
(WebCore::DOMJIT::branchTestIsElementOrShadowRootFlagOnNode): Deleted.
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::HTMLFormControlElement):

Canonical link: <a href="https://commits.webkit.org/294205@main">https://commits.webkit.org/294205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c03bd36b030fe5b49218edd95c27f842d8d800d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106274 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51753 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29282 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/77038 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34059 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104133 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16257 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91348 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57385 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16074 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/9371 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51101 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85978 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108630 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28254 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20809 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86003 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28616 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87549 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85541 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30260 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7987 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22353 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16448 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28184 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33465 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27996 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31316 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29554 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->