### PR TITLE
[JSC] Fold comparison with NaN in DFG

### DIFF
--- a/JSTests/stress/fold-nan-eq.js
+++ b/JSTests/stress/fold-nan-eq.js
@@ -1,0 +1,13 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(a) {
+   return a == NaN;
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; i ++) {
+    shouldBe(test(i), false);
+}

--- a/JSTests/stress/fold-nan-gt-valueOf.js
+++ b/JSTests/stress/fold-nan-gt-valueOf.js
@@ -1,0 +1,22 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(a) {
+   return a > NaN;
+}
+noInline(test);
+
+let called = 0;
+const value = (i) => ({
+    valueOf() {
+        called++;
+        return i;
+    }
+});
+for (let i = 0; i < testLoopCount; i ++) {
+    shouldBe(test(value(i)), false);
+}
+
+shouldBe(called, testLoopCount);

--- a/JSTests/stress/fold-nan-gt.js
+++ b/JSTests/stress/fold-nan-gt.js
@@ -1,0 +1,13 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(a) {
+   return a > NaN;
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; i ++) {
+    shouldBe(test(i), false);
+}

--- a/JSTests/stress/fold-nan-gte-valueOf.js
+++ b/JSTests/stress/fold-nan-gte-valueOf.js
@@ -1,0 +1,22 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(a) {
+   return a >= NaN;
+}
+noInline(test);
+
+let called = 0;
+const value = (i) => ({
+    valueOf() {
+        called++;
+        return i;
+    }
+});
+for (let i = 0; i < testLoopCount; i ++) {
+    shouldBe(test(value(i)), false);
+}
+
+shouldBe(called, testLoopCount);

--- a/JSTests/stress/fold-nan-gte.js
+++ b/JSTests/stress/fold-nan-gte.js
@@ -1,0 +1,13 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(a) {
+   return a >= NaN;
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; i ++) {
+    shouldBe(test(i), false);
+}

--- a/JSTests/stress/fold-nan-lt-valueOf.js
+++ b/JSTests/stress/fold-nan-lt-valueOf.js
@@ -1,0 +1,22 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(a) {
+   return a < NaN;
+}
+noInline(test);
+
+let called = 0;
+const value = (i) => ({
+    valueOf() {
+        called++;
+        return i;
+    }
+});
+for (let i = 0; i < testLoopCount; i ++) {
+    shouldBe(test(value(i)), false);
+}
+
+shouldBe(called, testLoopCount);

--- a/JSTests/stress/fold-nan-lt.js
+++ b/JSTests/stress/fold-nan-lt.js
@@ -1,0 +1,13 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(a) {
+   return a < NaN;
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; i ++) {
+    shouldBe(test(i), false);
+}

--- a/JSTests/stress/fold-nan-lte-valueOf.js
+++ b/JSTests/stress/fold-nan-lte-valueOf.js
@@ -1,0 +1,22 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(a) {
+   return a <= NaN;
+}
+noInline(test);
+
+let called = 0;
+const value = (i) => ({
+    valueOf() {
+        called++;
+        return i;
+    }
+});
+for (let i = 0; i < testLoopCount; i ++) {
+    shouldBe(test(value(i)), false);
+}
+
+shouldBe(called, testLoopCount);

--- a/JSTests/stress/fold-nan-lte.js
+++ b/JSTests/stress/fold-nan-lte.js
@@ -1,0 +1,13 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(a) {
+   return a <= NaN;
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; i ++) {
+    shouldBe(test(i), false);
+}

--- a/JSTests/stress/fold-nan-strict-eq.js
+++ b/JSTests/stress/fold-nan-strict-eq.js
@@ -1,0 +1,14 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(a) {
+   return a === NaN;
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; i ++) {
+    shouldBe(test(i), false);
+}
+

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2181,7 +2181,8 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         if (isClobbering)
             didFoldClobberWorld();
         
-        JSValue leftConst = forNode(node->child1()).value();
+        AbstractValue& abstractLeftValue = forNode(node->child1());
+        JSValue leftConst = abstractLeftValue.value();
         JSValue rightConst = forNode(node->child2()).value();
         if (leftConst && rightConst) {
             if (leftConst.isNumber() && rightConst.isNumber()) {
@@ -2316,6 +2317,14 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                     if (didFold)
                         break;
                 }
+            }
+        }
+
+        if (abstractLeftValue.isType(SpecFullNumber) && rightConst && rightConst.isNumber()) {
+            double rightValue = rightConst.asNumber();
+            if (std::isnan(rightValue)) {
+                setConstant(node, jsBoolean(false));
+                break;
             }
         }
 
@@ -2481,6 +2490,14 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                     if (didFold)
                         break;
                 }
+            }
+        }
+
+        if (node->op() == CompareStrictEq && right && right.isNumber()) {
+            double rightValue = right.asNumber();
+            if (std::isnan(rightValue)) {
+                setConstant(node, jsBoolean(false));
+                break;
             }
         }
 


### PR DESCRIPTION
#### c14cb0dc08b9837e6b603cbec3c507bbd1eb25a7
<pre>
[JSC] Fold comparison with NaN in DFG
<a href="https://bugs.webkit.org/show_bug.cgi?id=292246">https://bugs.webkit.org/show_bug.cgi?id=292246</a>

Reviewed by Yusuke Suzuki.

This patch chanes to fold comparison(==, ===, &lt;, &lt;=, &gt;, &gt;=)
with NaN in DFG.

* JSTests/stress/fold-nan-eq.js: Added.
(shouldBe):
(test):
* JSTests/stress/fold-nan-gt.js: Added.
(shouldBe):
(test):
* JSTests/stress/fold-nan-gte.js: Added.
(shouldBe):
(test):
* JSTests/stress/fold-nan-lt.js: Added.
(shouldBe):
(test):
* JSTests/stress/fold-nan-lte.js: Added.
(shouldBe):
(test):
* JSTests/stress/fold-nan-strict-eq.js: Added.
(shouldBe):
(test):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):

Canonical link: <a href="https://commits.webkit.org/295420@main">https://commits.webkit.org/295420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cd594ba5d56423db5bc84298e74ceeea7f143af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24744 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110247 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55710 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25156 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33288 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79759 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108036 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19583 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94799 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60066 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19335 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12875 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55087 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97712 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89051 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12920 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112752 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103648 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23698 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88840 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32561 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91019 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88469 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22555 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33361 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11149 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27569 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32119 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37499 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/127952 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31912 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35001 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35253 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33471 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->