### PR TITLE
[WPE] WPE Platform: add clipboard support

### DIFF
--- a/Source/WebKit/Shared/wpe/GRefPtrWPE.cpp
+++ b/Source/WebKit/Shared/wpe/GRefPtrWPE.cpp
@@ -45,6 +45,19 @@ template <> void derefGPtr(WPEEvent* ptr)
         wpe_event_unref(ptr);
 }
 
+template <> WPEClipboardContent* refGPtr(WPEClipboardContent* ptr)
+{
+    if (ptr)
+        wpe_clipboard_content_ref(ptr);
+    return ptr;
+}
+
+template <> void derefGPtr(WPEClipboardContent* ptr)
+{
+    if (ptr)
+        wpe_clipboard_content_unref(ptr);
+}
+
 } // namespace WTF
 
 #endif // ENABLE(WPE_PLATFORM)

--- a/Source/WebKit/Shared/wpe/GRefPtrWPE.h
+++ b/Source/WebKit/Shared/wpe/GRefPtrWPE.h
@@ -30,11 +30,15 @@
 #include <wtf/glib/GRefPtr.h>
 
 typedef struct _WPEEvent WPEEvent;
+typedef struct _WPEClipboardContent WPEClipboardContent;
 
 namespace WTF {
 
 template <> WPEEvent* refGPtr(WPEEvent*);
 template <> void derefGPtr(WPEEvent*);
+
+template <> WPEClipboardContent* refGPtr(WPEClipboardContent*);
+template <> void derefGPtr(WPEClipboardContent*);
 
 } // namespace WTF
 

--- a/Source/WebKit/WPEPlatform/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/CMakeLists.txt
@@ -11,15 +11,16 @@ configure_file(wpe/WPEConfig.h.in ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/WPEConf
 configure_file(wpe/WPEVersion.h.in ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/WPEVersion.h)
 
 set(WPEPlatform_SOURCES
-    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEEvent.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBuffer.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferDMABuf.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferDMABufFormats.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferSHM.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEClipboard.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEColor.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPECursorTheme.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEDisplay.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEEGLError.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEEvent.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEExtensions.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEInputMethodContext.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEInputMethodContextNone.cpp
@@ -40,15 +41,16 @@ set(WPEPlatform_SOURCES
 )
 
 set(WPEPlatform_INSTALLED_HEADERS
-    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEEvent.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBuffer.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferDMABuf.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferDMABufFormats.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferSHM.h
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEClipboard.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEColor.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEDefines.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEDisplay.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEEGLError.h
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEEvent.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEInputMethodContext.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeyUnicode.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeymap.h

--- a/Source/WebKit/WPEPlatform/wpe/WPEClipboard.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEClipboard.cpp
@@ -1,0 +1,464 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEClipboard.h"
+
+#include "WPEDisplay.h"
+#include <optional>
+#include <wtf/FastMalloc.h>
+#include <wtf/HashMap.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GWeakPtr.h>
+#include <wtf/glib/WTFGType.h>
+#include <wtf/text/CString.h>
+
+/**
+ * WPEClipboard:
+ *
+ */
+struct _WPEClipboardPrivate {
+    GWeakPtr<WPEDisplay> display;
+    int64_t changeCount;
+    bool isLocal;
+    WPEClipboardContent* content;
+    GRefPtr<GPtrArray> formats;
+};
+WEBKIT_DEFINE_TYPE(WPEClipboard, wpe_clipboard, G_TYPE_OBJECT)
+
+struct _WPEClipboardContent {
+    std::optional<CString> text;
+    std::optional<CString> markup;
+    std::optional<HashMap<const char*, GRefPtr<GBytes>>> buffers;
+    int referenceCount { 1 };
+};
+G_DEFINE_BOXED_TYPE(WPEClipboardContent, wpe_clipboard_content, wpe_clipboard_content_ref, wpe_clipboard_content_unref)
+
+enum {
+    PROP_0,
+
+    PROP_DISPLAY,
+    PROP_CHANGE_COUNT,
+
+    N_PROPERTIES
+};
+
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
+
+static void wpeClipboardDispose(GObject* object)
+{
+    auto* clipboard = WPE_CLIPBOARD(object);
+
+    g_clear_pointer(&clipboard->priv->content, wpe_clipboard_content_unref);
+
+    G_OBJECT_CLASS(wpe_clipboard_parent_class)->dispose(object);
+}
+
+static void wpeClipboardSetProperty(GObject* object, guint propId, const GValue* value, GParamSpec* paramSpec)
+{
+    auto* clipboard = WPE_CLIPBOARD(object);
+
+    switch (propId) {
+    case PROP_DISPLAY:
+        clipboard->priv->display.reset(WPE_DISPLAY(g_value_get_object(value)));
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
+    }
+}
+
+static void wpeClipboardGetProperty(GObject* object, guint propId, GValue* value, GParamSpec* paramSpec)
+{
+    auto* clipboard = WPE_CLIPBOARD(object);
+
+    switch (propId) {
+    case PROP_DISPLAY:
+        g_value_set_object(value, wpe_clipboard_get_display(clipboard));
+        break;
+    case PROP_CHANGE_COUNT:
+        g_value_set_int64(value, wpe_clipboard_get_change_count(clipboard));
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
+    }
+}
+
+static void wpeClipboardChanged(WPEClipboard* clipboard, GPtrArray* formats, gboolean isLocal, WPEClipboardContent* content)
+{
+    auto* priv = clipboard->priv;
+    priv->isLocal = isLocal;
+    priv->formats = formats;
+    g_clear_pointer(&priv->content, wpe_clipboard_content_unref);
+    priv->content = content ? wpe_clipboard_content_ref(content) : nullptr;
+
+    priv->changeCount++;
+    g_object_notify_by_pspec(G_OBJECT(clipboard), sObjProperties[PROP_CHANGE_COUNT]);
+}
+
+static void wpe_clipboard_class_init(WPEClipboardClass* clipboardClass)
+{
+    GObjectClass* objectClass = G_OBJECT_CLASS(clipboardClass);
+    objectClass->dispose = wpeClipboardDispose;
+    objectClass->set_property = wpeClipboardSetProperty;
+    objectClass->get_property = wpeClipboardGetProperty;
+
+    clipboardClass->changed = wpeClipboardChanged;
+
+    /**
+     * WPEClipboard:display:
+     *
+     * The #WPEDisplay of the clipboard.
+     */
+    sObjProperties[PROP_DISPLAY] =
+        g_param_spec_object(
+            "display",
+            nullptr, nullptr,
+            WPE_TYPE_DISPLAY,
+            static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+
+    /**
+     * WPEClipboard:change-count:
+     *
+     * A counter of changes in the clipboard.
+     */
+    sObjProperties[PROP_CHANGE_COUNT] =
+        g_param_spec_int64(
+            "change-count",
+            nullptr, nullptr,
+            0, G_MAXINT64, 0,
+            WEBKIT_PARAM_READABLE);
+
+    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties.data());
+}
+
+/**
+ * wpe_clipboard_new:
+ * @display: a #WPEDisplay
+ *
+ * Create a new #WPEClipboard for @display. The clipboard created is always local, so its
+ * contents are not shared with other applications.
+ *
+ * Returns: (transfer full): a new #WPEClipboard
+ */
+WPEClipboard* wpe_clipboard_new(WPEDisplay* display)
+{
+    g_return_val_if_fail(WPE_IS_DISPLAY(display), nullptr);
+
+    return WPE_CLIPBOARD(g_object_new(WPE_TYPE_CLIPBOARD, "display", display, nullptr));
+}
+
+/**
+ * wpe_clipboard_get_display:
+ * @clipboard: a #WPEClipoard
+ *
+ * Get the #WPEDisplay of @clipboard
+ *
+ * Returns: (transfer none): a #WPEDisplay
+ */
+WPEDisplay* wpe_clipboard_get_display(WPEClipboard* clipboard)
+{
+    g_return_val_if_fail(WPE_IS_CLIPBOARD(clipboard), nullptr);
+
+    return clipboard->priv->display.get();
+}
+
+/**
+ * wpe_clipboard_get_change_count:
+ * @clipboard: a #WPEClipoard
+ *
+ * Get the amount of times @clipboard changed since it was created.
+ *
+ * Returns: the change count
+ */
+gint64 wpe_clipboard_get_change_count(WPEClipboard* clipboard)
+{
+    g_return_val_if_fail(WPE_IS_CLIPBOARD(clipboard), -1);
+
+    return clipboard->priv->changeCount;
+}
+
+/**
+ * wpe_clipboard_get_formats:
+ * @clipboard: a #WPEClipoard
+ *
+ * Get the formats that clipboard can provide
+ *
+ * Returns: (array zero-terminated=1) (element-type utf8) (transfer none): A %NULL-terminated
+ *    array of formats, or %NULL if clipboard is empty.
+ */
+const char* const* wpe_clipboard_get_formats(WPEClipboard* clipboard)
+{
+    g_return_val_if_fail(WPE_IS_CLIPBOARD(clipboard), nullptr);
+
+    auto* priv = clipboard->priv;
+    return priv->formats ? reinterpret_cast<char**>(priv->formats->pdata) : nullptr;
+}
+
+/**
+ * wpe_clipboard_set_content:
+ * @clipboard: a #WPEClipoard
+ * @content: (transfer none) (nullable): a #WPEClipboardContent, or %NULL to clear the clipboard
+ *
+ * Set @content on @clipboard. Passing a %NULL @content will clear the @clipboard.
+ *
+ * If the @clipboard is not local-only the contents will be advertised to the system
+ * clipboard.
+ */
+void wpe_clipboard_set_content(WPEClipboard* clipboard, WPEClipboardContent* content)
+{
+    g_return_if_fail(WPE_IS_CLIPBOARD(clipboard));
+
+    GRefPtr<GPtrArray> formats;
+    if (content) {
+        formats = adoptGRef(g_ptr_array_new());
+        if (content->text) {
+            g_ptr_array_add(formats.get(), static_cast<gpointer>(const_cast<char*>(g_intern_static_string("text/plain"))));
+            g_ptr_array_add(formats.get(), static_cast<gpointer>(const_cast<char*>(g_intern_static_string("text/plain;charset=utf-8"))));
+        }
+        if (content->markup)
+            g_ptr_array_add(formats.get(), static_cast<gpointer>(const_cast<char*>(g_intern_static_string("text/html"))));
+        if (content->buffers) {
+            for (const auto* format : content->buffers->keys())
+                g_ptr_array_add(formats.get(), static_cast<gpointer>(const_cast<char*>(format)));
+        }
+        g_ptr_array_add(formats.get(), nullptr);
+    }
+
+    WPE_CLIPBOARD_GET_CLASS(clipboard)->changed(clipboard, formats.get(), TRUE, content);
+}
+
+/**
+ * wpe_clipboard_get_content:
+ * @clipboard: a #WPEClipoard
+ *
+ * Get the #WPEClipboardContent previously set with wpe_clipboard_set_content().
+ * This function returns %NULL if @clipboard is empty or its contents are owned
+ * by the system clipboard.
+ *
+ * Returns: (transfer none) (nullable): a #WPEClipboardContent or %NULL
+ */
+WPEClipboardContent* wpe_clipboard_get_content(WPEClipboard* clipboard)
+{
+    g_return_val_if_fail(WPE_IS_CLIPBOARD(clipboard), nullptr);
+
+    return clipboard->priv->content;
+}
+
+/**
+ * wpe_clipboard_read_bytes:
+ * @clipboard: a #WPEClipoard
+ * @format: the format of the text to read
+ *
+ * Get the contents of @clipboard for the given @format as bytes.
+ *
+ * Returns: (transfer full) (nullable): a new #GBytes, or %NULL
+ */
+GBytes* wpe_clipboard_read_bytes(WPEClipboard* clipboard, const char* format)
+{
+    g_return_val_if_fail(WPE_IS_CLIPBOARD(clipboard), nullptr);
+    g_return_val_if_fail(format && *format, nullptr);
+
+    auto* priv = clipboard->priv;
+    const auto* internalFormat = g_intern_string(format);
+    if (!priv->formats || !g_ptr_array_find(priv->formats.get(), internalFormat, nullptr))
+        return nullptr;
+
+    if (priv->isLocal) {
+        if (!priv->content)
+            return nullptr;
+
+        GRefPtr<GOutputStream> stream = adoptGRef(g_memory_output_stream_new_resizable());
+        if (!wpe_clipboard_content_serialize(priv->content, format, stream.get()))
+            return nullptr;
+
+        g_output_stream_close(stream.get(), nullptr, nullptr);
+        return g_memory_output_stream_steal_as_bytes(G_MEMORY_OUTPUT_STREAM(stream.get()));
+    }
+
+    auto* clipboardClass = WPE_CLIPBOARD_GET_CLASS(clipboard);
+    if (clipboardClass->read)
+        return clipboardClass->read(clipboard, format);
+
+    return nullptr;
+}
+
+/**
+ * wpe_clipboard_read_text:
+ * @clipboard: a #WPEClipoard
+ * @format: the format of the text to read
+ * @size: (out) (optional): location to return size of returned text.
+ *
+ * Get the contents of @clipboard for the given @format as text.
+ *
+ * Returns: (transfer full) (nullable): a new allocated string.
+ */
+char* wpe_clipboard_read_text(WPEClipboard* clipboard, const char* format, gsize* size)
+{
+    g_return_val_if_fail(WPE_IS_CLIPBOARD(clipboard), nullptr);
+    g_return_val_if_fail(format && *format, nullptr);
+
+    if (auto* bytes = wpe_clipboard_read_bytes(clipboard, format))
+        return static_cast<char*>(g_bytes_unref_to_data(bytes, size));
+
+    if (size)
+        *size = 0;
+    return nullptr;
+}
+
+/**
+ * wpe_clipboard_content_new:
+ *
+ * Create a new #WPEClipboardContent
+ *
+ * Returns: (transfer full): a new #WPEClipboardContent
+ */
+WPEClipboardContent* wpe_clipboard_content_new(void)
+{
+    auto* content = static_cast<WPEClipboardContent*>(fastMalloc(sizeof(WPEClipboardContent)));
+    new (content) WPEClipboardContent();
+    return content;
+}
+
+/**
+ * wpe_clipboard_content_ref:
+ * @content: a #WPEClipboardContent
+ *
+ * Atomically acquires a reference on the given @content.
+ *
+ * This function is MT-safe and may be called from any thread.
+ *
+ * Returns: The same @content with an additional reference.
+ */
+WPEClipboardContent* wpe_clipboard_content_ref(WPEClipboardContent* content)
+{
+    g_return_val_if_fail(content, nullptr);
+
+    g_atomic_int_inc(&content->referenceCount);
+    return content;
+}
+
+/**
+ * wpe_clipboard_content_unref:
+ * @content: a #WPEClipboardContent
+ *
+ * Atomically releases a reference on the given @content.
+ *
+ * If the reference was the last, the resources associated to the
+ * @content are freed. This function is MT-safe and may be called from
+ * any thread.
+ */
+void wpe_clipboard_content_unref(WPEClipboardContent* content)
+{
+    g_return_if_fail(content);
+
+    if (g_atomic_int_dec_and_test(&content->referenceCount)) {
+        content->~WPEClipboardContent();
+        fastFree(content);
+    }
+}
+
+/**
+ * wpe_clipboard_content_set_text:
+ * @content: a #WPEClipboardContent
+ * @text: the text to set
+ *
+ * Set @text on @content.
+ */
+void wpe_clipboard_content_set_text(WPEClipboardContent* content, const char* text)
+{
+    g_return_if_fail(content);
+
+    content->text = CString(text);
+}
+
+/**
+ * wpe_clipboard_content_set_markup:
+ * @content: a #WPEClipboardContent
+ * @markup: text markup to set
+ * @length: lenght of text, or -1 if @markup is nul-terminated.
+ *
+ * Set @markup text on @content
+ */
+void wpe_clipboard_content_set_markup(WPEClipboardContent* content, const char* markup, gssize length)
+{
+    g_return_if_fail(content);
+
+    if (length < 0)
+        length = markup ? strlen(markup) : 0;
+    content->markup = CString(std::span<const char>(markup, length));
+}
+
+/**
+ * wpe_clipboard_content_set_bytes:
+ * @content: a #WPEClipboardContent
+ * @format: a format
+ * @bytes: a #GBytes with the data to set
+ *
+ * Set @bytes data on @content for @format.
+ */
+void wpe_clipboard_content_set_bytes(WPEClipboardContent* content, const char* format, GBytes* bytes)
+{
+    g_return_if_fail(content);
+    g_return_if_fail(format && *format);
+
+    if (!content->buffers)
+        content->buffers = HashMap<const char*, GRefPtr<GBytes>>();
+    content->buffers->add(g_intern_string(format), bytes);
+}
+
+/**
+ * wpe_clipboard_content_serialize:
+ * @content: a #WPEClipboardContent
+ * @format: a format
+ * @stream: a #GOutputStream
+ *
+ * Serialize @content for @format in @stream.
+ *
+ * Returns: %TRUE if content was correctly serialized, or %FALSE otherwise
+ */
+gboolean wpe_clipboard_content_serialize(WPEClipboardContent* content, const char* format, GOutputStream* stream)
+{
+    g_return_val_if_fail(content, FALSE);
+    g_return_val_if_fail(format && *format, FALSE);
+    g_return_val_if_fail(G_IS_OUTPUT_STREAM(stream), FALSE);
+
+    const auto* internalFormat = g_intern_string(format);
+    if (internalFormat == g_intern_static_string("text/plain") || internalFormat == g_intern_static_string("text/plain;charset=utf-8")) {
+        if (content->text)
+            return g_output_stream_write_all(stream, content->text->data(), content->text->length(), nullptr, nullptr, nullptr);
+    } else if (internalFormat == g_intern_static_string("text/html")) {
+        if (content->markup)
+            return g_output_stream_write_all(stream, content->markup->data(), content->markup->length(), nullptr, nullptr, nullptr);
+    } else if (content->buffers) {
+        if (auto* bytes = content->buffers->get(internalFormat)) {
+            gsize dataLength;
+            const auto* data = g_bytes_get_data(bytes, &dataLength);
+            return g_output_stream_write_all(stream, data, dataLength, nullptr, nullptr, nullptr);
+        }
+    }
+
+    return FALSE;
+}

--- a/Source/WebKit/WPEPlatform/wpe/WPEClipboard.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEClipboard.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef WPEClipboard_h
+#define WPEClipboard_h
+
+#if !defined(__WPE_PLATFORM_H_INSIDE__) && !defined(BUILDING_WEBKIT)
+#error "Only <wpe/wpe-platform.h> can be included directly."
+#endif
+
+#include <gio/gio.h>
+#include <glib-object.h>
+#include <wpe/WPEDefines.h>
+
+G_BEGIN_DECLS
+
+#define WPE_TYPE_CLIPBOARD (wpe_clipboard_get_type())
+WPE_DECLARE_DERIVABLE_TYPE (WPEClipboard, wpe_clipboard, WPE, CLIPBOARD, GObject)
+
+typedef struct _WPEClipboardContent WPEClipboardContent;
+typedef struct _WPEDisplay WPEDisplay;
+
+struct _WPEClipboardClass
+{
+    GObjectClass parent_class;
+
+    GBytes* (*read)    (WPEClipboard        *clipboard,
+                        const char          *format);
+    void    (*changed) (WPEClipboard        *clipboard,
+                        GPtrArray           *formats,
+                        gboolean             is_local,
+                        WPEClipboardContent *content);
+
+    gpointer padding[32];
+};
+
+WPE_API WPEClipboard        *wpe_clipboard_new              (WPEDisplay          *display);
+WPE_API WPEDisplay          *wpe_clipboard_get_display      (WPEClipboard        *clipboard);
+WPE_API gint64               wpe_clipboard_get_change_count (WPEClipboard        *clipboard);
+WPE_API const char * const  *wpe_clipboard_get_formats      (WPEClipboard        *clipboard);
+WPE_API void                 wpe_clipboard_set_content      (WPEClipboard        *clipboard,
+                                                             WPEClipboardContent *content);
+WPE_API WPEClipboardContent *wpe_clipboard_get_content      (WPEClipboard        *clipboard);
+WPE_API GBytes              *wpe_clipboard_read_bytes       (WPEClipboard        *clipboard,
+                                                             const char          *format);
+WPE_API char                *wpe_clipboard_read_text        (WPEClipboard        *clipboard,
+                                                             const char          *format,
+                                                             gsize               *size);
+
+#define WPE_TYPE_CLIPBOARD_CONTENT (wpe_clipboard_content_get_type())
+
+WPE_API GType                wpe_clipboard_content_get_type   (void);
+WPE_API WPEClipboardContent *wpe_clipboard_content_new        (void);
+WPE_API WPEClipboardContent *wpe_clipboard_content_ref        (WPEClipboardContent *content);
+WPE_API void                 wpe_clipboard_content_unref      (WPEClipboardContent *content);
+WPE_API void                 wpe_clipboard_content_set_text   (WPEClipboardContent *content,
+                                                               const char          *text);
+WPE_API void  	      	     wpe_clipboard_content_set_markup (WPEClipboardContent *content,
+                                                               const char          *markup,
+                                                               gssize               length);
+WPE_API void                 wpe_clipboard_content_set_bytes  (WPEClipboardContent *content,
+                                                               const char          *format,
+                                                               GBytes              *bytes);
+WPE_API gboolean             wpe_clipboard_content_serialize  (WPEClipboardContent *content,
+                                                               const char          *format,
+                                                               GOutputStream       *stream);
+
+G_END_DECLS
+
+#endif /* WPEClipboard_h */

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
@@ -59,6 +59,7 @@ struct _WPEDisplayPrivate {
     HashMap<String, bool> extensionsMap;
     GRefPtr<WPEBufferDMABufFormats> preferredDMABufFormats;
     GRefPtr<WPEKeymap> keymap;
+    GRefPtr<WPEClipboard> clipboard;
     GRefPtr<WPESettings> settings;
     WPEAvailableInputDevices availableInputDevices;
 };
@@ -386,6 +387,31 @@ WPEKeymap* wpe_display_get_keymap(WPEDisplay* display)
             priv->keymap = adoptGRef(wpe_keymap_xkb_new());
     }
     return priv->keymap.get();
+}
+
+/**
+ * wpe_display_get_clipboard:
+ * @display: a #WPEDisplay
+ *
+ * Get the #WPEClipboard of @display. If the platform doesn't
+ * support clipboard, a local #WPEClipboard is created.
+ *
+ * Returns: (transfer none): a #WPEClipboard
+ */
+WPEClipboard* wpe_display_get_clipboard(WPEDisplay* display)
+{
+    g_return_val_if_fail(WPE_IS_DISPLAY(display), nullptr);
+
+    auto* priv = display->priv;
+    if (!priv->clipboard) {
+        auto* wpeDisplayClass = WPE_DISPLAY_GET_CLASS(display);
+        if (wpeDisplayClass->get_clipboard)
+            priv->clipboard = wpeDisplayClass->get_clipboard(display);
+
+        if (!priv->clipboard)
+            priv->clipboard = adoptGRef(wpe_clipboard_new(display));
+    }
+    return priv->clipboard.get();
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
@@ -32,6 +32,7 @@
 
 #include <glib-object.h>
 #include <wpe/WPEBufferDMABufFormats.h>
+#include <wpe/WPEClipboard.h>
 #include <wpe/WPEDefines.h>
 #include <wpe/WPEInputMethodContext.h>
 #include <wpe/WPEKeymap.h>
@@ -63,6 +64,7 @@ struct _WPEDisplayClass
     gpointer                (* get_egl_display)               (WPEDisplay *display,
                                                                GError    **error);
     WPEKeymap              *(* get_keymap)                    (WPEDisplay *display);
+    WPEClipboard           *(* get_clipboard)                 (WPEDisplay *display);
     WPEBufferDMABufFormats *(* get_preferred_dma_buf_formats) (WPEDisplay *display);
     guint                   (* get_n_screens)                 (WPEDisplay *display);
     WPEScreen              *(* get_screen)                    (WPEDisplay *display,
@@ -70,7 +72,6 @@ struct _WPEDisplayClass
     const char             *(* get_drm_device)                (WPEDisplay *display);
     const char             *(* get_drm_render_node)           (WPEDisplay *display);
     gboolean                (* use_explicit_sync)             (WPEDisplay *display);
-
     WPEInputMethodContext  *(* create_input_method_context)   (WPEDisplay *display,
                                                                WPEView    *view);
 
@@ -100,6 +101,7 @@ WPE_API gboolean                 wpe_display_connect                       (WPED
 WPE_API gpointer                 wpe_display_get_egl_display               (WPEDisplay *display,
                                                                             GError    **error);
 WPE_API WPEKeymap               *wpe_display_get_keymap                    (WPEDisplay *display);
+WPE_API WPEClipboard            *wpe_display_get_clipboard                 (WPEDisplay *display);
 WPE_API WPEBufferDMABufFormats  *wpe_display_get_preferred_dma_buf_formats (WPEDisplay *display);
 WPE_API guint                    wpe_display_get_n_screens                 (WPEDisplay *display);
 WPE_API WPEScreen               *wpe_display_get_screen                    (WPEDisplay *display,

--- a/Source/WebKit/WPEPlatform/wpe/wpe-platform.h
+++ b/Source/WebKit/WPEPlatform/wpe/wpe-platform.h
@@ -27,17 +27,18 @@
 
 #define __WPE_PLATFORM_H_INSIDE__
 
-#include <wpe/WPEEnumTypes.h>
-#include <wpe/WPEEvent.h>
 #include <wpe/WPEBuffer.h>
 #include <wpe/WPEBufferDMABuf.h>
 #include <wpe/WPEBufferDMABufFormats.h>
 #include <wpe/WPEBufferSHM.h>
+#include <wpe/WPEClipboard.h>
 #include <wpe/WPEColor.h>
 #include <wpe/WPEConfig.h>
 #include <wpe/WPEDefines.h>
 #include <wpe/WPEDisplay.h>
 #include <wpe/WPEEGLError.h>
+#include <wpe/WPEEnumTypes.h>
+#include <wpe/WPEEvent.h>
 #include <wpe/WPEGestureController.h>
 #include <wpe/WPEInputMethodContext.h>
 #include <wpe/WPEKeymap.h>

--- a/Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.cpp
@@ -34,6 +34,10 @@
 #include <WebKit/WKTextCheckerGLib.h>
 #include <wtf/RunLoop.h>
 
+#if ENABLE(WPE_PLATFORM)
+#include <wpe/wpe-platform.h>
+#endif
+
 namespace WTR {
 
 Ref<UIScriptController> UIScriptController::create(UIScriptContext& context)
@@ -56,8 +60,17 @@ void UIScriptControllerWPE::setContinuousSpellCheckingEnabled(bool enabled)
     WKTextCheckerSetContinuousSpellCheckingEnabled(enabled);
 }
 
-void UIScriptControllerWPE::copyText(JSStringRef)
+void UIScriptControllerWPE::copyText(JSStringRef text)
 {
+#if ENABLE(WPE_PLATFORM)
+    if (TestController::singleton().useWPEPlatformAPI()) {
+        auto* clipboard = wpe_display_get_clipboard(wpe_display_get_primary());
+        auto* content = wpe_clipboard_content_new();
+        wpe_clipboard_content_set_text(content, text->string().utf8().data());
+        wpe_clipboard_set_content(clipboard, content);
+        wpe_clipboard_content_unref(content);
+    }
+#endif
     // FIXME: implement.
 }
 


### PR DESCRIPTION
#### 6b152fb5e3abc63f49617726b453e32c39898d5b
<pre>
[WPE] WPE Platform: add clipboard support
<a href="https://bugs.webkit.org/show_bug.cgi?id=291075">https://bugs.webkit.org/show_bug.cgi?id=291075</a>

Reviewed by Patrick Griffis.

Add initial clipboard API with a default local only implementation and
support for text, markup and custom data.

* Source/WebKit/Shared/wpe/GRefPtrWPE.cpp:
(WTF::refGPtr):
(WTF::derefGPtr):
* Source/WebKit/Shared/wpe/GRefPtrWPE.h:
* Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp:
(WebKit::PageClientImpl::requestDOMPasteAccess):
* Source/WebKit/UIProcess/wpe/WebPasteboardProxyWPE.cpp:
(WebKit::clipboardFormats):
(WebKit::WebPasteboardProxy::getTypes):
(WebKit::WebPasteboardProxy::readText):
(WebKit::WebPasteboardProxy::readFilePaths):
(WebKit::WebPasteboardProxy::readBuffer):
(WebKit::WebPasteboardProxy::writeToClipboard):
(WebKit::WebPasteboardProxy::clearClipboard):
(WebKit::WebPasteboardProxy::typesSafeForDOMToReadAndWrite):
(WebKit::WebPasteboardProxy::writeCustomData):
(WebKit::pasteboardItemInfoFromFormats):
(WebKit::WebPasteboardProxy::allPasteboardItemInfo):
(WebKit::WebPasteboardProxy::informationForItemAtIndex):
(WebKit::WebPasteboardProxy::getPasteboardItemsCount):
(WebKit::WebPasteboardProxy::readURLFromPasteboard):
(WebKit::WebPasteboardProxy::readBufferFromPasteboard):
(WebKit::WebPasteboardProxy::getPasteboardChangeCount):
* Source/WebKit/WPEPlatform/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/WPEClipboard.cpp: Added.
(wpeClipboardDispose):
(wpeClipboardSetProperty):
(wpeClipboardGetProperty):
(wpeClipboardChanged):
(wpe_clipboard_class_init):
(wpe_clipboard_new):
(wpe_clipboard_get_display):
(wpe_clipboard_get_change_count):
(wpe_clipboard_get_formats):
(wpe_clipboard_set_content):
(wpe_clipboard_get_content):
(wpe_clipboard_read_bytes):
(wpe_clipboard_read_text):
(wpe_clipboard_content_new):
(wpe_clipboard_content_ref):
(wpe_clipboard_content_unref):
(wpe_clipboard_content_set_text):
(wpe_clipboard_content_set_markup):
(wpe_clipboard_content_set_bytes):
(wpe_clipboard_content_serialize):
* Source/WebKit/WPEPlatform/wpe/WPEClipboard.h: Added.
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp:
(wpe_display_get_clipboard):
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.h:
* Source/WebKit/WPEPlatform/wpe/wpe-platform.h:
* Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.cpp:
(WTR::UIScriptControllerWPE::copyText):

Canonical link: <a href="https://commits.webkit.org/294505@main">https://commits.webkit.org/294505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd9676ec969174cc5df7b47e6aed6e76bcf6e1d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101494 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106648 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52123 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77298 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34325 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104501 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57640 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16388 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9693 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51471 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86256 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108999 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28623 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21056 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86264 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28985 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87877 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85831 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30566 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8291 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22749 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16593 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28554 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33835 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28365 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31685 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29924 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->