### PR TITLE
Promote SwiftCXXThunk.h to WTF

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		53CAC0632C6FBD8200B1A77C /* ScopedPrintStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 53CAC0622C6FBD8200B1A77C /* ScopedPrintStream.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53F202252CAB267000A33D14 /* TaggedPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = 53F202242CAB267000A33D14 /* TaggedPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53FC70D023FB950C005B1990 /* OSLogPrintStream.mm in Sources */ = {isa = PBXBuildFile; fileRef = 53FC70CF23FB950C005B1990 /* OSLogPrintStream.mm */; };
+		5C12460E2DC25A130077D423 /* SwiftCXXThunk.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C12460D2DC25A130077D423 /* SwiftCXXThunk.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5C1F05932164356B0039302C /* CFURLExtras.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C1F05912164356B0039302C /* CFURLExtras.cpp */; };
 		5C1F0595216437B30039302C /* URLCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C1F0594216437B30039302C /* URLCF.cpp */; };
 		5C6552C029423F85008CD0F3 /* ThreadSafeWeakHashSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C6552BF29423F85008CD0F3 /* ThreadSafeWeakHashSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1337,6 +1338,7 @@
 		553071C91C40427200384898 /* TinyLRUCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TinyLRUCache.h; sourceTree = "<group>"; };
 		5597F82C1D94B9970066BC21 /* SynchronizedFixedQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SynchronizedFixedQueue.h; sourceTree = "<group>"; };
 		5B43383A5D0B463C9433D933 /* IndexMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IndexMap.h; sourceTree = "<group>"; };
+		5C12460D2DC25A130077D423 /* SwiftCXXThunk.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwiftCXXThunk.h; sourceTree = "<group>"; };
 		5C1F05912164356B0039302C /* CFURLExtras.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CFURLExtras.cpp; sourceTree = "<group>"; };
 		5C1F05922164356B0039302C /* CFURLExtras.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFURLExtras.h; sourceTree = "<group>"; };
 		5C1F0594216437B30039302C /* URLCF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = URLCF.cpp; sourceTree = "<group>"; };
@@ -2626,6 +2628,7 @@
 				E3260E972DA0E508003FC93F /* StructDump.h */,
 				93B07ED726B8715B00A09B34 /* SuspendableWorkQueue.cpp */,
 				93B07ED626B86BB500A09B34 /* SuspendableWorkQueue.h */,
+				5C12460D2DC25A130077D423 /* SwiftCXXThunk.h */,
 				5597F82C1D94B9970066BC21 /* SynchronizedFixedQueue.h */,
 				E3E158251EADA53C004A079D /* SystemFree.h */,
 				E4D2AE4D268A4C7F00DFEA02 /* SystemMalloc.h */,
@@ -3758,6 +3761,7 @@
 				FF8CB4012A88C0D3004AF498 /* SuperFastHash.h in Headers */,
 				DD3DC89A27A4BF8E007E5B61 /* SuspendableWorkQueue.h in Headers */,
 				E396C11E2BE885D9000CBAE1 /* sve.h in Headers */,
+				5C12460E2DC25A130077D423 /* SwiftCXXThunk.h in Headers */,
 				DDF307DA27C086DF006A526F /* SymbolImpl.h in Headers */,
 				DDF307EC27C086DF006A526F /* SymbolRegistry.h in Headers */,
 				DD3DC86727A4BF8E007E5B61 /* SynchronizedFixedQueue.h in Headers */,

--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -649,3 +649,7 @@
     ALLOW_COMMA_END \
     ALLOW_DEPRECATED_DECLARATIONS_END \
     ALLOW_UNUSED_PARAMETERS_END
+
+// Used to indicate that a class member has a specialized implementation in Swift. See
+// "SwiftCXXThunk.h".
+#define HAS_SWIFTCXX_THUNK  NS_REFINED_FOR_SWIFT

--- a/Source/WTF/wtf/SwiftCXXThunk.h
+++ b/Source/WTF/wtf/SwiftCXXThunk.h
@@ -25,10 +25,12 @@
 
 #pragma once
 
+#include <wtf/StdLibExtras.h>
+
 /*
  A system of macros to make it more ergonomic to implement C++ class member functions in Swift.
 
- Use HAS_SWIFTCXX_THUNK (from WebGPUExt.h) in headers, to mark a C++ member function as having
+ Use HAS_SWIFTCXX_THUNK (from wtf/Compiler.h) in headers, to mark a C++ member function as having
  a specialized definition in Swift.
 
  Use DEFINE_SWIFTCXX_THUNK in implementation sources, to define a function that calls through to a
@@ -36,49 +38,47 @@
  available through reverse interop.
  */
 
-#define REMOVE_PARENTHESIS(X) REMOVE_PARENTHESIS_IMPL X
-#define REMOVE_PARENTHESIS_IMPL(...) __VA_ARGS__
-
-#define CONCAT(A, B) A##B
+#define _WTF_REMOVE_PARENTHESIS(X) _WTF_REMOVE_PARENTHESIS_IMPL X
+#define _WTF_REMOVE_PARENTHESIS_IMPL(...) __VA_ARGS__
 
 #define _DEFINE_SWIFTCXX_THUNK0(Class, Member, ReturnType) \
 ReturnType Class::Member() { \
-    return CONCAT(Class, _##Member##_thunk)(this); \
+    return WTF_CONCAT(Class, _##Member##_thunk)(this); \
 }
 
 #define _DEFINE_SWIFTCXX_THUNK1(Class, Member, ReturnType, TypeOfArg1) \
-ReturnType Class::Member(REMOVE_PARENTHESIS((TypeOfArg1)) arg1) { \
-    return CONCAT(Class, _##Member##_thunk)(this, arg1); \
+ReturnType Class::Member(_WTF_REMOVE_PARENTHESIS((TypeOfArg1)) arg1) { \
+    return WTF_CONCAT(Class, _##Member##_thunk)(this, arg1); \
 }
 
 #define _DEFINE_SWIFTCXX_THUNK2(Class, Member, ReturnType, TypeOfArg1, TypeOfArg2) \
-ReturnType Class::Member(REMOVE_PARENTHESIS((TypeOfArg1)) arg1, REMOVE_PARENTHESIS((TypeOfArg2)) arg2) { \
-    return CONCAT(Class, _##Member##_thunk)(this, arg1, arg2); \
+ReturnType Class::Member(_WTF_REMOVE_PARENTHESIS((TypeOfArg1)) arg1, _WTF_REMOVE_PARENTHESIS((TypeOfArg2)) arg2) { \
+    return WTF_CONCAT(Class, _##Member##_thunk)(this, arg1, arg2); \
 }
 
 #define _DEFINE_SWIFTCXX_THUNK3(Class, Member, ReturnType, TypeOfArg1, TypeOfArg2, TypeOfArg3) \
-ReturnType Class::Member(REMOVE_PARENTHESIS((TypeOfArg1)) arg1, REMOVE_PARENTHESIS((TypeOfArg2)) arg2, REMOVE_PARENTHESIS((TypeOfArg3)) arg3) { \
-    return CONCAT(Class, _##Member##_thunk)(this, arg1, arg2, arg3); \
+ReturnType Class::Member(_WTF_REMOVE_PARENTHESIS((TypeOfArg1)) arg1, _WTF_REMOVE_PARENTHESIS((TypeOfArg2)) arg2, _WTF_REMOVE_PARENTHESIS((TypeOfArg3)) arg3) { \
+    return WTF_CONCAT(Class, _##Member##_thunk)(this, arg1, arg2, arg3); \
 }
 
 #define _DEFINE_SWIFTCXX_THUNK4(Class, Member, ReturnType, TypeOfArg1, TypeOfArg2, TypeOfArg3, TypeOfArg4) \
-ReturnType Class::Member(REMOVE_PARENTHESIS((TypeOfArg1)) arg1, REMOVE_PARENTHESIS((TypeOfArg2)) arg2, REMOVE_PARENTHESIS((TypeOfArg3)) arg3, REMOVE_PARENTHESIS((TypeOfArg4)) arg4) { \
-    return CONCAT(Class, _##Member##_thunk)(this, arg1, arg2, arg3, arg4); \
+ReturnType Class::Member(_WTF_REMOVE_PARENTHESIS((TypeOfArg1)) arg1, _WTF_REMOVE_PARENTHESIS((TypeOfArg2)) arg2, _WTF_REMOVE_PARENTHESIS((TypeOfArg3)) arg3, _WTF_REMOVE_PARENTHESIS((TypeOfArg4)) arg4) { \
+    return WTF_CONCAT(Class, _##Member##_thunk)(this, arg1, arg2, arg3, arg4); \
 }
 
 #define _DEFINE_SWIFTCXX_THUNK5(Class, Member, ReturnType, TypeOfArg1, TypeOfArg2, TypeOfArg3, TypeOfArg4, TypeOfArg5) \
-ReturnType Class::Member(REMOVE_PARENTHESIS((TypeOfArg1)) arg1, REMOVE_PARENTHESIS((TypeOfArg2)) arg2, REMOVE_PARENTHESIS((TypeOfArg3)) arg3, REMOVE_PARENTHESIS((TypeOfArg4)) arg4, REMOVE_PARENTHESIS((TypeOfArg5)) arg5) { \
-    return CONCAT(Class, _##Member##_thunk)(this, arg1, arg2, arg3, arg4, arg5); \
+ReturnType Class::Member(_WTF_REMOVE_PARENTHESIS((TypeOfArg1)) arg1, _WTF_REMOVE_PARENTHESIS((TypeOfArg2)) arg2, _WTF_REMOVE_PARENTHESIS((TypeOfArg3)) arg3, _WTF_REMOVE_PARENTHESIS((TypeOfArg4)) arg4, _WTF_REMOVE_PARENTHESIS((TypeOfArg5)) arg5) { \
+    return WTF_CONCAT(Class, _##Member##_thunk)(this, arg1, arg2, arg3, arg4, arg5); \
 }
 
 #define _DEFINE_SWIFTCXX_THUNK6(Class, Member, ReturnType, TypeOfArg1, TypeOfArg2, TypeOfArg3, TypeOfArg4, TypeOfArg5, TypeOfArg6) \
-ReturnType Class::Member(REMOVE_PARENTHESIS((TypeOfArg1)) arg1, REMOVE_PARENTHESIS((TypeOfArg2)) arg2, REMOVE_PARENTHESIS((TypeOfArg3)) arg3, REMOVE_PARENTHESIS((TypeOfArg4)) arg4, REMOVE_PARENTHESIS((TypeOfArg5)) arg5, REMOVE_PARENTHESIS((TypeOfArg6)) arg6) { \
-    return CONCAT(Class, _##Member##_thunk)(this, arg1, arg2, arg3, arg4, arg5, arg6); \
+ReturnType Class::Member(_WTF_REMOVE_PARENTHESIS((TypeOfArg1)) arg1, _WTF_REMOVE_PARENTHESIS((TypeOfArg2)) arg2, _WTF_REMOVE_PARENTHESIS((TypeOfArg3)) arg3, _WTF_REMOVE_PARENTHESIS((TypeOfArg4)) arg4, _WTF_REMOVE_PARENTHESIS((TypeOfArg5)) arg5, _WTF_REMOVE_PARENTHESIS((TypeOfArg6)) arg6) { \
+    return WTF_CONCAT(Class, _##Member##_thunk)(this, arg1, arg2, arg3, arg4, arg5, arg6); \
 }
 
 #define _DEFINE_SWIFTCXX_THUNK7(Class, Member, ReturnType, TypeOfArg1, TypeOfArg2, TypeOfArg3, TypeOfArg4, TypeOfArg5, TypeOfArg6, TypeOfArg7) \
-ReturnType Class::Member(REMOVE_PARENTHESIS(TypeOfArg1) arg1, REMOVE_PARENTHESIS((TypeOfArg2)) arg2, REMOVE_PARENTHESIS((TypeOfArg3)) arg3, REMOVE_PARENTHESIS((TypeOfArg4)) arg4, REMOVE_PARENTHESIS((TypeOfArg5)) arg5, REMOVE_PARENTHESIS((TypeOfArg6)) arg6, REMOVE_PARENTHESIS((TypeOfArg7)) arg7) { \
-    return CONCAT(Class, _##Member##_thunk)(this, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
+ReturnType Class::Member(_WTF_REMOVE_PARENTHESIS(TypeOfArg1) arg1, _WTF_REMOVE_PARENTHESIS((TypeOfArg2)) arg2, _WTF_REMOVE_PARENTHESIS((TypeOfArg3)) arg3, _WTF_REMOVE_PARENTHESIS((TypeOfArg4)) arg4, _WTF_REMOVE_PARENTHESIS((TypeOfArg5)) arg5, _WTF_REMOVE_PARENTHESIS((TypeOfArg6)) arg6, _WTF_REMOVE_PARENTHESIS((TypeOfArg7)) arg7) { \
+    return WTF_CONCAT(Class, _##Member##_thunk)(this, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
 }
 
 

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -540,7 +540,6 @@
 		97FA1A8729C085A60052D650 /* wgslc.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = wgslc.cpp; path = WGSL/wgslc.cpp; sourceTree = SOURCE_ROOT; };
 		97FA1AA229C0BB700052D650 /* wgslc.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = wgslc.xcconfig; sourceTree = "<group>"; };
 		DD5697FC2DC1311D00050321 /* rdar150228472.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = rdar150228472.swift; sourceTree = "<group>"; };
-		DD8EE22A2CE6AC77004DD6F8 /* SwiftCXXThunk.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwiftCXXThunk.h; sourceTree = "<group>"; };
 		DD8EE22F2CE6B4B3004DD6F8 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -679,7 +678,6 @@
 				1CEBD80D2716C3D800A5254D /* ShaderModule.h */,
 				1C5ACAB0273A426D0095F8D5 /* ShaderModule.mm */,
 				0DE2BFAC2C150DF700D04AEB /* ShaderStage.h */,
-				DD8EE22A2CE6AC77004DD6F8 /* SwiftCXXThunk.h */,
 				1C5ACA99273A426D0095F8D5 /* Texture.h */,
 				1C5ACAB1273A426D0095F8D5 /* Texture.mm */,
 				1C5ACADD273A4F3D0095F8D5 /* TextureView.h */,

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -27,7 +27,6 @@
 
 #import "BindableResource.h"
 #import "Instance.h"
-#import "SwiftCXXThunk.h"
 #import "WebGPU.h"
 #import "WebGPUExt.h"
 #import <Metal/Metal.h>
@@ -40,6 +39,7 @@
 #import <wtf/Ref.h>
 #import <wtf/RefCountedAndCanMakeWeakPtr.h>
 #import <wtf/RetainReleaseSwift.h>
+#import <wtf/SwiftCXXThunk.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/WeakPtr.h>
 

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -28,7 +28,6 @@
 #import "BindableResource.h"
 #import "CommandBuffer.h"
 #import "CommandsMixin.h"
-#import "SwiftCXXThunk.h"
 #import "WebGPU.h"
 #import "WebGPUExt.h"
 #import <wtf/FastMalloc.h>
@@ -36,6 +35,7 @@
 #import <wtf/Ref.h>
 #import <wtf/RefCountedAndCanMakeWeakPtr.h>
 #import <wtf/RetainReleaseSwift.h>
+#import <wtf/SwiftCXXThunk.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/Vector.h>
 #import <wtf/WeakPtr.h>

--- a/Source/WebGPU/WebGPU/WebGPUExt.h
+++ b/Source/WebGPU/WebGPU/WebGPUExt.h
@@ -174,10 +174,6 @@ WGPU_EXPORT String wgpuAdapterFeatureName(WGPUFeatureName feature) WGPU_FUNCTION
 #define PUBLIC_IN_WEBGPU_SWIFT
 #endif
 
-// Used to indicate that a class member has a specialized implementation in Swift. See
-// "SwiftCXXThunk.h".
-#define HAS_SWIFTCXX_THUNK  NS_REFINED_FOR_SWIFT
-
 #endif
 
 #endif // WEBGPUEXT_H_


### PR DESCRIPTION
#### 5dbb5a5c08b96f6197b2cedbd7ddf583b5b0dfdf
<pre>
Promote SwiftCXXThunk.h to WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=292327">https://bugs.webkit.org/show_bug.cgi?id=292327</a>

Reviewed by Elliott Williams.

This moves the existing SwiftCXXThunk.h header from WebGPU up into WTF, since
we expect to use it within WebKit in future. This header is useful in allowing
C++ classes to (appear to) have some of their member functions implemented in
Swift. In practice that&apos;s only achievable by small thunks, and the macros in
this header create those thunks.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/SwiftCXXThunk.h: Renamed from Source/WebGPU/WebGPU/SwiftCXXThunk.h.
* Source/WebGPU/WebGPU/Buffer.h:
* Source/WebGPU/WebGPU/CommandEncoder.h:

Canonical link: <a href="https://commits.webkit.org/294725@main">https://commits.webkit.org/294725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a5d9f7e55d7c7e97ecde9a49dcc71736024df02

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106775 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52251 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29783 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77388 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34419 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104624 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91767 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57725 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16504 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9784 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51598 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94289 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86371 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9861 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109128 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100227 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21162 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86361 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29111 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87968 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85924 "Found 1 new API test failure: /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22097 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30675 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8385 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/22902 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28678 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33967 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/123851 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28489 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34412 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31812 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30048 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->