### PR TITLE
Null-check WebPage in WebChromeClient::setUpPlaybackControlsManager

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1289,7 +1289,8 @@ void WebChromeClient::exitVideoFullscreenForVideoElement(HTMLVideoElement& video
 
 void WebChromeClient::setUpPlaybackControlsManager(HTMLMediaElement& mediaElement)
 {
-    protectedPage()->playbackSessionManager().setUpPlaybackControlsManager(mediaElement);
+    if (RefPtr page = m_page.get())
+        page->playbackSessionManager().setUpPlaybackControlsManager(mediaElement);
 }
 
 void WebChromeClient::clearPlaybackControlsManager()


### PR DESCRIPTION
#### 1b0eedf91cafbf18d3a1c34bc2a91e2776599056
<pre>
Null-check WebPage in WebChromeClient::setUpPlaybackControlsManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=292201">https://bugs.webkit.org/show_bug.cgi?id=292201</a>
<a href="https://rdar.apple.com/149758803">rdar://149758803</a>

Reviewed by Chris Dumez.

* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::setUpPlaybackControlsManager): Null-check page before using it.

Canonical link: <a href="https://commits.webkit.org/294231@main">https://commits.webkit.org/294231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9b87b59b2fd172e28e1f51ed959ae711da3392d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106290 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51769 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29298 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77044 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34071 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16269 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91359 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57391 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16086 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51117 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85989 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9442 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108646 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28270 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20816 "Found 5 new test failures: http/tests/iframe-monitor/data-url-resource.html http/tests/iframe-monitor/iframe-unload.html http/tests/iframe-monitor/workers/service-worker.html http/tests/security/dataURL/xss-DENIED-from-data-url-in-foreign-domain-subframe.html imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86013 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28632 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87560 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85552 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21781 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30273 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7997 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22369 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28200 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33470 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28012 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31332 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29570 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->