### PR TITLE
Add Node::isInclusiveDescendantOf

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -405,7 +405,7 @@ void AXObjectCache::updateCurrentModalNode()
             if (!isNodeVisible(element.get()) || !modalElementHasAccessibleContent(*element))
                 continue;
 
-            bool focusIsInsideElement = focusedElement && (focusedElement == element.get() || focusedElement->isDescendantOf(*element));
+            bool focusIsInsideElement = focusedElement && focusedElement->isInclusiveDescendantOf(*element);
 
             // If the modal we found previously is a descendant of this one, prefer the descendant and skip this one.
             if (modalElementToReturn && foundModalWithFocusInside && modalElementToReturn->isDescendantOf(*element))

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -977,8 +977,8 @@ std::optional<SimpleRange> AccessibilityObject::findTextRange(const Vector<Strin
     if (found) {
         // If the search started within a text control, ensure that the result is inside that element.
         if (element() && element()->isTextField()) {
-            if (!found->startContainer().isDescendantOrShadowDescendantOf(element())
-                || !found->endContainer().isDescendantOrShadowDescendantOf(element()))
+            if (!found->startContainer().isShadowIncludingDescendantOf(element())
+                || !found->endContainer().isShadowIncludingDescendantOf(element()))
                 return std::nullopt;
         }
     }
@@ -2001,7 +2001,7 @@ int AccessibilityObject::lineForPosition(const VisiblePosition& visiblePos) cons
 
     // If the position is not in the same editable region as this AX object, return -1.
     Node* containerNode = visiblePos.deepEquivalent().containerNode();
-    if (!containerNode->containsIncludingShadowDOM(node()) && !node()->containsIncludingShadowDOM(containerNode))
+    if (!containerNode->isShadowIncludingInclusiveAncestorOf(node()) && !node()->isShadowIncludingInclusiveAncestorOf(containerNode))
         return -1;
 
     int lineCount = -1;

--- a/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
+++ b/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
@@ -260,7 +260,7 @@ void disconnectSubframes(ContainerNode& root, SubframeDisconnectPolicy policy)
     for (auto& owner : frameOwners) {
         // Don't need to traverse up the tree for the first owner since no
         // script could have moved it.
-        if (isFirst || root.containsIncludingShadowDOM(&owner.get()))
+        if (isFirst || root.isShadowIncludingInclusiveAncestorOf(&owner.get()))
             owner.get().disconnectContentFrame();
         isFirst = false;
     }

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -262,7 +262,7 @@ void ContentVisibilityDocumentState::updateAnimations(const Element& element, Is
         if (!styleOriginatedAnimation)
             continue;
         auto owningElement = styleOriginatedAnimation->owningElement();
-        if (!owningElement || !owningElement->element.isDescendantOrShadowDescendantOf(&element))
+        if (!owningElement || !owningElement->element.isShadowIncludingDescendantOf(&element))
             continue;
 
         if (RefPtr timeline = styleOriginatedAnimation->timeline())

--- a/Source/WebCore/dom/CustomElementDefaultARIA.cpp
+++ b/Source/WebCore/dom/CustomElementDefaultARIA.cpp
@@ -47,7 +47,7 @@ void CustomElementDefaultARIA::setValueForAttribute(const QualifiedName& name, c
 
 static bool isElementVisible(const Element& element, const Element& thisElement)
 {
-    return !element.isConnected() || element.isInDocumentTree() || thisElement.isDescendantOrShadowDescendantOf(element.protectedRootNode());
+    return !element.isConnected() || element.isInDocumentTree() || thisElement.isShadowIncludingDescendantOf(element.protectedRootNode());
 }
 
 const AtomString& CustomElementDefaultARIA::valueForAttribute(const Element& thisElement, const QualifiedName& name) const

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1481,7 +1481,7 @@ RefPtr<Element> Element::offsetParentForBindings()
     RefPtr element = offsetParent();
     if (!element || !element->isInShadowTree())
         return element;
-    while (element && !isDescendantOrShadowDescendantOf(&element->rootNode()))
+    while (element && !isShadowIncludingDescendantOf(&element->rootNode()))
         element = element->offsetParent();
     return element;
 }
@@ -2391,7 +2391,7 @@ RefPtr<Element> Element::elementForAttributeInternal(const QualifiedName& attrib
             ASSERT(it->value.size() == 1);
             hasExplicitlySetElement = true;
             RefPtr explicitlySetElement = it->value[0].get();
-            if (explicitlySetElement && isDescendantOrShadowDescendantOf(explicitlySetElement->rootNode()))
+            if (explicitlySetElement && isShadowIncludingDescendantOf(explicitlySetElement->rootNode()))
                 element = explicitlySetElement;
         }
     }
@@ -2443,7 +2443,7 @@ std::optional<Vector<Ref<Element>>> Element::elementsArrayForAttributeInternal(c
             hasExplicitlySetElements = true;
             elements = compactMap(it->value, [&](auto& weakElement) -> std::optional<Ref<Element>> {
                 RefPtr element = weakElement.get();
-                if (element && isDescendantOrShadowDescendantOf(element->rootNode()))
+                if (element && isShadowIncludingDescendantOf(element->rootNode()))
                     return element.releaseNonNull();
                 return std::nullopt;
             });
@@ -4046,7 +4046,7 @@ void Element::focus(const FocusOptions& options)
 
     if (RefPtr root = shadowRootWithDelegatesFocus(*this)) {
         RefPtr currentlyFocusedElement = document->focusedElement();
-        if (root->containsIncludingShadowDOM(currentlyFocusedElement.get())) {
+        if (root->isShadowIncludingInclusiveAncestorOf(currentlyFocusedElement.get())) {
             if (RefPtr page = document->page())
                 page->chrome().client().elementDidRefocus(*currentlyFocusedElement, options);
             return;

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -444,14 +444,26 @@ public:
 
     ExceptionOr<void> checkSetPrefix(const AtomString& prefix);
 
+    // https://dom.spec.whatwg.org/#concept-tree-descendant
     WEBCORE_EXPORT bool isDescendantOf(const Node&) const;
     bool isDescendantOf(const Node* other) const { return other && isDescendantOf(*other); }
-    WEBCORE_EXPORT bool contains(const Node&) const;
-    bool contains(const Node* other) const { return other && contains(*other); }
 
-    WEBCORE_EXPORT bool isDescendantOrShadowDescendantOf(const Node&) const;
-    bool isDescendantOrShadowDescendantOf(const Node* other) const { return other && isDescendantOrShadowDescendantOf(*other); } 
-    WEBCORE_EXPORT bool containsIncludingShadowDOM(const Node*) const;
+    // https://dom.spec.whatwg.org/#concept-tree-inclusive-descendant
+    ALWAYS_INLINE bool isInclusiveDescendantOf(const Node& other) const { return this == &other || isDescendantOf(other); }
+    ALWAYS_INLINE bool isInclusiveDescendantOf(const Node* other) const { return other && isInclusiveDescendantOf(*other); }
+
+    // https://dom.spec.whatwg.org/#concept-tree-inclusive-ancestor
+    ALWAYS_INLINE bool contains(const Node& other) const { return other.isInclusiveDescendantOf(*this); }
+    ALWAYS_INLINE bool contains(const Node* other) const { return other && contains(*other); }
+
+    // https://dom.spec.whatwg.org/#concept-shadow-including-descendant
+    WEBCORE_EXPORT bool isShadowIncludingDescendantOf(const Node&) const;
+    ALWAYS_INLINE bool isShadowIncludingDescendantOf(const Node* other) const { return other && isShadowIncludingDescendantOf(*other); }
+
+    // https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-ancestor
+    ALWAYS_INLINE bool isShadowIncludingInclusiveAncestorOf(const Node& other) const { return this == &other || other.isShadowIncludingDescendantOf(*this); }
+    ALWAYS_INLINE bool isShadowIncludingInclusiveAncestorOf(const Node* other) const { return other && isShadowIncludingInclusiveAncestorOf(*other); }
+
     bool isComposedTreeDescendantOf(const Node&) const;
 
     // Whether or not a selection can be started in this object

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -967,7 +967,7 @@ void Range::nodeWillBeRemoved(Node& node)
 
 bool Range::parentlessNodeMovedToNewDocumentAffectsRange(Node& node)
 {
-    return node.containsIncludingShadowDOM(&m_start.container());
+    return node.isShadowIncludingInclusiveAncestorOf(&m_start.container());
 }
 
 void Range::updateRangeForParentlessNodeMovedToNewDocument(Node& node)

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -304,7 +304,7 @@ static ContainerNode& filterRootById(ContainerNode& rootNode, const CSSSelector&
                 if (LIKELY(!rootNode.treeScope().containsMultipleElementsWithId(idToMatch))) {
                     if (inAdjacentChain)
                         searchRoot = searchRoot->parentNode();
-                    if (searchRoot && (rootNode.isTreeScope() || searchRoot == &rootNode || searchRoot->isDescendantOf(rootNode)))
+                    if (searchRoot && (rootNode.isTreeScope() || searchRoot->isInclusiveDescendantOf(rootNode)))
                         return *searchRoot;
                 }
             }

--- a/Source/WebCore/dom/TreeScopeOrderedMap.cpp
+++ b/Source/WebCore/dom/TreeScopeOrderedMap.cpp
@@ -56,7 +56,7 @@ void TreeScopeOrderedMap::add(const AtomString& key, Element& element, const Tre
 {
     ASSERT_WITH_SECURITY_IMPLICATION(!key.isNull());
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(&element.treeScope() == &treeScope);
-    ASSERT_WITH_SECURITY_IMPLICATION(treeScope.rootNode().containsIncludingShadowDOM(&element));
+    ASSERT_WITH_SECURITY_IMPLICATION(treeScope.rootNode().isShadowIncludingInclusiveAncestorOf(&element));
 
     if (!element.isInTreeScope())
         return;

--- a/Source/WebCore/dom/TypedElementDescendantIteratorInlines.h
+++ b/Source/WebCore/dom/TypedElementDescendantIteratorInlines.h
@@ -85,13 +85,13 @@ template<typename ElementType> ElementDescendantIterator<ElementType> InclusiveE
 
 template<typename ElementType> ElementDescendantIterator<ElementType> InclusiveElementDescendantRange<ElementType>::beginAt(ElementType& descendant) const
 {
-    ASSERT(m_root.ptr() == &descendant || descendant.isDescendantOf(m_root));
+    ASSERT(descendant.isInclusiveDescendantOf(m_root));
     return ElementDescendantIterator<ElementType>(m_root, &descendant);
 }
 
 template<typename ElementType> ElementDescendantIterator<ElementType> InclusiveElementDescendantRange<ElementType>::from(Element& descendant) const
 {
-    ASSERT(m_root.ptr() == &descendant || descendant.isDescendantOf(m_root));
+    ASSERT(descendant.isInclusiveDescendantOf(m_root));
     if (auto descendantElement = dynamicDowncast<ElementType>(descendant))
         return ElementDescendantIterator<ElementType>(m_root, descendantElement);
     ElementType* next = Traversal<ElementType>::next(descendant, &m_root);

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -283,7 +283,7 @@ Position firstEditablePositionAfterPositionInRoot(const Position& position, Cont
     while (candidate.deprecatedNode() && !isEditablePosition(candidate) && candidate.protectedDeprecatedNode()->isDescendantOf(*highestRoot))
         candidate = isAtomicNode(candidate.deprecatedNode()) ? positionInParentAfterNode(candidate.protectedDeprecatedNode().get()) : nextVisuallyDistinctCandidate(candidate);
 
-    if (candidate.deprecatedNode() && candidate.deprecatedNode() != highestRoot && !candidate.protectedDeprecatedNode()->isDescendantOf(*highestRoot))
+    if (candidate.deprecatedNode() && !candidate.protectedDeprecatedNode()->isInclusiveDescendantOf(*highestRoot))
         return { };
 
     return candidate;
@@ -311,7 +311,7 @@ Position lastEditablePositionBeforePositionInRoot(const Position& position, Cont
     while (candidate.deprecatedNode() && !isEditablePosition(candidate) && candidate.protectedDeprecatedNode()->isDescendantOf(*highestRoot))
         candidate = isAtomicNode(candidate.deprecatedNode()) ? positionInParentBeforeNode(candidate.protectedDeprecatedNode().get()) : previousVisuallyDistinctCandidate(candidate);
     
-    if (candidate.deprecatedNode() && candidate.deprecatedNode() != highestRoot && !candidate.protectedDeprecatedNode()->isDescendantOf(*highestRoot))
+    if (candidate.deprecatedNode() && !candidate.protectedDeprecatedNode()->isInclusiveDescendantOf(*highestRoot))
         return { };
     
     return candidate;
@@ -840,25 +840,25 @@ void updatePositionForNodeRemoval(Position& position, Node& node)
         return;
     switch (position.anchorType()) {
     case Position::PositionIsBeforeChildren:
-        if (node.containsIncludingShadowDOM(position.containerNode()))
+        if (node.isShadowIncludingInclusiveAncestorOf(position.containerNode()))
             position = positionInParentBeforeNode(&node);
         break;
     case Position::PositionIsAfterChildren:
-        if (node.containsIncludingShadowDOM(position.containerNode()))
+        if (node.isShadowIncludingInclusiveAncestorOf(position.containerNode()))
             position = positionInParentBeforeNode(&node);
         break;
     case Position::PositionIsOffsetInAnchor:
         if (position.containerNode() == node.parentNode() && static_cast<unsigned>(position.offsetInContainerNode()) > node.computeNodeIndex())
             position.moveToOffset(position.offsetInContainerNode() - 1);
-        else if (node.containsIncludingShadowDOM(position.containerNode()))
+        else if (node.isShadowIncludingInclusiveAncestorOf(position.containerNode()))
             position = positionInParentBeforeNode(&node);
         break;
     case Position::PositionIsAfterAnchor:
-        if (node.containsIncludingShadowDOM(position.anchorNode()))
+        if (node.isShadowIncludingInclusiveAncestorOf(position.anchorNode()))
             position = positionInParentAfterNode(&node);
         break;
     case Position::PositionIsBeforeAnchor:
-        if (node.containsIncludingShadowDOM(position.anchorNode()))
+        if (node.isShadowIncludingInclusiveAncestorOf(position.anchorNode()))
             position = positionInParentBeforeNode(&node);
         break;
     }

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -579,7 +579,7 @@ static bool removingNodeRemovesPosition(Node& node, const Position& position)
         return true;
 
     RefPtr element = dynamicDowncast<Element>(node);
-    return element && element->containsIncludingShadowDOM(position.anchorNode());
+    return element && element->isShadowIncludingInclusiveAncestorOf(position.anchorNode());
 }
 
 void DragCaretController::nodeWillBeRemoved(Node& node)

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -424,7 +424,7 @@ static inline Node* nextNode(TextIteratorBehaviors options, Node& node)
 static inline bool isDescendantOf(TextIteratorBehaviors options, Node& node, Node& possibleAncestor)
 {
     if (UNLIKELY(options.contains(TextIteratorBehavior::TraversesFlatTree)))
-        return node.isDescendantOrShadowDescendantOf(&possibleAncestor);
+        return node.isShadowIncludingDescendantOf(&possibleAncestor);
     return node.isDescendantOf(&possibleAncestor);
 }
 

--- a/Source/WebCore/editing/ios/EditorIOS.mm
+++ b/Source/WebCore/editing/ios/EditorIOS.mm
@@ -235,7 +235,7 @@ void Editor::confirmMarkedText()
     Ref document = protectedDocument();
     RefPtr focused = document->focusedElement();
     RefPtr composition = compositionNode();
-    if (composition && focused && !composition->isDescendantOrShadowDescendantOf(*focused)) {
+    if (composition && focused && !composition->isShadowIncludingDescendantOf(*focused)) {
         cancelComposition();
         document->setFocusedElement(focused.get());
     } else

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -446,7 +446,7 @@ private:
     bool isDescendantOf(Node& node, Node& possibleAncestor)
     {
         if (UNLIKELY(m_useComposedTree))
-            return node.isDescendantOrShadowDescendantOf(&possibleAncestor);
+            return node.isShadowIncludingDescendantOf(&possibleAncestor);
         return node.isDescendantOf(&possibleAncestor);
     }
 
@@ -876,7 +876,7 @@ RefPtr<Node> StyledMarkupAccumulator::traverseNodesForSerialization(Node& startN
         else
             advanceToAncestorSibling();
 
-        ASSERT(next || !pastEnd || n->containsIncludingShadowDOM(pastEnd));
+        ASSERT(next || !pastEnd || n->isShadowIncludingInclusiveAncestorOf(pastEnd));
 
         if (isBlock(*n) && canHaveChildrenForEditing(*n) && next == pastEnd) {
             // Don't write out empty block containers that aren't fully selected.

--- a/Source/WebCore/html/FormAssociatedCustomElement.cpp
+++ b/Source/WebCore/html/FormAssociatedCustomElement.cpp
@@ -67,7 +67,7 @@ ExceptionOr<void> FormAssociatedCustomElement::setValidity(ValidityStateFlags va
     m_validityStateFlags = validityStateFlags;
     setCustomValidity(validityStateFlags.isValid() ? emptyString() : WTFMove(message));
 
-    if (validationAnchor && !validationAnchor->isDescendantOrShadowDescendantOf(*m_element))
+    if (validationAnchor && !validationAnchor->isShadowIncludingDescendantOf(*m_element))
         return Exception { ExceptionCode::NotFoundError };
 
     m_validationAnchor = validationAnchor;

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1259,7 +1259,7 @@ ExceptionOr<void> HTMLElement::hidePopoverInternal(FocusPreviousElement focusPre
 
     Ref document = this->document();
     if (RefPtr element = popoverData()->previouslyFocusedElement()) {
-        if (focusPreviousElement == FocusPreviousElement::Yes && containsIncludingShadowDOM(document->protectedFocusedElement().get())) {
+        if (focusPreviousElement == FocusPreviousElement::Yes && isShadowIncludingInclusiveAncestorOf(document->protectedFocusedElement().get())) {
             FocusOptions options;
             options.preventScroll = true;
             element->focus(options);

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -403,7 +403,7 @@ void HTMLFormControlElement::handlePopoverTargetAction(const EventTarget* eventT
     ASSERT(popover->popoverData());
 
     if (RefPtr eventTargetNode = dynamicDowncast<Node>(eventTarget)) {
-        if (popover->containsIncludingShadowDOM(eventTargetNode.get()) && popover->isDescendantOrShadowDescendantOf(this))
+        if (popover->isShadowIncludingInclusiveAncestorOf(eventTargetNode.get()) && popover->isShadowIncludingDescendantOf(this))
             return;
     }
 

--- a/Source/WebCore/html/HTMLLabelElement.cpp
+++ b/Source/WebCore/html/HTMLLabelElement.cpp
@@ -143,7 +143,7 @@ bool HTMLLabelElement::isEventTargetedAtInteractiveDescendants(Event& event) con
     if (!node)
         return false;
 
-    if (!containsIncludingShadowDOM(node.get()))
+    if (!isShadowIncludingInclusiveAncestorOf(node.get()))
         return false;
 
     for (const auto* it = node.get(); it && it != this; it = it->parentElementInComposedTree()) {
@@ -162,7 +162,7 @@ void HTMLLabelElement::defaultEventHandler(Event& event)
         // If we can't find a control or if the control received the click
         // event, then there's no need for us to do anything.
         auto* eventTarget = dynamicDowncast<Node>(event.target());
-        if (!control || (eventTarget && control->containsIncludingShadowDOM(eventTarget))) {
+        if (!control || (eventTarget && control->isShadowIncludingInclusiveAncestorOf(eventTarget))) {
             HTMLElement::defaultEventHandler(event);
             return;
         }

--- a/Source/WebCore/page/DOMSelection.cpp
+++ b/Source/WebCore/page/DOMSelection.cpp
@@ -299,7 +299,7 @@ ExceptionOr<void> DOMSelection::setBaseAndExtent(Node* baseNode, unsigned baseOf
             return result.releaseException();
         Ref document = *frame->document();
         if (frame->settings().selectionAPIForShadowDOMEnabled()) {
-            if (!document->containsIncludingShadowDOM(baseNode) || !document->containsIncludingShadowDOM(extentNode))
+            if (!document->isShadowIncludingInclusiveAncestorOf(baseNode) || !document->isShadowIncludingInclusiveAncestorOf(extentNode))
                 return { };
         } else {
             if (!document->contains(*baseNode) || !document->contains(*extentNode))

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -980,7 +980,7 @@ std::optional<HitTestResult> DragController::hitTestResultForDragStart(LocalFram
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::AllowChildFrameContent };
     auto hitTestResult = source.eventHandler().hitTestResultAtPoint(location, hitType);
 
-    bool sourceContainsHitNode = element.containsIncludingShadowDOM(hitTestResult.innerNode());
+    bool sourceContainsHitNode = element.isShadowIncludingInclusiveAncestorOf(hitTestResult.innerNode());
     if (!sourceContainsHitNode) {
         // The original node being dragged isn't under the drag origin anymore... maybe it was
         // hidden or moved out from under the cursor. Regardless, we don't want to start a drag on

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -1310,7 +1310,7 @@ Vector<TargetedElementInfo> ElementTargetingController::extractTargets(Vector<Re
                 candidateOrHost = pseudo->hostElement();
             else
                 candidateOrHost = &candidate;
-            return candidateOrHost && target.containsIncludingShadowDOM(candidateOrHost.get());
+            return candidateOrHost && target.isShadowIncludingInclusiveAncestorOf(candidateOrHost.get());
         };
 
         candidates.removeAllMatching([&](auto& candidate) {
@@ -1362,7 +1362,7 @@ Vector<TargetedElementInfo> ElementTargetingController::extractTargets(Vector<Re
                 continue;
 
             bool elementIsAlreadyTargeted = targets.containsIf([&element](auto& target) {
-                return target->containsIncludingShadowDOM(element.get());
+                return target->isShadowIncludingInclusiveAncestorOf(element.get());
             });
 
             if (elementIsAlreadyTargeted)

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -500,10 +500,10 @@ void EventHandler::clear()
 
 void EventHandler::nodeWillBeRemoved(Node& nodeToBeRemoved)
 {
-    if (nodeToBeRemoved.containsIncludingShadowDOM(RefPtr { m_clickNode }.get()))
+    if (nodeToBeRemoved.isShadowIncludingInclusiveAncestorOf(RefPtr { m_clickNode }.get()))
         m_clickNode = nullptr;
 
-    if (nodeToBeRemoved.containsIncludingShadowDOM(RefPtr { m_lastElementUnderMouse }.get()))
+    if (nodeToBeRemoved.isShadowIncludingInclusiveAncestorOf(RefPtr { m_lastElementUnderMouse }.get()))
         m_lastElementUnderMouse = nullptr;
 }
 

--- a/Source/WebCore/svg/SVGFEImageElement.cpp
+++ b/Source/WebCore/svg/SVGFEImageElement.cpp
@@ -188,7 +188,7 @@ std::tuple<RefPtr<ImageBuffer>, FloatRect> SVGFEImageElement::imageBufferForEffe
     if (!is<SVGElement>(target.element))
         return { };
 
-    if (isDescendantOrShadowDescendantOf(target.element.get()))
+    if (isShadowIncludingDescendantOf(target.element.get()))
         return { };
 
     RefPtr contextNode = static_pointer_cast<SVGElement>(target.element);

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -475,7 +475,7 @@ RefPtr<SVGElement> SVGUseElement::findTarget(AtomString* targetID) const
         if (target->contains(this))
             return nullptr;
         // Target should only refer to a node in the same tree or a node in another document.
-        ASSERT(!isDescendantOrShadowDescendantOf(target.get()));
+        ASSERT(!isShadowIncludingDescendantOf(target.get()));
     }
 
     return target;

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -787,7 +787,7 @@ void WebAutomationSessionProxy::computeElementLayout(WebCore::PageIdentifier pag
     // Check the case where a non-descendant element hit tests before the target element. For example, a child <option>
     // of a <select> does not obscure the <select>, but two sibling <div> that overlap at the IVCP will obscure each other.
     // Node::isDescendantOf() is not self-inclusive, so that is explicitly checked here.
-    isObscured = elementList[0] != containerElement && !RefPtr { elementList[0] }->isDescendantOrShadowDescendantOf(containerElement.get());
+    isObscured = elementList[0] != containerElement && !RefPtr { elementList[0] }->isShadowIncludingDescendantOf(containerElement.get());
 
     switch (coordinateSystem) {
     case CoordinateSystem::Page:

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -10140,7 +10140,7 @@ void WebPage::simulateClickOverFirstMatchingTextInViewportWithUserInteraction(co
                 HitTestRequest::Type::Active,
             });
             RefPtr innerNode = result.innerNonSharedNode();
-            return !innerNode || !target->containsIncludingShadowDOM(innerNode.get());
+            return !innerNode || !target->isShadowIncludingInclusiveAncestorOf(innerNode.get());
         });
     };
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5984,7 +5984,7 @@ void WebPage::scheduleEditorStateUpdateAfterAnimationIfNeeded(const Element& ani
         return;
 
     auto scheduleEditorStateUpdateForStartOrEndContainerNodeIfNeeded = [&](const Node* container) {
-        if (!animatedElement.containsIncludingShadowDOM(container))
+        if (!animatedElement.isShadowIncludingInclusiveAncestorOf(container))
             return false;
 
         frame->selection().setCaretRectNeedsUpdate();


### PR DESCRIPTION
#### c8f25024db035b47829a88b2694f83273f7234d6
<pre>
Add Node::isInclusiveDescendantOf
<a href="https://bugs.webkit.org/show_bug.cgi?id=292208">https://bugs.webkit.org/show_bug.cgi?id=292208</a>

Reviewed by Anne van Kesteren.

Add isInclusiveDescendantOf and uses it in a few places. Also rename containsIncludingShadowDOM
to isShadowIncludingInclusiveAncestorOf and isDescendantOrShadowDescendantOf to
isShadowIncludingDescendantOf to match the DOM specification&apos;s concepts.

In addition, generalize the optimization in Node::isDescendantOf so that it applies to a shadow
tree as well as a document tree.

Finally, reimplement Node::containsIncludingShadowDOM in terms of isShadowIncludingDescendantOf
to share more code and optimizations.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::updateCurrentModalNode):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::findTextRange const):
(WebCore::AccessibilityObject::lineForPosition const):
* Source/WebCore/dom/ContainerNodeAlgorithms.cpp:
(WebCore::disconnectSubframes):
* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
(WebCore::ContentVisibilityDocumentState::updateAnimations):
* Source/WebCore/dom/CustomElementDefaultARIA.cpp:
(WebCore::isElementVisible):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::offsetParentForBindings):
(WebCore::Element::elementForAttributeInternal const):
(WebCore::Element::elementsArrayForAttributeInternal const):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::isDescendantOf const):
(WebCore::Node::isShadowIncludingDescendantOf const):
(WebCore::isClosedShadowHiddenUsingSpecDefinition):
(WebCore::Node::isDescendantOrShadowDescendantOf const): Deleted.
(WebCore::Node::contains const): Deleted.
(WebCore::Node::containsIncludingShadowDOM const): Deleted.
* Source/WebCore/dom/Node.h:
(WebCore::Node::isDescendantOf const):
(WebCore::Node::isInclusiveDescendantOf const):
(WebCore::Node::contains const):
(WebCore::Node::isShadowIncludingDescendantOf const):
(WebCore::Node::isShadowIncludingInclusiveAncestorOf const):
(WebCore::Node::isDescendantOrShadowDescendantOf const): Deleted.
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::parentlessNodeMovedToNewDocumentAffectsRange):
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::filterRootById):
* Source/WebCore/dom/TreeScopeOrderedMap.cpp:
(WebCore::TreeScopeOrderedMap::add):
* Source/WebCore/dom/TypedElementDescendantIteratorInlines.h:
(WebCore::InclusiveElementDescendantRange&lt;ElementType&gt;::beginAt const):
(WebCore::InclusiveElementDescendantRange&lt;ElementType&gt;::from const):
* Source/WebCore/editing/Editing.cpp:
(WebCore::firstEditablePositionAfterPositionInRoot):
(WebCore::lastEditablePositionBeforePositionInRoot):
(WebCore::updatePositionForNodeRemoval):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::removingNodeRemovesPosition):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::isDescendantOf):
* Source/WebCore/editing/ios/EditorIOS.mm:
(WebCore::Editor::confirmMarkedText):
* Source/WebCore/editing/markup.cpp:
(WebCore::StyledMarkupAccumulator::traverseNodesForSerialization):
* Source/WebCore/html/FormAssociatedCustomElement.cpp:
(WebCore::FormAssociatedCustomElement::setValidity):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::hidePopoverInternal):
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::handlePopoverTargetAction):
* Source/WebCore/html/HTMLLabelElement.cpp:
(WebCore::HTMLLabelElement::isEventTargetedAtInteractiveDescendants const):
(WebCore::HTMLLabelElement::defaultEventHandler):
* Source/WebCore/page/DOMSelection.cpp:
(WebCore::DOMSelection::setBaseAndExtent):
* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::hitTestResultForDragStart const):
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::ElementTargetingController::extractTargets):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::nodeWillBeRemoved):
* Source/WebCore/rendering/RenderTextControlSingleLine.cpp:
(WebCore::RenderTextControlSingleLine::nodeAtPoint):
* Source/WebCore/svg/SVGFEImageElement.cpp:
(WebCore::SVGFEImageElement::imageBufferForEffect const):
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::findTarget const):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::computeElementLayout):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::simulateClickOverFirstMatchingTextInViewportWithUserInteraction):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::scheduleEditorStateUpdateAfterAnimationIfNeeded):

Canonical link: <a href="https://commits.webkit.org/294243@main">https://commits.webkit.org/294243@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02204f6928b557588b38821a972663ee6582f8a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101268 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11233 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/106436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51895 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103309 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21239 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29425 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77123 "90 flakes 124 failures") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34165 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16380 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91467 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57470 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16196 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9478 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51243 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86076 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108772 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28396 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86101 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28758 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87675 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/85659 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30384 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8089 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22495 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16467 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28326 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33597 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28138 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31458 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29696 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->