### PR TITLE
[CSS-Color] Make `textarea` have 'FieldText' and 'Field' for color and background-color

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/system-color-consistency-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/system-color-consistency-expected.txt
@@ -23,7 +23,7 @@ FAIL Property color value 'FieldText' resolves to the same color as text on a nu
 PASS Property color value 'Field' resolves to the same color as the background-color of a date field (light)
 FAIL Property color value 'FieldText' resolves to the same color as text on a date field (light) assert_equals: expected "rgb(0, 0, 0)" but got "rgba(0, 0, 0, 0.847)"
 PASS Property color value 'Field' resolves to the same color as the background-color of a text area (light)
-FAIL Property color value 'FieldText' resolves to the same color as text on a text area (light) assert_equals: expected "rgb(0, 0, 0)" but got "rgba(0, 0, 0, 0.847)"
+PASS Property color value 'FieldText' resolves to the same color as text on a text area (light)
 PASS Property color value 'Mark' has the same color as the background-color of a mark element (light)
 PASS Property color value 'MarkText' has the same color as the color of a mark element (light)
 PASS Property color value 'LinkText' has the same color as the color of an anchor element (light)
@@ -50,8 +50,8 @@ FAIL Property color value 'Field' resolves to the same color as the background-c
 FAIL Property color value 'FieldText' resolves to the same color as text on a number field (dark) assert_equals: expected "rgb(255, 255, 255)" but got "rgba(255, 255, 255, 0.847)"
 FAIL Property color value 'Field' resolves to the same color as the background-color of a date field (dark) assert_equals: expected "rgb(30, 30, 30)" but got "rgba(255, 255, 255, 0.247)"
 FAIL Property color value 'FieldText' resolves to the same color as text on a date field (dark) assert_equals: expected "rgb(255, 255, 255)" but got "rgba(255, 255, 255, 0.847)"
-FAIL Property color value 'Field' resolves to the same color as the background-color of a text area (dark) assert_equals: expected "rgb(30, 30, 30)" but got "rgba(255, 255, 255, 0.247)"
-FAIL Property color value 'FieldText' resolves to the same color as text on a text area (dark) assert_equals: expected "rgb(255, 255, 255)" but got "rgba(255, 255, 255, 0.847)"
+PASS Property color value 'Field' resolves to the same color as the background-color of a text area (dark)
+PASS Property color value 'FieldText' resolves to the same color as text on a text area (dark)
 PASS Property color value 'Mark' has the same color as the background-color of a mark element (dark)
 PASS Property color value 'MarkText' has the same color as the color of a mark element (dark)
 PASS Property color value 'LinkText' has the same color as the color of an anchor element (dark)

--- a/LayoutTests/platform/mac/editing/input/cocoa/writing-suggestions-textarea-multiple-lines-expected.txt
+++ b/LayoutTests/platform/mac/editing/input/cocoa/writing-suggestions-textarea-multiple-lines-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x326
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0
 layer at (8,8) size 306x306 clip at (9,9) size 304x304
-  RenderTextControl {TEXTAREA} at (0,0) size 306x306 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,0) size 306x306 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 300x54
       RenderText {#text} at (0,0) size 106x18
         text run at (0,0) width 106: "good morning."
@@ -14,7 +14,7 @@ layer at (8,8) size 306x306 clip at (9,9) size 304x304
       RenderBR {BR} at (0,18) size 0x18
       RenderText {#text} at (0,36) size 44x18
         text run at (0,36) width 44: "My na"
-      RenderInline (generated) at (43,36) size 40x18 [color=color(srgb 0 0 0 / 0.5)]
+      RenderInline (generated) at (43,36) size 40x18 [color=color(srgb 0 0 0 / 0.423529)]
         RenderText at (43,36) size 40x18
           text run at (43,36) width 40: "me is"
 caret: position 5 of child 2 {#text} of child 0 {DIV} of {#document-fragment} of child 1 {TEXTAREA} of body

--- a/LayoutTests/platform/mac/editing/input/reveal-caret-of-multiline-input-expected.txt
+++ b/LayoutTests/platform/mac/editing/input/reveal-caret-of-multiline-input-expected.txt
@@ -10,7 +10,7 @@ layer at (0,0) size 800x174
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
 layer at (8,26) size 91x136 clip at (9,27) size 74x134 scrollY 98 scrollHeight 420
-  RenderTextControl {TEXTAREA} at (0,0) size 91x136 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,0) size 91x136 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 70x416
       RenderText {#text} at (0,0) size 19x403
         text run at (0,0) width 14: "00"

--- a/LayoutTests/platform/mac/editing/inserting/4960120-1-expected.txt
+++ b/LayoutTests/platform/mac/editing/inserting/4960120-1-expected.txt
@@ -10,7 +10,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
 layer at (8,42) size 161x32 clip at (9,43) size 159x30
-  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 155x26
       RenderText {#text} at (0,0) size 0x13
         text run at (0,0) width 0: " "

--- a/LayoutTests/platform/mac/editing/mac/spelling/autocorrection-at-beginning-of-word-1-expected.txt
+++ b/LayoutTests/platform/mac/editing/mac/spelling/autocorrection-at-beginning-of-word-1-expected.txt
@@ -29,7 +29,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
 layer at (8,130) size 581x136 clip at (9,131) size 579x134
-  RenderTextControl {TEXTAREA} at (0,0) size 581x136 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,0) size 581x136 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 575x13
       RenderText {#text} at (0,0) size 54x13
         text run at (0,0) width 54: "mesage m"

--- a/LayoutTests/platform/mac/editing/mac/spelling/autocorrection-at-beginning-of-word-2-expected.txt
+++ b/LayoutTests/platform/mac/editing/mac/spelling/autocorrection-at-beginning-of-word-2-expected.txt
@@ -29,7 +29,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
 layer at (8,130) size 581x136 clip at (9,131) size 579x134
-  RenderTextControl {TEXTAREA} at (0,0) size 581x136 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,0) size 581x136 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 575x26
       RenderText {#text} at (0,0) size 45x13
         text run at (0,0) width 45: "mesage "

--- a/LayoutTests/platform/mac/editing/pasteboard/pasting-tabs-expected.txt
+++ b/LayoutTests/platform/mac/editing/pasteboard/pasting-tabs-expected.txt
@@ -29,7 +29,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (64,0) size 39x18
           text run at (64,0) width 39: "<-Tab"
 layer at (8,60) size 161x32 clip at (9,61) size 159x30
-  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 155x13
       RenderText {#text} at (0,0) size 82x13
         text run at (0,0) width 82: "Tab->\x{9}<-Tab"

--- a/LayoutTests/platform/mac/fast/block/float/overhanging-tall-block-expected.txt
+++ b/LayoutTests/platform/mac/fast/block/float/overhanging-tall-block-expected.txt
@@ -7,5 +7,5 @@ layer at (0,0) size 800x33554431
       RenderBlock {DIV} at (0,33554431) size 784x0
       RenderBlock {DIV} at (0,33554431) size 784x0
 layer at (8,8) size 161x33554431 backgroundClip at (8,8) size 161x33554424 clip at (9,9) size 159x33554423
-  RenderTextControl {TEXTAREA} at (0,0) size 161x33554431 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,0) size 161x33554431 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 155x13

--- a/LayoutTests/platform/mac/fast/block/margin-collapse/103-expected.txt
+++ b/LayoutTests/platform/mac/fast/block/margin-collapse/103-expected.txt
@@ -167,17 +167,17 @@ layer at (441,302) size 180x13
 layer at (441,321) size 180x13
   RenderBlock {DIV} at (3,3) size 180x13
 layer at (113,750) size 506x106 clip at (114,751) size 504x104
-  RenderTextControl {TEXTAREA} at (0,476) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,476) size 506x107 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 500x13
 layer at (113,1037) size 506x106 clip at (114,1038) size 504x104
-  RenderTextControl {TEXTAREA} at (0,763) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,763) size 506x107 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 500x13
 layer at (113,1168) size 506x106 clip at (114,1169) size 504x104
-  RenderTextControl {TEXTAREA} at (0,894) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,894) size 506x107 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 500x13
 layer at (113,1299) size 506x106 clip at (114,1300) size 504x104
-  RenderTextControl {TEXTAREA} at (0,1025) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,1025) size 506x107 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 500x13
 layer at (113,1476) size 506x106 clip at (114,1477) size 504x104
-  RenderTextControl {TEXTAREA} at (0,1202) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,1202) size 506x107 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 500x13

--- a/LayoutTests/platform/mac/fast/dom/HTMLTextAreaElement/reset-textarea-expected.txt
+++ b/LayoutTests/platform/mac/fast/dom/HTMLTextAreaElement/reset-textarea-expected.txt
@@ -26,10 +26,10 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,54) size 176x18
           text run at (0,54) width 176: "hasDefaultText: SUCCESS"
 layer at (8,8) size 161x32 clip at (9,9) size 159x30
-  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 155x13
 layer at (173,8) size 161x32 clip at (174,9) size 159x30
-  RenderTextControl {TEXTAREA} at (165,0) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (165,0) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 155x13
       RenderText {#text} at (0,0) size 63x13
         text run at (0,0) width 63: "Default Text"

--- a/LayoutTests/platform/mac/fast/dynamic/008-expected.txt
+++ b/LayoutTests/platform/mac/fast/dynamic/008-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 785x672
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0
 layer at (8,8) size 301x656 clip at (9,9) size 299x654
-  RenderTextControl {TEXTAREA} at (0,0) size 301x656 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,0) size 301x656 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 295x13
       RenderText {#text} at (0,0) size 62x13
         text run at (0,0) width 62: "Sample text"

--- a/LayoutTests/platform/mac/fast/forms/basic-textareas-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/basic-textareas-expected.txt
@@ -214,7 +214,7 @@ layer at (0,0) size 785x1395
                       text run at (0,42) width 32: "wrap\","
                   RenderBR {BR} at (81,43) size 0x14
         layer at (1,73) size 161x32 clip at (2,74) size 159x30
-          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 155x13
               RenderText {#text} at (0,0) size 98x13
                 text run at (0,0) width 98: "Lorem ipsum dolor"
@@ -227,7 +227,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (327,57) size 177x48 clip at (328,58) size 160x46 scrollHeight 72
-          RenderTextControl {TEXTAREA} at (1,29) size 177x48 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 177x48 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (11,11) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -235,7 +235,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (506,77) size 157x28 clip at (507,78) size 140x26 scrollHeight 52
-          RenderTextControl {TEXTAREA} at (1,29) size 157x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 157x28 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (1,1) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -243,7 +243,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (11,178) size 161x32 clip at (12,179) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (11,39) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (11,39) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -251,7 +251,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (184,188) size 161x32 clip at (185,189) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -259,7 +259,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (347,188) size 66x32 clip at (348,189) size 49x30 scrollHeight 147
-          RenderTextControl {TEXTAREA} at (1,29) size 66x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 66x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 45x143
               RenderText {#text} at (0,0) size 44x143
                 text run at (0,0) width 36: "Lorem "
@@ -274,7 +274,7 @@ layer at (0,0) size 785x1395
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
         layer at (429,152) size 102x68 clip at (430,153) size 85x66 scrollHeight 183
-          RenderTextControl {TEXTAREA} at (1,43) size 102x68 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,43) size 102x68 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (21,21) size 45x143
               RenderText {#text} at (0,0) size 44x143
                 text run at (0,0) width 36: "Lorem "
@@ -289,7 +289,7 @@ layer at (0,0) size 785x1395
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
         layer at (533,192) size 62x28 clip at (534,193) size 45x26 scrollHeight 143
-          RenderTextControl {TEXTAREA} at (1,43) size 62x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,43) size 62x28 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (1,1) size 45x143
               RenderText {#text} at (0,0) size 44x143
                 text run at (0,0) width 36: "Lorem "
@@ -304,7 +304,7 @@ layer at (0,0) size 785x1395
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
         layer at (615,154) size 161x66 clip at (616,155) size 159x64
-          RenderTextControl {TEXTAREA} at (1,29) size 161x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 161x66 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 155x52
               RenderText {#text} at (0,0) size 155x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -312,7 +312,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 44: "VWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (1,281) size 66x66 clip at (2,282) size 49x64 scrollHeight 147
-          RenderTextControl {TEXTAREA} at (1,43) size 66x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,43) size 66x66 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 45x143
               RenderText {#text} at (0,0) size 44x143
                 text run at (0,0) width 36: "Lorem "
@@ -327,7 +327,7 @@ layer at (0,0) size 785x1395
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
         layer at (83,315) size 146x32 clip at (84,316) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,29) size 146x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 146x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -335,7 +335,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (231,300) size 161x47 clip at (232,301) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,29) size 161x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 161x47 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -343,7 +343,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (394,281) size 66x66 clip at (395,282) size 64x64 scrollHeight 134
-          RenderTextControl {TEXTAREA} at (1,57) size 66x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,57) size 66x66 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 60x130
               RenderText {#text} at (0,0) size 60x130
                 text run at (0,0) width 36: "Lorem "
@@ -357,7 +357,7 @@ layer at (0,0) size 785x1395
                 text run at (0,104) width 60: "klmnopqrst"
                 text run at (0,117) width 13: "uv"
         layer at (476,281) size 66x66 clip at (477,282) size 49x49 scrollHeight 147
-          RenderTextControl {TEXTAREA} at (1,57) size 66x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,57) size 66x66 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 45x143
               RenderText {#text} at (0,0) size 44x143
                 text run at (0,0) width 36: "Lorem "
@@ -372,7 +372,7 @@ layer at (0,0) size 785x1395
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
         layer at (558,281) size 66x66 clip at (559,282) size 49x64 scrollHeight 147
-          RenderTextControl {TEXTAREA} at (1,43) size 66x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,43) size 66x66 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 45x143
               RenderText {#text} at (0,0) size 44x143
                 text run at (0,0) width 36: "Lorem "
@@ -387,7 +387,7 @@ layer at (0,0) size 785x1395
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
         layer at (640,281) size 66x66 clip at (641,282) size 49x64 scrollHeight 147
-          RenderTextControl {TEXTAREA} at (1,43) size 66x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,43) size 66x66 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 45x143
               RenderText {#text} at (0,0) size 44x143
                 text run at (0,0) width 36: "Lorem "
@@ -402,7 +402,7 @@ layer at (0,0) size 785x1395
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
         layer at (1,408) size 66x66 clip at (2,409) size 49x64 scrollHeight 147
-          RenderTextControl {TEXTAREA} at (1,57) size 66x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,57) size 66x66 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 45x143
               RenderText {#text} at (0,0) size 44x143
                 text run at (0,0) width 36: "Lorem "
@@ -417,7 +417,7 @@ layer at (0,0) size 785x1395
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
         layer at (83,442) size 42x32 clip at (84,443) size 25x30 scrollHeight 329
-          RenderTextControl {TEXTAREA} at (1,15) size 42x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,15) size 42x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 21x325
               RenderText {#text} at (0,0) size 23x325
                 text run at (0,0) width 17: "Lor"
@@ -446,7 +446,7 @@ layer at (0,0) size 785x1395
                 text run at (0,299) width 21: "qrst"
                 text run at (0,312) width 13: "uv"
         layer at (165,429) size 161x45 clip at (166,430) size 144x43 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,15) size 161x45 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,15) size 161x45 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -454,7 +454,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (328,442) size 70x32 clip at (329,443) size 53x30 scrollHeight 147
-          RenderTextControl {TEXTAREA} at (1,15) size 70x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,15) size 70x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 49x143
               RenderText {#text} at (0,0) size 49x143
                 text run at (0,0) width 36: "Lorem "
@@ -469,7 +469,7 @@ layer at (0,0) size 785x1395
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
         layer at (410,377) size 161x97 clip at (411,378) size 159x95
-          RenderTextControl {TEXTAREA} at (1,15) size 161x97 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,15) size 161x97 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 155x52
               RenderText {#text} at (0,0) size 155x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -477,7 +477,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 44: "VWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (573,416) size 56x58 clip at (574,417) size 39x56 scrollHeight 186
-          RenderTextControl {TEXTAREA} at (1,29) size 56x58 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 56x58 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 35x182
               RenderText {#text} at (0,0) size 38x182
                 text run at (0,0) width 36: "Lorem "
@@ -495,12 +495,12 @@ layer at (0,0) size 785x1395
                 text run at (0,156) width 30: "mnop"
                 text run at (0,169) width 34: "qrstuv"
         layer at (1,507) size 161x32 clip at (2,508) size 144x15 scrollWidth 430 scrollHeight 17
-          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 155x13
               RenderText {#text} at (0,0) size 429x13
                 text run at (0,0) width 429: "Lorem ipsum  dolor ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuv"
         layer at (164,507) size 161x32 clip at (165,508) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -508,7 +508,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (327,507) size 161x32 clip at (328,508) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -516,7 +516,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (490,507) size 161x32 clip at (491,508) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 71: "Lorem ipsum "
@@ -525,12 +525,12 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (1,572) size 161x32 clip at (2,573) size 144x15 scrollWidth 430 scrollHeight 17
-          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 155x13
               RenderText {#text} at (0,0) size 429x13
                 text run at (0,0) width 429: "Lorem ipsum  dolor ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuv"
         layer at (164,572) size 161x32 clip at (165,573) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -538,13 +538,13 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (327,572) size 161x32 clip at (328,573) size 144x15 scrollWidth 427 scrollHeight 17
-          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 155x13
               RenderText {#text} at (0,0) size 426x13
                 text run at (0,0) width 71: "Lorem ipsum "
                 text run at (70,0) width 356: "dolor ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuv"
         layer at (490,572) size 161x32 clip at (491,573) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 71: "Lorem ipsum "
@@ -553,14 +553,14 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (1,665) size 161x32 clip at (2,666) size 144x15 scrollWidth 197 scrollHeight 43
-          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x39
               RenderText {#text} at (0,0) size 198x39
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
                 text run at (0,13) width 198: "ABCDEFGHIJKLMNOPQRSTUVWXYZ "
                 text run at (0,26) width 127: "abcdefghijklmnopqrstuv"
         layer at (164,665) size 161x32 clip at (165,666) size 144x15 scrollWidth 197 scrollHeight 43
-          RenderTextControl {TEXTAREA} at (1,57) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,57) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x39
               RenderText {#text} at (0,0) size 198x39
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -777,7 +777,7 @@ layer at (0,0) size 785x1395
                       text run at (0,42) width 32: "wrap\","
                   RenderBR {BR} at (81,43) size 0x14
         layer at (1,73) size 161x32 clip at (2,74) size 159x30
-          RenderTextControl {TEXTAREA} at (1,1) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,1) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 155x13
               RenderText {#text} at (0,0) size 98x13
                 text run at (0,0) width 98: "Lorem ipsum dolor"
@@ -790,7 +790,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (327,57) size 177x48 clip at (328,58) size 160x46 scrollHeight 72
-          RenderTextControl {TEXTAREA} at (1,29) size 177x48 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 177x48 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (11,11) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -798,7 +798,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (506,77) size 157x28 clip at (507,78) size 140x26 scrollHeight 52
-          RenderTextControl {TEXTAREA} at (1,29) size 157x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 157x28 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (1,1) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -806,7 +806,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (11,175) size 161x32 clip at (12,176) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (11,39) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (11,39) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -814,7 +814,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (184,185) size 161x32 clip at (185,186) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -822,7 +822,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (347,185) size 60x32 clip at (348,186) size 43x30 scrollHeight 173
-          RenderTextControl {TEXTAREA} at (1,29) size 60x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 60x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 39x169
               RenderText {#text} at (0,0) size 39x169
                 text run at (0,0) width 36: "Lorem "
@@ -839,7 +839,7 @@ layer at (0,0) size 785x1395
                 text run at (0,143) width 37: "nopqrs"
                 text run at (0,156) width 17: "tuv"
         layer at (429,149) size 60x68 clip at (430,150) size 43x66 scrollHeight 911
-          RenderTextControl {TEXTAREA} at (1,43) size 60x68 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,43) size 60x68 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (21,21) size 3x871
               RenderText {#text} at (0,0) size 11x871
                 text run at (0,0) width 7: "L"
@@ -910,7 +910,7 @@ layer at (0,0) size 785x1395
                 text run at (0,845) width 7: "u"
                 text run at (0,858) width 6: "v"
         layer at (511,189) size 60x28 clip at (512,190) size 43x26 scrollHeight 156
-          RenderTextControl {TEXTAREA} at (1,43) size 60x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,43) size 60x28 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (1,1) size 43x156
               RenderText {#text} at (0,0) size 44x156
                 text run at (0,0) width 36: "Lorem "
@@ -926,7 +926,7 @@ layer at (0,0) size 785x1395
                 text run at (0,130) width 41: "opqrstu"
                 text run at (0,143) width 7: "v"
         layer at (593,157) size 161x60 clip at (594,158) size 159x58
-          RenderTextControl {TEXTAREA} at (1,29) size 161x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 161x60 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 155x52
               RenderText {#text} at (0,0) size 155x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -934,7 +934,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 44: "VWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (1,275) size 60x60 clip at (2,276) size 43x58 scrollHeight 173
-          RenderTextControl {TEXTAREA} at (1,43) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,43) size 60x60 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 39x169
               RenderText {#text} at (0,0) size 39x169
                 text run at (0,0) width 36: "Lorem "
@@ -951,7 +951,7 @@ layer at (0,0) size 785x1395
                 text run at (0,143) width 37: "nopqrs"
                 text run at (0,156) width 17: "tuv"
         layer at (83,303) size 146x32 clip at (84,304) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,29) size 146x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 146x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -959,7 +959,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (231,288) size 161x47 clip at (232,289) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,29) size 161x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 161x47 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -967,7 +967,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (394,275) size 60x60 clip at (395,276) size 58x58 scrollHeight 134
-          RenderTextControl {TEXTAREA} at (1,57) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,57) size 60x60 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 54x130
               RenderText {#text} at (0,0) size 54x130
                 text run at (0,0) width 36: "Lorem "
@@ -981,7 +981,7 @@ layer at (0,0) size 785x1395
                 text run at (0,104) width 53: "jklmnopqr"
                 text run at (0,117) width 23: "stuv"
         layer at (476,275) size 60x60 clip at (477,276) size 43x43 scrollHeight 173
-          RenderTextControl {TEXTAREA} at (1,57) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,57) size 60x60 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 39x169
               RenderText {#text} at (0,0) size 39x169
                 text run at (0,0) width 36: "Lorem "
@@ -998,7 +998,7 @@ layer at (0,0) size 785x1395
                 text run at (0,143) width 37: "nopqrs"
                 text run at (0,156) width 17: "tuv"
         layer at (558,275) size 60x60 clip at (559,276) size 43x58 scrollHeight 173
-          RenderTextControl {TEXTAREA} at (1,43) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,43) size 60x60 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 39x169
               RenderText {#text} at (0,0) size 39x169
                 text run at (0,0) width 36: "Lorem "
@@ -1015,7 +1015,7 @@ layer at (0,0) size 785x1395
                 text run at (0,143) width 37: "nopqrs"
                 text run at (0,156) width 17: "tuv"
         layer at (640,275) size 60x60 clip at (641,276) size 43x58 scrollHeight 173
-          RenderTextControl {TEXTAREA} at (1,43) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,43) size 60x60 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 39x169
               RenderText {#text} at (0,0) size 39x169
                 text run at (0,0) width 36: "Lorem "
@@ -1032,7 +1032,7 @@ layer at (0,0) size 785x1395
                 text run at (0,143) width 37: "nopqrs"
                 text run at (0,156) width 17: "tuv"
         layer at (1,393) size 60x60 clip at (2,394) size 43x58 scrollHeight 173
-          RenderTextControl {TEXTAREA} at (1,57) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,57) size 60x60 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 39x169
               RenderText {#text} at (0,0) size 39x169
                 text run at (0,0) width 36: "Lorem "
@@ -1049,7 +1049,7 @@ layer at (0,0) size 785x1395
                 text run at (0,143) width 37: "nopqrs"
                 text run at (0,156) width 17: "tuv"
         layer at (83,421) size 42x32 clip at (84,422) size 25x30 scrollHeight 329
-          RenderTextControl {TEXTAREA} at (1,15) size 42x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,15) size 42x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 21x325
               RenderText {#text} at (0,0) size 23x325
                 text run at (0,0) width 17: "Lor"
@@ -1078,7 +1078,7 @@ layer at (0,0) size 785x1395
                 text run at (0,299) width 21: "qrst"
                 text run at (0,312) width 13: "uv"
         layer at (165,408) size 161x45 clip at (166,409) size 144x43 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,15) size 161x45 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,15) size 161x45 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -1086,7 +1086,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (328,421) size 70x32 clip at (329,422) size 53x30 scrollHeight 147
-          RenderTextControl {TEXTAREA} at (1,15) size 70x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,15) size 70x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 49x143
               RenderText {#text} at (0,0) size 49x143
                 text run at (0,0) width 36: "Lorem "
@@ -1101,7 +1101,7 @@ layer at (0,0) size 785x1395
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
         layer at (410,356) size 161x97 clip at (411,357) size 159x95
-          RenderTextControl {TEXTAREA} at (1,15) size 161x97 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,15) size 161x97 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 155x52
               RenderText {#text} at (0,0) size 155x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -1109,7 +1109,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 44: "VWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (573,395) size 56x58 clip at (574,396) size 39x56 scrollHeight 186
-          RenderTextControl {TEXTAREA} at (1,29) size 56x58 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 56x58 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 35x182
               RenderText {#text} at (0,0) size 38x182
                 text run at (0,0) width 36: "Lorem "
@@ -1127,12 +1127,12 @@ layer at (0,0) size 785x1395
                 text run at (0,156) width 30: "mnop"
                 text run at (0,169) width 34: "qrstuv"
         layer at (1,483) size 161x32 clip at (2,484) size 144x15 scrollWidth 430 scrollHeight 17
-          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 155x13
               RenderText {#text} at (0,0) size 429x13
                 text run at (0,0) width 429: "Lorem ipsum  dolor ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuv"
         layer at (164,483) size 161x32 clip at (165,484) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -1140,7 +1140,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (327,483) size 161x32 clip at (328,484) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -1148,7 +1148,7 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (490,483) size 161x32 clip at (491,484) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 71: "Lorem ipsum "
@@ -1157,12 +1157,12 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (1,545) size 161x32 clip at (2,546) size 144x15 scrollWidth 430 scrollHeight 17
-          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 155x13
               RenderText {#text} at (0,0) size 429x13
                 text run at (0,0) width 429: "Lorem ipsum  dolor ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuv"
         layer at (164,545) size 161x32 clip at (165,546) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -1170,13 +1170,13 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (327,545) size 161x32 clip at (328,546) size 144x15 scrollWidth 427 scrollHeight 17
-          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 155x13
               RenderText {#text} at (0,0) size 426x13
                 text run at (0,0) width 71: "Lorem ipsum "
                 text run at (70,0) width 356: "dolor ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuv"
         layer at (490,545) size 161x32 clip at (491,546) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 71: "Lorem ipsum "
@@ -1185,14 +1185,14 @@ layer at (0,0) size 785x1395
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         layer at (1,635) size 161x32 clip at (2,636) size 144x15 scrollWidth 197 scrollHeight 43
-          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x39
               RenderText {#text} at (0,0) size 198x39
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
                 text run at (0,13) width 198: "ABCDEFGHIJKLMNOPQRSTUVWXYZ "
                 text run at (0,26) width 127: "abcdefghijklmnopqrstuv"
         layer at (164,635) size 161x32 clip at (165,636) size 144x15 scrollWidth 197 scrollHeight 43
-          RenderTextControl {TEXTAREA} at (1,57) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderTextControl {TEXTAREA} at (1,57) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
             RenderBlock {DIV} at (3,3) size 140x39
               RenderText {#text} at (0,0) size 198x39
                 text run at (0,0) width 104: "Lorem ipsum  dolor "

--- a/LayoutTests/platform/mac/fast/forms/basic-textareas-quirks-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/basic-textareas-quirks-expected.txt
@@ -225,12 +225,12 @@ layer at (0,0) size 785x1018
             text run at (175,20) width 5: " "
             text run at (179,20) width 10: "B"
 layer at (24,24) size 161x32 clip at (25,25) size 159x30
-  RenderTextControl {TEXTAREA} at (14,1) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 162x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 155x13
       RenderText {#text} at (0,0) size 98x13
         text run at (0,0) width 98: "Lorem ipsum dolor"
 layer at (24,75) size 161x32 clip at (25,76) size 144x30 scrollHeight 56
-  RenderTextControl {TEXTAREA} at (14,1) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 162x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 140x52
       RenderText {#text} at (0,0) size 140x52
         text run at (0,0) width 101: "Lorem ipsum dolor "
@@ -246,7 +246,7 @@ layer at (24,126) size 161x32 clip at (25,127) size 144x30 scrollHeight 56
         text run at (0,26) width 59: "TUVWXYZ "
         text run at (0,39) width 130: "abcdefghijklmnopqrstuv "
 layer at (24,177) size 177x48 clip at (25,178) size 160x46 scrollHeight 72
-  RenderTextControl {TEXTAREA} at (14,1) size 178x48 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 178x48 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (11,11) size 140x52
       RenderText {#text} at (0,0) size 140x52
         text run at (0,0) width 101: "Lorem ipsum dolor "
@@ -254,7 +254,7 @@ layer at (24,177) size 177x48 clip at (25,178) size 160x46 scrollHeight 72
         text run at (0,26) width 59: "TUVWXYZ "
         text run at (0,39) width 130: "abcdefghijklmnopqrstuv "
 layer at (24,244) size 157x28 clip at (25,245) size 140x26 scrollHeight 52
-  RenderTextControl {TEXTAREA} at (14,1) size 158x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 158x28 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (1,1) size 140x52
       RenderText {#text} at (0,0) size 140x52
         text run at (0,0) width 101: "Lorem ipsum dolor "
@@ -262,7 +262,7 @@ layer at (24,244) size 157x28 clip at (25,245) size 140x26 scrollHeight 52
         text run at (0,26) width 59: "TUVWXYZ "
         text run at (0,39) width 130: "abcdefghijklmnopqrstuv "
 layer at (34,301) size 161x32 clip at (35,302) size 144x30 scrollHeight 56
-  RenderTextControl {TEXTAREA} at (24,11) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (24,11) size 162x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 140x52
       RenderText {#text} at (0,0) size 140x52
         text run at (0,0) width 101: "Lorem ipsum dolor "
@@ -270,7 +270,7 @@ layer at (34,301) size 161x32 clip at (35,302) size 144x30 scrollHeight 56
         text run at (0,26) width 59: "TUVWXYZ "
         text run at (0,39) width 130: "abcdefghijklmnopqrstuv "
 layer at (24,362) size 161x32 clip at (25,363) size 144x30 scrollHeight 56
-  RenderTextControl {TEXTAREA} at (14,1) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 162x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 140x52
       RenderText {#text} at (0,0) size 140x52
         text run at (0,0) width 101: "Lorem ipsum dolor "
@@ -278,7 +278,7 @@ layer at (24,362) size 161x32 clip at (25,363) size 144x30 scrollHeight 56
         text run at (0,26) width 59: "TUVWXYZ "
         text run at (0,39) width 130: "abcdefghijklmnopqrstuv "
 layer at (24,413) size 42x32 clip at (25,414) size 25x30 scrollHeight 329
-  RenderTextControl {TEXTAREA} at (14,1) size 43x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 43x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 21x325
       RenderText {#text} at (0,0) size 21x325
         text run at (0,0) width 17: "Lor"
@@ -307,7 +307,7 @@ layer at (24,413) size 42x32 clip at (25,414) size 25x30 scrollHeight 329
         text run at (0,299) width 21: "qrst"
         text run at (0,312) width 16: "uv "
 layer at (24,464) size 161x45 clip at (25,465) size 144x43 scrollHeight 56
-  RenderTextControl {TEXTAREA} at (14,1) size 162x45 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 162x45 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 140x52
       RenderText {#text} at (0,0) size 140x52
         text run at (0,0) width 101: "Lorem ipsum dolor "
@@ -315,7 +315,7 @@ layer at (24,464) size 161x45 clip at (25,465) size 144x43 scrollHeight 56
         text run at (0,26) width 59: "TUVWXYZ "
         text run at (0,39) width 130: "abcdefghijklmnopqrstuv "
 layer at (24,528) size 91x32 clip at (25,529) size 74x30 scrollHeight 95
-  RenderTextControl {TEXTAREA} at (14,1) size 92x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 92x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 70x91
       RenderText {#text} at (0,0) size 71x91
         text run at (0,0) width 71: "Lorem ipsum "
@@ -326,7 +326,7 @@ layer at (24,528) size 91x32 clip at (25,529) size 74x30 scrollHeight 95
         text run at (0,65) width 64: "abcdefghijkl"
         text run at (0,78) width 66: "mnopqrstuv "
 layer at (24,579) size 161x136 clip at (25,580) size 159x134
-  RenderTextControl {TEXTAREA} at (14,1) size 162x136 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 162x136 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 155x52
       RenderText {#text} at (0,0) size 155x52
         text run at (0,0) width 101: "Lorem ipsum dolor "
@@ -334,7 +334,7 @@ layer at (24,579) size 161x136 clip at (25,580) size 159x134
         text run at (0,26) width 44: "VWXYZ "
         text run at (0,39) width 130: "abcdefghijklmnopqrstuv "
 layer at (24,734) size 56x58 clip at (25,735) size 39x56 scrollHeight 186
-  RenderTextControl {TEXTAREA} at (14,1) size 57x58 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 57x58 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 35x182
       RenderText {#text} at (0,0) size 37x182
         text run at (0,0) width 36: "Lorem "
@@ -352,7 +352,7 @@ layer at (24,734) size 56x58 clip at (25,735) size 39x56 scrollHeight 186
         text run at (0,156) width 30: "mnop"
         text run at (0,169) width 37: "qrstuv "
 layer at (376,24) size 60x32 clip at (377,25) size 43x30 scrollHeight 173
-  RenderTextControl {TEXTAREA} at (14,1) size 61x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 61x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 39x169
       RenderText {#text} at (0,0) size 39x169
         text run at (0,0) width 36: "Lorem "
@@ -369,7 +369,7 @@ layer at (376,24) size 60x32 clip at (377,25) size 43x30 scrollHeight 173
         text run at (0,143) width 37: "nopqrs"
         text run at (0,156) width 20: "tuv "
 layer at (376,75) size 60x68 clip at (377,76) size 43x66 scrollHeight 924
-  RenderTextControl {TEXTAREA} at (14,1) size 61x68 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 61x68 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (21,21) size 3x884
       RenderText {#text} at (0,0) size 11x884
         text run at (0,0) width 7: "L"
@@ -441,7 +441,7 @@ layer at (376,75) size 60x68 clip at (377,76) size 43x66 scrollHeight 924
         text run at (0,858) width 6: "v"
         text run at (0,871) width 4: " "
 layer at (376,162) size 60x28 clip at (377,163) size 43x26 scrollHeight 156
-  RenderTextControl {TEXTAREA} at (14,1) size 61x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 61x28 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (1,1) size 43x156
       RenderText {#text} at (0,0) size 44x156
         text run at (0,0) width 36: "Lorem "
@@ -457,7 +457,7 @@ layer at (376,162) size 60x28 clip at (377,163) size 43x26 scrollHeight 156
         text run at (0,130) width 41: "opqrstu"
         text run at (0,143) width 10: "v "
 layer at (376,209) size 161x60 clip at (377,210) size 159x58
-  RenderTextControl {TEXTAREA} at (14,1) size 162x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 162x60 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 155x52
       RenderText {#text} at (0,0) size 155x52
         text run at (0,0) width 101: "Lorem ipsum dolor "
@@ -465,7 +465,7 @@ layer at (376,209) size 161x60 clip at (377,210) size 159x58
         text run at (0,26) width 44: "VWXYZ "
         text run at (0,39) width 130: "abcdefghijklmnopqrstuv "
 layer at (376,288) size 60x60 clip at (377,289) size 43x58 scrollHeight 173
-  RenderTextControl {TEXTAREA} at (14,1) size 61x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 61x60 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 39x169
       RenderText {#text} at (0,0) size 39x169
         text run at (0,0) width 36: "Lorem "
@@ -482,7 +482,7 @@ layer at (376,288) size 60x60 clip at (377,289) size 43x58 scrollHeight 173
         text run at (0,143) width 37: "nopqrs"
         text run at (0,156) width 20: "tuv "
 layer at (376,367) size 146x32 clip at (377,368) size 144x30 scrollHeight 56
-  RenderTextControl {TEXTAREA} at (14,1) size 147x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 147x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 140x52
       RenderText {#text} at (0,0) size 140x52
         text run at (0,0) width 101: "Lorem ipsum dolor "
@@ -490,7 +490,7 @@ layer at (376,367) size 146x32 clip at (377,368) size 144x30 scrollHeight 56
         text run at (0,26) width 59: "TUVWXYZ "
         text run at (0,39) width 130: "abcdefghijklmnopqrstuv "
 layer at (376,418) size 161x47 clip at (377,419) size 144x30 scrollHeight 56
-  RenderTextControl {TEXTAREA} at (14,1) size 162x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 162x47 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 140x52
       RenderText {#text} at (0,0) size 140x52
         text run at (0,0) width 101: "Lorem ipsum dolor "
@@ -498,7 +498,7 @@ layer at (376,418) size 161x47 clip at (377,419) size 144x30 scrollHeight 56
         text run at (0,26) width 59: "TUVWXYZ "
         text run at (0,39) width 130: "abcdefghijklmnopqrstuv "
 layer at (376,484) size 60x60 clip at (377,485) size 58x58 scrollHeight 134
-  RenderTextControl {TEXTAREA} at (14,1) size 61x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 61x60 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 54x130
       RenderText {#text} at (0,0) size 54x130
         text run at (0,0) width 36: "Lorem "
@@ -512,7 +512,7 @@ layer at (376,484) size 60x60 clip at (377,485) size 58x58 scrollHeight 134
         text run at (0,104) width 53: "jklmnopqr"
         text run at (0,117) width 26: "stuv "
 layer at (376,563) size 60x60 clip at (377,564) size 43x43 scrollHeight 173
-  RenderTextControl {TEXTAREA} at (14,1) size 61x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 61x60 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 39x169
       RenderText {#text} at (0,0) size 39x169
         text run at (0,0) width 36: "Lorem "
@@ -529,7 +529,7 @@ layer at (376,563) size 60x60 clip at (377,564) size 43x43 scrollHeight 173
         text run at (0,143) width 37: "nopqrs"
         text run at (0,156) width 20: "tuv "
 layer at (376,642) size 60x60 clip at (377,643) size 43x58 scrollHeight 173
-  RenderTextControl {TEXTAREA} at (14,1) size 61x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 61x60 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 39x169
       RenderText {#text} at (0,0) size 39x169
         text run at (0,0) width 36: "Lorem "
@@ -546,7 +546,7 @@ layer at (376,642) size 60x60 clip at (377,643) size 43x58 scrollHeight 173
         text run at (0,143) width 37: "nopqrs"
         text run at (0,156) width 20: "tuv "
 layer at (376,721) size 60x60 clip at (377,722) size 43x58 scrollHeight 173
-  RenderTextControl {TEXTAREA} at (14,1) size 61x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 61x60 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 39x169
       RenderText {#text} at (0,0) size 39x169
         text run at (0,0) width 36: "Lorem "
@@ -563,7 +563,7 @@ layer at (376,721) size 60x60 clip at (377,722) size 43x58 scrollHeight 173
         text run at (0,143) width 37: "nopqrs"
         text run at (0,156) width 20: "tuv "
 layer at (376,800) size 60x60 clip at (377,801) size 43x58 scrollHeight 173
-  RenderTextControl {TEXTAREA} at (14,1) size 61x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 61x60 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 39x169
       RenderText {#text} at (0,0) size 39x169
         text run at (0,0) width 36: "Lorem "
@@ -580,7 +580,7 @@ layer at (376,800) size 60x60 clip at (377,801) size 43x58 scrollHeight 173
         text run at (0,143) width 37: "nopqrs"
         text run at (0,156) width 20: "tuv "
 layer at (376,879) size 161x32 clip at (377,880) size 144x15 scrollWidth 186 scrollHeight 212
-  RenderTextControl {TEXTAREA} at (14,1) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 162x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 140x208
       RenderText {#text} at (0,0) size 185x195
         text run at (0,0) width 4: " "
@@ -615,7 +615,7 @@ layer at (376,879) size 161x32 clip at (377,880) size 144x15 scrollWidth 186 scr
         text run at (184,182) width 1: " "
       RenderBR {BR} at (0,195) size 0x13
 layer at (376,930) size 161x32 clip at (377,931) size 144x30 scrollHeight 394
-  RenderTextControl {TEXTAREA} at (14,1) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 162x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 140x390
       RenderText {#text} at (0,0) size 121x377
         text run at (0,0) width 4: " "
@@ -664,7 +664,7 @@ layer at (376,930) size 161x32 clip at (377,931) size 144x30 scrollHeight 394
         text run at (63,364) width 1: " "
       RenderBR {BR} at (0,377) size 0x13
 layer at (376,981) size 161x32 clip at (377,982) size 144x30 scrollHeight 394
-  RenderTextControl {TEXTAREA} at (14,1) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (14,1) size 162x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 140x390
       RenderText {#text} at (0,0) size 121x377
         text run at (0,0) width 4: " "

--- a/LayoutTests/platform/mac/fast/forms/form-element-geometry-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/form-element-geometry-expected.txt
@@ -246,7 +246,7 @@ layer at (16,244) size 72x13
     RenderText {#text} at (0,0) size 47x13
       text run at (0,0) width 47: "text field"
 layer at (386,241) size 161x32 clip at (387,242) size 159x30
-  RenderTextControl {TEXTAREA} at (2,2) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (2,2) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 155x13
       RenderText {#text} at (0,0) size 43x13
         text run at (0,0) width 43: "textarea"
@@ -255,7 +255,7 @@ layer at (39,457) size 72x13
     RenderText {#text} at (0,0) size 47x13
       text run at (0,0) width 47: "text field"
 layer at (360,436) size 161x32 clip at (361,437) size 159x30
-  RenderTextControl {TEXTAREA} at (351,0) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (351,0) size 162x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 155x13
       RenderText {#text} at (0,0) size 43x13
         text run at (0,0) width 43: "textarea"

--- a/LayoutTests/platform/mac/fast/forms/negativeLineHeight-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/negativeLineHeight-expected.txt
@@ -15,7 +15,7 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (400,204) size 0x18
         RenderBR {BR} at (0,218) size 0x18
 layer at (8,60) size 400x200 clip at (9,61) size 398x198
-  RenderTextControl {TEXTAREA} at (0,18) size 400x200 [bgcolor=#FFFFFF] [border: (1px dotted #C0C0C0)]
+  RenderTextControl {TEXTAREA} at (0,18) size 400x200 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px dotted #C0C0C0)]
     RenderBlock {DIV} at (3,3) size 394x32
       RenderText {#text} at (0,0) size 388x32
         text run at (0,0) width 388: "Demo text here that wraps a bit and should demonstrate "

--- a/LayoutTests/platform/mac/fast/forms/placeholder-position-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/placeholder-position-expected.txt
@@ -70,7 +70,7 @@ layer at (33,68) size 101x13
 layer at (33,68) size 101x13
   RenderBlock {DIV} at (0,0) size 101x13
 layer at (8,84) size 161x32 clip at (9,85) size 159x30
-  RenderTextControl {TEXTAREA} at (0,76) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,76) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 155x13
     RenderBlock {DIV} at (3,3) size 155x13 [color=#A9A9A9]
       RenderText {#text} at (0,0) size 62x13
@@ -82,7 +82,7 @@ layer at (11,119) size 142x13
 layer at (11,119) size 142x13
   RenderBlock {DIV} at (3,3) size 142x13
 layer at (8,149) size 161x45 clip at (9,150) size 159x43
-  RenderTextControl {TEXTAREA} at (0,141) size 161x45 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,141) size 161x45 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,16) size 155x13
     RenderBlock {DIV} at (3,16) size 155x13 [color=#A9A9A9]
       RenderText {#text} at (0,0) size 62x13

--- a/LayoutTests/platform/mac/fast/forms/textAreaLineHeight-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/textAreaLineHeight-expected.txt
@@ -50,13 +50,13 @@ layer at (0,0) size 785x1199
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,1191) size 769x0
 layer at (8,60) size 406x206 clip at (9,61) size 404x204
-  RenderTextControl {TEXTAREA} at (0,18) size 406x206 [bgcolor=#FFFFFF] [border: (1px dotted #C0C0C0)]
+  RenderTextControl {TEXTAREA} at (0,18) size 406x206 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px dotted #C0C0C0)]
     RenderBlock {DIV} at (3,3) size 400x106
       RenderText {#text} at (0,18) size 388x69
         text run at (0,18) width 388: "Demo text here that wraps a bit and should demonstrate "
         text run at (0,71) width 184: "the goodness of line-height"
 layer at (8,829) size 161x32 clip at (9,830) size 144x30 scrollHeight 56
-  RenderTextControl {TEXTAREA} at (0,54) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,54) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 140x52
       RenderText {#text} at (0,0) size 143x52
         text run at (0,0) width 143: "Demo text here that wraps "
@@ -64,8 +64,8 @@ layer at (8,829) size 161x32 clip at (9,830) size 144x30 scrollHeight 56
         text run at (0,26) width 90: "demonstrate the "
         text run at (0,39) width 125: "goodness of line-height"
 layer at (8,901) size 161x32 clip at (9,902) size 159x30
-  RenderTextControl {TEXTAREA} at (0,126) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,126) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 155x13
 layer at (8,973) size 406x206 clip at (9,974) size 404x204
-  RenderTextControl {TEXTAREA} at (0,198) size 406x206 [bgcolor=#FFFFFF] [border: (1px dotted #C0C0C0)]
+  RenderTextControl {TEXTAREA} at (0,198) size 406x206 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px dotted #C0C0C0)]
     RenderBlock {DIV} at (3,3) size 400x54

--- a/LayoutTests/platform/mac/fast/forms/textarea-align-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/textarea-align-expected.txt
@@ -15,27 +15,27 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {DIV} at (0,162) size 784x32
 layer at (8,42) size 371x32 clip at (9,43) size 369x30
-  RenderTextControl {TEXTAREA} at (0,0) size 371x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,0) size 371x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 365x13
       RenderText {#text} at (0,0) size 188x13
         text run at (0,0) width 188: "This is should be aligned to the left."
 layer at (8,74) size 371x32 clip at (9,75) size 369x30
-  RenderTextControl {TEXTAREA} at (0,32) size 371x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,32) size 371x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 365x13
       RenderText {#text} at (0,0) size 188x13
         text run at (0,0) width 188: "This is should be aligned to the left."
 layer at (8,106) size 371x32 clip at (9,107) size 369x30
-  RenderTextControl {TEXTAREA} at (0,64) size 371x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,64) size 371x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 365x13
       RenderText {#text} at (0,0) size 188x13
         text run at (0,0) width 188: "This is should be aligned to the left."
 layer at (8,138) size 371x32 clip at (9,139) size 369x30
-  RenderTextControl {TEXTAREA} at (0,96) size 371x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,96) size 371x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 365x13
       RenderText {#text} at (0,0) size 188x13
         text run at (0,0) width 188: "This is should be aligned to the left."
 layer at (8,170) size 371x32 clip at (9,171) size 369x30
-  RenderTextControl {TEXTAREA} at (0,0) size 371x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,0) size 371x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 365x13
       RenderText {#text} at (0,0) size 188x13
         text run at (0,0) width 188: "This is should be aligned to the left."

--- a/LayoutTests/platform/mac/fast/forms/textarea-placeholder-pseudo-style-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/textarea-placeholder-pseudo-style-expected.txt
@@ -14,7 +14,7 @@ layer at (0,0) size 800x600
         text run at (491,36) width 4: " "
       RenderText {#text} at (0,0) size 0x0
 layer at (8,26) size 161x32 clip at (9,27) size 159x30
-  RenderTextControl {TEXTAREA} at (0,18) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,18) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 155x13
     RenderBlock {DIV} at (3,3) size 155x13 [color=#640000]
       RenderText {#text} at (0,0) size 21x13
@@ -26,7 +26,7 @@ layer at (173,26) size 161x32 clip at (174,27) size 159x30
       RenderText {#text} at (0,0) size 68x13
         text run at (0,0) width 68: "disabled text"
 layer at (338,26) size 161x32 clip at (339,27) size 159x30
-  RenderTextControl {TEXTAREA} at (330,18) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (330,18) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 155x13
     RenderBlock {DIV} at (3,3) size 155x13 [color=#A9A9A9]
       RenderText {#text} at (0,0) size 37x13

--- a/LayoutTests/platform/mac/fast/forms/textarea-placeholder-visibility-1-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/textarea-placeholder-visibility-1-expected.txt
@@ -10,7 +10,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
 layer at (8,42) size 161x32 clip at (9,43) size 159x30
-  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 155x13
       RenderBR {BR} at (0,0) size 0x13
     RenderBlock {DIV} at (3,3) size 155x13 [color=#A9A9A9]

--- a/LayoutTests/platform/mac/fast/forms/textarea-placeholder-visibility-2-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/textarea-placeholder-visibility-2-expected.txt
@@ -10,7 +10,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
 layer at (8,42) size 161x32 clip at (9,43) size 159x30
-  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 155x13
     RenderBlock {DIV} at (3,3) size 155x13 [color=#A9A9A9]
       RenderText {#text} at (0,0) size 62x13

--- a/LayoutTests/platform/mac/fast/forms/textarea-scroll-height-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/textarea-scroll-height-expected.txt
@@ -8,7 +8,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (204,186) size 52x18
         text run at (204,186) width 52: "183 316"
 layer at (8,8) size 200x200 clip at (9,9) size 183x198 scrollHeight 316
-  RenderTextControl {TEXTAREA} at (0,0) size 200x200 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,0) size 200x200 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 179x312
       RenderText {#text} at (0,0) size 83x299
         text run at (0,0) width 83: "Lots of content."

--- a/LayoutTests/platform/mac/fast/forms/textarea-scrollbar-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/textarea-scrollbar-expected.txt
@@ -8,7 +8,7 @@ layer at (0,0) size 800x600
       RenderBR {BR} at (447,0) size 1x18
       RenderText {#text} at (0,0) size 0x0
 layer at (8,26) size 161x84 clip at (9,27) size 144x82 scrollHeight 121
-  RenderTextControl {TEXTAREA} at (0,18) size 161x84 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,18) size 161x84 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 140x117
       RenderText {#text} at (0,0) size 8x52
         text run at (0,0) width 6: "1"

--- a/LayoutTests/platform/mac/fast/forms/textarea-scrolled-type-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/textarea-scrolled-type-expected.txt
@@ -11,7 +11,7 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (161,101) size 0x18
       RenderBlock {DIV} at (0,115) size 784x0
 layer at (8,26) size 161x97 clip at (9,27) size 144x95 scrollY 182 scrollHeight 277
-  RenderTextControl {TEXTAREA} at (0,18) size 161x97 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,18) size 161x97 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 140x273
       RenderText {#text} at (0,0) size 40x260
         text run at (0,0) width 6: "1"

--- a/LayoutTests/platform/mac/fast/forms/textarea-setinnerhtml-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/textarea-setinnerhtml-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderText {#text} at (0,0) size 0x0
 layer at (8,8) size 161x32 clip at (9,9) size 159x30
-  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 155x13
       RenderText {#text} at (0,0) size 63x13
         text run at (0,0) width 63: "Test Passed"

--- a/LayoutTests/platform/mac/fast/hidpi/resize-corner-hidpi-expected.txt
+++ b/LayoutTests/platform/mac/fast/hidpi/resize-corner-hidpi-expected.txt
@@ -9,5 +9,5 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,18) size 784x32
         RenderText {#text} at (0,0) size 0x0
 layer at (8,26) size 161x32 clip at (9,27) size 159x30
-  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 155x13

--- a/LayoutTests/platform/mac/fast/overflow/overflow-x-y-expected.txt
+++ b/LayoutTests/platform/mac/fast/overflow/overflow-x-y-expected.txt
@@ -73,12 +73,12 @@ layer at (8,126) size 300x100 clip at (8,126) size 300x85 scrollWidth 1208
       text run at (495,0) width 332: "X scroll X scroll X scroll X scroll X scroll X scroll "
       text run at (826,0) width 383: "X scroll X scroll X scroll X scroll X scroll X scroll X scroll"
 layer at (8,241) size 161x32 clip at (9,242) size 144x30
-  RenderTextControl {TEXTAREA} at (0,15) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,15) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 140x13
       RenderText {#text} at (0,0) size 88x13
         text run at (0,0) width 88: "Textarea y-scroll"
 layer at (173,226) size 161x47 clip at (174,227) size 159x30
-  RenderTextControl {TEXTAREA} at (165,0) size 161x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (165,0) size 161x47 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 155x13
       RenderText {#text} at (0,0) size 88x13
         text run at (0,0) width 88: "Textarea x-scroll"

--- a/LayoutTests/platform/mac/fast/parser/entity-comment-in-textarea-expected.txt
+++ b/LayoutTests/platform/mac/fast/parser/entity-comment-in-textarea-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (161,18) size 255x18
         text run at (161,18) width 255: " --> This should be outside the textarea."
 layer at (8,8) size 161x32 clip at (9,9) size 159x30
-  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 155x13
       RenderText {#text} at (0,0) size 21x13
         text run at (0,0) width 21: "<!--"

--- a/LayoutTests/platform/mac/fast/parser/open-comment-in-textarea-expected.txt
+++ b/LayoutTests/platform/mac/fast/parser/open-comment-in-textarea-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (161,18) size 252x18
         text run at (161,18) width 252: " This should not be part of the textarea."
 layer at (8,8) size 161x32 clip at (9,9) size 144x30 scrollHeight 56
-  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 140x52
       RenderText {#text} at (0,0) size 139x39
         text run at (0,0) width 21: "<!--"

--- a/LayoutTests/platform/mac/fast/replaced/width100percent-textarea-expected.txt
+++ b/LayoutTests/platform/mac/fast/replaced/width100percent-textarea-expected.txt
@@ -28,21 +28,21 @@ layer at (0,0) size 800x600
               RenderText {#text} at (1,8) size 4x18
                 text run at (1,1) width 4: " "
 layer at (10,28) size 6x32 clip at (0,0) size 0x0 scrollWidth 9 scrollHeight 43
-  RenderTextControl {TEXTAREA} at (1,1) size 6x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (1,1) size 6x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 0x39
       RenderText {#text} at (0,0) size 7x39
         text run at (0,0) width 7: "o"
         text run at (0,13) width 7: "n"
         text run at (0,26) width 7: "e"
 layer at (19,28) size 6x32 clip at (0,0) size 0x0 scrollWidth 11 scrollHeight 43
-  RenderTextControl {TEXTAREA} at (1,1) size 6x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (1,1) size 6x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 0x39
       RenderText {#text} at (0,0) size 9x39
         text run at (0,0) width 5: "t"
         text run at (0,13) width 9: "w"
         text run at (0,26) width 7: "o"
 layer at (28,28) size 6x32 clip at (0,0) size 0x0 scrollWidth 9 scrollHeight 69
-  RenderTextControl {TEXTAREA} at (1,1) size 6x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (1,1) size 6x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 0x65
       RenderText {#text} at (0,0) size 7x65
         text run at (0,0) width 5: "t"
@@ -51,7 +51,7 @@ layer at (28,28) size 6x32 clip at (0,0) size 0x0 scrollWidth 9 scrollHeight 69
         text run at (0,39) width 7: "e"
         text run at (0,52) width 7: "e"
 layer at (10,100) size 6x32 clip at (0,0) size 0x0 scrollWidth 11 scrollHeight 173
-  RenderTextControl {TEXTAREA} at (1,1) size 6x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (1,1) size 6x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 0x169
       RenderText {#text} at (0,0) size 9x169
         text run at (0,0) width 7: "o"
@@ -68,14 +68,14 @@ layer at (10,100) size 6x32 clip at (0,0) size 0x0 scrollWidth 11 scrollHeight 1
         text run at (0,143) width 7: "e"
         text run at (0,156) width 7: "e"
 layer at (19,100) size 6x32 clip at (0,0) size 0x0 scrollWidth 11 scrollHeight 43
-  RenderTextControl {TEXTAREA} at (1,1) size 6x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (1,1) size 6x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 0x39
       RenderText {#text} at (0,0) size 9x39
         text run at (0,0) width 5: "t"
         text run at (0,13) width 9: "w"
         text run at (0,26) width 7: "o"
 layer at (28,100) size 6x32 clip at (0,0) size 0x0 scrollWidth 9 scrollHeight 69
-  RenderTextControl {TEXTAREA} at (1,1) size 6x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (1,1) size 6x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 0x65
       RenderText {#text} at (0,0) size 7x65
         text run at (0,0) width 5: "t"

--- a/LayoutTests/platform/mac/fast/table/003-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/003-expected.txt
@@ -71,5 +71,5 @@ layer at (0,0) size 800x600
 layer at (68,14) size 718x13
   RenderBlock {DIV} at (3,3) size 718x13
 layer at (14,233) size 161x36 clip at (15,234) size 159x34
-  RenderTextControl {TEXTAREA} at (2,2) size 161x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (2,2) size 161x36 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 155x13

--- a/LayoutTests/platform/mac/fast/text/international/rtl-white-space-pre-wrap-expected.txt
+++ b/LayoutTests/platform/mac/fast/text/international/rtl-white-space-pre-wrap-expected.txt
@@ -38,7 +38,7 @@ layer at (0,0) size 800x600
 layer at (8,94) size 784x2 clip at (0,0) size 0x0
   RenderBlock {HR} at (0,86) size 784x2 [color=#808080] [border: (1px inset #808080)]
 layer at (8,178) size 199x62 clip at (9,179) size 197x60
-  RenderTextControl {TEXTAREA} at (0,18) size 199x62 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,18) size 199x62 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 193x56
       RenderText {#text} at (-3,0) size 196x56
         text run at (-2,0) width 8 RTL: " "

--- a/LayoutTests/platform/mac/fast/text/international/unicode-bidi-plaintext-in-textarea-expected.txt
+++ b/LayoutTests/platform/mac/fast/text/international/unicode-bidi-plaintext-in-textarea-expected.txt
@@ -14,7 +14,7 @@ layer at (0,0) size 800x300
           RenderBR {BR} at (371,168) size 0x18
           RenderText {#text} at (0,0) size 0x0
 layer at (8,44) size 371x58 clip at (9,45) size 369x56
-  RenderTextControl {TEXTAREA} at (0,0) size 371x58 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,0) size 371x58 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 365x40
       RenderText {#text} at (0,0) size 365x27
         text run at (336,0) width 29 RTL: "\x{5E9}\x{5DC}\x{5D5}\x{5DD}!"
@@ -23,7 +23,7 @@ layer at (8,44) size 371x58 clip at (9,45) size 369x56
         text run at (28,14) width 1: " "
       RenderBR {BR} at (0,27) size 0x13
 layer at (8,106) size 371x58 clip at (9,107) size 369x56
-  RenderTextControl {TEXTAREA} at (0,62) size 371x58 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,62) size 371x58 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 365x40
       RenderText {#text} at (0,0) size 365x27
         text run at (336,0) width 29 RTL: "\x{5E9}\x{5DC}\x{5D5}\x{5DD}!"
@@ -32,7 +32,7 @@ layer at (8,106) size 371x58 clip at (9,107) size 369x56
         text run at (28,14) width 1: " "
       RenderBR {BR} at (0,27) size 0x13
 layer at (8,168) size 371x58 clip at (9,169) size 369x56
-  RenderTextControl {TEXTAREA} at (0,124) size 371x58 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,124) size 371x58 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 365x40
       RenderText {#text} at (0,0) size 365x27
         text run at (336,0) width 29 RTL: "\x{5E9}\x{5DC}\x{5D5}\x{5DD}!"
@@ -41,7 +41,7 @@ layer at (8,168) size 371x58 clip at (9,169) size 369x56
         text run at (28,14) width 1: " "
       RenderBR {BR} at (0,27) size 0x13
 layer at (8,230) size 371x58 clip at (9,231) size 369x56
-  RenderTextControl {TEXTAREA} at (0,186) size 371x58 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,186) size 371x58 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 365x40
       RenderText {#text} at (0,0) size 365x27
         text run at (336,0) width 29 RTL: "\x{5E9}\x{5DC}\x{5D5}\x{5DD}!"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug194024-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug194024-expected.txt
@@ -100,47 +100,47 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (20,2) size 742x36 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
             RenderTableCell {TD} at (764,18) size 16x4 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
 layer at (20,26) size 760x32 clip at (21,27) size 758x30
-  RenderTextControl {TEXTAREA} at (0,0) size 760x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,0) size 760x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 754x13
       RenderText {#text} at (0,0) size 21x13
         text run at (0,0) width 21: "test"
 layer at (20,76) size 760x32 clip at (21,77) size 758x30
-  RenderTextControl {TEXTAREA} at (0,0) size 760x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,0) size 760x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 754x13
       RenderText {#text} at (0,0) size 21x13
         text run at (0,0) width 21: "test"
 layer at (24,128) size 752x32 clip at (25,129) size 750x30
-  RenderTextControl {TEXTAREA} at (0,0) size 752x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,0) size 752x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 746x13
       RenderText {#text} at (0,0) size 21x13
         text run at (0,0) width 21: "test"
 layer at (24,182) size 752x32 clip at (25,183) size 750x30
-  RenderTextControl {TEXTAREA} at (0,0) size 752x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (0,0) size 752x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 746x13
       RenderText {#text} at (0,0) size 21x13
         text run at (0,0) width 21: "test"
 layer at (27,237) size 746x32 clip at (28,238) size 744x30
-  RenderTextControl {TEXTAREA} at (1,1) size 746x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (1,1) size 746x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 740x13
       RenderText {#text} at (0,0) size 21x13
         text run at (0,0) width 21: "test"
 layer at (27,293) size 746x32 clip at (28,294) size 744x30
-  RenderTextControl {TEXTAREA} at (1,1) size 746x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (1,1) size 746x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 740x13
       RenderText {#text} at (0,0) size 21x13
         text run at (0,0) width 21: "test"
 layer at (24,348) size 752x32 clip at (25,349) size 750x30
-  RenderTextControl {TEXTAREA} at (1,1) size 752x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (1,1) size 752x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 746x13
       RenderText {#text} at (0,0) size 21x13
         text run at (0,0) width 21: "test"
 layer at (27,403) size 746x32 clip at (28,404) size 744x30
-  RenderTextControl {TEXTAREA} at (2,2) size 746x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (2,2) size 746x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 740x13
       RenderText {#text} at (0,0) size 21x13
         text run at (0,0) width 21: "test"
 layer at (31,461) size 738x32 clip at (32,462) size 736x30
-  RenderTextControl {TEXTAREA} at (2,2) size 738x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (2,2) size 738x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 732x13
       RenderText {#text} at (0,0) size 21x13
         text run at (0,0) width 21: "test"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug30559-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug30559-expected.txt
@@ -17,7 +17,7 @@ layer at (0,0) size 800x600
                     RenderTableCell {TD} at (2,2) size 60x36 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (0,0) size 0x0
 layer at (260,36) size 56x32 clip at (261,37) size 54x30
-  RenderTextControl {TEXTAREA} at (2,2) size 56x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (2,2) size 56x32 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 50x13
       RenderText {#text} at (0,0) size 18x13
         text run at (0,0) width 18: "bar"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug30692-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug30692-expected.txt
@@ -43,14 +43,14 @@ layer at (0,0) size 800x600
 layer at (8,70) size 784x2 clip at (0,0) size 0x0
   RenderBlock {HR} at (0,26) size 784x2 [color=#808080] [border: (1px inset #808080)]
 layer at (11,92) size 622x76 clip at (12,93) size 620x74
-  RenderTextControl {TEXTAREA} at (1,10) size 623x76 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (1,10) size 623x76 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 617x13
       RenderText {#text} at (0,0) size 223x13
         text run at (0,0) width 223: "BUG: the height of the textarea is not 80%"
 layer at (8,188) size 784x2 clip at (0,0) size 0x0
   RenderBlock {HR} at (0,144) size 784x2 [color=#808080] [border: (1px inset #808080)]
 layer at (11,208) size 622x80 clip at (12,209) size 620x78
-  RenderTextControl {TEXTAREA} at (1,8) size 623x80 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+  RenderTextControl {TEXTAREA} at (1,8) size 623x80 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
     RenderBlock {DIV} at (3,3) size 617x13
       RenderText {#text} at (0,0) size 218x13
         text run at (0,0) width 218: "OK: the height of the textarea is 80 pixels"

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -708,8 +708,8 @@ input::-webkit-list-button {
 textarea {
     appearance: auto;
 #if !(defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
-    color: CanvasText;
-    background-color: Canvas;
+    color: FieldText;
+    background-color: Field;
     border: 1px solid;
     -webkit-rtl-ordering: logical;
     -webkit-user-select: text;


### PR DESCRIPTION
#### 12324ab7aa60c040b2d076a5e6e7e5f2c37d358c
<pre>
[CSS-Color] Make `textarea` have &apos;FieldText&apos; and &apos;Field&apos; for color and background-color

<a href="https://bugs.webkit.org/show_bug.cgi?id=292189">https://bugs.webkit.org/show_bug.cgi?id=292189</a>
<a href="https://rdar.apple.com/150196743">rdar://150196743</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Currently, in WebKit, we have set `color` and `background-color` for &apos;textarea&apos;
as &apos;CanvasText&apos; and &apos;Canvas&apos;, while as per web specification [1], it should be
&apos;FieldText&apos; and &apos;Field&apos;, so this patch fixes this issue and ensure that input
field use correct system colors.

[1] <a href="https://www.w3.org/TR/css-color-4/#css-system-colors">https://www.w3.org/TR/css-color-4/#css-system-colors</a>

* Source/WebCore/css/html.css:
(textarea):
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/system-color-consistency-expected.txt:
* LayoutTests/platform/mac/editing/input/cocoa/writing-suggestions-textarea-multiple-lines-expected.txt:
* LayoutTests/platform/mac/editing/input/reveal-caret-of-multiline-input-expected.txt:
* LayoutTests/platform/mac/editing/inserting/4960120-1-expected.txt:
* LayoutTests/platform/mac/editing/mac/spelling/autocorrection-at-beginning-of-word-1-expected.txt:
* LayoutTests/platform/mac/editing/mac/spelling/autocorrection-at-beginning-of-word-2-expected.txt:
* LayoutTests/platform/mac/editing/pasteboard/pasting-tabs-expected.txt:
* LayoutTests/platform/mac/fast/block/float/overhanging-tall-block-expected.txt:
* LayoutTests/platform/mac/fast/block/margin-collapse/103-expected.txt:
* LayoutTests/platform/mac/fast/dom/HTMLTextAreaElement/reset-textarea-expected.txt:
* LayoutTests/platform/mac/fast/dynamic/008-expected.txt:
* LayoutTests/platform/mac/fast/forms/basic-textareas-expected.txt:
* LayoutTests/platform/mac/fast/forms/basic-textareas-quirks-expected.txt:
* LayoutTests/platform/mac/fast/forms/form-element-geometry-expected.txt:
* LayoutTests/platform/mac/fast/forms/negativeLineHeight-expected.txt:
* LayoutTests/platform/mac/fast/forms/placeholder-position-expected.txt:
* LayoutTests/platform/mac/fast/forms/textarea-align-expected.txt:
* LayoutTests/platform/mac/fast/forms/textarea-placeholder-pseudo-style-expected.txt:
* LayoutTests/platform/mac/fast/forms/textarea-placeholder-visibility-1-expected.txt:
* LayoutTests/platform/mac/fast/forms/textarea-placeholder-visibility-2-expected.txt:
* LayoutTests/platform/mac/fast/forms/textarea-scroll-height-expected.txt:
* LayoutTests/platform/mac/fast/forms/textarea-scrollbar-expected.txt:
* LayoutTests/platform/mac/fast/forms/textarea-scrolled-type-expected.txt:
* LayoutTests/platform/mac/fast/forms/textarea-setinnerhtml-expected.txt:
* LayoutTests/platform/mac/fast/forms/textAreaLineHeight-expected.txt:
* LayoutTests/platform/mac/fast/hidpi/resize-corner-hidpi-expected.txt:
* LayoutTests/platform/mac/fast/overflow/overflow-x-y-expected.txt:
* LayoutTests/platform/mac/fast/parser/entity-comment-in-textarea-expected.txt:
* LayoutTests/platform/mac/fast/parser/open-comment-in-textarea-expected.txt:
* LayoutTests/platform/mac/fast/replaced/width100percent-textarea-expected.txt:
* LayoutTests/platform/mac/fast/table/003-expected.txt:
* LayoutTests/platform/mac/fast/text/international/rtl-white-space-pre-wrap-expected.txt:
* LayoutTests/platform/mac/fast/text/international/unicode-bidi-plaintext-in-textarea-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug194024-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug30559-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug30692-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12324ab7aa60c040b2d076a5e6e7e5f2c37d358c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135917 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79957 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f8254317-e186-461a-ac92-f4d554f8777c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130397 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/666 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97841 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65756 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/43c7331e-7145-4f62-9c81-4f5193cdbcb8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131473 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/538 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115153 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78453 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/23807faa-d304-4f15-88c2-a81c346a0109) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/485 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33257 "Found 44 new test failures: editing/input/reveal-caret-of-multiline-input.html editing/inserting/4960120-1.html editing/mac/spelling/autocorrection-at-beginning-of-word-1.html editing/mac/spelling/autocorrection-at-beginning-of-word-2.html editing/mac/spelling/delete-autocorrected-word-2.html editing/pasteboard/pasting-tabs.html fast/block/margin-collapse/103.html fast/dom/HTMLTextAreaElement/reset-textarea.html fast/dynamic/008.html fast/forms/form-element-geometry.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79200 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108908 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33740 "Found 43 new test failures: accessibility/mac/spellcheck-with-voiceover.html editing/input/cocoa/writing-suggestions-textarea-multiple-lines.html editing/input/reveal-caret-of-multiline-input.html editing/inserting/4960120-1.html editing/mac/spelling/autocorrection-at-beginning-of-word-1.html editing/mac/spelling/autocorrection-at-beginning-of-word-2.html editing/pasteboard/pasting-tabs.html fast/block/margin-collapse/103.html fast/dom/HTMLTextAreaElement/reset-textarea.html fast/dynamic/008.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138366 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/628 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/595 "Found 60 new test failures: accessibility/mac/spellcheck-with-voiceover.html css3/filters/backdrop/effect-hw.html editing/input/cocoa/writing-suggestions-textarea-multiple-lines.html editing/input/reveal-caret-of-multiline-input.html editing/inserting/4960120-1.html editing/mac/spelling/autocorrection-at-beginning-of-word-1.html editing/mac/spelling/autocorrection-at-beginning-of-word-2.html editing/pasteboard/pasting-tabs.html fast/block/margin-collapse/103.html fast/dom/HTMLTextAreaElement/reset-textarea.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106377 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/673 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111490 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106191 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/526 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30029 "Found 43 new test failures: accessibility/mac/spellcheck-with-voiceover.html editing/input/cocoa/writing-suggestions-textarea-multiple-lines.html editing/input/reveal-caret-of-multiline-input.html editing/inserting/4960120-1.html editing/mac/spelling/autocorrection-at-beginning-of-word-1.html editing/mac/spelling/autocorrection-at-beginning-of-word-2.html editing/pasteboard/pasting-tabs.html fast/block/margin-collapse/103.html fast/dom/HTMLTextAreaElement/reset-textarea.html fast/dynamic/008.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52966 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/685 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63887 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/567 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/628 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/639 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->