### PR TITLE
TestWebKitAPI build broken for watchOS (undefined CGImageProperty symbols)

### DIFF
--- a/Tools/TestWebKitAPI/Configurations/TestWebKitAPIBase.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/TestWebKitAPIBase.xcconfig
@@ -101,6 +101,9 @@ WK_IMAGEIO_LDFLAGS_xros = -framework ImageIO
 WK_IMAGEIO_LDFLAGS_xrsimulator = -framework ImageIO
 WK_IMAGEIO_LDFLAGS_maccatalyst = -framework ImageIO
 WK_IMAGEIO_LDFLAGS_appletvos = -framework ImageIO
+WK_IMAGEIO_LDFLAGS_appletvsimulator = -framework ImageIO
+WK_IMAGEIO_LDFLAGS_watchos = -framework ImageIO
+WK_IMAGEIO_LDFLAGS_watchsimulator = -framework ImageIO
 WK_IMAGEIO_LDFLAGS_macosx = $(WK_IMAGEIO_LDFLAGS$(WK_MACOS_1300));
 WK_IMAGEIO_LDFLAGS_MACOS_SINCE_1300 = -framework ImageIO;
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AdaptiveImageGlyph.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AdaptiveImageGlyph.mm
@@ -760,13 +760,9 @@ TEST(AdaptiveImageGlyph, ContentsAsAttributedString)
 
 #if HAVE(NS_EMOJI_IMAGE_STRIKE_PROVENANCE)
             RetainPtr<NSDictionary> provenance = [adaptiveImageGlyph strikes].firstObject.provenance;
-
-            // FIXME: Remove the conditional once rdar://137757841 is in a build.
-            if ([provenance count]) {
-                EXPECT_WK_STREQ([provenance objectForKey:(__bridge NSString *)kCGImagePropertyIPTCCredit], "Apple Image Playground");
-                EXPECT_WK_STREQ([provenance objectForKey:(__bridge NSString *)kCGImagePropertyIPTCExtDigitalSourceType], "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia");
-                EXPECT_TRUE([provenance isEqualToDictionary:[value strikes].firstObject.provenance]);
-            }
+            EXPECT_WK_STREQ([provenance objectForKey:(__bridge NSString *)kCGImagePropertyIPTCCredit], "Apple Image Playground");
+            EXPECT_WK_STREQ([provenance objectForKey:(__bridge NSString *)kCGImagePropertyIPTCExtDigitalSourceType], "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia");
+            EXPECT_TRUE([provenance isEqualToDictionary:[value strikes].firstObject.provenance]);
 #endif
 
             // Reconstruction is lossy, so data cannot be compared directly against the original.


### PR DESCRIPTION
#### f9c1901a276fff734117d3f90e4882f21f2b0a7c
<pre>
TestWebKitAPI build broken for watchOS (undefined CGImageProperty symbols)
<a href="https://bugs.webkit.org/show_bug.cgi?id=292309">https://bugs.webkit.org/show_bug.cgi?id=292309</a>
<a href="https://rdar.apple.com/150327903">rdar://150327903</a>

Reviewed by Aditya Keerthi.

This patch links TestWebKitAPI against the ImageIO framework (for
watchOS, watchOS simulator, and tvOS simulator) so that we can resolve
the CGImageProperty constants referenced in the API tests on said
platforms.

* Tools/TestWebKitAPI/Configurations/TestWebKitAPIBase.xcconfig:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/AdaptiveImageGlyph.mm:
(TestWebKitAPI::TEST(AdaptiveImageGlyph, ContentsAsAttributedString)):

  Drive-by fix: remove the now unnecessary provenance conditional.

Canonical link: <a href="https://commits.webkit.org/294321@main">https://commits.webkit.org/294321@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de483de887e780adbe3d32a8358f504974c06de1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106579 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52055 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103466 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29584 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77244 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34280 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104433 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16517 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91610 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57586 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16337 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9627 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51403 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86213 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9700 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108931 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28555 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21005 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86218 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28917 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87816 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85779 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21827 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30515 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8231 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22672 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28486 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28297 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31617 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29856 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->