### PR TITLE
[WebGPU] Deduplication of array lengths with other bindings is incorrect in some cases

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_292315-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_292315-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: no validation error
+

--- a/LayoutTests/fast/webgpu/regression/repro_292315.html
+++ b/LayoutTests/fast/webgpu/regression/repro_292315.html
@@ -1,0 +1,59 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  async function window0() {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let vertexModule = device.createShaderModule({
+      code: `
+@group(0) @binding(10) var sam0: sampler;
+@group(0) @binding(50) var sam1: sampler;
+
+@vertex
+fn vertex0() -> @builtin(position) vec4f {
+  _ = sam0;
+  _ = sam1;
+  return vec4();
+}
+`,
+    });
+    let fragmentModule = device.createShaderModule({
+      code: `
+@group(0) @binding(0) var<storage, read_write> buffer0: array<u32>;
+@group(0) @binding(9) var sam0: sampler;
+
+@fragment
+fn fragment0() -> @location(0) vec4f {
+  _ = buffer0[0];
+  _ = sam0;
+  return vec4();
+}
+`,
+    });
+    let pipeline = device.createRenderPipeline({
+      layout: 'auto',
+      fragment: {module: fragmentModule, targets: [{format: 'bgra8unorm'}]},
+      vertex: {module: vertexModule},
+    });
+    await device.queue.onSubmittedWorkDone();
+    let error = await device.popErrorScope();
+    if (error) {
+      log(error.message);
+    } else {
+      log('no validation error');
+    }
+  }
+
+  onload = async () => {
+    try {
+      await window0();
+    } catch (e) {
+      log('error');
+      log(e);
+    }
+    globalThis.testRunner?.dumpAsText();
+    globalThis.testRunner?.notifyDone();
+  };
+</script>


### PR DESCRIPTION
#### 3b1b2929705c0e219bbb361a3540b5cc57b2e06b
<pre>
[WebGPU] Deduplication of array lengths with other bindings is incorrect in some cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=292315">https://bugs.webkit.org/show_bug.cgi?id=292315</a>
<a href="https://rdar.apple.com/150256934">rdar://150256934</a>

Reviewed by Tadeu Zagallo.

When an array length&apos;s webBinding collided with the binding number of
a non-array length, we would consider them to be equal and reject the pipeline
erroneously.

Ensure we segment the array lengths into their own range of binding indices
prior to attempting to deduplicate automatically generated bindings.

* LayoutTests/fast/webgpu/regression/repro_292315-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_292315.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::addPipelineLayouts):

Canonical link: <a href="https://commits.webkit.org/294337@main">https://commits.webkit.org/294337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f73f9222b299ba733e99cac26d5eb3c2407e515

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106619 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52095 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77274 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34304 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104473 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16543 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91633 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57616 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16364 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9652 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51443 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86233 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108971 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28595 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21029 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86244 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28957 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85810 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21839 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30544 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8254 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22713 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28526 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33806 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28337 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31657 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29896 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->