### PR TITLE
[GStreamer] Reduce includes in GStreamerCommon.h

### DIFF
--- a/Source/WTF/wtf/glib/GUniquePtr.h
+++ b/Source/WTF/wtf/glib/GUniquePtr.h
@@ -18,8 +18,7 @@
  *
  */
 
-#ifndef GUniquePtr_h
-#define GUniquePtr_h
+#pragma once
 
 #if USE(GLIB)
 
@@ -143,6 +142,3 @@ using WTF::GUniqueOutPtr;
 using WTF::GFreeDeleter;
 
 #endif // USE(GLIB)
-
-#endif // GUniquePtr_h
-

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -1097,7 +1097,7 @@ GRefPtr<GstPad> GStreamerMediaEndpoint::requestPad(const GRefPtr<GstCaps>& allow
             return false;
 
         bool isTransceiverAssociated = false;
-        for (auto pad : GstIteratorAdaptor<GstPad>(GUniquePtr<GstIterator>(gst_element_iterate_sink_pads(m_webrtcBin.get())))) {
+        for (auto pad : GstIteratorAdaptor<GstPad>(gst_element_iterate_sink_pads(m_webrtcBin.get()))) {
             GRefPtr<GstWebRTCRTPTransceiver> padTransceiver;
             g_object_get(pad, "transceiver", &padTransceiver.outPtr(), nullptr);
             if (padTransceiver.get() == transceiver.get()) {

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.h
@@ -22,6 +22,7 @@
 #if ENABLE(WEB_RTC) && USE(GSTREAMER_WEBRTC)
 
 #include "GRefPtrGStreamer.h"
+#include "GUniquePtrGStreamer.h"
 #include "RTCStatsReport.h"
 
 #include <wtf/CompletionHandler.h>
@@ -30,7 +31,6 @@
 #include <wtf/RefPtr.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/glib/GRefPtr.h>
-#include <wtf/glib/GUniquePtr.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
@@ -24,6 +24,7 @@
 
 #include "GStreamerCommon.h"
 #include "GStreamerVideoSinkCommon.h"
+#include "GUniquePtrGStreamer.h"
 #include "PlatformDisplay.h"
 #include <gst/gl/gl.h>
 #include <wtf/glib/WTFGType.h>

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -24,6 +24,7 @@
 #if USE(GSTREAMER)
 
 #include "ApplicationGLib.h"
+#include "FloatSize.h"
 #include "GLVideoSinkGStreamer.h"
 #include "GStreamerAudioMixer.h"
 #include "GStreamerQuirks.h"
@@ -33,6 +34,7 @@
 #include "GstAllocatorFastMalloc.h"
 #include "IntSize.h"
 #include "PlatformDisplay.h"
+#include "PlatformVideoColorSpace.h"
 #include "SharedBuffer.h"
 #include "VideoSinkGStreamer.h"
 #include "WebKitAudioSinkGStreamer.h"
@@ -43,6 +45,7 @@
 #include <wtf/FileSystem.h>
 #include <wtf/HashMap.h>
 #include <wtf/MallocSpan.h>
+#include <wtf/MediaTime.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/PrintStream.h>
 #include <wtf/RecursiveLockAdapter.h>
@@ -690,6 +693,19 @@ uint64_t toGstUnsigned64Time(const MediaTime& mediaTime)
     if (time.isInvalid())
         return GST_CLOCK_TIME_NONE;
     return time.timeValue();
+}
+
+GstClockTime toGstClockTime(const Seconds& seconds)
+{
+    return toGstClockTime(MediaTime::createWithDouble(seconds.seconds()));
+}
+
+MediaTime fromGstClockTime(GstClockTime time)
+{
+    if (!GST_CLOCK_TIME_IS_VALID(time))
+        return WTF::MediaTime::invalidTime();
+
+    return WTF::MediaTime(GST_TIME_AS_USECONDS(time), G_USEC_PER_SEC);
 }
 
 RefPtr<GstMappedOwnedBuffer> GstMappedOwnedBuffer::create(GRefPtr<GstBuffer>&& buffer)

--- a/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerSkia.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerSkia.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(VIDEO) && USE(GSTREAMER) && USE(SKIA)
 
 #include "NotImplemented.h"
+#include "PlatformVideoColorSpace.h"
 #include <skia/ColorSpaceSkia.h>
 #include <skia/core/SkImage.h>
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -95,7 +95,6 @@
 #include <wtf/URL.h>
 #include <wtf/UniStdExtras.h>
 #include <wtf/WallTime.h>
-#include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/RunLoopSourcePriority.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/CString.h>
@@ -4486,7 +4485,7 @@ std::optional<VideoFrameMetadata> MediaPlayerPrivateGStreamer::videoFrameMetadat
 
 static bool areAllSinksPlayingForBin(GstBin* bin)
 {
-    for (auto* element : GstIteratorAdaptor<GstElement>(GUniquePtr<GstIterator>(gst_bin_iterate_sinks(bin)))) {
+    for (auto* element : GstIteratorAdaptor<GstElement>(gst_bin_iterate_sinks(bin))) {
         if (GST_IS_BIN(element) && !areAllSinksPlayingForBin(GST_BIN_CAST(element)))
             return false;
 
@@ -4521,7 +4520,7 @@ void MediaPlayerPrivateGStreamer::checkPlayingConsistency()
 
 static void applyAudioSinkDevice(GstElement* audioSinkBin, const String& deviceId)
 {
-    for (auto* element : GstIteratorAdaptor<GstElement>(GUniquePtr<GstIterator>(gst_bin_iterate_sinks(GST_BIN_CAST(audioSinkBin))))) {
+    for (auto* element : GstIteratorAdaptor<GstElement>(gst_bin_iterate_sinks(GST_BIN_CAST(audioSinkBin)))) {
         // pulsesink and alsasink have a "device" property, whilst pipewiresink has "target-object"
         if (gstElementMatchesFactoryAndHasProperty(element, "pulsesink"_s, "device"_s) || gstElementMatchesFactoryAndHasProperty(element, "alsasink"_s, "device"_s))
             g_object_set(element, "device", deviceId.utf8().data(), nullptr);

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -30,6 +30,7 @@
 #include "GStreamerCommon.h"
 #include "GStreamerEMEUtilities.h"
 #include "GStreamerQuirks.h"
+#include "GUniquePtrGStreamer.h"
 #include "ImageOrientation.h"
 #include "Logging.h"
 #include "MainThreadNotifier.h"

--- a/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
@@ -25,6 +25,7 @@
 #include "GStreamerCommon.h"
 #include "GStreamerElementHarness.h"
 #include "GStreamerRegistryScanner.h"
+#include "GUniquePtrGStreamer.h"
 #include "VideoEncoderPrivateGStreamer.h"
 #include "VideoFrameGStreamer.h"
 #include <wtf/NeverDestroyed.h>
@@ -278,7 +279,7 @@ String GStreamerInternalVideoEncoder::initialize(const String& codecName)
 {
     GST_DEBUG_OBJECT(m_harness->element(), "Initializing encoder for codec %s", codecName.ascii().data());
     IntSize size { static_cast<int>(m_config.width), static_cast<int>(m_config.height) };
-    if (!videoEncoderSetCodec(WEBKIT_VIDEO_ENCODER(m_harness->element()), codecName, { size }))
+    if (!videoEncoderSetCodec(WEBKIT_VIDEO_ENCODER(m_harness->element()), codecName, size))
         return "Unable to set encoder format"_s;
 
     applyRates();

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -24,6 +24,7 @@
 #if ENABLE(VIDEO) && USE(GSTREAMER)
 
 #include "GStreamerCommon.h"
+#include "GUniquePtrGStreamer.h"
 #include "HTTPHeaderNames.h"
 #include "MediaPlayerPrivateGStreamer.h"
 #include "PlatformMediaResourceLoader.h"

--- a/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.h
@@ -26,7 +26,6 @@
 #include "GStreamerCommon.h"
 #include "SharedBuffer.h"
 #include <gst/gst.h>
-#include <wtf/glib/GSpanExtras.h>
 #include <wtf/text/WTFString.h>
 
 #define WEBCORE_GSTREAMER_EME_UTILITIES_CLEARKEY_UUID "1077efec-c0b2-4d02-ace3-3c1e52e2fb4b"
@@ -77,23 +76,7 @@ class ProtectionSystemEvents {
 public:
     using EventVector = Vector<GRefPtr<GstEvent>>;
 
-    explicit ProtectionSystemEvents(GstMessage* message)
-    {
-        const GstStructure* structure = gst_message_get_structure(message);
-
-        const GValue* streamEncryptionEventsList = gst_structure_get_value(structure, "stream-encryption-events");
-        ASSERT(streamEncryptionEventsList && GST_VALUE_HOLDS_LIST(streamEncryptionEventsList));
-        unsigned numEvents = gst_value_list_get_size(streamEncryptionEventsList);
-        m_events.reserveInitialCapacity(numEvents);
-        for (unsigned i = 0; i < numEvents; ++i)
-            m_events.append(GRefPtr<GstEvent>(static_cast<GstEvent*>(g_value_get_boxed(gst_value_list_get_value(streamEncryptionEventsList, i)))));
-        const GValue* streamEncryptionAllowedSystemsValue = gst_structure_get_value(structure, "available-stream-encryption-systems");
-        auto systemsArray = g_value_get_boxed(streamEncryptionAllowedSystemsValue);
-        if (!systemsArray)
-            return;
-        for (const auto system : span(static_cast<char**>(systemsArray)))
-            m_availableSystems.append(String::fromLatin1(system));
-    }
+    explicit ProtectionSystemEvents(GstMessage*);
     const EventVector& events() const { return m_events; }
     const Vector<String>& availableSystems() const { return m_availableSystems; }
 

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -28,6 +28,7 @@
 #include "CDMProxy.h"
 #include "GStreamerCommon.h"
 #include "GStreamerEMEUtilities.h"
+#include "GUniquePtrGStreamer.h"
 #include <wtf/Condition.h>
 #include <wtf/PrintStream.h>
 #include <wtf/RunLoop.h>

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -20,8 +20,6 @@
 
 #include "config.h"
 #include "AppendPipeline.h"
-#include "AbortableTaskQueue.h"
-#include "MediaSourcePrivateGStreamer.h"
 
 #if ENABLE(VIDEO) && USE(GSTREAMER) && ENABLE(MEDIA_SOURCE)
 
@@ -33,6 +31,7 @@
 #include "InbandTextTrackPrivateGStreamer.h"
 #include "MediaDescription.h"
 #include "MediaSampleGStreamer.h"
+#include "MediaSourcePrivateGStreamer.h"
 #include "SourceBufferPrivateGStreamer.h"
 #include "VideoTrackPrivateGStreamer.h"
 #include <functional>
@@ -495,7 +494,7 @@ void AppendPipeline::didReceiveInitializationSegment()
 
     if (isFirstInitializationSegment) {
         // Create a Track object per pad.
-        for (GstPad* pad : GstIteratorAdaptor<GstPad>(GUniquePtr<GstIterator>(gst_element_iterate_src_pads(m_demux.get())))) {
+        for (GstPad* pad : GstIteratorAdaptor<GstPad>(gst_element_iterate_src_pads(m_demux.get()))) {
             auto [createTrackResult, track] = tryCreateTrackFromPad(pad);
             if (createTrackResult == CreateTrackResult::AppendParsingFailed) {
                 // appendParsingFailed() will immediately cause a resetParserState() which will stop demuxing, then the
@@ -510,7 +509,7 @@ void AppendPipeline::didReceiveInitializationSegment()
         UncheckedKeyHashSet<String> videoPadStreamIDs;
         UncheckedKeyHashSet<String> audioPadStreamIDs;
         UncheckedKeyHashSet<String> textPadStreamIDs;
-        for (auto pad : GstIteratorAdaptor<GstPad>(GUniquePtr<GstIterator>(gst_element_iterate_src_pads(m_demux.get())))) {
+        for (auto pad : GstIteratorAdaptor<GstPad>(gst_element_iterate_src_pads(m_demux.get()))) {
             auto [parsedCaps, streamType, presentationSize] = parseDemuxerSrcPadCaps(adoptGRef(gst_pad_get_current_caps(pad)).get());
             UNUSED_VARIABLE(parsedCaps);
             UNUSED_VARIABLE(presentationSize);
@@ -566,7 +565,7 @@ void AppendPipeline::didReceiveInitializationSegment()
 
         // Link pads to existing Track objects that don't have a linked pad yet. Existing linked
         // tracks are recycled if their stream type matches the new demuxer source pads.
-        for (GstPad* pad : GstIteratorAdaptor<GstPad>(GUniquePtr<GstIterator>(gst_element_iterate_src_pads(m_demux.get())))) {
+        for (GstPad* pad : GstIteratorAdaptor<GstPad>(gst_element_iterate_src_pads(m_demux.get()))) {
             if (!recycleTrackForPad(pad)) {
                 GST_WARNING_OBJECT(pipeline(), "Can't match pad to existing tracks in the AppendPipeline: %" GST_PTR_FORMAT, pad);
                 m_sourceBufferPrivate.appendParsingFailed();

--- a/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
@@ -508,7 +508,7 @@ static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> av1CapsFromCodecString(cons
     return { inputCaps, outputCaps };
 }
 
-std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> GStreamerCodecUtilities::capsFromCodecString(const String& codecString, std::optional<IntSize> size, std::optional<double> frameRate)
+std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> GStreamerCodecUtilities::capsFromCodecString(const String& codecString, const IntSize& size, std::optional<double> frameRate)
 {
     ensureDebugCategoryInitialized();
 
@@ -525,8 +525,8 @@ std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> GStreamerCodecUtilities::capsFromC
             gst_structure_remove_field(structure, "framerate");
         }
 
-        if (size)
-            gst_caps_set_simple(caps.get(), "width", G_TYPE_INT, size->width(), "height", G_TYPE_INT, size->height(), nullptr);
+        if (!size.isEmpty())
+            gst_caps_set_simple(caps.get(), "width", G_TYPE_INT, size.width(), "height", G_TYPE_INT, size.height(), nullptr);
         else if (!gst_caps_is_any(caps.get()) && !gst_caps_is_empty(caps.get())) {
             auto structure = gst_caps_get_structure(caps.get(), 0);
             gst_structure_remove_fields(structure, "width", "height", nullptr);

--- a/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.h
@@ -31,7 +31,7 @@ namespace GStreamerCodecUtilities {
 
 std::pair<const char*, const char*> parseH264ProfileAndLevel(const String& codec);
 const char* parseHEVCProfile(const String& codec);
-std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> capsFromCodecString(const String&, std::optional<IntSize> = std::nullopt, std::optional<double> frameRate = std::nullopt);
+std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> capsFromCodecString(const String&, const IntSize&, std::optional<double> frameRate = std::nullopt);
 
 } // namespace GStreamerCodecUtilities
 

--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
@@ -23,6 +23,7 @@
 #if USE(GSTREAMER)
 
 #include "GStreamerCommon.h"
+#include "GUniquePtrGStreamer.h"
 
 #include <wtf/FileSystem.h>
 #include <wtf/PrintStream.h>
@@ -615,17 +616,17 @@ void MermaidBuilder::dumpElement(GStreamerElementHarness& harness, GstElement* e
     m_stringBuilder.append("subgraph "_s, elementId, " [<center>"_s, unsafeSpan(G_OBJECT_TYPE_NAME(element)), "\\n<small>"_s, unsafeSpan(GST_ELEMENT_NAME(element)), "]\n"_s);
 
     if (GST_IS_BIN(element)) {
-        for (auto element : GstIteratorAdaptor<GstElement>(GUniquePtr<GstIterator>(gst_bin_iterate_recurse(GST_BIN_CAST(element)))))
+        for (auto element : GstIteratorAdaptor<GstElement>(gst_bin_iterate_recurse(GST_BIN_CAST(element))))
             dumpElement(harness, element);
     }
 
     GRefPtr<GstPad> firstSinkPad, firstSrcPad;
-    for (auto pad : GstIteratorAdaptor<GstPad>(GUniquePtr<GstIterator>(gst_element_iterate_sink_pads(element)))) {
+    for (auto pad : GstIteratorAdaptor<GstPad>(gst_element_iterate_sink_pads(element))) {
         if (!firstSinkPad)
             firstSinkPad = pad;
         dumpPad(harness, pad);
     }
-    for (auto pad : GstIteratorAdaptor<GstPad>(GUniquePtr<GstIterator>(gst_element_iterate_src_pads(element)))) {
+    for (auto pad : GstIteratorAdaptor<GstPad>(gst_element_iterate_src_pads(element))) {
         if (!firstSrcPad)
             firstSrcPad = pad;
         dumpPad(harness, pad);

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcomBase.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcomBase.cpp
@@ -137,7 +137,7 @@ void GStreamerQuirkBroadcomBase::setupBufferingPercentageCorrection(MediaPlayerP
         if (alsoGetMultiqueue && !state.m_multiqueue) {
             // Also get the multiqueue (if there's one) attached to the vidfilter/aacparse+audfilter.
             // We'll need it later to correct the buffering level.
-            for (auto* sinkPad : GstIteratorAdaptor<GstPad>(GUniquePtr<GstIterator>(gst_element_iterate_sink_pads(element.get())))) {
+            for (auto* sinkPad : GstIteratorAdaptor<GstPad>(gst_element_iterate_sink_pads(element.get()))) {
                 GRefPtr<GstPad> peerSrcPad = adoptGRef(gst_pad_get_peer(sinkPad));
                 if (!peerSrcPad)
                     continue; // And end the loop, because there's only one srcpad.
@@ -145,7 +145,7 @@ void GStreamerQuirkBroadcomBase::setupBufferingPercentageCorrection(MediaPlayerP
 
                 // If it's NOT a multiqueue, it's probably a parser like aacparse. We try to traverse before it.
                 if (peerElement && g_strcmp0(G_OBJECT_TYPE_NAME(element.get()), "GstMultiQueue")) {
-                    for (auto* peerElementSinkPad : GstIteratorAdaptor<GstPad>(GUniquePtr<GstIterator>(gst_element_iterate_sink_pads(peerElement.get())))) {
+                    for (auto* peerElementSinkPad : GstIteratorAdaptor<GstPad>(gst_element_iterate_sink_pads(peerElement.get()))) {
                         peerSrcPad = adoptGRef(gst_pad_get_peer(peerElementSinkPad));
                         if (!peerSrcPad)
                             continue; // And end the loop.

--- a/Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp
@@ -34,6 +34,7 @@
 #include "PlatformSpeechSynthesisVoice.h"
 #include "WebKitAudioSinkGStreamer.h"
 #include "WebKitFliteSourceGStreamer.h"
+#include <wtf/MediaTime.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
@@ -25,6 +25,8 @@
 
 #include "GStreamerCodecUtilities.h"
 #include "GStreamerCommon.h"
+#include "GUniquePtrGStreamer.h"
+#include "IntSize.h"
 #include "NotImplemented.h"
 #include <wtf/StdMap.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -488,11 +490,11 @@ EncoderId videoEncoderFindForFormat([[maybe_unused]] WebKitVideoEncoder* self, c
 
 bool videoEncoderSupportsCodec(WebKitVideoEncoder* self, const String& codecName)
 {
-    auto [_, outputCaps] = GStreamerCodecUtilities::capsFromCodecString(codecName);
+    auto [_, outputCaps] = GStreamerCodecUtilities::capsFromCodecString(codecName, { });
     return videoEncoderFindForFormat(self, outputCaps) != None;
 }
 
-bool videoEncoderSetCodec(WebKitVideoEncoder* self, const String& codecName, std::optional<IntSize> size, std::optional<double> frameRate)
+bool videoEncoderSetCodec(WebKitVideoEncoder* self, const String& codecName, const IntSize& size, std::optional<double> frameRate)
 {
     auto [inputCaps, outputCaps] = GStreamerCodecUtilities::capsFromCodecString(codecName, size, frameRate);
     GST_DEBUG_OBJECT(self, "Input caps: %" GST_PTR_FORMAT, inputCaps.get());

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.h
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.h
@@ -87,6 +87,6 @@ private:
 };
 
 bool videoEncoderSupportsCodec(WebKitVideoEncoder*, const String&);
-bool videoEncoderSetCodec(WebKitVideoEncoder*, const String&, std::optional<WebCore::IntSize> = std::nullopt, std::optional<double> frameRate = std::nullopt);
+bool videoEncoderSetCodec(WebKitVideoEncoder*, const String&, const WebCore::IntSize&, std::optional<double> frameRate = std::nullopt);
 void videoEncoderSetBitRateAllocation(WebKitVideoEncoder*, RefPtr<WebKitVideoEncoderBitRateAllocation>&&);
 void teardownVideoEncoderSingleton();

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
@@ -27,6 +27,7 @@
 #include "GStreamerCommon.h"
 #include "GStreamerMediaStreamSource.h"
 #include "GStreamerRegistryScanner.h"
+#include "IntSize.h"
 #include "MediaRecorderPrivateOptions.h"
 #include "MediaStreamPrivate.h"
 #include "VideoEncoderPrivateGStreamer.h"
@@ -317,7 +318,7 @@ GRefPtr<GstEncodingContainerProfile> MediaRecorderPrivateBackend::containerProfi
             }
         } else
             m_videoCodec = codecs.first();
-        auto [_, videoCaps] = GStreamerCodecUtilities::capsFromCodecString(m_videoCodec);
+        auto [_, videoCaps] = GStreamerCodecUtilities::capsFromCodecString(m_videoCodec, { });
         GST_DEBUG("Creating video encoding profile for caps %" GST_PTR_FORMAT, videoCaps.get());
         m_videoEncodingProfile = adoptGRef(GST_ENCODING_PROFILE(gst_encoding_video_profile_new(videoCaps.get(), nullptr, nullptr, 1)));
         gst_encoding_container_profile_add_profile(profile.get(), m_videoEncodingProfile.get());
@@ -426,7 +427,7 @@ void MediaRecorderPrivateBackend::configureAudioEncoder(GstElement* element)
 
 void MediaRecorderPrivateBackend::configureVideoEncoder(GstElement* element)
 {
-    videoEncoderSetCodec(WEBKIT_VIDEO_ENCODER(element), m_videoCodec);
+    videoEncoderSetCodec(WEBKIT_VIDEO_ENCODER(element), m_videoCodec, { });
 
     auto bitrate = [options = m_options]() -> unsigned {
         if (options.videoBitsPerSecond)

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.h
@@ -28,6 +28,7 @@
 #include <wtf/Condition.h>
 #include <wtf/Forward.h>
 #include <wtf/Lock.h>
+#include <wtf/MediaTime.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -60,7 +60,7 @@
 #include <wtf/text/WTFString.h>
 
 #if USE(GSTREAMER)
-#include "GUniquePtrGStreamer.h"
+#include <gst/gststructure.h>
 #include <wtf/glib/GRefPtr.h>
 #endif
 
@@ -145,7 +145,7 @@ public:
         virtual void videoFrameAvailable(VideoFrame&, VideoFrameTimeMetadata) = 0;
 
 #if USE(GSTREAMER_WEBRTC)
-        virtual GUniquePtr<GstStructure> queryAdditionalStats() { return nullptr; }
+        virtual /* transfer full */ GstStructure* queryAdditionalStats() { return nullptr; }
 #endif
     };
 

--- a/Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.h
@@ -25,6 +25,7 @@
 #include <gio/gio.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
+#include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/WTFGType.h>

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
@@ -26,6 +26,7 @@
 #include "GStreamerAudioCapturer.h"
 
 #include <gst/app/gstappsink.h>
+#include <wtf/MediaTime.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.h
@@ -26,6 +26,10 @@
 
 #include "GStreamerCapturer.h"
 
+namespace WTF {
+class MediaTime;
+}
+
 namespace WebCore {
 
 class GStreamerAudioCapturer final : public GStreamerCapturer {
@@ -39,7 +43,7 @@ public:
 
     bool setSampleRate(int);
 
-    using SinkAudioDataCallback = Function<void(GRefPtr<GstSample>&&, MediaTime&&)>;
+    using SinkAudioDataCallback = Function<void(GRefPtr<GstSample>&&, WTF::MediaTime&&)>;
     void setSinkAudioCallback(SinkAudioDataCallback&&);
 
 private:

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
@@ -27,6 +27,7 @@
 #include "GStreamerCommon.h"
 #include "GStreamerMockDeviceProvider.h"
 #include <wtf/glib/GSpanExtras.h>
+#include <wtf/glib/GUniquePtr.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h
@@ -29,6 +29,7 @@
 #include "GStreamerCaptureDevice.h"
 #include "GStreamerCapturer.h"
 #include "GStreamerVideoCapturer.h"
+#include "GUniquePtrGStreamer.h"
 #include "PipeWireCaptureDevice.h"
 #include "PipeWireCaptureDeviceManager.h"
 #include "RealtimeMediaSourceCenter.h"

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerDisplayCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerDisplayCaptureDeviceManager.cpp
@@ -27,6 +27,7 @@
 #include "GStreamerVideoCaptureSource.h"
 #include "PipeWireCaptureDevice.h"
 #include <wtf/UUID.h>
+#include <wtf/glib/GUniquePtr.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h
@@ -22,6 +22,7 @@
 
 #include "GStreamerMediaEndpoint.h"
 #include "GStreamerWebRTCCommon.h"
+#include "GUniquePtrGStreamer.h"
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -576,7 +576,7 @@ public:
         return m_eosPending;
     }
 
-    GUniquePtr<GstStructure> queryAdditionalStats()
+    GstStructure* queryAdditionalStats() final
     {
         GUniquePtr<GstStructure> stats;
         auto query = adoptGRef(gst_query_new_custom(GST_QUERY_CUSTOM, gst_structure_new_empty("webkit-video-decoder-stats")));
@@ -588,7 +588,7 @@ public:
             stats.reset(gst_structure_new_empty("webkit-video-decoder-stats"));
 
         gst_structure_set(stats.get(), "track-identifier", G_TYPE_STRING, m_track->id().utf8().data(), nullptr);
-        return stats;
+        return stats.release();
     }
 
     bool isEnded() const { return m_isEnded; }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp
@@ -25,6 +25,7 @@
 
 #include "CaptureDevice.h"
 #include "GStreamerCommon.h"
+#include "GUniquePtrGStreamer.h"
 #include <wtf/glib/WTFGType.h>
 
 using namespace WebCore;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp
@@ -24,6 +24,7 @@
 #if ENABLE(MEDIA_STREAM) && USE(GSTREAMER)
 
 #include "GStreamerMockDevice.h"
+#include "GUniquePtrGStreamer.h"
 #include "MockRealtimeMediaSourceCenter.h"
 #include <wtf/glib/WTFGType.h>
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h
@@ -25,6 +25,7 @@
 #if ENABLE(MEDIA_STREAM) && USE(GSTREAMER)
 
 #include "GStreamerCapturer.h"
+#include "IntSize.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
@@ -26,6 +26,7 @@
 #include "GStreamerCommon.h"
 #include "GStreamerRegistryScanner.h"
 #include "HEVCUtilities.h"
+#include "IntSize.h"
 #include "VP9Utilities.h"
 #include "VideoEncoderPrivateGStreamer.h"
 #include <gst/rtp/rtp.h>
@@ -122,7 +123,7 @@ RefPtr<GStreamerVideoRTPPacketizer> GStreamerVideoRTPPacketizer::create(RefPtr<U
         payloadType = gstStructureGet<int>(encodingParameters.get(), "payload"_s);
 
     GRefPtr<GstElement> encoder = gst_element_factory_make("webkitvideoencoder", nullptr);
-    if (!videoEncoderSetCodec(WEBKIT_VIDEO_ENCODER(encoder.get()), WTFMove(codec))) {
+    if (!videoEncoderSetCodec(WEBKIT_VIDEO_ENCODER(encoder.get()), WTFMove(codec), { })) {
         GST_ERROR("Unable to set encoder format");
         return nullptr;
     }

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp
@@ -27,6 +27,7 @@
 #include "MockRealtimeVideoSourceGStreamer.h"
 
 #include "GStreamerCaptureDeviceManager.h"
+#include "IntSize.h"
 #include "MockRealtimeMediaSourceCenter.h"
 #include "PixelBuffer.h"
 #include "VideoFrameGStreamer.h"

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp
@@ -24,6 +24,7 @@
 
 #include "GStreamerCommon.h"
 #include "GStreamerWebRTCUtils.h"
+#include "GUniquePtrGStreamer.h"
 #include "VideoFrameGStreamer.h"
 #include <wtf/text/MakeString.h>
 
@@ -110,7 +111,7 @@ const GstStructure* RealtimeIncomingVideoSourceGStreamer::stats()
     m_stats.reset(gst_structure_new_empty("incoming-video-stats"));
 
     forEachVideoFrameObserver([&](auto& observer) {
-        auto stats = observer.queryAdditionalStats();
+        GUniquePtr<GstStructure> stats(observer.queryAdditionalStats());
         if (!stats)
             return;
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp
@@ -31,6 +31,8 @@
 
 #include <WebCore/GStreamerCodecUtilities.h>
 #include <WebCore/GStreamerCommon.h>
+#include <WebCore/GUniquePtrGStreamer.h>
+#include <WebCore/IntSize.h>
 #include <wtf/text/MakeString.h>
 
 using namespace WebCore;
@@ -151,7 +153,7 @@ TEST_F(GStreamerTest, capsFromCodecString)
     using namespace GStreamerCodecUtilities;
 
 #define TEST_CAPS_FROM_CODEC(codecString, expectedInputFormat, expectedOutputCaps) G_STMT_START { \
-        auto [input, output] = capsFromCodecString(codecString);        \
+        auto [input, output] = capsFromCodecString(codecString, { });   \
         auto inputStructure = gst_caps_get_structure(input.get(), 0);   \
         const char* inputFormat = gst_structure_get_string(inputStructure, "format"); \
         ASSERT_STREQ(inputFormat, expectedInputFormat);                 \
@@ -160,7 +162,7 @@ TEST_F(GStreamerTest, capsFromCodecString)
     } G_STMT_END
 
 #define TEST_CAPS_FROM_CODEC_FULL(codecString, expectedInputCaps, expectedOutputCaps) G_STMT_START { \
-        auto [input, output] = capsFromCodecString(codecString);        \
+        auto [input, output] = capsFromCodecString(codecString, { });   \
         GUniquePtr<char> inputCaps(gst_caps_to_string(input.get()));    \
         ASSERT_STREQ(inputCaps.get(), expectedInputCaps);               \
         GUniquePtr<char> outputCaps(gst_caps_to_string(output.get()));  \

--- a/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp
@@ -33,6 +33,7 @@
 #include <WebCore/GStreamerElementHarness.h>
 #include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
+#include <wtf/glib/GUniquePtr.h>
 
 using namespace WebCore;
 
@@ -318,7 +319,7 @@ TEST_F(GStreamerTest, harnessDecodeMP4Video)
     GRefPtr<GstElement> element = gst_element_factory_make("decodebin3", nullptr);
 
     // Disable internal buffering in decodebin3.
-    for (auto child : GstIteratorAdaptor<GstElement>(GUniquePtr<GstIterator>(gst_bin_iterate_recurse(GST_BIN_CAST(element.get()))))) {
+    for (auto child : GstIteratorAdaptor<GstElement>(gst_bin_iterate_recurse(GST_BIN_CAST(element.get())))) {
         if (g_str_has_prefix(GST_OBJECT_NAME(GST_OBJECT_CAST(child)), "multiqueue")) {
             g_object_set(child, "max-size-buffers", 1, nullptr);
             break;


### PR DESCRIPTION
#### 324c2ca1c8562b656b0258b1bedb97789cf48311
<pre>
[GStreamer] Reduce includes in GStreamerCommon.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=292323">https://bugs.webkit.org/show_bug.cgi?id=292323</a>

Reviewed by Xabier Rodriguez-Calvar.

Several inline functions had to move to the cpp unit and the IteratorAdaptor dependency on
GUniquePtr was removed, so that GUniquePtrGStreamer no longer needs to be included in
GStreamerCommon.h. The VideoFrameObserver::queryAdditionalStats() return value was also adapted for
the same reason.

Several fly-by changes are included:

- Use #pragma once in GUniquePtr.h.
- IntSize parameters in the encoder and codec utilities were switched from std::optional to const
  references so that IntSize can be forward-declared in the involved header files.
- MediaTime.h includes were reduced where forward declarations were possible.

* Source/WTF/wtf/glib/GUniquePtr.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::requestPad):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::toGstClockTime):
(WebCore::fromGstClockTime):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
(WebCore::toGstClockTime):
(GstIteratorAdaptor::GstIteratorAdaptor):
(GstIteratorAdaptor::~GstIteratorAdaptor):
(GstIteratorAdaptor::begin):
(GstIteratorAdaptor::end):
(WebCore::fromGstClockTime): Deleted.
* Source/WebCore/platform/graphics/gstreamer/ImageGStreamerSkia.cpp:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::areAllSinksPlayingForBin):
(WebCore::applyAudioSinkDevice):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp:
(WebCore::GStreamerInternalVideoEncoder::initialize):
* Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.cpp:
(WebCore::ProtectionSystemEvents::ProtectionSystemEvents):
* Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.h:
(WebCore::ProtectionSystemEvents::ProtectionSystemEvents): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::didReceiveInitializationSegment):
* Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp:
(WebCore::GStreamerCodecUtilities::capsFromCodecString):
* Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.h:
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp:
(WebCore::MermaidBuilder::dumpElement):
* Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcomBase.cpp:
(WebCore::GStreamerQuirkBroadcomBase::setupBufferingPercentageCorrection const):
* Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp:
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(videoEncoderSupportsCodec):
(videoEncoderSetCodec):
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp:
(WebCore::MediaRecorderPrivateBackend::containerProfile):
(WebCore::MediaRecorderPrivateBackend::configureVideoEncoder):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerDisplayCaptureDeviceManager.cpp:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp:
(WebCore::GStreamerVideoRTPPacketizer::create):
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp:
(WebCore::RealtimeIncomingVideoSourceGStreamer::stats):
* Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp:
(TestWebKitAPI::TEST_F(GStreamerTest, capsFromCodecString)):
* Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp:
(TestWebKitAPI::TEST_F(GStreamerTest, harnessDecodeMP4Video)):

Canonical link: <a href="https://commits.webkit.org/294615@main">https://commits.webkit.org/294615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d33a5fcc9af39c119124c8538bfd497a446c1ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107607 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53083 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104485 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22423 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77942 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34933 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17370 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92473 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58279 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17207 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10501 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52440 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/95117 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87024 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10572 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109982 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/101055 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21811 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86921 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29942 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86514 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22012 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31340 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9061 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23823 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29506 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34809 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124689 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29317 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34599 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32640 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30876 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->