### PR TITLE
[scroll-animations] WPT test scroll-animations/view-timelines/fieldset-source.html is a failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/fieldset-source-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/fieldset-source-expected.txt
@@ -1,8 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input1 expected -74 +/- 0.1 but got -74.40625
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input2 expected -48 +/- 0.1 but got -48.40625
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input3 expected -22 +/- 0.1 but got -22.40625
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input4 expected 4 +/- 0.1 but got 3.59375
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input5 expected 30 +/- 0.1 but got 29.59375
 Reservation Details
 Name:
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/fieldset-source.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/fieldset-source.html
@@ -87,7 +87,7 @@
           parseFloat(getComputedStyle(fieldset).borderBottom);
 
       // Validate the start and end offsets for each view timeline.
-      anims.forEach(async (anim) => {
+      for (let anim of anims) {
         assert_equals(anim.timeline.source.id, 'fieldset');
         assert_equals(anim.timeline.subject.tagName, 'INPUT');
         const bounds = anim.effect.target.getBoundingClientRect();
@@ -96,13 +96,13 @@
         const expectedEndOffset = bounds.bottom - fieldsetContentTop;
         assert_approx_equals(
             parseFloat(anim.timeline.startOffset),
-            expectedStartOffset, 0.1,
+            expectedStartOffset, 0.5,
             `Unexpected start offset for ${anim.effect.target.id}`);
         assert_approx_equals(
             parseFloat(anim.timeline.endOffset),
-            expectedEndOffset, 0.1,
+            expectedEndOffset, 0.5,
             `Unexpected end offset for ${anim.effect.target.id}`);
-      });
+      };
     }, 'Fieldset is a valid source for a view timeline');
   }
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7626,7 +7626,6 @@ webkit.org/b/284595 imported/w3c/web-platform-tests/css/css-grid/masonry/tentati
 
 # webkit.org/b/284096 (REGRESSION (286687@main): [ iOS ] 2 imported scroll-animations tests are consistently failing.)
 imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-responsiveness-from-endpoint.html [ Pass Failure ]
-imported/w3c/web-platform-tests/scroll-animations/view-timelines/fieldset-source.html [ Failure ]
 
 webkit.org/b/284419 imported/w3c/web-platform-tests/html/rendering/the-details-element/details-pseudo-elements-006.html [ Failure ]
 

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -33,9 +33,7 @@
 #include "Element.h"
 #include "LegacyRenderSVGModelObject.h"
 #include "RenderBlock.h"
-#include "RenderBox.h"
-#include "RenderBoxInlines.h"
-#include "RenderInline.h"
+#include "RenderBoxModelObject.h"
 #include "RenderLayerScrollableArea.h"
 #include "RenderSVGModelObject.h"
 #include "ScrollAnchoringController.h"
@@ -321,10 +319,8 @@ void ViewTimeline::cacheCurrentTime()
         subjectOffset -= scrollDirection.isVertical ? scrollerPaddingBoxOrigin.y() : scrollerPaddingBoxOrigin.x();
 
         auto subjectBounds = [&] -> FloatSize {
-            if (CheckedPtr subjectRenderBox = dynamicDowncast<RenderBox>(subjectRenderer.get()))
-                return subjectRenderBox->contentBoxRect().size();
-            if (CheckedPtr subjectRenderInline = dynamicDowncast<RenderInline>(subjectRenderer.get()))
-                return subjectRenderInline->borderBoundingBox().size();
+            if (CheckedPtr subjectRenderBoxModelObject = dynamicDowncast<RenderBoxModelObject>(subjectRenderer.get()))
+                return subjectRenderBoxModelObject->borderBoundingBox().size();
             if (CheckedPtr subjectRenderSVGModelObject = dynamicDowncast<RenderSVGModelObject>(subjectRenderer.get()))
                 return subjectRenderSVGModelObject->borderBoxRectEquivalent().size();
             if (is<LegacyRenderSVGModelObject>(subjectRenderer.get()))


### PR DESCRIPTION
#### 8e43c7ee7af5c26271a901a99efd2cf56a64daca
<pre>
[scroll-animations] WPT test scroll-animations/view-timelines/fieldset-source.html is a failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=292191">https://bugs.webkit.org/show_bug.cgi?id=292191</a>
<a href="https://rdar.apple.com/150198507">rdar://150198507</a>

Reviewed by Antti Koivisto.

This view timeline subject in this test is an &lt;input&gt; element which has 2px of padding and 4px of margin.
The test uses `getBoundingClientRect()` to compute the bounds of the subject and compute the expected timeline
end offset based on the reported height.

Internally, `ViewTimeline::cacheCurrentTime()` would compute the subject bounds using `RenderBox::contentBoxRect()`,
but that method explicitly retracts padding and margin. Since `RenderBoxModelObject::borderBoundingBox()` accounts
for those, we switch to using that method, and unify the `RenderBox` and `RenderInline` code paths to use that
method since `RenderInline` was already using it.

We also modify the WPT test in two ways:

    - increase the tolerance from 0.1px to 0.5px
    - stop using `Array.forEach()` to iterate through the animations in favor of a for-of loops since running
      assertions in the `Array.forEach()` callback would not correctly report the failures up to the runner and
      this test was marked as passing even though it was failing assertions.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/fieldset-source-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/fieldset-source.html:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::cacheCurrentTime):

Canonical link: <a href="https://commits.webkit.org/294259@main">https://commits.webkit.org/294259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eedc2d19e122894f7e0b9ebc6ad112926bafd6e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20971 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11275 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106459 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51936 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103350 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29466 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77159 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34195 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104316 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16411 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91504 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57506 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16229 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9516 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51284 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/86106 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108813 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28437 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86136 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28799 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87711 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85696 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30417 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8126 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22538 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16477 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28367 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33641 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28179 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31499 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29737 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->