### PR TITLE
[Webcore] Wrap-around using comparison instead of a modulo

### DIFF
--- a/Source/WebCore/html/TypeAhead.cpp
+++ b/Source/WebCore/html/TypeAhead.cpp
@@ -93,11 +93,13 @@ int TypeAhead::handleEvent(KeyboardEvent* event, MatchModeFlags matchMode)
         index %= optionCount;
 
         String prefixWithCaseFolded(prefix.foldCase());
-        for (int i = 0; i < optionCount; ++i, index = (index + 1) % optionCount) {
+        for (int i = 0; i < optionCount; ++i) {
             // Fold the option string and check if its prefix is equal to the folded prefix.
             String text = m_dataSource->optionAtIndex(index);
             if (stripLeadingWhiteSpace(text).foldCase().startsWith(prefixWithCaseFolded))
                 return index;
+            if (++index >= optionCount)
+                index = 0;
         }
     }
 


### PR DESCRIPTION
<pre>[Webcore] Wrap-around using comparison instead of a modulo
https://bugs.webkit.org/show_bug.cgi?id=266253

Reviewed by NOBODY (OOPS!).

Because optionCount is greater than 0, and index
is less than optionCount, we can just wrap around
not using a modulo.

* Source/WebCore/html/TypeAhead.cpp:
  (WebCore::TypeAhead::handleEvent): Wrap around.

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b311f6f88eb59120ada2540fca2aa83614819bcb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106330 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51809 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103223 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21153 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29338 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77069 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34101 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16305 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91398 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57668 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16123 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9718 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51157 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86017 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108686 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28310 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21103 "Found 6 new test failures: http/tests/iframe-monitor/data-url-resource.html http/tests/iframe-monitor/workers/service-worker.html http/tests/media/media-play-stream-chunked-icy.html http/tests/security/contentSecurityPolicy/extensions/manifest-v3/style-src/manifest-v3-style-src-allows-keywords.html http/wpt/import-maps/data-driven/resolving-data-url-prefix.html pdf/pdf-in-embed-rounded-border.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86309 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28672 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87599 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85871 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30310 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8030 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/22409 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28240 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33511 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28052 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31372 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29610 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->