### PR TITLE
[WGSL][ASAN] Check if poisoning is allowed before asserting

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTBuilder.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTBuilder.cpp
@@ -54,6 +54,20 @@ void Builder::allocateArena()
 #endif
 }
 
+#if ASAN_ENABLED
+bool Builder::canPoison()
+{
+    bool canPoison;
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [&] {
+        uintptr_t address;
+        __asan_poison_memory_region(&address, sizeof(address));
+        canPoison = __asan_address_is_poisoned(&address);
+    });
+    return canPoison;
+}
+#endif
+
 auto Builder::saveCurrentState() -> State
 {
     State state;

--- a/Source/WebGPU/WGSL/AST/ASTBuilder.h
+++ b/Source/WebGPU/WGSL/AST/ASTBuilder.h
@@ -72,7 +72,7 @@ public:
             allocateArena();
 
 #if ASAN_ENABLED
-        RELEASE_ASSERT(__asan_address_is_poisoned(m_arena.data()));
+        RELEASE_ASSERT(!canPoison() || __asan_address_is_poisoned(m_arena.data()));
         __asan_unpoison_memory_region(m_arena.data(), size);
 #endif
 
@@ -100,6 +100,10 @@ private:
     {
         return (size + sizeof(WTF::AllocAlignmentInteger) - 1) & ~(sizeof(WTF::AllocAlignmentInteger) - 1);
     }
+
+#if ASAN_ENABLED
+    static bool canPoison();
+#endif
 
     void allocateArena();
 

--- a/Source/WebGPU/WGSL/tests/asan-disallow-user-poisoning.wgsl
+++ b/Source/WebGPU/WGSL/tests/asan-disallow-user-poisoning.wgsl
@@ -1,0 +1,3 @@
+// RUN: ASAN_OPTIONS=allow_user_poisoning=0 %wgslc
+
+const x = 1;


### PR DESCRIPTION
#### 15cd6df03d2a209491306a111d259eecc41c1649
<pre>
[WGSL][ASAN] Check if poisoning is allowed before asserting
<a href="https://bugs.webkit.org/show_bug.cgi?id=292274">https://bugs.webkit.org/show_bug.cgi?id=292274</a>
<a href="https://rdar.apple.com/150203489">rdar://150203489</a>

Reviewed by Mike Wyrzykowski.

We were failing the RELEASE_ASSERT when ASAN was enabled but allow_user_poisoning
was set to 0. To fix that we simply test poisoning a local variable to check if
we can poison. I added a test to verify that we no longer crash, but it&apos;s not
trivial to add a test that confirms we do poison when allow_user_poisoning=1.
I tested that locally by removing the call to unpoison and confirming we crash
with a user-after-poison failure.

* Source/WebGPU/WGSL/AST/ASTBuilder.cpp:
(WGSL::AST::Builder::canPoison):
* Source/WebGPU/WGSL/AST/ASTBuilder.h:
(WGSL::AST::Builder::construct):
* Source/WebGPU/WGSL/tests/asan-disallow-user-poisoning.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/294282@main">https://commits.webkit.org/294282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ec1c348a2fefef3da26ca76413f16b05ff963ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106487 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51963 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21307 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29493 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77181 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34216 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16436 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91528 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57528 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16255 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51311 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86144 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108840 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28464 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20945 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86164 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28826 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85715 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21806 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30441 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8149 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22578 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28394 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33668 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28206 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31526 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29764 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->