### PR TITLE
Use inline capacity in some vectors

### DIFF
--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4346,7 +4346,7 @@ RenderingUpdateScheduler* Page::existingRenderingUpdateScheduler()
 
 void Page::forEachDocumentFromMainFrame(const Frame& mainFrame, NOESCAPE const Function<void(Document&)>& functor)
 {
-    Vector<Ref<Document>> documents;
+    Vector<Ref<Document>, 8> documents;
     for (RefPtr frame = &mainFrame; frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(*frame);
         if (!localFrame)
@@ -4354,6 +4354,7 @@ void Page::forEachDocumentFromMainFrame(const Frame& mainFrame, NOESCAPE const F
         if (RefPtr document = localFrame->document())
             documents.append(document.releaseNonNull());
     }
+
     for (auto& document : documents)
         functor(document);
 }
@@ -4380,7 +4381,7 @@ bool Page::findMatchingLocalDocument(NOESCAPE const Function<bool(Document&)>& f
 
 void Page::forEachRenderableDocument(NOESCAPE const Function<void(Document&)>& functor) const
 {
-    Vector<Ref<Document>> documents;
+    Vector<Ref<Document>, 8> documents;
     for (RefPtr frame = &mainFrame(); frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(*frame);
         if (!localFrame)

--- a/Source/WebKit/UIProcess/DisplayLink.cpp
+++ b/Source/WebKit/UIProcess/DisplayLink.cpp
@@ -190,7 +190,7 @@ void DisplayLink::notifyObserversDisplayDidRefresh()
 
     tracePoint(DisplayLinkUpdate);
 
-    auto maxFramesPerSecond = [](const Vector<ObserverInfo>& observers) {
+    auto maxFramesPerSecond = [](const Vector<ObserverInfo, 1>& observers) {
         std::optional<FramesPerSecond> observersMaxFramesPerSecond;
         for (const auto& observer : observers)
             observersMaxFramesPerSecond = std::max(observersMaxFramesPerSecond.value_or(0), observer.preferredFramesPerSecond);

--- a/Source/WebKit/UIProcess/DisplayLink.h
+++ b/Source/WebKit/UIProcess/DisplayLink.h
@@ -120,7 +120,7 @@ private:
 
     struct ClientInfo {
         unsigned fullSpeedUpdatesClientCount { 0 };
-        Vector<ObserverInfo> observers;
+        Vector<ObserverInfo, 1> observers;
     };
 
 #if PLATFORM(MAC)


### PR DESCRIPTION
#### f8eb4cf035d529c6e55ebfd28c92fdc9468981d5
<pre>
Use inline capacity in some vectors
<a href="https://bugs.webkit.org/show_bug.cgi?id=292296">https://bugs.webkit.org/show_bug.cgi?id=292296</a>
<a href="https://rdar.apple.com/150313874">rdar://150313874</a>

Reviewed by Sammy Gill.

Use inline capacity in a few places to avoid allocations.

This is a re-land of 294134@main without the change to RemoteLayerTreeDrawingAreaProxy.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::forEachDocumentFromMainFrame):
(WebCore::Page::forEachRenderableDocument const):
* Source/WebKit/UIProcess/DisplayLink.cpp:
(WebKit::DisplayLink::notifyObserversDisplayDidRefresh):
* Source/WebKit/UIProcess/DisplayLink.h:

Canonical link: <a href="https://commits.webkit.org/294305@main">https://commits.webkit.org/294305@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16c8533003e4827f20a11efa449a18f838dacd56

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106540 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52016 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103427 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29545 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/77219 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34256 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16483 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/91575 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57561 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16304 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9587 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51364 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/86183 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9661 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108892 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20981 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86196 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28878 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87777 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85755 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21816 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30483 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8194 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22633 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28447 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33726 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28258 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31578 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29817 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->