### PR TITLE
Fullscreening KeyNote shared by getDisplayMedia does not trigger the prompt to continue sharing if user mutes then unmutes capture

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
@@ -62,6 +62,7 @@
 
 - (instancetype)initWithCallback:(WebCore::ScreenCaptureKitSharingSessionManager*)callback;
 - (void)disconnect;
+- (BOOL)hasObservingSession;
 - (void)startObservingSession:(SCContentSharingSession *)session;
 - (void)stopObservingSession:(SCContentSharingSession *)session;
 - (void)sessionDidEnd:(SCContentSharingSession *)session;
@@ -94,6 +95,11 @@
     for (auto& session : _sessions)
         [session setDelegate:nil];
     _sessions.clear();
+}
+
+- (BOOL)hasObservingSession
+{
+    return _sessions.isEmpty();
 }
 
 - (void)startObservingSession:(SCContentSharingSession *)session
@@ -251,7 +257,8 @@ void ScreenCaptureKitSharingSessionManager::cancelPicking()
 #if HAVE(SC_CONTENT_SHARING_PICKER)
     if (useSCContentSharingPicker()) {
         RetainPtr picker = [PAL::getSCContentSharingPickerClass() sharedPicker];
-        [picker setActive:NO];
+        if (![m_promptHelper hasObservingSession])
+            [picker setActive:NO];
         if (m_activeSources.isEmpty())
             [m_promptHelper stopObservingPicker:picker.get()];
     }


### PR DESCRIPTION
#### 80172a1b06231a9d4a6d243fd7fecfb236bc9016
<pre>
Fullscreening KeyNote shared by getDisplayMedia does not trigger the prompt to continue sharing if user mutes then unmutes capture
<a href="https://rdar.apple.com/150187534">rdar://150187534</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292181">https://bugs.webkit.org/show_bug.cgi?id=292181</a>

Reviewed by Eric Carlson.

Before the patch, we would set back [SCContentSharingPicker active] to NO when a screen capture stops,
either when the capture is terminated permanently or temporarily (in case of mute/unmute).
This breaks fullscreening KeyNote.

To prevent this, we are now resetting [SCContentSharingPicker active] to NO if there is no active screenshare session.

Manually tested.

* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm:
(-[WebDisplayMediaPromptHelper hasObservingSession]):
(WebCore::ScreenCaptureKitSharingSessionManager::cancelPicking):

Canonical link: <a href="https://commits.webkit.org/294249@main">https://commits.webkit.org/294249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62efa3102723245a8893a7f3f9a41c76d7d4ccad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20759 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106245 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51724 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103138 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21068 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29253 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77008 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34031 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104104 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16228 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91313 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57355 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16044 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9340 "Found 3 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51072 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85950 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9396 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108601 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28225 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20783 "Found 3 new test failures: http/wpt/selection-live-range/textcontrols/onselectionchange-content-attribute.html imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page.html imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-default-writing-mode-rl.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85975 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28587 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87513 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85511 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21789 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30233 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7957 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22320 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28155 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33423 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27967 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31287 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29525 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->