### PR TITLE
[JSC] Support cloning more DFG nodes for loop unrolling

### DIFF
--- a/JSTests/stress/loop-unrolling-variable-with-switch-char.js
+++ b/JSTests/stress/loop-unrolling-variable-with-switch-char.js
@@ -1,0 +1,30 @@
+function test(x) {
+    let sum = 0;
+    for (let i = 0; i < x.length; i++) {
+        switch (x[i]) {
+            case 'a':
+                sum += 1;
+                break;
+            case 'b':
+                sum += 2;
+                break;
+            case 'c':
+                sum += 3;
+                break;
+            default:
+                sum += 10;
+                break;
+        }
+    }
+    return sum;
+}
+noInline(test);
+
+let expected = 0;
+for (let i = 0; i < 1e5; i++) {
+    let res = test(['a', 'b', 'c', 'd']);
+    if (i == 0)
+        expected = res;
+    if (expected != res)
+        throw new Error("bad");
+}

--- a/JSTests/stress/loop-unrolling-variable-with-switch-imm.js
+++ b/JSTests/stress/loop-unrolling-variable-with-switch-imm.js
@@ -1,0 +1,30 @@
+function test(x) {
+    let sum = 0;
+    for (let i = 0; i < x; i++) {
+        switch (i) {
+            case 0:
+                sum += 1;
+                break;
+            case 1:
+                sum += 2;
+                break;
+            case 2:
+                sum += 3;
+                break;
+            default:
+                sum += 10;
+                break;
+        }
+    }
+    return sum;
+}
+noInline(test);
+
+let expected = 0;
+for (let i = 0; i < 1e5; i++) {
+    let res = test(4);
+    if (i == 0)
+        expected = res;
+    if (expected != res)
+        throw new Error("bad");
+}

--- a/JSTests/stress/loop-unrolling-variable-with-switch-string.js
+++ b/JSTests/stress/loop-unrolling-variable-with-switch-string.js
@@ -1,0 +1,30 @@
+function test(x) {
+    let sum = 0;
+    for (let i = 0; i < x.length; i++) {
+        switch (x[i]) {
+            case 'aa':
+                sum += 1;
+                break;
+            case 'bb':
+                sum += 2;
+                break;
+            case 'cc':
+                sum += 3;
+                break;
+            default:
+                sum += 10;
+                break;
+        }
+    }
+    return sum;
+}
+noInline(test);
+
+let expected = 0;
+for (let i = 0; i < 1e5; i++) {
+    let res = test(['aa', 'bb', 'cc', 'dd']);
+    if (i == 0)
+        expected = res;
+    if (expected != res)
+        throw new Error("bad");
+}

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.cpp
@@ -136,6 +136,14 @@ Node* CloneHelper::cloneNodeImpl(BasicBlock* into, Node* node)
             clone->child1() = cloneEdge(node->child1());
             return clone;
         }
+        case Switch: {
+            Node* clone = into->cloneAndAppend(m_graph, node);
+            SwitchData& cloneData = *m_graph.m_switchData.add();
+            cloneData = *clone->switchData();
+            clone->setOpInfo(OpInfo(&cloneData));
+            clone->child1() = cloneEdge(node->child1());
+            return clone;
+        }
         default:
             RELEASE_ASSERT_NOT_REACHED();
             return nullptr;

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.h
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.h
@@ -116,6 +116,8 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
 }
 
 #define FOR_EACH_NODE_CLONE_STATUS(CLONE_STATUS) \
+    CLONE_STATUS(AllocatePropertyStorage, Common) \
+    CLONE_STATUS(ArithAbs, Common) \
     CLONE_STATUS(ArithAdd, Common) \
     CLONE_STATUS(ArithBitAnd, Common) \
     CLONE_STATUS(ArithBitLShift, Common) \
@@ -123,47 +125,237 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
     CLONE_STATUS(ArithBitOr, Common) \
     CLONE_STATUS(ArithBitRShift, Common) \
     CLONE_STATUS(ArithBitXor, Common) \
+    CLONE_STATUS(ArithCeil, Common) \
+    CLONE_STATUS(ArithClz32, Common) \
     CLONE_STATUS(ArithDiv, Common) \
+    CLONE_STATUS(ArithF16Round, Common) \
+    CLONE_STATUS(ArithFloor, Common) \
+    CLONE_STATUS(ArithFRound, Common) \
+    CLONE_STATUS(ArithIMul, Common) \
+    CLONE_STATUS(ArithMax, Common) \
+    CLONE_STATUS(ArithMin, Common) \
     CLONE_STATUS(ArithMod, Common) \
     CLONE_STATUS(ArithMul, Common) \
+    CLONE_STATUS(ArithNegate, Common) \
+    CLONE_STATUS(ArithPow, Common) \
+    CLONE_STATUS(ArithRandom, Common) \
+    CLONE_STATUS(ArithRound, Common) \
+    CLONE_STATUS(ArithSqrt, Common) \
     CLONE_STATUS(ArithSub, Common) \
+    CLONE_STATUS(ArithTrunc, Common) \
+    CLONE_STATUS(ArithUnary, Common) \
+    CLONE_STATUS(ArrayIncludes, Common) \
+    CLONE_STATUS(ArrayIndexOf, Common) \
+    CLONE_STATUS(ArrayPop, Common) \
+    CLONE_STATUS(ArrayPush, Common) \
+    CLONE_STATUS(ArraySlice, Common) \
+    CLONE_STATUS(ArraySplice, Common) \
+    CLONE_STATUS(Arrayify, Common) \
     CLONE_STATUS(ArrayifyToStructure, Common) \
     CLONE_STATUS(AssertNotEmpty, Common) \
     CLONE_STATUS(BitURShift, Common) \
+    CLONE_STATUS(BooleanToNumber, Common) \
+    CLONE_STATUS(BottomValue, Common) \
     CLONE_STATUS(Branch, Special) \
+    CLONE_STATUS(Call, Common) \
+    CLONE_STATUS(CallCustomAccessorGetter, Common) \
+    CLONE_STATUS(CallDirectEval, Common) \
+    CLONE_STATUS(CallVarargs, Common) \
     CLONE_STATUS(Check, Common) \
     CLONE_STATUS(CheckArray, Common) \
+    CLONE_STATUS(CheckBadValue, Common) \
+    CLONE_STATUS(CheckIdent, Common) \
+    CLONE_STATUS(CheckIsConstant, Common) \
+    CLONE_STATUS(CheckNotEmpty, Common) \
     CLONE_STATUS(CheckStructure, Common) \
+    CLONE_STATUS(CheckStructureOrEmpty, Common) \
     CLONE_STATUS(CheckVarargs, Common) \
+    CLONE_STATUS(CompareBelow, Common) \
+    CLONE_STATUS(CompareBelowEq, Common) \
     CLONE_STATUS(CompareEq, Common) \
+    CLONE_STATUS(CompareEqPtr, Common) \
     CLONE_STATUS(CompareGreater, Common) \
     CLONE_STATUS(CompareGreaterEq, Common) \
     CLONE_STATUS(CompareLess, Common) \
     CLONE_STATUS(CompareLessEq, Common) \
     CLONE_STATUS(CompareStrictEq, Common) \
+    CLONE_STATUS(ConstantStoragePointer, Common) \
+    CLONE_STATUS(Construct, Common) \
+    CLONE_STATUS(ConstructVarargs, Common) \
+    CLONE_STATUS(CreateActivation, Common) \
+    CLONE_STATUS(CreateDirectArguments, Common) \
+    CLONE_STATUS(CreateRest, Common) \
+    CLONE_STATUS(DataViewGetByteLength, Common) \
+    CLONE_STATUS(DataViewGetByteLengthAsInt52, Common) \
+    CLONE_STATUS(DataViewGetFloat, Common) \
+    CLONE_STATUS(DataViewGetInt, Common) \
+    CLONE_STATUS(DataViewSet, Common) \
+    CLONE_STATUS(DateGetTime, Common) \
+    CLONE_STATUS(DateSetTime, Common) \
+    CLONE_STATUS(Dec, Common) \
+    CLONE_STATUS(DeleteById, Common) \
+    CLONE_STATUS(DirectCall, Common) \
+    CLONE_STATUS(DirectConstruct, Common) \
+    CLONE_STATUS(DirectTailCallInlinedCaller, Common) \
+    CLONE_STATUS(DoubleAsInt32, Common) \
+    CLONE_STATUS(DoubleConstant, Common) \
     CLONE_STATUS(DoubleRep, Common) \
+    CLONE_STATUS(EnumeratorGetByVal, Common) \
+    CLONE_STATUS(EnumeratorHasOwnProperty, Common) \
+    CLONE_STATUS(EnumeratorNextUpdateIndexAndMode, Common) \
+    CLONE_STATUS(EnumeratorNextUpdatePropertyName, Common) \
+    CLONE_STATUS(EnumeratorPutByVal, Common) \
     CLONE_STATUS(ExitOK, Common) \
+    CLONE_STATUS(ExtractFromTuple, Common) \
     CLONE_STATUS(FilterCallLinkStatus, Common) \
+    CLONE_STATUS(FilterGetByStatus, Common) \
+    CLONE_STATUS(FilterInByStatus, Common) \
+    CLONE_STATUS(FilterPutByStatus, Common) \
     CLONE_STATUS(Flush, Common) \
+    CLONE_STATUS(GetArrayLength, Common) \
     CLONE_STATUS(GetButterfly, Common) \
+    CLONE_STATUS(GetById, Common) \
+    CLONE_STATUS(GetByIdFlush, Common) \
+    CLONE_STATUS(GetByIdMegamorphic, Common) \
+    CLONE_STATUS(GetByIdWithThis, Common) \
+    CLONE_STATUS(GetByIdWithThisMegamorphic, Common) \
+    CLONE_STATUS(GetByOffset, Common) \
     CLONE_STATUS(GetByVal, Common) \
+    CLONE_STATUS(GetByValMegamorphic, Common) \
+    CLONE_STATUS(GetByValWithThis, Common) \
+    CLONE_STATUS(GetByValWithThisMegamorphic, Common) \
+    CLONE_STATUS(GetClosureVar, Common) \
+    CLONE_STATUS(GetExecutable, Common) \
+    CLONE_STATUS(GetGlobalLexicalVariable, Common) \
+    CLONE_STATUS(GetGlobalVar, Common) \
+    CLONE_STATUS(GetIndexedPropertyStorage, Common) \
+    CLONE_STATUS(GetInternalField, Common) \
     CLONE_STATUS(GetLocal, Common) \
+    CLONE_STATUS(GetPropertyEnumerator, Common) \
+    CLONE_STATUS(GetPrototypeOf, Common) \
+    CLONE_STATUS(GetRegExpObjectLastIndex, Common) \
+    CLONE_STATUS(GetRestLength, Common) \
+    CLONE_STATUS(GetScope, Common) \
+    CLONE_STATUS(GetUndetachedTypeArrayLength, Common) \
+    CLONE_STATUS(GlobalIsNaN, Common) \
+    CLONE_STATUS(HasOwnProperty, Common) \
+    CLONE_STATUS(HasIndexedProperty, Common) \
+    CLONE_STATUS(InById, Common) \
+    CLONE_STATUS(InByVal, Common) \
+    CLONE_STATUS(InByValMegamorphic, Common) \
+    CLONE_STATUS(Inc, Common) \
+    CLONE_STATUS(InstanceOf, Common) \
+    CLONE_STATUS(InstanceOfCustom, Common) \
+    CLONE_STATUS(InstanceOfMegamorphic, Common) \
+    CLONE_STATUS(Int52Constant, Common) \
+    CLONE_STATUS(Int52Rep, Common) \
     CLONE_STATUS(InvalidationPoint, Common) \
+    CLONE_STATUS(IsCellWithType, Common) \
+    CLONE_STATUS(IsEmptyStorage, Common) \
+    CLONE_STATUS(IsNumber, Common) \
+    CLONE_STATUS(IsObject, Common) \
     CLONE_STATUS(JSConstant, Common) \
     CLONE_STATUS(Jump, Common) \
+    CLONE_STATUS(LoadMapValue, Common) \
+    CLONE_STATUS(LoadVarargs, Common) \
+    CLONE_STATUS(LogicalNot, Common) \
     CLONE_STATUS(LoopHint, Common) \
+    CLONE_STATUS(MakeAtomString, Common) \
+    CLONE_STATUS(MakeRope, Common) \
+    CLONE_STATUS(MapGet, Common) \
+    CLONE_STATUS(MapHash, Common) \
+    CLONE_STATUS(MapIteratorKey, Common) \
+    CLONE_STATUS(MapIteratorNext, Common) \
+    CLONE_STATUS(MapIteratorValue, Common) \
+    CLONE_STATUS(MapSet, Common) \
+    CLONE_STATUS(MatchStructure, Common) \
     CLONE_STATUS(MovHint, Common) \
+    CLONE_STATUS(MultiGetByOffset, Common) \
+    CLONE_STATUS(MultiPutByOffset, Common) \
+    CLONE_STATUS(NewArray, Common) \
+    CLONE_STATUS(NewArrayBuffer, Common) \
     CLONE_STATUS(NewArrayWithConstantSize, Common) \
     CLONE_STATUS(NewArrayWithSize, Common) \
+    CLONE_STATUS(NewArrayWithSpread, Common) \
+    CLONE_STATUS(NewFunction, Common) \
+    CLONE_STATUS(NewInternalFieldObject, Common) \
+    CLONE_STATUS(NewMap, Common) \
+    CLONE_STATUS(NewObject, Common) \
+    CLONE_STATUS(NewRegExp, Common) \
+    CLONE_STATUS(NewRegExpUntyped, Common) \
+    CLONE_STATUS(NewSet, Common) \
+    CLONE_STATUS(NormalizeMapKey, Common) \
+    CLONE_STATUS(NumberToStringWithValidRadixConstant, Common) \
+    CLONE_STATUS(NukeStructureAndSetButterfly, Common) \
+    CLONE_STATUS(ObjectAssign, Common) \
+    CLONE_STATUS(ObjectKeys, Common) \
+    CLONE_STATUS(ObjectToString, Common) \
+    CLONE_STATUS(ParseInt, Common) \
     CLONE_STATUS(PhantomLocal, Common) \
     CLONE_STATUS(Phi, PreCloned) \
     CLONE_STATUS(PurifyNaN, Common) \
+    CLONE_STATUS(PutById, Common) \
+    CLONE_STATUS(PutByIdFlush, Common) \
+    CLONE_STATUS(PutByIdMegamorphic, Common) \
+    CLONE_STATUS(PutByIdWithThis, Common) \
+    CLONE_STATUS(PutByOffset, Common) \
     CLONE_STATUS(PutByVal, Common) \
     CLONE_STATUS(PutByValAlias, Common) \
+    CLONE_STATUS(PutByValDirect, Common) \
+    CLONE_STATUS(PutByValWithThis, Common) \
+    CLONE_STATUS(PutClosureVar, Common) \
+    CLONE_STATUS(PutGlobalVariable, Common) \
+    CLONE_STATUS(PutInternalField, Common) \
+    CLONE_STATUS(PutStructure, Common) \
+    CLONE_STATUS(ReallocatePropertyStorage, Common) \
+    CLONE_STATUS(RegExpTest, Common) \
+    CLONE_STATUS(RegExpTestInline, Common) \
+    CLONE_STATUS(ResolveRope, Common) \
+    CLONE_STATUS(SameValue, Common) \
+    CLONE_STATUS(SetAdd, Common) \
+    CLONE_STATUS(SetArgumentCountIncludingThis, Common) \
     CLONE_STATUS(SetArgumentDefinitely, Common) \
+    CLONE_STATUS(SetArgumentMaybe, Common) \
+    CLONE_STATUS(SetCallee, Common) \
     CLONE_STATUS(SetLocal, Common) \
+    CLONE_STATUS(SkipScope, Common) \
+    CLONE_STATUS(Spread, Common) \
+    CLONE_STATUS(StringCharAt, Common) \
+    CLONE_STATUS(StringCharCodeAt, Common) \
+    CLONE_STATUS(StringCodePointAt, Common) \
+    CLONE_STATUS(StringFromCharCode, Common) \
+    CLONE_STATUS(StringIndexOf, Common) \
+    CLONE_STATUS(StringLocaleCompare, Common) \
+    CLONE_STATUS(StringReplace, Common) \
+    CLONE_STATUS(StringReplaceString, Common) \
+    CLONE_STATUS(StringSlice, Common) \
+    CLONE_STATUS(StringSubstring, Common) \
+    CLONE_STATUS(StrCat, Common) \
+    CLONE_STATUS(Switch, Special) \
+    CLONE_STATUS(TailCallForwardVarargsInlinedCaller, Common) \
+    CLONE_STATUS(TailCallInlinedCaller, Common) \
+    CLONE_STATUS(TailCallVarargsInlinedCaller, Common) \
+    CLONE_STATUS(ToLength, Common) \
+    CLONE_STATUS(ToLowerCase, Common) \
+    CLONE_STATUS(ToPrimitive, Common) \
+    CLONE_STATUS(ToString, Common) \
+    CLONE_STATUS(ToThis, Common) \
+    CLONE_STATUS(TypeOf, Common) \
+    CLONE_STATUS(TypeOfIsFunction, Common) \
+    CLONE_STATUS(TypeOfIsObject, Common) \
+    CLONE_STATUS(TypeOfIsUndefined, Common) \
+    CLONE_STATUS(UInt32ToNumber, Common) \
+    CLONE_STATUS(ValueAdd, Common) \
+    CLONE_STATUS(ValueBitAnd, Common) \
+    CLONE_STATUS(ValueBitLShift, Common) \
+    CLONE_STATUS(ValueBitOr, Common) \
+    CLONE_STATUS(ValueBitRShift, Common) \
+    CLONE_STATUS(ValueBitXor, Common) \
+    CLONE_STATUS(ValueNegate, Common) \
     CLONE_STATUS(ValueRep, Common) \
+    CLONE_STATUS(ValueSub, Common) \
     CLONE_STATUS(ValueToInt32, Common) \
+    CLONE_STATUS(VarargsLength, Common) \
     CLONE_STATUS(ZombieHint, Common)
 
 } } // namespace JSC::DFG


### PR DESCRIPTION
#### 3eb35821ddf0e2e9ee5688279012456b12c48ba9
<pre>
[JSC] Support cloning more DFG nodes for loop unrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=292193">https://bugs.webkit.org/show_bug.cgi?id=292193</a>
<a href="https://rdar.apple.com/150201404">rdar://150201404</a>

Reviewed by Yusuke Suzuki.

To support broader loop unrolling opportunities in DFG, we extend CloneHelper
to clone more types of nodes. This patch updates cloneNodeImpl to handle
additional node types and expands the FOR_EACH_NODE_CLONE_STATUS list accordingly.

* JSTests/stress/loop-unrolling-variable-with-switch-char.js: Added.
(test):
* JSTests/stress/loop-unrolling-variable-with-switch-imm.js: Added.
(test):
* JSTests/stress/loop-unrolling-variable-with-switch-string.js: Added.
(test):
* Source/JavaScriptCore/dfg/DFGCloneHelper.cpp:
(JSC::DFG::CloneHelper::cloneNodeImpl):
* Source/JavaScriptCore/dfg/DFGCloneHelper.h:

Canonical link: <a href="https://commits.webkit.org/294222@main">https://commits.webkit.org/294222@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2228771d7f3b9a24a44d8700fdf90e9d07dfab8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20786 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11089 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106272 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51751 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29280 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77031 "Found 1 new test failure: fast/css/view-transitions-nested-transparency-layers.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34055 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104131 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16253 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91349 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57378 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16070 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9372 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51099 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/93791 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85975 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9432 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108628 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/99733 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28252 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20805 "Found 2 new test failures: http/tests/iframe-monitor/just-use-eligible-subresource.html http/tests/iframe-monitor/workers/service-worker.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85999 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28614 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85536 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21778 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30254 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7988 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22351 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28182 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33451 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/123359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27994 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/123359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31314 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29552 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->