### PR TITLE
Web Inspector: Remove undocked-title-area element since inspector already adjusts based on safeAreaInsets

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Base/Main.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Main.js
@@ -476,11 +476,6 @@ WI.contentLoaded = function()
         WI._dockedResizerElement.addEventListener("mousedown", WI._handleDockedResizerMouseDown);
     }
 
-    if (supportsUndocked) {
-        let undockedTitleAreaElement = document.getElementById("undocked-title-area");
-        undockedTitleAreaElement.addEventListener("mousedown", WI._handleUndockedTitleAreaMouseDown);
-    }
-
     WI._dockingAvailable = false;
 
     WI._updateDockNavigationItems();
@@ -2039,17 +2034,11 @@ WI._handleDockedResizerMouseDown = function(event)
     WI.resizeDockedFrameMouseDown(event);
 };
 
-WI._handleUndockedTitleAreaMouseDown = function(event)
-{
-    WI.moveUndockedWindowMouseDown(event);
-};
-
 WI._domStorageWasInspected = function(event)
 {
     WI.showStorageTab({initiatorHint: WI.TabBrowser.TabNavigationInitiator.Inspect});
     WI.showRepresentedObject(event.data.domStorage, null, {ignoreSearchTab: true});
 };
-
 
 WI._domNodeWasInspected = function(event)
 {
@@ -2591,19 +2580,6 @@ WI.setLayoutDirection = function(value)
     WI.settings.debugLayoutDirection.value = value;
 
     InspectorFrontendHost.reopen();
-};
-
-WI.undockedTitleAreaHeight = function()
-{
-    if (WI.dockConfiguration !== WI.DockConfiguration.Undocked)
-        return 0;
-
-    if (WI.Platform.name === "mac") {
-        /* Keep in sync with `--undocked-title-area-height` CSS variable. */
-        return 27 / WI.getZoomFactor();
-    }
-
-    return 0;
 };
 
 WI._showTabAtIndexFromShortcut = function(i)

--- a/Source/WebInspectorUI/UserInterface/Main.html
+++ b/Source/WebInspectorUI/UserInterface/Main.html
@@ -990,7 +990,6 @@
 </head>
 <body>
 <div id="docked-resizer"></div>
-<div id="undocked-title-area"></div>
 <div id="tab-bar"></div>
 <div id="main">
     <div id="content">

--- a/Source/WebInspectorUI/UserInterface/Views/Main.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Main.css
@@ -106,32 +106,6 @@ body.docked.left #docked-resizer {
     cursor: col-resize;
 }
 
-#undocked-title-area {
-    position: absolute;
-    top: 0;
-    right: 0;
-    left: 0;
-    height: var(--undocked-title-area-height);
-    background: var(--undocked-title-area-background);
-}
-
-body.mac-platform #undocked-title-area {
-    --undocked-title-area-background: white;
-}
-
-body:not(.mac-platform) #undocked-title-area {
-    --undocked-title-area-background: linear-gradient(to bottom, hsl(0, 0%, 92%), hsl(0, 0%, 87%));
-    box-shadow: inset hsla(0, 0%, 100%, 0.5) 0 1px 1px;
-}
-
-body.docked #undocked-title-area {
-    display: none;
-}
-
-body.window-inactive #undocked-title-area {
-    --undocked-title-area-background: hsl(0, 0%, 96%);
-}
-
 input[type=range] {
     appearance: none;
 }
@@ -148,7 +122,7 @@ input[type=range]::-webkit-slider-runnable-track {
 
 #main {
     position: absolute;
-    top: calc(var(--undocked-title-area-height) + var(--tab-bar-height));
+    top: var(--tab-bar-height);
     left: 0;
     right: 0;
     bottom: 0;
@@ -549,26 +523,6 @@ body[dir=rtl] [dir=ltr] .go-to-arrow {
 }
 
 @media (prefers-color-scheme: dark) {
-    #undocked-title-area {
-        box-shadow: none;
-    }
-
-    body.mac-platform #undocked-title-area {
-        --undocked-title-area-background: var(--background-color-content);
-    }
-
-    body:not(.mac-platform) #undocked-title-area {
-        --undocked-title-area-background: linear-gradient(to bottom, hsl(0, 0%, 26%), hsl(0, 0%, 23%));
-    }
-
-    body.mac-platform.window-inactive #undocked-title-area {
-        --undocked-title-area-background: hsl(0, 0%, 11%);
-    }
-
-    body:not(.mac-platform).window-inactive #undocked-title-area {
-        --undocked-title-area-background: hsl(0, 0%, 19%);
-    }
-
     .go-to-arrow {
         filter: invert();
     }

--- a/Source/WebInspectorUI/UserInterface/Views/Popover.js
+++ b/Source/WebInspectorUI/UserInterface/Views/Popover.js
@@ -253,8 +253,7 @@ WI.Popover = class Popover extends WI.Object
             this._preferredSize = new WI.Size(Math.ceil(popoverBounds.width), Math.ceil(popoverBounds.height));
         }
 
-        var titleBarOffset = WI.undockedTitleAreaHeight();
-        var containerFrame = new WI.Rect(0, titleBarOffset, window.innerWidth, window.innerHeight - titleBarOffset);
+        let containerFrame = new WI.Rect(0, 0, window.innerWidth, window.innerHeight);
         // The frame of the window with a little inset to make sure we have room for shadows.
         containerFrame = containerFrame.inset(WI.Popover.ShadowEdgeInsets);
 

--- a/Source/WebInspectorUI/UserInterface/Views/TabBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TabBar.css
@@ -26,7 +26,7 @@
 .tab-bar {
     display: flex;
     position: absolute;
-    top: var(--undocked-title-area-height);
+    top: 0;
     left: 0;
     right: 0;
     height: var(--tab-bar-height);

--- a/Source/WebInspectorUI/UserInterface/Views/Variables.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Variables.css
@@ -196,7 +196,6 @@
     /* Invert colors yet preserve the hue */
     --filter-invert: invert(100%) hue-rotate(180deg);
 
-    --undocked-title-area-height: 0px;
     --tab-bar-height: var(--navigation-bar-height);
     --navigation-bar-height: 29px;
 
@@ -433,10 +432,5 @@ body {
             --border-color: hsl(0, 0%, 30%);
             --border-color-secondary: hsl(0, 0%, 24%);
         }
-    }
-
-    /* Only needed by the Mac port, keep in sync with `WI.undockedTitleAreaHeight` */
-    &.mac-platform:not(.docked) {
-        --undocked-title-area-height: calc(27px / var(--zoom-factor));
     }
 }

--- a/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.h
+++ b/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.h
@@ -43,7 +43,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) WKWebView *webView;
 @property (nonatomic, weak) id <WKInspectorViewControllerDelegate> delegate;
-@property (nonatomic) BOOL isAttached;
 
 - (instancetype)initWithConfiguration:(_WKInspectorConfiguration *)configuration inspectedPage:(NakedPtr<WebKit::WebPageProxy>)inspectedPage;
 

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -839,8 +839,6 @@ void WebInspectorUIProxy::platformAttach()
     RetainPtr inspectedView = protectedInspectedPage()->inspectorAttachmentView();
     WKWebView *inspectorView = [m_inspectorViewController webView];
 
-    [m_inspectorViewController setIsAttached:YES];
-
     if (m_inspectorWindow) {
         [m_inspectorWindow setDelegate:nil];
         [m_inspectorWindow close];
@@ -876,8 +874,6 @@ void WebInspectorUIProxy::platformDetach()
     RefPtr inspectedPage = m_inspectedPage.get();
     RetainPtr inspectedView = inspectedPage ? inspectedPage->inspectorAttachmentView() : nil;
     WKWebView *inspectorView = [m_inspectorViewController webView];
-
-    [m_inspectorViewController setIsAttached:NO];
 
     [inspectorView removeFromSuperview];
     [inspectorView setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];


### PR DESCRIPTION
#### afe7a8d8ea3366ef7a6870e27b5329645cfb956a
<pre>
Web Inspector: Remove undocked-title-area element since inspector already adjusts based on safeAreaInsets
<a href="https://rdar.apple.com/149898806">rdar://149898806</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292205">https://bugs.webkit.org/show_bug.cgi?id=292205</a>

Reviewed by Devin Rousso and BJ Burg.

The patch <a href="https://github.com/WebKit/WebKit/pull/43779">https://github.com/WebKit/WebKit/pull/43779</a> made Web Inspector
automatically adjust its visible area based on the WKInspectorWKWebView&apos;s
safeAreaInsets, which natively computes the margins on all four edges
that are blocked by other view elements. That patch introduced a
regression that the undocked Web Inspector started to have an extra
white space on the top under the title bar, which we then fixed in <a href="https://github.com/WebKit/WebKit/pull/44438.">https://github.com/WebKit/WebKit/pull/44438.</a>
However, it turns out safeAreaInsets already includes the title bar&apos;s
height, so there is actually no need for the undocked-title-area element
anymore as the auto-adjustment already does the job well.

Note that dragging the title bar to move the window is an effect handled
by the window natively. By removing the undocked-title-area and thus a
call to WI.moveUndockedWindowMouseDown, we&apos;re letting the window itself
handle the drag to move instead. This preserves the normal dragging
behavior, and I tested that manually.

* Source/WebInspectorUI/UserInterface/Base/Main.js:
* Source/WebInspectorUI/UserInterface/Main.html:
* Source/WebInspectorUI/UserInterface/Views/Main.css:
(#main):
(#undocked-title-area): Deleted.
(body.mac-platform #undocked-title-area): Deleted.
(body:not(.mac-platform) #undocked-title-area): Deleted.
(body.docked #undocked-title-area): Deleted.
(body.window-inactive #undocked-title-area): Deleted.
(@media (prefers-color-scheme: dark) #undocked-title-area): Deleted.
(@media (prefers-color-scheme: dark) body.mac-platform #undocked-title-area): Deleted.
(@media (prefers-color-scheme: dark) body:not(.mac-platform) #undocked-title-area): Deleted.
(@media (prefers-color-scheme: dark) body.mac-platform.window-inactive #undocked-title-area): Deleted.
(@media (prefers-color-scheme: dark) body:not(.mac-platform).window-inactive #undocked-title-area): Deleted.
* Source/WebInspectorUI/UserInterface/Views/Popover.js:
* Source/WebInspectorUI/UserInterface/Views/TabBar.css:
(.tab-bar):
* Source/WebInspectorUI/UserInterface/Views/Variables.css:
(:root):
(&amp;.mac-platform:not(.docked)): Deleted.
   - Deprecate and remove the undocked-title-area element.

* Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.h:
* Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm:
(-[WKInspectorViewController webView]):
(-[WKInspectorViewController observeValueForKeyPath:ofObject:change:context:]):
(-[WKInspectorViewController webViewWebContentProcessDidTerminate:]):
(-[WKInspectorViewController setIsAttached:]): Deleted.
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(WebKit::WebInspectorUIProxy::platformAttach):
(WebKit::WebInspectorUIProxy::platformDetach):
   - Restore the auto-adjusting behavior to also still take effect while
     inspector is undocked, to let that handle the padding required for
     the title bar&apos;s height.

Canonical link: <a href="https://commits.webkit.org/294303@main">https://commits.webkit.org/294303@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5df790cc32e04568b20c04c8bbc3f2ca33b67c68

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106519 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51995 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21338 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29524 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77206 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34244 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104373 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16464 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91562 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57547 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16284 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9573 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51343 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86165 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9648 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108871 "Hash 5df790cc for PR 44623 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28495 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20968 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/108871 "Hash 5df790cc for PR 44623 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87764 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/108871 "Hash 5df790cc for PR 44623 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30466 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8181 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22612 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16505 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28426 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33705 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28237 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31557 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29796 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->