### PR TITLE
[Quirk] Allow users to upload HEIC images on zillow.com

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -703,6 +703,18 @@ bool Quirks::shouldAvoidScrollingWhenFocusedContentIsVisible() const
     return needsQuirks() && m_quirksData.shouldAvoidScrollingWhenFocusedContentIsVisibleQuirk;
 }
 
+// Some input only specify image/* as an acceptable type, which is failing sometimes for certains domain names
+// which do not support HEIC.
+bool Quirks::shouldTranscodeHeicImagesForURL(const URL& url)
+{
+    auto quirksDomain = RegistrableDomain(url);
+    // zillow.com rdar://79872092
+    if (quirksDomain.string() == "zillow.com"_s)
+        return true;
+
+    return false;
+}
+
 // att.com rdar://55185021
 bool Quirks::shouldUseLegacySelectPopoverDismissalBehaviorInDataActivation() const
 {

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -136,6 +136,8 @@ public:
 
     static bool shouldMakeEventListenerPassive(const EventTarget&, const EventTypeInfo&);
 
+    WEBCORE_EXPORT static bool shouldTranscodeHeicImagesForURL(const URL&);
+
 #if ENABLE(MEDIA_STREAM)
     bool shouldEnableLegacyGetUserMediaQuirk() const;
     bool shouldDisableImageCaptureQuirk() const;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10416,8 +10416,16 @@ bool WebPageProxy::didChooseFilesForOpenPanelWithImageTranscoding(const Vector<S
 {
 #if PLATFORM(MAC)
     auto transcodingMIMEType = WebCore::MIMETypeRegistry::preferredImageMIMETypeForEncoding(allowedMIMETypes, { });
-    if (transcodingMIMEType.isNull())
-        return false;
+
+    if (transcodingMIMEType.isNull()) {
+        // For designated sites which are sending "image/*", we need to force the mimetype
+        // to be able to transcode from HEIC to JPEG.
+        if (protectedPreferences()->needsSiteSpecificQuirks()) {
+            if (Quirks::shouldTranscodeHeicImagesForURL(URL { currentURL() }))
+                transcodingMIMEType = "image/jpeg"_s;
+        } else
+            return false;
+    }
 
     auto transcodingURLs = findImagesForTranscoding(fileURLs, allowedMIMETypes);
     if (transcodingURLs.isEmpty())


### PR DESCRIPTION
#### ac5ea97ba27365aafaa79c15b47f935e076d2e51
<pre>
[Quirk] Allow users to upload HEIC images on zillow.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=292041">https://bugs.webkit.org/show_bug.cgi?id=292041</a>
<a href="https://rdar.apple.com/79872092">rdar://79872092</a>

Reviewed by Brent Fulgham.

When users of the zillow websites want to upload an HEIC images,
they get a message saying:

    HEIC format is not supported on web. Please download
    the Zillow Rental Manager App to upload, or convert
    the files to .png, .jpg, .jpeg, or .gif to upload.

WebKit added the possibility to automatically convert the HEIC image
format to one that the site accepts.
<a href="https://github.com/WebKit/WebKit/commit/1fd3fe3f407ad3cbc9fde83b03a9a0641e6d3e58">https://github.com/WebKit/WebKit/commit/1fd3fe3f407ad3cbc9fde83b03a9a0641e6d3e58</a>

The current input on the zillow website is

    &lt;input accept=&quot;image/*&quot; multiple=&quot;&quot; type=&quot;file&quot;&gt;

To benefit from WebKit capability to auto-convert the file
to the format of website choice, it is necessary to specify
in the accept attribute, the accepted format, for example:

    accept=&quot;image/jpeg, image/png, image/gif&quot;

This quirk is forcing for zillow image/jpeg as a conversion target.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldTranscodeHeicImagesForURL):
* Source/WebCore/page/Quirks.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didChooseFilesForOpenPanelWithImageTranscoding):

Canonical link: <a href="https://commits.webkit.org/294726@main">https://commits.webkit.org/294726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/744288cd20e58f1e7758a28a8b5f9b16abc571bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107748 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53224 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104626 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78036 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35012 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17481 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92809 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.RunOpenPanel (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58371 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17320 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10619 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52581 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87129 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10688 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110123 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29719 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21913 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87017 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30083 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88785 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86620 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31442 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9170 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23969 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16688 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29647 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34959 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29458 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32781 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31017 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->