### PR TITLE
[SwiftUI] Support the standard `findNavigator` view modifier

### DIFF
--- a/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
@@ -62,21 +62,6 @@ extension View {
         environment(\.webViewElementFullscreenBehavior, value)
     }
 
-    @_spi(Private)
-    public nonisolated func webViewFindNavigator(isPresented: Binding<Bool>) -> some View {
-        environment(\.webViewFindContext, .init(isPresented: isPresented))
-    }
-
-    @_spi(Private)
-    public nonisolated func webViewFindDisabled(_ isDisabled: Bool = true) -> some View {
-        transformEnvironment(\.webViewFindContext) { $0.canFind = !isDisabled }
-    }
-
-    @_spi(Private)
-    public nonisolated func webViewReplaceDisabled(_ isDisabled: Bool = true) -> some View {
-        transformEnvironment(\.webViewFindContext) { $0.canReplace = !isDisabled }
-    }
-
     /// Adds an item-based context menu to a WebView, replacing the default set of context menu items.
     ///
     /// - Parameters:

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/CocoaWebViewAdapter.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/CocoaWebViewAdapter.swift
@@ -71,9 +71,11 @@ class CocoaWebViewAdapter: CocoaView, PlatformTextSearching {
                 return
             }
 
+#if canImport(SwiftUI, _version: "7.0.57")
             if let isPresented = findContext?.isPresented {
                 isPresented.wrappedValue = isFindBarVisible
             }
+#endif
 
             if isFindBarVisible {
                 findBarDidBecomeVisible()
@@ -88,7 +90,9 @@ class CocoaWebViewAdapter: CocoaView, PlatformTextSearching {
 
     // MARK: Find-in-Page support
 
+#if canImport(SwiftUI, _version: "7.0.57")
     var findContext: FindContext?
+#endif
 
     var scrollPosition: ScrollPositionContext?
 
@@ -237,21 +241,29 @@ extension CocoaWebViewAdapter: @preconcurrency NSTextFinderBarContainer {
 extension CocoaWebViewAdapter: WebPageWebView.Delegate {
 #if os(iOS)
     func findInteraction(_ interaction: UIFindInteraction, didBegin session: UIFindSession) {
+#if canImport(SwiftUI, _version: "7.0.57")
         if let isPresented = findContext?.isPresented {
             isPresented.wrappedValue = true
         }
+#endif
     }
 
     func findInteraction(_ interaction: UIFindInteraction, didEnd session: UIFindSession) {
+#if canImport(SwiftUI, _version: "7.0.57")
         if let isPresented = findContext?.isPresented {
             isPresented.wrappedValue = false
         }
+#endif
     }
 
     func supportsTextReplacement() -> Bool {
+#if canImport(SwiftUI, _version: "7.0.57")
         findContext?.canReplace ?? false
-    }
+#else
+        false
 #endif
+    }
+#endif // os(iOS)
 
     func geometryDidChange(_ geometry: WKScrollGeometryAdapter) {
         let newScrollGeometry = ScrollGeometry(geometry)

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift
@@ -41,9 +41,6 @@ extension EnvironmentValues {
     var webViewElementFullscreenBehavior = WebView.ElementFullscreenBehavior.automatic
 
     @Entry
-    var webViewFindContext: FindContext = .init()
-
-    @Entry
     var webViewContextMenuContext: ContextMenuContext? = nil
 
     @Entry

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/ViewModifierContexts.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/ViewModifierContexts.swift
@@ -35,12 +35,6 @@ struct OnScrollGeometryChangeContext {
     let action: (AnyHashable, AnyHashable) -> Void
 }
 
-struct FindContext {
-    var isPresented: Binding<Bool>?
-    var canFind = true
-    var canReplace = true
-}
-
 struct ScrollPositionContext {
     var position: Binding<ScrollPosition>?
 }

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
@@ -131,8 +131,10 @@ final class WebViewCoordinator {
     func update(_ view: CocoaWebViewAdapter, configuration: WebViewRepresentable, context: WebViewRepresentable.Context) {
         self.configuration = configuration
 
-        self.updateFindInteraction(view, context: context)
-        self.updateScrollPosition(view, context: context)
+#if canImport(SwiftUI, _version: "7.0.57")
+        updateFindInteraction(view, context: context)
+#endif
+        updateScrollPosition(view, context: context)
     }
 
     private func updateScrollPosition(_ view: CocoaWebViewAdapter, context: WebViewRepresentable.Context) {
@@ -165,6 +167,7 @@ final class WebViewCoordinator {
         }
     }
 
+#if canImport(SwiftUI, _version: "7.0.57")
     private func updateFindInteraction(_ view: CocoaWebViewAdapter, context: WebViewRepresentable.Context) {
         guard let webView = view.webView else {
             return
@@ -172,11 +175,11 @@ final class WebViewCoordinator {
 
         let environment = context.environment
 
-        let findContext = environment.webViewFindContext
+        let findContext = environment.findContext
         view.findContext = findContext
 
 #if os(iOS)
-        webView.isFindInteractionEnabled = findContext.canFind
+        webView.isFindInteractionEnabled = findContext != nil
 #endif
 
         guard let findInteraction = view.findInteraction else {
@@ -186,16 +189,17 @@ final class WebViewCoordinator {
         let isFindNavigatorVisible = view.isFindNavigatorVisible
 
         // Showing or hiding the find navigator can change the first responder, which triggers a graph cycle if done synchronously.
-        if findContext.canFind && findContext.isPresented?.wrappedValue == true && !isFindNavigatorVisible {
+        if let findContext, findContext.isPresented?.wrappedValue == true && !isFindNavigatorVisible {
             onNextMainRunLoop {
                 findInteraction.presentFindNavigator(showingReplace: false)
             }
-        } else if findContext.isPresented?.wrappedValue == false && isFindNavigatorVisible {
+        } else if findContext?.isPresented?.wrappedValue == false && isFindNavigatorVisible {
             onNextMainRunLoop {
                 findInteraction.dismissFindNavigator()
             }
         }
     }
+#endif // canImport(SwiftUI, _version: "7.0.57")
 }
 
 #if canImport(UIKit)

--- a/Tools/SwiftBrowser/Source/Views/ContentView.swift
+++ b/Tools/SwiftBrowser/Source/Views/ContentView.swift
@@ -233,7 +233,7 @@ struct ContentView: View {
                 .webViewLinkPreviews(.enabled)
                 .webViewTextSelection(.enabled)
                 .webViewElementFullscreenBehavior(.enabled)
-                .webViewFindNavigator(isPresented: $findNavigatorIsPresented)
+                .findNavigator(isPresented: $findNavigatorIsPresented)
                 .task {
                     // FIXME: Observe navigation changes.
                 }


### PR DESCRIPTION
#### 89ae1db8d2023fa260344907f26020938f661dbd
<pre>
[SwiftUI] Support the standard `findNavigator` view modifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=292216">https://bugs.webkit.org/show_bug.cgi?id=292216</a>
<a href="https://rdar.apple.com/141503384">rdar://141503384</a>

Reviewed by Aditya Keerthi.

Add support for the standard `findNavigator` set of view modifiers instead of having to use ad-hoc
custom view modifiers like `webViewFindNavigator` by leveraging the `findContext` environment value.

* Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift:
(View.webViewFindNavigator(_:)): Deleted.
(View.webViewFindDisabled(_:)): Deleted.
(View.webViewReplaceDisabled(_:)): Deleted.

Remove the old custom view modifiers.

* Source/WebKit/_WebKit_SwiftUI/Implementation/CocoaWebViewAdapter.swift:
(CocoaWebViewAdapter.isFindBarVisible):

Add compile-time guards to protect the build against configurations where `FindContext` is unavailable.

* Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift:
(EnvironmentValues.webViewFindContext): Deleted.

Remove the custom environment value entry.

* Source/WebKit/_WebKit_SwiftUI/Implementation/ViewModifierContexts.swift:
(FindContext.isPresented): Deleted.

Remove the custom WebKit-specific FindContext struct.

* Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift:
(WebViewCoordinator.update(_:configuration:context:)):
(WebViewCoordinator.updateFindInteraction(_:context:)):

Adjust the implementation for the slightly different interface of `SwiftUI.FindContext` compared to the
previous `WebKit.FindContext` struct. Specifically, `findContext == nil` implies that
`findContext.canFind == false`.

* Tools/SwiftBrowser/Source/Views/ContentView.swift:
(ContentView.body):

Update the test app to use the standard view modifier.

Canonical link: <a href="https://commits.webkit.org/294223@main">https://commits.webkit.org/294223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76a9778c11901ed033bd1075c47851f42e5c6c11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101195 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20857 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11160 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/106343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51822 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103236 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29351 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/106343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34105 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16312 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91402 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/106343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/16130 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/9415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/51170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/86021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9485 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108699 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28323 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28685 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87603 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85593 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/30324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/8034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/22422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16456 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28253 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33524 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28065 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31385 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->