### PR TITLE
Extended colors should be clamped so they look the same in SDR and HDR layers

### DIFF
--- a/LayoutTests/fast/images/hdr-extended-color-clamped-expected.html
+++ b/LayoutTests/fast/images/hdr-extended-color-clamped-expected.html
@@ -1,0 +1,32 @@
+<style>
+    .box {
+        position: fixed;
+        border: 30px solid green;
+        padding: 30px;
+    }
+</style>
+<body>
+    <div class="box" style="top: 40px; left: 40px;">
+        <img class="image-box">
+    </div>
+    <script>
+        if (window.internals && window.testRunner) {
+            internals.clearMemoryCache();
+            internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
+            testRunner.waitUntilDone();
+        }
+
+        var image = new Image;
+        image.onload = (() => {
+            if (window.internals)
+                internals.setHasHDRContentForTesting(image);
+
+            var imgElement = document.querySelector("img.image-box");
+            imgElement.src = image.src;
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        });
+        image.src = "resources/green-400x400.png";
+    </script>
+</body>

--- a/LayoutTests/fast/images/hdr-extended-color-clamped.html
+++ b/LayoutTests/fast/images/hdr-extended-color-clamped.html
@@ -1,0 +1,33 @@
+<style>
+    .box {
+        position: fixed;
+        border: 30px solid green;
+        padding: 30px;
+        background-color: color(srgb 5 5 5);
+    }
+</style>
+<body>
+    <div class="box" style="top: 40px; left: 40px;">
+        <img class="image-box">
+    </div>
+    <script>
+        if (window.internals && window.testRunner) {
+            internals.clearMemoryCache();
+            internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
+            testRunner.waitUntilDone();
+        }
+
+        var image = new Image;
+        image.onload = (() => {
+            if (window.internals)
+                internals.setHasHDRContentForTesting(image);
+
+            var imgElement = document.querySelector("img.image-box");
+            imgElement.src = image.src;
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        });
+        image.src = "resources/green-400x400.png";
+    </script>
+</body>

--- a/Source/WebCore/platform/graphics/cg/ColorCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ColorCG.cpp
@@ -167,7 +167,14 @@ static RetainPtr<CGColorRef> createCGColor(const Color& color)
 {
     auto [colorSpace, components] = color.colorSpaceAndResolvedColorComponents();
     auto [cgColorSpace, cgCompatibleComponents] = convertToCGCompatibleComponents(colorSpace, components);
-    
+
+    // Clamp the extended colors so they look the same on SDR and HDR layers.
+    if (CGColorSpaceUsesExtendedRange(cgColorSpace)) {
+        auto [c1, c2, c3, c4] = cgCompatibleComponents;
+        auto clampedComponents = makeFromComponentsClamping<SRGBA<float>>(c1, c2, c3, c4);
+        cgCompatibleComponents = asColorComponents(clampedComponents.resolved());
+    }
+
     auto [c1, c2, c3, c4] = cgCompatibleComponents;
     std::array<CGFloat, 4> cgFloatComponents { c1, c2, c3, c4 };
 


### PR DESCRIPTION
#### 3606a7e320075743b132908ad3608a67c5979b34
<pre>
Extended colors should be clamped so they look the same in SDR and HDR layers
<a href="https://bugs.webkit.org/show_bug.cgi?id=292226">https://bugs.webkit.org/show_bug.cgi?id=292226</a>
<a href="https://rdar.apple.com/150231788">rdar://150231788</a>

Reviewed by NOBODY (OOPS!).

Extended colors should be displayed the same regardless of the HDR-ness of
the layer.

Ideally an HDR layer should be created if any extended color is going to be
displayed in this layer. Till this happens, extended colors will be clamped.

* LayoutTests/fast/images/hdr-extended-color-clamped-expected.html: Added.
* LayoutTests/fast/images/hdr-extended-color-clamped.html: Added.
* Source/WebCore/platform/graphics/cg/ColorCG.cpp:
(WebCore::createCGColor):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3606a7e320075743b132908ad3608a67c5979b34

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20867 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11170 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106353 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51832 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103246 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21176 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29361 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77083 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34116 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16330 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91418 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57430 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16146 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9428 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51180 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86033 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9502 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108709 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28333 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20854 "Found 1 new test failure: imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-default-writing-mode-rl.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86055 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28695 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87621 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85605 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30332 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8045 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22432 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28263 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33534 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28075 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31395 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29633 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->