### PR TITLE
Move more code to NodeInlines.h

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -544,7 +544,6 @@ dom/MutationObserverRegistration.cpp
 dom/MutationRecord.cpp
 dom/NamedNodeMap.cpp
 dom/Node.cpp
-dom/Node.h
 dom/NodeIterator.cpp
 dom/NodeList.h
 dom/NodeRareData.h

--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -32,6 +32,7 @@
 #include "Event.h"
 #include "HTMLNames.h"
 #include "MutableStyleProperties.h"
+#include "NodeInlines.h"
 #include "ScopedEventQueue.h"
 #include "StyledElement.h"
 #include "TextNodeTraversal.h"

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -47,6 +47,7 @@
 #include "LabelsNodeList.h"
 #include "LocalFrameView.h"
 #include "MutationEvent.h"
+#include "NodeInlines.h"
 #include "NodeRareData.h"
 #include "NodeRenderStyle.h"
 #include "RadioNodeList.h"

--- a/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
+++ b/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
@@ -31,6 +31,7 @@
 #include "HTMLFrameOwnerElement.h"
 #include "HTMLTextAreaElement.h"
 #include "InspectorInstrumentation.h"
+#include "NodeInlines.h"
 #include "ScriptDisallowedScope.h"
 #include "ShadowRoot.h"
 #include "TypedElementDescendantIteratorInlines.h"

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -186,6 +186,7 @@
 #include "Navigator.h"
 #include "NavigatorMediaSession.h"
 #include "NestingLevelIncrementer.h"
+#include "NodeInlines.h"
 #include "NodeIterator.h"
 #include "NodeRareData.h"
 #include "NodeWithIndex.h"

--- a/Source/WebCore/dom/ProcessingInstruction.cpp
+++ b/Source/WebCore/dom/ProcessingInstruction.cpp
@@ -33,6 +33,7 @@
 #include "LocalFrame.h"
 #include "MediaQueryParser.h"
 #include "MediaQueryParserContext.h"
+#include "NodeInlines.h"
 #include "StyleScope.h"
 #include "StyleSheetContents.h"
 #include "XMLDocumentParser.h"

--- a/Source/WebCore/html/HTMLBodyElement.cpp
+++ b/Source/WebCore/html/HTMLBodyElement.cpp
@@ -35,6 +35,7 @@
 #include "JSHTMLBodyElement.h"
 #include "LocalDOMWindow.h"
 #include "MutableStyleProperties.h"
+#include "NodeInlines.h"
 #include "NodeName.h"
 #include "ResourceLoaderOptions.h"
 #include <wtf/NeverDestroyed.h>

--- a/Source/WebCore/html/HTMLEmbedElement.cpp
+++ b/Source/WebCore/html/HTMLEmbedElement.cpp
@@ -32,6 +32,7 @@
 #include "HTMLObjectElement.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
+#include "NodeInlines.h"
 #include "NodeName.h"
 #include "PluginDocument.h"
 #include "RenderEmbeddedObject.h"

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -52,6 +52,7 @@
 #include "MIMETypeRegistry.h"
 #include "MediaQueryEvaluator.h"
 #include "MouseEvent.h"
+#include "NodeInlines.h"
 #include "NodeName.h"
 #include "NodeTraversal.h"
 #include "PlatformMouseEvent.h"

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -62,6 +62,7 @@
 #include "LocalFrameView.h"
 #include "LocalizedStrings.h"
 #include "MouseEvent.h"
+#include "NodeInlines.h"
 #include "NodeName.h"
 #include "NodeRenderStyle.h"
 #include "Page.h"

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -56,6 +56,7 @@
 #include "MediaQueryParser.h"
 #include "MediaQueryParserContext.h"
 #include "MouseEvent.h"
+#include "NodeInlines.h"
 #include "NodeName.h"
 #include "Page.h"
 #include "ParsedContentType.h"

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -38,6 +38,7 @@
 #include "LocalFrame.h"
 #include "MIMETypeRegistry.h"
 #include "NodeList.h"
+#include "NodeInlines.h"
 #include "NodeName.h"
 #include "Page.h"
 #include "RenderEmbeddedObject.h"

--- a/Source/WebCore/html/HTMLScriptElement.cpp
+++ b/Source/WebCore/html/HTMLScriptElement.cpp
@@ -30,6 +30,7 @@
 #include "HTMLNames.h"
 #include "HTMLParserIdioms.h"
 #include "JSRequestPriority.h"
+#include "NodeInlines.h"
 #include "NodeName.h"
 #include "RequestPriority.h"
 #include "Settings.h"

--- a/Source/WebCore/html/HTMLTableCellElement.cpp
+++ b/Source/WebCore/html/HTMLTableCellElement.cpp
@@ -31,6 +31,7 @@
 #include "HTMLNames.h"
 #include "HTMLParserIdioms.h"
 #include "HTMLTableElement.h"
+#include "NodeInlines.h"
 #include "NodeName.h"
 #include "RenderTableCell.h"
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/html/HTMLTableElement.cpp
+++ b/Source/WebCore/html/HTMLTableElement.cpp
@@ -38,6 +38,7 @@
 #include "HTMLTableRowsCollection.h"
 #include "HTMLTableSectionElement.h"
 #include "MutableStyleProperties.h"
+#include "NodeInlines.h"
 #include "NodeName.h"
 #include "NodeRareData.h"
 #include "RenderTable.h"

--- a/Source/WebCore/html/HTMLTemplateElement.cpp
+++ b/Source/WebCore/html/HTMLTemplateElement.cpp
@@ -37,6 +37,7 @@
 #include "ElementInlines.h"
 #include "ElementRareData.h"
 #include "HTMLNames.h"
+#include "NodeInlines.h"
 #include "NodeTraversal.h"
 #include "ShadowRoot.h"
 #include "ShadowRootInit.h"

--- a/Source/WebCore/html/track/TextTrackCue.cpp
+++ b/Source/WebCore/html/track/TextTrackCue.cpp
@@ -43,6 +43,7 @@
 #include "HTMLDivElement.h"
 #include "HTMLStyleElement.h"
 #include "Logging.h"
+#include "NodeInlines.h"
 #include "NodeTraversal.h"
 #include "Page.h"
 #include "ScriptDisallowedScope.h"

--- a/Source/WebCore/page/DOMSelection.cpp
+++ b/Source/WebCore/page/DOMSelection.cpp
@@ -36,6 +36,7 @@
 #include "Editing.h"
 #include "FrameSelection.h"
 #include "LocalFrame.h"
+#include "NodeInlines.h"
 #include "Quirks.h"
 #include "Range.h"
 #include "Settings.h"

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -45,6 +45,7 @@
 #include "LoaderStrategy.h"
 #include "LocalFrame.h"
 #include "MatchResultCache.h"
+#include "NodeInlines.h"
 #include "NodeRenderStyle.h"
 #include "Page.h"
 #include "PlatformStrategies.h"

--- a/Source/WebCore/svg/SVGCursorElement.cpp
+++ b/Source/WebCore/svg/SVGCursorElement.cpp
@@ -23,6 +23,7 @@
 #include "SVGCursorElement.h"
 
 #include "Document.h"
+#include "NodeInlines.h"
 #include "SVGNames.h"
 #include "SVGStringList.h"
 #include "StyleCursorImage.h"

--- a/Source/WebCore/svg/SVGFEImageElement.cpp
+++ b/Source/WebCore/svg/SVGFEImageElement.cpp
@@ -30,6 +30,7 @@
 #include "FEImage.h"
 #include "Image.h"
 #include "LegacyRenderSVGResource.h"
+#include "NodeInlines.h"
 #include "RenderObject.h"
 #include "SVGElementInlines.h"
 #include "SVGNames.h"

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -28,6 +28,7 @@
 #include "HTMLParserIdioms.h"
 #include "LegacyRenderSVGImage.h"
 #include "LegacyRenderSVGResource.h"
+#include "NodeInlines.h"
 #include "NodeName.h"
 #include "RenderImageResource.h"
 #include "RenderSVGImage.h"

--- a/Source/WebCore/svg/SVGScriptElement.cpp
+++ b/Source/WebCore/svg/SVGScriptElement.cpp
@@ -25,6 +25,7 @@
 #include "Document.h"
 #include "DocumentInlines.h"
 #include "Event.h"
+#include "NodeInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {


### PR DESCRIPTION
#### a0b88c20c9152bcbfb261f0955797782f5924df3
<pre>
Move more code to NodeInlines.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=292243">https://bugs.webkit.org/show_bug.cgi?id=292243</a>

Reviewed by Anne van Kesteren.

Moved more inline functions from Node.h to NodeInlines.h

* Source/WebCore/dom/Attr.cpp:
* Source/WebCore/dom/ContainerNode.cpp:
* Source/WebCore/dom/ContainerNodeAlgorithms.cpp:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/dom/Node.h:
(WebCore::Node::relaxAdoptionRequirement): Moved to NodeInlines.h.
(WebCore::Node::hasOneRef const): Ditto.
(WebCore::addSubresourceURL): Ditto.
(WebCore::Node::parentNodeGuaranteedHostFree const): Ditto.
(WebCore::Node::clearStyleFlags): Ditto.
(WebCore::Node::clearChildNeedsStyleRecalc): Ditto.
(WebCore::Node::setHasValidStyle): Ditto.
(WebCore::Node::setTreeScopeRecursively): Ditto.
(WebCore::Node::traverseToRootNodeInternal): Ditto.
* Source/WebCore/dom/NodeInlines.h:
(WebCore::Node::hasOneRef const): Moved from Node.h.
(WebCore::Node::clearStyleFlags): Ditto.
(WebCore::Node::clearChildNeedsStyleRecalc): Ditto.
(WebCore::Node::setHasValidStyle): Ditto.
(WebCore::Node::setTreeScopeRecursively): Ditto.
(WebCore::Node::parentNodeGuaranteedHostFree const): Ditto.
(WebCore::Node::traverseToRootNodeInternal): Ditto.
(WebCore::Node::relaxAdoptionRequirement): Ditto.
(WebCore::addSubresourceURL): Ditto.
* Source/WebCore/dom/ProcessingInstruction.cpp:
* Source/WebCore/html/HTMLBodyElement.cpp:
* Source/WebCore/html/HTMLEmbedElement.cpp:
* Source/WebCore/html/HTMLImageElement.cpp:
* Source/WebCore/html/HTMLInputElement.cpp:
* Source/WebCore/html/HTMLLinkElement.cpp:
* Source/WebCore/html/HTMLObjectElement.cpp:
* Source/WebCore/html/HTMLScriptElement.cpp:
* Source/WebCore/html/HTMLTableCellElement.cpp:
* Source/WebCore/html/HTMLTableElement.cpp:
* Source/WebCore/html/HTMLTemplateElement.cpp:
* Source/WebCore/html/track/TextTrackCue.cpp:
* Source/WebCore/page/DOMSelection.cpp:
* Source/WebCore/style/StyleTreeResolver.cpp:
* Source/WebCore/svg/SVGCursorElement.cpp:
* Source/WebCore/svg/SVGFEImageElement.cpp:
* Source/WebCore/svg/SVGImageElement.cpp:
* Source/WebCore/svg/SVGScriptElement.cpp:

Canonical link: <a href="https://commits.webkit.org/294302@main">https://commits.webkit.org/294302@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfbc7b358b25c329038e4c214fc63230e9d7cf7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101363 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21027 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11332 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106516 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51992 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103403 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29521 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77209 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34245 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16463 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91557 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57550 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16283 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9567 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51340 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86164 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108868 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28492 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20964 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86184 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28854 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85741 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30465 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8176 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22609 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16504 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28423 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33702 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28234 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31554 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29793 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->