### PR TITLE
[Cocoa] Add tests to validate the behavior of SpatialAudioExperience

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -2405,6 +2405,7 @@ set(WebCoreTestSupport_IDL_FILES
 )
 
 list(APPEND WebCoreTestSupport_SOURCES
+    testing/EventTargetForTesting.cpp
     testing/GCObservation.cpp
     testing/InternalSettings.cpp
     testing/Internals.cpp

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1919,6 +1919,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/MediaSessionIdentifier.h
     platform/MediaStrategy.h
     platform/MediaUniqueIdentifier.h
+    platform/MessageClientForTesting.h
+    platform/MessageForTesting.h
+    platform/MessageTargetForTesting.h
     platform/NowPlayingManager.h
     platform/NotImplemented.h
     platform/OrientationNotifier.h

--- a/Source/WebCore/dom/CustomEvent.h
+++ b/Source/WebCore/dom/CustomEvent.h
@@ -43,7 +43,7 @@ public:
         JSC::JSValue detail;
     };
 
-    static Ref<CustomEvent> create(const AtomString& type, const Init&, IsTrusted = IsTrusted::No);
+    WEBCORE_EXPORT static Ref<CustomEvent> create(const AtomString& type, const Init&, IsTrusted = IsTrusted::No);
 
     void initCustomEvent(const AtomString& type, bool canBubble, bool cancelable, JSC::JSValue detail = JSC::JSValue::JSUndefined);
 

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -80,7 +80,7 @@ private:
     EventTargetData m_eventTargetData;
 };
 
-class EventTarget : public ScriptWrappable, public CanMakeWeakPtrWithBitField<EventTarget, WeakPtrFactoryInitialization::Lazy, WeakPtrImplWithEventTargetData> {
+class WEBCORE_EXPORT EventTarget : public ScriptWrappable, public CanMakeWeakPtrWithBitField<EventTarget, WeakPtrFactoryInitialization::Lazy, WeakPtrImplWithEventTargetData> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(EventTarget);
 public:
     static Ref<EventTarget> create(ScriptExecutionContext&);
@@ -91,20 +91,20 @@ public:
     virtual enum EventTargetInterfaceType eventTargetInterface() const = 0;
     virtual ScriptExecutionContext* scriptExecutionContext() const = 0;
 
-    WEBCORE_EXPORT virtual bool isPaymentRequest() const;
+    virtual bool isPaymentRequest() const;
 
     using AddEventListenerOptionsOrBoolean = Variant<AddEventListenerOptions, bool>;
-    WEBCORE_EXPORT void addEventListenerForBindings(const AtomString& eventType, RefPtr<EventListener>&&, AddEventListenerOptionsOrBoolean&&);
+    void addEventListenerForBindings(const AtomString& eventType, RefPtr<EventListener>&&, AddEventListenerOptionsOrBoolean&&);
     using EventListenerOptionsOrBoolean = Variant<EventListenerOptions, bool>;
-    WEBCORE_EXPORT void removeEventListenerForBindings(const AtomString& eventType, RefPtr<EventListener>&&, EventListenerOptionsOrBoolean&&);
-    WEBCORE_EXPORT ExceptionOr<bool> dispatchEventForBindings(Event&);
+    void removeEventListenerForBindings(const AtomString& eventType, RefPtr<EventListener>&&, EventListenerOptionsOrBoolean&&);
+    ExceptionOr<bool> dispatchEventForBindings(Event&);
 
-    WEBCORE_EXPORT virtual bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&);
-    WEBCORE_EXPORT virtual bool removeEventListener(const AtomString& eventType, EventListener&, const EventListenerOptions& = { });
+    virtual bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&);
+    virtual bool removeEventListener(const AtomString& eventType, EventListener&, const EventListenerOptions& = { });
 
-    WEBCORE_EXPORT virtual void removeAllEventListeners();
-    WEBCORE_EXPORT virtual void dispatchEvent(Event&);
-    WEBCORE_EXPORT virtual void uncaughtExceptionInEventHandler();
+    virtual void removeAllEventListeners();
+    virtual void dispatchEvent(Event&);
+    virtual void uncaughtExceptionInEventHandler();
 
     static const AtomString& legacyTypeForEvent(const Event&);
 
@@ -157,7 +157,7 @@ protected:
         setEventTargetFlag(EventTargetFlag::IsNode, true);
     }
 
-    WEBCORE_EXPORT virtual ~EventTarget();
+    virtual ~EventTarget();
 
     // Flags for ownership & relationship.
     enum class EventTargetFlag : uint16_t {

--- a/Source/WebCore/dom/EventTarget.idl
+++ b/Source/WebCore/dom/EventTarget.idl
@@ -20,6 +20,7 @@
 
 [
     CustomToJSObject,
+    ExportMacro=WEBCORE_EXPORT,
     Exposed=*,
     IsImmutablePrototypeExoticObjectOnPrototype,
     JSCustomHeader,

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -43,6 +43,7 @@
 #include "MediaProducer.h"
 #include "MediaResourceSniffer.h"
 #include "MediaUniqueIdentifier.h"
+#include "MessageTargetForTesting.h"
 #include "PlatformDynamicRangeLimit.h"
 #include "ReducedResolutionSeconds.h"
 #include "TextTrackClient.h"
@@ -95,6 +96,7 @@ class Event;
 class HTMLSourceElement;
 class HTMLTrackElement;
 class InbandTextTrackPrivate;
+class AggregateMessageClientForTesting;
 class JSDOMGlobalObject;
 class MediaController;
 class MediaControls;
@@ -108,6 +110,7 @@ class MediaSource;
 class MediaSourceHandle;
 class MediaSourceInterfaceProxy;
 class MediaStream;
+class MessageClientForTesting;
 class PausableIntervalTimer;
 class RenderMedia;
 class ScriptController;
@@ -173,6 +176,7 @@ class HTMLMediaElement
     , public MediaControllerInterface
     , public PlatformMediaSessionClient
     , public Identified<HTMLMediaElementIdentifier>
+    , private MessageTargetForTesting
     , private MediaCanStartListener
     , private MediaPlayerClient
     , private MediaProducer
@@ -726,6 +730,9 @@ public:
 
     void addClient(HTMLMediaElementClient&);
     void removeClient(const HTMLMediaElementClient&);
+
+    void addMessageClientForTesting(MessageClientForTesting&) override;
+    void removeMessageClientForTesting(const MessageClientForTesting&) override;
 
     void audioSessionCategoryChanged(AudioSessionCategory, AudioSessionMode, RouteSharingPolicy);
 
@@ -1486,6 +1493,8 @@ private:
     WeakHashSet<HTMLMediaElementClient> m_clients;
 
     bool m_hasEverPreparedToPlay { false };
+
+    RefPtr<AggregateMessageClientForTesting> m_internalMessageClient;
 };
 
 String convertEnumerationToString(HTMLMediaElement::AutoplayEventPlaybackState);

--- a/Source/WebCore/platform/MessageClientForTesting.h
+++ b/Source/WebCore/platform/MessageClientForTesting.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
+#include <wtf/Ref.h>
+#include <wtf/WeakHashSet.h>
+
+namespace WebCore {
+
+struct MessageForTesting;
+
+class MessageClientForTesting : public AbstractRefCountedAndCanMakeWeakPtr<MessageClientForTesting> {
+public:
+    virtual void sendInternalMessage(const MessageForTesting&) = 0;
+};
+
+class AggregateMessageClientForTesting
+    : public MessageClientForTesting
+    , public RefCounted<AggregateMessageClientForTesting> {
+public:
+    static Ref<AggregateMessageClientForTesting> create() { return *new AggregateMessageClientForTesting(); }
+
+    void addClient(MessageClientForTesting& client) { m_clients.add(client); }
+    void removeClient(const MessageClientForTesting& client) { m_clients.remove(client); }
+    bool isEmpty() const { return m_clients.isEmptyIgnoringNullReferences(); }
+
+    void sendInternalMessage(const MessageForTesting& message) override
+    {
+        m_clients.forEach([&] (auto& client) {
+            Ref { client }->sendInternalMessage(message);
+        });
+    }
+
+    void ref() const override { return RefCounted::ref(); }
+    void deref() const override { return RefCounted::deref(); }
+
+private:
+    AggregateMessageClientForTesting() = default;
+
+    WeakHashSet<MessageClientForTesting> m_clients;
+};
+
+}

--- a/Source/WebCore/platform/MessageForTesting.h
+++ b/Source/WebCore/platform/MessageForTesting.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+struct MessageForTesting {
+    AtomString type;
+    String data;
+};
+
+}

--- a/Source/WebCore/platform/MessageTargetForTesting.h
+++ b/Source/WebCore/platform/MessageTargetForTesting.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
+
+namespace WebCore {
+
+class MessageClientForTesting;
+
+class MessageTargetForTesting : public AbstractRefCountedAndCanMakeWeakPtr<MessageTargetForTesting> {
+public:
+    virtual void addMessageClientForTesting(MessageClientForTesting&) = 0;
+    virtual void removeMessageClientForTesting(const MessageClientForTesting&) = 0;
+};
+
+}
+

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -40,6 +40,7 @@
 #include "MIMETypeRegistry.h"
 #include "MediaPlayerPrivate.h"
 #include "MediaStrategy.h"
+#include "MessageClientForTesting.h"
 #include "OriginAccessPatterns.h"
 #include "PlatformMediaResourceLoader.h"
 #include "PlatformMediaSessionManager.h"
@@ -635,6 +636,8 @@ void MediaPlayer::loadWithNextMediaEngine(const MediaPlayerFactory* current)
         m_private = playerPrivate;
         if (playerPrivate) {
             client().mediaPlayerEngineUpdated();
+            playerPrivate->setMessageClientForTesting(m_internalMessageClient);
+
             if (m_pageIsVisible)
                 playerPrivate->setPageIsVisible(m_pageIsVisible);
             if (m_visibleInViewport)
@@ -2063,6 +2066,17 @@ const Logger& MediaPlayer::mediaPlayerLogger()
     return client().mediaPlayerLogger();
 }
 #endif
+
+void MediaPlayer::setMessageClientForTesting(WeakPtr<MessageClientForTesting> internalMessageClient)
+{
+    m_internalMessageClient = WTFMove(internalMessageClient);
+    m_private->setMessageClientForTesting(m_internalMessageClient);
+}
+
+MessageClientForTesting* MediaPlayer::messageClientForTesting() const
+{
+    return m_internalMessageClient.get();
+}
 
 String convertEnumerationToString(MediaPlayer::ReadyState enumerationValue)
 {

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -94,6 +94,7 @@ class DestinationColorSpace;
 class GraphicsContextGL;
 class GraphicsContext;
 class InbandTextTrackPrivate;
+class MessageClientForTesting;
 class LegacyCDM;
 class LegacyCDMSession;
 class LegacyCDMSessionClient;
@@ -810,6 +811,9 @@ public:
     const String& sceneIdentifier() const { return m_sceneIdentifier; }
 #endif
 
+    void setMessageClientForTesting(WeakPtr<MessageClientForTesting>);
+    MessageClientForTesting* messageClientForTesting() const;
+
 private:
     MediaPlayer(MediaPlayerClient&);
     MediaPlayer(MediaPlayerClient&, MediaPlayerEnums::MediaEngineIdentifier);
@@ -877,6 +881,8 @@ private:
 #if PLATFORM(IOS_FAMILY)
     String m_sceneIdentifier;
 #endif
+
+    WeakPtr<MessageClientForTesting> m_internalMessageClient;
 };
 
 class MediaPlayerFactory : public CanMakeWeakPtr<MediaPlayerFactory> {

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -42,6 +42,7 @@
 
 namespace WebCore {
 
+class MessageClientForTesting;
 class VideoFrame;
 
 // MediaPlayerPrivateInterface subclasses should be ref-counted, but each subclass may choose whether
@@ -376,6 +377,8 @@ public:
 #endif
 
     virtual void soundStageSizeDidChange() { }
+
+    virtual void setMessageClientForTesting(WeakPtr<MessageClientForTesting>) { }
 
 protected:
     mutable PlatformTimeRanges m_seekable;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -53,6 +53,8 @@
 #import "MediaPlaybackTargetMock.h"
 #import "MediaSelectionGroupAVFObjC.h"
 #import "MediaSessionManagerCocoa.h"
+#import "MessageClientForTesting.h"
+#import "MessageForTesting.h"
 #import "OutOfBandTextTrackPrivateAVF.h"
 #import "PixelBufferConformerCV.h"
 #import "PlatformDynamicRangeLimitCocoa.h"
@@ -4092,6 +4094,10 @@ void MediaPlayerPrivateAVFoundationObjC::updateSpatialTrackingLabel()
         });
         ALWAYS_LOG(LOGIDENTIFIER, "Setting spatialAudioExperience: ", spatialAudioExperienceDescription(experience.get()));
         [m_avPlayer setIntendedSpatialAudioExperience:experience.get()];
+
+        if (RefPtr client = player->messageClientForTesting())
+            client->sendInternalMessage({ "media-player-spatial-experience-change"_s, spatialAudioExperienceDescription(experience.get()) });
+
         return;
     }
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -41,6 +41,8 @@
 #import "MediaSourcePrivate.h"
 #import "MediaSourcePrivateAVFObjC.h"
 #import "MediaSourcePrivateClient.h"
+#import "MessageClientForTesting.h"
+#import "MessageForTesting.h"
 #import "PixelBufferConformerCV.h"
 #import "PlatformDynamicRangeLimitCocoa.h"
 #import "PlatformScreen.h"
@@ -1821,6 +1823,10 @@ void MediaPlayerPrivateMediaSourceAVFObjC::updateSpatialTrackingLabel()
         });
         ALWAYS_LOG(LOGIDENTIFIER, "Setting spatialAudioExperience: ", spatialAudioExperienceDescription(experience.get()));
         [m_synchronizer setIntendedSpatialAudioExperience:experience.get()];
+
+        if (RefPtr client = player->messageClientForTesting())
+            client->sendInternalMessage({ "media-player-spatial-experience-change"_s, spatialAudioExperienceDescription(experience.get()) });
+
         return;
     }
 #endif

--- a/Source/WebCore/testing/EventTargetForTesting.cpp
+++ b/Source/WebCore/testing/EventTargetForTesting.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "EventTargetForTesting.h"
+
+#include "ContextDestructionObserverInlines.h"
+#include "CustomEvent.h"
+#include "MessageForTesting.h"
+#include "MessageTargetForTesting.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(EventTargetForTesting);
+
+Ref<EventTargetForTesting> EventTargetForTesting::create(ScriptExecutionContext& context, MessageTargetForTesting& target)
+{
+    return *new EventTargetForTesting(context, target);
+}
+
+EventTargetForTesting::EventTargetForTesting(ScriptExecutionContext& context, MessageTargetForTesting& target)
+    : ActiveDOMObject { &context }
+    , m_messageTarget { target }
+{
+    target.addMessageClientForTesting(*this);
+}
+
+EventTargetForTesting::~EventTargetForTesting()
+{
+    if (RefPtr messageTarget = m_messageTarget.get())
+        messageTarget->removeMessageClientForTesting(*this);
+}
+
+void EventTargetForTesting::sendInternalMessage(const MessageForTesting& message)
+{
+    RefPtr scriptExecutionContext = this->scriptExecutionContext();
+    if (!scriptExecutionContext)
+        return;
+
+    JSC::JSValue detail = jsNontrivialString(scriptExecutionContext->vm(), message.data);
+
+    dispatchEvent(CustomEvent::create(message.type, CustomEvent::Init {
+        { },
+        detail,
+    }));
+}
+
+}

--- a/Source/WebCore/testing/EventTargetForTesting.h
+++ b/Source/WebCore/testing/EventTargetForTesting.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ActiveDOMObject.h"
+#include "EventTarget.h"
+#include "EventTargetInterfaces.h"
+#include "MessageClientForTesting.h"
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class MessageTargetForTesting;
+
+class EventTargetForTesting final
+    : public ActiveDOMObject
+    , public EventTarget
+    , public RefCounted<EventTargetForTesting>
+    , private MessageClientForTesting {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(EventTargetForTesting);
+public:
+    static Ref<EventTargetForTesting> create(ScriptExecutionContext&, MessageTargetForTesting&);
+    virtual ~EventTargetForTesting();
+
+    // MessageClientForTesting, ActiveDOMObject
+    void ref() const final { return RefCounted::ref(); }
+    void deref() const final { return RefCounted::deref(); }
+
+private:
+    EventTargetForTesting(ScriptExecutionContext&, MessageTargetForTesting&);
+
+    // ActiveDOMObject.
+    void stop() final { }
+    void suspend(ReasonForSuspension) final { }
+    bool virtualHasPendingActivity() const final { return !!m_messageTarget; }
+
+    // EventTarget
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::EventTarget; }
+    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    void refEventTarget() final { return RefCounted::ref(); }
+    void derefEventTarget() final { return RefCounted::deref(); }
+
+    // MessageClientForTesting
+    void sendInternalMessage(const MessageForTesting&) final;
+
+    WeakPtr<MessageTargetForTesting> m_messageTarget;
+};
+
+}

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -85,6 +85,8 @@
 #include "EventListener.h"
 #include "EventLoop.h"
 #include "EventNames.h"
+#include "EventTargetForTesting.h"
+#include "EventTargetInlines.h"
 #include "ExtendableEvent.h"
 #include "ExtensionStyleSheets.h"
 #include "FetchRequest.h"
@@ -7775,6 +7777,11 @@ const String& Internals::defaultSpatialTrackingLabel() const
 bool Internals::isEffectivelyMuted(const HTMLMediaElement& element)
 {
     return element.effectiveMuted();
+}
+
+Ref<EventTarget> Internals::addInternalEventTarget(HTMLMediaElement& element)
+{
+    return EventTargetForTesting::create(element.document(), element);
 }
 #endif
 

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -107,8 +107,9 @@ class HTMLSelectElement;
 class HTMLVideoElement;
 class ImageData;
 class InspectorStubFrontend;
-class InternalsMapLike;
+class EventTargetForTesting;
 class InternalSettings;
+class InternalsMapLike;
 class InternalsSetLike;
 class LocalFrame;
 class Location;
@@ -1549,6 +1550,7 @@ public:
 
 #if ENABLE(VIDEO)
     bool isEffectivelyMuted(const HTMLMediaElement&);
+    Ref<EventTarget> addInternalEventTarget(HTMLMediaElement&);
 #endif
 
     using RenderingMode = WebCore::RenderingMode;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1443,6 +1443,7 @@ enum ContentsFormat {
     readonly attribute DOMString defaultSpatialTrackingLabel;
 
     [Conditional=VIDEO] boolean isEffectivelyMuted(HTMLMediaElement element);
+    [Conditional=VIDEO] EventTarget addInternalEventTarget(HTMLMediaElement element);
 
     RenderingMode? getEffectiveRenderingModeOfNewlyCreatedAcceleratedImageBuffer();
     Promise<ImageBufferResourceLimits> getImageBufferResourceLimits();

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -1372,6 +1372,16 @@ void RemoteMediaPlayerProxy::setSoundStageSize(SoundStageSize size)
     protectedPlayer()->soundStageSizeDidChange();
 }
 
+void RemoteMediaPlayerProxy::setHasMessageClientForTesting(bool hasClient)
+{
+    protectedPlayer()->setMessageClientForTesting(hasClient ? this : nullptr);
+}
+
+void RemoteMediaPlayerProxy::sendInternalMessage(const WebCore::MessageForTesting& message)
+{
+    protectedConnection()->send(Messages::MediaPlayerPrivateRemote::SendInternalMessage { message }, m_id);
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(GPU_PROCESS) && ENABLE(VIDEO)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -43,6 +43,7 @@
 #include <WebCore/MediaPlayer.h>
 #include <WebCore/MediaPlayerIdentifier.h>
 #include <WebCore/MediaPromiseTypes.h>
+#include <WebCore/MessageClientForTesting.h>
 #include <WebCore/PlatformDynamicRangeLimit.h>
 #include <WebCore/PlatformMediaResourceLoader.h>
 #include <optional>
@@ -111,6 +112,7 @@ class RemoteVideoTrackProxy;
 class RemoteMediaPlayerProxy final
     : public RefCounted<RemoteMediaPlayerProxy>
     , public WebCore::MediaPlayerClient
+    , private WebCore::MessageClientForTesting
     , private IPC::MessageReceiver {
     WTF_MAKE_TZONE_ALLOCATED(RemoteMediaPlayerProxy);
 public:
@@ -394,6 +396,9 @@ private:
     using SoundStageSize = WebCore::MediaPlayer::SoundStageSize;
     void setSoundStageSize(SoundStageSize);
         SoundStageSize mediaPlayerSoundStageSize() const final { return m_soundStageSize; }
+
+    void setHasMessageClientForTesting(bool);
+    void sendInternalMessage(const WebCore::MessageForTesting&) final;
 
 #if !RELEASE_LOG_DISABLED
     const Logger& mediaPlayerLogger() final { return m_logger; }

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
@@ -162,6 +162,8 @@ messages -> RemoteMediaPlayerProxy {
     AudioOutputDeviceChanged(String deviceId)
     IsInFullscreenOrPictureInPictureChanged(bool value)
     SetSoundStageSize(enum:uint8_t WebCore::MediaPlayerSoundStageSize value)
+
+    SetHasMessageClientForTesting(bool value)
 }
 
 #endif

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -9142,3 +9142,8 @@ enum class WebCore::ProcessSwapDisposition : uint8_t {
     COOP,
     Other
 };
+
+struct WebCore::MessageForTesting {
+    AtomString type;
+    String data;
+};

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -46,6 +46,7 @@
 #include <WebCore/GraphicsContext.h>
 #include <WebCore/MediaPlayer.h>
 #include <WebCore/MediaStrategy.h>
+#include <WebCore/MessageClientForTesting.h>
 #include <WebCore/NotImplemented.h>
 #include <WebCore/PlatformScreen.h>
 #include <WebCore/PlatformStrategies.h>
@@ -1892,6 +1893,25 @@ void MediaPlayerPrivateRemote::sceneIdentifierDidChange()
         protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetSceneIdentifier(player->sceneIdentifier()), m_id);
 }
 #endif
+
+void MediaPlayerPrivateRemote::setMessageClientForTesting(WeakPtr<MessageClientForTesting> client)
+{
+    m_internalMessageClient = WTFMove(client);
+    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetHasMessageClientForTesting(!!m_internalMessageClient), m_id);
+}
+
+void MediaPlayerPrivateRemote::sendInternalMessage(const WebCore::MessageForTesting& message)
+{
+    if (RefPtr client = m_internalMessageClient.get()) {
+        client->sendInternalMessage(message);
+        return;
+    }
+
+    // We were sent a message, but no internal message client exists. Notify the
+    // GPU process that we have no internal message client.
+    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetHasMessageClientForTesting(false), m_id);
+}
+
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -57,6 +57,7 @@ class MachSendRight;
 
 namespace WebCore {
 struct GenericCueData;
+struct MessageForTesting;
 class ISOWebVTTCue;
 class SerializedPlatformDataCueValue;
 class VideoLayerManager;
@@ -499,6 +500,9 @@ private:
     void sceneIdentifierDidChange() final;
 #endif
 
+    void setMessageClientForTesting(WeakPtr<WebCore::MessageClientForTesting>) final;
+    void sendInternalMessage(const WebCore::MessageForTesting&);
+
     ThreadSafeWeakPtr<WebCore::MediaPlayer> m_player;
 #if PLATFORM(COCOA)
     mutable UniqueRef<WebCore::VideoLayerManager> m_videoLayerManager;
@@ -554,6 +558,7 @@ private:
     bool m_isGatheringVideoFrameMetadata { false };
     String m_defaultSpatialTrackingLabel;
     String m_spatialTrackingLabel;
+    WeakPtr<WebCore::MessageClientForTesting> m_internalMessageClient;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in
@@ -106,6 +106,7 @@ messages -> MediaPlayerPrivateRemote {
 
     CommitAllTransactions() -> ()
     ReportGPUMemoryFootprint(uint64_t memoryFootPrint)
+    SendInternalMessage(struct WebCore::MessageForTesting message)
 }
 
 #endif

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1233,8 +1233,11 @@
 		CDC8E48D1BC5CB4500594FEC /* AudioSessionCategoryIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDC8E4851BC5B19400594FEC /* AudioSessionCategoryIOS.mm */; };
 		CDC9442E1EF1FC080059C3C4 /* MediaStreamTrackDetached.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDC9442C1EF1FC080059C3C4 /* MediaStreamTrackDetached.mm */; };
 		CDCFA7AA1E45183200C2433D /* SampleMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDCFA7A91E45122F00C2433D /* SampleMap.cpp */; };
+		CDDFA89E2DBD6BFF00312417 /* spatial-audio-experience-with-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDDFA89D2DBD6BFF00312417 /* spatial-audio-experience-with-audio.html */; };
 		CDE4E4E52B7E787900B3AE35 /* InWindowFullscreen.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDE4E4E42B7E787900B3AE35 /* InWindowFullscreen.mm */; };
 		CDE77D2525A6591C00D4115E /* FullscreenPointerLeave.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDE77D2425A6591C00D4115E /* FullscreenPointerLeave.mm */; };
+		CDEEC7CD2DBC662A00F5B8EB /* SpatialAudioExperience.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD5F16612DBC652000CE85D9 /* SpatialAudioExperience.mm */; };
+		CDEEC7D02DBC6B7200F5B8EB /* spatial-audio-experience-with-video.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDEEC7CF2DBC6B7200F5B8EB /* spatial-audio-experience-with-video.html */; };
 		CE06DF9B1E1851F200E570C9 /* SecurityOrigin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE06DF9A1E1851F200E570C9 /* SecurityOrigin.cpp */; };
 		CE1866491F72E8F100A0CAB6 /* MarkedText.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE1866471F72E8F100A0CAB6 /* MarkedText.cpp */; };
 		CE3524F81B1431F60028A7C5 /* TextFieldDidBeginAndEndEditing_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE3524F21B142B8D0028A7C5 /* TextFieldDidBeginAndEndEditing_Bundle.cpp */; };
@@ -2057,6 +2060,8 @@
 				A17C47FB2C98E5C20023F3C7 /* skinny-autoplaying-video-with-audio.html in Copy Resources */,
 				A17C46F22C98E54B0023F3C7 /* spacebar-scrolling.html in Copy Resources */,
 				A17C47FC2C98E5C20023F3C7 /* SpaceOnly.otf in Copy Resources */,
+				CDDFA89E2DBD6BFF00312417 /* spatial-audio-experience-with-audio.html in Copy Resources */,
+				CDEEC7D02DBC6B7200F5B8EB /* spatial-audio-experience-with-video.html in Copy Resources */,
 				A17C47FD2C98E5C20023F3C7 /* speechrecognition-basic.html in Copy Resources */,
 				A17C47FE2C98E5C20023F3C7 /* speechrecognition-user-permission-persistence.html in Copy Resources */,
 				EEA52EAB2D69203B00D578B5 /* stagemode-model-page.html in Copy Resources */,
@@ -3629,6 +3634,7 @@
 		CD57779B211CE6CE001B371E /* video-with-audio-and-web-audio.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "video-with-audio-and-web-audio.html"; sourceTree = "<group>"; };
 		CD59F53219E910AA00CF1835 /* file-with-mse.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "file-with-mse.html"; sourceTree = "<group>"; };
 		CD59F53319E910BC00CF1835 /* test-mse.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = "test-mse.mp4"; sourceTree = "<group>"; };
+		CD5F16612DBC652000CE85D9 /* SpatialAudioExperience.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SpatialAudioExperience.mm; sourceTree = "<group>"; };
 		CD5FF4962162E27E004BD86F /* ISOBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ISOBox.cpp; sourceTree = "<group>"; };
 		CD758A6E20572D540071834A /* video-with-paused-audio-and-playing-muted.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "video-with-paused-audio-and-playing-muted.html"; sourceTree = "<group>"; };
 		CD780E752BBE176D002A3DEC /* WKWebViewSpatialTrackingLabels.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewSpatialTrackingLabels.mm; sourceTree = "<group>"; };
@@ -3667,11 +3673,13 @@
 		CDCFFEC022E268D500DF4223 /* NoPauseWhenSwitchingTabs.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NoPauseWhenSwitchingTabs.mm; sourceTree = "<group>"; };
 		CDD68F0C22C18317000CF0AE /* WKWebViewCloseAllMediaPresentations.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewCloseAllMediaPresentations.mm; sourceTree = "<group>"; };
 		CDDC7C6825FFF6D000224278 /* FullscreenRemoveNodeBeforeEnter.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenRemoveNodeBeforeEnter.mm; sourceTree = "<group>"; };
+		CDDFA89D2DBD6BFF00312417 /* spatial-audio-experience-with-audio.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "spatial-audio-experience-with-audio.html"; sourceTree = "<group>"; };
 		CDE195B21CFE0ADE0053D256 /* FullscreenTopContentInset.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = FullscreenTopContentInset.html; sourceTree = "<group>"; };
 		CDE195B31CFE0ADE0053D256 /* ObscuredContentInsets.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ObscuredContentInsets.mm; sourceTree = "<group>"; };
 		CDE4E4E42B7E787900B3AE35 /* InWindowFullscreen.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = InWindowFullscreen.mm; sourceTree = "<group>"; };
 		CDE77D2425A6591C00D4115E /* FullscreenPointerLeave.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenPointerLeave.mm; sourceTree = "<group>"; };
 		CDED342E249DDD9D0002AE7A /* AudioRoutingArbitration.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AudioRoutingArbitration.mm; sourceTree = "<group>"; };
+		CDEEC7CF2DBC6B7200F5B8EB /* spatial-audio-experience-with-video.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "spatial-audio-experience-with-video.html"; sourceTree = "<group>"; };
 		CDF0B789216D484300421ECC /* CloseWebViewDuringEnterFullscreen.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CloseWebViewDuringEnterFullscreen.mm; sourceTree = "<group>"; };
 		CDF92236216D186400647AA7 /* CloseWebViewAfterEnterFullscreen.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CloseWebViewAfterEnterFullscreen.mm; sourceTree = "<group>"; };
 		CE06DF9A1E1851F200E570C9 /* SecurityOrigin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SecurityOrigin.cpp; sourceTree = "<group>"; };
@@ -4650,6 +4658,7 @@
 				5C24A002294A75DD00463E2B /* SkipDecidePolicyForResponsePlugIn.mm */,
 				2DFF7B6C1DA487AF00814614 /* SnapshotStore.mm */,
 				5774AA6721FBBF7800AF2A1B /* SOAuthorizationTests.mm */,
+				CD5F16612DBC652000CE85D9 /* SpatialAudioExperience.mm */,
 				9342589B255B609A0059EEDD /* SpeechRecognition.mm */,
 				CDC0932D21C993440030C4B0 /* StopSuspendResumeAllMedia.mm */,
 				414AD6852285D1B000777F2D /* StorageQuota.mm */,
@@ -5487,6 +5496,8 @@
 				F4D060072734A08C008FA67A /* simple-editor.html */,
 				F4F405BB1D4C0CF8007A9707 /* skinny-autoplaying-video-with-audio.html */,
 				F4CFCDD8249FC9D900527482 /* SpaceOnly.otf */,
+				CDDFA89D2DBD6BFF00312417 /* spatial-audio-experience-with-audio.html */,
+				CDEEC7CF2DBC6B7200F5B8EB /* spatial-audio-experience-with-video.html */,
 				9360270525A3B28E00367670 /* speechrecognition-basic.html */,
 				9342589D255B66A00059EEDD /* speechrecognition-user-permission-persistence.html */,
 				0721D4582838295400A95853 /* start-offset.ts */,
@@ -7498,6 +7509,7 @@
 				510A91F824D3622100BFD89C /* SonyDualShock3.mm in Sources */,
 				51EB126424CA6B66000CB030 /* SonyDualShock4.mm in Sources */,
 				7CCE7F151A411AE600447C4C /* SpacebarScrolling.cpp in Sources */,
+				CDEEC7CD2DBC662A00F5B8EB /* SpatialAudioExperience.mm in Sources */,
 				F4CDF3D227E97C7E00191928 /* SpellCheckerDocumentTag.mm in Sources */,
 				83BC5AC020E6C0DF00F5879F /* StartLoadInDidFailProvisionalLoad.mm in Sources */,
 				51EB126524CA6B66000CB030 /* SteelSeriesNimbus.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SpatialAudioExperience.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SpatialAudioExperience.mm
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#import "PlatformUtilities.h"
+#import "TestWKWebView.h"
+#import "WKWebViewConfigurationExtras.h"
+#import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <wtf/RetainPtr.h>
+
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+
+namespace TestWebKitAPI {
+static BOOL isDone;
+}
+
+@interface SpatialAudioExperienceMessageHandler : NSObject <WKScriptMessageHandler>
+@property (nonatomic, retain) NSString *expectedBody;
+@end
+
+@implementation SpatialAudioExperienceMessageHandler
+- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
+{
+    if (![_expectedBody isEqual:message.body])
+        return;
+
+    TestWebKitAPI::isDone = true;
+}
+@end
+
+namespace TestWebKitAPI {
+
+static RetainPtr<WKWebViewConfiguration> autoplayingInternalsConfiguration()
+{
+    RetainPtr configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+    configuration.get().mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
+    configuration.get().allowsInlineMediaPlayback = YES;
+    configuration.get()._inlineMediaPlaybackRequiresPlaysInlineAttribute = NO;
+    return configuration;
+}
+
+TEST(SpatialAudioExperience, NoWindow)
+{
+    isDone = false;
+
+    RetainPtr configuration = autoplayingInternalsConfiguration();
+    auto messageHandler = adoptNS([[SpatialAudioExperienceMessageHandler alloc] init]);
+
+    [messageHandler setExpectedBody:@"{CAHeadTrackedSpatialAudio: soundStageSize(0), anchoringStrategy: {CAAutomaticAnchoringStrategy}}"];
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"media-player-spatial-experience-change"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow:NO]);
+
+    [webView synchronouslyLoadTestPageNamed:@"spatial-audio-experience-with-video"];
+
+    [webView stringByEvaluatingJavaScript:@"go()"];
+
+    TestWebKitAPI::Util::run(&isDone);
+}
+
+TEST(SpatialAudioExperience, WindowWithWindowScene)
+{
+    // This test must run in TestWebKitAPI.app
+    if (![NSBundle.mainBundle.bundleIdentifier isEqualToString:@"org.webkit.TestWebKitAPI"])
+        return;
+
+    isDone = false;
+
+    RetainPtr configuration = autoplayingInternalsConfiguration();
+    auto messageHandler = adoptNS([[SpatialAudioExperienceMessageHandler alloc] init]);
+
+    [messageHandler setExpectedBody:@"{CAHeadTrackedSpatialAudio: soundStageSize(0), anchoringStrategy: {CAAutomaticAnchoringStrategy}}"];
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"media-player-spatial-experience-change"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+
+    [webView synchronouslyLoadTestPageNamed:@"spatial-audio-experience-with-video"];
+
+    [webView stringByEvaluatingJavaScript:@"go()"];
+
+    TestWebKitAPI::Util::run(&isDone);
+
+    [messageHandler setExpectedBody:[NSString stringWithFormat:@"{CAHeadTrackedSpatialAudio: soundStageSize(0), anchoringStrategy: {CASceneAnchoringStrategy: sceneId: %@}}", (NSString *)[webView window].windowScene.session.persistentIdentifier]];
+    isDone = false;
+
+    [webView stringByEvaluatingJavaScript:@"document.querySelector('video').style.display = 'none'"];
+    TestWebKitAPI::Util::run(&isDone);
+}
+
+TEST(SpatialAudioExperience, AudioOnly)
+{
+    // This test must run in TestWebKitAPI.app
+    if (![NSBundle.mainBundle.bundleIdentifier isEqualToString:@"org.webkit.TestWebKitAPI"])
+        return;
+
+    isDone = false;
+
+    RetainPtr configuration = autoplayingInternalsConfiguration();
+    auto messageHandler = adoptNS([[SpatialAudioExperienceMessageHandler alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"media-player-spatial-experience-change"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+
+    [webView synchronouslyLoadTestPageNamed:@"spatial-audio-experience-with-audio"];
+
+    [messageHandler setExpectedBody:[NSString stringWithFormat:@"{CAHeadTrackedSpatialAudio: soundStageSize(0), anchoringStrategy: {CASceneAnchoringStrategy: sceneId: %@}}", (NSString *)[webView window].windowScene.session.persistentIdentifier]];
+
+    [webView stringByEvaluatingJavaScript:@"go()"];
+
+    TestWebKitAPI::Util::run(&isDone);
+}
+
+}
+
+#endif

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/spatial-audio-experience-with-audio.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/spatial-audio-experience-with-audio.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script>
+    var audioInternalEventHandler;
+
+    function go() {
+        let video = document.querySelector('audio');
+        audio.src = 'video-with-audio.mp4';
+        audio.play();
+    }
+
+    function postEventToMessageHandler(event) {
+        window.webkit.messageHandlers[event.type].postMessage(event.detail);
+    }
+
+    window.addEventListener('load', event => {
+        let audio = document.querySelector('audio');
+        if (!window.internals)
+            return;
+        audioInternalEventHandler = internals.addInternalEventTarget(audio);
+        audioInternalEventHandler.addEventListener('media-player-spatial-experience-change', postEventToMessageHandler);
+    });
+    </script>
+</head>
+<body onload="go()">
+    <audio></audio>
+</body>
+</html>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/spatial-audio-experience-with-video.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/spatial-audio-experience-with-video.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script>
+    var videoInternalEventHandler;
+
+    function go() {
+        let video = document.querySelector('video');
+        video.src = 'video-with-audio.mp4';
+        video.play();
+    }
+
+    function postEventToMessageHandler(event) {
+        window.webkit.messageHandlers[event.type].postMessage(event.detail);
+    }
+
+    window.addEventListener('load', event => {
+        let video = document.querySelector('video');
+        if (!window.internals)
+            return;
+        videoInternalEventHandler = internals.addInternalEventTarget(video);
+        videoInternalEventHandler.addEventListener('media-player-spatial-experience-change', postEventToMessageHandler);
+    });
+    </script>
+</head>
+<body onload="go()">
+    <video webkit-playsinline></video>
+</body>
+</html>


### PR DESCRIPTION
#### 50eeda809aa991027d04d2d93738622c8bf90464
<pre>
[Cocoa] Add tests to validate the behavior of SpatialAudioExperience
<a href="https://bugs.webkit.org/show_bug.cgi?id=292195">https://bugs.webkit.org/show_bug.cgi?id=292195</a>
&lt;<a href="https://rdar.apple.com/problem/150212519">rdar://problem/150212519</a>&gt;

Reviewed by Andy Estes.

After adopting -setIntendedSpatialAudioExperience:, make the behavior testable
by adding a facility to pass messages up from the GPU process to the Internals
object. This facility can be re-used for other messages and other objects:

- MessageClientForTesting: An abstract interface which allows introspected objects
  to pass generic messages to clients for testing purposes.
- MessageForTesting: A simple message object containing a type and data string.
- EventTargetForTesting: A concrete EventTarget instantiated by Internals
- CustomEvent: A concrete Event subclass which can be initialized with a payload.

These classes are used by HTMLMediaElement, MediaPlayer, MediaPlayerInterface,
MediaPlayerPrivateRemote and RemoteMediaPlayer to provide a channel between
concrete MediaPlayerInterface classes like MediaPlayerPrivateAVFoundationObjC
and MediaPlayerPrivateMediaSourceAVFObjC, and the Internals object in the
WebContent process.

And this in turn enables tests like SpatialAudioExperience.NoWindow,
SpatialAudioExperience.WindowWithWindowScene and SpatialAudioExperience.AudioOnly.

* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/EventInterfaces.in:
* Source/WebCore/dom/EventTargetFactory.in:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::addMessageClientForTesting):
(WebCore::HTMLMediaElement::removeMessageClientForTesting):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/platform/MessageClientForTesting.h: Added.
(WebCore::AggregateMessageClientForTesting::create):
(WebCore::AggregateMessageClientForTesting::addClient):
(WebCore::AggregateMessageClientForTesting::removeClient):
(WebCore::AggregateMessageClientForTesting::isEmpty const):
* Source/WebCore/platform/MessageForTesting.h: Added.
* Source/WebCore/platform/MessageTargetForTesting.h: Added.
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::loadWithNextMediaEngine):
(WebCore::MediaPlayer::setMessageClientForTesting):
(WebCore::MediaPlayer::protectedMessageClientForTesting const):
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::setMessageClientForTesting):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::updateSpatialTrackingLabel):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateSpatialTrackingLabel):
* Source/WebCore/testing/EventForTesting.h: Added.
(WebCore::EventForTesting::create):
(WebCore::EventForTesting::data const):
(WebCore::EventForTesting::EventForTesting):
* Source/WebCore/testing/EventForTesting.idl: Added.
* Source/WebCore/testing/EventTargetForTesting.cpp: Added.
(WebCore::EventTargetForTesting::create):
(WebCore::EventTargetForTesting::~EventTargetForTesting):
(WebCore::EventTargetForTesting::EventTargetForTesting):
(WebCore::EventTargetForTesting::sendInternalMessage):
* Source/WebCore/testing/EventTargetForTesting.h: Added.
* Source/WebCore/testing/EventTargetForTesting.idl: Added.
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::addInternalEventTarget):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::setHasMessageClientForTesting):
(WebKit::RemoteMediaPlayerProxy::sendInternalMessage):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift:
(WKSLinearMediaPlayer.isImmersiveVideo):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::setMessageClientForTesting):
(WebKit::MediaPlayerPrivateRemote::sendInternalMessage):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWebKitAPI.xcscheme:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SpatialAudioExperience.mm: Added.
(-[SpatialAudioExperienceMessageHandler userContentController:didReceiveScriptMessage:]):
(TestWebKitAPI::autoplayingInternalsConfiguration):
(TestWebKitAPI::TEST(SpatialAudioExperience, NoWindow)):
(TestWebKitAPI::TEST(SpatialAudioExperience, WindowWithWindowScene)):
(TestWebKitAPI::TEST(SpatialAudioExperience, AudioOnly)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/spatial-audio-experience-with-audio.html: Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/spatial-audio-experience-with-video.html: Added.

Canonical link: <a href="https://commits.webkit.org/295336@main">https://commits.webkit.org/295336@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3171cc114fb61bf09887c7684b8822445d95a99e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109948 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55408 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106774 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24837 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79535 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107740 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19312 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94529 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59842 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19080 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12606 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54786 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88777 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112345 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31899 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23462 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88610 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90755 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88234 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22496 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33119 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10899 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27212 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31824 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37177 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31616 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34957 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33175 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->