### PR TITLE
Unreviewed, revert 292724@main "Make objectIsRelayoutBoundary detect all new formatting contexts as a boundary instead of just hidden overflow."

### DIFF
--- a/LayoutTests/fast/attachment/mac/wide-attachment-image-controls-basic-expected.txt
+++ b/LayoutTests/fast/attachment/mac/wide-attachment-image-controls-basic-expected.txt
@@ -10,9 +10,9 @@ layer at (0,0) size 800x98
               RenderImage {IMG} at (0,0) size 52x52
             RenderFlexibleBox {DIV} at (80,0) size 162x80
               RenderGrid {DIV} at (0,40) size 162x0
-      RenderText {#text} at (268,26) size 4x18
-        text run at (268,26) width 4: " "
-      RenderImage {IMG} at (272,20) size 20x20
+      RenderText {#text} at (268,52) size 4x18
+        text run at (268,52) width 4: " "
+      RenderImage {IMG} at (272,46) size 20x20
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/fast/repaint/align-self-overflow-change-expected.txt
+++ b/LayoutTests/fast/repaint/align-self-overflow-change-expected.txt
@@ -6,5 +6,6 @@ Tests invalidation on align-self style change (just overflow). Passes if there i
   (rect 0 52 200 200)
   (rect 0 252 200 100)
   (rect 0 2 200 50)
+  (rect 0 2 800 14)
 )
 

--- a/LayoutTests/fast/repaint/justify-self-overflow-change-expected.txt
+++ b/LayoutTests/fast/repaint/justify-self-overflow-change-expected.txt
@@ -6,6 +6,7 @@ Tests invalidation on justify-self style change. Passes if there is no red.
   (rect 0 52 150 300)
   (rect 150 52 50 300)
   (rect -50 52 50 300)
+  (rect -50 16 50 336)
   (rect -50 0 50 352)
 )
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -925,13 +925,11 @@ void RenderBlockFlow::simplifiedNormalFlowLayout()
     bool shouldUpdateOverflow = false;
     for (InlineWalker walker(*this); !walker.atEnd(); walker.advance()) {
         RenderObject& renderer = *walker.current();
-        if (!renderer.isOutOfFlowPositioned()) {
-            if (CheckedPtr element = dynamicDowncast<RenderBox>(renderer)) {
-                element->layoutIfNeeded();
-                shouldUpdateOverflow = true;
-            }
-        }
-        if (is<RenderText>(renderer) || is<RenderInline>(renderer))
+        if (!renderer.isOutOfFlowPositioned() && (renderer.isReplacedOrAtomicInline() || renderer.isFloating())) {
+            RenderBox& box = downcast<RenderBox>(renderer);
+            box.layoutIfNeeded();
+            shouldUpdateOverflow = true;
+        } else if (is<RenderText>(renderer) || is<RenderInline>(renderer))
             renderer.clearNeedsLayout();
     }
 


### PR DESCRIPTION
#### 8d86f0f62dd95bf90211e295aa7ce5c7d7778300
<pre>
Unreviewed, revert 292724@main &quot;Make objectIsRelayoutBoundary detect all new formatting contexts as a boundary instead of just hidden overflow.&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=292059">https://bugs.webkit.org/show_bug.cgi?id=292059</a>
dar://150037613

This reverts commit ce15de8768af93d1dbd3b4437db3517221b0bc9f.

Canonical link: <a href="https://commits.webkit.org/294318@main">https://commits.webkit.org/294318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0c3881207e8eba0f1658087750db71fb4a2b8d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106595 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52071 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103482 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21414 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29600 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77257 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34288 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16527 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91619 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57599 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16347 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9636 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51419 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/86222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9709 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108947 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28571 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/21017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86230 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28933 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87825 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85792 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21824 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30528 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8240 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22688 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28502 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33782 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28313 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31633 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29872 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->