### PR TITLE
LibWebRTCCodecs is not preserving encoder timestamps

### DIFF
--- a/LayoutTests/http/wpt/webrtc/video-rtpTimestamp-transform-expected.txt
+++ b/LayoutTests/http/wpt/webrtc/video-rtpTimestamp-transform-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS VP8 Validate RTP timestamp progression
+PASS H264 Validate RTP timestamp progression
+

--- a/LayoutTests/http/wpt/webrtc/video-rtpTimestamp-transform.html
+++ b/LayoutTests/http/wpt/webrtc/video-rtpTimestamp-transform.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <video id="video" autoplay playsInline></video>
+        <script src="routines.js"></script>
+        <script>
+function waitForMessage(port, data)
+{
+    let lastData;
+    let gotMessage;
+    const promise = new Promise((resolve, reject) => {
+        gotMessage = resolve;
+        setTimeout(() => { reject("did not get " + data + ", got: '" + lastData + "'") }, 5000);
+    });
+    port.onmessage = event => {
+       lastData = event.data;
+       if (event.data === data)
+           gotMessage();
+    };
+    return promise;
+}
+
+let senderTransform, receiverTransform;
+let stream;
+let worker;
+
+async function doSetup(senderPCCallback)
+{
+    worker = new Worker('video-rtpTimestamp-transform.js');
+    const data = await new Promise(resolve => worker.onmessage = (event) => resolve(event.data));
+    assert_equals(data, "registered");
+
+    const localStream = await navigator.mediaDevices.getUserMedia({video: true});
+
+    const senderChannel = new MessageChannel;
+    const receiverChannel = new MessageChannel;
+    let sender, receiver;
+    senderTransform = new RTCRtpScriptTransform(worker, {name:'MockRTCRtpTransform', mediaType:'video', side:'sender', port:senderChannel.port2}, [senderChannel.port2]);
+    receiverTransform = new RTCRtpScriptTransform(worker, {name:'MockRTCRtpTransform', mediaType:'video', side:'receiver', port:receiverChannel.port2}, [receiverChannel.port2]);
+    senderTransform.port = senderChannel.port1;
+    receiverTransform.port = receiverChannel.port1;
+
+    promise1 = waitForMessage(senderTransform.port, "started video sender");
+    promise2 = waitForMessage(receiverTransform.port, "started video receiver");
+
+    const codecs = RTCRtpSender.getCapabilities("video").codecs;
+    const h264Codec = codecs.filter(codec => { return codec.mimeType === "video/H264"; })[0];
+
+    let pc1, pc2;
+    stream = await new Promise((resolve, reject) => {
+        createConnections((firstConnection) => {
+            sender = firstConnection.addTrack(localStream.getVideoTracks()[0], localStream);
+            sender.transform = senderTransform;
+            senderPCCallback(firstConnection);
+            pc1 = firstConnection;
+        }, (secondConnection) => {
+            secondConnection.ontrack = (trackEvent) => {
+                receiver = trackEvent.receiver;
+                receiver.transform = receiverTransform;
+                resolve(trackEvent.streams[0]);
+            };
+            pc2 = secondConnection;
+        });
+        setTimeout(() => reject("Test timed out"), 5000);
+    });
+
+    await promise1;
+    await promise2;
+    return [pc1, pc2];
+}
+
+promise_test(async (test) => {
+    const codecs = RTCRtpSender.getCapabilities("video").codecs;
+    const vp8Codec = codecs.filter(codec => { return codec.mimeType === "video/VP8"; })[0];
+
+    const [pc1, pc2 ] = await doSetup(senderPc => senderPc.getTransceivers().forEach((transceiver) => { transceiver.setCodecPreferences([vp8Codec]); }));
+
+    senderTransform.port.postMessage("validateRTPTimestamp");
+    receiverTransform.port.postMessage("validateRTPTimestamp");
+
+    await waitForMessage(senderTransform.port, "PASS");
+    await waitForMessage(receiverTransform.port, "PASS");
+
+    pc1.close();
+    pc2.close();
+}, "VP8 Validate RTP timestamp progression");
+
+promise_test(async (test) => {
+    const codecs = RTCRtpSender.getCapabilities("video").codecs;
+    const h264Codec = codecs.filter(codec => { return codec.mimeType === "video/H264"; })[0];
+
+    const [pc1, pc2 ] = await doSetup(senderPc => senderPc.getTransceivers().forEach((transceiver) => { transceiver.setCodecPreferences([h264Codec]); }));
+
+    senderTransform.port.postMessage("validateRTPTimestamp");
+    receiverTransform.port.postMessage("validateRTPTimestamp");
+
+    await waitForMessage(senderTransform.port, "PASS");
+    await waitForMessage(receiverTransform.port, "PASS");
+
+    pc1.close();
+    pc2.close();
+}, "H264 Validate RTP timestamp progression");
+        </script>
+    </body>
+</html>

--- a/LayoutTests/http/wpt/webrtc/video-rtpTimestamp-transform.js
+++ b/LayoutTests/http/wpt/webrtc/video-rtpTimestamp-transform.js
@@ -1,0 +1,51 @@
+class MockRTCRtpTransformer {
+    constructor(transformer) {
+        this.validateRTPTimestamp = false;
+        this.startTime = undefined;
+        this.context = transformer;
+        this.context.options.port.onmessage = (event) => {
+            if (event.data === "validateRTPTimestamp")
+                this.validateRTPTimestamp = true;
+        };
+        this.start();
+    }
+    start()
+    {
+        this.reader = this.context.readable.getReader();
+        this.writer = this.context.writable.getWriter();
+        this.process();
+        this.context.options.port.postMessage("started " + this.context.options.mediaType + " " + this.context.options.side);
+    }
+
+    process()
+    {
+        this.reader.read().then(chunk => {
+            if (chunk.done)
+                return;
+
+            if (this.validateRTPTimestamp) {
+                if (!this.startTime) {
+                    this.startTime = Date.now();
+                    this.startRTPTimestamp = chunk.value.getMetadata().rtpTimestamp;
+                }
+                const currentDelay = Date.now() - this.startTime;
+                if (currentDelay >= 1000) {
+                    const rtpTimestampDelta = chunk.value.getMetadata().rtpTimestamp - this.startRTPTimestamp;
+                    const frequency = rtpTimestampDelta / currentDelay;
+                    this.context.options.port.postMessage(frequency > 40 && frequency < 140 ? "PASS" : ("FAIL with delta " + rtpTimestampDelta));
+                    this.validateRTPTimestamp = false;
+                    this.startTime = undefined;
+                }
+            }
+
+            this.writer.write(chunk.value);
+            this.process();
+        });
+    }
+};
+
+onrtctransform = (event) => {
+    new MockRTCRtpTransformer(event.transformer);
+};
+
+self.postMessage("registered");

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2278,6 +2278,7 @@ http/wpt/webrtc/third-party-frame-ice-candidate-filtering.html [ Skip ]
 # The GstWebRTC backend doesn't support transforms yet.
 webkit.org/b/235885 http/wpt/webrtc/no-webrtc-transform.html [ Pass ]
 webkit.org/b/235885 http/wpt/webrtc/audiovideo-script-transform.html [ Skip ]
+http/wpt/webrtc/video-rtpTimestamp-transform.html [ Skip ]
 webkit.org/b/235885 http/wpt/webrtc/video-script-transform-keyframe-only.html [ Skip ]
 webkit.org/b/235885 http/wpt/webrtc/video-script-transform.html [ Skip ]
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-audio-transform.https.html [ Skip ]

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -710,7 +710,7 @@ template<typename Frame> RefPtr<LibWebRTCCodecs::FramePromise> LibWebRTCCodecs::
 
 int32_t LibWebRTCCodecs::encodeFrame(Encoder& encoder, const webrtc::VideoFrame& frame, bool shouldEncodeAsKeyFrame)
 {
-    auto promise = encodeFrameInternal(encoder, frame, shouldEncodeAsKeyFrame, toVideoRotation(frame.rotation()), MediaTime::createWithDouble(Seconds::fromMicroseconds(frame.timestamp_us()).value()), frame.timestamp_us(), { });
+    auto promise = encodeFrameInternal(encoder, frame, shouldEncodeAsKeyFrame, toVideoRotation(frame.rotation()), MediaTime::createWithDouble(Seconds::fromMicroseconds(frame.timestamp_us()).value()), frame.rtp_timestamp(), { });
     return promise ? WEBRTC_VIDEO_CODEC_OK : WEBRTC_VIDEO_CODEC_ERROR;
 }
 


### PR DESCRIPTION
#### 8460decced8458bfbac71b9caa53f9c33f3cd5e9
<pre>
LibWebRTCCodecs is not preserving encoder timestamps
<a href="https://rdar.apple.com/147843294">rdar://147843294</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292273">https://bugs.webkit.org/show_bug.cgi?id=292273</a>

Reviewed by Jean-Yves Avenard.

When doing the WebRTC resync, renaming of libwebrtc timestamp getters required to update LibWebRTCCodecs and we used the NTP timestamp instead of the RTP timestamp in one place.
Fix that issue and cover it with a WebRTC encoded transform test that validates that the RTP timestamp frequency is roughly 90kHz.

* LayoutTests/http/wpt/webrtc/video-rtpTimestamp-transform-expected.txt: Added.
* LayoutTests/http/wpt/webrtc/video-rtpTimestamp-transform.html: Added.
* LayoutTests/http/wpt/webrtc/video-rtpTimestamp-transform.js: Added.
(MockRTCRtpTransformer):
(MockRTCRtpTransformer.prototype.start):
(MockRTCRtpTransformer.prototype.process):
(onrtctransform):
* LayoutTests/platform/glib/TestExpectations:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::encodeFrame):

Canonical link: <a href="https://commits.webkit.org/294323@main">https://commits.webkit.org/294323@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c552456f573ae6fb28f87b13f08ef2c4ca26d477

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21014 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106502 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51978 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29508 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77196 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34232 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104358 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16451 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91546 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57536 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16271 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9556 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51326 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86152 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9632 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108855 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20955 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86170 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28841 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87748 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85723 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21826 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30453 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8165 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22593 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28413 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33691 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28221 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31541 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29779 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->