### PR TITLE
Fullscreening KeyNote shared by getDisplayMedia does not trigger the prompt to continue sharing

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
@@ -75,7 +75,7 @@ public:
 private:
     // DisplayCaptureSourceCocoa::Capturer
     bool start() final;
-    void stop() final { stopInternal([] { }); }
+    void stop() final;
     void end() final;
     DisplayCaptureSourceCocoa::DisplayFrameType generateFrame() final;
     CaptureDevice::DeviceType deviceType() const final;
@@ -91,7 +91,8 @@ private:
     void sessionFilterDidChange(SCContentFilter*) final;
     void sessionStreamDidEnd(SCStream*) final;
 
-    void stopInternal(CompletionHandler<void()>&&);
+    enum class IsPrewarming : bool { No, Yes };
+    void startInternal(IsPrewarming = IsPrewarming::No);
     void startContentStream();
     void findShareableContent();
     RetainPtr<SCStreamConfiguration> streamConfiguration();
@@ -124,6 +125,7 @@ private:
     bool m_isRunning { false };
     bool m_isVideoEffectEnabled { false };
     bool m_didReceiveVideoFrame { false };
+    bool m_isPrewarming { false };
     CompletionHandler<void(CaptureSourceError&&)> m_whenReadyCallback;
 };
 


### PR DESCRIPTION
#### 14baf9ab9f5402ef12386f34c084cafec4b76708
<pre>
Fullscreening KeyNote shared by getDisplayMedia does not trigger the prompt to continue sharing
<a href="https://rdar.apple.com/148422248">rdar://148422248</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292176">https://bugs.webkit.org/show_bug.cgi?id=292176</a>

Reviewed by Eric Carlson.

Before the patch, we make sure to start ScreenCaptureKitCaptureSource to get a first frame.
This allows to compute the exact MediaStreamTrack settings (width and height).

This prewarming was doing the following flow:
- start screensharing
- wait for a first frame
- stop screensharing
Then the actual screensharing would start when the web process asks to produce data.

The issue is that when stopping screensharing, we would set SCContentSharingPicker active to NO.
And we would set SCContentSharingPicker active to YES when starting to produce data.

This confuses KeyNote fullscreen prompting, so we do a different prewarming:
- We introduce a m_isPrewarming boolean which is set to true at prewarm time.
- We start screenshare when prewarming but process only the first video frame.
- When asking to produce data, we set m_isPrewarming to false, which will allow to process the coming video frames.

Manually tested.

* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm:
(WebCore::ScreenCaptureKitCaptureSource::whenReady):
(WebCore::ScreenCaptureKitCaptureSource::start):
(WebCore::ScreenCaptureKitCaptureSource::startInternal):
(WebCore::ScreenCaptureKitCaptureSource::stop):
(WebCore::ScreenCaptureKitCaptureSource::streamDidOutputVideoSampleBuffer):
(WebCore::ScreenCaptureKitCaptureSource::stopInternal): Deleted.

Canonical link: <a href="https://commits.webkit.org/294242@main">https://commits.webkit.org/294242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c45527b6ba81c39bd7d398d63f7bd2f2914ca744

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11235 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106418 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51897 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103311 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21241 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29427 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/77124 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34159 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91470 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57471 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16194 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9481 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51245 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/86074 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9556 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108774 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28398 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86102 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87678 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85655 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21785 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30383 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8092 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22497 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28328 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33599 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28140 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31460 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29698 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->