### PR TITLE
WebDriver BiDi: support cookie-related commands (storage domain)

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -959,6 +959,7 @@ set(WebKit_WEBDRIVER_BIDI_PROTOCOL_GENERATOR_INPUTS
     ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiLog.json
     ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiScript.json
     ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiSession.json
+    ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiStorage.json
 )
 
 add_custom_command(

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -518,6 +518,7 @@ $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiBrowsingContext.json
 $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiLog.json
 $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiScript.json
 $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiSession.json
+$(PROJECT_DIR)/UIProcess/Automation/protocol/BidiStorage.json
 $(PROJECT_DIR)/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
 $(PROJECT_DIR)/UIProcess/Cocoa/UserMediaCaptureManagerProxy.messages.in
 $(PROJECT_DIR)/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -528,6 +528,7 @@ WEBDRIVER_BIDI_PROTOCOL_INPUT_FILES = \
     $(WebKit2)/UIProcess/Automation/protocol/BidiLog.json \
     $(WebKit2)/UIProcess/Automation/protocol/BidiScript.json \
     $(WebKit2)/UIProcess/Automation/protocol/BidiSession.json \
+    $(WebKit2)/UIProcess/Automation/protocol/BidiStorage.json \
 #
 
 WEBDRIVER_BIDI_PROTOCOL_OUTPUT_FILES = \

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -565,6 +565,7 @@ UIProcess/Authentication/WebProtectionSpace.cpp
 UIProcess/Automation/BidiBrowserAgent.cpp @no-unify
 UIProcess/Automation/BidiBrowsingContextAgent.cpp @no-unify
 UIProcess/Automation/BidiScriptAgent.cpp @no-unify
+UIProcess/Automation/BidiStorageAgent.cpp @no-unify
 UIProcess/Automation/BidiUserContext.cpp @no-unify
 UIProcess/Automation/SimulatedInputDispatcher.cpp @no-unify
 UIProcess/Automation/WebAutomationSession.cpp @no-unify

--- a/Source/WebKit/UIProcess/Automation/BidiStorageAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiStorageAgent.cpp
@@ -1,0 +1,303 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "BidiStorageAgent.h"
+
+#if ENABLE(WEBDRIVER_BIDI)
+
+#include "AutomationProtocolObjects.h"
+#include "Logging.h"
+#include "WebAutomationSession.h"
+#include "WebAutomationSessionMacros.h"
+#include "WebDriverBidiProtocolObjects.h"
+#include "WebPageProxy.h"
+#include "WebsiteDataStore.h"
+
+namespace WebKit {
+
+using namespace Inspector;
+using PartitionKey = Inspector::Protocol::BidiStorage::PartitionKey;
+using PartialCookie = Inspector::Protocol::BidiStorage::PartialCookie;
+using CookieFilter = Inspector::Protocol::BidiStorage::CookieFilter;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BidiStorageAgent);
+
+BidiStorageAgent::BidiStorageAgent(WebAutomationSession& session, BackendDispatcher& backendDispatcher)
+    : m_session(session)
+    , m_storageDomainDispatcher(BidiStorageBackendDispatcher::create(backendDispatcher, this))
+{
+}
+
+BidiStorageAgent::~BidiStorageAgent() = default;
+
+static Ref<PartialCookie> buildObjectForCookie(const WebCore::Cookie& cookie)
+{
+    auto partialCookie = PartialCookie::create()
+        .setValue(cookie.value)
+        .setName(cookie.name)
+        .setDomain(cookie.domain)
+        .release();
+
+    partialCookie->setPath(cookie.path);
+    partialCookie->setHttpOnly(cookie.httpOnly);
+    partialCookie->setSecure(cookie.secure);
+    return partialCookie;
+}
+
+static Ref<JSON::ArrayOf<PartialCookie>> buildArrayForCookies(const Vector<WebCore::Cookie>& cookiesList)
+{
+    auto cookies = JSON::ArrayOf<PartialCookie>::create();
+
+    for (const auto& cookie : cookiesList)
+        cookies->addItem(buildObjectForCookie(cookie));
+
+    return cookies;
+}
+
+static bool cookieMatchesFilter(const WebCore::Cookie& cookie, const RefPtr<JSON::Object> optionalFilter)
+{
+
+    String optionalFilterName = optionalFilter->getString("name"_s);
+    if (!optionalFilterName.isEmpty()) {
+        if (cookie.name != optionalFilterName)
+            return false;
+    }
+
+    auto optionalFilterValue = optionalFilter->getString("value"_s);
+    if (!optionalFilterValue.isEmpty()) {
+        if (cookie.value != optionalFilterValue)
+            return false;
+    }
+
+    auto optionalFilterDomain = optionalFilter->getString("domain"_s);
+    if (!optionalFilterDomain.isEmpty()) {
+        if (cookie.domain != optionalFilterDomain)
+            return false;
+    }
+
+    auto optionalFilterPath = optionalFilter->getString("path"_s);
+    if (!optionalFilterPath.isEmpty()) {
+        if (cookie.path != optionalFilterPath)
+            return false;
+    }
+
+    auto optionalFilterHttpOnly = optionalFilter->getBoolean("httpOnly"_s);
+    if (optionalFilterHttpOnly) {
+        if (cookie.httpOnly != optionalFilterHttpOnly.value())
+            return false;
+    }
+
+    auto optionalFilterSecure = optionalFilter->getBoolean("secure"_s);
+    if (optionalFilterSecure) {
+        if (cookie.secure != optionalFilterSecure.value())
+            return false;
+    }
+
+    return true;
+}
+
+Inspector::Protocol::ErrorStringOr<Ref<PartitionKey>> BidiStorageAgent::makePartitionKey(RefPtr<JSON::Object> partitionDescriptor)
+{
+    RefPtr session = m_session.get();
+    SYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    auto partitionKey = PartitionKey::create().release();
+    if (!partitionDescriptor)
+        SYNC_FAIL_WITH_PREDEFINED_ERROR(InvalidParameter);
+
+    auto type = partitionDescriptor->getString("type"_s);
+    if (type == "context"_s) {
+        auto browsingContextHandle = partitionDescriptor->getString("context"_s);
+        if (browsingContextHandle.isEmpty())
+            SYNC_FAIL_WITH_PREDEFINED_ERROR(InvalidParameter);
+        auto page = session->webPageProxyForHandle(browsingContextHandle);
+
+        if (!page)
+            SYNC_FAIL_WITH_PREDEFINED_ERROR(InternalError);
+
+        URL pageURL = URL({ }, page->currentURL());
+        if (pageURL.isValid())
+            partitionKey->setSourceOrigin(pageURL.string());
+
+    } else if (type == "storageKey"_s) {
+        // FIXME: support storage key https://bugs.webkit.org/show_bug.cgi?id=292393
+        SYNC_FAIL_WITH_PREDEFINED_ERROR(InternalError);
+    } else {
+        LOG(Automation, "partitionDescriptor invalid structure or unknown type");
+        SYNC_FAIL_WITH_PREDEFINED_ERROR(InvalidParameter);
+    }
+    return { WTFMove(partitionKey) };
+}
+
+Inspector::Protocol::ErrorStringOr<Ref<API::HTTPCookieStore>> BidiStorageAgent::cookieStoreForPartition(RefPtr<JSON::Object> partitionDescriptor)
+{
+    RefPtr session = m_session.get();
+    SYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    if (!partitionDescriptor) {
+        auto page = session->webPageProxyForHandle("default"_s);
+        if (!page)
+            SYNC_FAIL_WITH_PREDEFINED_ERROR(InternalError);
+        return { page->protectedWebsiteDataStore()->cookieStore() };
+    }
+
+    auto type = partitionDescriptor->getString("type"_s);
+    if (type == "context"_s) {
+        auto browsingContextHandle = partitionDescriptor->getString("context"_s);
+        if (browsingContextHandle.isEmpty())
+            SYNC_FAIL_WITH_PREDEFINED_ERROR(InternalError);
+
+        auto page = session->webPageProxyForHandle(browsingContextHandle);
+        if (!page)
+            SYNC_FAIL_WITH_PREDEFINED_ERROR(InternalError);
+
+        return { page->protectedWebsiteDataStore()->cookieStore() };
+    }
+
+    SYNC_FAIL_WITH_PREDEFINED_ERROR(InternalError);
+}
+
+void BidiStorageAgent::getCookies(RefPtr<JSON::Object>&& optionalFilter, RefPtr<JSON::Object>&& optionalPartition, Inspector::CommandCallbackOf<Ref<JSON::ArrayOf<Inspector::Protocol::BidiStorage::PartialCookie>>, Ref<Inspector::Protocol::BidiStorage::PartitionKey>>&& callback)
+{
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    auto parsedPartitionKey = makePartitionKey(optionalPartition);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!parsedPartitionKey, InternalError);
+    auto partitionKey = parsedPartitionKey.value();
+
+    auto parsedCookieStore = cookieStoreForPartition(optionalPartition);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!parsedCookieStore, InternalError);
+    Ref<API::HTTPCookieStore> resolvedCookieStore = parsedCookieStore.value();
+
+    if (!optionalFilter)
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR(InvalidParameter);
+
+    resolvedCookieStore->cookies([callback = WTFMove(callback), filter = WTFMove(optionalFilter), partitionKey = WTFMove(partitionKey)](Vector<WebCore::Cookie>&& cookiesList) mutable {
+        Vector<WebCore::Cookie> matchingCookies;
+        matchingCookies.reserveInitialCapacity(cookiesList.size());
+
+        for (const auto& cookie : cookiesList) {
+            if (cookieMatchesFilter(cookie, filter))
+                matchingCookies.append(cookie);
+        }
+
+        callback({ { buildArrayForCookies(matchingCookies), partitionKey } });
+    });
+}
+
+void BidiStorageAgent::setCookie(Ref<JSON::Object>&& cookie, RefPtr<JSON::Object>&& optionalPartition, Inspector::CommandCallback<Ref<PartitionKey>>&& callback)
+{
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    auto parsedPartitionKey = makePartitionKey(optionalPartition);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!parsedPartitionKey, InternalError);
+    auto partitionKey = parsedPartitionKey.value();
+
+    auto parsedCookieStore = cookieStoreForPartition(optionalPartition);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!parsedCookieStore, InternalError);
+    auto cookieStore = parsedCookieStore.value();
+
+    String name = cookie->getString("name"_s);
+    String value = cookie->getString("value"_s);
+    String domain = cookie->getString("domain"_s);
+
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(name.isEmpty(), InternalError);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(value.isEmpty(), InternalError);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(domain.isEmpty(), InternalError);
+
+    WebCore::Cookie webCoreCookie;
+    webCoreCookie.name = name;
+    webCoreCookie.value = value;
+    webCoreCookie.domain = domain;
+    webCoreCookie.path = cookie->getString("path"_s);
+
+    auto secureOptional = cookie->getBoolean("secure"_s);
+    webCoreCookie.secure = secureOptional.value_or(false);
+
+    auto httpOnlyOptional = cookie->getBoolean("httpOnly"_s);
+    webCoreCookie.httpOnly = httpOnlyOptional.value_or(false);
+
+    Vector<WebCore::Cookie> cookiesToSet;
+    cookiesToSet.append(WTFMove(webCoreCookie));
+
+    cookieStore->setCookies(WTFMove(cookiesToSet), [callback = WTFMove(callback), partitionKey = WTFMove(partitionKey)]() mutable {
+        callback({ WTFMove(partitionKey) });
+    });
+};
+
+static void deleteCookiesSequentially(RefPtr<API::HTTPCookieStore> store, Vector<WebCore::Cookie> cookies, size_t index, Ref<PartitionKey> partitionKey, Inspector::CommandCallback<Ref<PartitionKey>> callback)
+{
+    if (index >= cookies.size()) {
+        callback({ partitionKey });
+        return;
+    }
+    store->deleteCookie(cookies[index], [store, cookies = WTFMove(cookies), index, partitionKey = WTFMove(partitionKey), callback = WTFMove(callback)]() mutable {
+        deleteCookiesSequentially(store, WTFMove(cookies), index + 1, partitionKey, WTFMove(callback));
+    });
+}
+
+void BidiStorageAgent::deleteCookies(RefPtr<JSON::Object>&& optionalFilter, RefPtr<JSON::Object>&& optionalPartition, Inspector::CommandCallback<Ref<PartitionKey>>&& callback)
+{
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    auto parsedPartitionKey = makePartitionKey(optionalPartition);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!parsedPartitionKey, InternalError);
+    auto partitionKey = parsedPartitionKey.value();
+
+    auto parsedCookieStore = cookieStoreForPartition(optionalPartition);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!parsedCookieStore, InternalError);
+    Ref<API::HTTPCookieStore> cookieStore = parsedCookieStore.value();
+
+    if (!optionalFilter)
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR(InvalidParameter);
+
+    cookieStore->cookies([callback = WTFMove(callback), filter = WTFMove(optionalFilter), partitionKey = WTFMove(partitionKey), cookieStore](Vector<WebCore::Cookie>&& fetchedCookies) mutable {
+        Vector<WebCore::Cookie> toDelete;
+        toDelete.reserveInitialCapacity(fetchedCookies.size());
+
+        if (filter) {
+            for (auto& cookie : fetchedCookies) {
+                if (cookieMatchesFilter(cookie, filter))
+                    toDelete.append(cookie);
+            }
+        }
+
+        if (toDelete.isEmpty()) {
+            callback({ partitionKey });
+            return;
+        }
+
+        LOG(Automation, "deleteCookies: %zu cookies matched; deleting one-by-one.", toDelete.size());
+        deleteCookiesSequentially(WTFMove(cookieStore), WTFMove(toDelete), 0, partitionKey, WTFMove(callback));
+    });
+}
+
+}
+
+#endif // ENABLE(WEBDRIVER_BIDI)

--- a/Source/WebKit/UIProcess/Automation/BidiStorageAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiStorageAgent.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBDRIVER_BIDI)
+
+#include "APIHTTPCookieStore.h"
+#include "WebDriverBidiBackendDispatchers.h"
+
+namespace WebKit {
+
+class WebAutomationSession;
+
+class BidiStorageAgent final : public Inspector::BidiStorageBackendDispatcherHandler {
+    WTF_MAKE_TZONE_ALLOCATED(BidiStorageAgent);
+public:
+    BidiStorageAgent(WebAutomationSession&, Inspector::BackendDispatcher&);
+    ~BidiStorageAgent() override;
+
+    Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::BidiStorage::PartitionKey>> makePartitionKey(RefPtr<JSON::Object> partitionDescriptor);
+    Inspector::Protocol::ErrorStringOr<Ref<API::HTTPCookieStore>> cookieStoreForPartition(RefPtr<JSON::Object> partitionDescriptor);
+    void getCookies(RefPtr<JSON::Object>&& optionalFilter, RefPtr<JSON::Object>&& optionalPartition, Inspector::CommandCallbackOf<Ref<JSON::ArrayOf<Inspector::Protocol::BidiStorage::PartialCookie>>, Ref<Inspector::Protocol::BidiStorage::PartitionKey>>&&) override;
+    void setCookie(Ref<JSON::Object>&& cookie, RefPtr<JSON::Object>&& optionalPartition, Inspector::CommandCallback<Ref<Inspector::Protocol::BidiStorage::PartitionKey>>&&) override;
+    void deleteCookies(RefPtr<JSON::Object>&& optionalFilter, RefPtr<JSON::Object>&& optionalPartition, Inspector::CommandCallback<Ref<Inspector::Protocol::BidiStorage::PartitionKey>>&&) override;
+
+private:
+    WeakPtr<WebAutomationSession> m_session;
+    Ref<Inspector::BidiStorageBackendDispatcher> m_storageDomainDispatcher;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBDRIVER_BIDI)

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
@@ -34,6 +34,7 @@
 #include "BidiBrowserAgent.h"
 #include "BidiBrowsingContextAgent.h"
 #include "BidiScriptAgent.h"
+#include "BidiStorageAgent.h"
 #include "Logging.h"
 #include "WebAutomationSession.h"
 #include <JavaScriptCore/InspectorBackendDispatcher.h>
@@ -54,6 +55,7 @@ WebDriverBidiProcessor::WebDriverBidiProcessor(WebAutomationSession& session)
     , m_browserAgent(makeUnique<BidiBrowserAgent>(session, m_backendDispatcher))
     , m_browsingContextAgent(makeUnique<BidiBrowsingContextAgent>(session, m_backendDispatcher))
     , m_scriptAgent(makeUnique<BidiScriptAgent>(session, m_backendDispatcher))
+    , m_storageAgent(makeUnique<BidiStorageAgent>(session, m_backendDispatcher))
     , m_browsingContextDomainNotifier(makeUnique<BidiBrowsingContextFrontendDispatcher>(m_frontendRouter))
     , m_logDomainNotifier(makeUnique<BidiLogFrontendDispatcher>(m_frontendRouter))
 {

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
@@ -39,6 +39,7 @@ namespace WebKit {
 class BidiBrowserAgent;
 class BidiBrowsingContextAgent;
 class BidiScriptAgent;
+class BidiStorageAgent;
 class WebAutomationSession;
 class WebPageProxy;
 
@@ -74,6 +75,7 @@ private:
     std::unique_ptr<BidiBrowserAgent> m_browserAgent;
     std::unique_ptr<BidiBrowsingContextAgent> m_browsingContextAgent;
     std::unique_ptr<BidiScriptAgent> m_scriptAgent;
+    std::unique_ptr<BidiStorageAgent> m_storageAgent;
     std::unique_ptr<Inspector::BidiBrowsingContextFrontendDispatcher> m_browsingContextDomainNotifier;
     std::unique_ptr<Inspector::BidiLogFrontendDispatcher> m_logDomainNotifier;
 };

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiStorage.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiStorage.json
@@ -1,0 +1,144 @@
+{
+    "domain": "BidiStorage",
+    "exposedAs": "storage",
+    "condition": "ENABLE(WEBDRIVER_BIDI)",
+    "description": "The storage module contains functionality and events related to storage.",
+    "spec": "https://w3c.github.io/webdriver-bidi/#module-storage",
+    "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/storage",
+    "types": [
+        {
+            "id": "PartitionKey",
+            "type": "object",
+            "description": "The <code>BidiStorage.PartitionKey</code> type represents a storage partition key.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-storage-PartitionKey",
+            "properties": [
+                { "name": "userContext", "$ref": "BidiBrowser.UserContext", "optional": true},
+                { "name": "sourceOrigin", "type": "string", "optional": true, "description": "The serialization of the origin of resources that can access the storage partition." }
+            ]
+        },
+        {
+            "id": "CookieFilter",
+            "type": "object",
+            "description": "Filter parameters for cookie retrieval and deletion.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-storage-getCookies",
+            "properties": [
+                { "name": "name", "type": "string", "optional": true, "description": "The name of the cookie." },
+                { "name": "value", "type": "string", "optional": true, "description": "The value of the cookie (as a string)." },
+                { "name": "domain", "type": "string", "optional": true, "description": "The domain of the cookie." },
+                { "name": "path", "type": "string", "optional": true, "description": "The path of the cookie." },
+                { "name": "size", "type": "integer", "optional": true, "description": "The size of the cookie." },
+                { "name": "httpOnly", "type": "boolean", "optional": true, "description": "If the cookie is HTTP only." },
+                { "name": "secure", "type": "boolean", "optional": true, "description": "If the cookie is secure." },
+                { "name": "sameSite", "type": "string", "optional": true, "description": "The <code>SameSite</code> attribute of the cookie." },
+                { "name": "expiry", "type": "integer", "optional": true, "description": "The expiry timestamp of the cookie." }
+            ]
+        },
+        {
+            "id": "BrowsingContextPartitionDescriptor",
+            "type": "object",
+            "description": "Describes a storage partition based on a browsing context.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-storage-getCookies",
+            "properties": [
+                { "name": "type", "type": "string", "enum": [ "context"], "description": "The type of partition descriptor." },
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "description": "The identifier of the browsing context." }
+            ]
+        },
+        {
+            "id": "StorageKeyPartitionDescriptor",
+            "type": "object",
+            "description": "Describes a storage partition based on a storage key.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-storage-getCookies",
+            "properties": [
+                { "name": "type", "type": "string", "enum": [ "storageKey"], "description": "The type of partition descriptor." },
+                { "name": "userContext", "$ref": "BidiBrowser.UserContext", "optional": true},
+                { "name": "sourceOrigin", "type": "string", "optional": true, "description": "The serialization of the origin of resources that can access the storage partition." }
+            ]
+        },
+        {
+             "id": "PartitionDescriptorType",
+             "type": "string",
+             "description": "The type of storage partition descriptor.",
+             "enum": [ "context", "storageKey"]
+        },
+        {
+            "id": "PartitionDescriptor",
+            "type": "object",
+            "description": "Describes a storage partition.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-storage-getCookies",
+            "properties": [
+                { "name": "type", "$ref": "PartitionDescriptorType", "description": "The type of partition descriptor." },
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "optional": true, "description": "The identifier of the browsing context." },
+                { "name": "userContext", "$ref": "BidiBrowser.UserContext", "optional": true},
+                { "name": "sourceOrigin", "type": "string", "optional": true, "description": "The serialization of the origin of resources that can access the storage partition." }
+            ]
+        },
+        {
+            "id": "CookieSameSitePolicy",
+            "type": "string",
+            "description": "Enumerates values for cookies same site policy.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-storage-getCookies",
+            "enum": [ "None", "Lax", "Strict"]
+        },
+        {
+            "id": "PartialCookie",
+            "type": "object",
+            "description": "Represents a cookie to be set.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-storage-getCookies",
+            "properties": [
+                { "name": "name", "type": "string", "description": "The name of the cookie." },
+                { "name": "value", "type": "string", "description": "The value of the cookie (as a string)." },
+                { "name": "domain", "type": "string", "description": "The domain of the cookie." },
+                { "name": "path", "type": "string", "optional": true, "description": "The path of the cookie." },
+                { "name": "httpOnly", "type": "boolean", "optional": true, "description": "Whether the cookie is HTTP only." },
+                { "name": "secure", "type": "boolean", "optional": true, "description": "Whether the cookie is secure." },
+                { "name": "sameSite", "$ref": "CookieSameSitePolicy", "optional": true, "description": "The <code>SameSite</code> attribute of the cookie." },
+                { "name": "expiry", "type": "integer", "optional": true, "description": "The expiry timestamp of the cookie." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "getCookies",
+            "description": "Retrieves zero or more cookies which match a set of provided parameters.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-storage-getCookies",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/storage/get_cookies",
+            "parameters": [
+                { "name": "filter", "$ref": "BidiStorage.CookieFilter", "optional": true, "description": "Filter parameters for cookie retrieval." },
+                { "name": "partition", "$ref": "BidiStorage.PartitionDescriptor", "optional": true, "description": "The storage partition in which to get cookies." }
+            ],
+            "returns": [
+                { "name": "cookies", "type": "array", "items": { "$ref": "BidiStorage.PartialCookie" }, "description": "The list of matching cookies" },
+                { "name": "partitionKey", "$ref": "BidiStorage.PartitionKey", "description": "The storage partition key" }
+            ],
+            "async": true
+        },
+        {
+            "name": "setCookie",
+            "description": "Creates a new cookie in a cookie store, replacing any cookie in that store which matches.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-storage-setCookie",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/storage/set_cookie",
+            "parameters": [
+                { "name": "cookie", "$ref": "BidiStorage.PartialCookie", "description": "The cookie to set." },
+                { "name": "partition", "$ref": "BidiStorage.PartitionDescriptor", "optional": true, "description": "The storage partition in which to set cookies." }
+            ],
+            "returns": [
+                { "name": "partitionKey", "$ref": "BidiStorage.PartitionKey", "description": "The storage partition key." }
+            ],
+            "async": true
+        },
+        {
+            "name": "deleteCookies",
+            "description": "Removes zero or more cookies which match a set of provided parameters.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-storage-deleteCookies",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/storage/delete_cookies",
+            "parameters": [
+                { "name": "filter", "$ref": "BidiStorage.CookieFilter", "optional": true, "description": "Filter parameters for cookie deletion." },
+                { "name": "partition", "$ref": "BidiStorage.PartitionDescriptor", "optional": true, "description": "The storage partition in which to delete cookies." }
+            ],
+            "returns": [
+                { "name": "partitionKey", "$ref": "BidiStorage.PartitionKey", "description": "The storage partition key." }
+            ],
+            "async": true
+        }
+    ]
+}

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1589,6 +1589,8 @@
 		5CE912142293C280005BEC78 /* WKMain.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CE9120B2293C1E0005BEC78 /* WKMain.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5CF62B9628D4436A00C0EAE0 /* DaemonCoders.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CF62B9428D4436A00C0EAE0 /* DaemonCoders.h */; };
 		5CFC9C812B71809600F8D289 /* CoreIPCCFDictionary.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5CFC9C7F2B717EFA00F8D289 /* CoreIPCCFDictionary.mm */; };
+		5EEC724C2DC1B30700D012DD /* BidiStorageAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5EEC724B2DC1B30700D012DD /* BidiStorageAgent.cpp */; };
+		5EEC724E2DC1B31800D012DD /* BidiStorageAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EEC724D2DC1B31300D012DD /* BidiStorageAgent.h */; };
 		63108F961F96719C00A0DB84 /* _WKApplicationManifest.h in Headers */ = {isa = PBXBuildFile; fileRef = 63108F941F96719C00A0DB84 /* _WKApplicationManifest.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		63108F991F9671F700A0DB84 /* _WKApplicationManifestInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 63108F981F9671F700A0DB84 /* _WKApplicationManifestInternal.h */; };
 		634842511FB26E7100946E3C /* APIApplicationManifest.h in Headers */ = {isa = PBXBuildFile; fileRef = 6348424F1FB26E7100946E3C /* APIApplicationManifest.h */; };
@@ -6571,6 +6573,9 @@
 		5CFC9C802B717EFA00F8D289 /* CoreIPCCFDictionary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCCFDictionary.h; sourceTree = "<group>"; };
 		5CFECB031E1ED1C800F88504 /* LegacyCustomProtocolManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LegacyCustomProtocolManager.cpp; sourceTree = "<group>"; };
 		5DAD73F1116FF90C00EE5396 /* BaseTarget.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = BaseTarget.xcconfig; sourceTree = "<group>"; };
+		5EB592AB2DC2049A0058664B /* BidiStorage.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = BidiStorage.json; sourceTree = "<group>"; };
+		5EEC724B2DC1B30700D012DD /* BidiStorageAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiStorageAgent.cpp; sourceTree = "<group>"; };
+		5EEC724D2DC1B31300D012DD /* BidiStorageAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiStorageAgent.h; sourceTree = "<group>"; };
 		63108F941F96719C00A0DB84 /* _WKApplicationManifest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKApplicationManifest.h; sourceTree = "<group>"; };
 		63108F951F96719C00A0DB84 /* _WKApplicationManifest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKApplicationManifest.mm; sourceTree = "<group>"; };
 		63108F981F9671F700A0DB84 /* _WKApplicationManifestInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKApplicationManifestInternal.h; sourceTree = "<group>"; };
@@ -14209,6 +14214,8 @@
 				F3272B7C2DB997C6007B3A9A /* BidiBrowsingContextAgent.h */,
 				F3272B7F2DB997C6007B3A9A /* BidiScriptAgent.cpp */,
 				F3272B7E2DB997C6007B3A9A /* BidiScriptAgent.h */,
+				5EEC724B2DC1B30700D012DD /* BidiStorageAgent.cpp */,
+				5EEC724D2DC1B31300D012DD /* BidiStorageAgent.h */,
 				F3A94F002DB6F3310023CE9D /* BidiUserContext.cpp */,
 				F3A94EFF2DB6F3310023CE9D /* BidiUserContext.h */,
 				995226D5207D184600F78420 /* SimulatedInputDispatcher.cpp */,
@@ -14231,6 +14238,7 @@
 				996D00422D7AA0CD0049C7D8 /* BidiLog.json */,
 				996D00432D7AA0CD0049C7D8 /* BidiScript.json */,
 				99965A552DA096EF0039DFF5 /* BidiSession.json */,
+				5EB592AB2DC2049A0058664B /* BidiStorage.json */,
 			);
 			path = protocol;
 			sourceTree = "<group>";
@@ -17096,6 +17104,7 @@
 				F3EEEE592DB318270038CC1D /* BidiBrowserAgent.h in Headers */,
 				F3272B822DB997C6007B3A9A /* BidiBrowsingContextAgent.h in Headers */,
 				F3272B832DB997C6007B3A9A /* BidiScriptAgent.h in Headers */,
+				5EEC724E2DC1B31800D012DD /* BidiStorageAgent.h in Headers */,
 				F3A94F022DB6F3310023CE9D /* BidiUserContext.h in Headers */,
 				E164A2F2191AF14E0010737D /* BlobDataFileReferenceWithSandboxExtension.h in Headers */,
 				E170876C16D6CA6900F99226 /* BlobRegistryProxy.h in Headers */,
@@ -20610,6 +20619,7 @@
 				F3EEEE5A2DB318270038CC1D /* BidiBrowserAgent.cpp in Sources */,
 				F3272B802DB997C6007B3A9A /* BidiBrowsingContextAgent.cpp in Sources */,
 				F3272B812DB997C6007B3A9A /* BidiScriptAgent.cpp in Sources */,
+				5EEC724C2DC1B30700D012DD /* BidiStorageAgent.cpp in Sources */,
 				F3A94F012DB6F3310023CE9D /* BidiUserContext.cpp in Sources */,
 				1C62747E288B4C3E00CED3A2 /* CocoaHelpers.mm in Sources */,
 				49DC1DE127E5129100C1CB36 /* CSPExtensionUtilities.mm in Sources */,


### PR DESCRIPTION
#### b1f15f6fc24a45d8a148299aff2c3cc95b47bda5
<pre>
WebDriver BiDi: support cookie-related commands (storage domain)
<a href="https://rdar.apple.com/136802953">rdar://136802953</a>

Reviewed by BJ Burg.

Implementing more core functionality within the storage module. Introducing the ability
to get, set and delete cookies by accessing cookie stores. Currently storage keys are
not supported, so browsingContext is the main method of identifying cookie stores.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/Automation/BidiStorageAgent.cpp: Added.
(WebKit::BidiStorageAgent::BidiStorageAgent):
(WebKit::buildObjectForCookie):
(WebKit::buildArrayForCookies):
(WebKit::matchesCookieFilter):
(WebKit::BidiStorageAgent::makePartitionKey):
(WebKit::BidiStorageAgent::cookieStoreForPartition):
(WebKit::BidiStorageAgent::getCookies):
(WebKit::BidiStorageAgent::setCookie):
(WebKit::deleteCookiesSequentially):
(WebKit::BidiStorageAgent::deleteCookies):
* Source/WebKit/UIProcess/Automation/BidiStorageAgent.h: Added.
* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp:
(WebKit::WebDriverBidiProcessor::WebDriverBidiProcessor):
* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h:
* Source/WebKit/UIProcess/Automation/protocol/BidiStorage.json: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/295759@main">https://commits.webkit.org/295759@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8b508b2e8583348d068cd612d546dd37528fc93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14607 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109687 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55151 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24683 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32734 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79331 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107486 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19195 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94296 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59658 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18977 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54520 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88674 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112072 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31641 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23305 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88372 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32005 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90529 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88038 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22766 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32933 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10708 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/26118 "The change is no longer eligible for processing.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31568 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36908 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31360 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34699 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32920 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->