### PR TITLE
[JSC] Enable partial loop unrolling with inlining-aware code size exclusion

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGBasicBlock.h
+++ b/Source/JavaScriptCore/dfg/DFGBasicBlock.h
@@ -264,6 +264,11 @@ public:
     };
     std::unique_ptr<SSAData> ssa;
 
+    // Indicates this block was synthetically generated (e.g., via loop unrolling or
+    // additional jump pad insertion due to loop unrolling) and should not contribute
+    // to FTL inlining code size heuristics.
+    bool isExcludedFromFTLCodeSizeEstimation { false };
+
 #if ASSERT_ENABLED
     // Points to the original block this one was cloned from during loop unrolling.
     BasicBlock* cloneSource { nullptr };

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.h
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.h
@@ -112,6 +112,7 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
 #if ASSERT_ENABLED
     clone->cloneSource = block;
 #endif
+    clone->isExcludedFromFTLCodeSizeEstimation = true;
     return clone;
 }
 

--- a/Source/JavaScriptCore/dfg/DFGCriticalEdgeBreakingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCriticalEdgeBreakingPhase.cpp
@@ -127,6 +127,8 @@ public:
                 }
                 }
             }
+
+            pad->isExcludedFromFTLCodeSizeEstimation = true;
         }
     }
 private:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -538,8 +538,11 @@ private:
             if (result == CodeGenerationResult::Generated)
                 ++codeGeneratedNodes;
             if (!notTerminated)
-                return codeGeneratedNodes;
+                break;
         }
+
+        if (block->isExcludedFromFTLCodeSizeEstimation)
+            return 0;
         return codeGeneratedNodes;
     }
 

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -632,6 +632,12 @@ static void overrideDefaults()
     // So, we need a much larger ReservedZoneSize to allow stack overflow handlers to execute.
     Options::reservedZoneSize() = 3 * Options::reservedZoneSize();
 #endif
+
+#if PLATFORM(IOS_FAMILY)
+    // This is used to mitigate performance regression rdar://150522186.
+    if (Options::usePartialLoopUnrolling())
+        Options::maxPartialLoopUnrollingBodyNodeSize() = 50;
+#endif
 }
 
 bool Options::setAllJITCodeValidations(const char* valueStr)

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -593,13 +593,13 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, dumpBaselineJITSizeStatistics, false, Normal, nullptr) \
     v(Bool, dumpDFGJITSizeStatistics, false, Normal, nullptr) \
     v(Bool, useLoopUnrolling, true, Normal, nullptr) \
-    v(Bool, usePartialLoopUnrolling, false, Normal, nullptr) \
+    v(Bool, usePartialLoopUnrolling, true, Normal, nullptr) \
     v(Bool, verboseLoopUnrolling, false, Normal, nullptr) \
     v(Bool, disallowLoopUnrollingForNonInnermost, true, Normal, nullptr) \
-    v(Unsigned, maxLoopUnrollingCount, 2, Normal, nullptr) \
+    v(Unsigned, maxLoopUnrollingCount, 5, Normal, nullptr) \
     v(Unsigned, maxLoopUnrollingBodyNodeSize, 200, Normal, nullptr) \
     v(Unsigned, maxLoopUnrollingIterationCount, 4, Normal, nullptr) \
-    v(Unsigned, maxPartialLoopUnrollingBodyNodeSize, 200, Normal, nullptr) \
+    v(Unsigned, maxPartialLoopUnrollingBodyNodeSize, 70, Normal, nullptr) \
     v(Unsigned, maxPartialLoopUnrollingIterationCount, 4, Normal, nullptr) \
     v(Bool, printEachUnrolledLoop, false, Normal, nullptr) \
     v(Bool, verboseExecutablePoolAllocation, false, Normal, nullptr) \


### PR DESCRIPTION
#### 0dcb36857ab239cbb6a44066ada6b2ed972be306
<pre>
[JSC] Enable partial loop unrolling with inlining-aware code size exclusion
<a href="https://bugs.webkit.org/show_bug.cgi?id=292302">https://bugs.webkit.org/show_bug.cgi?id=292302</a>
<a href="https://rdar.apple.com/150321349">rdar://150321349</a>

Reviewed by Yusuke Suzuki.

This patch enables partial loop unrolling by default and lowers the threshold
(maxPartialLoopUnrollingBodyNodeSize) from 200 to 70. However, unrolling may
inflate the callee’s JITed code size and negatively impact FTL inlining heuristics.

To mitigate this, we introduce `BasicBlock::isExcludedFromFTLCodeSizeEstimation`.
Blocks generated during loop unrolling and jump pad insertion are flagged as excluded.
These are skipped in FTL’s code size estimation to avoid penalizing inlining.

Additionally:
- Skips unrolling loops that only contain PutByVal operations without corresponding GetByVal,
  since they tend to be memory-bound and unprofitable for unrolling (<a href="https://rdar.apple.com/150524264">rdar://150524264</a>).
- Applies a more conservative partial unrolling threshold (50) on iOS to mitigate a known regression (<a href="https://rdar.apple.com/150522186">rdar://150522186</a>).
- Disables loop unrolling for `StringFromCharCode` due to a specific performance regression (<a href="https://rdar.apple.com/150526635">rdar://150526635</a>).

This allows loop unrolling optimizations to proceed without degrading inlining-based performance.

* Source/JavaScriptCore/dfg/DFGBasicBlock.h:
* Source/JavaScriptCore/dfg/DFGCloneHelper.h:
(JSC::DFG::CloneHelper::cloneBlock):
* Source/JavaScriptCore/dfg/DFGCriticalEdgeBreakingPhase.cpp:
(JSC::DFG::CriticalEdgeBreakingPhase::performFixJumpPadAvailability):
* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
(JSC::DFG::LoopUnrollingPhase::isLoopBodyUnrollable):
(JSC::DFG::LoopUnrollingPhase::LoopData::isProfitableToUnroll):
(JSC::DFG::LoopUnrollingPhase::LoopData::analyzeLoopNode):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileBlock):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::overrideDefaults):
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/294467@main">https://commits.webkit.org/294467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56dd9cfff79e476279a258635d7d3e7102cb72c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106984 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52460 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30001 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77542 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34559 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104833 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16850 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91952 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57871 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16677 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9971 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51811 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94498 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86530 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10047 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109341 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100436 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21332 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86513 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29320 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86085 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30842 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8562 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23130 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16578 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28887 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34178 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124061 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28698 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34462 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32021 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30257 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->