### PR TITLE
Introduce EventTargetInlines.h and move inline functions there

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1122,6 +1122,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/EventOptions.h
     dom/EventTarget.h
     dom/EventTargetConcrete.h
+    dom/EventTargetInlines.h
     dom/Exception.h
     dom/ExceptionCode.h
     dom/ExceptionData.h

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -27,6 +27,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "GPUBindGroupEntry.h"
 #include "GPUComputePipeline.h"
 #include "GPUDeviceLostInfo.h"

--- a/Source/WebCore/Modules/applepay/ApplePaySession.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePaySession.cpp
@@ -48,6 +48,7 @@
 #include "Document.h"
 #include "DocumentLoader.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "JSDOMPromiseDeferred.h"
 #include "LinkIconCollector.h"
 #include "LinkIconType.h"

--- a/Source/WebCore/Modules/applepay/ApplePaySession.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySession.h
@@ -31,6 +31,7 @@
 #include "ApplePayPaymentAuthorizationResult.h"
 #include "ApplePayPaymentRequest.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "ExceptionOr.h"
 #include "PaymentSession.h"
 #include <wtf/Ref.h>

--- a/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
+++ b/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
@@ -31,6 +31,7 @@
 #include "CommonAtomStrings.h"
 #include "Document.h"
 #include "Editor.h"
+#include "EventTargetInterfaces.h"
 #include "JSBlob.h"
 #include "JSClipboardItem.h"
 #include "JSDOMPromiseDeferred.h"

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
@@ -31,6 +31,7 @@
 #include "AudioSession.h"
 #include "Document.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "Page.h"
 #include "PermissionsPolicy.h"
 #include "PlatformMediaSessionManager.h"

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.h
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.h
@@ -30,6 +30,7 @@
 #include "ActiveDOMObject.h"
 #include "AudioSession.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "ExceptionOr.h"
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -36,6 +36,8 @@
 #include "CookieStoreGetOptions.h"
 #include "Document.h"
 #include "EventNames.h"
+#include "EventTargetInterfaces.h"
+#include "EventTargetInlines.h"
 #include "ExceptionOr.h"
 #include "JSCookieListItem.h"
 #include "JSDOMPromiseDeferred.h"

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
@@ -34,6 +34,7 @@
 #include "CDMInstanceSession.h"
 #include "ContextDestructionObserverInlines.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "IDLTypes.h"
 #include "MediaKeyMessageType.h"
 #include "MediaKeySessionType.h"

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
@@ -30,6 +30,7 @@
 #include "ActiveDOMObject.h"
 #include "ContextDestructionObserverInlines.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "ExceptionOr.h"
 #include "LegacyCDMSession.h"
 #include "Timer.h"

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
@@ -28,6 +28,7 @@
 
 #include "DOMStringList.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "IDBConnectionProxy.h"
 #include "IDBConnectionToServer.h"
 #include "IDBIndex.h"

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "IDBActiveDOMObject.h"
 #include "IDBConnectionProxy.h"
 #include "IDBDatabaseConnectionIdentifier.h"

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
@@ -30,6 +30,7 @@
 #include "Event.h"
 #include "EventDispatcher.h"
 #include "EventNames.h"
+#include "EventTargetInterfaces.h"
 #include "IDBBindingUtilities.h"
 #include "IDBConnectionProxy.h"
 #include "IDBCursor.h"

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "IDBActiveDOMObject.h"
 #include "IDBError.h"
 #include "IDBGetAllRecordsData.h"

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
@@ -28,6 +28,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "ExceptionOr.h"
 #include "MediaRecorderPrivateOptions.h"
 #include "MediaStream.h"

--- a/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.cpp
@@ -30,6 +30,7 @@
 
 #include "Document.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "JSDOMException.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSMediaSessionCoordinatorState.h"

--- a/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h
@@ -29,6 +29,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "MediaSession.h"
 #include "MediaSessionCoordinatorPrivate.h"
 #include "MediaSessionCoordinatorState.h"

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -42,6 +42,7 @@
 #include "DocumentInlines.h"
 #include "Event.h"
 #include "EventNames.h"
+#include "EventTargetInterfaces.h"
 #include "HTMLMediaElement.h"
 #include "InbandTextTrack.h"
 #include "InbandTextTrackPrivate.h"

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -36,6 +36,7 @@
 #include "ActiveDOMObject.h"
 #include "AudioTrackClient.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "ExceptionOr.h"
 #include "SourceBufferPrivate.h"
 #include "SourceBufferPrivateClient.h"

--- a/Source/WebCore/Modules/mediasource/SourceBufferList.h
+++ b/Source/WebCore/Modules/mediasource/SourceBufferList.h
@@ -34,6 +34,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include <wtf/RefCounted.h>
 #include <wtf/Vector.h>
 

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -39,6 +39,7 @@
 #include "DocumentInlines.h"
 #include "Event.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "FrameDestructionObserverInlines.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSInputDeviceInfo.h"

--- a/Source/WebCore/Modules/mediastream/MediaDevices.h
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.h
@@ -36,6 +36,7 @@
 #include "ActiveDOMObject.h"
 #include "EventNames.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "ExceptionOr.h"
 #include "IDLTypes.h"
 #include "MediaTrackConstraints.h"

--- a/Source/WebCore/Modules/mediastream/MediaStream.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStream.cpp
@@ -33,6 +33,7 @@
 #include "Document.h"
 #include "Event.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "Logging.h"
 #include "MediaStreamTrackEvent.h"
 #include "Page.h"

--- a/Source/WebCore/Modules/mediastream/MediaStream.h
+++ b/Source/WebCore/Modules/mediastream/MediaStream.h
@@ -31,6 +31,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "MediaCanStartListener.h"
 #include "MediaProducer.h"
 #include "MediaStreamPrivate.h"

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -34,6 +34,7 @@
 #include "Document.h"
 #include "Event.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "ExceptionCode.h"
 #include "FrameLoader.h"
 #include "JSDOMPromiseDeferred.h"

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -32,6 +32,7 @@
 #include "ActiveDOMObject.h"
 #include "Blob.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "IDLTypes.h"
 #include "JSDOMPromiseDeferred.h"
 #include "MediaProducer.h"

--- a/Source/WebCore/Modules/mediastream/RTCDTMFSender.h
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFSender.h
@@ -29,6 +29,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "ExceptionOr.h"
 #include "ScriptWrappable.h"
 #include "Timer.h"

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.h
@@ -31,6 +31,7 @@
 #include "DetachedRTCDataChannel.h"
 #include "Event.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "ExceptionOr.h"
 #include "NetworkSendQueue.h"
 #include "RTCDataChannelHandler.h"

--- a/Source/WebCore/Modules/mediastream/RTCDtlsTransport.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDtlsTransport.cpp
@@ -31,6 +31,7 @@
 #include "Blob.h"
 #include "ContextDestructionObserverInlines.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "Logging.h"
 #include "NotImplemented.h"
 #include "RTCDtlsTransportBackend.h"

--- a/Source/WebCore/Modules/mediastream/RTCDtlsTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCDtlsTransport.h
@@ -29,6 +29,7 @@
 #include "ActiveDOMObject.h"
 #include "Event.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "RTCDtlsTransportBackend.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 

--- a/Source/WebCore/Modules/mediastream/RTCIceTransport.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCIceTransport.cpp
@@ -31,6 +31,7 @@
 #include "ContextDestructionObserverInlines.h"
 #include "Event.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "RTCPeerConnection.h"
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/Modules/mediastream/RTCIceTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCIceTransport.h
@@ -35,6 +35,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "RTCIceCandidate.h"
 #include "RTCIceGatheringState.h"
 #include "RTCIceTransportBackend.h"

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -37,6 +37,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "MediaEndpointConfiguration.h"
 #include "MediaStream.h"
 #include "PeerConnectionBackend.h"

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
@@ -30,6 +30,7 @@
 
 #include "ContextDestructionObserverInlines.h"
 #include "CryptoKeyRaw.h"
+#include "EventTargetInlines.h"
 #include "JSDOMConvertBufferSource.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSRTCEncodedAudioFrame.h"

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
@@ -29,6 +29,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include "RTCRtpSFrameTransformer.h"
 #include <wtf/WeakPtr.h>

--- a/Source/WebCore/Modules/mediastream/RTCSctpTransport.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCSctpTransport.cpp
@@ -29,6 +29,7 @@
 
 #include "ContextDestructionObserverInlines.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "Logging.h"
 #include "RTCDtlsTransport.h"
 #include "RTCSctpTransportBackend.h"

--- a/Source/WebCore/Modules/mediastream/RTCSctpTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCSctpTransport.h
@@ -29,6 +29,7 @@
 #include "ActiveDOMObject.h"
 #include "Event.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "RTCSctpTransportBackend.h"
 
 namespace WebCore {

--- a/Source/WebCore/Modules/notifications/Notification.cpp
+++ b/Source/WebCore/Modules/notifications/Notification.cpp
@@ -38,6 +38,7 @@
 #include "DedicatedWorkerGlobalScope.h"
 #include "Event.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "FrameDestructionObserverInlines.h"
 #include "JSDOMPromiseDeferred.h"
 #include "LocalDOMWindow.h"

--- a/Source/WebCore/Modules/notifications/Notification.h
+++ b/Source/WebCore/Modules/notifications/Notification.h
@@ -36,6 +36,7 @@
 #include "ActiveDOMObject.h"
 #include "ContextDestructionObserverInlines.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "NotificationDirection.h"
 #include "NotificationPayload.h"
 #include "NotificationPermission.h"

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
@@ -31,6 +31,7 @@
 #include "ApplePayPaymentHandler.h"
 #include "Document.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "FrameDestructionObserverInlines.h"
 #include "JSDOMPromise.h"
 #include "JSDOMPromiseDeferred.h"

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.h
@@ -29,6 +29,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "ExceptionOr.h"
 #include "IDLTypes.h"
 #include "PaymentDetailsInit.h"

--- a/Source/WebCore/Modules/paymentrequest/PaymentResponse.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentResponse.h
@@ -30,6 +30,7 @@
 #include "ActiveDOMObject.h"
 #include "ContextDestructionObserver.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "JSValueInWrappedObject.h"
 #include "PaymentAddress.h"
 #include <wtf/WeakPtr.h>

--- a/Source/WebCore/Modules/permissions/PermissionStatus.cpp
+++ b/Source/WebCore/Modules/permissions/PermissionStatus.cpp
@@ -30,6 +30,7 @@
 #include "Document.h"
 #include "DocumentInlines.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "MainThreadPermissionObserver.h"
 #include "PermissionController.h"
 #include "PermissionState.h"

--- a/Source/WebCore/Modules/permissions/PermissionStatus.h
+++ b/Source/WebCore/Modules/permissions/PermissionStatus.h
@@ -28,6 +28,7 @@
 #include "ActiveDOMObject.h"
 #include "ClientOrigin.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "MainThreadPermissionObserverIdentifier.h"
 #include "Page.h"
 #include "PermissionDescriptor.h"

--- a/Source/WebCore/Modules/pictureinpicture/PictureInPictureWindow.h
+++ b/Source/WebCore/Modules/pictureinpicture/PictureInPictureWindow.h
@@ -30,6 +30,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "IntSize.h"
 #include <wtf/RefCounted.h>
 

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
@@ -29,6 +29,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "WebCoreOpaqueRoot.h"
 #include <wtf/HashMap.h>
 #include <wtf/LoggerHelper.h>

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp
@@ -28,6 +28,7 @@
 
 #include "Document.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "Exception.h"
 #include "JSDOMPromiseDeferred.h"
 #include "WakeLockManager.h"

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.h
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.h
@@ -27,6 +27,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "WakeLockType.h"
 #include <wtf/RefCounted.h>
 

--- a/Source/WebCore/Modules/speech/SpeechRecognition.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognition.cpp
@@ -29,6 +29,7 @@
 #include "ClientOrigin.h"
 #include "Document.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "FrameDestructionObserverInlines.h"
 #include "Page.h"
 #include "PermissionsPolicy.h"

--- a/Source/WebCore/Modules/speech/SpeechRecognition.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognition.h
@@ -27,6 +27,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "SpeechRecognitionConnection.h"
 #include "SpeechRecognitionConnectionClient.h"
 #include "SpeechRecognitionResult.h"

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -30,6 +30,7 @@
 
 #include "Document.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "FrameDestructionObserverInlines.h"
 #include "LocalFrame.h"
 #include "Page.h"

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(SPEECH_SYNTHESIS)
 
+#include "EventTargetInterfaces.h"
 #include "PlatformSpeechSynthesisUtterance.h"
 #include "PlatformSpeechSynthesizer.h"
 #include "SpeechSynthesisClient.h"

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp
@@ -30,6 +30,7 @@
 
 #include "ContextDestructionObserverInlines.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "SpeechSynthesisErrorEvent.h"
 #include "SpeechSynthesisEvent.h"
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
@@ -29,6 +29,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "PlatformSpeechSynthesisUtterance.h"
 #include "SpeechSynthesisErrorCode.h"
 #include "SpeechSynthesisVoice.h"

--- a/Source/WebCore/Modules/webaudio/AudioNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNode.cpp
@@ -35,6 +35,7 @@
 #include "AudioNodeOutput.h"
 #include "AudioParam.h"
 #include "ContextDestructionObserverInlines.h"
+#include "EventTargetInterfaces.h"
 #include "Logging.h"
 #include <wtf/Atomics.h>
 #include <wtf/MainThread.h>

--- a/Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.cpp
@@ -32,6 +32,7 @@
 #include "AudioUtilities.h"
 #include "Event.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "ScriptController.h"
 #include "ScriptExecutionContext.h"
 #include <algorithm>

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -55,6 +55,7 @@
 #include "DocumentInlines.h"
 #include "DynamicsCompressorNode.h"
 #include "EventNames.h"
+#include "EventTargetInterfaces.h"
 #include "FFTFrame.h"
 #include "FrameLoader.h"
 #include "GainNode.h"

--- a/Source/WebCore/Modules/webaudio/ScriptProcessorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ScriptProcessorNode.cpp
@@ -37,6 +37,7 @@
 #include "AudioUtilities.h"
 #include "Document.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include <JavaScriptCore/Float32Array.h>
 #include <wtf/MainThread.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
@@ -29,6 +29,7 @@
 #if ENABLE(WEB_CODECS)
 
 #include "AudioDecoder.h"
+#include "EventTargetInterfaces.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include "WebCodecsAudioDecoderConfig.h"
 #include "WebCodecsAudioDecoderSupport.h"

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
@@ -29,6 +29,7 @@
 #if ENABLE(WEB_CODECS)
 
 #include "AudioEncoder.h"
+#include "EventTargetInterfaces.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include "WebCodecsAudioEncoderConfig.h"
 #include "WebCodecsBase.h"

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEB_CODECS)
 
+#include "EventTargetInterfaces.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include "VideoDecoder.h"
 #include "WebCodecsBase.h"

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEB_CODECS)
 
+#include "EventTargetInterfaces.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include "VideoEncoder.h"
 #include "WebCodecsBase.h"

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -40,6 +40,7 @@
 #include "Event.h"
 #include "EventListener.h"
 #include "EventNames.h"
+#include "EventTargetInterfaces.h"
 #include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "InspectorInstrumentation.h"

--- a/Source/WebCore/Modules/webxr/WebXRLayer.h
+++ b/Source/WebCore/Modules/webxr/WebXRLayer.h
@@ -29,6 +29,7 @@
 
 #include "ContextDestructionObserver.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "PlatformXR.h"
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -30,6 +30,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include "WebXRFrame.h"
 #include "WebXRInputSourceArray.h"

--- a/Source/WebCore/Modules/webxr/WebXRSpace.h
+++ b/Source/WebCore/Modules/webxr/WebXRSpace.h
@@ -29,6 +29,7 @@
 
 #include "ContextDestructionObserver.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "TransformationMatrix.h"
 #include "WebXRSession.h"
 #include <wtf/RefCounted.h>

--- a/Source/WebCore/Modules/webxr/WebXRSystem.h
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.h
@@ -30,6 +30,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "HTMLCanvasElement.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include "PlatformXR.h"

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -43,6 +43,7 @@
 #include "Editor.h"
 #include "EditorClient.h"
 #include "ElementAncestorIteratorInlines.h"
+#include "EventTargetInlines.h"
 #include "FloatRect.h"
 #include "FocusOptions.h"
 #include "FrameLoader.h"

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
@@ -30,6 +30,7 @@
 
 #include "AXObjectCache.h"
 #include "ElementChildIteratorInlines.h"
+#include "EventTargetInlines.h"
 #include "HTMLNames.h"
 #include "RenderIterator.h"
 #include "RenderText.h"

--- a/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
+++ b/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
@@ -31,6 +31,7 @@
 #import "AXRemoteFrame.h"
 #import "AccessibilityRenderObject.h"
 #import "EventNames.h"
+#import "EventTargetInlines.h"
 #import "HTMLInputElement.h"
 #import "HTMLNames.h"
 #import "LocalFrameView.h"

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -32,6 +32,7 @@
 #include "CSSNumericValue.h"
 #include "ContextDestructionObserverInlines.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "ExceptionOr.h"
 #include "IDLTypes.h"
 #include "Styleable.h"

--- a/Source/WebCore/bindings/js/JSEventTargetCustom.h
+++ b/Source/WebCore/bindings/js/JSEventTargetCustom.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "EventTargetInlines.h"
 #include "JSDOMBinding.h"
 #include "JSDOMBindingSecurity.h"
 #include "JSDOMOperation.h"

--- a/Source/WebCore/bindings/scripts/InFilesCompiler.pm
+++ b/Source/WebCore/bindings/scripts/InFilesCompiler.pm
@@ -224,7 +224,7 @@ sub generateInterfacesHeader()
 
     print F "namespace WebCore {\n";
     print F "\n";
-    print F "enum class ${namespace}InterfaceType {\n";
+    print F "enum class ${namespace}InterfaceType : uint8_t {\n";
 
     my $suffix = "InterfaceType";
     if ($useNamespaceAsSuffix eq "true") {

--- a/Source/WebCore/css/FontFaceSet.h
+++ b/Source/WebCore/css/FontFaceSet.h
@@ -28,6 +28,7 @@
 #include "ActiveDOMObject.h"
 #include "CSSFontFaceSet.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "IDLTypes.h"
 #include <wtf/UniqueRef.h>
 

--- a/Source/WebCore/css/MediaQueryList.cpp
+++ b/Source/WebCore/css/MediaQueryList.cpp
@@ -24,6 +24,7 @@
 #include "Document.h"
 #include "DocumentInlines.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "HTMLFrameOwnerElement.h"
 #include "MediaQueryEvaluator.h"
 #include "MediaQueryListEvent.h"

--- a/Source/WebCore/css/MediaQueryList.h
+++ b/Source/WebCore/css/MediaQueryList.h
@@ -21,6 +21,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "MediaQuery.h"
 #include "MediaQueryMatcher.h"
 

--- a/Source/WebCore/dom/AbortSignal.cpp
+++ b/Source/WebCore/dom/AbortSignal.cpp
@@ -31,6 +31,7 @@
 #include "DOMTimer.h"
 #include "Event.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "JSDOMException.h"
 #include "ScriptExecutionContext.h"
 #include "WebCoreOpaqueRoot.h"

--- a/Source/WebCore/dom/AbortSignal.h
+++ b/Source/WebCore/dom/AbortSignal.h
@@ -27,6 +27,7 @@
 
 #include "ContextDestructionObserverInlines.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "JSValueInWrappedObject.h"
 #include <wtf/Function.h>
 #include <wtf/Ref.h>

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -28,6 +28,7 @@
 
 #include "BroadcastChannelRegistry.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "MessageEvent.h"
 #include "Page.h"
 #include "PartitionedSecurityOrigin.h"

--- a/Source/WebCore/dom/BroadcastChannel.h
+++ b/Source/WebCore/dom/BroadcastChannel.h
@@ -29,6 +29,7 @@
 #include "BroadcastChannelIdentifier.h"
 #include "ClientOrigin.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "ExceptionOr.h"
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>

--- a/Source/WebCore/dom/EventContext.cpp
+++ b/Source/WebCore/dom/EventContext.cpp
@@ -30,6 +30,7 @@
 
 #include "Document.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "FocusEvent.h"
 #include "HTMLFieldSetElement.h"
 #include "HTMLFormElement.h"

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -37,6 +37,7 @@
 #include "EventNames.h"
 #include "EventPath.h"
 #include "EventTargetConcrete.h"
+#include "EventTargetInlines.h"
 #include "HTMLBodyElement.h"
 #include "HTMLHtmlElement.h"
 #include "InspectorInstrumentation.h"
@@ -412,6 +413,17 @@ void EventTarget::removeAllEventListeners()
     }
 
     threadData->setIsInRemoveAllEventListeners(false);
+}
+
+bool EventTarget::hasAnyEventListeners(Vector<AtomString> eventTypes) const
+{
+    if (auto* data = eventTargetData()) {
+        for (const auto& eventType : eventTypes) {
+            if (data->eventListenerMap.contains(eventType))
+                return true;
+        }
+    }
+    return false;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/EventTargetFactory.in
+++ b/Source/WebCore/dom/EventTargetFactory.in
@@ -2,6 +2,7 @@ namespace="EventTarget"
 factoryFunction=toJS
 useNamespaceAsSuffix=true
 
+
 AbortSignal
 ApplePaySession conditional=APPLE_PAY
 AudioNode conditional=WEB_AUDIO

--- a/Source/WebCore/dom/EventTargetInlines.h
+++ b/Source/WebCore/dom/EventTargetInlines.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
+ *           (C) 1999 Antti Koivisto (koivisto@kde.org)
+ *           (C) 2001 Dirk Mueller (mueller@kde.org)
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2006 Alexey Proskuryakov (ap@webkit.org)
+ *           (C) 2007, 2008 Nikolas Zimmermann <zimmermann@kde.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#pragma once
+
+#include "EventTarget.h"
+
+namespace WebCore {
+
+inline bool EventTarget::hasEventListeners() const
+{
+    auto* data = eventTargetData();
+    return data && !data->eventListenerMap.isEmpty();
+}
+
+inline bool EventTarget::hasEventListeners(const AtomString& eventType) const
+{
+    auto* data = eventTargetData();
+    return data && data->eventListenerMap.contains(eventType);
+}
+
+inline bool EventTarget::hasCapturingEventListeners(const AtomString& eventType)
+{
+    auto* data = eventTargetData();
+    return data && data->eventListenerMap.containsCapturing(eventType);
+}
+
+inline const EventTargetData* EventTarget::eventTargetData() const
+{
+    if (hasEventTargetData())
+        return &weakPtrFactory().impl()->eventTargetData();
+    return nullptr;
+}
+
+inline EventTargetData* EventTarget::eventTargetData()
+{
+    if (hasEventTargetData())
+        return &weakPtrFactory().impl()->eventTargetData();
+    return nullptr;
+}
+
+inline EventTargetData* EventTarget::eventTargetDataConcurrently()
+{
+    bool flag = this->hasEventTargetData();
+    auto fencedFlag = Dependency::fence(flag);
+    if (flag)
+        return &fencedFlag.consume(this)->weakPtrFactory().impl()->eventTargetData();
+    return nullptr;
+}
+
+inline EventTargetData& EventTarget::ensureEventTargetData()
+{
+    if (auto* data = eventTargetData())
+        return *data;
+    initializeWeakPtrFactory();
+    WTF::storeStoreFence();
+    setEventTargetFlag(EventTargetFlag::HasEventTargetData, true);
+    return weakPtrFactory().impl()->eventTargetData();
+}
+
+template<typename CallbackType>
+inline void EventTarget::enumerateEventListenerTypes(NOESCAPE const CallbackType& callback) const
+{
+    if (auto* data = eventTargetData())
+        data->eventListenerMap.enumerateEventListenerTypes(callback);
+}
+
+template<typename CallbackType>
+inline bool EventTarget::containsMatchingEventListener(NOESCAPE const CallbackType& callback) const
+{
+    if (auto* data = eventTargetData())
+        return data->eventListenerMap.containsMatchingEventListener(callback);
+    return false;
+}
+
+template<typename Visitor>
+inline void EventTarget::visitJSEventListeners(Visitor& visitor)
+{
+    if (auto* data = eventTargetDataConcurrently())
+        data->eventListenerMap.visitJSEventListeners(visitor);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -29,6 +29,7 @@
 
 #include "Document.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "Logging.h"
 #include "MessageEvent.h"
 #include "MessagePortChannelProvider.h"

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -29,6 +29,7 @@
 #include "ActiveDOMObject.h"
 #include "ContextDestructionObserverInlines.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "ExceptionOr.h"
 #include "MessagePortChannel.h"
 #include "MessagePortIdentifier.h"

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -44,6 +44,7 @@
 #include "EventHandler.h"
 #include "EventLoop.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "GCReachableRef.h"
 #include "HTMLAreaElement.h"
 #include "HTMLBodyElement.h"

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -32,6 +32,7 @@
 #include "ElementAncestorIteratorInlines.h"
 #include "ElementRareData.h"
 #include "EventLoop.h"
+#include "EventTargetInlines.h"
 #include "HTMLBRElement.h"
 #include "HTMLElement.h"
 #include "HTMLInputElement.h"

--- a/Source/WebCore/fileapi/FileReader.h
+++ b/Source/WebCore/fileapi/FileReader.h
@@ -33,6 +33,7 @@
 #include "ActiveDOMObject.h"
 #include "DOMException.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "ExceptionCode.h"
 #include "ExceptionOr.h"
 #include "FileReaderLoader.h"

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -39,6 +39,7 @@
 #include "DocumentInlines.h"
 #include "ElementInlines.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "GPU.h"
 #include "GPUBasedCanvasRenderingContext.h"
 #include "GPUCanvasContext.h"

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -60,6 +60,7 @@
 #include "ElementChildIteratorInlines.h"
 #include "EventLoop.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "FourCC.h"
 #include "FrameLoader.h"
 #include "HTMLAudioElement.h"

--- a/Source/WebCore/html/HTMLTrackElement.cpp
+++ b/Source/WebCore/html/HTMLTrackElement.cpp
@@ -33,6 +33,7 @@
 #include "ElementInlines.h"
 #include "Event.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "HTMLMediaElement.h"
 #include "HTMLNames.h"
 #include "LoadableTextTrack.h"

--- a/Source/WebCore/html/MediaController.h
+++ b/Source/WebCore/html/MediaController.h
@@ -30,6 +30,7 @@
 #include "ContextDestructionObserver.h"
 #include "Event.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "MediaControllerInterface.h"
 #include "Timer.h"
 #include <wtf/Vector.h>

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -32,6 +32,7 @@
 #include "CanvasBase.h"
 #include "ContextDestructionObserver.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "ExceptionOr.h"
 #include "IDLTypes.h"
 #include "ImageBuffer.h"

--- a/Source/WebCore/html/closewatcher/CloseWatcher.cpp
+++ b/Source/WebCore/html/closewatcher/CloseWatcher.cpp
@@ -30,6 +30,7 @@
 #include "DocumentInlines.h"
 #include "Event.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "KeyboardEvent.h"
 #include "LocalDOMWindow.h"
 #include "ScriptExecutionContext.h"

--- a/Source/WebCore/html/closewatcher/CloseWatcher.h
+++ b/Source/WebCore/html/closewatcher/CloseWatcher.h
@@ -28,6 +28,7 @@
 #include "AbortSignal.h"
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include <wtf/ListHashSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>

--- a/Source/WebCore/html/track/AudioTrackList.cpp
+++ b/Source/WebCore/html/track/AudioTrackList.cpp
@@ -30,6 +30,7 @@
 
 #include "AudioTrack.h"
 #include "ContextDestructionObserverInlines.h"
+#include "EventTargetInterfaces.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -29,6 +29,7 @@
 #if ENABLE(VIDEO)
 
 #include "ContextDestructionObserverInlines.h"
+#include "EventTargetInterfaces.h"
 #include "PlatformTimeRanges.h"
 #include "TextTrackCue.h"
 #include "TrackBase.h"

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -35,6 +35,7 @@
 
 #include "ActiveDOMObject.h"
 #include "DocumentFragment.h"
+#include "EventTargetInterfaces.h"
 #include "HTMLElement.h"
 #include <wtf/JSONValues.h>
 #include <wtf/MediaTime.h>

--- a/Source/WebCore/html/track/TextTrackList.cpp
+++ b/Source/WebCore/html/track/TextTrackList.cpp
@@ -29,6 +29,7 @@
 
 #include "TextTrackList.h"
 
+#include "EventTargetInterfaces.h"
 #include "InbandTextTrack.h"
 #include "InbandTextTrackPrivate.h"
 #include "LoadableTextTrack.h"

--- a/Source/WebCore/html/track/VideoTrackList.cpp
+++ b/Source/WebCore/html/track/VideoTrackList.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(VIDEO)
 
 #include "ContextDestructionObserverInlines.h"
+#include "EventTargetInterfaces.h"
 #include "ScriptExecutionContext.h"
 #include "VideoTrack.h"
 

--- a/Source/WebCore/inspector/InspectorAuditDOMObject.cpp
+++ b/Source/WebCore/inspector/InspectorAuditDOMObject.cpp
@@ -28,6 +28,7 @@
 #include "InspectorAuditDOMObject.h"
 
 #include "Document.h"
+#include "EventTargetInlines.h"
 #include "Node.h"
 #include "UserGestureEmulationScope.h"
 #include "VoidCallback.h"

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -46,6 +46,7 @@
 #include "ElementChildIteratorInlines.h"
 #include "ElementRareData.h"
 #include "EventTarget.h"
+#include "EventTargetInlines.h"
 #include "Font.h"
 #include "FontCache.h"
 #include "FontCascade.h"

--- a/Source/WebCore/loader/appcache/DOMApplicationCache.h
+++ b/Source/WebCore/loader/appcache/DOMApplicationCache.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "LocalDOMWindowProperty.h"
 #include <wtf/WeakPtr.h>
 

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -27,6 +27,7 @@
 
 #include "DocumentEnums.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "GlobalWindowIdentifier.h"
 #include "ImageBitmap.h"
 #include "ScrollTypes.h"

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -49,6 +49,7 @@
 #include "EditorClient.h"
 #include "ElementInlines.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "FileList.h"
 #include "FloatPoint.h"
 #include "FloatRect.h"

--- a/Source/WebCore/page/EventSource.h
+++ b/Source/WebCore/page/EventSource.h
@@ -34,6 +34,7 @@
 #include "ActiveDOMObject.h"
 #include "EventLoop.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "ExceptionOr.h"
 #include "ThreadableLoaderClient.h"
 #include "Timer.h"

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -63,6 +63,7 @@
 #include "EventLoop.h"
 #include "EventNames.h"
 #include "EventPath.h"
+#include "EventTargetInlines.h"
 #include "FloatRect.h"
 #include "FocusController.h"
 #include "FrameLoadRequest.h"

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -29,6 +29,7 @@
 #include "Base64Utilities.h"
 #include "ContextDestructionObserverInlines.h"
 #include "DOMWindow.h"
+#include "EventTargetInterfaces.h"
 #include "ExceptionOr.h"
 #include "LocalFrame.h"
 #include "PushManager.h"

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -36,6 +36,7 @@
 #include "DocumentLoader.h"
 #include "ErrorEvent.h"
 #include "EventNames.h"
+#include "EventTargetInterfaces.h"
 #include "Exception.h"
 #include "FormState.h"
 #include "FrameLoadRequest.h"

--- a/Source/WebCore/page/NavigationHistoryEntry.cpp
+++ b/Source/WebCore/page/NavigationHistoryEntry.cpp
@@ -28,6 +28,8 @@
 
 #include "DocumentInlines.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
+#include "EventTargetInterfaces.h"
 #include "FrameLoader.h"
 #include "HistoryController.h"
 #include "JSDOMGlobalObject.h"

--- a/Source/WebCore/page/Performance.h
+++ b/Source/WebCore/page/Performance.h
@@ -35,6 +35,7 @@
 #include "ContextDestructionObserver.h"
 #include "DOMHighResTimeStamp.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "ExceptionOr.h"
 #include "ReducedResolutionSeconds.h"
 #include "ScriptExecutionContext.h"

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -31,6 +31,7 @@
 #include "Element.h"
 #include "EventHandler.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "EventTarget.h"
 #include "HitTestResult.h"
 #include "MouseEventTypes.h"

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -38,6 +38,7 @@
 #include "ElementInlines.h"
 #include "ElementTargetingTypes.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "FrameLoader.h"
 #include "HTMLArticleElement.h"
 #include "HTMLBodyElement.h"

--- a/Source/WebCore/page/ScreenOrientation.cpp
+++ b/Source/WebCore/page/ScreenOrientation.cpp
@@ -32,6 +32,7 @@
 #include "Element.h"
 #include "Event.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "FrameDestructionObserverInlines.h"
 #include "JSDOMPromiseDeferred.h"
 #include "LocalDOMWindow.h"

--- a/Source/WebCore/page/ScreenOrientation.h
+++ b/Source/WebCore/page/ScreenOrientation.h
@@ -28,6 +28,7 @@
 #include "ActiveDOMObject.h"
 #include "ContextDestructionObserverInlines.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "ScreenOrientationLockType.h"
 #include "ScreenOrientationManager.h"
 #include "ScreenOrientationType.h"

--- a/Source/WebCore/page/VisualViewport.cpp
+++ b/Source/WebCore/page/VisualViewport.cpp
@@ -32,6 +32,7 @@
 #include "Document.h"
 #include "Event.h"
 #include "EventNames.h"
+#include "EventTargetInterfaces.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"

--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -38,6 +38,7 @@
 #import "ElementRareData.h"
 #import "EventHandler.h"
 #import "EventNames.h"
+#import "EventTargetInlines.h"
 #import "FormController.h"
 #import "FrameSelection.h"
 #import "HTMLAreaElement.h"

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -38,6 +38,7 @@
 #include "ElementAncestorIteratorInlines.h"
 #include "ElementInlines.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "HTMLBodyElement.h"
 #include "HTMLDialogElement.h"
 #include "HTMLDivElement.h"

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -35,6 +35,7 @@
 #include "ElementChildIteratorInlines.h"
 #include "Event.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "HTMLElement.h"
 #include "HTMLNames.h"
 #include "HTMLParserIdioms.h"

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -33,6 +33,7 @@
 #include "ElementChildIteratorInlines.h"
 #include "Event.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "LegacyRenderSVGResource.h"
 #include "LegacyRenderSVGTransformableContainer.h"
 #include "NodeName.h"

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
@@ -35,6 +35,7 @@
 #include "ContentSecurityPolicyResponseHeaders.h"
 #include "DedicatedWorkerThread.h"
 #include "EventNames.h"
+#include "EventTargetInterfaces.h"
 #include "JSRTCRtpScriptTransformer.h"
 #include "LocalDOMWindow.h"
 #include "MessageEvent.h"

--- a/Source/WebCore/workers/Worker.h
+++ b/Source/WebCore/workers/Worker.h
@@ -29,6 +29,7 @@
 #include "ActiveDOMObject.h"
 #include "ContentSecurityPolicyResponseHeaders.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "FetchRequestCredentials.h"
 #include "MessagePort.h"
 #include "WorkerOptions.h"

--- a/Source/WebCore/workers/service/ServiceWorker.cpp
+++ b/Source/WebCore/workers/service/ServiceWorker.cpp
@@ -28,6 +28,7 @@
 
 #include "Document.h"
 #include "EventNames.h"
+#include "EventTargetInterfaces.h"
 #include "Logging.h"
 #include "MessagePort.h"
 #include "SWClientConnection.h"

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.h
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.h
@@ -28,6 +28,7 @@
 #include "ActiveDOMObject.h"
 #include "AddEventListenerOptions.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "IDLTypes.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include "MessageEvent.h"

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
@@ -29,6 +29,8 @@
 #include "Document.h"
 #include "EventLoop.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
+#include "EventTargetInterfaces.h"
 #include "ExtendableEvent.h"
 #include "FetchEvent.h"
 #include "FrameLoader.h"

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
@@ -33,6 +33,8 @@
 #include "Event.h"
 #include "EventLoop.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
+#include "EventTargetInterfaces.h"
 #include "JSDOMPromise.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSNotification.h"

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.h
@@ -30,6 +30,7 @@
 #include "BackgroundFetchInformation.h"
 #include "BackgroundFetchResult.h"
 #include "EventTarget.h"
+#include "EventTargetInterfaces.h"
 #include "JSDOMPromiseDeferred.h"
 #include <wtf/RefCounted.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/workers/shared/SharedWorker.cpp
+++ b/Source/WebCore/workers/shared/SharedWorker.cpp
@@ -31,6 +31,7 @@
 #include "Document.h"
 #include "DocumentInlines.h"
 #include "EventNames.h"
+#include "EventTargetInterfaces.h"
 #include "Logging.h"
 #include "MessageChannel.h"
 #include "MessagePort.h"

--- a/Source/WebCore/workers/shared/SharedWorkerGlobalScope.h
+++ b/Source/WebCore/workers/shared/SharedWorkerGlobalScope.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "EventTargetInterfaces.h"
 #include "TransferredMessagePort.h"
 #include "WorkerGlobalScope.h"
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/worklets/WorkletGlobalScope.h
+++ b/Source/WebCore/worklets/WorkletGlobalScope.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "Document.h"
+#include "EventTargetInterfaces.h"
 #include "ExceptionOr.h"
 #include "FetchRequestCredentials.h"
 #include "ScriptExecutionContext.h"

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -31,6 +31,7 @@
 #include "DOMFormData.h"
 #include "Event.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "File.h"
 #include "HTMLDocument.h"
 #include "HTMLIFrameElement.h"

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "ActiveDOMObject.h"
+#include "EventTargetInterfaces.h"
 #include "ExceptionOr.h"
 #include "FormData.h"
 #include "ResourceResponse.h"

--- a/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
@@ -31,6 +31,7 @@
 #include "EventLoop.h"
 #include "EventNames.h"
 #include "EventTarget.h"
+#include "EventTargetInlines.h"
 #include "ScriptExecutionContext.h"
 #include "XMLHttpRequest.h"
 #include "XMLHttpRequestProgressEvent.h"

--- a/Source/WebCore/xml/XMLHttpRequestUpload.cpp
+++ b/Source/WebCore/xml/XMLHttpRequestUpload.cpp
@@ -28,6 +28,7 @@
 
 #include "ContextDestructionObserverInlines.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "WebCoreOpaqueRoot.h"
 #include "XMLHttpRequestProgressEvent.h"
 #include <wtf/Assertions.h>

--- a/Source/WebCore/xml/XMLHttpRequestUpload.h
+++ b/Source/WebCore/xml/XMLHttpRequestUpload.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "EventTargetInterfaces.h"
 #include "XMLHttpRequest.h"
 #include <wtf/Forward.h>
 


### PR DESCRIPTION
#### 02ffb3d0d1d2c07f9640571915fad69d7a9614a7
<pre>
Introduce EventTargetInlines.h and move inline functions there
<a href="https://bugs.webkit.org/show_bug.cgi?id=292245">https://bugs.webkit.org/show_bug.cgi?id=292245</a>

Reviewed by Anne van Kesteren.

This PR extracts EventTargetInlines.h out of EventTarget.h.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/WebGPU/GPUDevice.h:
* Source/WebCore/Modules/applepay/ApplePaySession.cpp:
* Source/WebCore/Modules/applepay/ApplePaySession.h:
* Source/WebCore/Modules/async-clipboard/Clipboard.cpp:
* Source/WebCore/Modules/audiosession/DOMAudioSession.cpp:
* Source/WebCore/Modules/audiosession/DOMAudioSession.h:
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.h:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h:
* Source/WebCore/Modules/indexeddb/IDBDatabase.cpp:
* Source/WebCore/Modules/indexeddb/IDBDatabase.h:
* Source/WebCore/Modules/indexeddb/IDBRequest.cpp:
* Source/WebCore/Modules/indexeddb/IDBTransaction.h:
* Source/WebCore/Modules/mediarecorder/MediaRecorder.h:
* Source/WebCore/Modules/mediasession/MediaSessionCoordinator.cpp:
* Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h:
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/Modules/mediasource/SourceBufferList.h:
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
* Source/WebCore/Modules/mediastream/MediaDevices.h:
* Source/WebCore/Modules/mediastream/MediaStream.cpp:
* Source/WebCore/Modules/mediastream/MediaStream.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/RTCDTMFSender.h:
* Source/WebCore/Modules/mediastream/RTCDataChannel.h:
* Source/WebCore/Modules/mediastream/RTCDtlsTransport.cpp:
* Source/WebCore/Modules/mediastream/RTCDtlsTransport.h:
* Source/WebCore/Modules/mediastream/RTCIceTransport.cpp:
* Source/WebCore/Modules/mediastream/RTCIceTransport.h:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.h:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h:
* Source/WebCore/Modules/mediastream/RTCSctpTransport.cpp:
* Source/WebCore/Modules/mediastream/RTCSctpTransport.h:
* Source/WebCore/Modules/notifications/Notification.cpp:
* Source/WebCore/Modules/notifications/Notification.h:
* Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp:
* Source/WebCore/Modules/paymentrequest/PaymentRequest.h:
* Source/WebCore/Modules/paymentrequest/PaymentResponse.h:
* Source/WebCore/Modules/permissions/PermissionStatus.cpp:
* Source/WebCore/Modules/permissions/PermissionStatus.h:
* Source/WebCore/Modules/pictureinpicture/PictureInPictureWindow.h:
* Source/WebCore/Modules/remoteplayback/RemotePlayback.h:
* Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp:
* Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.h:
* Source/WebCore/Modules/speech/SpeechRecognition.cpp:
* Source/WebCore/Modules/speech/SpeechRecognition.h:
* Source/WebCore/Modules/speech/SpeechSynthesis.cpp:
* Source/WebCore/Modules/speech/SpeechSynthesis.h:
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp:
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h:
* Source/WebCore/Modules/webaudio/AudioNode.cpp:
* Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.cpp:
* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
* Source/WebCore/Modules/webaudio/ScriptProcessorNode.cpp:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h:
* Source/WebCore/Modules/websockets/WebSocket.cpp:
* Source/WebCore/Modules/webxr/WebXRLayer.h:
* Source/WebCore/Modules/webxr/WebXRSession.h:
* Source/WebCore/Modules/webxr/WebXRSpace.h:
* Source/WebCore/Modules/webxr/WebXRSystem.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
* Source/WebCore/accessibility/AccessibilitySVGObject.cpp:
* Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm:
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/bindings/js/JSEventTargetCustom.h:
* Source/WebCore/bindings/scripts/InFilesCompiler.pm:
(generateInterfacesHeader):
* Source/WebCore/css/FontFaceSet.h:
* Source/WebCore/css/MediaQueryList.cpp:
* Source/WebCore/css/MediaQueryList.h:
* Source/WebCore/dom/AbortSignal.cpp:
* Source/WebCore/dom/AbortSignal.h:
* Source/WebCore/dom/BroadcastChannel.cpp:
* Source/WebCore/dom/BroadcastChannel.h:
* Source/WebCore/dom/EventContext.cpp:
* Source/WebCore/dom/EventTarget.cpp:
(WebCore::EventTarget::hasAnyEventListeners const):
* Source/WebCore/dom/EventTarget.h:
(WebCore::EventTarget::eventTargetData const): Deleted.
(WebCore::EventTarget::eventTargetData): Deleted.
(WebCore::EventTarget::eventTargetDataConcurrently): Deleted.
(WebCore::EventTarget::enumerateEventListenerTypes const): Deleted.
(WebCore::EventTarget::containsMatchingEventListener const): Deleted.
(WebCore::EventTarget::ensureEventTargetData): Deleted.
(WebCore::EventTarget::hasEventListeners const): Deleted.
(WebCore::EventTarget::hasAnyEventListeners const): Deleted.
(WebCore::EventTarget::hasCapturingEventListeners): Deleted.
(WebCore::EventTarget::visitJSEventListeners): Deleted.
* Source/WebCore/dom/EventTargetFactory.in:
* Source/WebCore/dom/EventTargetInlines.h: Added.
(WebCore::EventTarget::hasEventListeners const):
(WebCore::EventTarget::hasCapturingEventListeners):
(WebCore::EventTarget::eventTargetData const):
(WebCore::EventTarget::eventTargetData):
(WebCore::EventTarget::eventTargetDataConcurrently):
(WebCore::EventTarget::ensureEventTargetData):
(WebCore::EventTarget::enumerateEventListenerTypes const):
(WebCore::EventTarget::containsMatchingEventListener const):
(WebCore::EventTarget::visitJSEventListeners):
* Source/WebCore/dom/MessagePort.cpp:
* Source/WebCore/dom/MessagePort.h:
* Source/WebCore/dom/Node.cpp:
* Source/WebCore/editing/TextManipulationController.cpp:
* Source/WebCore/fileapi/FileReader.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
* Source/WebCore/html/HTMLMediaElement.cpp:
* Source/WebCore/html/HTMLTrackElement.cpp:
* Source/WebCore/html/MediaController.h:
* Source/WebCore/html/OffscreenCanvas.h:
* Source/WebCore/html/closewatcher/CloseWatcher.cpp:
* Source/WebCore/html/closewatcher/CloseWatcher.h:
* Source/WebCore/html/track/AudioTrackList.cpp:
* Source/WebCore/html/track/TextTrack.h:
* Source/WebCore/html/track/TextTrackCue.h:
* Source/WebCore/html/track/TextTrackList.cpp:
* Source/WebCore/html/track/VideoTrackList.cpp:
* Source/WebCore/inspector/InspectorAuditDOMObject.cpp:
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
* Source/WebCore/loader/appcache/DOMApplicationCache.h:
* Source/WebCore/page/DOMWindow.h:
* Source/WebCore/page/EventHandler.cpp:
* Source/WebCore/page/EventSource.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/Navigation.cpp:
* Source/WebCore/page/NavigationHistoryEntry.cpp:
* Source/WebCore/page/Performance.h:
* Source/WebCore/page/PointerCaptureController.cpp:
* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/page/ScreenOrientation.cpp:
* Source/WebCore/page/ScreenOrientation.h:
* Source/WebCore/page/VisualViewport.cpp:
* Source/WebCore/page/ios/FrameIOS.mm:
* Source/WebCore/style/StyleAdjuster.cpp:
* Source/WebCore/svg/SVGElement.cpp:
* Source/WebCore/svg/SVGUseElement.cpp:
* Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp:
* Source/WebCore/workers/Worker.h:
* Source/WebCore/workers/service/ServiceWorker.cpp:
* Source/WebCore/workers/service/ServiceWorkerContainer.h:
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp:
* Source/WebCore/workers/service/ServiceWorkerRegistration.cpp:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.h:
* Source/WebCore/workers/shared/SharedWorker.cpp:
* Source/WebCore/workers/shared/SharedWorkerGlobalScope.h:
* Source/WebCore/worklets/WorkletGlobalScope.h:
* Source/WebCore/xml/XMLHttpRequest.cpp:
* Source/WebCore/xml/XMLHttpRequest.h:
* Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp:
* Source/WebCore/xml/XMLHttpRequestUpload.cpp:
* Source/WebCore/xml/XMLHttpRequestUpload.h:

Canonical link: <a href="https://commits.webkit.org/294283@main">https://commits.webkit.org/294283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83bee42005830d09fde0e8dc250bc419472d946d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101282 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106430 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51909 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103323 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21253 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29439 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77139 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34170 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104289 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16389 "Found 1 new test failure: fast/forms/ios/remove-view-after-focus.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91479 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57486 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16205 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9490 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51257 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86135 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9565 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108786 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28410 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20901 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86119 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28772 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85675 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30393 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8101 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22509 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16491 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28340 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33615 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28152 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31472 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29710 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->