### PR TITLE
AX: Many places where instances of AccessibilityText are created unnecessarily copy a string where it could be moved instead

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -621,7 +621,11 @@ struct AccessibilityText {
     String text;
     AccessibilityTextSource textSource;
 
-    AccessibilityText(const String& text, const AccessibilityTextSource& source)
+    AccessibilityText(String&& text, AccessibilityTextSource source)
+        : text(WTFMove(text))
+        , textSource(source)
+    { }
+    AccessibilityText(const String& text, AccessibilityTextSource source)
         : text(text)
         , textSource(source)
     { }

--- a/Source/WebCore/accessibility/AccessibilityAttachment.cpp
+++ b/Source/WebCore/accessibility/AccessibilityAttachment.cpp
@@ -92,13 +92,13 @@ void AccessibilityAttachment::accessibilityText(Vector<AccessibilityText>& textO
     auto& action = getAttribute(actionAttr);
     
     if (action.length())
-        textOrder.append(AccessibilityText(action, AccessibilityTextSource::Action));
+        textOrder.append(AccessibilityText(WTFMove(action), AccessibilityTextSource::Action));
 
     if (title.length())
-        textOrder.append(AccessibilityText(title, AccessibilityTextSource::Title));
+        textOrder.append(AccessibilityText(WTFMove(title), AccessibilityTextSource::Title));
 
     if (subtitle.length())
-        textOrder.append(AccessibilityText(subtitle, AccessibilityTextSource::Subtitle));
+        textOrder.append(AccessibilityText(WTFMove(subtitle), AccessibilityTextSource::Subtitle));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityImageMapLink.cpp
+++ b/Source/WebCore/accessibility/AccessibilityImageMapLink.cpp
@@ -89,7 +89,7 @@ void AccessibilityImageMapLink::accessibilityText(Vector<AccessibilityText>& tex
 {
     String description = this->description();
     if (!description.isEmpty())
-        textOrder.append(AccessibilityText(description, AccessibilityTextSource::Alternative));
+        textOrder.append(AccessibilityText(WTFMove(description), AccessibilityTextSource::Alternative));
 
     const AtomString& titleText = getAttribute(titleAttr);
     if (!titleText.isEmpty())

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
@@ -113,11 +113,11 @@ void AccessibilitySVGObject::accessibilityText(Vector<AccessibilityText>& textOr
 {
     String description = this->description();
     if (!description.isEmpty())
-        textOrder.append(AccessibilityText(description, AccessibilityTextSource::Alternative));
+        textOrder.append(AccessibilityText(WTFMove(description), AccessibilityTextSource::Alternative));
 
     String helptext = helpText();
     if (!helptext.isEmpty())
-        textOrder.append(AccessibilityText(helptext, AccessibilityTextSource::Help));
+        textOrder.append(AccessibilityText(WTFMove(helptext), AccessibilityTextSource::Help));
 }
 
 String AccessibilitySVGObject::description() const

--- a/Source/WebCore/accessibility/AccessibilityTable.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTable.cpp
@@ -907,7 +907,7 @@ void AccessibilityTable::labelText(Vector<AccessibilityText>& textOrder) const
 {
     String title = this->title();
     if (!title.isEmpty())
-        textOrder.append(AccessibilityText(title, AccessibilityTextSource::LabelByElement));
+        textOrder.append(AccessibilityText(WTFMove(title), AccessibilityTextSource::LabelByElement));
 }
 
 String AccessibilityTable::title() const


### PR DESCRIPTION
#### 7b821671deb901620c446fff8f52fa6b11973691
<pre>
AX: Many places where instances of AccessibilityText are created unnecessarily copy a string where it could be moved instead
<a href="https://bugs.webkit.org/show_bug.cgi?id=292297">https://bugs.webkit.org/show_bug.cgi?id=292297</a>
<a href="https://rdar.apple.com/150315733">rdar://150315733</a>

Reviewed by Chris Fleizach.

Also pass AccessibilityTextSource by value instead of by reference. The type of this enum is an int, and it&apos;s actually
less efficient to pass small types by-reference.

* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AccessibilityText::AccessibilityText):
* Source/WebCore/accessibility/AccessibilityAttachment.cpp:
(WebCore::AccessibilityAttachment::accessibilityText const):
* Source/WebCore/accessibility/AccessibilityImageMapLink.cpp:
(WebCore::AccessibilityImageMapLink::accessibilityText const):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::alternativeText const):
(WebCore::AccessibilityNodeObject::visibleText const):
(WebCore::AccessibilityNodeObject::accessibilityText const):
(WebCore::AccessibilityNodeObject::ariaLabeledByText const):
* Source/WebCore/accessibility/AccessibilitySVGObject.cpp:
(WebCore::AccessibilitySVGObject::accessibilityText const):
* Source/WebCore/accessibility/AccessibilityTable.cpp:
(WebCore::AccessibilityTable::labelText const):

Canonical link: <a href="https://commits.webkit.org/294314@main">https://commits.webkit.org/294314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee35bbf0a7407b2bf9d123597d0f4d76892fffc6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11361 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106544 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52020 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103431 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29549 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77225 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34258 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104398 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91581 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57567 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16308 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9593 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51368 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/86187 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9667 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108896 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28520 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20985 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86200 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28882 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87783 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85759 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21821 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30488 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8200 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22637 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28451 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33730 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28262 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31582 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29821 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->