### PR TITLE
SVG Image art work might not be ready when given to MediaSession

### DIFF
--- a/LayoutTests/fast/mediasession/metadata/artworkdownload-svg-expected.html
+++ b/LayoutTests/fast/mediasession/metadata/artworkdownload-svg-expected.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<style>
+img {
+  width: 200px;
+  height: 200px;
+  background-color: red;
+}
+</style>
+<img src="../../../svg/as-image/resources/image-with-nested-rects.svg">

--- a/LayoutTests/fast/mediasession/metadata/artworkdownload-svg.html
+++ b/LayoutTests/fast/mediasession/metadata/artworkdownload-svg.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<img id=result src="" style="image-rendering: pixelated;">
+<script>
+if (window.internals && window.testRunner) {
+  testRunner.waitUntilDone();
+
+  const canvas = document.createElement('canvas');
+  canvas.width = 200;
+  canvas.height = 200;
+  const context = canvas.getContext('2d');
+
+  context.fillStyle = "red";
+  context.fillRect(0, 0, canvas.width, canvas.height);
+
+  internals.loadArtworkImage("../../../svg/as-image/resources/image-with-nested-data-uri-images.svg").then(data => {
+    context.drawImage(data, 0, 0);
+    const image = document.getElementById("result");
+    image.src = canvas.toDataURL();
+    image.onload = () => testRunner.notifyDone();
+  });
+}
+</script>

--- a/LayoutTests/fast/mediasession/metadata/artworkdownload.html
+++ b/LayoutTests/fast/mediasession/metadata/artworkdownload.html
@@ -11,8 +11,8 @@ promise_test((test) => {
     if (!window.internals)
         return Promise.rejects("Test needs internals");
     return internals.loadArtworkImage(IMAGE_SRC).then((data) => {
-        assert_equals(data.width, 16);
-        assert_equals(data.height, 16);
+        assert_equals(data.codedWidth, 16);
+        assert_equals(data.codedHeight, 16);
     });
 }, "ensure loading artwork image method operates properly");
 

--- a/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
@@ -83,7 +83,10 @@ void ArtworkImageLoader::notifyFinished(CachedResource& resource, const NetworkL
         m_callback(nullptr);
         return;
     }
-    m_callback(m_cachedImage->image());
+    Ref image = *m_cachedImage->image();
+    image->subresourcesAreFinished(nullptr, [image, callback = std::exchange(m_callback, { })]() mutable {
+        callback(image.ptr());
+    });
 }
 
 ExceptionOr<Ref<MediaMetadata>> MediaMetadata::create(ScriptExecutionContext& context, std::optional<MediaMetadataInit>&& init)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -333,6 +333,11 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutio
     return WebCodecsVideoFrame::create(context, videoFrame.releaseNonNull(), WTFMove(init));
 }
 
+ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutionContext& context, Ref<NativeImage>&& image)
+{
+    return initializeFrameWithResourceAndSize(context, WTFMove(image), { });
+}
+
 Ref<WebCodecsVideoFrame> WebCodecsVideoFrame::create(ScriptExecutionContext& context, Ref<VideoFrame>&& videoFrame, BufferInit&& init)
 {
     ASSERT(isValidVideoFrameBufferInit(init));

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
@@ -101,6 +101,7 @@ public:
     static ExceptionOr<Ref<WebCodecsVideoFrame>> create(ScriptExecutionContext&, Ref<WebCodecsVideoFrame>&&, Init&&);
     static ExceptionOr<Ref<WebCodecsVideoFrame>> create(ScriptExecutionContext&, BufferSource&&, BufferInit&&);
     static ExceptionOr<Ref<WebCodecsVideoFrame>> create(ScriptExecutionContext&, ImageBuffer&, IntSize, Init&&);
+    WEBCORE_EXPORT static ExceptionOr<Ref<WebCodecsVideoFrame>> create(ScriptExecutionContext&, Ref<NativeImage>&&);
     static Ref<WebCodecsVideoFrame> create(ScriptExecutionContext&, Ref<VideoFrame>&&, BufferInit&&);
     static Ref<WebCodecsVideoFrame> create(ScriptExecutionContext& context, WebCodecsVideoFrameData&& data) { return adoptRef(*new WebCodecsVideoFrame(context, WTFMove(data))); }
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.idl
@@ -38,6 +38,7 @@ typedef (HTMLImageElement
 
 // FIXME: Support Serializable and Transferable.
 [
+    ExportMacro=WEBCORE_EXPORT,
     Conditional=WEB_CODECS,
     EnabledBySetting=WebCodecsVideoEnabled,
     Exposed=(Window,DedicatedWorker),

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -108,7 +108,6 @@ rendering/updating/RenderTreeUpdater.cpp
 style/Styleable.cpp
 style/values/StyleValueTypes.h
 style/values/images/StyleGradient.cpp
-testing/Internals.cpp
 testing/MockMediaSessionCoordinator.cpp
 workers/Worker.cpp
 workers/WorkerMessagingProxy.cpp

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -187,6 +187,7 @@ class PlatformSpeechSynthesizerMock;
 #endif
 
 #if ENABLE(WEB_CODECS)
+class WebCodecsVideoFrame;
 class WebCodecsVideoDecoder;
 #endif
 
@@ -1459,7 +1460,7 @@ public:
     ExceptionOr<double> currentMediaSessionPosition(const MediaSession&);
     ExceptionOr<void> sendMediaSessionAction(MediaSession&, const MediaSessionActionDetails&);
 
-        using ArtworkImagePromise = DOMPromiseDeferred<IDLInterface<ImageData>>;
+    using ArtworkImagePromise = DOMPromiseDeferred<IDLInterface<WebCodecsVideoFrame>>;
     void loadArtworkImage(String&&, ArtworkImagePromise&&);
     ExceptionOr<Vector<String>> platformSupportedCommands() const;
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1379,7 +1379,7 @@ enum ContentsFormat {
 
     [Conditional=MEDIA_SESSION] double currentMediaSessionPosition(MediaSession session);
     [Conditional=MEDIA_SESSION] undefined sendMediaSessionAction(MediaSession session, MediaSessionActionDetails actionDetails);
-    [Conditional=MEDIA_SESSION] Promise<ImageData> loadArtworkImage(DOMString url);
+    [Conditional=MEDIA_SESSION] Promise<WebCodecsVideoFrame> loadArtworkImage(DOMString url);
     [Conditional=MEDIA_SESSION] sequence<DOMString> platformSupportedCommands();
 
     [Conditional=MEDIA_SESSION_COORDINATOR, CallWith=CurrentScriptExecutionContext] undefined registerMockMediaSessionCoordinator(StringCallback callback);


### PR DESCRIPTION
#### eb5cdf97ac212fe34e17ae8aa5d5e5f015cdabbe
<pre>
SVG Image art work might not be ready when given to MediaSession
<a href="https://bugs.webkit.org/show_bug.cgi?id=290615">https://bugs.webkit.org/show_bug.cgi?id=290615</a>
<a href="https://rdar.apple.com/148089535">rdar://148089535</a>

Reviewed by Youenn Fablet.

* LayoutTests/fast/mediasession/metadata/artworkdownload-svg-expected.html: Added.
* LayoutTests/fast/mediasession/metadata/artworkdownload-svg.html: Added.

Make sure SVG image has the correct pixels. Use pixelated rendering for
iOS to account for a slight difference in rendering.

* LayoutTests/fast/mediasession/metadata/artworkdownload.html:

Modify existing test to account for it now getting a VideoFrame.

* Source/WebCore/Modules/mediasession/MediaMetadata.cpp:
(WebCore::ArtworkImageLoader::notifyFinished):

Fix the actual bug by using subresourcesAreFinished().

* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::WebCodecsVideoFrame::create):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.idl:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::loadArtworkImage):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Update test infrastructure so the fix can be tested.

Canonical link: <a href="https://commits.webkit.org/294334@main">https://commits.webkit.org/294334@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97357ab3067c4997ee8d5beae5c7fd6d3fe829ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106641 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52116 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103527 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21460 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77293 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34319 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104494 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16560 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91650 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57635 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16382 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9669 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51464 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86250 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9743 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108992 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28616 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21050 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86261 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28978 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87857 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85828 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30561 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8271 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22737 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16517 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28547 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33828 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28358 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31678 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29917 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->