### PR TITLE
Add compact malloc variants to the bmalloc and WTF DebugHeaps

### DIFF
--- a/Source/WTF/wtf/DebugHeap.cpp
+++ b/Source/WTF/wtf/DebugHeap.cpp
@@ -78,4 +78,39 @@ void DebugHeap::free(void* object)
 
 } // namespace WTF
 
+#if USE(APPLE_INTERNAL_SDK)
+#include <WebKitAdditions/DebugHeapAdditions.cpp>
+#else
+
+namespace WTF {
+
+void* DebugHeap::mallocCompact(size_t size)
+{
+    return malloc(size);
+}
+
+void* DebugHeap::callocCompact(size_t numElements, size_t elementSize)
+{
+    return calloc(numElements, elementSize);
+}
+
+void* DebugHeap::memalignCompact(size_t alignment, size_t size, bool crashOnFailure)
+{
+    return memalign(alignment, size, crashOnFailure);
+}
+
+void* DebugHeap::reallocCompact(void* object, size_t size)
+{
+    return realloc(object, size);
+}
+
+void DebugHeap::free(void* object)
+{
+    malloc_zone_free(m_zone, object);
+}
+
+} // namespace WTF
+
+#endif
+
 #endif // ENABLE(MALLOC_HEAP_BREAKDOWN)

--- a/Source/WTF/wtf/DebugHeap.h
+++ b/Source/WTF/wtf/DebugHeap.h
@@ -50,6 +50,10 @@ public:
     WTF_EXPORT_PRIVATE void* calloc(size_t numElements, size_t elementSize);
     WTF_EXPORT_PRIVATE void* memalign(size_t alignment, size_t, bool crashOnFailure);
     WTF_EXPORT_PRIVATE void* realloc(void*, size_t);
+    WTF_EXPORT_PRIVATE void* mallocCompact(size_t);
+    WTF_EXPORT_PRIVATE void* callocCompact(size_t numElements, size_t elementSize);
+    WTF_EXPORT_PRIVATE void* memalignCompact(size_t alignment, size_t, bool crashOnFailure);
+    WTF_EXPORT_PRIVATE void* reallocCompact(void*, size_t);
     WTF_EXPORT_PRIVATE void free(void*);
 
 private:
@@ -92,7 +96,25 @@ private:
     struct MakeDebugHeapMallocedImplMacroSemicolonifier##Type { }
 
 #define DECLARE_COMPACT_ALLOCATOR_WITH_HEAP_IDENTIFIER_AND_EXPORT(Type, Export) \
-    DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER_AND_EXPORT(Type, Export)
+    struct Type##Malloc { \
+        static Export WTF::DebugHeap& debugHeap(); \
+\
+        static void* malloc(size_t size) { return debugHeap().mallocCompact(size); } \
+\
+        static void* tryMalloc(size_t size) { return debugHeap().mallocCompact(size); } \
+\
+        static void* zeroedMalloc(size_t size) { return debugHeap().callocCompact(1, size); } \
+\
+        static void* tryZeroedMalloc(size_t size) { return debugHeap().callocCompact(1, size); } \
+\
+        static void* realloc(void* p, size_t size) { return debugHeap().reallocCompact(p, size); } \
+\
+        static void* tryRealloc(void* p, size_t size) { return debugHeap().reallocCompact(p, size); } \
+\
+        static void free(void* p) { debugHeap().free(p); } \
+\
+        static constexpr ALWAYS_INLINE size_t nextCapacity(size_t capacity) { return capacity + capacity / 4 + 1; } \
+    }
 
 #define DEFINE_COMPACT_ALLOCATOR_WITH_HEAP_IDENTIFIER(Type) \
     DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(Type)

--- a/Source/bmalloc/bmalloc/DebugHeap.cpp
+++ b/Source/bmalloc/bmalloc/DebugHeap.cpp
@@ -220,17 +220,44 @@ bool pas_debug_heap_is_enabled(pas_heap_config_kind kind)
 
 void* pas_debug_heap_malloc(size_t size)
 {
-    return DebugHeap::getExisting()->malloc(size, FailureAction::ReturnNull);
+    auto debugHeap = DebugHeap::getExisting();
+    PAS_PROFILE(DEBUG_HEAP_ALLOCATION, debugHeap, size, 1, pas_non_compact_allocation_mode);
+    return debugHeap->malloc(size, FailureAction::ReturnNull);
 }
 
 void* pas_debug_heap_memalign(size_t alignment, size_t size)
 {
-    return DebugHeap::getExisting()->memalign(alignment, size, FailureAction::ReturnNull);
+    auto debugHeap = DebugHeap::getExisting();
+    PAS_PROFILE(DEBUG_HEAP_ALLOCATION, debugHeap, size, alignment, pas_non_compact_allocation_mode);
+    return debugHeap->memalign(alignment, size, FailureAction::ReturnNull);
 }
 
 void* pas_debug_heap_realloc(void* ptr, size_t size)
 {
-    return DebugHeap::getExisting()->realloc(ptr, size, FailureAction::ReturnNull);
+    auto debugHeap = DebugHeap::getExisting();
+    PAS_PROFILE(DEBUG_HEAP_REALLOCATION, debugHeap, ptr, size, pas_non_compact_allocation_mode);
+    return debugHeap->realloc(ptr, size, FailureAction::ReturnNull);
+}
+
+void* pas_debug_heap_malloc_compact(size_t size)
+{
+    auto debugHeap = DebugHeap::getExisting();
+    PAS_PROFILE(DEBUG_HEAP_ALLOCATION, debugHeap, size, 1, pas_maybe_compact_allocation_mode);
+    return debugHeap->malloc(size, FailureAction::ReturnNull);
+}
+
+void* pas_debug_heap_memalign_compact(size_t alignment, size_t size)
+{
+    auto debugHeap = DebugHeap::getExisting();
+    PAS_PROFILE(DEBUG_HEAP_ALLOCATION, debugHeap, size, alignment, pas_maybe_compact_allocation_mode);
+    return debugHeap->memalign(alignment, size, FailureAction::ReturnNull);
+}
+
+void* pas_debug_heap_realloc_compact(void* ptr, size_t size)
+{
+    auto debugHeap = DebugHeap::getExisting();
+    PAS_PROFILE(DEBUG_HEAP_REALLOCATION, debugHeap, ptr, size, pas_maybe_compact_allocation_mode);
+    return debugHeap->realloc(ptr, size, FailureAction::ReturnNull);
 }
 
 void pas_debug_heap_free(void* ptr)
@@ -262,6 +289,29 @@ void* pas_debug_heap_memalign(size_t alignment, size_t size)
 }
 
 void* pas_debug_heap_realloc(void* ptr, size_t size)
+{
+    BUNUSED_PARAM(ptr);
+    BUNUSED_PARAM(size);
+    RELEASE_BASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+void* pas_debug_heap_malloc_compact(size_t size)
+{
+    BUNUSED_PARAM(size);
+    RELEASE_BASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+void* pas_debug_heap_memalign_compact(size_t alignment, size_t size)
+{
+    BUNUSED_PARAM(size);
+    BUNUSED_PARAM(alignment);
+    RELEASE_BASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+void* pas_debug_heap_realloc_compact(void* ptr, size_t size)
 {
     BUNUSED_PARAM(ptr);
     BUNUSED_PARAM(size);

--- a/Source/bmalloc/bmalloc/DebugHeap.h
+++ b/Source/bmalloc/bmalloc/DebugHeap.h
@@ -64,6 +64,10 @@ public:
     static DebugHeap* tryGet();
     static DebugHeap* getExisting();
 
+#if BOS(DARWIN)
+    malloc_zone_t* zone() const { return m_zone; };
+#endif
+
 private:
     static DebugHeap* tryGetSlow();
     

--- a/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
@@ -327,7 +327,9 @@ pas_try_reallocate(void* old_ptr,
             
             PAS_ASSERT(free_mode == pas_reallocate_free_if_successful);
 
-            raw_result = pas_debug_heap_realloc(old_ptr, new_size);
+            raw_result = allocation_mode == pas_non_compact_allocation_mode
+                ? pas_debug_heap_realloc(old_ptr, new_size)
+                : pas_debug_heap_realloc_compact(old_ptr, new_size);
 
             result = pas_allocation_result_create_failure();
 


### PR DESCRIPTION
#### 503b587d52aeada93ea75674491dd0e5c7849a95
<pre>
Add compact malloc variants to the bmalloc and WTF DebugHeaps
<a href="https://bugs.webkit.org/show_bug.cgi?id=292306">https://bugs.webkit.org/show_bug.cgi?id=292306</a>
<a href="https://rdar.apple.com/148397735">rdar://148397735</a>

Reviewed by Mark Lam.

Adds &quot;compact&quot; variants of WTF::DebugHeap and bmalloc::DebugHeap malloc
functions, which we call when we know the returned address may be used
in a packed or compact pointer.

* Source/WTF/wtf/DebugHeap.cpp:
(WTF::DebugHeap::mallocCompact):
(WTF::DebugHeap::callocCompact):
(WTF::DebugHeap::memalignCompact):
(WTF::DebugHeap::reallocCompact):
(WTF::DebugHeap::free):
* Source/WTF/wtf/DebugHeap.h:
* Source/bmalloc/bmalloc/DebugHeap.cpp:
(pas_debug_heap_malloc):
(pas_debug_heap_memalign):
(pas_debug_heap_realloc):
(pas_debug_heap_malloc_compact):
(pas_debug_heap_memalign_compact):
(pas_debug_heap_realloc_compact):
* Source/bmalloc/bmalloc/DebugHeap.h:
(bmalloc::DebugHeap::zone const):
* Source/bmalloc/libpas/src/libpas/pas_debug_heap.h:
(pas_debug_heap_malloc_compact):
(pas_debug_heap_memalign_compact):
(pas_debug_heap_realloc_compact):
(pas_debug_heap_allocate):
* Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h:
(pas_try_reallocate):

Canonical link: <a href="https://commits.webkit.org/294365@main">https://commits.webkit.org/294365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4026dd6cf2e821d2a29971af2d836dd199633e89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101420 "17 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21085 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106573 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52049 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29578 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77255 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34277 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104427 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16510 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91607 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57597 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16330 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9624 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51397 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94089 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86206 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9697 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108925 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100030 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21003 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86227 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28911 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85789 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21858 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30511 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8228 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22666 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28480 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33760 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/123655 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28291 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34384 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31611 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29850 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->