### PR TITLE
WebChromeClient::page() should return a raw pointer instead of a reference

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -177,8 +177,8 @@ namespace WebKit {
 using namespace WebCore;
 using namespace HTMLNames;
 
-AXRelayProcessSuspendedNotification::AXRelayProcessSuspendedNotification(Ref<WebPage> page, AutomaticallySend automaticallySend)
-    : m_page(page.get())
+AXRelayProcessSuspendedNotification::AXRelayProcessSuspendedNotification(WebPage& page, AutomaticallySend automaticallySend)
+    : m_page(page)
     , m_automaticallySend(automaticallySend)
 {
     if (m_automaticallySend == AutomaticallySend::Yes)
@@ -208,14 +208,10 @@ void WebChromeClient::chromeDestroyed()
 {
 }
 
-Ref<WebPage> WebChromeClient::protectedPage() const
-{
-    return *m_page;
-}
-
 void WebChromeClient::setWindowRect(const FloatRect& windowFrame)
 {
-    protectedPage()->sendSetWindowFrame(windowFrame);
+    if (RefPtr page = m_page.get())
+        page->sendSetWindowFrame(windowFrame);
 }
 
 FloatRect WebChromeClient::windowRect() const
@@ -223,7 +219,9 @@ FloatRect WebChromeClient::windowRect() const
 #if PLATFORM(IOS_FAMILY)
     return FloatRect();
 #else
-    auto page = protectedPage();
+    RefPtr page = m_page.get();
+    if (!page)
+        return { };
 #if PLATFORM(MAC)
     if (page->hasCachedWindowFrame())
         return page->windowFrameInUnflippedScreenCoordinates();
@@ -237,54 +235,66 @@ FloatRect WebChromeClient::windowRect() const
 
 FloatRect WebChromeClient::pageRect() const
 {
-    return FloatRect(FloatPoint(), page().size());
+    if (!m_page)
+        return { };
+
+    return FloatRect(FloatPoint(), m_page->size());
 }
 
 void WebChromeClient::focus()
 {
-    protectedPage()->send(Messages::WebPageProxy::SetFocus(true));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::SetFocus(true));
 }
 
 void WebChromeClient::unfocus()
 {
-    protectedPage()->send(Messages::WebPageProxy::SetFocus(false));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::SetFocus(false));
 }
 
 #if PLATFORM(COCOA)
 
 void WebChromeClient::elementDidFocus(Element& element, const FocusOptions& options)
 {
-    protectedPage()->elementDidFocus(element, options);
+    if (RefPtr page = m_page.get())
+        page->elementDidFocus(element, options);
 }
 
 void WebChromeClient::elementDidRefocus(Element& element, const FocusOptions& options)
 {
-    protectedPage()->elementDidRefocus(element, options);
+    if (RefPtr page = m_page.get())
+        page->elementDidRefocus(element, options);
 }
 
 void WebChromeClient::elementDidBlur(Element& element)
 {
-    protectedPage()->elementDidBlur(element);
+    if (RefPtr page = m_page.get())
+        page->elementDidBlur(element);
 }
 
 void WebChromeClient::focusedElementDidChangeInputMode(Element& element, InputMode mode)
 {
-    protectedPage()->focusedElementDidChangeInputMode(element, mode);
+    if (RefPtr page = m_page.get())
+        page->focusedElementDidChangeInputMode(element, mode);
 }
 
 void WebChromeClient::focusedSelectElementDidChangeOptions(const WebCore::HTMLSelectElement& element)
 {
-    protectedPage()->focusedSelectElementDidChangeOptions(element);
+    if (RefPtr page = m_page.get())
+        page->focusedSelectElementDidChangeOptions(element);
 }
 
 void WebChromeClient::makeFirstResponder()
 {
-    protectedPage()->send(Messages::WebPageProxy::MakeFirstResponder());
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::MakeFirstResponder());
 }
 
 void WebChromeClient::assistiveTechnologyMakeFirstResponder()
 {
-    protectedPage()->send(Messages::WebPageProxy::AssistiveTechnologyMakeFirstResponder());
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::AssistiveTechnologyMakeFirstResponder());
 }
 
 #endif    
@@ -297,7 +307,8 @@ bool WebChromeClient::canTakeFocus(FocusDirection) const
 
 void WebChromeClient::takeFocus(FocusDirection direction)
 {
-    protectedPage()->send(Messages::WebPageProxy::TakeFocus(direction));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::TakeFocus(direction));
 }
 
 void WebChromeClient::focusedElementChanged(Element* element)
@@ -309,15 +320,17 @@ void WebChromeClient::focusedElementChanged(Element* element)
     RefPtr frame = element->document().frame();
     RefPtr webFrame = WebFrame::fromCoreFrame(*frame);
     ASSERT(webFrame);
-    auto page = protectedPage();
-    page->injectedBundleFormClient().didFocusTextField(page.ptr(), *inputElement, webFrame.get());
+    if (RefPtr page = m_page.get())
+        page->injectedBundleFormClient().didFocusTextField(page.get(), *inputElement, webFrame.get());
 }
 
 void WebChromeClient::focusedFrameChanged(Frame* frame)
 {
-    auto webFrame = frame ? WebFrame::fromCoreFrame(*frame) : nullptr;
+    if (!m_page)
+        return;
 
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebPageProxy::FocusedFrameChanged(webFrame ? std::make_optional(webFrame->frameID()) : std::nullopt), page().identifier());
+    auto webFrame = frame ? WebFrame::fromCoreFrame(*frame) : nullptr;
+    WebProcess::singleton().parentProcessConnection()->send(Messages::WebPageProxy::FocusedFrameChanged(webFrame ? std::make_optional(webFrame->frameID()) : std::nullopt), m_page->identifier());
 }
 
 RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& openedMainFrameName, const WindowFeatures& windowFeatures, const NavigationAction& navigationAction)
@@ -333,6 +346,10 @@ RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& open
 
     RefPtr webFrame = WebFrame::fromCoreFrame(frame);
 
+    RefPtr page = m_page.get();
+    if (!page)
+        return nullptr;
+
     NavigationActionData navigationActionData {
         navigationAction.type(),
         modifiersForNavigationAction(navigationAction),
@@ -340,7 +357,7 @@ RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& open
         syntheticClickType(navigationAction),
         webProcess.userGestureTokenIdentifier(navigationAction.requester()->pageID, navigationAction.userGestureToken()),
         navigationAction.userGestureToken() ? navigationAction.userGestureToken()->authorizationToken() : std::nullopt,
-        protectedPage()->canHandleRequest(navigationAction.originalRequest()),
+        page->canHandleRequest(navigationAction.originalRequest()),
         navigationAction.shouldOpenExternalURLsPolicy(),
         navigationAction.downloadAttribute(),
         mouseEventData ? mouseEventData->locationInRootViewCoordinates : FloatPoint { },
@@ -377,7 +394,7 @@ RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& open
         navigationAction.originalRequest() /* request */
     };
 
-    auto sendResult = webProcess.parentProcessConnection()->sendSync(Messages::WebPageProxy::CreateNewPage(windowFeatures, navigationActionData), page().identifier(), IPC::Timeout::infinity(), { IPC::SendSyncOption::MaintainOrderingWithAsyncMessages });
+    auto sendResult = webProcess.parentProcessConnection()->sendSync(Messages::WebPageProxy::CreateNewPage(windowFeatures, navigationActionData), page->identifier(), IPC::Timeout::infinity(), { IPC::SendSyncOption::MaintainOrderingWithAsyncMessages });
     if (!sendResult.succeeded())
         return nullptr;
 
@@ -386,7 +403,7 @@ RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& open
         return nullptr;
     ASSERT(parameters);
 
-    parameters->oldPageID = page().identifier();
+    parameters->oldPageID = page->identifier();
 
     webProcess.createWebPage(*newPageID, WTFMove(*parameters));
     return webProcess.webPage(*newPageID)->corePage();
@@ -394,26 +411,32 @@ RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& open
 
 bool WebChromeClient::testProcessIncomingSyncMessagesWhenWaitingForSyncReply()
 {
+    if (!m_page)
+        return false;
+
     IPC::UnboundedSynchronousIPCScope unboundedSynchronousIPCScope;
 
-    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::TestProcessIncomingSyncMessagesWhenWaitingForSyncReply(page().webPageProxyIdentifier()), 0);
+    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::TestProcessIncomingSyncMessagesWhenWaitingForSyncReply(m_page->webPageProxyIdentifier()), 0);
     auto [handled] = sendResult.takeReplyOr(false);
     return handled;
 }
 
 void WebChromeClient::show()
 {
-    protectedPage()->show();
+    if (RefPtr page = m_page.get())
+        page->show();
 }
 
 bool WebChromeClient::canRunModal() const
 {
-    return protectedPage()->canRunModal();
+    RefPtr page = m_page.get();
+    return page && page->canRunModal();
 }
 
 void WebChromeClient::runModal()
 {
-    protectedPage()->runModal();
+    if (RefPtr page = m_page.get())
+        page->runModal();
 }
 
 void WebChromeClient::reportProcessCPUTime(Seconds cpuTime, ActivityStateForCPUSampling activityState)
@@ -423,13 +446,17 @@ void WebChromeClient::reportProcessCPUTime(Seconds cpuTime, ActivityStateForCPUS
 
 void WebChromeClient::setToolbarsVisible(bool toolbarsAreVisible)
 {
-    protectedPage()->send(Messages::WebPageProxy::SetToolbarsAreVisible(toolbarsAreVisible));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::SetToolbarsAreVisible(toolbarsAreVisible));
 }
 
 bool WebChromeClient::toolbarsVisible() const
 {
-    auto page = protectedPage();
-    API::InjectedBundle::PageUIClient::UIElementVisibility toolbarsVisibility = page->injectedBundleUIClient().toolbarsAreVisible(page.ptr());
+    RefPtr page = m_page.get();
+    if (!page)
+        return false;
+
+    API::InjectedBundle::PageUIClient::UIElementVisibility toolbarsVisibility = page->injectedBundleUIClient().toolbarsAreVisible(page.get());
     if (toolbarsVisibility != API::InjectedBundle::PageUIClient::UIElementVisibility::Unknown)
         return toolbarsVisibility == API::InjectedBundle::PageUIClient::UIElementVisibility::Visible;
     
@@ -440,13 +467,17 @@ bool WebChromeClient::toolbarsVisible() const
 
 void WebChromeClient::setStatusbarVisible(bool statusBarIsVisible)
 {
-    protectedPage()->send(Messages::WebPageProxy::SetStatusBarIsVisible(statusBarIsVisible));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::SetStatusBarIsVisible(statusBarIsVisible));
 }
 
 bool WebChromeClient::statusbarVisible() const
 {
-    auto page = protectedPage();
-    API::InjectedBundle::PageUIClient::UIElementVisibility statusbarVisibility = page->injectedBundleUIClient().statusBarIsVisible(page.ptr());
+    RefPtr page = m_page.get();
+    if (!page)
+        return false;
+
+    API::InjectedBundle::PageUIClient::UIElementVisibility statusbarVisibility = page->injectedBundleUIClient().statusBarIsVisible(page.get());
     if (statusbarVisibility != API::InjectedBundle::PageUIClient::UIElementVisibility::Unknown)
         return statusbarVisibility == API::InjectedBundle::PageUIClient::UIElementVisibility::Visible;
 
@@ -468,13 +499,17 @@ bool WebChromeClient::scrollbarsVisible() const
 
 void WebChromeClient::setMenubarVisible(bool menuBarVisible)
 {
-    protectedPage()->send(Messages::WebPageProxy::SetMenuBarIsVisible(menuBarVisible));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::SetMenuBarIsVisible(menuBarVisible));
 }
 
 bool WebChromeClient::menubarVisible() const
 {
-    auto page = protectedPage();
-    API::InjectedBundle::PageUIClient::UIElementVisibility menubarVisibility = page->injectedBundleUIClient().menuBarIsVisible(page.ptr());
+    RefPtr page = m_page.get();
+    if (!page)
+        return false;
+
+    API::InjectedBundle::PageUIClient::UIElementVisibility menubarVisibility = page->injectedBundleUIClient().menuBarIsVisible(page.get());
     if (menubarVisibility != API::InjectedBundle::PageUIClient::UIElementVisibility::Unknown)
         return menubarVisibility == API::InjectedBundle::PageUIClient::UIElementVisibility::Visible;
     
@@ -485,15 +520,19 @@ bool WebChromeClient::menubarVisible() const
 
 void WebChromeClient::setResizable(bool resizable)
 {
-    protectedPage()->send(Messages::WebPageProxy::SetIsResizable(resizable));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::SetIsResizable(resizable));
 }
 
 void WebChromeClient::addMessageToConsole(MessageSource source, MessageLevel level, const String& message, unsigned lineNumber, unsigned columnNumber, const String& sourceID)
 {
     // Notify the bundle client.
-    auto page = protectedPage();
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
     // FIXME: Remove this after rdar://143399667 is fixed.
-    page->injectedBundleUIClient().willAddMessageToConsole(page.ptr(), source, level, message, lineNumber, columnNumber, sourceID);
+    page->injectedBundleUIClient().willAddMessageToConsole(page.get(), source, level, message, lineNumber, columnNumber, sourceID);
 
     if (!page->shouldSendConsoleLogsToUIProcessForTesting())
         return;
@@ -502,13 +541,14 @@ void WebChromeClient::addMessageToConsole(MessageSource source, MessageLevel lev
 
 void WebChromeClient::addMessageWithArgumentsToConsole(MessageSource source, MessageLevel level, const String& message, std::span<const String> messageArguments, unsigned lineNumber, unsigned columnNumber, const String& sourceID)
 {
-    auto page = protectedPage();
-    page->injectedBundleUIClient().willAddMessageWithArgumentsToConsole(page.ptr(), source, level, message, messageArguments, lineNumber, columnNumber, sourceID);
+    if (RefPtr page = m_page.get())
+        page->injectedBundleUIClient().willAddMessageWithArgumentsToConsole(page.get(), source, level, message, messageArguments, lineNumber, columnNumber, sourceID);
 }
 
 bool WebChromeClient::canRunBeforeUnloadConfirmPanel()
 {
-    return protectedPage()->canRunBeforeUnloadConfirmPanel();
+    RefPtr page = m_page.get();
+    return page && page->canRunBeforeUnloadConfirmPanel();
 }
 
 bool WebChromeClient::runBeforeUnloadConfirmPanel(const String& message, LocalFrame& frame)
@@ -517,8 +557,11 @@ bool WebChromeClient::runBeforeUnloadConfirmPanel(const String& message, LocalFr
 
     HangDetectionDisabler hangDetectionDisabler;
 
-    auto page = protectedPage();
-    auto relay = AXRelayProcessSuspendedNotification(page);
+    RefPtr page = m_page.get();
+    if (!page)
+        return false;
+
+    auto relay = AXRelayProcessSuspendedNotification(*page);
 
     auto sendResult = page->sendSyncWithDelayedReply(Messages::WebPageProxy::RunBeforeUnloadConfirmPanel(webFrame->frameID(), webFrame->info(), message));
     auto [shouldClose] = sendResult.takeReplyOr(false);
@@ -534,7 +577,10 @@ void WebChromeClient::closeWindow()
     // a close execute synchronously as part of window.close, but other parts
     // later on.
 
-    auto page = protectedPage();
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
     page->corePage()->setGroupName(String());
 
     Ref frame = page->mainWebFrame();
@@ -546,13 +592,19 @@ void WebChromeClient::closeWindow()
 
 void WebChromeClient::rootFrameAdded(const WebCore::LocalFrame& frame)
 {
-    if (auto* drawingArea = page().drawingArea())
+    if (!m_page)
+        return;
+
+    if (auto* drawingArea = m_page->drawingArea())
         drawingArea->addRootFrame(frame.frameID());
 }
 
 void WebChromeClient::rootFrameRemoved(const WebCore::LocalFrame& frame)
 {
-    if (auto* drawingArea = page().drawingArea())
+    if (!m_page)
+        return;
+
+    if (auto* drawingArea = m_page->drawingArea())
         drawingArea->removeRootFrame(frame.frameID());
 }
 
@@ -573,14 +625,17 @@ void WebChromeClient::runJavaScriptAlert(LocalFrame& frame, const String& alertT
     ASSERT(webFrame);
 
     // Notify the bundle client.
-    auto page = protectedPage();
-    page->injectedBundleUIClient().willRunJavaScriptAlert(page.ptr(), alertText, webFrame.get());
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    page->injectedBundleUIClient().willRunJavaScriptAlert(page.get(), alertText, webFrame.get());
     page->prepareToRunModalJavaScriptDialog();
 
     HangDetectionDisabler hangDetectionDisabler;
     IPC::UnboundedSynchronousIPCScope unboundedSynchronousIPCScope;
 
-    auto relay = AXRelayProcessSuspendedNotification(page);
+    auto relay = AXRelayProcessSuspendedNotification(*page);
 
     page->sendSyncWithDelayedReply(Messages::WebPageProxy::RunJavaScriptAlert(webFrame->frameID(), webFrame->info(), alertText), { IPC::SendSyncOption::MaintainOrderingWithAsyncMessages });
 }
@@ -594,14 +649,17 @@ bool WebChromeClient::runJavaScriptConfirm(LocalFrame& frame, const String& mess
     ASSERT(webFrame);
 
     // Notify the bundle client.
-    auto page = protectedPage();
-    page->injectedBundleUIClient().willRunJavaScriptConfirm(page.ptr(), message, webFrame.get());
+    RefPtr page = m_page.get();
+    if (!page)
+        return false;
+
+    page->injectedBundleUIClient().willRunJavaScriptConfirm(page.get(), message, webFrame.get());
     page->prepareToRunModalJavaScriptDialog();
 
     HangDetectionDisabler hangDetectionDisabler;
     IPC::UnboundedSynchronousIPCScope unboundedSynchronousIPCScope;
 
-    auto relay = AXRelayProcessSuspendedNotification(page);
+    auto relay = AXRelayProcessSuspendedNotification(*page);
 
     auto sendResult = page->sendSyncWithDelayedReply(Messages::WebPageProxy::RunJavaScriptConfirm(webFrame->frameID(), webFrame->info(), message), { IPC::SendSyncOption::MaintainOrderingWithAsyncMessages });
     auto [result] = sendResult.takeReplyOr(false);
@@ -617,14 +675,17 @@ bool WebChromeClient::runJavaScriptPrompt(LocalFrame& frame, const String& messa
     ASSERT(webFrame);
 
     // Notify the bundle client.
-    auto page = protectedPage();
-    page->injectedBundleUIClient().willRunJavaScriptPrompt(page.ptr(), message, defaultValue, webFrame.get());
+    RefPtr page = m_page.get();
+    if (!page)
+        return false;
+
+    page->injectedBundleUIClient().willRunJavaScriptPrompt(page.get(), message, defaultValue, webFrame.get());
     page->prepareToRunModalJavaScriptDialog();
 
     HangDetectionDisabler hangDetectionDisabler;
     IPC::UnboundedSynchronousIPCScope unboundedSynchronousIPCScope;
 
-    auto relay = AXRelayProcessSuspendedNotification(page);
+    auto relay = AXRelayProcessSuspendedNotification(*page);
 
     auto sendResult = page->sendSyncWithDelayedReply(Messages::WebPageProxy::RunJavaScriptPrompt(webFrame->frameID(), webFrame->info(), message, defaultValue), { IPC::SendSyncOption::MaintainOrderingWithAsyncMessages });
     if (!sendResult.succeeded())
@@ -636,40 +697,52 @@ bool WebChromeClient::runJavaScriptPrompt(LocalFrame& frame, const String& messa
 
 KeyboardUIMode WebChromeClient::keyboardUIMode()
 {
-    return protectedPage()->keyboardUIMode();
+    RefPtr page = m_page.get();
+    return page ? page->keyboardUIMode() : KeyboardAccessDefault;
 }
 
 bool WebChromeClient::hoverSupportedByPrimaryPointingDevice() const
 {
-    return protectedPage()->hoverSupportedByPrimaryPointingDevice();
+    RefPtr page = m_page.get();
+    return page && page->hoverSupportedByPrimaryPointingDevice();
 }
 
 bool WebChromeClient::hoverSupportedByAnyAvailablePointingDevice() const
 {
-    return protectedPage()->hoverSupportedByAnyAvailablePointingDevice();
+    RefPtr page = m_page.get();
+    return page && page->hoverSupportedByAnyAvailablePointingDevice();
 }
 
 std::optional<PointerCharacteristics> WebChromeClient::pointerCharacteristicsOfPrimaryPointingDevice() const
 {
-    return protectedPage()->pointerCharacteristicsOfPrimaryPointingDevice();
+    RefPtr page = m_page.get();
+    return page ? page->pointerCharacteristicsOfPrimaryPointingDevice() : std::nullopt;
 }
 
 OptionSet<PointerCharacteristics> WebChromeClient::pointerCharacteristicsOfAllAvailablePointingDevices() const
 {
-    return protectedPage()->pointerCharacteristicsOfAllAvailablePointingDevices();
+    RefPtr page = m_page.get();
+    if (!page)
+        return { };
+    return page->pointerCharacteristicsOfAllAvailablePointingDevices();
 }
 
 #if ENABLE(POINTER_LOCK)
 
 bool WebChromeClient::requestPointerLock()
 {
-    protectedPage()->send(Messages::WebPageProxy::RequestPointerLock());
+    RefPtr page = m_page.get();
+    if (!page)
+        return false;
+
+    page->send(Messages::WebPageProxy::RequestPointerLock());
     return true;
 }
 
 void WebChromeClient::requestPointerUnlock()
 {
-    protectedPage()->send(Messages::WebPageProxy::RequestPointerUnlock());
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::RequestPointerUnlock());
 }
 
 #endif
@@ -681,7 +754,10 @@ void WebChromeClient::invalidateRootView(const IntRect&)
 
 void WebChromeClient::invalidateContentsAndRootView(const IntRect& rect)
 {
-    auto page = protectedPage();
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
     RefPtr corePage = page->protectedCorePage();
     if (!corePage)
         return;
@@ -696,7 +772,10 @@ void WebChromeClient::invalidateContentsAndRootView(const IntRect& rect)
 
 void WebChromeClient::invalidateContentsForSlowScroll(const IntRect& rect)
 {
-    auto page = protectedPage();
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
     RefPtr corePage = page->protectedCorePage();
     if (!corePage)
         return;
@@ -712,39 +791,48 @@ void WebChromeClient::invalidateContentsForSlowScroll(const IntRect& rect)
 
 void WebChromeClient::scroll(const IntSize& scrollDelta, const IntRect& scrollRect, const IntRect& clipRect)
 {
-    auto page = protectedPage();
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
     page->pageDidScroll();
     page->drawingArea()->scroll(intersection(scrollRect, clipRect), scrollDelta);
 }
 
 IntPoint WebChromeClient::screenToRootView(const IntPoint& point) const
 {
-    return protectedPage()->screenToRootView(point);
+    RefPtr page = m_page.get();
+    return page ? page->screenToRootView(point) : IntPoint();
 }
 
 IntPoint WebChromeClient::rootViewToScreen(const IntPoint& point) const
 {
-    return protectedPage()->rootViewToScreen(point);
+    RefPtr page = m_page.get();
+    return page ? page->rootViewToScreen(point) : IntPoint();
 }
 
 IntRect WebChromeClient::rootViewToScreen(const IntRect& rect) const
 {
-    return protectedPage()->rootViewToScreen(rect);
+    RefPtr page = m_page.get();
+    return page ? page->rootViewToScreen(rect) : IntRect();
 }
     
 IntPoint WebChromeClient::accessibilityScreenToRootView(const IntPoint& point) const
 {
-    return protectedPage()->accessibilityScreenToRootView(point);
+    RefPtr page = m_page.get();
+    return page ? page->accessibilityScreenToRootView(point) : IntPoint();
 }
 
 IntRect WebChromeClient::rootViewToAccessibilityScreen(const IntRect& rect) const
 {
-    return protectedPage()->rootViewToAccessibilityScreen(rect);
+    RefPtr page = m_page.get();
+    return page ? page->rootViewToAccessibilityScreen(rect) : IntRect();
 }
 
 void WebChromeClient::didFinishLoadingImageForElement(HTMLImageElement& element)
 {
-    protectedPage()->didFinishLoadingImageForElement(element);
+    if (RefPtr page = m_page.get())
+        page->didFinishLoadingImageForElement(element);
 }
 
 PlatformPageClient WebChromeClient::platformPageClient() const
@@ -755,7 +843,8 @@ PlatformPageClient WebChromeClient::platformPageClient() const
 
 void WebChromeClient::intrinsicContentsSizeChanged(const IntSize& size) const
 {
-    protectedPage()->scheduleIntrinsicContentSizeUpdate(size);
+    if (RefPtr page = m_page.get())
+        page->scheduleIntrinsicContentSizeUpdate(size);
 }
 
 void WebChromeClient::contentsSizeChanged(LocalFrame& frame, const IntSize& size) const
@@ -765,7 +854,10 @@ void WebChromeClient::contentsSizeChanged(LocalFrame& frame, const IntSize& size
     if (&frame.page()->mainFrame() != &frame)
         return;
 
-    auto page = protectedPage();
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
     page->send(Messages::WebPageProxy::DidChangeContentSize(size));
 
     page->drawingArea()->mainFrameContentSizeChanged(frame.frameID(), size);
@@ -785,7 +877,8 @@ void WebChromeClient::contentsSizeChanged(LocalFrame& frame, const IntSize& size
 
 void WebChromeClient::scrollMainFrameToRevealRect(const IntRect& rect) const
 {
-    protectedPage()->send(Messages::WebPageProxy::RequestScrollToRect(rect, rect.center()));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::RequestScrollToRect(rect, rect.center()));
 }
 
 void WebChromeClient::scrollContainingScrollViewsToRevealRect(const IntRect&) const
@@ -826,8 +919,11 @@ void WebChromeClient::mouseDidMoveOverElement(const HitTestResult& hitTestResult
     auto wkModifiers = modifiersFromPlatformEventModifiers(modifiers);
 
     // Notify the bundle client.
-    auto page = protectedPage();
-    page->injectedBundleUIClient().mouseDidMoveOverElement(page.ptr(), hitTestResult, wkModifiers, userData);
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    page->injectedBundleUIClient().mouseDidMoveOverElement(page.get(), hitTestResult, wkModifiers, userData);
 
     // Notify the UIProcess.
     WebHitTestResultData webHitTestResultData(hitTestResult, toolTip);
@@ -849,8 +945,11 @@ void WebChromeClient::print(LocalFrame& frame, const StringWithDirection& title)
 #endif
 
     auto truncatedTitle = truncateFromEnd(title, maxTitleLength);
-    auto page = protectedPage();
-    auto relay = AXRelayProcessSuspendedNotification(page);
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    auto relay = AXRelayProcessSuspendedNotification(*page);
 
     IPC::UnboundedSynchronousIPCScope unboundedSynchronousIPCScope;
     page->sendSyncWithDelayedReply(Messages::WebPageProxy::PrintFrame(webFrame->frameID(), truncatedTitle.string, pdfFirstPageSize));
@@ -858,12 +957,17 @@ void WebChromeClient::print(LocalFrame& frame, const StringWithDirection& title)
 
 RefPtr<ColorChooser> WebChromeClient::createColorChooser(ColorChooserClient& client, const Color& initialColor)
 {
-    return WebColorChooser::create(protectedPage().ptr(), &client, initialColor);
+    RefPtr page = m_page.get();
+    return WebColorChooser::create(page.get(), &client, initialColor);
 }
 
 RefPtr<DataListSuggestionPicker> WebChromeClient::createDataListSuggestionPicker(DataListSuggestionsClient& client)
 {
-    return WebDataListSuggestionPicker::create(protectedPage(), client);
+    RefPtr page = m_page.get();
+    if (!page)
+        return nullptr;
+
+    return WebDataListSuggestionPicker::create(page.releaseNonNull(), client);
 }
 
 bool WebChromeClient::canShowDataListSuggestionLabels() const
@@ -877,16 +981,20 @@ bool WebChromeClient::canShowDataListSuggestionLabels() const
 
 RefPtr<DateTimeChooser> WebChromeClient::createDateTimeChooser(DateTimeChooserClient& client)
 {
-    return WebDateTimeChooser::create(protectedPage(), client);
+    RefPtr page = m_page.get();
+    if (!page)
+        return nullptr;
+
+    return WebDateTimeChooser::create(page.releaseNonNull(), client);
 }
 
 void WebChromeClient::runOpenPanel(LocalFrame& frame, FileChooser& fileChooser)
 {
-    auto page = protectedPage();
-    if (page->activeOpenPanelResultListener())
+    RefPtr page = m_page.get();
+    if (!page || page->activeOpenPanelResultListener())
         return;
 
-    page->setActiveOpenPanelResultListener(WebOpenPanelResultListener::create(page, fileChooser));
+    page->setActiveOpenPanelResultListener(WebOpenPanelResultListener::create(*page, fileChooser));
 
     auto webFrame = WebFrame::fromCoreFrame(frame);
     ASSERT(webFrame);
@@ -895,23 +1003,27 @@ void WebChromeClient::runOpenPanel(LocalFrame& frame, FileChooser& fileChooser)
     
 void WebChromeClient::showShareSheet(ShareDataWithParsedURL& shareData, CompletionHandler<void(bool)>&& callback)
 {
-    protectedPage()->showShareSheet(shareData, WTFMove(callback));
+    if (RefPtr page = m_page.get())
+        page->showShareSheet(shareData, WTFMove(callback));
 }
 
 void WebChromeClient::showContactPicker(const WebCore::ContactsRequestData& requestData, WTF::CompletionHandler<void(std::optional<Vector<WebCore::ContactInfo>>&&)>&& callback)
 {
-    protectedPage()->showContactPicker(requestData, WTFMove(callback));
+    if (RefPtr page = m_page.get())
+        page->showContactPicker(requestData, WTFMove(callback));
 }
 
 #if HAVE(DIGITAL_CREDENTIALS_UI)
 void WebChromeClient::showDigitalCredentialsPicker(const WebCore::DigitalCredentialsRequestData& requestData, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& callback)
 {
-    protectedPage()->showDigitalCredentialsPicker(requestData, WTFMove(callback));
+    if (RefPtr page = m_page.get())
+        page->showDigitalCredentialsPicker(requestData, WTFMove(callback));
 }
 
 void WebChromeClient::dismissDigitalCredentialsPicker(WTF::CompletionHandler<void(bool)>&& completionHandler)
 {
-    protectedPage()->dismissDigitalCredentialsPicker(WTFMove(completionHandler));
+    if (RefPtr page = m_page.get())
+        page->dismissDigitalCredentialsPicker(WTFMove(completionHandler));
 }
 #endif
 
@@ -922,12 +1034,14 @@ void WebChromeClient::loadIconForFiles(const Vector<String>& filenames, FileIcon
 
 void WebChromeClient::setCursor(const Cursor& cursor)
 {
-    protectedPage()->send(Messages::WebPageProxy::SetCursor(cursor));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::SetCursor(cursor));
 }
 
 void WebChromeClient::setCursorHiddenUntilMouseMoves(bool hiddenUntilMouseMoves)
 {
-    protectedPage()->send(Messages::WebPageProxy::SetCursorHiddenUntilMouseMoves(hiddenUntilMouseMoves));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::SetCursorHiddenUntilMouseMoves(hiddenUntilMouseMoves));
 }
 
 #if !PLATFORM(COCOA)
@@ -943,14 +1057,14 @@ void WebChromeClient::didAssociateFormControls(const Vector<RefPtr<Element>>& el
 {
     auto webFrame = WebFrame::fromCoreFrame(frame);
     ASSERT(webFrame);
-    auto page = protectedPage();
-    return page->injectedBundleFormClient().didAssociateFormControls(page.ptr(), elements, webFrame.get());
+    if (RefPtr page = m_page.get())
+        page->injectedBundleFormClient().didAssociateFormControls(page.get(), elements, webFrame.get());
 }
 
 bool WebChromeClient::shouldNotifyOnFormChanges()
 {
-    auto page = protectedPage();
-    return page->injectedBundleFormClient().shouldNotifyOnFormChanges(page.ptr());
+    RefPtr page = m_page.get();
+    return page && page->injectedBundleFormClient().shouldNotifyOnFormChanges(page.get());
 }
 
 bool WebChromeClient::selectItemWritingDirectionIsNatural()
@@ -965,17 +1079,21 @@ bool WebChromeClient::selectItemAlignmentFollowsMenuWritingDirection()
 
 RefPtr<PopupMenu> WebChromeClient::createPopupMenu(PopupMenuClient& client) const
 {
-    return WebPopupMenu::create(protectedPage().ptr(), &client);
+    RefPtr page = m_page.get();
+    return WebPopupMenu::create(page.get(), &client);
 }
 
 RefPtr<SearchPopupMenu> WebChromeClient::createSearchPopupMenu(PopupMenuClient& client) const
 {
-    return WebSearchPopupMenu::create(protectedPage().ptr(), &client);
+    RefPtr page = m_page.get();
+    return WebSearchPopupMenu::create(page.get(), &client);
 }
 
 GraphicsLayerFactory* WebChromeClient::graphicsLayerFactory() const
 {
-    auto page = protectedPage();
+    RefPtr page = m_page.get();
+    if (!page)
+        return nullptr;
     if (auto drawingArea = page->drawingArea())
         return drawingArea->graphicsLayerFactory();
     return nullptr;
@@ -983,14 +1101,18 @@ GraphicsLayerFactory* WebChromeClient::graphicsLayerFactory() const
 
 WebCore::DisplayRefreshMonitorFactory* WebChromeClient::displayRefreshMonitorFactory() const
 {
-    return page().drawingArea();
+    return m_page ? m_page->drawingArea() : nullptr;
 }
 
 #if ENABLE(GPU_PROCESS)
 RefPtr<ImageBuffer> WebChromeClient::createImageBuffer(const FloatSize& size, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, ImageBufferPixelFormat pixelFormat) const
 {
-    if (WebProcess::singleton().shouldUseRemoteRenderingFor(purpose))
-        return protectedPage()->ensureRemoteRenderingBackendProxy().createImageBuffer(size, renderingMode, purpose, resolutionScale, colorSpace, pixelFormat);
+    if (WebProcess::singleton().shouldUseRemoteRenderingFor(purpose)) {
+        RefPtr page = m_page.get();
+        if (!page)
+            return nullptr;
+        return page->ensureRemoteRenderingBackendProxy().createImageBuffer(size, renderingMode, purpose, resolutionScale, colorSpace, pixelFormat);
+    }
 
     if (purpose == RenderingPurpose::ShareableSnapshot || purpose == RenderingPurpose::ShareableLocalSnapshot)
         return ImageBuffer::create<ImageBufferShareableBitmapBackend>(size, resolutionScale, colorSpace, ImageBufferPixelFormat::BGRA8, purpose, { });
@@ -1002,14 +1124,22 @@ RefPtr<ImageBuffer> WebChromeClient::sinkIntoImageBuffer(std::unique_ptr<Seriali
 {
     if (!is<RemoteSerializedImageBufferProxy>(imageBuffer))
         return SerializedImageBuffer::sinkIntoImageBuffer(WTFMove(imageBuffer));
+
+    RefPtr page = m_page.get();
+    if (!page)
+        return nullptr;
+
     auto remote = std::unique_ptr<RemoteSerializedImageBufferProxy>(static_cast<RemoteSerializedImageBufferProxy*>(imageBuffer.release()));
-    return RemoteSerializedImageBufferProxy::sinkIntoImageBuffer(WTFMove(remote), protectedPage()->ensureRemoteRenderingBackendProxy());
+    return RemoteSerializedImageBufferProxy::sinkIntoImageBuffer(WTFMove(remote), page->ensureRemoteRenderingBackendProxy());
 }
 #endif
 
 std::unique_ptr<WebCore::WorkerClient> WebChromeClient::createWorkerClient(SerialFunctionDispatcher& dispatcher)
 {
-    return WebWorkerClient::create(*protectedPage()->corePage(), dispatcher).moveToUniquePtr();
+    RefPtr page = m_page.get();
+    if (!page)
+        return nullptr;
+    return WebWorkerClient::create(*page->corePage(), dispatcher).moveToUniquePtr();
 }
 
 #if ENABLE(WEBGL)
@@ -1019,8 +1149,12 @@ RefPtr<GraphicsContextGL> WebChromeClient::createGraphicsContextGL(const Graphic
     WebProcess::singleton().initializePlatformDisplayIfNeeded();
 #endif
 #if ENABLE(GPU_PROCESS)
-    if (WebProcess::singleton().shouldUseRemoteRenderingForWebGL())
-        return RemoteGraphicsContextGLProxy::create(attributes, protectedPage());
+    if (WebProcess::singleton().shouldUseRemoteRenderingForWebGL()) {
+        RefPtr page = m_page.get();
+        if (!page)
+            return nullptr;
+        return RemoteGraphicsContextGLProxy::create(attributes, page.releaseNonNull());
+    }
 #endif
     return WebCore::createWebProcessGraphicsContextGL(attributes);
 }
@@ -1030,7 +1164,10 @@ RefPtr<GraphicsContextGL> WebChromeClient::createGraphicsContextGL(const Graphic
 RefPtr<WebCore::WebGPU::GPU> WebChromeClient::createGPUForWebGPU() const
 {
 #if ENABLE(GPU_PROCESS)
-    return RemoteGPUProxy::create(WebGPU::DowncastConvertToBackingContext::create(), protectedPage());
+    RefPtr page = m_page.get();
+    if (!page)
+        return nullptr;
+    return RemoteGPUProxy::create(WebGPU::DowncastConvertToBackingContext::create(), page.releaseNonNull());
 #else
     return WebCore::WebGPU::create([](WebCore::WebGPU::WorkItem&& workItem) {
         callOnMainRunLoop(WTFMove(workItem));
@@ -1042,7 +1179,10 @@ RefPtr<WebCore::WebGPU::GPU> WebChromeClient::createGPUForWebGPU() const
 RefPtr<WebCore::ShapeDetection::BarcodeDetector> WebChromeClient::createBarcodeDetector(const WebCore::ShapeDetection::BarcodeDetectorOptions& barcodeDetectorOptions) const
 {
 #if ENABLE(GPU_PROCESS)
-    auto page = protectedPage();
+    RefPtr page = m_page.get();
+    if (!page)
+        return nullptr;
+
     auto& remoteRenderingBackendProxy = page->ensureRemoteRenderingBackendProxy();
     // FIXME(https://bugs.webkit.org/show_bug.cgi?id=275245): Does not work when GPUP crashes.
     RefPtr connection = remoteRenderingBackendProxy.connection();
@@ -1059,7 +1199,11 @@ RefPtr<WebCore::ShapeDetection::BarcodeDetector> WebChromeClient::createBarcodeD
 void WebChromeClient::getBarcodeDetectorSupportedFormats(CompletionHandler<void(Vector<WebCore::ShapeDetection::BarcodeFormat>&&)>&& completionHandler) const
 {
 #if ENABLE(GPU_PROCESS)
-    auto page = protectedPage();
+    RefPtr page = m_page.get();
+    if (!page) {
+        completionHandler({ });
+        return;
+    }
     auto& remoteRenderingBackendProxy = page->ensureRemoteRenderingBackendProxy();
     // FIXME(https://bugs.webkit.org/show_bug.cgi?id=275245): Does not work when GPUP crashes.
     RefPtr connection = remoteRenderingBackendProxy.connection();
@@ -1078,7 +1222,10 @@ void WebChromeClient::getBarcodeDetectorSupportedFormats(CompletionHandler<void(
 RefPtr<WebCore::ShapeDetection::FaceDetector> WebChromeClient::createFaceDetector(const WebCore::ShapeDetection::FaceDetectorOptions& faceDetectorOptions) const
 {
 #if ENABLE(GPU_PROCESS)
-    auto page = protectedPage();
+    RefPtr page = m_page.get();
+    if (!page)
+        return nullptr;
+
     auto& remoteRenderingBackendProxy = page->ensureRemoteRenderingBackendProxy();
     // FIXME(https://bugs.webkit.org/show_bug.cgi?id=275245): Does not work when GPUP crashes.
     RefPtr connection = remoteRenderingBackendProxy.connection();
@@ -1095,7 +1242,10 @@ RefPtr<WebCore::ShapeDetection::FaceDetector> WebChromeClient::createFaceDetecto
 RefPtr<WebCore::ShapeDetection::TextDetector> WebChromeClient::createTextDetector() const
 {
 #if ENABLE(GPU_PROCESS)
-    auto page = protectedPage();
+    RefPtr page = m_page.get();
+    if (!page)
+        return nullptr;
+
     auto& remoteRenderingBackendProxy = page->ensureRemoteRenderingBackendProxy();
     // FIXME(https://bugs.webkit.org/show_bug.cgi?id=275245): Does not work when GPUP crashes.
     RefPtr connection = remoteRenderingBackendProxy.connection();
@@ -1111,7 +1261,10 @@ RefPtr<WebCore::ShapeDetection::TextDetector> WebChromeClient::createTextDetecto
 
 void WebChromeClient::attachRootGraphicsLayer(LocalFrame& frame, GraphicsLayer* layer)
 {
-    auto page = protectedPage();
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
     if (layer)
         page->enterAcceleratedCompositingMode(frame, layer);
     else
@@ -1120,7 +1273,10 @@ void WebChromeClient::attachRootGraphicsLayer(LocalFrame& frame, GraphicsLayer* 
 
 void WebChromeClient::attachViewOverlayGraphicsLayer(GraphicsLayer* graphicsLayer)
 {
-    auto page = protectedPage();
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
     auto* drawingArea = page->drawingArea();
     if (!drawingArea)
         return;
@@ -1137,19 +1293,25 @@ void WebChromeClient::setNeedsOneShotDrawingSynchronization()
 
 bool WebChromeClient::shouldTriggerRenderingUpdate(unsigned rescheduledRenderingUpdateCount) const
 {
-    return protectedPage()->shouldTriggerRenderingUpdate(rescheduledRenderingUpdateCount);
+    RefPtr page = m_page.get();
+    return page && page->shouldTriggerRenderingUpdate(rescheduledRenderingUpdateCount);
 }
 
 void WebChromeClient::triggerRenderingUpdate()
 {
-    auto page = protectedPage();
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
     if (auto* drawingArea = page->drawingArea())
         drawingArea->triggerRenderingUpdate();
 }
 
 bool WebChromeClient::scheduleRenderingUpdate()
 {
-    auto page = protectedPage();
+    RefPtr page = m_page.get();
+    if (!page)
+        return false;
     if (auto* drawingArea = page->drawingArea())
         return drawingArea->scheduleRenderingUpdate();
     return false;
@@ -1157,14 +1319,18 @@ bool WebChromeClient::scheduleRenderingUpdate()
 
 void WebChromeClient::renderingUpdateFramesPerSecondChanged()
 {
-    auto page = protectedPage();
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
     if (auto* drawingArea = page->drawingArea())
         drawingArea->renderingUpdateFramesPerSecondChanged();
 }
 
 unsigned WebChromeClient::remoteImagesCountForTesting() const
 {
-    return protectedPage()->remoteImagesCountForTesting();
+    RefPtr page = m_page.get();
+    return page ? page->remoteImagesCountForTesting() : 0;
 }
 
 void WebChromeClient::registerBlobPathForTesting(const String& path, CompletionHandler<void()>&& completionHandler)
@@ -1176,13 +1342,17 @@ void WebChromeClient::registerBlobPathForTesting(const String& path, CompletionH
 void WebChromeClient::contentRuleListNotification(const URL& url, const ContentRuleListResults& results)
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    protectedPage()->send(Messages::WebPageProxy::ContentRuleListNotification(url, results));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::ContentRuleListNotification(url, results));
 #endif
 }
 
 bool WebChromeClient::layerTreeStateIsFrozen() const
 {
-    auto page = protectedPage();
+    RefPtr page = m_page.get();
+    if (!page)
+        return false;
+
     if (auto* drawingArea = page->drawingArea())
         return drawingArea->layerTreeStateIsFrozen();
 
@@ -1193,16 +1363,19 @@ bool WebChromeClient::layerTreeStateIsFrozen() const
 
 RefPtr<WebCore::ScrollingCoordinator> WebChromeClient::createScrollingCoordinator(Page& corePage) const
 {
-    auto page = protectedPage();
+    RefPtr page = m_page.get();
+    if (!page)
+        return nullptr;
+
     ASSERT_UNUSED(corePage, page->corePage() == &corePage);
 #if PLATFORM(COCOA)
     switch (page->drawingArea()->type()) {
 #if PLATFORM(MAC)
     case DrawingAreaType::TiledCoreAnimation:
-        return TiledCoreAnimationScrollingCoordinator::create(page.ptr());
+        return TiledCoreAnimationScrollingCoordinator::create(page.get());
 #endif
     case DrawingAreaType::RemoteLayerTree:
-        return RemoteScrollingCoordinator::create(page.ptr());
+        return RemoteScrollingCoordinator::create(page.get());
     }
 #endif
     return nullptr;
@@ -1213,7 +1386,10 @@ RefPtr<WebCore::ScrollingCoordinator> WebChromeClient::createScrollingCoordinato
 #if PLATFORM(MAC)
 void WebChromeClient::ensureScrollbarsController(Page& corePage, ScrollableArea& area, bool update) const
 {
-    auto page = protectedPage();
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
     ASSERT(page->corePage() == &corePage);
     auto* currentScrollbarsController = area.existingScrollbarsController();
 
@@ -1244,27 +1420,32 @@ void WebChromeClient::ensureScrollbarsController(Page& corePage, ScrollableArea&
 
 void WebChromeClient::prepareForVideoFullscreen()
 {
-    protectedPage()->videoPresentationManager();
+    if (RefPtr page = m_page.get())
+        page->videoPresentationManager();
 }
 
 bool WebChromeClient::canEnterVideoFullscreen(HTMLMediaElementEnums::VideoFullscreenMode mode) const
 {
-    return protectedPage()->videoPresentationManager().canEnterVideoFullscreen(mode);
+    RefPtr page = m_page.get();
+    return page && page->videoPresentationManager().canEnterVideoFullscreen(mode);
 }
 
 bool WebChromeClient::supportsVideoFullscreen(HTMLMediaElementEnums::VideoFullscreenMode mode)
 {
-    return protectedPage()->videoPresentationManager().supportsVideoFullscreen(mode);
+    RefPtr page = m_page.get();
+    return page && page->videoPresentationManager().supportsVideoFullscreen(mode);
 }
 
 bool WebChromeClient::supportsVideoFullscreenStandby()
 {
-    return protectedPage()->videoPresentationManager().supportsVideoFullscreenStandby();
+    RefPtr page = m_page.get();
+    return page && page->videoPresentationManager().supportsVideoFullscreenStandby();
 }
 
 void WebChromeClient::setMockVideoPresentationModeEnabled(bool enabled)
 {
-    protectedPage()->send(Messages::WebPageProxy::SetMockVideoPresentationModeEnabled(enabled));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::SetMockVideoPresentationModeEnabled(enabled));
 }
 
 void WebChromeClient::enterVideoFullscreenForVideoElement(HTMLVideoElement& videoElement, HTMLMediaElementEnums::VideoFullscreenMode mode, bool standby)
@@ -1274,17 +1455,20 @@ void WebChromeClient::enterVideoFullscreenForVideoElement(HTMLVideoElement& vide
 #else
     ASSERT(mode != HTMLMediaElementEnums::VideoFullscreenModeNone);
 #endif
-    protectedPage()->videoPresentationManager().enterVideoFullscreenForVideoElement(videoElement, mode, standby);
+    if (RefPtr page = m_page.get())
+        page->videoPresentationManager().enterVideoFullscreenForVideoElement(videoElement, mode, standby);
 }
 
 void WebChromeClient::setPlayerIdentifierForVideoElement(HTMLVideoElement& videoElement)
 {
-    protectedPage()->videoPresentationManager().setPlayerIdentifierForVideoElement(videoElement);
+    if (RefPtr page = m_page.get())
+        page->videoPresentationManager().setPlayerIdentifierForVideoElement(videoElement);
 }
 
 void WebChromeClient::exitVideoFullscreenForVideoElement(HTMLVideoElement& videoElement, CompletionHandler<void(bool)>&& completionHandler)
 {
-    protectedPage()->videoPresentationManager().exitVideoFullscreenForVideoElement(videoElement, WTFMove(completionHandler));
+    if (RefPtr page = m_page.get())
+        page->videoPresentationManager().exitVideoFullscreenForVideoElement(videoElement, WTFMove(completionHandler));
 }
 
 void WebChromeClient::setUpPlaybackControlsManager(HTMLMediaElement& mediaElement)
@@ -1301,7 +1485,8 @@ void WebChromeClient::clearPlaybackControlsManager()
 
 void WebChromeClient::mediaEngineChanged(WebCore::HTMLMediaElement& mediaElement)
 {
-    protectedPage()->playbackSessionManager().mediaEngineChanged(mediaElement);
+    if (RefPtr page = m_page.get())
+        page->playbackSessionManager().mediaEngineChanged(mediaElement);
 }
 
 #endif
@@ -1309,17 +1494,20 @@ void WebChromeClient::mediaEngineChanged(WebCore::HTMLMediaElement& mediaElement
 #if ENABLE(MEDIA_USAGE)
 void WebChromeClient::addMediaUsageManagerSession(MediaSessionIdentifier identifier, const String& bundleIdentifier, const URL& pageURL)
 {
-    protectedPage()->addMediaUsageManagerSession(identifier, bundleIdentifier, pageURL);
+    if (RefPtr page = m_page.get())
+        page->addMediaUsageManagerSession(identifier, bundleIdentifier, pageURL);
 }
 
 void WebChromeClient::updateMediaUsageManagerSessionState(MediaSessionIdentifier identifier, const MediaUsageInfo& usage)
 {
-    protectedPage()->updateMediaUsageManagerSessionState(identifier, usage);
+    if (RefPtr page = m_page.get())
+        page->updateMediaUsageManagerSessionState(identifier, usage);
 }
 
 void WebChromeClient::removeMediaUsageManagerSession(MediaSessionIdentifier identifier)
 {
-    protectedPage()->removeMediaUsageManagerSession(identifier);
+    if (RefPtr page = m_page.get())
+        page->removeMediaUsageManagerSession(identifier);
 }
 #endif // ENABLE(MEDIA_USAGE)
 
@@ -1327,17 +1515,20 @@ void WebChromeClient::removeMediaUsageManagerSession(MediaSessionIdentifier iden
 
 void WebChromeClient::exitVideoFullscreenToModeWithoutAnimation(HTMLVideoElement& videoElement, HTMLMediaElementEnums::VideoFullscreenMode targetMode)
 {
-    protectedPage()->videoPresentationManager().exitVideoFullscreenToModeWithoutAnimation(videoElement, targetMode);
+    if (RefPtr page = m_page.get())
+        page->videoPresentationManager().exitVideoFullscreenToModeWithoutAnimation(videoElement, targetMode);
 }
 
 void WebChromeClient::setVideoFullscreenMode(HTMLVideoElement& videoElement, HTMLMediaElementEnums::VideoFullscreenMode mode)
 {
-    protectedPage()->videoPresentationManager().setVideoFullscreenMode(videoElement, mode);
+    if (RefPtr page = m_page.get())
+        page->videoPresentationManager().setVideoFullscreenMode(videoElement, mode);
 }
 
 void WebChromeClient::clearVideoFullscreenMode(HTMLVideoElement& videoElement, HTMLMediaElementEnums::VideoFullscreenMode mode)
 {
-    protectedPage()->videoPresentationManager().clearVideoFullscreenMode(videoElement, mode);
+    if (RefPtr page = m_page.get())
+        page->videoPresentationManager().clearVideoFullscreenMode(videoElement, mode);
 }
 
 #endif
@@ -1346,12 +1537,15 @@ void WebChromeClient::clearVideoFullscreenMode(HTMLVideoElement& videoElement, H
 
 bool WebChromeClient::supportsFullScreenForElement(const Element& element, bool withKeyboard)
 {
-    return protectedPage()->fullScreenManager().supportsFullScreenForElement(element, withKeyboard);
+    RefPtr page = m_page.get();
+    return page && page->fullScreenManager().supportsFullScreenForElement(element, withKeyboard);
 }
 
 void WebChromeClient::enterFullScreenForElement(Element& element, HTMLMediaElementEnums::VideoFullscreenMode mode, CompletionHandler<void(ExceptionOr<void>)>&& willEnterFullscreen, CompletionHandler<bool(bool)>&& didEnterFullscreen)
 {
-    protectedPage()->fullScreenManager().enterFullScreenForElement(element, mode, WTFMove(willEnterFullscreen), WTFMove(didEnterFullscreen));
+    RefPtr page = m_page.get();
+    ASSERT(page);
+    page->fullScreenManager().enterFullScreenForElement(element, mode, WTFMove(willEnterFullscreen), WTFMove(didEnterFullscreen));
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     if (RefPtr videoElement = dynamicDowncast<HTMLVideoElement>(element); videoElement && mode == HTMLMediaElementEnums::VideoFullscreenModeInWindow)
         setVideoFullscreenMode(*videoElement, mode);
@@ -1361,7 +1555,8 @@ void WebChromeClient::enterFullScreenForElement(Element& element, HTMLMediaEleme
 #if ENABLE(QUICKLOOK_FULLSCREEN)
 void WebChromeClient::updateImageSource(Element& element)
 {
-    protectedPage()->fullScreenManager().updateImageSource(element);
+    if (RefPtr page = m_page.get())
+        page->fullScreenManager().updateImageSource(element);
 }
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
 
@@ -1374,7 +1569,8 @@ void WebChromeClient::exitFullScreenForElement(Element* element, CompletionHandl
             exitingInWindowFullscreen = videoElement->fullscreenMode() == HTMLMediaElementEnums::VideoFullscreenModeInWindow;
     }
 #endif
-    protectedPage()->fullScreenManager().exitFullScreenForElement(element, WTFMove(completionHandler));
+    if (RefPtr page = m_page.get())
+        page->fullScreenManager().exitFullScreenForElement(element, WTFMove(completionHandler));
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     if (exitingInWindowFullscreen)
         clearVideoFullscreenMode(*dynamicDowncast<HTMLVideoElement>(*element), HTMLMediaElementEnums::VideoFullscreenModeInWindow);
@@ -1387,109 +1583,133 @@ void WebChromeClient::exitFullScreenForElement(Element* element, CompletionHandl
 
 FloatSize WebChromeClient::screenSize() const
 {
-    return protectedPage()->screenSize();
+    RefPtr page = m_page.get();
+    return page ? page->screenSize() : FloatSize();
 }
 
 FloatSize WebChromeClient::availableScreenSize() const
 {
-    return protectedPage()->availableScreenSize();
+    RefPtr page = m_page.get();
+    return page ? page->availableScreenSize() : FloatSize();
 }
 
 FloatSize WebChromeClient::overrideScreenSize() const
 {
-    return protectedPage()->overrideScreenSize();
+    RefPtr page = m_page.get();
+    return page ? page->overrideScreenSize() : FloatSize();
 }
 
 FloatSize WebChromeClient::overrideAvailableScreenSize() const
 {
-    return protectedPage()->overrideAvailableScreenSize();
+    RefPtr page = m_page.get();
+    return page ? page->overrideAvailableScreenSize() : FloatSize();
 }
 
 #endif
 
 FloatSize WebChromeClient::screenSizeForFingerprintingProtections(const LocalFrame& frame, FloatSize defaultSize) const
 {
-    return protectedPage()->screenSizeForFingerprintingProtections(frame, defaultSize);
+    RefPtr page = m_page.get();
+    return page ? page->screenSizeForFingerprintingProtections(frame, defaultSize) : FloatSize();
 }
 
 void WebChromeClient::dispatchDisabledAdaptationsDidChange(const OptionSet<DisabledAdaptations>& disabledAdaptations) const
 {
-    protectedPage()->disabledAdaptationsDidChange(disabledAdaptations);
+    if (RefPtr page = m_page.get())
+        page->disabledAdaptationsDidChange(disabledAdaptations);
 }
 
 void WebChromeClient::dispatchViewportPropertiesDidChange(const ViewportArguments& viewportArguments) const
 {
-    protectedPage()->viewportPropertiesDidChange(viewportArguments);
+    if (RefPtr page = m_page.get())
+        page->viewportPropertiesDidChange(viewportArguments);
 }
 
 void WebChromeClient::notifyScrollerThumbIsVisibleInRect(const IntRect& scrollerThumb)
 {
-    protectedPage()->send(Messages::WebPageProxy::NotifyScrollerThumbIsVisibleInRect(scrollerThumb));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::NotifyScrollerThumbIsVisibleInRect(scrollerThumb));
 }
 
 void WebChromeClient::recommendedScrollbarStyleDidChange(ScrollbarStyle newStyle)
 {
-    protectedPage()->send(Messages::WebPageProxy::RecommendedScrollbarStyleDidChange(static_cast<int32_t>(newStyle)));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::RecommendedScrollbarStyleDidChange(static_cast<int32_t>(newStyle)));
 }
 
 std::optional<ScrollbarOverlayStyle> WebChromeClient::preferredScrollbarOverlayStyle()
 {
-    return protectedPage()->scrollbarOverlayStyle();
+    RefPtr page = m_page.get();
+    return page ? page->scrollbarOverlayStyle() : std::nullopt;
 }
 
 Color WebChromeClient::underlayColor() const
 {
-    return protectedPage()->underlayColor();
+    RefPtr page = m_page.get();
+    return page ? page->underlayColor() : Color();
 }
 
 void WebChromeClient::themeColorChanged() const
 {
-    protectedPage()->themeColorChanged();
+    if (RefPtr page = m_page.get())
+        page->themeColorChanged();
 }
 
 void WebChromeClient::pageExtendedBackgroundColorDidChange() const
 {
-    protectedPage()->pageExtendedBackgroundColorDidChange();
+    if (RefPtr page = m_page.get())
+        page->pageExtendedBackgroundColorDidChange();
 }
 
 void WebChromeClient::sampledPageTopColorChanged() const
 {
-    protectedPage()->sampledPageTopColorChanged();
+    if (RefPtr page = m_page.get())
+        page->sampledPageTopColorChanged();
 }
 
 #if ENABLE(WEB_PAGE_SPATIAL_BACKDROP)
 void WebChromeClient::spatialBackdropSourceChanged() const
 {
-    protectedPage()->spatialBackdropSourceChanged();
+    if (RefPtr page = m_page.get())
+        page->spatialBackdropSourceChanged();
 }
 #endif
 
 #if ENABLE(APP_HIGHLIGHTS)
 WebCore::HighlightVisibility WebChromeClient::appHighlightsVisiblility() const
 {
-    return page().appHighlightsVisiblility();
+    if (!m_page)
+        return { };
+
+    return m_page->appHighlightsVisiblility();
 }
 #endif
 
 void WebChromeClient::wheelEventHandlersChanged(bool hasHandlers)
 {
-    protectedPage()->wheelEventHandlersChanged(hasHandlers);
+    if (RefPtr page = m_page.get())
+        page->wheelEventHandlersChanged(hasHandlers);
 }
 
 void WebChromeClient::enableSuddenTermination()
 {
-    protectedPage()->send(Messages::WebProcessProxy::EnableSuddenTermination());
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebProcessProxy::EnableSuddenTermination());
 }
 
 void WebChromeClient::disableSuddenTermination()
 {
-    protectedPage()->send(Messages::WebProcessProxy::DisableSuddenTermination());
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebProcessProxy::DisableSuddenTermination());
 }
 
 void WebChromeClient::didAddHeaderLayer(GraphicsLayer& headerParent)
 {
 #if HAVE(RUBBER_BANDING)
-    auto page = protectedPage();
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
     if (auto* banner = page->headerPageBanner())
         banner->didAddParentLayer(&headerParent);
 #else
@@ -1500,7 +1720,10 @@ void WebChromeClient::didAddHeaderLayer(GraphicsLayer& headerParent)
 void WebChromeClient::didAddFooterLayer(GraphicsLayer& footerParent)
 {
 #if HAVE(RUBBER_BANDING)
-    auto page = protectedPage();
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
     if (auto* banner = page->footerPageBanner())
         banner->didAddParentLayer(&footerParent);
 #else
@@ -1510,12 +1733,13 @@ void WebChromeClient::didAddFooterLayer(GraphicsLayer& footerParent)
 
 bool WebChromeClient::shouldUseTiledBackingForFrameView(const LocalFrameView& frameView) const
 {
-    return protectedPage()->drawingArea()->shouldUseTiledBackingForFrameView(frameView);
+    RefPtr page = m_page.get();
+    return page && page->drawingArea()->shouldUseTiledBackingForFrameView(frameView);
 }
 
 void WebChromeClient::frameViewLayoutOrVisualViewportChanged(const LocalFrameView& frameView)
 {
-    RefPtr page = protectedPage();
+    RefPtr page = m_page.get();
     if (!page)
         return;
 
@@ -1525,40 +1749,49 @@ void WebChromeClient::frameViewLayoutOrVisualViewportChanged(const LocalFrameVie
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
 void WebChromeClient::isAnyAnimationAllowedToPlayDidChange(bool anyAnimationCanPlay)
 {
-    protectedPage()->isAnyAnimationAllowedToPlayDidChange(anyAnimationCanPlay);
+    if (RefPtr page = m_page.get())
+        page->isAnyAnimationAllowedToPlayDidChange(anyAnimationCanPlay);
 }
 #endif
 
 void WebChromeClient::resolveAccessibilityHitTestForTesting(FrameIdentifier frameID, const IntPoint& point, CompletionHandler<void(String)>&& callback)
 {
-    protectedPage()->sendWithAsyncReply(Messages::WebPageProxy::ResolveAccessibilityHitTestForTesting(frameID, point), WTFMove(callback));
+    if (RefPtr page = m_page.get())
+        page->sendWithAsyncReply(Messages::WebPageProxy::ResolveAccessibilityHitTestForTesting(frameID, point), WTFMove(callback));
+    else
+        callback({ });
 }
 
 void WebChromeClient::isPlayingMediaDidChange(MediaProducerMediaStateFlags state)
 {
-    protectedPage()->isPlayingMediaDidChange(state);
+    if (RefPtr page = m_page.get())
+        page->isPlayingMediaDidChange(state);
 }
 
 void WebChromeClient::handleAutoplayEvent(AutoplayEvent event, OptionSet<AutoplayEventFlags> flags)
 {
-    protectedPage()->send(Messages::WebPageProxy::HandleAutoplayEvent(event, flags));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::HandleAutoplayEvent(event, flags));
 }
 
 void WebChromeClient::setTextIndicator(const WebCore::TextIndicatorData& indicatorData) const
 {
-    protectedPage()->setTextIndicator(indicatorData);
+    if (RefPtr page = m_page.get())
+        page->setTextIndicator(indicatorData);
 }
 
 void WebChromeClient::updateTextIndicator(const WebCore::TextIndicatorData& indicatorData) const
 {
-    protectedPage()->updateTextIndicator(indicatorData);
+    if (RefPtr page = m_page.get())
+        page->updateTextIndicator(indicatorData);
 }
 
 #if ENABLE(TELEPHONE_NUMBER_DETECTION) && PLATFORM(MAC)
 
 void WebChromeClient::handleTelephoneNumberClick(const String& number, const IntPoint& point, const IntRect& rect)
 {
-    protectedPage()->handleTelephoneNumberClick(number, point, rect);
+    if (RefPtr page = m_page.get())
+        page->handleTelephoneNumberClick(number, point, rect);
 }
 
 #endif
@@ -1567,7 +1800,8 @@ void WebChromeClient::handleTelephoneNumberClick(const String& number, const Int
 
 void WebChromeClient::handleClickForDataDetectionResult(const DataDetectorElementInfo& info, const IntPoint& clickLocation)
 {
-    protectedPage()->handleClickForDataDetectionResult(info, clickLocation);
+    if (RefPtr page = m_page.get())
+        page->handleClickForDataDetectionResult(info, clickLocation);
 }
 
 #endif
@@ -1576,7 +1810,8 @@ void WebChromeClient::handleClickForDataDetectionResult(const DataDetectorElemen
 
 void WebChromeClient::handleSelectionServiceClick(WebCore::FrameIdentifier frameID, FrameSelection& selection, const Vector<String>& telephoneNumbers, const IntPoint& point)
 {
-    protectedPage()->handleSelectionServiceClick(frameID, selection, telephoneNumbers, point);
+    if (RefPtr page = m_page.get())
+        page->handleSelectionServiceClick(frameID, selection, telephoneNumbers, point);
 }
 
 bool WebChromeClient::hasRelevantSelectionServices(bool isTextOnly) const
@@ -1586,19 +1821,22 @@ bool WebChromeClient::hasRelevantSelectionServices(bool isTextOnly) const
 
 void WebChromeClient::handleImageServiceClick(WebCore::FrameIdentifier frameID, const IntPoint& point, Image& image, HTMLImageElement& element)
 {
-    protectedPage()->handleImageServiceClick(frameID, point, image, element);
+    if (RefPtr page = m_page.get())
+        page->handleImageServiceClick(frameID, point, image, element);
 }
 
 void WebChromeClient::handlePDFServiceClick(WebCore::FrameIdentifier frameID, const IntPoint& point, HTMLAttachmentElement& element)
 {
-    protectedPage()->handlePDFServiceClick(frameID, point, element);
+    if (RefPtr page = m_page.get())
+        page->handlePDFServiceClick(frameID, point, element);
 }
 
 #endif
 
 bool WebChromeClient::shouldDispatchFakeMouseMoveEvents() const
 {
-    return protectedPage()->shouldDispatchFakeMouseMoveEvents();
+    RefPtr page = m_page.get();
+    return page && page->shouldDispatchFakeMouseMoveEvents();
 }
 
 RefPtr<API::Object> userDataFromJSONData(JSON::Value& value)
@@ -1634,12 +1872,15 @@ RefPtr<API::Object> userDataFromJSONData(JSON::Value& value)
 
 void WebChromeClient::handleAutoFillButtonClick(HTMLInputElement& inputElement)
 {
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
     RefPtr<API::Object> userData;
 
     // Notify the bundle client.
     auto nodeHandle = InjectedBundleNodeHandle::getOrCreate(inputElement);
-    auto page = protectedPage();
-    page->injectedBundleUIClient().didClickAutoFillButton(page, nodeHandle.get(), userData);
+    page->injectedBundleUIClient().didClickAutoFillButton(*page, nodeHandle.get(), userData);
 
     if (!userData) {
         auto userInfo = inputElement.userInfo();
@@ -1655,12 +1896,15 @@ void WebChromeClient::handleAutoFillButtonClick(HTMLInputElement& inputElement)
 
 void WebChromeClient::inputElementDidResignStrongPasswordAppearance(HTMLInputElement& inputElement)
 {
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
     RefPtr<API::Object> userData;
 
     // Notify the bundle client.
     auto nodeHandle = InjectedBundleNodeHandle::getOrCreate(inputElement);
-    auto page = protectedPage();
-    page->injectedBundleUIClient().didResignInputElementStrongPasswordAppearance(page, nodeHandle.get(), userData);
+    page->injectedBundleUIClient().didResignInputElementStrongPasswordAppearance(*page, nodeHandle.get(), userData);
 
     // Notify the UIProcess.
     page->send(Messages::WebPageProxy::DidResignInputElementStrongPasswordAppearance { UserData { WebProcess::singleton().transformObjectsToHandles(userData.get()).get() } });
@@ -1668,24 +1912,30 @@ void WebChromeClient::inputElementDidResignStrongPasswordAppearance(HTMLInputEle
 
 void WebChromeClient::performSwitchHapticFeedback()
 {
-    protectedPage()->send(Messages::WebPageProxy::PerformSwitchHapticFeedback());
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::PerformSwitchHapticFeedback());
 }
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET) && !PLATFORM(IOS_FAMILY)
 
 void WebChromeClient::addPlaybackTargetPickerClient(PlaybackTargetClientContextIdentifier contextId)
 {
-    protectedPage()->send(Messages::WebPageProxy::AddPlaybackTargetPickerClient(contextId));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::AddPlaybackTargetPickerClient(contextId));
 }
 
 void WebChromeClient::removePlaybackTargetPickerClient(PlaybackTargetClientContextIdentifier contextId)
 {
-    protectedPage()->send(Messages::WebPageProxy::RemovePlaybackTargetPickerClient(contextId));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::RemovePlaybackTargetPickerClient(contextId));
 }
 
 void WebChromeClient::showPlaybackTargetPicker(PlaybackTargetClientContextIdentifier contextId, const IntPoint& position, bool isVideo)
 {
-    auto page = protectedPage();
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
     RefPtr frameView = page->localMainFrameView();
     if (!frameView)
         return;
@@ -1696,62 +1946,81 @@ void WebChromeClient::showPlaybackTargetPicker(PlaybackTargetClientContextIdenti
 
 void WebChromeClient::playbackTargetPickerClientStateDidChange(PlaybackTargetClientContextIdentifier contextId, MediaProducerMediaStateFlags state)
 {
-    protectedPage()->send(Messages::WebPageProxy::PlaybackTargetPickerClientStateDidChange(contextId, state));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::PlaybackTargetPickerClientStateDidChange(contextId, state));
 }
 
 void WebChromeClient::setMockMediaPlaybackTargetPickerEnabled(bool enabled)
 {
-    protectedPage()->send(Messages::WebPageProxy::SetMockMediaPlaybackTargetPickerEnabled(enabled));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::SetMockMediaPlaybackTargetPickerEnabled(enabled));
 }
 
 void WebChromeClient::setMockMediaPlaybackTargetPickerState(const String& name, MediaPlaybackTargetContext::MockState state)
 {
-    protectedPage()->send(Messages::WebPageProxy::SetMockMediaPlaybackTargetPickerState(name, state));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::SetMockMediaPlaybackTargetPickerState(name, state));
 }
 
 void WebChromeClient::mockMediaPlaybackTargetPickerDismissPopup()
 {
-    protectedPage()->send(Messages::WebPageProxy::MockMediaPlaybackTargetPickerDismissPopup());
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::MockMediaPlaybackTargetPickerDismissPopup());
 }
 #endif
 
 void WebChromeClient::imageOrMediaDocumentSizeChanged(const IntSize& newSize)
 {
-    protectedPage()->imageOrMediaDocumentSizeChanged(newSize);
+    if (RefPtr page = m_page.get())
+        page->imageOrMediaDocumentSizeChanged(newSize);
 }
 
 void WebChromeClient::didInvalidateDocumentMarkerRects()
 {
-    protectedPage()->findController().didInvalidateFindRects();
+    if (RefPtr page = m_page.get())
+        page->findController().didInvalidateFindRects();
 }
 
 void WebChromeClient::hasStorageAccess(RegistrableDomain&& subFrameDomain, RegistrableDomain&& topFrameDomain, LocalFrame& frame, CompletionHandler<void(bool)>&& completionHandler)
 {
     auto webFrame = WebFrame::fromCoreFrame(frame);
     ASSERT(webFrame);
-    protectedPage()->hasStorageAccess(WTFMove(subFrameDomain), WTFMove(topFrameDomain), *webFrame, WTFMove(completionHandler));
+    if (RefPtr page = m_page.get())
+        page->hasStorageAccess(WTFMove(subFrameDomain), WTFMove(topFrameDomain), *webFrame, WTFMove(completionHandler));
+    else
+        completionHandler(false);
 }
 
 void WebChromeClient::requestStorageAccess(RegistrableDomain&& subFrameDomain, RegistrableDomain&& topFrameDomain, LocalFrame& frame, StorageAccessScope scope, CompletionHandler<void(RequestStorageAccessResult)>&& completionHandler)
 {
     auto webFrame = WebFrame::fromCoreFrame(frame);
     ASSERT(webFrame);
-    protectedPage()->requestStorageAccess(WTFMove(subFrameDomain), WTFMove(topFrameDomain), *webFrame, scope, WTFMove(completionHandler));
+    if (RefPtr page = m_page.get())
+        page->requestStorageAccess(WTFMove(subFrameDomain), WTFMove(topFrameDomain), *webFrame, scope, WTFMove(completionHandler));
+    else
+        completionHandler({ });
 }
 
 void WebChromeClient::setLoginStatus(RegistrableDomain&& domain, IsLoggedIn loggedInStatus, CompletionHandler<void()>&& completionHandler)
 {
-    protectedPage()->setLoginStatus(WTFMove(domain), loggedInStatus, WTFMove(completionHandler));
+    if (RefPtr page = m_page.get())
+        page->setLoginStatus(WTFMove(domain), loggedInStatus, WTFMove(completionHandler));
+    else
+        completionHandler();
 }
 
 void WebChromeClient::isLoggedIn(RegistrableDomain&& domain, CompletionHandler<void(bool)>&& completionHandler)
 {
-    protectedPage()->isLoggedIn(WTFMove(domain), WTFMove(completionHandler));
+    if (RefPtr page = m_page.get())
+        page->isLoggedIn(WTFMove(domain), WTFMove(completionHandler));
+    else
+        completionHandler(false);
 }
 
 bool WebChromeClient::hasPageLevelStorageAccess(const WebCore::RegistrableDomain& topLevelDomain, const WebCore::RegistrableDomain& resourceDomain) const
 {
-    return protectedPage()->hasPageLevelStorageAccess(topLevelDomain, resourceDomain);
+    RefPtr page = m_page.get();
+    return page && page->hasPageLevelStorageAccess(topLevelDomain, resourceDomain);
 }
 
 #if ENABLE(DEVICE_ORIENTATION)
@@ -1759,7 +2028,10 @@ void WebChromeClient::shouldAllowDeviceOrientationAndMotionAccess(LocalFrame& fr
 {
     auto webFrame = WebFrame::fromCoreFrame(frame);
     ASSERT(webFrame);
-    protectedPage()->shouldAllowDeviceOrientationAndMotionAccess(webFrame->frameID(), webFrame->info(), mayPrompt, WTFMove(callback));
+    if (RefPtr page = m_page.get())
+        page->shouldAllowDeviceOrientationAndMotionAccess(webFrame->frameID(), webFrame->info(), mayPrompt, WTFMove(callback));
+    else
+        callback(DeviceOrientationOrMotionPermissionState::Denied);
 }
 #endif
 
@@ -1773,23 +2045,27 @@ IntDegrees WebChromeClient::deviceOrientation() const
 
 void WebChromeClient::configureLoggingChannel(const String& channelName, WTFLogChannelState state, WTFLogLevel level)
 {
-    protectedPage()->configureLoggingChannel(channelName, state, level);
+    if (RefPtr page = m_page.get())
+        page->configureLoggingChannel(channelName, state, level);
 }
 
 bool WebChromeClient::userIsInteracting() const
 {
-    return protectedPage()->userIsInteracting();
+    RefPtr page = m_page.get();
+    return page && page->userIsInteracting();
 }
 
 void WebChromeClient::setUserIsInteracting(bool userIsInteracting)
 {
-    protectedPage()->setUserIsInteracting(userIsInteracting);
+    if (RefPtr page = m_page.get())
+        page->setUserIsInteracting(userIsInteracting);
 }
 
 #if ENABLE(WEB_AUTHN)
 void WebChromeClient::setMockWebAuthenticationConfiguration(const MockWebAuthenticationConfiguration& configuration)
 {
-    protectedPage()->send(Messages::WebPageProxy::SetMockWebAuthenticationConfiguration(configuration));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::SetMockWebAuthenticationConfiguration(configuration));
 }
 #endif
 
@@ -1812,13 +2088,15 @@ void WebChromeClient::postAccessibilityFrameLoadingEventNotification(WebCore::Ac
 
 void WebChromeClient::animationDidFinishForElement(const Element& element)
 {
-    protectedPage()->animationDidFinishForElement(element);
+    if (RefPtr page = m_page.get())
+        page->animationDidFinishForElement(element);
 }
 
 #if PLATFORM(MAC)
 void WebChromeClient::changeUniversalAccessZoomFocus(const WebCore::IntRect& viewRect, const WebCore::IntRect& selectionRect)
 {
-    protectedPage()->send(Messages::WebPageProxy::ChangeUniversalAccessZoomFocus(viewRect, selectionRect));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::ChangeUniversalAccessZoomFocus(viewRect, selectionRect));
 }
 #endif
 
@@ -1826,31 +2104,40 @@ void WebChromeClient::changeUniversalAccessZoomFocus(const WebCore::IntRect& vie
 
 void WebChromeClient::requestTextRecognition(Element& element, TextRecognitionOptions&& options, CompletionHandler<void(RefPtr<Element>&&)>&& completion)
 {
-    protectedPage()->requestTextRecognition(element, WTFMove(options), WTFMove(completion));
+    if (RefPtr page = m_page.get())
+        page->requestTextRecognition(element, WTFMove(options), WTFMove(completion));
+    else
+        completion(nullptr);
 }
 
 #endif
 
 std::pair<URL, DidFilterLinkDecoration> WebChromeClient::applyLinkDecorationFilteringWithResult(const URL& url, LinkDecorationFilteringTrigger trigger) const
 {
-    return protectedPage()->applyLinkDecorationFilteringWithResult(url, trigger);
+    RefPtr page = m_page.get();
+    if (!page)
+        return { };
+    return page->applyLinkDecorationFilteringWithResult(url, trigger);
 }
 
 URL WebChromeClient::allowedQueryParametersForAdvancedPrivacyProtections(const URL& url) const
 {
-    return protectedPage()->allowedQueryParametersForAdvancedPrivacyProtections(url);
+    RefPtr page = m_page.get();
+    return page ? page->allowedQueryParametersForAdvancedPrivacyProtections(url) : URL();
 }
 
 void WebChromeClient::didAddOrRemoveViewportConstrainedObjects()
 {
-    protectedPage()->didAddOrRemoveViewportConstrainedObjects();
+    if (RefPtr page = m_page.get())
+        page->didAddOrRemoveViewportConstrainedObjects();
 }
 
 #if ENABLE(TEXT_AUTOSIZING)
 
 void WebChromeClient::textAutosizingUsesIdempotentModeChanged()
 {
-    protectedPage()->textAutosizingUsesIdempotentModeChanged();
+    if (RefPtr page = m_page.get())
+        page->textAutosizingUsesIdempotentModeChanged();
 }
 
 #endif
@@ -1859,7 +2146,8 @@ void WebChromeClient::textAutosizingUsesIdempotentModeChanged()
 
 double WebChromeClient::baseViewportLayoutSizeScaleFactor() const
 {
-    return protectedPage()->baseViewportLayoutSizeScaleFactor();
+    RefPtr page = m_page.get();
+    return page ? page->baseViewportLayoutSizeScaleFactor() : 0;
 }
 
 #endif
@@ -1868,7 +2156,10 @@ double WebChromeClient::baseViewportLayoutSizeScaleFactor() const
 
 void WebChromeClient::showMediaControlsContextMenu(FloatRect&& targetFrame, Vector<MediaControlsContextMenuItem>&& items, CompletionHandler<void(MediaControlsContextMenuItem::ID)>&& completionHandler)
 {
-    protectedPage()->showMediaControlsContextMenu(WTFMove(targetFrame), WTFMove(items), WTFMove(completionHandler));
+    if (RefPtr page = m_page.get())
+        page->showMediaControlsContextMenu(WTFMove(targetFrame), WTFMove(items), WTFMove(completionHandler));
+    else
+        completionHandler({ });
 }
 
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
@@ -1876,12 +2167,18 @@ void WebChromeClient::showMediaControlsContextMenu(FloatRect&& targetFrame, Vect
 #if ENABLE(WEBXR) && !USE(OPENXR)
 void WebChromeClient::enumerateImmersiveXRDevices(CompletionHandler<void(const PlatformXR::Instance::DeviceList&)>&& completionHandler)
 {
-    protectedPage()->xrSystemProxy().enumerateImmersiveXRDevices(WTFMove(completionHandler));
+    if (RefPtr page = m_page.get())
+        page->xrSystemProxy().enumerateImmersiveXRDevices(WTFMove(completionHandler));
+    else
+        completionHandler({ });
 }
 
 void WebChromeClient::requestPermissionOnXRSessionFeatures(const SecurityOriginData& origin, PlatformXR::SessionMode mode, const PlatformXR::Device::FeatureList& granted, const PlatformXR::Device::FeatureList& consentRequired, const PlatformXR::Device::FeatureList& consentOptional, const PlatformXR::Device::FeatureList& requiredFeaturesRequested, const PlatformXR::Device::FeatureList& optionalFeaturesRequested,  CompletionHandler<void(std::optional<PlatformXR::Device::FeatureList>&&)>&& completionHandler)
 {
-    protectedPage()->xrSystemProxy().requestPermissionOnSessionFeatures(origin, mode, granted, consentRequired, consentOptional, requiredFeaturesRequested, optionalFeaturesRequested, WTFMove(completionHandler));
+    if (RefPtr page = m_page.get())
+        page->xrSystemProxy().requestPermissionOnSessionFeatures(origin, mode, granted, consentRequired, consentOptional, requiredFeaturesRequested, optionalFeaturesRequested, WTFMove(completionHandler));
+    else
+        completionHandler(std::nullopt);
 }
 #endif
 
@@ -1889,12 +2186,16 @@ void WebChromeClient::requestPermissionOnXRSessionFeatures(const SecurityOriginD
 
 void WebChromeClient::startApplePayAMSUISession(const URL& originatingURL, const ApplePayAMSUIRequest& request, CompletionHandler<void(std::optional<bool>&&)>&& completionHandler)
 {
-    protectedPage()->sendWithAsyncReply(Messages::WebPageProxy::StartApplePayAMSUISession(originatingURL, request), WTFMove(completionHandler));
+    if (RefPtr page = m_page.get())
+        page->sendWithAsyncReply(Messages::WebPageProxy::StartApplePayAMSUISession(originatingURL, request), WTFMove(completionHandler));
+    else
+        completionHandler(false);
 }
 
 void WebChromeClient::abortApplePayAMSUISession()
 {
-    protectedPage()->send(Messages::WebPageProxy::AbortApplePayAMSUISession());
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::AbortApplePayAMSUISession());
 }
 
 #endif // ENABLE(APPLE_PAY_AMS_UI)
@@ -1902,19 +2203,26 @@ void WebChromeClient::abortApplePayAMSUISession()
 #if USE(SYSTEM_PREVIEW)
 void WebChromeClient::beginSystemPreview(const URL& url, const SecurityOriginData& topOrigin, const SystemPreviewInfo& systemPreviewInfo, CompletionHandler<void()>&& completionHandler)
 {
-    protectedPage()->sendWithAsyncReply(Messages::WebPageProxy::BeginSystemPreview(WTFMove(url), topOrigin, WTFMove(systemPreviewInfo)), WTFMove(completionHandler));
+    if (RefPtr page = m_page.get())
+        page->sendWithAsyncReply(Messages::WebPageProxy::BeginSystemPreview(WTFMove(url), topOrigin, WTFMove(systemPreviewInfo)), WTFMove(completionHandler));
+    else
+        completionHandler();
 }
 #endif
 
 void WebChromeClient::requestCookieConsent(CompletionHandler<void(CookieConsentDecisionResult)>&& completion)
 {
-    protectedPage()->sendWithAsyncReply(Messages::WebPageProxy::RequestCookieConsent(), WTFMove(completion));
+    if (RefPtr page = m_page.get())
+        page->sendWithAsyncReply(Messages::WebPageProxy::RequestCookieConsent(), WTFMove(completion));
+    else
+        completion(CookieConsentDecisionResult::NotSupported);
 }
 
 bool WebChromeClient::isUsingUISideCompositing() const
 {
 #if PLATFORM(COCOA)
-    return protectedPage()->drawingArea()->type() == DrawingAreaType::RemoteLayerTree;
+    RefPtr page = m_page.get();
+    return page && page->drawingArea()->type() == DrawingAreaType::RemoteLayerTree;
 #else
     return false;
 #endif
@@ -1923,7 +2231,8 @@ bool WebChromeClient::isUsingUISideCompositing() const
 bool WebChromeClient::isInStableState() const
 {
 #if PLATFORM(IOS_FAMILY)
-    return protectedPage()->isInStableState();
+    RefPtr page = m_page.get();
+    return page && page->isInStableState();
 #else
     // FIXME (255877): Implement this client hook on macOS.
     return true;
@@ -1932,13 +2241,15 @@ bool WebChromeClient::isInStableState() const
 
 void WebChromeClient::didAdjustVisibilityWithSelectors(Vector<String>&& selectors)
 {
-    return protectedPage()->didAdjustVisibilityWithSelectors(WTFMove(selectors));
+    if (RefPtr page = m_page.get())
+        page->didAdjustVisibilityWithSelectors(WTFMove(selectors));
 }
 
 #if ENABLE(GAMEPAD)
 void WebChromeClient::gamepadsRecentlyAccessed()
 {
-    protectedPage()->gamepadsRecentlyAccessed();
+    if (RefPtr page = m_page.get())
+        page->gamepadsRecentlyAccessed();
 }
 #endif
 
@@ -1946,65 +2257,79 @@ void WebChromeClient::gamepadsRecentlyAccessed()
 
 void WebChromeClient::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::TextSuggestion::ID& replacementID, WebCore::IntRect selectionBoundsInRootView)
 {
-    protectedPage()->proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(replacementID, selectionBoundsInRootView);
+    if (RefPtr page = m_page.get())
+        page->proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(replacementID, selectionBoundsInRootView);
 }
 
 void WebChromeClient::proofreadingSessionUpdateStateForSuggestionWithID(WritingTools::TextSuggestion::State state, const WritingTools::TextSuggestion::ID& replacementID)
 {
-    protectedPage()->proofreadingSessionUpdateStateForSuggestionWithID(state, replacementID);
+    if (RefPtr page = m_page.get())
+        page->proofreadingSessionUpdateStateForSuggestionWithID(state, replacementID);
 }
 
 void WebChromeClient::removeTextAnimationForAnimationID(const WTF::UUID& animationID)
 {
-    protectedPage()->removeTextAnimationForAnimationID(animationID);
+    if (RefPtr page = m_page.get())
+        page->removeTextAnimationForAnimationID(animationID);
 }
 
 void WebChromeClient::removeInitialTextAnimationForActiveWritingToolsSession()
 {
-    protectedPage()->removeInitialTextAnimationForActiveWritingToolsSession();
+    if (RefPtr page = m_page.get())
+        page->removeInitialTextAnimationForActiveWritingToolsSession();
 }
 
 void WebChromeClient::addInitialTextAnimationForActiveWritingToolsSession()
 {
-    protectedPage()->addInitialTextAnimationForActiveWritingToolsSession();
+    if (RefPtr page = m_page.get())
+        page->addInitialTextAnimationForActiveWritingToolsSession();
 }
 
 void WebChromeClient::addSourceTextAnimationForActiveWritingToolsSession(const WTF::UUID& sourceAnimationUUID, const WTF::UUID& destinationAnimationUUID, bool finished, const CharacterRange& range, const String& string, CompletionHandler<void(WebCore::TextAnimationRunMode)>&& completionHandler)
 {
-    protectedPage()->addSourceTextAnimationForActiveWritingToolsSession(sourceAnimationUUID, destinationAnimationUUID, finished, range, string, WTFMove(completionHandler));
+    if (RefPtr page = m_page.get())
+        page->addSourceTextAnimationForActiveWritingToolsSession(sourceAnimationUUID, destinationAnimationUUID, finished, range, string, WTFMove(completionHandler));
 }
 
 void WebChromeClient::addDestinationTextAnimationForActiveWritingToolsSession(const WTF::UUID& sourceAnimationUUID, const WTF::UUID& destinationAnimationUUID, const std::optional<CharacterRange>& range, const String& string)
 {
-    protectedPage()->addDestinationTextAnimationForActiveWritingToolsSession(sourceAnimationUUID, destinationAnimationUUID, range, string);
+    if (RefPtr page = m_page.get())
+        page->addDestinationTextAnimationForActiveWritingToolsSession(sourceAnimationUUID, destinationAnimationUUID, range, string);
 }
 
 void WebChromeClient::saveSnapshotOfTextPlaceholderForAnimation(const WebCore::SimpleRange& placeholderRange)
 {
-    protectedPage()->saveSnapshotOfTextPlaceholderForAnimation(placeholderRange);
+    if (RefPtr page = m_page.get())
+        page->saveSnapshotOfTextPlaceholderForAnimation(placeholderRange);
 }
 
 void WebChromeClient::clearAnimationsForActiveWritingToolsSession()
 {
-    protectedPage()->clearAnimationsForActiveWritingToolsSession();
+    if (RefPtr page = m_page.get())
+        page->clearAnimationsForActiveWritingToolsSession();
 }
 
 #endif
 
 void WebChromeClient::setIsInRedo(bool isInRedo)
 {
-    protectedPage()->setIsInRedo(isInRedo);
+    if (RefPtr page = m_page.get())
+        page->setIsInRedo(isInRedo);
 }
 
 void WebChromeClient::hasActiveNowPlayingSessionChanged(bool hasActiveNowPlayingSession)
 {
-    protectedPage()->hasActiveNowPlayingSessionChanged(hasActiveNowPlayingSession);
+    if (RefPtr page = m_page.get())
+        page->hasActiveNowPlayingSessionChanged(hasActiveNowPlayingSession);
 }
 
 #if ENABLE(GPU_PROCESS)
 void WebChromeClient::getImageBufferResourceLimitsForTesting(CompletionHandler<void(std::optional<ImageBufferResourceLimits>)>&& callback) const
 {
-    protectedPage()->ensureRemoteRenderingBackendProxy().getImageBufferResourceLimitsForTesting(WTFMove(callback));
+    if (RefPtr page = m_page.get())
+        page->ensureRemoteRenderingBackendProxy().getImageBufferResourceLimitsForTesting(WTFMove(callback));
+    else
+        callback(std::nullopt);
 }
 #endif
 
@@ -2015,23 +2340,31 @@ bool WebChromeClient::requiresScriptTelemetryForURL(const URL& url, const Securi
 
 void WebChromeClient::callAfterPendingSyntheticClick(CompletionHandler<void(SyntheticClickResult)>&& completion)
 {
-    protectedPage()->callAfterPendingSyntheticClick(WTFMove(completion));
+    if (RefPtr page = m_page.get())
+        page->callAfterPendingSyntheticClick(WTFMove(completion));
+    else
+        completion(SyntheticClickResult::Failed);
 }
 
 void WebChromeClient::didDispatchClickEvent(const PlatformMouseEvent& event, Node& node)
 {
-    protectedPage()->didDispatchClickEvent(event, node);
+    if (RefPtr page = m_page.get())
+        page->didDispatchClickEvent(event, node);
 }
 
 void WebChromeClient::didProgrammaticallyClearTextFormControl(const HTMLTextFormControlElement& element)
 {
-    protectedPage()->didProgrammaticallyClearTextFormControl(element);
+    if (RefPtr page = m_page.get())
+        page->didProgrammaticallyClearTextFormControl(element);
 }
 
 #if ENABLE(DAMAGE_TRACKING)
 void WebChromeClient::resetDamageHistoryForTesting()
 {
-    const auto* drawingArea = page().drawingArea();
+    if (!m_page)
+        return;
+
+    const auto* drawingArea = m_page->drawingArea();
     if (!drawingArea)
         return;
 
@@ -2041,7 +2374,10 @@ void WebChromeClient::resetDamageHistoryForTesting()
 
 WebCore::FrameDamageHistory* WebChromeClient::damageHistoryForTesting() const
 {
-    const auto* drawingArea = page().drawingArea();
+    if (!m_page)
+        return nullptr;
+
+    const auto* drawingArea = m_page->drawingArea();
     if (!drawingArea)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -57,9 +57,7 @@ public:
     WebChromeClient(WebPage&);
     ~WebChromeClient();
 
-    // FIXME: these functions should return (ref) pointers that should be null-checked at callsites.
-    WebPage& page() const { return *m_page; }
-    Ref<WebPage> protectedPage() const;
+    WebPage* page() const { return m_page.get(); }
 
 #if PLATFORM(IOS_FAMILY)
     void relayAccessibilityNotification(const String&, const RetainPtr<NSData>&) const final;
@@ -580,7 +578,7 @@ class AXRelayProcessSuspendedNotification {
 public:
     enum class AutomaticallySend : bool { No, Yes };
 
-    explicit AXRelayProcessSuspendedNotification(Ref<WebPage>, AutomaticallySend = AutomaticallySend::Yes);
+    explicit AXRelayProcessSuspendedNotification(WebPage&, AutomaticallySend = AutomaticallySend::Yes);
     ~AXRelayProcessSuspendedNotification();
 
     void sendProcessSuspendMessage(bool suspended);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2370,7 +2370,7 @@ void WebPage::tryRestoreScrollPosition()
 WebPage* WebPage::fromCorePage(Page& page)
 {
     auto& client = page.chrome().client();
-    return client.isEmptyChromeClient() ? nullptr : &downcast<WebChromeClient>(client).page();
+    return client.isEmptyChromeClient() ? nullptr : downcast<WebChromeClient>(client).page();
 }
 
 RefPtr<WebCore::Page> WebPage::protectedCorePage() const


### PR DESCRIPTION
#### 47438b5caa885411cf61fdb7c22d961987561558
<pre>
WebChromeClient::page() should return a raw pointer instead of a reference
<a href="https://bugs.webkit.org/show_bug.cgi?id=292299">https://bugs.webkit.org/show_bug.cgi?id=292299</a>

Reviewed by Per Arne Vollan.

WebChromeClient::page() should return a raw pointer instead of a reference
since it can return a null pointer.

So far, we&apos;ve spot-fixed null -dereference crashes but we should address
the situation more generally by returning a raw pointer.

* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::AXRelayProcessSuspendedNotification::AXRelayProcessSuspendedNotification):
(WebKit::WebChromeClient::setWindowRect):
(WebKit::WebChromeClient::windowRect const):
(WebKit::WebChromeClient::pageRect const):
(WebKit::WebChromeClient::focus):
(WebKit::WebChromeClient::unfocus):
(WebKit::WebChromeClient::elementDidFocus):
(WebKit::WebChromeClient::elementDidRefocus):
(WebKit::WebChromeClient::elementDidBlur):
(WebKit::WebChromeClient::focusedElementDidChangeInputMode):
(WebKit::WebChromeClient::focusedSelectElementDidChangeOptions):
(WebKit::WebChromeClient::makeFirstResponder):
(WebKit::WebChromeClient::assistiveTechnologyMakeFirstResponder):
(WebKit::WebChromeClient::takeFocus):
(WebKit::WebChromeClient::focusedElementChanged):
(WebKit::WebChromeClient::focusedFrameChanged):
(WebKit::WebChromeClient::createWindow):
(WebKit::WebChromeClient::testProcessIncomingSyncMessagesWhenWaitingForSyncReply):
(WebKit::WebChromeClient::show):
(WebKit::WebChromeClient::canRunModal const):
(WebKit::WebChromeClient::runModal):
(WebKit::WebChromeClient::setToolbarsVisible):
(WebKit::WebChromeClient::toolbarsVisible const):
(WebKit::WebChromeClient::setStatusbarVisible):
(WebKit::WebChromeClient::statusbarVisible const):
(WebKit::WebChromeClient::setMenubarVisible):
(WebKit::WebChromeClient::menubarVisible const):
(WebKit::WebChromeClient::setResizable):
(WebKit::WebChromeClient::addMessageToConsole):
(WebKit::WebChromeClient::addMessageWithArgumentsToConsole):
(WebKit::WebChromeClient::canRunBeforeUnloadConfirmPanel):
(WebKit::WebChromeClient::runBeforeUnloadConfirmPanel):
(WebKit::WebChromeClient::closeWindow):
(WebKit::WebChromeClient::rootFrameAdded):
(WebKit::WebChromeClient::rootFrameRemoved):
(WebKit::WebChromeClient::runJavaScriptAlert):
(WebKit::WebChromeClient::runJavaScriptConfirm):
(WebKit::WebChromeClient::runJavaScriptPrompt):
(WebKit::WebChromeClient::keyboardUIMode):
(WebKit::WebChromeClient::hoverSupportedByPrimaryPointingDevice const):
(WebKit::WebChromeClient::hoverSupportedByAnyAvailablePointingDevice const):
(WebKit::WebChromeClient::pointerCharacteristicsOfPrimaryPointingDevice const):
(WebKit::WebChromeClient::pointerCharacteristicsOfAllAvailablePointingDevices const):
(WebKit::WebChromeClient::requestPointerLock):
(WebKit::WebChromeClient::requestPointerUnlock):
(WebKit::WebChromeClient::invalidateContentsAndRootView):
(WebKit::WebChromeClient::invalidateContentsForSlowScroll):
(WebKit::WebChromeClient::scroll):
(WebKit::WebChromeClient::screenToRootView const):
(WebKit::WebChromeClient::rootViewToScreen const):
(WebKit::WebChromeClient::accessibilityScreenToRootView const):
(WebKit::WebChromeClient::rootViewToAccessibilityScreen const):
(WebKit::WebChromeClient::didFinishLoadingImageForElement):
(WebKit::WebChromeClient::intrinsicContentsSizeChanged const):
(WebKit::WebChromeClient::contentsSizeChanged const):
(WebKit::WebChromeClient::scrollMainFrameToRevealRect const):
(WebKit::WebChromeClient::mouseDidMoveOverElement):
(WebKit::WebChromeClient::print):
(WebKit::WebChromeClient::createColorChooser):
(WebKit::WebChromeClient::createDataListSuggestionPicker):
(WebKit::WebChromeClient::createDateTimeChooser):
(WebKit::WebChromeClient::runOpenPanel):
(WebKit::WebChromeClient::showShareSheet):
(WebKit::WebChromeClient::showContactPicker):
(WebKit::WebChromeClient::showDigitalCredentialsPicker):
(WebKit::WebChromeClient::dismissDigitalCredentialsPicker):
(WebKit::WebChromeClient::setCursor):
(WebKit::WebChromeClient::setCursorHiddenUntilMouseMoves):
(WebKit::WebChromeClient::didAssociateFormControls):
(WebKit::WebChromeClient::shouldNotifyOnFormChanges):
(WebKit::WebChromeClient::createPopupMenu const):
(WebKit::WebChromeClient::createSearchPopupMenu const):
(WebKit::WebChromeClient::graphicsLayerFactory const):
(WebKit::WebChromeClient::displayRefreshMonitorFactory const):
(WebKit::WebChromeClient::createImageBuffer const):
(WebKit::WebChromeClient::sinkIntoImageBuffer):
(WebKit::WebChromeClient::createWorkerClient):
(WebKit::WebChromeClient::createGraphicsContextGL const):
(WebKit::WebChromeClient::createGPUForWebGPU const):
(WebKit::WebChromeClient::createBarcodeDetector const):
(WebKit::WebChromeClient::getBarcodeDetectorSupportedFormats const):
(WebKit::WebChromeClient::createFaceDetector const):
(WebKit::WebChromeClient::createTextDetector const):
(WebKit::WebChromeClient::attachRootGraphicsLayer):
(WebKit::WebChromeClient::attachViewOverlayGraphicsLayer):
(WebKit::WebChromeClient::shouldTriggerRenderingUpdate const):
(WebKit::WebChromeClient::triggerRenderingUpdate):
(WebKit::WebChromeClient::scheduleRenderingUpdate):
(WebKit::WebChromeClient::renderingUpdateFramesPerSecondChanged):
(WebKit::WebChromeClient::remoteImagesCountForTesting const):
(WebKit::WebChromeClient::contentRuleListNotification):
(WebKit::WebChromeClient::layerTreeStateIsFrozen const):
(WebKit::WebChromeClient::createScrollingCoordinator const):
(WebKit::WebChromeClient::ensureScrollbarsController const):
(WebKit::WebChromeClient::prepareForVideoFullscreen):
(WebKit::WebChromeClient::canEnterVideoFullscreen const):
(WebKit::WebChromeClient::supportsVideoFullscreen):
(WebKit::WebChromeClient::supportsVideoFullscreenStandby):
(WebKit::WebChromeClient::setMockVideoPresentationModeEnabled):
(WebKit::WebChromeClient::enterVideoFullscreenForVideoElement):
(WebKit::WebChromeClient::setPlayerIdentifierForVideoElement):
(WebKit::WebChromeClient::exitVideoFullscreenForVideoElement):
(WebKit::WebChromeClient::mediaEngineChanged):
(WebKit::WebChromeClient::addMediaUsageManagerSession):
(WebKit::WebChromeClient::updateMediaUsageManagerSessionState):
(WebKit::WebChromeClient::removeMediaUsageManagerSession):
(WebKit::WebChromeClient::exitVideoFullscreenToModeWithoutAnimation):
(WebKit::WebChromeClient::setVideoFullscreenMode):
(WebKit::WebChromeClient::clearVideoFullscreenMode):
(WebKit::WebChromeClient::supportsFullScreenForElement):
(WebKit::WebChromeClient::enterFullScreenForElement):
(WebKit::WebChromeClient::updateImageSource):
(WebKit::WebChromeClient::exitFullScreenForElement):
(WebKit::WebChromeClient::screenSize const):
(WebKit::WebChromeClient::availableScreenSize const):
(WebKit::WebChromeClient::overrideScreenSize const):
(WebKit::WebChromeClient::overrideAvailableScreenSize const):
(WebKit::WebChromeClient::screenSizeForFingerprintingProtections const):
(WebKit::WebChromeClient::dispatchDisabledAdaptationsDidChange const):
(WebKit::WebChromeClient::dispatchViewportPropertiesDidChange const):
(WebKit::WebChromeClient::notifyScrollerThumbIsVisibleInRect):
(WebKit::WebChromeClient::recommendedScrollbarStyleDidChange):
(WebKit::WebChromeClient::preferredScrollbarOverlayStyle):
(WebKit::WebChromeClient::underlayColor const):
(WebKit::WebChromeClient::themeColorChanged const):
(WebKit::WebChromeClient::pageExtendedBackgroundColorDidChange const):
(WebKit::WebChromeClient::sampledPageTopColorChanged const):
(WebKit::WebChromeClient::spatialBackdropSourceChanged const):
(WebKit::WebChromeClient::appHighlightsVisiblility const):
(WebKit::WebChromeClient::wheelEventHandlersChanged):
(WebKit::WebChromeClient::enableSuddenTermination):
(WebKit::WebChromeClient::disableSuddenTermination):
(WebKit::WebChromeClient::didAddHeaderLayer):
(WebKit::WebChromeClient::didAddFooterLayer):
(WebKit::WebChromeClient::shouldUseTiledBackingForFrameView const):
(WebKit::WebChromeClient::frameViewLayoutOrVisualViewportChanged):
(WebKit::WebChromeClient::isAnyAnimationAllowedToPlayDidChange):
(WebKit::WebChromeClient::resolveAccessibilityHitTestForTesting):
(WebKit::WebChromeClient::isPlayingMediaDidChange):
(WebKit::WebChromeClient::handleAutoplayEvent):
(WebKit::WebChromeClient::setTextIndicator const):
(WebKit::WebChromeClient::updateTextIndicator const):
(WebKit::WebChromeClient::handleTelephoneNumberClick):
(WebKit::WebChromeClient::handleClickForDataDetectionResult):
(WebKit::WebChromeClient::handleSelectionServiceClick):
(WebKit::WebChromeClient::handleImageServiceClick):
(WebKit::WebChromeClient::handlePDFServiceClick):
(WebKit::WebChromeClient::shouldDispatchFakeMouseMoveEvents const):
(WebKit::WebChromeClient::handleAutoFillButtonClick):
(WebKit::WebChromeClient::inputElementDidResignStrongPasswordAppearance):
(WebKit::WebChromeClient::performSwitchHapticFeedback):
(WebKit::WebChromeClient::addPlaybackTargetPickerClient):
(WebKit::WebChromeClient::removePlaybackTargetPickerClient):
(WebKit::WebChromeClient::showPlaybackTargetPicker):
(WebKit::WebChromeClient::playbackTargetPickerClientStateDidChange):
(WebKit::WebChromeClient::setMockMediaPlaybackTargetPickerEnabled):
(WebKit::WebChromeClient::setMockMediaPlaybackTargetPickerState):
(WebKit::WebChromeClient::mockMediaPlaybackTargetPickerDismissPopup):
(WebKit::WebChromeClient::imageOrMediaDocumentSizeChanged):
(WebKit::WebChromeClient::didInvalidateDocumentMarkerRects):
(WebKit::WebChromeClient::hasStorageAccess):
(WebKit::WebChromeClient::requestStorageAccess):
(WebKit::WebChromeClient::setLoginStatus):
(WebKit::WebChromeClient::isLoggedIn):
(WebKit::WebChromeClient::hasPageLevelStorageAccess const):
(WebKit::WebChromeClient::shouldAllowDeviceOrientationAndMotionAccess):
(WebKit::WebChromeClient::configureLoggingChannel):
(WebKit::WebChromeClient::userIsInteracting const):
(WebKit::WebChromeClient::setUserIsInteracting):
(WebKit::WebChromeClient::setMockWebAuthenticationConfiguration):
(WebKit::WebChromeClient::animationDidFinishForElement):
(WebKit::WebChromeClient::changeUniversalAccessZoomFocus):
(WebKit::WebChromeClient::requestTextRecognition):
(WebKit::WebChromeClient::applyLinkDecorationFilteringWithResult const):
(WebKit::WebChromeClient::allowedQueryParametersForAdvancedPrivacyProtections const):
(WebKit::WebChromeClient::didAddOrRemoveViewportConstrainedObjects):
(WebKit::WebChromeClient::textAutosizingUsesIdempotentModeChanged):
(WebKit::WebChromeClient::baseViewportLayoutSizeScaleFactor const):
(WebKit::WebChromeClient::showMediaControlsContextMenu):
(WebKit::WebChromeClient::enumerateImmersiveXRDevices):
(WebKit::WebChromeClient::requestPermissionOnXRSessionFeatures):
(WebKit::WebChromeClient::startApplePayAMSUISession):
(WebKit::WebChromeClient::abortApplePayAMSUISession):
(WebKit::WebChromeClient::beginSystemPreview):
(WebKit::WebChromeClient::requestCookieConsent):
(WebKit::WebChromeClient::isUsingUISideCompositing const):
(WebKit::WebChromeClient::isInStableState const):
(WebKit::WebChromeClient::didAdjustVisibilityWithSelectors):
(WebKit::WebChromeClient::gamepadsRecentlyAccessed):
(WebKit::WebChromeClient::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect):
(WebKit::WebChromeClient::proofreadingSessionUpdateStateForSuggestionWithID):
(WebKit::WebChromeClient::removeTextAnimationForAnimationID):
(WebKit::WebChromeClient::removeInitialTextAnimationForActiveWritingToolsSession):
(WebKit::WebChromeClient::addInitialTextAnimationForActiveWritingToolsSession):
(WebKit::WebChromeClient::addSourceTextAnimationForActiveWritingToolsSession):
(WebKit::WebChromeClient::addDestinationTextAnimationForActiveWritingToolsSession):
(WebKit::WebChromeClient::saveSnapshotOfTextPlaceholderForAnimation):
(WebKit::WebChromeClient::clearAnimationsForActiveWritingToolsSession):
(WebKit::WebChromeClient::setIsInRedo):
(WebKit::WebChromeClient::hasActiveNowPlayingSessionChanged):
(WebKit::WebChromeClient::getImageBufferResourceLimitsForTesting const):
(WebKit::WebChromeClient::callAfterPendingSyntheticClick):
(WebKit::WebChromeClient::didDispatchClickEvent):
(WebKit::WebChromeClient::didProgrammaticallyClearTextFormControl):
(WebKit::WebChromeClient::resetDamageHistoryForTesting):
(WebKit::WebChromeClient::damageHistoryForTesting const):
(WebKit::WebChromeClient::protectedPage const): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/ios/WebChromeClientIOS.mm:
(WebKit::WebChromeClient::didPreventDefaultForEvent):
(WebKit::WebChromeClient::didReceiveMobileDocType):
(WebKit::WebChromeClient::didFinishContentChangeObserving):
(WebKit::WebChromeClient::notifyRevealedSelectionByScrollingFrame):
(WebKit::WebChromeClient::didLayout):
(WebKit::WebChromeClient::didStartOverflowScroll):
(WebKit::WebChromeClient::didEndOverflowScroll):
(WebKit::WebChromeClient::hasStablePageScaleFactor const):
(WebKit::WebChromeClient::showPlaybackTargetPicker):
(WebKit::WebChromeClient::eventThrottlingDelay):
(WebKit::WebChromeClient::deviceOrientation const):
(WebKit::WebChromeClient::showDataDetectorsUIForElement):
(WebKit::WebChromeClient::relayAccessibilityNotification const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::fromCorePage):

Canonical link: <a href="https://commits.webkit.org/294312@main">https://commits.webkit.org/294312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/443558b7c4cc5a459dce411f876445014e84112d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101402 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106555 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52031 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21374 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29560 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77231 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34265 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16493 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91587 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57573 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16314 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51379 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/86191 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108907 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28531 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20991 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86212 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28893 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87791 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85772 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21819 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30496 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8208 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22648 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28462 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33742 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28273 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31593 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29832 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->