### PR TITLE
Remove a dependency on wtf from WebKit exported headers.

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristic.cpp
+++ b/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristic.cpp
@@ -75,15 +75,15 @@ double FullscreenTouchSecheuristic::distanceScore(const CGPoint& nextLocation, c
         m_parameters.yWeight * pow(m_size.height, 2));
     double scaledDistance = distance / sizeFactor;
     if (scaledDistance <= m_parameters.gammaCutoff)
-        return scaledDistance * (m_parameters.rampUpSpeed / deltaTime);
+        return scaledDistance * (Seconds { m_parameters.rampUpSpeedSeconds } / deltaTime);
 
     double exponentialDistance = m_parameters.gammaCutoff + pow((scaledDistance - m_parameters.gammaCutoff) / (1 - m_parameters.gammaCutoff), m_parameters.gamma);
-    return exponentialDistance * (m_parameters.rampUpSpeed / deltaTime);
+    return exponentialDistance * (Seconds { m_parameters.rampUpSpeedSeconds } / deltaTime);
 }
 
 double FullscreenTouchSecheuristic::attenuationFactor(Seconds delta)
 {
-    double normalizedTimeDelta = delta / m_parameters.rampDownSpeed;
+    double normalizedTimeDelta = delta / Seconds { m_parameters.rampDownSpeedSeconds };
     return std::max(std::min(normalizedTimeDelta * m_weight, 1.0), 0.0);
 }
 

--- a/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristic.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristic.h
@@ -28,6 +28,7 @@
 #ifdef __cplusplus
 
 #include <WebKit/FullscreenTouchSecheuristicParameters.h>
+#include <wtf/Seconds.h>
 
 namespace WebKit {
 
@@ -40,8 +41,8 @@ public:
     void setParameters(const FullscreenTouchSecheuristicParameters& parameters) { m_parameters = parameters; }
     double requiredScore() const { return m_parameters.requiredScore; }
 
-    void setRampUpSpeed(Seconds speed) { m_parameters.rampUpSpeed = speed; }
-    void setRampDownSpeed(Seconds speed) { m_parameters.rampDownSpeed = speed; }
+    void setRampUpSpeed(Seconds speed) { m_parameters.rampUpSpeedSeconds = speed.seconds(); }
+    void setRampDownSpeed(Seconds speed) { m_parameters.rampDownSpeedSeconds = speed.seconds(); }
     void setXWeight(double weight) { m_parameters.xWeight = weight; }
     void setYWeight(double weight) { m_parameters.yWeight = weight; }
     void setSize(CGSize size) { m_size = size; }

--- a/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristicParameters.cpp
+++ b/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristicParameters.cpp
@@ -31,8 +31,8 @@ namespace WebKit {
 FullscreenTouchSecheuristicParameters FullscreenTouchSecheuristicParameters::iosParameters()
 {
     return {
-        .rampUpSpeed = 0.25_s,
-        .rampDownSpeed = 1_s,
+        .rampUpSpeedSeconds = 0.25,
+        .rampDownSpeedSeconds = 1,
         .xWeight = 0,
         .yWeight = 1,
         .gamma = 0.1,

--- a/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristicParameters.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristicParameters.h
@@ -28,13 +28,12 @@
 #ifdef __cplusplus
 
 #include <WebKit/WKDeclarationSpecifiers.h>
-#include <wtf/Seconds.h>
 
 namespace WebKit {
 
 struct FullscreenTouchSecheuristicParameters {
-    Seconds rampUpSpeed;
-    Seconds rampDownSpeed;
+    double rampUpSpeedSeconds;
+    double rampDownSpeedSeconds;
     double xWeight;
     double yWeight;
     double gamma;


### PR DESCRIPTION
#### 6d4ee58077de12ee76f993ad8e0dceba9939f865
<pre>
Remove a dependency on wtf from WebKit exported headers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=292321">https://bugs.webkit.org/show_bug.cgi?id=292321</a>

Reviewed by NOBODY (OOPS!).

As we adopt Swift/C++ interop, we need clang to be able to parse WebKit&apos;s
headers in isolated contexts (&quot;clang modules&quot;).
FullscreenTouchSecheuristicParameters.h was part of WebKit&apos;s private
exported framework headers, but could not be parsed since it relied on
internal wtf headers. This PR breaks that dependency.

* Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristic.cpp:
(WebKit::FullscreenTouchSecheuristic::distanceScore):
(WebKit::FullscreenTouchSecheuristic::attenuationFactor):
* Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristic.h:
(WebKit::FullscreenTouchSecheuristic::setRampUpSpeed):
(WebKit::FullscreenTouchSecheuristic::setRampDownSpeed):
* Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristicParameters.cpp:
(WebKit::FullscreenTouchSecheuristicParameters::iosParameters):
* Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristicParameters.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d4ee58077de12ee76f993ad8e0dceba9939f865

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11459 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106643 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52118 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21462 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/29682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77292 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34321 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16563 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91652 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57634 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16385 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51466 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86253 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9745 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108994 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28618 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21051 "44 flakes 2 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86262 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28980 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87859 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85829 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30562 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8273 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/22742 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28549 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33830 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28360 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31680 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29919 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->