### PR TITLE
[JSC] DFG BackwardsPropagation should be more robust

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2667,7 +2667,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
 
                     if (arrayMode.isOutOfBounds()) {
                         if (m_graph.isWatchingArrayPrototypeChainIsSaneWatchpoint(node)) {
-                            if (arrayMode.type() == Array::Double && arrayMode.isOutOfBoundsSaneChain() && !(node->flags() & NodeBytecodeUsesAsOther))
+                            if (arrayMode.type() == Array::Double && node->hasDoubleResult())
                                 setConstant(node, jsNumber(PNaN));
                             else
                                 setConstant(node, jsUndefined());
@@ -2864,7 +2864,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             } else if (arrayMode.isInBoundsSaneChain())
                 setNonCellTypeForNode(node, SpecBytecodeDouble);
             else if (arrayMode.isOutOfBoundsSaneChain()) {
-                if (!!(node->flags() & NodeBytecodeUsesAsOther))
+                if (!node->hasDoubleResult())
                     setNonCellTypeForNode(node, SpecBytecodeDouble | SpecOther);
                 else
                     setNonCellTypeForNode(node, SpecBytecodeDouble);

--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
@@ -604,32 +604,34 @@ private:
             node->child1()->mergeFlags(flags);
             break;
 
-        case ValueRep:
+        case Int52Rep: {
             ASSERT(m_graph.afterFixup());
-            // ValueRep is used to box a double or int52 to a JSValue. So, we shouldn't propagate any node flags to its child.
+            auto& edge = node->child1();
+            if (edge->hasDoubleResult()) {
+                if (bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
+                    edge.setUseKind(DoubleRepRealUse);
+                else
+                    edge.setUseKind(DoubleRepAnyIntUse);
+            } else if (!edge->shouldSpeculateInt32ForArithmetic()) {
+                if (bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
+                    edge.setUseKind(RealNumberUse);
+                else
+                    edge.setUseKind(AnyIntUse);
+            }
+            // The results of these nodes are pure unboxed integers. Then, we
+            // should definitely tell their children that you will be used as an integer.
+            flags |= NodeBytecodeUsesAsInt;
+            node->child1()->mergeFlags(flags);
             break;
+        }
 
-        case Int52Rep:
         case ValueToInt32:
         case DoubleAsInt32:
             ASSERT(m_graph.afterFixup());
             // The results of these nodes are pure unboxed integers. Then, we
             // should definitely tell their children that you will be used as an integer.
-            node->child1()->mergeFlags(NodeBytecodeUsesAsInt);
-            if (node->op() == Int52Rep) {
-                auto& edge = node->child1();
-                if (edge->hasDoubleResult()) {
-                    if (bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
-                        edge.setUseKind(DoubleRepRealUse);
-                    else
-                        edge.setUseKind(DoubleRepAnyIntUse);
-                } else if (!edge->shouldSpeculateInt32ForArithmetic()) {
-                    if (bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
-                        edge.setUseKind(RealNumberUse);
-                    else
-                        edge.setUseKind(AnyIntUse);
-                }
-            }
+            flags |= NodeBytecodeUsesAsInt;
+            node->child1()->mergeFlags(flags);
             break;
 
         case DoubleRep:
@@ -646,26 +648,12 @@ private:
                 node->child1()->mergeFlags(NodeBytecodeUsesAsInt);
             break;
 
-        case CheckStructureOrEmpty:
-        case CheckArrayOrEmpty:
-        case Arrayify:
-        case ArrayifyToStructure:
-        case GetIndexedPropertyStorage:
-        case ResolveRope:
-        case MakeRope:
-        case GetRegExpObjectLastIndex:
-        case HasIndexedProperty:
-        case CallDOM:
-            // Not interested so far.
-            ASSERT(m_graph.afterFixup());
-            break;
-
         // Note: ArithSqrt, ArithUnary and other math intrinsics don't have special
         // rules in here because they are always followed by Phantoms to signify that if the
         // method call speculation fails, the bytecode may use the arguments in arbitrary ways.
         // This corresponds to that possibility of someone doing something like:
         // Math.sin = function(x) { doArbitraryThingsTo(x); }
-            
+
         default:
             mergeDefaultFlags(node);
             break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -2843,8 +2843,6 @@ void SpeculativeJIT::compileGetByVal(Node* node, const ScopedLambda<std::tuple<J
             break;
         }
 
-        bool resultIsUnboxed = node->arrayMode().isOutOfBoundsSaneChain() && !(node->flags() & NodeBytecodeUsesAsOther);
-
         SpeculateCellOperand base(this, m_graph.varArgChild(node, 0));
         SpeculateStrictInt32Operand property(this, m_graph.varArgChild(node, 1));
         StorageOperand storage(this, m_graph.varArgChild(node, 2));
@@ -2862,7 +2860,7 @@ void SpeculativeJIT::compileGetByVal(Node* node, const ScopedLambda<std::tuple<J
         JSValueRegs resultRegs;
         DataFormat format;
         constexpr bool needsFlush = false;
-        std::tie(resultRegs, format) = prefix(resultIsUnboxed ? DataFormatDouble : DataFormatJS, needsFlush);
+        std::tie(resultRegs, format) = prefix(node->hasDoubleResult() ? DataFormatDouble : DataFormatJS, needsFlush);
 
         JumpList slowCases;
 


### PR DESCRIPTION
#### 20d58337eba8c5f0fcb7ff485a5b29cf88b004ac
<pre>
[JSC] DFG BackwardsPropagation should be more robust
<a href="https://bugs.webkit.org/show_bug.cgi?id=292318">https://bugs.webkit.org/show_bug.cgi?id=292318</a>
<a href="https://rdar.apple.com/150349703">rdar://150349703</a>

Reviewed by Yijia Huang.

Some of DFG BackwardsPropagation nodes are not properly propagating
flags (e.g. ValueRep). The reason is that DFGSpeculativeJIT etc. is
using NodeBytecodeUsesAsOther flag to select the result format, and
changing these flags from Fixup phase makes it confused. But this is
simply not appropriate: since FixupPhase already set result flags, we
should just use that information in DFGSpeculativeJIT. By refactoring
this part, we can just make DFG BackwardsPropagation sane with these
nodes. We also use bytecodeCanIgnoreNegativeZero in FTLLowerDFGToB3&apos;s
MultiGetByVal with Int52 result since these flags are now appropriately
propagated through this phase.

* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp:
(JSC::DFG::BackwardsPropagationPhase::propagate):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compileGetByVal):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileGetByValImpl):
(JSC::FTL::DFG::LowerDFGToB3::compileMultiGetByVal):

Canonical link: <a href="https://commits.webkit.org/294346@main">https://commits.webkit.org/294346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5120ce46d1a4de5eba08476c5e3df8fb1fe499f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101472 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11442 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106625 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52101 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21445 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29631 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77279 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34309 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104479 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16547 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91638 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57621 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16369 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9657 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51449 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94141 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86237 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9729 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108977 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100082 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28601 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21035 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86250 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28963 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87845 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85816 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30548 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8259 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22722 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16521 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28532 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33812 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/123707 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28343 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34389 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31663 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29902 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->