### PR TITLE
Cease to rely on wtf from WKRetainPtr.h

### DIFF
--- a/Source/WebKit/UIProcess/API/cpp/WKRetainPtr.h
+++ b/Source/WebKit/UIProcess/API/cpp/WKRetainPtr.h
@@ -29,9 +29,10 @@
 
 #include <WebKit/WKType.h>
 #include <algorithm>
-#include <wtf/HashTraits.h>
 
 namespace WebKit {
+
+enum WKRetainPtrHashDeletedValueType { WKRetainPtrDeletedValue = -1 };
 
 template<typename T> class WKRetainPtr {
 public:
@@ -81,7 +82,7 @@ public:
     }
 
     // Hash table deleted values, which are only constructed and never copied or destroyed.
-    WKRetainPtr(WTF::HashTableDeletedValueType)
+    WKRetainPtr(WKRetainPtrHashDeletedValueType)
         : m_ptr(hashTableDeletedValue())
     {
     }
@@ -243,22 +244,10 @@ using WebKit::retainWK;
 namespace WTF {
 
 template<typename> struct IsSmartPtr;
-template<typename> struct DefaultHash;
 
 template<typename T> struct IsSmartPtr<WKRetainPtr<T>> {
     WTF_INTERNAL static const bool value = true;
     WTF_INTERNAL static constexpr bool isNullable = true;
-};
-
-template<typename P> struct DefaultHash<WKRetainPtr<P>> : PtrHash<WKRetainPtr<P>> { };
-
-template<typename P> struct HashTraits<WKRetainPtr<P>> : SimpleClassHashTraits<WKRetainPtr<P>> {
-    static P emptyValue() { return nullptr; }
-    static bool isEmptyValue(const WKRetainPtr<P>& value) { return !value; }
-
-    typedef P PeekType;
-    static PeekType peek(const WKRetainPtr<P>& value) { return value.get(); }
-    static PeekType peek(P value) { return value; }
 };
 
 } // namespace WTF

--- a/Tools/WebKitTestRunner/WKRetainPtrHashSupport.h
+++ b/Tools/WebKitTestRunner/WKRetainPtrHashSupport.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2010 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,13 +23,11 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
+#pragma once
 
-#if WK_HAVE_C_SPI
+#ifdef __cplusplus
 
-#include "PlatformUtilities.h"
 #include <WebKit/WKRetainPtr.h>
-#include <wtf/HashMap.h>
 #include <wtf/HashTraits.h>
 
 namespace WTF {
@@ -51,29 +49,4 @@ template<typename P> struct HashTraits<WKRetainPtr<P>> : GenericHashTraits<WKRet
 
 } // namespace WTF
 
-namespace TestWebKitAPI {
-
-TEST(WebKit, WKRetainPtr)
-{
-    WKRetainPtr<WKStringRef> string1 = adoptWK(WKStringCreateWithUTF8CString("a"));
-    WKRetainPtr<WKStringRef> string2 = adoptWK(WKStringCreateWithUTF8CString("a"));
-    WKRetainPtr<WKStringRef> string3 = adoptWK(WKStringCreateWithUTF8CString("a"));
-    WKRetainPtr<WKStringRef> string4 = adoptWK(WKStringCreateWithUTF8CString("a"));
-
-    HashMap<WKRetainPtr<WKStringRef>, int> map;
-
-    map.set(string2, 2);
-    map.set(string1, 1);
-
-    EXPECT_TRUE(map.contains(string1));
-    EXPECT_TRUE(map.contains(string2));
-    EXPECT_FALSE(map.contains(string3));
-    EXPECT_FALSE(map.contains(string4));
-
-    EXPECT_EQ(1, map.get(string1));
-    EXPECT_EQ(2, map.get(string2));
-}
-
-} // namespace TestWebKitAPI
-
-#endif
+#endif // __cplusplus

--- a/Tools/WebKitTestRunner/WebNotificationProvider.h
+++ b/Tools/WebKitTestRunner/WebNotificationProvider.h
@@ -26,6 +26,8 @@
 #ifndef WebNotificationProvider_h
 #define WebNotificationProvider_h
 
+#include "WKRetainPtrHashSupport.h"
+
 #include <WebKit/WKNotificationManager.h>
 #include <WebKit/WKNotificationProvider.h>
 #include <WebKit/WKRetainPtr.h>


### PR DESCRIPTION
#### 56423be87210442addf3491a55223aecd8d7c490
<pre>
Cease to rely on wtf from WKRetainPtr.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=292321">https://bugs.webkit.org/show_bug.cgi?id=292321</a>

Reviewed by NOBODY (OOPS!).

Swift/C++ interop will build WebKit using clang&apos;s -fmodules option, in which
headers are compiled into abstract syntax trees in their own compilation
context. This means that WebKit&apos;s private framework headers can no longer get
away with referring to wtf headers, since they do not exist in that independent
compilation context.

This PR removes a dependency on wtf/HashTraits.h from WKRetainPtr.h,
by removing hash support from WKRetainPtr and instead keeping it elsewhere
in clients that depend upon wtf already.

Unfortunately, this introduces a little duplication since there are now
two places in the codebase which rely on the combination of WKRetainPtr
and wtf/HashTraits. These places are WebKitTestRunner and TestWebKitAPI,
which don&apos;t currently have a common dependency where we could put the support
code.

Alternatives considered:
* Add a WebKitTestSupport project. Seems excessive just for a few lines
  of WKRetainPtr hash support, but is probably architecturally the correct
  thing to do.
* Remove the use of HashMaps from TestWebKitAPI/Tests/WebKit/WKRetainPtr.cpp.
  This seems viable if the current approach is not OK.
* Retain the hashing support in WKRetainPtr.h, but without depending
  on the trait base classes from wtf/HashTraits. This is also viable
  but results in more code duplication than the current approach.

Overall, the duplication of a few lines of hash support traits seemed the
least complex approach.

Combined changes:
* Source/WebKit/UIProcess/API/cpp/WKRetainPtr.h:
(WebKit::WKRetainPtr::WKRetainPtr):
(WTF::HashTraits&lt;WKRetainPtr&lt;P&gt;&gt;::emptyValue): Deleted.
(WTF::HashTraits&lt;WKRetainPtr&lt;P&gt;&gt;::isEmptyValue): Deleted.
(WTF::HashTraits&lt;WKRetainPtr&lt;P&gt;&gt;::peek): Deleted.
* Tools/TestWebKitAPI/Tests/WebKit/WKRetainPtr.cpp:
(WTF::HashTraits&lt;WKRetainPtr&lt;P&gt;&gt;::constructDeletedValue):
(WTF::HashTraits&lt;WKRetainPtr&lt;P&gt;&gt;::isDeletedValue):
(WTF::HashTraits&lt;WKRetainPtr&lt;P&gt;&gt;::emptyValue):
(WTF::HashTraits&lt;WKRetainPtr&lt;P&gt;&gt;::isEmptyValue):
(WTF::HashTraits&lt;WKRetainPtr&lt;P&gt;&gt;::peek):
* Tools/WebKitTestRunner/WKRetainPtrHashSupport.h: Copied from Tools/TestWebKitAPI/Tests/WebKit/WKRetainPtr.cpp.
(WTF::HashTraits&lt;WKRetainPtr&lt;P&gt;&gt;::constructDeletedValue):
(WTF::HashTraits&lt;WKRetainPtr&lt;P&gt;&gt;::isDeletedValue):
(WTF::HashTraits&lt;WKRetainPtr&lt;P&gt;&gt;::emptyValue):
(WTF::HashTraits&lt;WKRetainPtr&lt;P&gt;&gt;::isEmptyValue):
(WTF::HashTraits&lt;WKRetainPtr&lt;P&gt;&gt;::peek):
* Tools/WebKitTestRunner/WebNotificationProvider.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56423be87210442addf3491a55223aecd8d7c490

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101488 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11458 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106642 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52117 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103528 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29648 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77291 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34320 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104495 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57633 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16383 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9670 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51465 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/86280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9744 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108993 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28617 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21052 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86260 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28979 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87858 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85826 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30560 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8272 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/22741 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28548 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33829 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28359 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31679 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29918 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->