### PR TITLE
Remove extra resize event when entering fullscreen with site isolation on

### DIFF
--- a/LayoutTests/http/tests/site-isolation/fullscreen-resize-events-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/fullscreen-resize-events-expected.txt
@@ -1,0 +1,6 @@
+
+Resize event: 600x800
+Size after entering fullscreen: 600x800
+Resize event: 150x300
+Size after exiting fullscreen: 150x300
+

--- a/LayoutTests/http/tests/site-isolation/fullscreen-resize-events.html
+++ b/LayoutTests/http/tests/site-isolation/fullscreen-resize-events.html
@@ -1,0 +1,14 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script>
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsText()
+    }
+    addEventListener("message", (event) => {
+        document.getElementById("mylog").innerHTML += event.data + "<br>";
+        if (event.data.startsWith('Size after exiting') && window.testRunner) { testRunner.notifyDone() }
+    });
+</script>
+<iframe allowfullscreen src="http://localhost:8000/site-isolation/resources/fullscreen-resize-events.html" frameborder=0></iframe>
+<div id=mylog>
+</div>

--- a/LayoutTests/http/tests/site-isolation/resources/fullscreen-resize-events.html
+++ b/LayoutTests/http/tests/site-isolation/resources/fullscreen-resize-events.html
@@ -1,0 +1,23 @@
+<script>
+    window.addEventListener("resize", ()=>{
+        window.parent.postMessage("Resize event: " + window.innerHeight + "x" + window.innerWidth, "*");
+    });
+    async function enterFullScreen() {
+        await document.documentElement.requestFullscreen();
+        if (window.testRunner) { await testRunner.updatePresentation() }
+        window.parent.postMessage("Size after entering fullscreen: " + document.body.clientHeight + "x" + document.body.clientWidth, "*");
+    }
+    async function exitFullScreen() {
+        await document.exitFullscreen();
+        if (window.testRunner) { await testRunner.updatePresentation() }
+        window.parent.postMessage("Size after exiting fullscreen: " + document.body.clientHeight + "x" + document.body.clientWidth, "*");
+    }
+    if (window.internals) {
+        internals.withUserGesture(async () => {
+            await enterFullScreen();
+            await exitFullScreen();
+        });
+    }
+</script>
+<button onclick="enterFullScreen()">Enter</button>
+<button onclick="exitFullScreen()">Exit</button>

--- a/Source/WebKit/Shared/NavigationActionData.h
+++ b/Source/WebKit/Shared/NavigationActionData.h
@@ -33,6 +33,7 @@
 #include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/FloatPoint.h>
 #include <WebCore/FrameLoaderTypes.h>
+#include <WebCore/IntSize.h>
 #include <WebCore/NavigationIdentifier.h>
 #include <WebCore/OwnerPermissionsPolicyData.h>
 #include <WebCore/PrivateClickMeasurement.h>
@@ -85,6 +86,7 @@ struct NavigationActionData {
     FrameInfoData originatingFrameInfoData;
     std::optional<WebPageProxyIdentifier> originatingPageID;
     FrameInfoData frameInfo;
+    std::optional<WebCore::IntSize> frameSize;
     std::optional<WebCore::NavigationIdentifier> navigationID;
     WebCore::ResourceRequest originalRequest;
     WebCore::ResourceRequest request;

--- a/Source/WebKit/Shared/NavigationActionData.serialization.in
+++ b/Source/WebKit/Shared/NavigationActionData.serialization.in
@@ -59,6 +59,7 @@ struct WebKit::NavigationActionData {
     WebKit::FrameInfoData originatingFrameInfoData;
     std::optional<WebKit::WebPageProxyIdentifier> originatingPageID;
     WebKit::FrameInfoData frameInfo;
+    std::optional<WebCore::IntSize> frameSize;
     std::optional<WebCore::NavigationIdentifier> navigationID;
     WebCore::ResourceRequest originalRequest;
     [EncodeRequestBody] WebCore::ResourceRequest request;

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -51,7 +51,7 @@ ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<FrameProc
         frame.layerHostingContextIdentifier(),
         frame.effectiveSandboxFlags(),
         frame.scrollingMode(),
-        frame.remoteFrameSize()
+        frame.frameSize()
     }), frame.frameID());
 }
 

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -295,7 +295,7 @@ void ProvisionalPageProxy::initializeWebPage(RefPtr<API::WebsitePolicies>&& webs
             std::nullopt,
             mainFrame->effectiveSandboxFlags(),
             mainFrame->scrollingMode(),
-            mainFrame->remoteFrameSize()
+            mainFrame->frameSize()
         };
     }
     process->send(Messages::WebProcess::CreateWebPage(m_webPageID, WTFMove(creationParameters)), 0);

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -756,7 +756,7 @@ void WebFrameProxy::updateScrollingMode(WebCore::ScrollbarMode scrollingMode)
 
 void WebFrameProxy::updateRemoteFrameSize(WebCore::IntSize size)
 {
-    m_remoteFrameSize = size;
+    m_frameSize = size;
     send(Messages::WebFrame::UpdateFrameSize(size));
 }
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -231,7 +231,8 @@ public:
     WebFrameProxy* opener() { return m_opener.get(); }
     void disownOpener() { m_opener = nullptr; }
 
-    std::optional<WebCore::IntSize> remoteFrameSize() const { return m_remoteFrameSize; }
+    std::optional<WebCore::IntSize> frameSize() const { return m_frameSize; }
+    void setFrameSize(WebCore::IntSize size) { m_frameSize = size; }
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
     static void sendCancelReply(IPC::Connection&, IPC::Decoder&);
@@ -273,7 +274,7 @@ private:
     CompletionHandler<void(std::optional<WebCore::PageIdentifier>, std::optional<WebCore::FrameIdentifier>)> m_navigateCallback;
     const WebCore::LayerHostingContextIdentifier m_layerHostingContextIdentifier;
     bool m_isPendingInitialHistoryItem { false };
-    std::optional<WebCore::IntSize> m_remoteFrameSize;
+    std::optional<WebCore::IntSize> m_frameSize;
     WebCore::SandboxFlags m_effectiveSandboxFlags;
     WebCore::ScrollbarMode m_scrollingMode;
 };

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7769,6 +7769,9 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
     if (navigationID)
         navigation = navigationState->navigation(*navigationID);
 
+    if (navigationActionData.frameSize)
+        frame.setFrameSize(*navigationActionData.frameSize);
+
     // When process-swapping on a redirect, the navigationActionData / originatingFrameInfoData provided by the fresh new WebProcess are inaccurate since
     // the new process does not have sufficient information. To address the issue, we restore the information we stored on the NavigationAction during the original request
     // policy decision.

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -373,6 +373,7 @@ RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& open
         webFrame->page()->webPageProxyIdentifier(),
         webFrame->info(), /* frameInfo */
         std::nullopt, /* navigationID */
+        std::nullopt, // FIXME this should have the frame size.
         navigationAction.originalRequest(), /* originalRequest */
         navigationAction.originalRequest() /* request */
     };

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -521,6 +521,7 @@ void WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJS(SameDocum
         std::nullopt, /* originatingPageID */
         m_frame->info(),
         { }, /* navigationID */
+        std::nullopt, // FIXME this should have the frame size.
         { }, /* originalRequest */
         { } /* request */
     };
@@ -1027,6 +1028,7 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const Nav
         std::nullopt, /* originatingPageID */
         m_frame->info(),
         { }, /* navigationID */
+        std::nullopt, // FIXME this should have the frame size.
         { }, /* originalRequest */
         request
     };


### PR DESCRIPTION
#### 82a75229b5284e68c24f3fc2a912905a42893a8a
<pre>
Remove extra resize event when entering fullscreen with site isolation on
<a href="https://bugs.webkit.org/show_bug.cgi?id=292311">https://bugs.webkit.org/show_bug.cgi?id=292311</a>
<a href="https://rdar.apple.com/150329731">rdar://150329731</a>

Reviewed by NOBODY (OOPS!).

When entering fullscreen, we should have one resize event with the new size.
When exiting fullscreen, we should have one resize event with the new size.
Before this change, we had 2 resize events when entering fullscreen with site
isolation on because the first time we calculated the non-zero size for the
iframe is when WebFrame::loadDidCommitInAnotherProcess gets called, at which
point we sent an IPC to tell the iframe about the pre-fullscreen size.
This fixes that by sending the frame size with the NavigationActionData.

* LayoutTests/http/tests/site-isolation/fullscreen-resize-events-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/fullscreen-resize-events.html: Added.
* LayoutTests/http/tests/site-isolation/resources/fullscreen-resize-events.html: Added.
* Source/WebKit/Shared/NavigationActionData.h:
* Source/WebKit/Shared/NavigationActionData.serialization.in:
* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp:
(WebKit::ProvisionalFrameProxy::ProvisionalFrameProxy):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::initializeWebPage):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::updateRemoteFrameSize):
* Source/WebKit/UIProcess/WebFrameProxy.h:
(WebKit::WebFrameProxy::frameSize const):
(WebKit::WebFrameProxy::setFrameSize):
(WebKit::WebFrameProxy::remoteFrameSize const): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createWindow):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::navigationActionData const):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJS):
(WebKit::WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82a75229b5284e68c24f3fc2a912905a42893a8a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106586 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52062 "Hash 82a75229 for PR 44725 does not build (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29591 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77250 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/52062 "Hash 82a75229 for PR 44725 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104440 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16521 "Found 1 new test failure: http/tests/site-isolation/fullscreen-resize-events.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91611 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57592 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16341 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9628 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51410 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86217 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9701 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108938 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28562 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21011 "Found 1 new test failure: http/tests/site-isolation/fullscreen-resize-events.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86223 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28924 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87817 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85785 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30519 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8232 "Found 2 new test failures: fast/webgpu/nocrash/fuzz-291988b.html http/tests/site-isolation/fullscreen-resize-events.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22679 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28493 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33773 "Found 1 new failure in WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28304 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31624 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29863 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->