### PR TITLE
RealtimeMediaSource::setShouldApplyRotation() does not need to take a parameter

### DIFF
--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -287,7 +287,7 @@ public:
     virtual void delaySamples(Seconds) { };
     virtual void setInterruptedForTesting(bool);
 
-    virtual bool setShouldApplyRotation(bool) { return false; }
+    virtual bool setShouldApplyRotation();
     virtual void setIsInBackground(bool);
 
     std::optional<PageIdentifier> pageIdentifier() const { return m_pageIdentifier.asOptional(); }
@@ -478,6 +478,11 @@ inline void RealtimeMediaSource::setIsInBackground(bool)
 inline const String& RealtimeMediaSource::hashedGroupId() const
 {
     return m_hashedGroupId;
+}
+
+inline bool RealtimeMediaSource::setShouldApplyRotation()
+{
+    return false;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.cpp
@@ -97,7 +97,7 @@ void RealtimeOutgoingVideoSource::setSource(Ref<MediaStreamTrackPrivate>&& newSo
 
     if (!m_areSinksAskingToApplyRotation)
         return;
-    if (!m_videoSource->source().setShouldApplyRotation(true))
+    if (!m_videoSource->source().setShouldApplyRotation())
         m_shouldApplyRotation = true;
 }
 
@@ -108,7 +108,7 @@ void RealtimeOutgoingVideoSource::applyRotation()
             return;
 
         m_areSinksAskingToApplyRotation = true;
-        if (!m_videoSource->source().setShouldApplyRotation(true))
+        if (!m_videoSource->source().setShouldApplyRotation())
             m_shouldApplyRotation = true;
     });
 }

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -139,7 +139,7 @@ public:
         protectedSource()->requestToEnd(*this);
     }
 
-    void setShouldApplyRotation(bool shouldApplyRotation) { m_shouldApplyRotation = true; }
+    void setShouldApplyRotation() { m_shouldApplyRotation = true; }
     void setIsInBackground(bool value) { m_source->setIsInBackground(value); }
 
     bool isPowerEfficient()
@@ -773,10 +773,10 @@ void UserMediaCaptureManagerProxy::endProducingData(RealtimeMediaSourceIdentifie
         proxy->end();
 }
 
-void UserMediaCaptureManagerProxy::setShouldApplyRotation(RealtimeMediaSourceIdentifier sourceID, bool shouldApplyRotation)
+void UserMediaCaptureManagerProxy::setShouldApplyRotation(RealtimeMediaSourceIdentifier sourceID)
 {
     if (RefPtr proxy = m_proxies.get(sourceID))
-        proxy->setShouldApplyRotation(shouldApplyRotation);
+        proxy->setShouldApplyRotation();
 }
 
 void UserMediaCaptureManagerProxy::setIsInBackground(RealtimeMediaSourceIdentifier sourceID, bool isInBackground)

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
@@ -118,7 +118,7 @@ private:
     void applyConstraints(WebCore::RealtimeMediaSourceIdentifier, WebCore::MediaConstraints&&);
     void clone(WebCore::RealtimeMediaSourceIdentifier clonedID, WebCore::RealtimeMediaSourceIdentifier cloneID, WebCore::PageIdentifier);
     void endProducingData(WebCore::RealtimeMediaSourceIdentifier);
-    void setShouldApplyRotation(WebCore::RealtimeMediaSourceIdentifier, bool shouldApplyRotation);
+    void setShouldApplyRotation(WebCore::RealtimeMediaSourceIdentifier);
     void setIsInBackground(WebCore::RealtimeMediaSourceIdentifier, bool);
     void isPowerEfficient(WebCore::RealtimeMediaSourceIdentifier, CompletionHandler<void(bool)>&&);
 

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.messages.in
@@ -39,7 +39,7 @@ messages -> UserMediaCaptureManagerProxy {
     GetPhotoSettings(WebCore::RealtimeMediaSourceIdentifier sourceID) -> (Expected<WebCore::PhotoSettings, String> result) Async
     Clone(WebCore::RealtimeMediaSourceIdentifier clonedID, WebCore::RealtimeMediaSourceIdentifier cloneID, WebCore::PageIdentifier pageIdentifier)
     EndProducingData(WebCore::RealtimeMediaSourceIdentifier sourceID)
-    SetShouldApplyRotation(WebCore::RealtimeMediaSourceIdentifier sourceID, bool shouldApplyRotation)
+    SetShouldApplyRotation(WebCore::RealtimeMediaSourceIdentifier sourceID)
     SetIsInBackground(WebCore::RealtimeMediaSourceIdentifier sourceID, bool isInBackground)
     IsPowerEfficient(WebCore::RealtimeMediaSourceIdentifier sourceID) -> (bool isPowerEfficient) Synchronous
 }

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp
@@ -57,9 +57,9 @@ RemoteRealtimeVideoSource::RemoteRealtimeVideoSource(RemoteRealtimeMediaSourcePr
 
 RemoteRealtimeVideoSource::~RemoteRealtimeVideoSource() = default;
 
-bool RemoteRealtimeVideoSource::setShouldApplyRotation(bool shouldApplyRotation)
+bool RemoteRealtimeVideoSource::setShouldApplyRotation()
 {
-    connection().send(Messages::UserMediaCaptureManagerProxy::SetShouldApplyRotation { identifier(), shouldApplyRotation }, 0);
+    connection().send(Messages::UserMediaCaptureManagerProxy::SetShouldApplyRotation { identifier() }, 0);
     return true;
 }
 

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.h
@@ -53,7 +53,7 @@ private:
     RemoteRealtimeVideoSource(RemoteRealtimeMediaSourceProxy&&, WebCore::MediaDeviceHashSalts&&, UserMediaCaptureManager&, std::optional<WebCore::PageIdentifier>);
 
     Ref<RealtimeMediaSource> clone() final;
-    bool setShouldApplyRotation(bool) final;
+    bool setShouldApplyRotation() final;
     double observedFrameRate() const final { return m_observedFrameRate; }
 
     Deque<double> m_observedFrameTimeStamps;


### PR DESCRIPTION
#### 5a4e5df3e4a6b37a3af10acab36765746bdf03e2
<pre>
RealtimeMediaSource::setShouldApplyRotation() does not need to take a parameter
<a href="https://rdar.apple.com/150189888">rdar://150189888</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292185">https://bugs.webkit.org/show_bug.cgi?id=292185</a>

Reviewed by Jean-Yves Avenard.

We remove the parameter from setShouldApplyRotation since it is always true and there is no easy way to make use of a value of false.

* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.cpp:
(WebCore::RealtimeOutgoingVideoSource::setSource):
(WebCore::RealtimeOutgoingVideoSource::applyRotation):
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::setShouldApplyRotation):
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h:
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp:
(WebKit::RemoteRealtimeVideoSource::setShouldApplyRotation):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.h:

Canonical link: <a href="https://commits.webkit.org/294240@main">https://commits.webkit.org/294240@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0db877e472809dfad42d24909edeacb1eb9fb44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106253 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51732 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103146 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21076 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29261 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77014 "Found 1 new test failure: fast/css/view-transitions-nested-transparency-layers.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34042 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16237 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91323 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57361 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16053 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9350 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51080 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85959 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9406 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108609 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28233 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20790 "Found 2 new test failures: http/tests/iframe-monitor/data-url-resource.html http/tests/iframe-monitor/just-use-eligible-subresource.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85985 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28595 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85522 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21784 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30241 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7966 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22328 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28163 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33431 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27975 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31295 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29533 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->