### PR TITLE
Invalidation selectors should be copied

### DIFF
--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -173,10 +173,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     bool isFirstInTagHistory() const { return m_isFirstInTagHistory; }
     bool isLastInTagHistory() const { return m_isLastInTagHistory; }
 
-    // FIXME: These should ideally be private, but CSSSelectorList and StyleRule use them.
+    // FIXME: This should ideally be private, but StyleRule uses it.
     void setLastInSelectorList() { m_isLastInSelectorList = true; }
-    void setNotFirstInTagHistory() { m_isFirstInTagHistory = false; }
-    void setNotLastInTagHistory() { m_isLastInTagHistory = false; }
 
     bool isForPage() const { return m_isForPage; }
 
@@ -188,6 +186,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif
 
 private:
+    friend class CSSSelectorList;
     friend class MutableCSSSelector;
 
     void setValue(const AtomString&, bool matchLowerCase = false);

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -74,17 +74,68 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                 operator delete (currentSelector);
             }
             if (current != first)
-                m_selectorArray[arrayIndex].setNotFirstInTagHistory();
+                m_selectorArray[arrayIndex].m_isFirstInTagHistory = false;
             current = current->tagHistory();
             ASSERT(!m_selectorArray[arrayIndex].isLastInSelectorList() || (flattenedSize == arrayIndex + 1));
             if (current)
-                m_selectorArray[arrayIndex].setNotLastInTagHistory();
+                m_selectorArray[arrayIndex].m_isLastInTagHistory = false;
             ++arrayIndex;
         }
         ASSERT(m_selectorArray[arrayIndex - 1].isLastInTagHistory());
     }
     ASSERT(flattenedSize == arrayIndex);
-    m_selectorArray[arrayIndex - 1].setLastInSelectorList();
+    m_selectorArray[arrayIndex - 1].m_isLastInSelectorList = true;
+}
+
+CSSSelectorList CSSSelectorList::makeCopyingSimpleSelector(const CSSSelector& simpleSelector)
+{
+    auto selectorArray = makeUniqueArray<CSSSelector>(1);
+
+    new (NotNull, &selectorArray[0]) CSSSelector(simpleSelector);
+    selectorArray[0].m_isFirstInTagHistory = true;
+    selectorArray[0].m_isLastInTagHistory = true;
+    selectorArray[0].m_isLastInSelectorList = true;
+
+    return CSSSelectorList { WTFMove(selectorArray) };
+}
+
+CSSSelectorList CSSSelectorList::makeCopyingComplexSelector(const CSSSelector& complexSelector)
+{
+    size_t length = 0;
+    for (auto* selector = &complexSelector; selector; selector = selector->tagHistory())
+        ++length;
+
+    auto selectorArray = makeUniqueArray<CSSSelector>(length);
+
+    size_t i = 0;
+    for (auto* selector = &complexSelector; selector; selector = selector->tagHistory(), ++i)
+        new (NotNull, &selectorArray[i]) CSSSelector(*selector);
+    selectorArray[length - 1].m_isLastInSelectorList = true;
+
+    return CSSSelectorList { WTFMove(selectorArray) };
+}
+
+CSSSelectorList CSSSelectorList::makeJoining(const CSSSelectorList& a, const CSSSelectorList& b)
+{
+    if (a.isEmpty())
+        return b;
+    if (b.isEmpty())
+        return a;
+
+    auto aComponentCount = a.componentCount();
+    auto bComponentCount = b.componentCount();
+
+    auto selectorArray = makeUniqueArray<CSSSelector>(aComponentCount + bComponentCount);
+
+    for (size_t i = 0; i < aComponentCount; ++i)
+        new (NotNull, &selectorArray[i]) CSSSelector(a.m_selectorArray[i]);
+    for (size_t i = 0; i < bComponentCount; ++i)
+        new (NotNull, &selectorArray[aComponentCount + i]) CSSSelector(b.m_selectorArray[i]);
+
+    selectorArray[aComponentCount - 1].m_isLastInSelectorList = false;
+    selectorArray[aComponentCount + bComponentCount - 1].m_isLastInSelectorList = true;
+
+    return CSSSelectorList { WTFMove(selectorArray) };
 }
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -46,6 +46,10 @@ public:
     explicit CSSSelectorList(UniqueArray<CSSSelector>&& array)
         : m_selectorArray(WTFMove(array)) { }
 
+    static CSSSelectorList makeCopyingSimpleSelector(const CSSSelector&);
+    static CSSSelectorList makeCopyingComplexSelector(const CSSSelector&);
+    static CSSSelectorList makeJoining(const CSSSelectorList&, const CSSSelectorList&);
+
     bool isEmpty() const { return !m_selectorArray; }
     const CSSSelector* first() const { return m_selectorArray.get(); }
     static const CSSSelector* next(const CSSSelector*);

--- a/Source/WebCore/style/AttributeChangeInvalidation.cpp
+++ b/Source/WebCore/style/AttributeChangeInvalidation.cpp
@@ -77,13 +77,10 @@ void AttributeChangeInvalidation::invalidateStyle(const QualifiedName& attribute
             if (onlyMatchElement && invalidationRuleSet.matchElement != onlyMatchElement)
                 continue;
 
-            for (auto* selector : invalidationRuleSet.invalidationSelectors) {
-                if (!selector->isAttributeSelector()) {
-                    ASSERT_NOT_REACHED();
-                    continue;
-                }
-                bool oldMatches = !oldValue.isNull() && SelectorChecker::attributeSelectorMatches(m_element, attributeName, oldValue, *selector);
-                bool newMatches = !newValue.isNull() && SelectorChecker::attributeSelectorMatches(m_element, attributeName, newValue, *selector);
+            for (auto& selector : invalidationRuleSet.invalidationSelectors) {
+                ASSERT(selector.isAttributeSelector());
+                bool oldMatches = !oldValue.isNull() && SelectorChecker::attributeSelectorMatches(m_element, attributeName, oldValue, selector);
+                bool newMatches = !newValue.isNull() && SelectorChecker::attributeSelectorMatches(m_element, attributeName, newValue, selector);
                 if (oldMatches != newMatches) {
                     Invalidator::addToMatchElementRuleSets(m_matchElementRuleSets, invalidationRuleSet);
                     break;

--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -69,22 +69,22 @@ void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElemen
         SelectorChecker::CheckingContext checkingContext(SelectorChecker::Mode::CollectingRulesIgnoringVirtualPseudoElements);
         checkingContext.matchesAllHasScopes = true;
 
-        for (auto* selector : invalidationRuleSet.invalidationSelectors) {
+        for (auto& selector : invalidationRuleSet.invalidationSelectors) {
             if (isFirst && invalidationRuleSet.isNegation == IsNegation::No) {
                 // If this :has() matches ignoring this mutation, nothing actually changes and we don't need to invalidate.
                 // FIXME: We could cache this state across invalidations instead of just testing a single sibling.
                 RefPtr sibling = m_childChange.previousSiblingElement ? m_childChange.previousSiblingElement : m_childChange.nextSiblingElement;
-                if (sibling && selectorChecker.match(*selector, *sibling, checkingContext)) {
-                    matchingHasSelectors.add(selector);
+                if (sibling && selectorChecker.match(selector, *sibling, checkingContext)) {
+                    matchingHasSelectors.add(&selector);
                     continue;
                 }
             }
 
-            if (matchingHasSelectors.contains(selector))
+            if (matchingHasSelectors.contains(&selector))
                 continue;
 
-            if (selectorChecker.match(*selector, changedElement, checkingContext)) {
-                matchingHasSelectors.add(selector);
+            if (selectorChecker.match(selector, changedElement, checkingContext)) {
+                matchingHasSelectors.add(&selector);
                 return true;
             }
         }

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include "CSSSelector.h"
+#include "CSSSelectorList.h"
 #include "CommonAtomStrings.h"
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
@@ -85,9 +85,9 @@ struct RuleFeature : public RuleAndSelector {
 static_assert(sizeof(RuleFeature) <= 16, "RuleFeature is a frequently allocated object. Keep it small.");
 
 struct RuleFeatureWithInvalidationSelector : public RuleFeature {
-    RuleFeatureWithInvalidationSelector(const RuleData&, MatchElement, IsNegation, const CSSSelector* invalidationSelector);
+    RuleFeatureWithInvalidationSelector(const RuleData&, MatchElement, IsNegation, CSSSelectorList&& invalidationSelector);
 
-    const CSSSelector* invalidationSelector { nullptr };
+    CSSSelectorList invalidationSelector;
 };
 #pragma pack(pop)
 

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -326,10 +326,8 @@ static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& ke
 
             invalidationRuleSet.ruleSet->addRule(*feature.styleRule, feature.selectorIndex, feature.selectorListIndex);
 
-            if constexpr (std::is_same<typename RuleFeatureVectorType::ValueType, RuleFeatureWithInvalidationSelector>::value) {
-                if (feature.invalidationSelector)
-                    invalidationRuleSet.invalidationSelectors.append(feature.invalidationSelector);
-            }
+            if constexpr (std::is_same<typename RuleFeatureVectorType::ValueType, RuleFeatureWithInvalidationSelector>::value)
+                invalidationRuleSet.invalidationSelectors = CSSSelectorList::makeJoining(invalidationRuleSet.invalidationSelectors, feature.invalidationSelector);
         }
 
         return makeUnique<Vector<InvalidationRuleSet>>(WTF::map(invalidationRuleSetMap.values(), [](auto&& invalidationRuleSet) {

--- a/Source/WebCore/style/StyleScopeRuleSets.h
+++ b/Source/WebCore/style/StyleScopeRuleSets.h
@@ -48,7 +48,11 @@ class Resolver;
 
 struct InvalidationRuleSet {
     RefPtr<RuleSet> ruleSet;
-    Vector<const CSSSelector*> invalidationSelectors;
+    // Invalidation selectors are used for attribute selector and :has() invalidation.
+    // For attributes selectors it contains the simple selectors for fast testing of whether an attribute mutation may have an effect.
+    // For :has() it contains the complex argument selectors for testing if adding or removing a node may affect :has() matching.
+    // Otherwise the list is empty.
+    CSSSelectorList invalidationSelectors;
     MatchElement matchElement;
     IsNegation isNegation;
 };


### PR DESCRIPTION
#### ab18fe2424ddd91a744df289aee67cb936b60283
<pre>
Invalidation selectors should be copied
<a href="https://bugs.webkit.org/show_bug.cgi?id=292179">https://bugs.webkit.org/show_bug.cgi?id=292179</a>
<a href="https://rdar.apple.com/150184491">rdar://150184491</a>

Reviewed by Alan Baradlay.

Instead of keeping a raw pointer to a component selector within a selector list
copy the relevant selector to a its own selector list.

* Source/WebCore/css/CSSSelector.h:
(WebCore::CSSSelector::setLastInSelectorList):
(WebCore::CSSSelector::setNotFirstInTagHistory): Deleted.
(WebCore::CSSSelector::setNotLastInTagHistory): Deleted.
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::CSSSelectorList):
(WebCore::CSSSelectorList::makeCopyingSimpleSelector):
(WebCore::CSSSelectorList::makeCopyingComplexSelector):
(WebCore::CSSSelectorList::makeJoining):

Add some helpers.

* Source/WebCore/css/CSSSelectorList.h:
* Source/WebCore/style/AttributeChangeInvalidation.cpp:
(WebCore::Style::AttributeChangeInvalidation::invalidateStyle):
* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::ChildChangeInvalidation::invalidateForChangedElement):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureWithInvalidationSelector::RuleFeatureWithInvalidationSelector):
(WebCore::Style::RuleFeatureSet::collectFeatures):

Use CSSSelectorList instead of a raw pointer.

* Source/WebCore/style/RuleFeature.h:
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ensureInvalidationRuleSets):

Use CSSSelectorList instead of a raw pointer.

* Source/WebCore/style/StyleScopeRuleSets.h:

Canonical link: <a href="https://commits.webkit.org/294191@main">https://commits.webkit.org/294191@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c649f747998f137a39fb64ef0df6ed0f7dadd35e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101095 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20757 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106243 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51722 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103136 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21066 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29251 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77006 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34032 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104102 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91317 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57353 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16045 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9344 "Found 6 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html imported/w3c/web-platform-tests/svg/painting/marker-005.svg imported/w3c/web-platform-tests/svg/painting/marker-006.svg media/media-source/media-source-video-renders.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51070 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85951 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9400 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108599 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28223 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20779 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85977 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28585 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87517 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85513 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21762 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30232 "Found 1 new test failure: resize-observer/contain-instrinsic-size-should-not-leak-nodes.html (failure)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7960 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22318 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28153 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33421 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27965 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31285 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29523 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->