### PR TITLE
[webkitscmpy] Test gardening commits without a specific title format are being misclassified

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_classifier.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_classifier.py
@@ -65,10 +65,11 @@ class CommitClassifier(object):
                 return re.compile(header)
             return None
 
-        def __init__(self, name, pickable=True, headers=None, trailers=None, paths=None, **kwargs):
+        def __init__(self, name, pickable=True, headers=None, contents=None, trailers=None, paths=None, **kwargs):
             self.name = name
             self.pickable = pickable
             self.headers = [CommitClassifier.LineFilter(header) for header in headers or []]
+            self.contents = [CommitClassifier.LineFilter(content) for content in contents or []]
             self.trailers = [CommitClassifier.LineFilter(trailer) for trailer in trailers or []]
             self.paths = [re.compile(r'^{}'.format(path)) for path in (paths or [])]
 
@@ -108,6 +109,7 @@ class CommitClassifier(object):
     def classify(self, commit, repository=None):
         header = commit.message.splitlines()[0]
         trailers = commit.trailers
+        contents = commit.message
         paths_for = CallByNeed(
             callback=lambda: repository.files_changed(commit.hash or str(commit)) if repository else [],
             type=list,
@@ -116,13 +118,15 @@ class CommitClassifier(object):
         for klass in self.classes:
             matching_header = bool(klass.headers and header)
             matching_trailer = bool(klass.trailers and trailers)
-            can_exclude = matching_header or matching_trailer or bool(klass.paths and paths_for.value)
+            matching_content = bool(klass.contents and contents)
+            can_exclude = matching_header or matching_trailer or bool(klass.paths and paths_for.value) or matching_content
             if not can_exclude:
                 continue
 
             matches_header = klass.headers and header and any([f(header) for f in klass.headers])
             matches_trailers = klass.trailers and trailers and any([any([f(trailer) for f in klass.trailers]) for trailer in trailers])
-            if (matching_header or matching_trailer) and not matches_header and not matches_trailers:
+            matches_content = klass.contents and contents and any([f(contents) for f in klass.contents])
+            if (matching_header or matching_trailer or matching_content) and not matches_header and not matches_trailers and not matches_content:
                 continue
 
             if klass.paths and paths_for.value and not all([

--- a/metadata/commit_classes.json
+++ b/metadata/commit_classes.json
@@ -35,6 +35,9 @@
 			{"value": "are constant failures"},
 			{"value": "tests consistently failing"}
 		],
+		"contents": [
+			{"value": "unreviewed test gardening"}
+		],
 		"paths": [
 			"LayoutTests/",
 			"Tools/TestWebKitAPI"


### PR DESCRIPTION
#### 77107973021a8f4eae84eb43313ba31818d6d4a9
<pre>
[webkitscmpy] Test gardening commits without a specific title format are being misclassified
<a href="https://bugs.webkit.org/show_bug.cgi?id=292221">https://bugs.webkit.org/show_bug.cgi?id=292221</a>
<a href="https://rdar.apple.com/150227595">rdar://150227595</a>

Reviewed by Jonathan Bedard.

We should classify commits with &quot;unreviewed test gardening&quot; in the message as Gardening.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_classifier.py:
    - Add a &quot;contents&quot; filter to our CommitClassifier to search the commit message for particular strings.
(CommitClassifier.CommitClass.__init__):
(CommitClassifier.classify):
* metadata/commit_classes.json:
    - Add &quot;unreviewed test gardening&quot; under the Gardening class

Canonical link: <a href="https://commits.webkit.org/294295@main">https://commits.webkit.org/294295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1e96c6093237abd0141150b6d1aa36baca0c716

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101190 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/20852 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11155 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/106338 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/51817 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103231 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/21161 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/29346 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/106338 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/51817 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104197 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/21161 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/91403 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/106338 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/100664 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/21161 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/9416 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/51165 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/21161 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/9486 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/108694 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/28318 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/29346 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/108694 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/100748 "Passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/28680 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/87604 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/108694 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/8035 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/22417 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16499 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/28248 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/28060 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/31380 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/29618 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->