### PR TITLE
Document the overloaded slots of CallFrame

### DIFF
--- a/Source/JavaScriptCore/interpreter/CallFrame.h
+++ b/Source/JavaScriptCore/interpreter/CallFrame.h
@@ -122,35 +122,55 @@ using JSInstruction = BaseInstruction<JSOpcodeTraits>;
     static_assert(sizeof(CallerFrameAndPC) == prologueStackPointerDelta());
 #endif
 
-    //      Layout of CallFrame
+    //  Layout of CallFrame
+    //
+    //  Higher addresses are on top.
+    //  Slots marked with "(+)" have a different meaning when executing Wasm code.
+    //  See details below the diagram.
+    //
     //
     //   |          ......            |   |
     //   +----------------------------+   |
-    //   |           argN             |   v  lower address
+    //   |           argN             |   v  lower addresses
+    //   +----------------------------+
+    //   |           ...              |
     //   +----------------------------+
     //   |           arg1             |
     //   +----------------------------+
     //   |           arg0             |
     //   +----------------------------+
-    //   |           this             |
+    //   |          this(+)           |
     //   +----------------------------+
     //   | argumentCountIncludingThis |
     //   +----------------------------+
     //   |          callee            |
     //   +----------------------------+
-    //   |        codeBlock           |
+    //   |       codeBlock(+)         |
     //   +----------------------------+
-    //   |      return-address        |
+    //   |       returnAddress        |
     //   +----------------------------+
-    //   |       callerFrame          |
-    //   +----------------------------+  <- callee's cfr is pointing this address
+    //   |        callerFrame         |  <- callee's cfr is pointing at this address
+    //   +----------------------------+
     //   |          local0            |
     //   +----------------------------+
     //   |          local1            |
     //   +----------------------------+
+    //   |           ...              |
+    //   +----------------------------+
     //   |          localN            |
     //   +----------------------------+
     //   |          ......            |
+    //
+    //
+    //  Overloaded slots:
+    //
+    //    - 'this': when executing wasm code, the slot contains the value of SP saved before the call.
+    //      Saving the value allows moving the SP freely in tail calls.
+    //    - 'codeBlock': when executing wasm code, the slot contains a pointer to the Wasm instance.
+    //      The pointer is determined by 'resolveWasmCall()' in WasmIPIntSlowPaths.cpp.
+    //      A special case is calling a module import whose functionCallLinkInfo.targetInstance is
+    //      null, which is the case when the imported function is a JS function.
+    //      In that case, 'codeBlock' points at the functionCallLinkInfo object.
 
     enum class CallFrameSlot {
         codeBlock = CallerFrameAndPC::sizeInRegisters,


### PR DESCRIPTION
#### 77ca7c19f55c302e8d4a024960e547392a36d19b
<pre>
Document the overloaded slots of CallFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=292240">https://bugs.webkit.org/show_bug.cgi?id=292240</a>
<a href="https://rdar.apple.com/150250023">rdar://150250023</a>

Reviewed by Mark Lam and Yusuke Suzuki.

Some CallFrame slots have a different meaning when executing Wasm code.
This PR updates CallFrame documentation to explain the difference.
Additionally, resolveWasmCall() which computes the value of codeBlock
(wasmInstance) is refactored to make it more clear what&apos;s going on.

* Source/JavaScriptCore/interpreter/CallFrame.h:
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::resolveWasmCall):

Canonical link: <a href="https://commits.webkit.org/294265@main">https://commits.webkit.org/294265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1b566294119a8c09154b7f40beb1f751e36cd25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106408 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51887 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29417 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77118 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34154 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16370 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91460 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57465 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16186 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9471 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51235 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/93927 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86068 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108764 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/99869 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28388 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20890 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86092 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28750 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87668 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85647 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30375 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8082 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/22487 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16481 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28318 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33589 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/123495 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28130 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34363 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31450 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29688 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->