### PR TITLE
Nullptr crash in NetworkDataTaskCocoa constructor

### DIFF
--- a/LayoutTests/ipc/coreipc.js
+++ b/LayoutTests/ipc/coreipc.js
@@ -572,6 +572,7 @@ export class ArgumentSerializer {
                     return ArgumentSerializer.serializeStdArray(innerType, argument);
                 case 'HashSet':
                     return ArgumentSerializer.serializeHashSet(innerType, argument);
+                case 'std::variant':
                 case 'Variant':
                     return ArgumentSerializer.serializeVariant(innerType, argument);
                 case 'std::pair':
@@ -1111,7 +1112,8 @@ export class ArgumentParser {
                     const [newPosition, value] = ArgumentParser.parseKeyValuePair(buffer, position, innerType);
                     return [newPosition, {parsedType: argumentDefinition.type, parsedValue: value}];
                 }
-                case 'std::variant': {
+                case 'std::variant':
+                case 'Variant': {
                     const [newPosition, variant] = ArgumentParser.parseVariant(buffer, position, innerType);
                     return [newPosition, {parsedType: argumentDefinition.type, parsedValue: variant}];
                 }

--- a/LayoutTests/ipc/invalid-url-network-data-task-crash-expected.txt
+++ b/LayoutTests/ipc/invalid-url-network-data-task-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/invalid-url-network-data-task-crash.html
+++ b/LayoutTests/ipc/invalid-url-network-data-task-crash.html
@@ -1,0 +1,61 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+setTimeout(async () => {
+    if (!window.IPC)
+        return testRunner?.notifyDone();
+
+    const { CoreIPC } = await import('./coreipc.js');
+    const url = unescape('RN-f%25%07sk%08S%22%5BDW6x.%0Ed%3B%270%7D%19lC%05%7Eykp%03r%0Cy%21%024%28%1B%19%60%0C%20%1DO2%10%3B%26uG%16/Z%13%7C%22kNy%1E%00b_fSGI.%03%3C%0B3PT%13%3C%3Ad%1B%09Mc');
+
+    CoreIPC.Networking.NetworkConnectionToWebProcess.LoadImageForDecoding(0, {
+        request: {
+            getRequestDataToSerialize: {
+                variantType: 'WebCore::ResourceRequest::RequestData',
+                variant: {
+                    m_url: { string: url },
+                    m_firstPartyForCookies: { string: '' },
+                    m_timeoutInterval: 100,
+                    m_httpMethod: '',
+                    m_httpHeaderFields: {
+                        commonHeaders: [
+                            { key: 7, value: '' },
+                            { key: 89, value: '' }
+                        ],
+                        uncommonHeaders: [
+                            { key: 'A', value: '' },
+                        ]
+                    },
+                    m_responseContentDispositionEncodingFallbackArray: ['', '', 'A', '', ''],
+                    m_cachePolicy: 4,
+                    m_sameSiteDisposition: 0,
+                    m_priority: 3,
+                    m_requester: 7,
+                    m_allowCookies: false,
+                    m_isTopSite: true,
+                    m_isAppInitiated: false,
+                    m_privacyProxyFailClosedForUnreachableNonMainHosts: false,
+                    m_useAdvancedPrivacyProtections: true,
+                    m_didFilterLinkDecoration: true,
+                    m_isPrivateTokenUsageByThirdPartyAllowed: true,
+                    m_wasSchemeOptimisticallyUpgraded: false
+                }
+            },
+            cachePartition: '',
+            hiddenFromInspector: true
+        },
+        pageID: IPC.pageID,
+        maximumBytesFromNetwork: 410
+    });
+
+    testRunner?.notifyDone();
+}, 10);
+</script>
+<body>
+    <p>This test passes if WebKit does not crash.</p>
+</body>
+

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -224,6 +224,8 @@ void NetworkConnectionToWebProcess::hasUploadStateChanged(bool hasUpload)
 
 void NetworkConnectionToWebProcess::loadImageForDecoding(WebCore::ResourceRequest&& request, WebPageProxyIdentifier pageID, size_t maximumBytesFromNetwork, CompletionHandler<void(Expected<Ref<WebCore::FragmentedSharedBuffer>, WebCore::ResourceError>&&)>&& completionHandler)
 {
+    auto url = request.url();
+    MESSAGE_CHECK_COMPLETION(!url.isValid(), completionHandler(makeUnexpected<WebCore::ResourceError>({ })));
     CheckedPtr networkSession = this->networkSession();
     if (!networkSession)
         return completionHandler(makeUnexpected<WebCore::ResourceError>({ }));

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -195,7 +195,7 @@ NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataT
 {
     auto request = parameters.request;
     auto url = request.url();
-    if (url.isNull()) {
+    if (!url.isValid()) {
         scheduleFailure(FailureType::InvalidURL);
         return;
     }


### PR DESCRIPTION
#### 8a4582da742a64bf007395da71af324540eeee94
<pre>
Nullptr crash in NetworkDataTaskCocoa constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=292235">https://bugs.webkit.org/show_bug.cgi?id=292235</a>
<a href="https://rdar.apple.com/149214672">rdar://149214672</a>

Reviewed by Ryosuke Niwa and Alex Christensen.

Added message check for url validity.

* LayoutTests/ipc/coreipc.js:
(export.ArgumentSerializer):
* LayoutTests/ipc/invalid-url-network-data-task-crash-expected.txt: Added.
* LayoutTests/ipc/invalid-url-network-data-task-crash.html: Added.
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::loadImageForDecoding):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::NetworkDataTaskCocoa):

Canonical link: <a href="https://commits.webkit.org/294297@main">https://commits.webkit.org/294297@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74a58854b184467eab7636c65f8387c1a9940e54

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101369 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21033 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11338 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106522 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51998 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29527 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/77210 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34247 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16468 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91560 "Found 1 new API test failure: TestWebKitAPI.WebKit.LoadAndDecodeImage (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57551 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16288 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9571 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51346 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/86168 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9646 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108874 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28498 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86186 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28860 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87762 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85744 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30469 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/8179 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/22615 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16500 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28429 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33708 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28240 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31560 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29799 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->