### PR TITLE
[JSC] Remove redundant Code::forAllTmps()

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirCode.h
+++ b/Source/JavaScriptCore/b3/air/AirCode.h
@@ -143,17 +143,6 @@ public:
         }
         ASSERT_NOT_REACHED();
     }
-    
-    template<typename Func>
-    void forEachTmp(const Func& func)
-    {
-        for (unsigned bankIndex = 0; bankIndex < numBanks; ++bankIndex) {
-            Bank bank = static_cast<Bank>(bankIndex);
-            unsigned numTmps = this->numTmps(bank);
-            for (unsigned i = 0; i < numTmps; ++i)
-                func(Tmp::tmpForIndex(bank, i));
-        }
-    }
 
     template<Bank bank, typename Func>
     void forEachTmp(const Func& func)
@@ -161,6 +150,14 @@ public:
         unsigned numTmps = this->numTmps(bank);
         for (unsigned i = 0; i < numTmps; ++i)
             func(Tmp::tmpForIndex(bank, i));
+    }
+
+    template<typename Func>
+    void forEachTmp(const Func& func)
+    {
+        static_assert(numBanks == 2);
+        forEachTmp<GP>(func);
+        forEachTmp<FP>(func);
     }
 
     unsigned callArgAreaSizeInBytes() const { return m_callArgAreaSize; }
@@ -311,15 +308,6 @@ public:
 
     const SparseCollection<Special>& specials() const { return m_specials; }
     SparseCollection<Special>& specials() { return m_specials; }
-
-    template<typename Callback>
-    void forAllTmps(const Callback& callback) const
-    {
-        for (unsigned i = m_numGPTmps; i--;)
-            callback(Tmp::gpTmpForIndex(i));
-        for (unsigned i = m_numFPTmps; i--;)
-            callback(Tmp::fpTmpForIndex(i));
-    }
 
     void addFastTmp(Tmp);
 

--- a/Source/JavaScriptCore/b3/air/AirTmpWidth.cpp
+++ b/Source/JavaScriptCore/b3/air/AirTmpWidth.cpp
@@ -76,7 +76,7 @@ void TmpWidth::recompute(Code& code)
         });
 
     if (beCareful) {
-        code.forAllTmps(assumeTheWorst);
+        code.forEachTmp(assumeTheWorst);
         
         // We fall through because the fixpoint that follows can only make things even more
         // conservative. This mode isn't meant to be fast, just safe.


### PR DESCRIPTION
#### 325ff3e97b16d656ffedb041206253779881fcdd
<pre>
[JSC] Remove redundant Code::forAllTmps()
<a href="https://bugs.webkit.org/show_bug.cgi?id=292207">https://bugs.webkit.org/show_bug.cgi?id=292207</a>
<a href="https://rdar.apple.com/150217568">rdar://150217568</a>

Reviewed by Yijia Huang and Yusuke Suzuki.

forAllTmps() and forEachTmp() have the same semantics, so remove
forAllTmps(), which only has one caller, in favor of forEachTmp().

One advantage forAllTmps() had was that it removes the branch
on bank within the loop. Rewrite forEachTmp() to give the compiler
the opportunity to do that.

Canonical link: <a href="https://commits.webkit.org/294271@main">https://commits.webkit.org/294271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2144721e30d0f970311fe9c94180194c5d21961

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101159 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106307 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51786 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21130 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29315 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77059 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34083 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16288 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91376 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57406 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16106 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9395 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51134 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/93826 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86006 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9459 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108663 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/99768 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28287 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20832 "Found 2 new test failures: http/tests/iframe-monitor/data-url-resource.html http/tests/iframe-monitor/iframe-unload.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86028 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28649 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87577 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85568 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21801 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30290 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8013 "Found 1 new test failure: fullscreen/full-screen-request-removed-with-raf.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22386 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28217 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33488 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/123394 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28029 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34356 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31349 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29587 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->