### PR TITLE
Add a mechanism to detect when authors have specified their own padding on form controls

### DIFF
--- a/LayoutTests/fast/forms/input-text-padding-expected.txt
+++ b/LayoutTests/fast/forms/input-text-padding-expected.txt
@@ -1,0 +1,18 @@
+This test checks that padding applies to text inputs with native appearance.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+PASS getComputedStyle(input1).paddingTop is "22px"
+PASS getComputedStyle(input2).paddingRight is "22px"
+PASS getComputedStyle(input3).paddingBottom is "22px"
+PASS getComputedStyle(input4).paddingLeft is "22px"
+PASS getComputedStyle(input5).paddingBlockStart is "22px"
+PASS getComputedStyle(input6).paddingInlineEnd is "22px"
+PASS getComputedStyle(input7).paddingBlockEnd is "22px"
+PASS getComputedStyle(input8).paddingInlineStart is "22px"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/input-text-padding.html
+++ b/LayoutTests/fast/forms/input-text-padding.html
@@ -1,0 +1,70 @@
+<!-- webkit-test-runner [ VectorBasedControlsOnMacEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+#input1 {
+    padding-top: 22px;
+}
+
+#input2 {
+    padding-right: 22px;
+}
+
+#input3 {
+    padding-bottom: 22px;
+}
+
+#input4 {
+    padding-left: 22px;
+}
+
+#input5 {
+    padding-block-start: 22px;
+}
+
+#input6 {
+    padding-inline-end: 22px;
+}
+
+#input7 {
+    padding-block-end: 22px;
+}
+
+#input8 {
+    padding-inline-start: 22px;
+}
+
+</style>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<p id="description"></p>
+
+<input id="input1">
+<input id="input2">
+<input id="input3">
+<input id="input4">
+<input id="input5">
+<input id="input6">
+<input id="input7">
+<input id="input8">
+
+<div id="console"></div>
+<script>
+
+description('This test checks that padding applies to text inputs with native appearance.');
+
+shouldBeEqualToString('getComputedStyle(input1).paddingTop', '22px');
+shouldBeEqualToString('getComputedStyle(input2).paddingRight', '22px');
+shouldBeEqualToString('getComputedStyle(input3).paddingBottom', '22px');
+shouldBeEqualToString('getComputedStyle(input4).paddingLeft', '22px');
+shouldBeEqualToString('getComputedStyle(input5).paddingBlockStart', '22px');
+shouldBeEqualToString('getComputedStyle(input6).paddingInlineEnd', '22px');
+shouldBeEqualToString('getComputedStyle(input7).paddingBlockEnd', '22px');
+shouldBeEqualToString('getComputedStyle(input8).paddingInlineStart', '22px');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -6848,6 +6848,7 @@
                 "animation-wrapper-requires-additional-parameters": ["{ LengthWrapper::Flags::IsLengthPercentage, LengthWrapper::Flags::NegativeLengthsAreInvalid }"],
                 "render-style-initial": "initialPadding",
                 "style-builder-converter": "Length",
+                "style-builder-custom": "All",
                 "parser-grammar": "<length-percentage [0,inf]>"
             },
             "specification": {
@@ -6918,6 +6919,7 @@
                 "animation-wrapper-requires-additional-parameters": ["{ LengthWrapper::Flags::IsLengthPercentage, LengthWrapper::Flags::NegativeLengthsAreInvalid }"],
                 "render-style-initial": "initialPadding",
                 "style-builder-converter": "Length",
+                "style-builder-custom": "All",
                 "parser-grammar": "<length-percentage [0,inf]>"
             },
             "specification": {
@@ -6938,6 +6940,7 @@
                 "animation-wrapper-requires-additional-parameters": ["{ LengthWrapper::Flags::IsLengthPercentage, LengthWrapper::Flags::NegativeLengthsAreInvalid }"],
                 "render-style-initial": "initialPadding",
                 "style-builder-converter": "Length",
+                "style-builder-custom": "All",
                 "parser-grammar": "<length-percentage [0,inf]>"
             },
             "specification": {
@@ -6958,6 +6961,7 @@
                 "animation-wrapper-requires-additional-parameters": ["{ LengthWrapper::Flags::IsLengthPercentage, LengthWrapper::Flags::NegativeLengthsAreInvalid }"],
                 "render-style-initial": "initialPadding",
                 "style-builder-converter": "Length",
+                "style-builder-custom": "All",
                 "parser-grammar": "<length-percentage [0,inf]>"
             },
             "specification": {

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -739,6 +739,12 @@ public:
     inline const Length& paddingStart() const;
     inline const Length& paddingEnd() const;
 
+    inline bool hasExplicitlySetPadding() const;
+    inline bool hasExplicitlySetPaddingBottom() const;
+    inline bool hasExplicitlySetPaddingLeft() const;
+    inline bool hasExplicitlySetPaddingRight() const;
+    inline bool hasExplicitlySetPaddingTop() const;
+
     CursorType cursor() const { return static_cast<CursorType>(m_inheritedFlags.cursor); }
 
 #if ENABLE(CURSOR_VISIBILITY)
@@ -1435,6 +1441,11 @@ public:
     void setPaddingEnd(Length&&);
     void setPaddingBefore(Length&&);
     void setPaddingAfter(Length&&);
+
+    inline void setHasExplicitlySetPaddingBottom(bool);
+    inline void setHasExplicitlySetPaddingLeft(bool);
+    inline void setHasExplicitlySetPaddingRight(bool);
+    inline void setHasExplicitlySetPaddingTop(bool);
 
     void setCursor(CursorType c) { m_inheritedFlags.cursor = static_cast<unsigned>(c); }
     void addCursor(RefPtr<StyleImage>&&, const std::optional<IntPoint>& hotSpot);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -315,6 +315,11 @@ inline bool RenderStyle::hasExplicitlySetBorderBottomRightRadius() const { retur
 inline bool RenderStyle::hasExplicitlySetBorderRadius() const { return hasExplicitlySetBorderBottomLeftRadius() || hasExplicitlySetBorderBottomRightRadius() || hasExplicitlySetBorderTopLeftRadius() || hasExplicitlySetBorderTopRightRadius(); }
 inline bool RenderStyle::hasExplicitlySetBorderTopLeftRadius() const { return m_nonInheritedData->surroundData->hasExplicitlySetBorderTopLeftRadius; }
 inline bool RenderStyle::hasExplicitlySetBorderTopRightRadius() const { return m_nonInheritedData->surroundData->hasExplicitlySetBorderTopRightRadius; }
+inline bool RenderStyle::hasExplicitlySetPadding() const { return hasExplicitlySetPaddingBottom() || hasExplicitlySetPaddingLeft() || hasExplicitlySetPaddingRight() || hasExplicitlySetPaddingTop(); }
+inline bool RenderStyle::hasExplicitlySetPaddingBottom() const { return m_nonInheritedData->surroundData->hasExplicitlySetPaddingBottom; }
+inline bool RenderStyle::hasExplicitlySetPaddingLeft() const { return m_nonInheritedData->surroundData->hasExplicitlySetPaddingLeft; }
+inline bool RenderStyle::hasExplicitlySetPaddingRight() const { return m_nonInheritedData->surroundData->hasExplicitlySetPaddingRight; }
+inline bool RenderStyle::hasExplicitlySetPaddingTop() const { return m_nonInheritedData->surroundData->hasExplicitlySetPaddingTop; }
 inline bool RenderStyle::hasExplicitlySetStrokeColor() const { return m_rareInheritedData->hasSetStrokeColor; }
 inline bool RenderStyle::hasFilter() const { return !filter().isEmpty(); }
 inline bool RenderStyle::hasInFlowPosition() const { return position() == PositionType::Relative || position() == PositionType::Sticky; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -186,6 +186,10 @@ inline void RenderStyle::setHasExplicitlySetBorderBottomLeftRadius(bool value) {
 inline void RenderStyle::setHasExplicitlySetBorderBottomRightRadius(bool value) { SET_NESTED(m_nonInheritedData, surroundData, hasExplicitlySetBorderBottomRightRadius, value); }
 inline void RenderStyle::setHasExplicitlySetBorderTopLeftRadius(bool value) { SET_NESTED(m_nonInheritedData, surroundData, hasExplicitlySetBorderTopLeftRadius, value); }
 inline void RenderStyle::setHasExplicitlySetBorderTopRightRadius(bool value) { SET_NESTED(m_nonInheritedData, surroundData, hasExplicitlySetBorderTopRightRadius, value); }
+inline void RenderStyle::setHasExplicitlySetPaddingBottom(bool value) { SET_NESTED(m_nonInheritedData, surroundData, hasExplicitlySetPaddingBottom, value); }
+inline void RenderStyle::setHasExplicitlySetPaddingLeft(bool value) { SET_NESTED(m_nonInheritedData, surroundData, hasExplicitlySetPaddingLeft, value); }
+inline void RenderStyle::setHasExplicitlySetPaddingRight(bool value) { SET_NESTED(m_nonInheritedData, surroundData, hasExplicitlySetPaddingRight, value); }
+inline void RenderStyle::setHasExplicitlySetPaddingTop(bool value) { SET_NESTED(m_nonInheritedData, surroundData, hasExplicitlySetPaddingTop, value); }
 inline void RenderStyle::setHasExplicitlySetStrokeColor(bool value) { SET(m_rareInheritedData, hasSetStrokeColor, static_cast<unsigned>(value)); }
 inline void RenderStyle::setHasExplicitlySetStrokeWidth(bool value) { SET(m_rareInheritedData, hasSetStrokeWidth, static_cast<unsigned>(value)); }
 inline void RenderStyle::setHasPseudoStyles(PseudoIdSet set) { m_nonInheritedFlags.setHasPseudoStyles(set); }

--- a/Source/WebCore/rendering/style/StyleSurroundData.cpp
+++ b/Source/WebCore/rendering/style/StyleSurroundData.cpp
@@ -33,6 +33,10 @@ StyleSurroundData::StyleSurroundData()
     , hasExplicitlySetBorderBottomRightRadius(false)
     , hasExplicitlySetBorderTopLeftRadius(false)
     , hasExplicitlySetBorderTopRightRadius(false)
+    , hasExplicitlySetPaddingBottom(false)
+    , hasExplicitlySetPaddingLeft(false)
+    , hasExplicitlySetPaddingRight(false)
+    , hasExplicitlySetPaddingTop(false)
     , margin(LengthType::Fixed)
     , padding(LengthType::Fixed)
 {
@@ -44,6 +48,10 @@ inline StyleSurroundData::StyleSurroundData(const StyleSurroundData& o)
     , hasExplicitlySetBorderBottomRightRadius(o.hasExplicitlySetBorderBottomRightRadius)
     , hasExplicitlySetBorderTopLeftRadius(o.hasExplicitlySetBorderTopLeftRadius)
     , hasExplicitlySetBorderTopRightRadius(o.hasExplicitlySetBorderTopRightRadius)
+    , hasExplicitlySetPaddingBottom(o.hasExplicitlySetPaddingBottom)
+    , hasExplicitlySetPaddingLeft(o.hasExplicitlySetPaddingLeft)
+    , hasExplicitlySetPaddingRight(o.hasExplicitlySetPaddingRight)
+    , hasExplicitlySetPaddingTop(o.hasExplicitlySetPaddingTop)
     , offset(o.offset)
     , margin(o.margin)
     , padding(o.padding)
@@ -62,7 +70,11 @@ bool StyleSurroundData::operator==(const StyleSurroundData& o) const
         && hasExplicitlySetBorderBottomLeftRadius == o.hasExplicitlySetBorderBottomLeftRadius
         && hasExplicitlySetBorderBottomRightRadius == o.hasExplicitlySetBorderBottomRightRadius
         && hasExplicitlySetBorderTopLeftRadius == o.hasExplicitlySetBorderTopLeftRadius
-        && hasExplicitlySetBorderTopRightRadius == o.hasExplicitlySetBorderTopRightRadius;
+        && hasExplicitlySetBorderTopRightRadius == o.hasExplicitlySetBorderTopRightRadius
+        && hasExplicitlySetPaddingBottom == o.hasExplicitlySetPaddingBottom
+        && hasExplicitlySetPaddingLeft == o.hasExplicitlySetPaddingLeft
+        && hasExplicitlySetPaddingRight == o.hasExplicitlySetPaddingRight
+        && hasExplicitlySetPaddingTop == o.hasExplicitlySetPaddingTop;
 }
 
 #if !LOG_DISABLED
@@ -72,6 +84,11 @@ void StyleSurroundData::dumpDifferences(TextStream& ts, const StyleSurroundData&
     LOG_IF_DIFFERENT(hasExplicitlySetBorderBottomRightRadius);
     LOG_IF_DIFFERENT(hasExplicitlySetBorderTopLeftRadius);
     LOG_IF_DIFFERENT(hasExplicitlySetBorderTopRightRadius);
+
+    LOG_IF_DIFFERENT(hasExplicitlySetPaddingBottom);
+    LOG_IF_DIFFERENT(hasExplicitlySetPaddingLeft);
+    LOG_IF_DIFFERENT(hasExplicitlySetPaddingRight);
+    LOG_IF_DIFFERENT(hasExplicitlySetPaddingTop);
 
     LOG_IF_DIFFERENT(offset);
     LOG_IF_DIFFERENT(margin);

--- a/Source/WebCore/rendering/style/StyleSurroundData.h
+++ b/Source/WebCore/rendering/style/StyleSurroundData.h
@@ -54,6 +54,11 @@ public:
     bool hasExplicitlySetBorderTopLeftRadius : 1;
     bool hasExplicitlySetBorderTopRightRadius : 1;
 
+    bool hasExplicitlySetPaddingBottom : 1;
+    bool hasExplicitlySetPaddingLeft : 1;
+    bool hasExplicitlySetPaddingRight : 1;
+    bool hasExplicitlySetPaddingTop : 1;
+
     LengthBox offset;
     LengthBox margin;
     LengthBox padding;

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -127,6 +127,10 @@ public:
     DECLARE_PROPERTY_CUSTOM_HANDLERS(MaskBorderRepeat);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(MaskBorderSlice);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(MaskBorderWidth);
+    DECLARE_PROPERTY_CUSTOM_HANDLERS(PaddingBottom);
+    DECLARE_PROPERTY_CUSTOM_HANDLERS(PaddingLeft);
+    DECLARE_PROPERTY_CUSTOM_HANDLERS(PaddingRight);
+    DECLARE_PROPERTY_CUSTOM_HANDLERS(PaddingTop);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(OutlineStyle);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(Stroke);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(TextEmphasisStyle);
@@ -1846,6 +1850,78 @@ inline void BuilderCustom::applyValueContainIntrinsicHeight(BuilderState& builde
         auto lengthValue = pair->second.resolveAsLength<WebCore::Length>(builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f));
         style.setContainIntrinsicHeight(lengthValue);
     }
+}
+
+inline void BuilderCustom::applyInitialPaddingBottom(BuilderState& builderState)
+{
+    builderState.style().setPaddingBottom(RenderStyle::initialPadding());
+    builderState.style().setHasExplicitlySetPaddingBottom(builderState.isAuthorOrigin());
+}
+
+inline void BuilderCustom::applyInheritPaddingBottom(BuilderState& builderState)
+{
+    builderState.style().setPaddingBottom(forwardInheritedValue(builderState.parentStyle().paddingBottom()));
+    builderState.style().setHasExplicitlySetPaddingBottom(builderState.isAuthorOrigin());
+}
+
+inline void BuilderCustom::applyValuePaddingBottom(BuilderState& builderState, CSSValue& value)
+{
+    builderState.style().setPaddingBottom(BuilderConverter::convertLength(builderState, value));
+    builderState.style().setHasExplicitlySetPaddingBottom(builderState.isAuthorOrigin());
+}
+
+inline void BuilderCustom::applyInitialPaddingLeft(BuilderState& builderState)
+{
+    builderState.style().setPaddingLeft(RenderStyle::initialPadding());
+    builderState.style().setHasExplicitlySetPaddingLeft(builderState.isAuthorOrigin());
+}
+
+inline void BuilderCustom::applyInheritPaddingLeft(BuilderState& builderState)
+{
+    builderState.style().setPaddingLeft(forwardInheritedValue(builderState.parentStyle().paddingLeft()));
+    builderState.style().setHasExplicitlySetPaddingLeft(builderState.isAuthorOrigin());
+}
+
+inline void BuilderCustom::applyValuePaddingLeft(BuilderState& builderState, CSSValue& value)
+{
+    builderState.style().setPaddingLeft(BuilderConverter::convertLength(builderState, value));
+    builderState.style().setHasExplicitlySetPaddingLeft(builderState.isAuthorOrigin());
+}
+
+inline void BuilderCustom::applyInitialPaddingRight(BuilderState& builderState)
+{
+    builderState.style().setPaddingRight(RenderStyle::initialPadding());
+    builderState.style().setHasExplicitlySetPaddingRight(builderState.isAuthorOrigin());
+}
+
+inline void BuilderCustom::applyInheritPaddingRight(BuilderState& builderState)
+{
+    builderState.style().setPaddingRight(forwardInheritedValue(builderState.parentStyle().paddingRight()));
+    builderState.style().setHasExplicitlySetPaddingRight(builderState.isAuthorOrigin());
+}
+
+inline void BuilderCustom::applyValuePaddingRight(BuilderState& builderState, CSSValue& value)
+{
+    builderState.style().setPaddingRight(BuilderConverter::convertLength(builderState, value));
+    builderState.style().setHasExplicitlySetPaddingRight(builderState.isAuthorOrigin());
+}
+
+inline void BuilderCustom::applyInitialPaddingTop(BuilderState& builderState)
+{
+    builderState.style().setPaddingTop(RenderStyle::initialPadding());
+    builderState.style().setHasExplicitlySetPaddingTop(builderState.isAuthorOrigin());
+}
+
+inline void BuilderCustom::applyInheritPaddingTop(BuilderState& builderState)
+{
+    builderState.style().setPaddingTop(forwardInheritedValue(builderState.parentStyle().paddingTop()));
+    builderState.style().setHasExplicitlySetPaddingTop(builderState.isAuthorOrigin());
+}
+
+inline void BuilderCustom::applyValuePaddingTop(BuilderState& builderState, CSSValue& value)
+{
+    builderState.style().setPaddingTop(BuilderConverter::convertLength(builderState, value));
+    builderState.style().setHasExplicitlySetPaddingTop(builderState.isAuthorOrigin());
 }
 
 }


### PR DESCRIPTION
#### e9a6fa1fde2f2e0f229e2216a2292af5c40fa977
<pre>
Add a mechanism to detect when authors have specified their own padding on form controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=292186">https://bugs.webkit.org/show_bug.cgi?id=292186</a>
<a href="https://rdar.apple.com/148454896">rdar://148454896</a>

Reviewed by Richard Robinson.

Introduce `RenderStyle::hasExplicitlySetPadding` to detect when authors have
specified padding.

Add a test that verifies that padding can be customized on text inputs.

* LayoutTests/fast/forms/input-text-padding-expected.txt: Added.
* LayoutTests/fast/forms/input-text-padding.html: Added.
* Source/WebCore/css/CSSProperties.json:

The code generator does not yet handle the &quot;has explicitly set&quot; pattern,
so opt in to custom code.

* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::hasExplicitlySetPadding const):
(WebCore::RenderStyle::hasExplicitlySetPaddingBottom const):
(WebCore::RenderStyle::hasExplicitlySetPaddingLeft const):
(WebCore::RenderStyle::hasExplicitlySetPaddingRight const):
(WebCore::RenderStyle::hasExplicitlySetPaddingTop const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setHasExplicitlySetPaddingBottom):
(WebCore::RenderStyle::setHasExplicitlySetPaddingLeft):
(WebCore::RenderStyle::setHasExplicitlySetPaddingRight):
(WebCore::RenderStyle::setHasExplicitlySetPaddingTop):
* Source/WebCore/rendering/style/StyleSurroundData.cpp:
(WebCore::StyleSurroundData::StyleSurroundData):
(WebCore::StyleSurroundData::operator== const):
(WebCore::StyleSurroundData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleSurroundData.h:

The 4 newly added bits fit in unused bits, and the size of `StyleSurroundData`
remains the same.

* Source/WebCore/style/StyleBuilderCustom.h:

Set the &quot;has explicitly set&quot; flag when the value is applied from the
author-origin.

(WebCore::Style::BuilderCustom::applyInitialPaddingBottom):
(WebCore::Style::BuilderCustom::applyInheritPaddingBottom):
(WebCore::Style::BuilderCustom::applyValuePaddingBottom):
(WebCore::Style::BuilderCustom::applyInitialPaddingLeft):
(WebCore::Style::BuilderCustom::applyInheritPaddingLeft):
(WebCore::Style::BuilderCustom::applyValuePaddingLeft):
(WebCore::Style::BuilderCustom::applyInitialPaddingRight):
(WebCore::Style::BuilderCustom::applyInheritPaddingRight):
(WebCore::Style::BuilderCustom::applyValuePaddingRight):
(WebCore::Style::BuilderCustom::applyInitialPaddingTop):
(WebCore::Style::BuilderCustom::applyInheritPaddingTop):
(WebCore::Style::BuilderCustom::applyValuePaddingTop):

Canonical link: <a href="https://commits.webkit.org/294232@main">https://commits.webkit.org/294232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/622fafb229723fe219fe37a1266c38ae1708366e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106255 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51734 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21078 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29263 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77019 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34045 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104114 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16238 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91327 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57366 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16055 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9354 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51082 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/93774 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85960 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9410 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108611 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28235 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20792 "Found 3 new test failures: http/tests/iframe-monitor/iframe-unload.html http/tests/iframe-monitor/workers/service-worker.html imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-default-writing-mode-rl.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85987 "Found 1 new test failure: fast/events/domactivate-sets-underlying-click-event-as-handled.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28597 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87528 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85524 "Found 100 new API test failures: /TestWebKit:WebKit.EnumerateDevicesCrash, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/file-chooser-request, /TestWebKit:WebKit.PageLoadDidChangeLocationWithinPage, /WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-activate, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/simple, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/display-usermedia-permission-request, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/test-page-list, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/open-window-no-default-size, /TestWebKit:WebKit.LoadPageAfterCrash ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30243 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7970 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22331 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16461 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28165 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33434 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27977 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31297 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29535 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->