### PR TITLE
[WebDriver] Remove unused APIAutomationClient methods

### DIFF
--- a/Source/WebKit/UIProcess/API/APIAutomationClient.h
+++ b/Source/WebKit/UIProcess/API/APIAutomationClient.h
@@ -29,19 +29,12 @@
 #include <wtf/Forward.h>
 #include <wtf/TZoneMallocInlines.h>
 
-namespace WebKit {
-class WebProcessPool;
-}
-
 namespace API {
 
 class AutomationClient {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(AutomationClient);
 public:
     virtual ~AutomationClient() { }
-
-    virtual bool allowsRemoteAutomation(WebKit::WebProcessPool*) { return false; }
-    virtual void didRequestAutomationSession(WebKit::WebProcessPool*, const WTF::String&) { }
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/Cocoa/AutomationClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationClient.h
@@ -45,10 +45,6 @@ public:
     virtual ~AutomationClient();
 
 private:
-    // API::AutomationClient
-    bool allowsRemoteAutomation(WebProcessPool*) final { return remoteAutomationAllowed(); }
-    void didRequestAutomationSession(WebKit::WebProcessPool*, const String& sessionIdentifier) final;
-
     // RemoteInspector::Client
     bool remoteAutomationAllowed() const final;
     void requestAutomationSession(const String& sessionIdentifier, const Inspector::RemoteInspector::Client::SessionCapabilities&) final;

--- a/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
@@ -62,13 +62,6 @@ AutomationClient::~AutomationClient()
     RemoteInspector::singleton().setClient(nullptr);
 }
 
-// MARK: API::AutomationClient
-
-void AutomationClient::didRequestAutomationSession(WebKit::WebProcessPool*, const String& sessionIdentifier)
-{
-    requestAutomationSession(sessionIdentifier, { });
-}
-
 // MARK: RemoteInspector::Client
 
 bool AutomationClient::remoteAutomationAllowed() const

--- a/Source/WebKit/UIProcess/win/AutomationClientWin.h
+++ b/Source/WebKit/UIProcess/win/AutomationClientWin.h
@@ -38,10 +38,6 @@ public:
     ~AutomationClient();
 
 private:
-    // API::AutomationClient
-    bool allowsRemoteAutomation(WebKit::WebProcessPool*) final { return remoteAutomationAllowed(); }
-    void didRequestAutomationSession(WebKit::WebProcessPool*, const String& sessionIdentifier) final { }
-
     // RemoteInspector::Client
     bool remoteAutomationAllowed() const override { return true; }
 


### PR DESCRIPTION
#### caa4d9dbcb6ed012fde0f34672f52832bf5da7a0
<pre>
[WebDriver] Remove unused APIAutomationClient methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=292285">https://bugs.webkit.org/show_bug.cgi?id=292285</a>

Reviewed by BJ Burg.

Actual delegation is implemented via RemoteInspector::Client
interface in all ports and APIAutomationClient is only used
for binding the client&apos;s lifetime to the lifetime of owning
WebProcessPool.

* Source/WebKit/UIProcess/API/APIAutomationClient.h:
(API::AutomationClient::~AutomationClient):
(API::AutomationClient::allowsRemoteAutomation): Deleted.
(API::AutomationClient::didRequestAutomationSession): Deleted.
* Source/WebKit/UIProcess/Cocoa/AutomationClient.h:
* Source/WebKit/UIProcess/Cocoa/AutomationClient.mm:
(WebKit::AutomationClient::didRequestAutomationSession): Deleted.
* Source/WebKit/UIProcess/win/AutomationClientWin.h:

Canonical link: <a href="https://commits.webkit.org/294338@main">https://commits.webkit.org/294338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1a1a62e948dab8025e17549ce5dfd4389027d03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106561 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52037 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29615 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77234 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34270 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16496 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91593 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57576 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16317 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51385 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86194 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9681 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108913 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28537 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21023 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86211 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28899 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85771 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21838 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30497 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8214 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22654 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28468 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33748 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28279 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31599 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29838 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->