### PR TITLE
[css-anchor-position-1] Put position-visibility under a separate feature flag

### DIFF
--- a/LayoutTests/fast/css/css-anchor-position/anchor-feature-disabled-expected.txt
+++ b/LayoutTests/fast/css/css-anchor-position/anchor-feature-disabled-expected.txt
@@ -1,4 +1,7 @@
 
+PASS e.style['position-visibility'] = "always" should not set the property value
+PASS e.style['position-visibility'] = "anchors-valid" should not set the property value
+PASS e.style['position-visibility'] = "anchors-valid anchors-visible" should not set the property value
 PASS e.style['align-self'] = "anchor-center" should not set the property value
 PASS e.style['align-items'] = "anchor-center" should not set the property value
 PASS e.style['justify-self'] = "anchor-center" should not set the property value

--- a/LayoutTests/fast/css/css-anchor-position/anchor-feature-disabled.html
+++ b/LayoutTests/fast/css/css-anchor-position/anchor-feature-disabled.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ CSSAnchorPositioningEnabled=false ] -->
+<!-- webkit-test-runner [ CSSAnchorPositioningEnabled=false CSSAnchorPositioningPositionVisibilityEnabled=false ] -->
 <!DOCTYPE html>
 <html>
 
@@ -15,8 +15,12 @@
 <script>
 // FIXME: test the following features are disabled too:
 // anchor(), anchor-size(), anchor-name, anchor-scope, position-anchor,
-// position-area, position-visibility, position-try-fallbacks, position-try-order,
+// position-area, position-try-fallbacks, position-try-order,
 // position-try, @position-try.
+
+test_invalid_value('position-visibility', 'always');
+test_invalid_value('position-visibility', 'anchors-valid');
+test_invalid_value('position-visibility', 'anchors-valid anchors-visible');
 
 test_invalid_value('align-self', 'anchor-center');
 test_invalid_value('align-items', 'anchor-center');

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1081,7 +1081,7 @@ CSSAnchorPositioningEnabled:
   status: stable
   category: css
   humanReadableName: "CSS Anchor Positioning"
-  humanReadableDescription: "Enable CSS Anchor Positioning"
+  humanReadableDescription: "Enable CSS Anchor Positioning (except position-visibility)"
   defaultValue:
     WebKitLegacy:
       default: true
@@ -1089,6 +1089,20 @@ CSSAnchorPositioningEnabled:
       default: true
     WebCore:
       default: true
+
+CSSAnchorPositioningPositionVisibilityEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS Anchor Positioning: position-visibility"
+  humanReadableDescription: "Enable position-visibility specified in CSS Anchor Positioning"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
 
 CSSAppearanceBaseEnabled:
   type: bool

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -11936,7 +11936,7 @@
                 "no-overflow"
             ],
             "codegen-properties": {
-                "settings-flag": "cssAnchorPositioningEnabled",
+                "settings-flag": "cssAnchorPositioningPositionVisibilityEnabled",
                 "style-builder-converter": "PositionVisibility",
                 "parser-grammar": "always | [ anchors-valid || anchors-visible || no-overflow ]@(no-single-item-opt)"
             },


### PR DESCRIPTION
#### 5cbd2c6671e241133c925f04b48c9fc187f4d249
<pre>
[css-anchor-position-1] Put position-visibility under a separate feature flag
<a href="https://rdar.apple.com/150086754">rdar://150086754</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292090">https://bugs.webkit.org/show_bug.cgi?id=292090</a>

Reviewed by Antti Koivisto.

Currently, all CSS anchor positioning features are behind an enabled-by-default
flag, CSSAnchorPositioningEnabled. However, position-visibility hasn&apos;t reached
feature complete yet (parsing is implemented but not layout implementation),
so put it under a separate, disabled-by-default flag.

* LayoutTests/fast/css/css-anchor-position/anchor-feature-disabled-expected.txt:
* LayoutTests/fast/css/css-anchor-position/anchor-feature-disabled.html:
    - Added tests to ensure position-visibility doesn&apos;t parse when the feature
      flag is disabled.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
    - Added new feature flag for position-visibility.

* Source/WebCore/css/CSSProperties.json:
    - Changed position-visibility to use the new feature flag.

Canonical link: <a href="https://commits.webkit.org/294361@main">https://commits.webkit.org/294361@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b356b95accd342da605b992bed641a6f89932831

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106551 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52027 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29556 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77235 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34267 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104405 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16500 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91585 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57577 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16322 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9599 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51375 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94067 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86198 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9672 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108903 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100008 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28527 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20989 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86203 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28889 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87788 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85763 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21856 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30493 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8205 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22644 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28458 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33737 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/123633 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28269 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34381 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31589 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29828 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->