### PR TITLE
Add support for logical background-position shorthands

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-block-computed.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-block-computed.tentative-expected.txt
@@ -1,0 +1,16 @@
+
+PASS Property background-position-block value 'center'
+PASS Property background-position-block value 'start'
+PASS Property background-position-block value 'end'
+PASS Property background-position-block value '-20%'
+PASS Property background-position-block value '10px'
+PASS Property background-position-block value '0.5em'
+PASS Property background-position-block value 'calc(10px - 0.5em)'
+PASS Property background-position-block value 'start -20%'
+PASS Property background-position-block value 'end -10px'
+PASS Property background-position-block value '-20%, 10px'
+PASS Property background-position-block value 'center, start, end'
+PASS Property background-position-block value '0.5em, center'
+PASS Property background-position-block value 'calc(10px - 0.5em), -20%, 10px'
+PASS Property background-position-block value 'calc(10px - 0.5em), start -20%, end 10px'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-block-computed.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-block-computed.tentative.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Module Level 4: getComputedStyle().backgroundPositionBlock</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position-block">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<style>
+  #target {
+    font-size: 40px;
+  }
+</style>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("background-position-block", "center", "50%");
+test_computed_value("background-position-block", "start", "0%");
+test_computed_value("background-position-block", "end", "100%");
+test_computed_value("background-position-block", "-20%");
+test_computed_value("background-position-block", "10px");
+test_computed_value("background-position-block", "0.5em", "20px");
+test_computed_value("background-position-block", "calc(10px - 0.5em)", "-10px");
+test_computed_value("background-position-block", "start -20%", "-20%");
+test_computed_value("background-position-block", "end -10px", "calc(100% + 10px)");
+test_computed_value("background-position-block", "-20%, 10px", "-20%");
+test_computed_value("background-position-block", "center, start, end", "50%");
+test_computed_value("background-position-block", "0.5em, center", "20px");
+test_computed_value("background-position-block", "calc(10px - 0.5em), -20%, 10px", "-10px");
+test_computed_value("background-position-block", "calc(10px - 0.5em), start -20%, end 10px", "-10px");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-block-invalid.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-block-invalid.tentative-expected.txt
@@ -1,0 +1,18 @@
+
+PASS e.style['background-position-block'] = "auto" should not set the property value
+PASS e.style['background-position-block'] = "top" should not set the property value
+PASS e.style['background-position-block'] = "bottom" should not set the property value
+PASS e.style['background-position-block'] = "x-start" should not set the property value
+PASS e.style['background-position-block'] = "x-end" should not set the property value
+PASS e.style['background-position-block'] = "y-start" should not set the property value
+PASS e.style['background-position-block'] = "y-end" should not set the property value
+PASS e.style['background-position-block'] = "center 10px" should not set the property value
+PASS e.style['background-position-block'] = "20% left" should not set the property value
+PASS e.style['background-position-block'] = "right left" should not set the property value
+PASS e.style['background-position-block'] = "x-start center" should not set the property value
+PASS e.style['background-position-block'] = "left, center right" should not set the property value
+PASS e.style['background-position-block'] = "start garbage" should not set the property value
+PASS e.style['background-position-block'] = "garbage end" should not set the property value
+PASS e.style['background-position-block'] = "20% garbage" should not set the property value
+PASS e.style['background-position-block'] = "garbage 20px" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-block-invalid.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-block-invalid.tentative.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Module Level 4: parsing background-position-block with invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position-block">
+<meta name="assert" content="background-position-block supports only the grammar '[ center | [ start | end ]? <length-percentage>? ]#'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("background-position-block", "auto");
+test_invalid_value("background-position-block", "top");
+test_invalid_value("background-position-block", "bottom");
+test_invalid_value("background-position-block", "x-start");
+test_invalid_value("background-position-block", "x-end");
+test_invalid_value("background-position-block", "y-start");
+test_invalid_value("background-position-block", "y-end");
+test_invalid_value("background-position-block", "center 10px");
+test_invalid_value("background-position-block", "20% left");
+test_invalid_value("background-position-block", "right left");
+test_invalid_value("background-position-block", "x-start center");
+test_invalid_value("background-position-block", "left, center right");
+test_invalid_value("background-position-block", "start garbage");
+test_invalid_value("background-position-block", "garbage end");
+test_invalid_value("background-position-block", "20% garbage");
+test_invalid_value("background-position-block", "garbage 20px");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-block-valid.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-block-valid.tentative-expected.txt
@@ -1,0 +1,15 @@
+
+PASS e.style['background-position-block'] = "center" should set the property value
+PASS e.style['background-position-block'] = "start" should set the property value
+PASS e.style['background-position-block'] = "end" should set the property value
+PASS e.style['background-position-block'] = "-20%" should set the property value
+PASS e.style['background-position-block'] = "10px" should set the property value
+PASS e.style['background-position-block'] = "0.5em" should set the property value
+PASS e.style['background-position-block'] = "calc(10px - 0.5em)" should set the property value
+PASS e.style['background-position-block'] = "start -20%" should set the property value
+PASS e.style['background-position-block'] = "end 10px" should set the property value
+PASS e.style['background-position-block'] = "-20%, 10px" should set the property value
+PASS e.style['background-position-block'] = "center, start, end" should set the property value
+PASS e.style['background-position-block'] = "0.5em, end, start" should set the property value
+PASS e.style['background-position-block'] = "calc(10px - 0.5em), end -20%, start 10px" should set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-block-valid.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-block-valid.tentative.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Module Level 4: parsing background-position-block with valid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position-block">
+<meta name="assert" content="background-position-block supports the full grammar '[ center | [ start | end ]? <length-percentage>? ]#'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("background-position-block", "center");
+test_valid_value("background-position-block", "start");
+test_valid_value("background-position-block", "end");
+test_valid_value("background-position-block", "-20%");
+test_valid_value("background-position-block", "10px");
+test_valid_value("background-position-block", "0.5em");
+test_valid_value("background-position-block", "calc(10px - 0.5em)", "calc(-0.5em + 10px)");
+test_valid_value("background-position-block", "start -20%");
+test_valid_value("background-position-block", "end 10px");
+test_valid_value("background-position-block", "-20%, 10px");
+test_valid_value("background-position-block", "center, start, end");
+test_valid_value("background-position-block", "0.5em, end, start");
+test_valid_value("background-position-block", "calc(10px - 0.5em), end -20%, start 10px", "calc(-0.5em + 10px), end -20%, start 10px");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-computed.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-computed.tentative-expected.txt
@@ -1,0 +1,16 @@
+
+PASS Property background-position-inline value 'center'
+PASS Property background-position-inline value 'start'
+PASS Property background-position-inline value 'end'
+PASS Property background-position-inline value '-20%'
+PASS Property background-position-inline value '10px'
+PASS Property background-position-inline value '0.5em'
+PASS Property background-position-inline value 'calc(10px - 0.5em)'
+PASS Property background-position-inline value 'start -20%'
+PASS Property background-position-inline value 'end -10px'
+PASS Property background-position-inline value '-20%, 10px'
+PASS Property background-position-inline value 'center, start, end'
+PASS Property background-position-inline value '0.5em, center'
+PASS Property background-position-inline value 'calc(10px - 0.5em), -20%, 10px'
+PASS Property background-position-inline value 'calc(10px - 0.5em), start -20%, end 10px'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-computed.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-computed.tentative.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Module Level 4: getComputedStyle().backgroundPositionInline</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position-inline">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<style>
+  #target {
+    font-size: 40px;
+  }
+</style>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("background-position-inline", "center", "50%");
+test_computed_value("background-position-inline", "start", "0%");
+test_computed_value("background-position-inline", "end", "100%");
+test_computed_value("background-position-inline", "-20%");
+test_computed_value("background-position-inline", "10px");
+test_computed_value("background-position-inline", "0.5em", "20px");
+test_computed_value("background-position-inline", "calc(10px - 0.5em)", "-10px");
+test_computed_value("background-position-inline", "start -20%", "-20%");
+test_computed_value("background-position-inline", "end -10px", "calc(100% + 10px)");
+test_computed_value("background-position-inline", "-20%, 10px", "-20%");
+test_computed_value("background-position-inline", "center, start, end", "50%");
+test_computed_value("background-position-inline", "0.5em, center", "20px");
+test_computed_value("background-position-inline", "calc(10px - 0.5em), -20%, 10px", "-10px");
+test_computed_value("background-position-inline", "calc(10px - 0.5em), start -20%, end 10px", "-10px");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-invalid.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-invalid.tentative-expected.txt
@@ -1,0 +1,18 @@
+
+PASS e.style['background-position-inline'] = "auto" should not set the property value
+PASS e.style['background-position-inline'] = "top" should not set the property value
+PASS e.style['background-position-inline'] = "bottom" should not set the property value
+PASS e.style['background-position-inline'] = "x-start" should not set the property value
+PASS e.style['background-position-inline'] = "x-end" should not set the property value
+PASS e.style['background-position-inline'] = "y-start" should not set the property value
+PASS e.style['background-position-inline'] = "y-end" should not set the property value
+PASS e.style['background-position-inline'] = "center 10px" should not set the property value
+PASS e.style['background-position-inline'] = "20% left" should not set the property value
+PASS e.style['background-position-inline'] = "right left" should not set the property value
+PASS e.style['background-position-inline'] = "x-start center" should not set the property value
+PASS e.style['background-position-inline'] = "left, center right" should not set the property value
+PASS e.style['background-position-inline'] = "start garbage" should not set the property value
+PASS e.style['background-position-inline'] = "garbage end" should not set the property value
+PASS e.style['background-position-inline'] = "20% garbage" should not set the property value
+PASS e.style['background-position-inline'] = "garbage 20px" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-invalid.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-invalid.tentative.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Module Level 4: parsing background-position-inline with invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position-inline">
+<meta name="assert" content="background-position-inline supports only the grammar '[ center | [ start | end ]? <length-percentage>? ]#'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("background-position-inline", "auto");
+test_invalid_value("background-position-inline", "top");
+test_invalid_value("background-position-inline", "bottom");
+test_invalid_value("background-position-inline", "x-start");
+test_invalid_value("background-position-inline", "x-end");
+test_invalid_value("background-position-inline", "y-start");
+test_invalid_value("background-position-inline", "y-end");
+test_invalid_value("background-position-inline", "center 10px");
+test_invalid_value("background-position-inline", "20% left");
+test_invalid_value("background-position-inline", "right left");
+test_invalid_value("background-position-inline", "x-start center");
+test_invalid_value("background-position-inline", "left, center right");
+test_invalid_value("background-position-inline", "start garbage");
+test_invalid_value("background-position-inline", "garbage end");
+test_invalid_value("background-position-inline", "20% garbage");
+test_invalid_value("background-position-inline", "garbage 20px");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-valid.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-valid.tentative-expected.txt
@@ -1,0 +1,15 @@
+
+PASS e.style['background-position-inline'] = "center" should set the property value
+PASS e.style['background-position-inline'] = "start" should set the property value
+PASS e.style['background-position-inline'] = "end" should set the property value
+PASS e.style['background-position-inline'] = "-20%" should set the property value
+PASS e.style['background-position-inline'] = "10px" should set the property value
+PASS e.style['background-position-inline'] = "0.5em" should set the property value
+PASS e.style['background-position-inline'] = "calc(10px - 0.5em)" should set the property value
+PASS e.style['background-position-inline'] = "start -20%" should set the property value
+PASS e.style['background-position-inline'] = "end 10px" should set the property value
+PASS e.style['background-position-inline'] = "-20%, 10px" should set the property value
+PASS e.style['background-position-inline'] = "center, start, end" should set the property value
+PASS e.style['background-position-inline'] = "0.5em, end, start" should set the property value
+PASS e.style['background-position-inline'] = "calc(10px - 0.5em), end -20%, start 10px" should set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-valid.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-valid.tentative.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Module Level 4: parsing background-position-inline with valid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position-inline">
+<meta name="assert" content="background-position-inline supports the full grammar '[ center | [ start | end ]? <length-percentage>? ]#'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("background-position-inline", "center");
+test_valid_value("background-position-inline", "start");
+test_valid_value("background-position-inline", "end");
+test_valid_value("background-position-inline", "-20%");
+test_valid_value("background-position-inline", "10px");
+test_valid_value("background-position-inline", "0.5em");
+test_valid_value("background-position-inline", "calc(10px - 0.5em)", "calc(-0.5em + 10px)");
+test_valid_value("background-position-inline", "start -20%");
+test_valid_value("background-position-inline", "end 10px");
+test_valid_value("background-position-inline", "-20%, 10px");
+test_valid_value("background-position-inline", "center, start, end");
+test_valid_value("background-position-inline", "0.5em, end, start");
+test_valid_value("background-position-inline", "calc(10px - 0.5em), end -20%, start 10px", "calc(-0.5em + 10px), end -20%, start 10px");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-longhand-shorthand-overriding.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-longhand-shorthand-overriding.tentative-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Test with style 'background-position: right top'
+PASS Test with style 'background-position: center center'
+PASS Test with style 'background-position-block: 10%; background-position-inline: 20%'
+PASS Test with style 'background-position-block: 10%; background-position-inline: 20%; background-position-x: 30%; background-position-y: 40%;'
+PASS Test with style 'background-position-x: 30%; background-position-y: 40%; background-position-block: 10%; background-position-inline: 20%;'
+PASS Test with style 'background-position-x: 30%; background-position-block: 10%; background-position-y: 40%; background-position-inline: 20%;'
+PASS Test with style 'background-position-block: 10%; background-position-inline: 20%; background-position: 30px 40px;'
+PASS Test with style 'background-position: 30px 40px; background-position-block: 10%; background-position-inline: 20%;'
+PASS Test with style 'background-position-block: 10%; background-position: 30px 40px; background-position-inline: 20%;'
+PASS Test with style '--foo: 1px 2px; background-position-block: 10%; background-position-inline: 20%; background-position: var(--foo);'
+PASS Test with style '--foo: 1px 2px; background-position: var(--foo); background-position-block: 10%; background-position-inline: 20%;'
+PASS Test with style '--foo: 1px 2px; background-position-block: 10%; background-position: var(--foo); background-position-inline: 20%;'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-longhand-shorthand-overriding.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-longhand-shorthand-overriding.tentative.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Module Level 4: Interaction between background-position-* longhands and background-position shorthand</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<style>
+  #target {
+    font-size: 40px;
+  }
+</style>
+</head>
+<body>
+<div id="target"></div>
+<script>
+const test_cases = [
+  {
+    style: "background-position: right top",
+    expected: {
+      "background-position-x": "100%",
+      "background-position-y": "0%",
+      "background-position-block": "0%",
+      "background-position-inline": "100%",
+      "background-position": "100% 0%",
+    }
+  },
+  {
+    style: "background-position: center center",
+    expected: {
+      "background-position-x": "50%",
+      "background-position-y": "50%",
+      "background-position-block": "50%",
+      "background-position-inline": "50%",
+      "background-position": "50% 50%",
+    }
+  },
+  {
+    style: "background-position-block: 10%; background-position-inline: 20%",
+    expected: {
+      "background-position-x": "20%",
+      "background-position-y": "10%",
+      "background-position-block": "10%",
+      "background-position-inline": "20%",
+      "background-position": "20% 10%",
+    }
+  },
+  {
+    style: "background-position-block: 10%; background-position-inline: 20%; background-position-x: 30%; background-position-y: 40%;",
+    expected: {
+      "background-position-x": "30%",
+      "background-position-y": "40%",
+      "background-position-block": "40%",
+      "background-position-inline": "30%",
+      "background-position": "30% 40%",
+    }
+  },
+  {
+    style: "background-position-x: 30%; background-position-y: 40%; background-position-block: 10%; background-position-inline: 20%;",
+    expected: {
+      "background-position-x": "20%",
+      "background-position-y": "10%",
+      "background-position-block": "10%",
+      "background-position-inline": "20%",
+      "background-position": "20% 10%",
+    }
+  },
+  {
+    style: "background-position-x: 30%; background-position-block: 10%; background-position-y: 40%; background-position-inline: 20%;",
+    expected: {
+      "background-position-x": "20%",
+      "background-position-y": "40%",
+      "background-position-block": "40%",
+      "background-position-inline": "20%",
+      "background-position": "20% 40%",
+    }
+  },
+  {
+    style: "background-position-block: 10%; background-position-inline: 20%; background-position: 30px 40px;",
+    expected: {
+      "background-position-x": "30px",
+      "background-position-y": "40px",
+      "background-position-block": "40px",
+      "background-position-inline": "30px",
+      "background-position": "30px 40px",
+    }
+  },
+  {
+    style: "background-position: 30px 40px; background-position-block: 10%; background-position-inline: 20%;",
+    expected: {
+      "background-position-x": "20%",
+      "background-position-y": "10%",
+      "background-position-block": "10%",
+      "background-position-inline": "20%",
+      "background-position": "20% 10%",
+    }
+  },
+  {
+    style: "background-position-block: 10%; background-position: 30px 40px; background-position-inline: 20%;",
+    expected: {
+      "background-position-x": "20%",
+      "background-position-y": "40px",
+      "background-position-block": "40px",
+      "background-position-inline": "20%",
+      "background-position": "20% 40px",
+    }
+  },
+  {
+    style: "--foo: 1px 2px; background-position-block: 10%; background-position-inline: 20%; background-position: var(--foo);",
+    expected: {
+      "background-position-x": "1px",
+      "background-position-y": "2px",
+      "background-position-block": "2px",
+      "background-position-inline": "1px",
+      "background-position": "1px 2px",
+    }
+  },
+  {
+    style: "--foo: 1px 2px; background-position: var(--foo); background-position-block: 10%; background-position-inline: 20%;",
+    expected: {
+      "background-position-x": "20%",
+      "background-position-y": "10%",
+      "background-position-block": "10%",
+      "background-position-inline": "20%",
+      "background-position": "20% 10%",
+    }
+  },
+  {
+    style: "--foo: 1px 2px; background-position-block: 10%; background-position: var(--foo); background-position-inline: 20%;",
+    expected: {
+      "background-position-x": "20%",
+      "background-position-y": "2px",
+      "background-position-block": "2px",
+      "background-position-inline": "20%",
+      "background-position": "20% 2px",
+    }
+  }
+];
+
+for (let test_case of test_cases) {
+  test(function(){
+      var div = document.getElementById('target');
+      div.style = "";
+      try {
+          div.style = test_case.style;
+
+          for (let property in test_case.expected) {
+            const readValue = window.getComputedStyle(div)[property];
+            assert_equals(readValue, test_case.expected[property], `computed value for '${property}' matches provided expectation '${test_case.expected[property]}'`);
+          }
+      } finally {
+          div.style = "";
+      }
+  }, `Test with style '${test_case.style}'`);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-writing-mode.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-writing-mode.tentative-expected.txt
@@ -1,0 +1,22 @@
+
+PASS Test with style 'writing-mode: horizontal-tb; direction: ltr; background-position-block: start; background-position-inline: start;'
+PASS Test with style 'writing-mode: horizontal-tb; direction: ltr; background-position-x: left; background-position-y: top;'
+FAIL Test with style 'writing-mode: horizontal-tb; direction: rtl; background-position-block: 0%; background-position-inline: 0%;' assert_equals: computed value for 'background-position-inline' matches provided expectation expected "0%" but got "100%"
+FAIL Test with style 'writing-mode: horizontal-tb; direction: rtl; background-position-x: left; background-position-y: top;' assert_equals: computed value for 'background-position-inline' matches provided expectation expected "100%" but got "0%"
+PASS Test with style 'writing-mode: vertical-rl; direction: rtl; background-position-block: start; background-position-inline: end;'
+PASS Test with style 'writing-mode: vertical-rl; direction: rtl; background-position-x: left; background-position-y: bottom;'
+FAIL Test with style 'writing-mode: sideways-rl; direction: rtl; background-position-block: start; background-position-inline: end;' assert_equals: computed value for 'background-position-x' matches provided expectation expected "0%" but got "100%"
+FAIL Test with style 'writing-mode: sideways-rl; direction: rtl; background-position-x: left; background-position-y: bottom;' assert_equals: computed value for 'background-position-block' matches provided expectation expected "100%" but got "0%"
+FAIL Test with style 'writing-mode: vertical-rl; direction: ltr; background-position-block: start; background-position-inline: end;' assert_equals: computed value for 'background-position-x' matches provided expectation expected "0%" but got "100%"
+FAIL Test with style 'writing-mode: vertical-rl; direction: ltr; background-position-x: left; background-position-y: bottom;' assert_equals: computed value for 'background-position-block' matches provided expectation expected "100%" but got "0%"
+FAIL Test with style 'writing-mode: sideways-rl; direction: ltr; background-position-block: start; background-position-inline: end;' assert_equals: computed value for 'background-position-x' matches provided expectation expected "0%" but got "100%"
+FAIL Test with style 'writing-mode: sideways-rl; direction: ltr; background-position-x: left; background-position-y: bottom;' assert_equals: computed value for 'background-position-block' matches provided expectation expected "100%" but got "0%"
+PASS Test with style 'writing-mode: vertical-lr; direction: rtl; background-position-block: start; background-position-inline: end;'
+FAIL Test with style 'writing-mode: vertical-lr; direction: rtl; background-position-x: left; background-position-y: bottom;' assert_equals: computed value for 'background-position-block' matches provided expectation expected "100%" but got "0%"
+PASS Test with style 'writing-mode: sideways-lr; direction: ltr; background-position-block: start; background-position-inline: end;'
+FAIL Test with style 'writing-mode: sideways-lr; direction: ltr; background-position-x: left; background-position-y: bottom;' assert_equals: computed value for 'background-position-block' matches provided expectation expected "100%" but got "0%"
+FAIL Test with style 'writing-mode: vertical-lr; direction: ltr; background-position-block: start; background-position-inline: end;' assert_equals: computed value for 'background-position-y' matches provided expectation expected "0%" but got "100%"
+FAIL Test with style 'writing-mode: vertical-lr; direction: ltr; background-position-x: left; background-position-y: bottom;' assert_equals: computed value for 'background-position-block' matches provided expectation expected "100%" but got "0%"
+FAIL Test with style 'writing-mode: sideways-lr; direction: rtl; background-position-block: start; background-position-inline: end;' assert_equals: computed value for 'background-position-y' matches provided expectation expected "0%" but got "100%"
+FAIL Test with style 'writing-mode: sideways-lr; direction: rtl; background-position-x: left; background-position-y: bottom;' assert_equals: computed value for 'background-position-block' matches provided expectation expected "100%" but got "0%"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-writing-mode.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-writing-mode.tentative.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Module Level 4: background-position with different writing modes</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<style>
+  #target {
+    font-size: 40px;
+  }
+</style>
+</head>
+<body>
+<div id="target"></div>
+<script>
+const test_cases = [  
+  // writing-mode: horizontal-tb; direction: ltr
+  {
+    style: "writing-mode: horizontal-tb; direction: ltr; background-position-block: start; background-position-inline: start;",
+    expected: {
+      "background-position-x": "0%",
+      "background-position-y": "0%",
+      "background-position-block": "0%",
+      "background-position-inline": "0%",
+      "background-position": "0% 0%",
+    }
+  },
+  {
+    style: "writing-mode: horizontal-tb; direction: ltr; background-position-x: left; background-position-y: top;",
+    expected: {
+      "background-position-x": "0%",
+      "background-position-y": "0%",
+      "background-position-block": "0%",
+      "background-position-inline": "0%",
+      "background-position": "0% 0%",
+    }
+  },
+
+  // writing-mode: horizontal-tb; direction: rtl
+  {
+    style: "writing-mode: horizontal-tb; direction: rtl; background-position-block: 0%; background-position-inline: 0%;",
+    expected: {
+      "background-position-x": "100%",
+      "background-position-y": "0%",
+      "background-position-block": "0%",
+      "background-position-inline": "0%",
+      "background-position": "100% 0%",
+    }
+  },
+  {
+    style: "writing-mode: horizontal-tb; direction: rtl; background-position-x: left; background-position-y: top;",
+    expected: {
+      "background-position-x": "0%",
+      "background-position-y": "0%",
+      "background-position-block": "0%",
+      "background-position-inline": "100%",
+      "background-position": "0% 0%",
+    }
+  },
+
+  // writing-mode: vertical-rl; direction: rtl
+  {
+    style: "writing-mode: vertical-rl; direction: rtl; background-position-block: start; background-position-inline: end;",
+    expected: {
+      "background-position-x": "100%",
+      "background-position-y": "0%",
+      "background-position-block": "100%",
+      "background-position-inline": "0%",
+      "background-position": "100% 0%",
+    }
+  },
+  {
+    style: "writing-mode: vertical-rl; direction: rtl; background-position-x: left; background-position-y: bottom;",
+    expected: {
+      "background-position-x": "0%",
+      "background-position-y": "100%",
+      "background-position-block": "0%",
+      "background-position-inline": "100%",
+      "background-position": "0% 100%",
+    }
+  },
+
+  // writing-mode: sideways-rl; direction: rtl
+  {
+    style: "writing-mode: sideways-rl; direction: rtl; background-position-block: start; background-position-inline: end;",
+    expected: {
+      "background-position-x": "0%",
+      "background-position-y": "0%",
+      "background-position-block": "0%",
+      "background-position-inline": "0%",
+      "background-position": "0% 0%",
+    }
+  },
+  {
+    style: "writing-mode: sideways-rl; direction: rtl; background-position-x: left; background-position-y: bottom;",
+    expected: {
+      "background-position-x": "0%",
+      "background-position-y": "100%",
+      "background-position-block": "100%",
+      "background-position-inline": "0%",
+      "background-position": "0% 100%",
+    }
+  },
+
+  // writing-mode: vertical-rl; direction: ltr
+  {
+    style: "writing-mode: vertical-rl; direction: ltr; background-position-block: start; background-position-inline: end;",
+    expected: {
+      "background-position-x": "0%",
+      "background-position-y": "0%",
+      "background-position-block": "0%",
+      "background-position-inline": "0%",
+      "background-position": "0% 0%",
+    }
+  },
+  {
+    style: "writing-mode: vertical-rl; direction: ltr; background-position-x: left; background-position-y: bottom;",
+    expected: {
+      "background-position-x": "0%",
+      "background-position-y": "100%",
+      "background-position-block": "100%",
+      "background-position-inline": "0%",
+      "background-position": "0% 100%",
+    }
+  },
+
+  // writing-mode: sideways-rl; direction: ltr
+  {
+    style: "writing-mode: sideways-rl; direction: ltr; background-position-block: start; background-position-inline: end;",
+    expected: {
+      "background-position-x": "0%",
+      "background-position-y": "0%",
+      "background-position-block": "0%",
+      "background-position-inline": "0%",
+      "background-position": "0% 0%",
+    }
+  },
+  {
+    style: "writing-mode: sideways-rl; direction: ltr; background-position-x: left; background-position-y: bottom;",
+    expected: {
+      "background-position-x": "0%",
+      "background-position-y": "100%",
+      "background-position-block": "100%",
+      "background-position-inline": "0%",
+      "background-position": "0% 100%",
+    }
+  },
+
+  // writing-mode: vertical-lr; direction: rtl
+  {
+    style: "writing-mode: vertical-lr; direction: rtl; background-position-block: start; background-position-inline: end;",
+    expected: {
+      "background-position-x": "0%",
+      "background-position-y": "0%",
+      "background-position-block": "0%",
+      "background-position-inline": "0%",
+      "background-position": "0% 0%",
+    }
+  },
+  {
+    style: "writing-mode: vertical-lr; direction: rtl; background-position-x: left; background-position-y: bottom;",
+    expected: {
+      "background-position-x": "0%",
+      "background-position-y": "100%",
+      "background-position-block": "100%",
+      "background-position-inline": "0%",
+      "background-position": "0% 100%",
+    }
+  },
+
+  // writing-mode: sideways-lr; direction: ltr
+  {
+    style: "writing-mode: sideways-lr; direction: ltr; background-position-block: start; background-position-inline: end;",
+    expected: {
+      "background-position-x": "0%",
+      "background-position-y": "0%",
+      "background-position-block": "0%",
+      "background-position-inline": "0%",
+      "background-position": "0% 0%",
+    }
+  },
+  {
+    style: "writing-mode: sideways-lr; direction: ltr; background-position-x: left; background-position-y: bottom;",
+    expected: {
+      "background-position-x": "0%",
+      "background-position-y": "100%",
+      "background-position-block": "100%",
+      "background-position-inline": "0%",
+      "background-position": "0% 100%",
+    }
+  },
+
+  // writing-mode: vertical-lr; direction: ltr
+  {
+    style: "writing-mode: vertical-lr; direction: ltr; background-position-block: start; background-position-inline: end;",
+    expected: {
+      "background-position-x": "0%",
+      "background-position-y": "0%",
+      "background-position-block": "0%",
+      "background-position-inline": "0%",
+      "background-position": "0% 0%",
+    }
+  },
+  {
+    style: "writing-mode: vertical-lr; direction: ltr; background-position-x: left; background-position-y: bottom;",
+    expected: {
+      "background-position-x": "0%",
+      "background-position-y": "100%",
+      "background-position-block": "100%",
+      "background-position-inline": "0%",
+      "background-position": "0% 100%",
+    }
+  },
+
+  // writing-mode: sideways-lr; direction: rtl
+  {
+    style: "writing-mode: sideways-lr; direction: rtl; background-position-block: start; background-position-inline: end;",
+    expected: {
+      "background-position-x": "0%",
+      "background-position-y": "0%",
+      "background-position-block": "0%",
+      "background-position-inline": "0%",
+      "background-position": "0% 0%",
+    }
+  },
+  {
+    style: "writing-mode: sideways-lr; direction: rtl; background-position-x: left; background-position-y: bottom;",
+    expected: {
+      "background-position-x": "0%",
+      "background-position-y": "100%",
+      "background-position-block": "100%",
+      "background-position-inline": "0%",
+      "background-position": "0% 100%",
+    }
+  }
+];
+
+for (let test_case of test_cases) {
+  test(function(){
+      var div = document.getElementById('target');
+      div.style = "";
+      try {
+          div.style = test_case.style;
+
+          for (let property in test_case.expected) {
+            const readValue = window.getComputedStyle(div)[property];
+            assert_equals(readValue, test_case.expected[property], `computed value for '${property}' matches provided expectation`);
+          }
+      } finally {
+          div.style = "";
+      }
+  }, `Test with style '${test_case.style}'`);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/position/position-computed.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/position/position-computed.tentative.html
@@ -46,6 +46,20 @@ test_computed_value(property, "y-end", "50% 100%");
 test_computed_value(property, "10px y-end", "10px 100%");
 test_computed_value(property, "left 10px y-end 20%", "10px 80%");
 
+test_computed_value(property, "block-start", "50% 0%");
+test_computed_value(property, "block-end", "50% 100%");
+test_computed_value(property, "inline-start", "0% 50%");
+test_computed_value(property, "inline-end", "100% 50%");
+test_computed_value(property, "block-start 10% inline-start 20px", "20px 10%");
+test_computed_value(property, "block-end 10% inline-start 20%", "20px calc(100% - 10px)");
+
+test_computed_value(property, "start start", "0% 0%");
+test_computed_value(property, "end end", "100% 100%");
+test_computed_value(property, "start end", "100% 0%");
+test_computed_value(property, "end start", "0% 100%");
+test_computed_value(property, "start 10px start 20%", "20% 10px");
+test_computed_value(property, "end 10px start 20%", "20% calc(100% - 10px)");
+
 function test_writing_modes(property) {
   const writing_modes = [
     {
@@ -57,6 +71,12 @@ function test_writing_modes(property) {
         { "x-end": "right" },
         { "y-start": "top" },
         { "y-end": "bottom" },
+        { "block-start": "top" },
+        { "block-end": "bottom" },
+        { "inline-start": "left" },
+        { "inline-end": "right" },
+        { "block-start 10px inline-start 20px": "top 10px left 20px" },
+        { "inline-start 20px block-start 10px": "left 20px top 10px" },
       ]
     },
     {
@@ -68,6 +88,12 @@ function test_writing_modes(property) {
         { "x-end": "left" },
         { "y-start": "top" },
         { "y-end": "bottom" },
+        { "block-start": "top" },
+        { "block-end": "bottom" },
+        { "inline-start": "right" },
+        { "inline-end": "left" },
+        { "block-start 10px inline-start 20px": "top 10px right 20px" },
+        { "inline-start 20px block-start 10px": "right 20px top 10px" },
       ]
     },
     {
@@ -80,6 +106,12 @@ function test_writing_modes(property) {
         { "x-end": "left" },
         { "y-start": "bottom" },
         { "y-end": "top" },
+        { "block-start": "right" },
+        { "block-end": "left" },
+        { "inline-start": "bottom" },
+        { "inline-end": "top" },
+        { "block-start 10px inline-start 20px": "right 10px bottom 20px" },
+        { "inline-start 20px block-start 10px": "bottom 20px right 10px" },
       ]
     },
     {
@@ -92,6 +124,12 @@ function test_writing_modes(property) {
         { "x-end": "left" },
         { "y-start": "top" },
         { "y-end": "bottom" },
+        { "block-start": "right" },
+        { "block-end": "left" },
+        { "inline-start": "top" },
+        { "inline-end": "bottom" },
+        { "block-start 10px inline-start 20px": "right 10px top 20px" },
+        { "inline-start 20px block-start 10px": "top 20px right 10px" },
       ]
     },
     {
@@ -103,6 +141,12 @@ function test_writing_modes(property) {
         { "x-end": "right" },
         { "y-start": "bottom" },
         { "y-end": "top" },
+        { "block-start": "left" },
+        { "block-end": "right" },
+        { "inline-start": "bottom" },
+        { "inline-end": "top" },
+        { "block-start 10px inline-start 20px": "left 10px bottom 20px" },
+        { "inline-start 20px block-start 10px": "bottom 20px left 10px" },
       ]
     },
     {
@@ -114,6 +158,12 @@ function test_writing_modes(property) {
         { "x-end": "right" },
         { "y-start": "bottom" },
         { "y-end": "top" },
+        { "block-start": "left" },
+        { "block-end": "right" },
+        { "inline-start": "bottom" },
+        { "inline-end": "top" },
+        { "block-start 10px inline-start 20px": "left 10px bottom 20px" },
+        { "inline-start 20px block-start 10px": "bottom 20px left 10px" },
       ]
     },
     {
@@ -125,6 +175,12 @@ function test_writing_modes(property) {
         { "x-end": "right" },
         { "y-start": "top" },
         { "y-end": "bottom" },
+        { "block-start": "left" },
+        { "block-end": "right" },
+        { "inline-start": "top" },
+        { "inline-end": "bottom" },
+        { "block-start 10px inline-start 20px": "left 10px top 20px" },
+        { "inline-start 20px block-start 10px": "top 20px left 10px" },
       ]
     },
     {
@@ -136,8 +192,26 @@ function test_writing_modes(property) {
         { "x-end": "right" },
         { "y-start": "top" },
         { "y-end": "bottom" },
+        { "block-start": "left" },
+        { "block-end": "right" },
+        { "inline-start": "top" },
+        { "inline-end": "bottom" },
+        { "block-start 10px inline-start 20px": "left 10px top 20px" },
+        { "inline-start 20px block-start 10px": "top 20px left 10px" },
       ]
     },
+  ];
+
+  // These mapping equivilances hold for all writing modes.
+  const canonical_mappings = [
+    { "start center": "block-start" },
+    { "end center": "block-end" },
+    { "center start": "inline-start" },
+    { "center end": "inline-end" },
+    { "start start": "block-start inline-start" },
+    { "start end": "block-start inline-end" },
+    { "end start": "block-end inline-start" },
+    { "end end": "block-end inline-end" },
   ];
 
   function inner_test(property, specified, expected_to_match, container_styles) {
@@ -173,6 +247,12 @@ function test_writing_modes(property) {
       }
       
       for (let mapping of writing_mode.mappings) {
+        for (let key in mapping) {
+          inner_test(property, key, mapping[key], container_styles);
+        }
+      }
+
+      for (let mapping of canonical_mappings) {
         for (let key in mapping) {
           inner_test(property, key, mapping[key], container_styles);
         }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/position/position-invalid.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/position/position-invalid.tentative.html
@@ -34,6 +34,10 @@ test_invalid_value(property, "right top 5px");
 test_invalid_value(property, "bottom 6% center");
 test_invalid_value(property, "bottom 7% left");
 test_invalid_value(property, "bottom right 8%");
+test_invalid_value(property, "x-start block-end");
+test_invalid_value(property, "inline-start end");
+test_invalid_value(property, "inline-end 10px");
+test_invalid_value(property, "10px end");
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/position/position-valid.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/position/position-valid.tentative.html
@@ -48,6 +48,20 @@ test_valid_value(property, "y-end", "center y-end");
 test_valid_value(property, "10px y-end");
 test_valid_value(property, "left 10px y-end 20%");
 test_valid_value(property, "y-end 20% left 10px", "left 10px y-end 20%");
+
+test_valid_value(property, "block-start", "block-start center");
+test_valid_value(property, "block-end", "block-end center");
+test_valid_value(property, "inline-start", "center inline-start");
+test_valid_value(property, "inline-end", "center inline-end");
+test_valid_value(property, "block-start 10% inline-start 20px");
+test_valid_value(property, "block-end 10% inline-start 20%");
+
+test_valid_value(property, "start start");
+test_valid_value(property, "end end");
+test_valid_value(property, "start end");
+test_valid_value(property, "end start");
+test_valid_value(property, "start 10px start 20%");
+test_valid_value(property, "end 10px start 20%");
 </script>
 </body>
 </html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1258,6 +1258,20 @@ CSSFieldSizingEnabled:
     WebCore:
       default: false
 
+CSSFlowRelativePositionKeywordsEnabled:
+  type: bool
+  category: css
+  status: preview
+  humanReadableName: "CSS flow relative keywords in <position>"
+  humanReadableDescription: "Enable support for CSS Values and Units Module Level 5 flow relative keywords in <position>"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSFontFaceSizeAdjustEnabled:
   type: bool
   status: stable
@@ -1334,6 +1348,20 @@ CSSLineFitEdgeEnabled:
   category: css
   humanReadableName: "CSS line-fit-edge"
   humanReadableDescription: "Enable CSS line-fit-edge"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
+CSSLogicalBackgroundPositionEnabled:
+  type: bool
+  category: css
+  status: preview
+  humanReadableName: "CSS logical background-position longhands"
+  humanReadableDescription: "Enable support for CSS Backgrounds Module Level 4 logical background-position longhands"
   defaultValue:
     WebKitLegacy:
       default: false

--- a/Source/WebCore/css/CSSPositionValue.cpp
+++ b/Source/WebCore/css/CSSPositionValue.cpp
@@ -113,4 +113,32 @@ IterationStatus CSSPositionYValue::customVisitChildren(NOESCAPE const Function<I
     return CSS::visitCSSValueChildren(func, m_position);
 }
 
+// MARK: PositionLogical
+
+Ref<CSSPositionLogicalValue> CSSPositionLogicalValue::create(CSS::PositionLogical&& position)
+{
+    return adoptRef(*new CSSPositionLogicalValue(WTFMove(position)));
+}
+
+CSSPositionLogicalValue::CSSPositionLogicalValue(CSS::PositionLogical&& position)
+    : CSSValue(ClassType::PositionLogical)
+    , m_position(WTFMove(position))
+{
+}
+
+String CSSPositionLogicalValue::customCSSText(const CSS::SerializationContext& context) const
+{
+    return CSS::serializationForCSS(context, m_position);
+}
+
+bool CSSPositionLogicalValue::equals(const CSSPositionLogicalValue& other) const
+{
+    return m_position == other.m_position;
+}
+
+IterationStatus CSSPositionLogicalValue::customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>& func) const
+{
+    return CSS::visitCSSValueChildren(func, m_position);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/CSSPositionValue.h
+++ b/Source/WebCore/css/CSSPositionValue.h
@@ -80,8 +80,26 @@ private:
     CSS::PositionY m_position;
 };
 
+class CSSPositionLogicalValue final : public CSSValue {
+public:
+    static Ref<CSSPositionLogicalValue> create(CSS::PositionLogical&&);
+
+    const CSS::PositionLogical& position() const { return m_position; }
+
+    String customCSSText(const CSS::SerializationContext&) const;
+    bool equals(const CSSPositionLogicalValue&) const;
+
+    IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;
+
+private:
+    CSSPositionLogicalValue(CSS::PositionLogical&&);
+
+    CSS::PositionLogical m_position;
+};
+
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSPositionValue, isPositionValue())
 SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSPositionXValue, isPositionXValue())
 SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSPositionYValue, isPositionYValue())
+SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSPositionLogicalValue, isPositionLogicalValue())

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -2156,6 +2156,10 @@
             "animation-type": "repeatable list",
             "initial": "0%",
             "codegen-properties": {
+                "logical-property-group": {
+                    "name": "background-position",
+                    "resolver": "horizontal"
+                },
                 "animation-wrapper": "FillLayersWrapper",
                 "fill-layer-name-for-methods": "XPosition",
                 "fill-layer-property": true,
@@ -2171,6 +2175,11 @@
             "animation-type": "repeatable list",
             "initial": "0%",
             "codegen-properties": {
+                "logical-property-group": {
+                    "name": "background-position",
+                    "resolver": "vertical"
+                },
+                "disables-native-appearance": true,
                 "animation-wrapper": "FillLayersWrapper",
                 "fill-layer-name-for-methods": "YPosition",
                 "fill-layer-property": true,
@@ -2180,6 +2189,42 @@
             "specification": {
                 "category": "css-backgrounds",
                 "url": "https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position-y"
+            }
+        },
+        "background-position-block": {
+            "animation-type": "repeatable list",
+            "initial": "0%",
+            "codegen-properties": {
+                "settings-flag": "cssLogicalBackgroundPositionEnabled",
+                "skip-style-builder": true,
+                "logical-property-group": {
+                    "name": "background-position",
+                    "resolver": "block"
+                },
+                "disables-native-appearance": true,
+                "parser-grammar": "<single-background-position-block>#"
+            },
+            "specification": {
+                "category": "css-backgrounds",
+                "url": "https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position-block"
+            }
+        },
+        "background-position-inline": {
+            "animation-type": "repeatable list",
+            "initial": "0%",
+            "codegen-properties": {
+                "settings-flag": "cssLogicalBackgroundPositionEnabled",
+                "skip-style-builder": true,
+                "logical-property-group": {
+                    "name": "background-position",
+                    "resolver": "inline"
+                },
+                "disables-native-appearance": true,
+                "parser-grammar": "<single-background-position-inline>#"
+            },
+            "specification": {
+                "category": "css-backgrounds",
+                "url": "https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position-inline"
             }
         },
         "background-repeat": {
@@ -5665,6 +5710,10 @@
             "animation-type": "repeatable list",
             "initial": "0%",
             "codegen-properties": {
+                "logical-property-group": {
+                    "name": "-webkit-mask-position-position",
+                    "resolver": "horizontal"
+                },
                 "animation-wrapper": "FillLayersWrapper",
                 "fill-layer-name-for-methods": "XPosition",
                 "fill-layer-property": true,
@@ -5683,10 +5732,56 @@
             "animation-type": "repeatable list",
             "initial": "0%",
             "codegen-properties": {
+                "logical-property-group": {
+                    "name": "-webkit-mask-position-position",
+                    "resolver": "vertical"
+                },
                 "animation-wrapper": "FillLayersWrapper",
                 "fill-layer-name-for-methods": "YPosition",
                 "fill-layer-property": true,
                 "parser-grammar": "<single-webkit-mask-position-y>#"
+            },
+            "status": {
+                "status": "non-standard",
+                "comment": "The unprefixed property should be internal-only"
+            },
+            "specification": {
+                "category": "css-masking",
+                "url": "https://drafts.fxtf.org/css-masking-1/#propdef-mask-position"
+            }
+        },
+        "-webkit-mask-position-block": {
+            "animation-type": "repeatable list",
+            "initial": "0%",
+            "codegen-properties": {
+                "settings-flag": "cssLogicalBackgroundPositionEnabled",
+                "skip-style-builder": true,
+                "logical-property-group": {
+                    "name": "-webkit-mask-position-position",
+                    "resolver": "block"
+                },
+                "parser-grammar": "<single-webkit-mask-position-block>#"
+            },
+            "status": {
+                "status": "non-standard",
+                "comment": "The unprefixed property should be internal-only"
+            },
+            "specification": {
+                "category": "css-masking",
+                "url": "https://drafts.fxtf.org/css-masking-1/#propdef-mask-position"
+            }
+        },
+        "-webkit-mask-position-inline": {
+            "animation-type": "repeatable list",
+            "initial": "0%",
+            "codegen-properties": {
+                "settings-flag": "cssLogicalBackgroundPositionEnabled",
+                "skip-style-builder": true,
+                "logical-property-group": {
+                    "name": "-webkit-mask-position-position",
+                    "resolver": "inline"
+                },
+                "parser-grammar": "<single-webkit-mask-position-inline>#"
             },
             "status": {
                 "status": "non-standard",
@@ -13124,14 +13219,34 @@
         "<single-background-position-x>": {
             "grammar": "<position-x>",
             "exported": true,
-            "status": "non-standard",
-            "comment": "Internally used to represent horizontal part of standard <bg-position>"
+            "specification": {
+                "category": "css-backgrounds",
+                "url": "https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position-x"
+            }
         },
         "<single-background-position-y>": {
             "grammar": "<position-y>",
             "exported": true,
-            "status": "non-standard",
-            "comment": "Internally used to represent vertical part of standard <bg-position>"
+            "specification": {
+                "category": "css-backgrounds",
+                "url": "https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position-y"
+            }
+        },
+        "<single-background-position-block>": {
+            "grammar": "<position-block>",
+            "exported": true,
+            "specification": {
+                "category": "css-backgrounds",
+                "url": "https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position-block"
+            }
+        },
+        "<single-background-position-inline>": {
+            "grammar": "<position-inline>",
+            "exported": true,
+            "specification": {
+                "category": "css-backgrounds",
+                "url": "https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position-inline"
+            }
         },
         "<single-mask-clip>": {
             "grammar": "<box> | no-clip",
@@ -13210,6 +13325,16 @@
         },
         "<single-webkit-mask-position-y>": {
             "grammar": "<position-y>",
+            "exported": true,
+            "status": "non-standard"
+        },
+        "<single-webkit-mask-position-block>": {
+            "grammar": "<position-block>",
+            "exported": true,
+            "status": "non-standard"
+        },
+        "<single-webkit-mask-position-inline>": {
+            "grammar": "<position-inline>",
             "exported": true,
             "status": "non-standard"
         },

--- a/Source/WebCore/css/CSSProperty.h
+++ b/Source/WebCore/css/CSSProperty.h
@@ -111,6 +111,7 @@ public:
     // NOTE: These return true if the CSSPropertyID is member of the named logical
     // property group or is the shorthand of a member of the logical property group.
 
+    static bool isBackgroundPositionProperty(CSSPropertyID);
     static bool isBorderColorProperty(CSSPropertyID);
     static bool isBorderRadiusProperty(CSSPropertyID);
     static bool isBorderStyleProperty(CSSPropertyID);
@@ -127,6 +128,7 @@ public:
     static bool isScrollMarginProperty(CSSPropertyID);
     static bool isScrollPaddingProperty(CSSPropertyID);
     static bool isSizeProperty(CSSPropertyID);
+    static bool isWebkitMaskPositionPositionProperty(CSSPropertyID);
 
     // Check if a property is a sizing property, as defined in:
     // https://drafts.csswg.org/css-sizing-3/#sizing-property

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -201,6 +201,8 @@ template<typename Visitor> constexpr decltype(auto) CSSValue::visitDerived(Visit
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSPositionXValue>(*this));
     case PositionY:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSPositionYValue>(*this));
+    case PositionLogical:
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSPositionLogicalValue>(*this));
     case Primitive:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSPrimitiveValue>(*this));
     case Quad:

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -114,6 +114,7 @@ public:
     bool isPositionValue() const { return m_classType == ClassType::Position; }
     bool isPositionXValue() const { return m_classType == ClassType::PositionX; }
     bool isPositionYValue() const { return m_classType == ClassType::PositionY; }
+    bool isPositionLogicalValue() const { return m_classType == ClassType::PositionLogical; }
     bool isPrimitiveValue() const { return m_classType == ClassType::Primitive; }
     bool isQuad() const { return m_classType == ClassType::Quad; }
     bool isRatioValue() const { return m_classType == ClassType::Ratio; }
@@ -245,6 +246,7 @@ protected:
         Position,
         PositionX,
         PositionY,
+        PositionLogical,
         Quad,
         Ratio,
         Ray,

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -477,11 +477,102 @@ static Ref<CSSValueList> createPositionListForLayer(const FillLayer& layer, cons
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
-static Ref<CSSValue> createSingleAxisPositionValueForLayer(CSSPropertyID propertyID, const FillLayer& layer, const RenderStyle& style)
+static Ref<CSSValue> createSingleXAxisPositionValueForLayer(const FillLayer& layer, const RenderStyle& style)
 {
-    if (propertyID == CSSPropertyBackgroundPositionX || propertyID == CSSPropertyWebkitMaskPositionX)
-        return ComputedStyleExtractor::zoomAdjustedPixelValueForLength(layer.xPosition(), style);
+    return ComputedStyleExtractor::zoomAdjustedPixelValueForLength(layer.xPosition(), style);
+}
+
+static Ref<CSSValue> createSingleYAxisPositionValueForLayer(const FillLayer& layer, const RenderStyle& style)
+{
     return ComputedStyleExtractor::zoomAdjustedPixelValueForLength(layer.yPosition(), style);
+}
+
+static Ref<CSSValue> createSingleXAxisPositionValueForLayerReflectingIfNeeded(const FillLayer& layer, const RenderStyle& style, bool reflect)
+{
+    if (reflect)
+        return ComputedStyleExtractor::zoomAdjustedPixelValueForLength(convertTo100PercentMinusLength(layer.xPosition()), style);
+    return ComputedStyleExtractor::zoomAdjustedPixelValueForLength(layer.xPosition(), style);
+}
+
+static Ref<CSSValue> createSingleYAxisPositionValueForLayerReflectingIfNeeded(const FillLayer& layer, const RenderStyle& style, bool reflect)
+{
+    if (reflect)
+        return ComputedStyleExtractor::zoomAdjustedPixelValueForLength(convertTo100PercentMinusLength(layer.yPosition()), style);
+    return ComputedStyleExtractor::zoomAdjustedPixelValueForLength(layer.yPosition(), style);
+}
+
+static Ref<CSSValue> positionValueForPosition(const FillLayer& layers, const RenderStyle& style)
+{
+    if (!layers.next())
+        return createPositionListForLayer(layers, style);
+    CSSValueListBuilder list;
+    for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next())
+        list.append(createPositionListForLayer(*currLayer, style));
+    return CSSValueList::createCommaSeparated(WTFMove(list));
+}
+
+static Ref<CSSValue> positionValueForPositionX(const FillLayer& layers, const RenderStyle& style)
+{
+    if (!layers.next())
+        return createSingleXAxisPositionValueForLayer(layers, style);
+    CSSValueListBuilder list;
+    for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next())
+        list.append(createSingleXAxisPositionValueForLayer(*currLayer, style));
+    return CSSValueList::createCommaSeparated(WTFMove(list));
+}
+
+static Ref<CSSValue> positionValueForPositionY(const FillLayer& layers, const RenderStyle& style)
+{
+    if (!layers.next())
+        return createSingleYAxisPositionValueForLayer(layers, style);
+    CSSValueListBuilder list;
+    for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next())
+        list.append(createSingleYAxisPositionValueForLayer(*currLayer, style));
+    return CSSValueList::createCommaSeparated(WTFMove(list));
+}
+
+static Ref<CSSValue> positionValueForPositionBlock(const FillLayer& layers, const RenderStyle& style)
+{
+    auto writingMode = style.writingMode();
+    if (writingMode.isVertical()) {
+        bool needsReflection = !writingMode.isAnyLeftToRight();
+        if (!layers.next())
+            return createSingleXAxisPositionValueForLayerReflectingIfNeeded(layers, style, needsReflection);
+        CSSValueListBuilder list;
+        for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next())
+            list.append(createSingleXAxisPositionValueForLayerReflectingIfNeeded(*currLayer, style, needsReflection));
+        return CSSValueList::createCommaSeparated(WTFMove(list));
+    } else {
+        bool needsReflection = !writingMode.isAnyTopToBottom();
+        if (!layers.next())
+            return createSingleYAxisPositionValueForLayerReflectingIfNeeded(layers, style, needsReflection);
+        CSSValueListBuilder list;
+        for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next())
+            list.append(createSingleYAxisPositionValueForLayerReflectingIfNeeded(*currLayer, style, needsReflection));
+        return CSSValueList::createCommaSeparated(WTFMove(list));
+    }
+}
+
+static Ref<CSSValue> positionValueForPositionInline(const FillLayer& layers, const RenderStyle& style)
+{
+    auto writingMode = style.writingMode();
+    if (writingMode.isVertical()) {
+        bool needsReflection = !writingMode.isAnyLeftToRight();
+        if (!layers.next())
+            return createSingleXAxisPositionValueForLayerReflectingIfNeeded(layers, style, needsReflection);
+        CSSValueListBuilder list;
+        for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next())
+            list.append(createSingleXAxisPositionValueForLayerReflectingIfNeeded(*currLayer, style, needsReflection));
+        return CSSValueList::createCommaSeparated(WTFMove(list));
+    } else {
+        bool needsReflection = !writingMode.isAnyTopToBottom();
+        if (!layers.next())
+            return createSingleYAxisPositionValueForLayerReflectingIfNeeded(layers, style, needsReflection);
+        CSSValueListBuilder list;
+        for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next())
+            list.append(createSingleYAxisPositionValueForLayerReflectingIfNeeded(*currLayer, style, needsReflection));
+        return CSSValueList::createCommaSeparated(WTFMove(list));
+    }
 }
 
 static Length getOffsetComputedLength(const RenderStyle& style, CSSPropertyID propertyID)
@@ -3604,10 +3695,9 @@ bool ComputedStyleExtractor::hasProperty(CSSPropertyID propertyID) const
 
 RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderStyle& style, CSSPropertyID propertyID, RenderElement* renderer, PropertyValueType valueType) const
 {
-    auto& cssValuePool = CSSValuePool::singleton();
-    propertyID = CSSProperty::resolveDirectionAwareProperty(propertyID, style.writingMode());
-
     ASSERT(isExposed(propertyID, m_element->document().settings()));
+
+    auto& cssValuePool = CSSValuePool::singleton();
 
     switch (propertyID) {
     case CSSPropertyInvalid:
@@ -3711,36 +3801,18 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         return CSSValueList::createCommaSeparated(WTFMove(list));
     }
     case CSSPropertyBackgroundPosition:
+        return positionValueForPosition(style.backgroundLayers(), style);
     case CSSPropertyWebkitMaskPosition:
-    case CSSPropertyMaskPosition: {
-        auto& layers = propertyID == CSSPropertyBackgroundPosition ? style.backgroundLayers() : style.maskLayers();
-        if (!layers.next())
-            return createPositionListForLayer(layers, style);
-        CSSValueListBuilder list;
-        for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next())
-            list.append(createPositionListForLayer(*currLayer, style));
-        return CSSValueList::createCommaSeparated(WTFMove(list));
-    }
+    case CSSPropertyMaskPosition:
+        return positionValueForPosition(style.maskLayers(), style);
     case CSSPropertyBackgroundPositionX:
-    case CSSPropertyWebkitMaskPositionX: {
-        auto& layers = propertyID == CSSPropertyWebkitMaskPositionX ? style.maskLayers() : style.backgroundLayers();
-        if (!layers.next())
-            return createSingleAxisPositionValueForLayer(propertyID, layers, style);
-        CSSValueListBuilder list;
-        for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next())
-            list.append(createSingleAxisPositionValueForLayer(propertyID, *currLayer, style));
-        return CSSValueList::createCommaSeparated(WTFMove(list));
-    }
+        return positionValueForPositionX(style.backgroundLayers(), style);
     case CSSPropertyBackgroundPositionY:
-    case CSSPropertyWebkitMaskPositionY: {
-        auto& layers = propertyID == CSSPropertyWebkitMaskPositionY ? style.maskLayers() : style.backgroundLayers();
-        if (!layers.next())
-            return createSingleAxisPositionValueForLayer(propertyID, layers, style);
-        CSSValueListBuilder list;
-        for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next())
-            list.append(createSingleAxisPositionValueForLayer(propertyID, *currLayer, style));
-        return CSSValueList::createCommaSeparated(WTFMove(list));
-    }
+        return positionValueForPositionY(style.backgroundLayers(), style);
+    case CSSPropertyWebkitMaskPositionX:
+        return positionValueForPositionX(style.maskLayers(), style);
+    case CSSPropertyWebkitMaskPositionY:
+        return positionValueForPositionY(style.maskLayers(), style);
     case CSSPropertyBlockEllipsis:
         switch (style.blockEllipsis().type) {
         case BlockEllipsis::Type::None:
@@ -5078,7 +5150,7 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     case CSSPropertyAll:
         return nullptr;
 
-    // Directional properties are resolved by resolveDirectionAwareProperty() before the switch.
+    // Most directional properties are resolved by recursing using resolveDirectionAwareProperty() to find the appropriate mapped property.
     case CSSPropertyBorderBlockEndColor:
     case CSSPropertyBorderBlockEndStyle:
     case CSSPropertyBorderBlockEndWidth:
@@ -5131,8 +5203,17 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     case CSSPropertyScrollPaddingInlineStart:
     case CSSPropertyContainIntrinsicBlockSize:
     case CSSPropertyContainIntrinsicInlineSize:
-        ASSERT_NOT_REACHED();
-        return nullptr;
+        return valueForPropertyInStyle(style, CSSProperty::resolveDirectionAwareProperty(propertyID, style.writingMode()), renderer, valueType);
+
+    // A few direction aware properties need special attention to allow additional processing of the value.
+    case CSSPropertyBackgroundPositionBlock:
+        return positionValueForPositionBlock(style.backgroundLayers(), style);
+    case CSSPropertyBackgroundPositionInline:
+        return positionValueForPositionInline(style.backgroundLayers(), style);
+    case CSSPropertyWebkitMaskPositionBlock:
+        return positionValueForPositionBlock(style.maskLayers(), style);
+    case CSSPropertyWebkitMaskPositionInline:
+        return positionValueForPositionInline(style.maskLayers(), style);
 
     // Internal properties should be handled by isExposed above.
     case CSSPropertyWebkitFontSizeDelta:

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -118,6 +118,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , cssTreeCountingFunctionsEnabled { document.settings().cssTreeCountingFunctionsEnabled() }
     , cssURLModifiersEnabled { document.settings().cssURLModifiersEnabled() }
     , cssAxisRelativePositionKeywordsEnabled { document.settings().cssAxisRelativePositionKeywordsEnabled() }
+    , cssFlowRelativePositionKeywordsEnabled { document.settings().cssFlowRelativePositionKeywordsEnabled() }
     , webkitMediaTextTrackDisplayQuirkEnabled { document.quirks().needsWebKitMediaTextTrackDisplayQuirk() }
     , propertySettings { CSSPropertySettings { document.settings() } }
 {
@@ -159,7 +160,8 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.cssRandomFunctionEnabled                  << 27
         | context.cssTreeCountingFunctionsEnabled           << 28
         | context.cssURLModifiersEnabled                    << 29
-        | context.cssAxisRelativePositionKeywordsEnabled    << 30;
+        | context.cssAxisRelativePositionKeywordsEnabled    << 30
+        | context.cssFlowRelativePositionKeywordsEnabled    << 31;
     add(hasher, context.baseURL, context.charset, context.propertySettings, context.mode, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -89,6 +89,7 @@ struct CSSParserContext {
     bool cssTreeCountingFunctionsEnabled : 1 { false };
     bool cssURLModifiersEnabled : 1 { false };
     bool cssAxisRelativePositionKeywordsEnabled : 1 { false };
+    bool cssFlowRelativePositionKeywordsEnabled : 1 { false };
     bool webkitMediaTextTrackDisplayQuirkEnabled : 1 { false };
 
     // Settings, those affecting properties.

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -2335,7 +2335,9 @@ bool CSSPropertyParser::consumeBackgroundShorthand(const StylePropertyShorthand&
 
                 if (property == CSSPropertyBackgroundPositionX || property == CSSPropertyWebkitMaskPositionX) {
                     // Note: This assumes y properties (for example background-position-y) follow the x properties in the shorthand array.
-                    auto position = consumeBackgroundPositionUnresolved(m_range, state);
+
+                    // Splitting does not support flow relative keywords yet. See https://github.com/w3c/csswg-drafts/issues/12132.
+                    auto position = consumeBackgroundPositionXYUnresolved(m_range, state);
                     if (!position)
                         continue;
                     auto [positionX, positionY] = CSS::split(WTFMove(*position));
@@ -2420,7 +2422,8 @@ bool CSSPropertyParser::consumeBackgroundPositionShorthand(const StylePropertySh
     CSSValueListBuilder x;
     CSSValueListBuilder y;
     do {
-        auto position = consumeBackgroundPositionUnresolved(m_range, state);
+        // Splitting does not support flow relative keywords yet. See https://github.com/w3c/csswg-drafts/issues/12132.
+        auto position = consumeBackgroundPositionXYUnresolved(m_range, state);
         if (!position)
             return false;
         auto [positionX, positionY] = CSS::split(WTFMove(*position));
@@ -2472,7 +2475,7 @@ bool CSSPropertyParser::consumeMaskPositionShorthand(CSS::PropertyParserState& s
     CSSValueListBuilder x;
     CSSValueListBuilder y;
     do {
-        auto position = consumePositionUnresolved(m_range, state);
+        auto position = consumePositionXYUnresolved(m_range, state);
         if (!position)
             return false;
         auto [positionX, positionY] = CSS::split(WTFMove(*position));
@@ -2946,7 +2949,7 @@ bool CSSPropertyParser::consumeContainIntrinsicSizeShorthand(CSS::PropertyParser
 
 bool CSSPropertyParser::consumeTransformOriginShorthand(CSS::PropertyParserState& state)
 {
-    if (auto position = consumeOneOrTwoComponentPositionUnresolved(m_range, state)) {
+    if (auto position = consumeTransformOriginXY(m_range, state)) {
         m_range.consumeWhitespace();
         bool atEnd = m_range.atEnd();
         auto resultZ = CSSPrimitiveValueResolver<CSS::Length<>>::consumeAndResolve(m_range, state);
@@ -2964,7 +2967,7 @@ bool CSSPropertyParser::consumeTransformOriginShorthand(CSS::PropertyParserState
 
 bool CSSPropertyParser::consumePerspectiveOriginShorthand(CSS::PropertyParserState& state)
 {
-    if (auto position = consumePositionUnresolved(m_range, state)) {
+    if (auto position = consumePositionXYUnresolved(m_range, state)) {
         auto [positionX, positionY] = CSS::split(WTFMove(*position));
         addPropertyForCurrentShorthand(state, CSSPropertyPerspectiveOriginX, CSSPositionXValue::create(WTFMove(positionX)));
         addPropertyForCurrentShorthand(state, CSSPropertyPerspectiveOriginY, CSSPositionYValue::create(WTFMove(positionY)));

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
@@ -493,7 +493,7 @@ template<CSSValueID Name> static RefPtr<CSSValue> consumePrefixedRadialGradient(
     };
     static constexpr SortedArrayMap extentMap { extentMappings };
 
-    auto position = consumeOneOrTwoComponentPositionUnresolved(range, state);
+    auto position = consumeLegacyBackgroundPositionUnresolved(range, state);
     if (position) {
         if (!consumeCommaIncludingWhitespace(range))
             return nullptr;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Position.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Position.cpp
@@ -59,7 +59,7 @@ using namespace CSS::Literals;
 
 // Sub-productions
 
-// <position-one> = [ left | center | right | top | bottom | x-start | x-end | y-start | y-end | <length-percentage> ]
+// <position-one> = [ left | center | right | top | bottom | x-start | x-end | y-start | y-end | block-start | block-end | inline-start | inline-end | <length-percentage> ]
 //
 // <position-two> = [
 //   [ left | center | right | x-start | x-end ] &&
@@ -67,6 +67,11 @@ using namespace CSS::Literals;
 // |
 //   [ left | center | right | x-start | x-end | <length-percentage> ]
 //   [ top | center | bottom | y-start | y-end | <length-percentage> ]
+// |
+//   [ block-start | center | block-end ] &&
+//   [ inline-start | center | inline-end ]
+// |
+//   [ start | center | end ]{2}
 // ]
 //
 // <bg-position-three> = [
@@ -75,11 +80,28 @@ using namespace CSS::Literals;
 // |
 //   [ center | left |  right | x-start | x-end ] &&
 //   [ [         top | bottom | y-start | y-end ] <length-percentage> ]
+// |
+//   [ [         block-start |  block-end ] <length-percentage> ] &&
+//   [ center | inline-start | inline-end ]
+// |
+//   [ center |  block-start |  block-end ] &&
+//   [ [        inline-start | inline-end ] <length-percentage> ]
+// |
+//   [ [        start | end ] <length-percentage> ]
+//   [ center | start | end ]
+// |
+//   [ center | start | end ]
+//   [ [        start | end ] <length-percentage> ]
 // ]
 //
 // <position-four> = [
 //   [ [ left | right | x-start | x-end ] <length-percentage> ] &&
 //   [ [ top | bottom | y-start | y-end ] <length-percentage> ]
+// |
+//   [ [ block-start | block-end ] <length-percentage> ] &&
+//   [ [ inline-start | inline-end ] <length-percentage> ]
+// |
+//   [ [ start | end ] <length-percentage> ]{2}
 // ]
 
 // MARK: Unresolved Position
@@ -96,6 +118,14 @@ using PositionUnresolvedComponent = Variant<
     CSS::Keyword::Bottom,
     CSS::Keyword::YStart,
     CSS::Keyword::YEnd,
+
+    // Flow
+    CSS::Keyword::BlockStart,
+    CSS::Keyword::BlockEnd,
+    CSS::Keyword::InlineStart,
+    CSS::Keyword::InlineEnd,
+    CSS::Keyword::Start,
+    CSS::Keyword::End,
 
     // Any Axis
     CSS::Keyword::Center,
@@ -125,7 +155,32 @@ template<typename T> concept IsVerticalSecondComponent =
     || std::same_as<T, CSS::Keyword::Center>
     || std::same_as<T, CSS::LengthPercentage<>>;
 
-static std::optional<PositionUnresolvedComponent> consumePositionUnresolvedComponent(CSSParserTokenRange& range, CSS::PropertyParserState& state)
+template<typename T> concept IsBlockOnlyComponent =
+       std::same_as<T, CSS::Keyword::BlockStart>
+    || std::same_as<T, CSS::Keyword::BlockEnd>;
+
+template<typename T> concept IsBlockSecondComponent =
+       IsBlockOnlyComponent<T>
+    || std::same_as<T, CSS::Keyword::Center>;
+
+template<typename T> concept IsInlineOnlyComponent =
+       std::same_as<T, CSS::Keyword::InlineStart>
+    || std::same_as<T, CSS::Keyword::InlineEnd>;
+
+template<typename T> concept IsInlineSecondComponent =
+       IsInlineOnlyComponent<T>
+    || std::same_as<T, CSS::Keyword::Center>;
+
+template<typename T> concept IsStartEndOnlyComponent =
+       std::same_as<T, CSS::Keyword::Start>
+    || std::same_as<T, CSS::Keyword::End>;
+
+template<typename T> concept IsStartEndSecondComponent =
+       IsStartEndOnlyComponent<T>
+    || std::same_as<T, CSS::Keyword::Center>;
+
+
+static std::optional<PositionUnresolvedComponent> consumePositionUnresolvedComponent(CSSParserTokenRange& range, CSS::PropertyParserState& state, OptionSet<AllowedPositionKeywords> allowedKeywords)
 {
     if (range.peek().type() == IdentToken) {
         switch (range.peek().id()) {
@@ -136,12 +191,12 @@ static std::optional<PositionUnresolvedComponent> consumePositionUnresolvedCompo
             range.consumeIncludingWhitespace();
             return PositionUnresolvedComponent { CSS::Keyword::Right { } };
         case CSSValueXStart:
-            if (!state.context.cssAxisRelativePositionKeywordsEnabled)
+            if (!allowedKeywords.contains(AllowedPositionKeywords::AxisRelative) || !state.context.cssAxisRelativePositionKeywordsEnabled)
                 return { };
             range.consumeIncludingWhitespace();
             return PositionUnresolvedComponent { CSS::Keyword::XStart { } };
         case CSSValueXEnd:
-            if (!state.context.cssAxisRelativePositionKeywordsEnabled)
+            if (!allowedKeywords.contains(AllowedPositionKeywords::AxisRelative) || !state.context.cssAxisRelativePositionKeywordsEnabled)
                 return { };
             range.consumeIncludingWhitespace();
             return PositionUnresolvedComponent { CSS::Keyword::XEnd { } };
@@ -152,15 +207,45 @@ static std::optional<PositionUnresolvedComponent> consumePositionUnresolvedCompo
             range.consumeIncludingWhitespace();
             return PositionUnresolvedComponent { CSS::Keyword::Top { } };
         case CSSValueYStart:
-            if (!state.context.cssAxisRelativePositionKeywordsEnabled)
+            if (!allowedKeywords.contains(AllowedPositionKeywords::AxisRelative) || !state.context.cssAxisRelativePositionKeywordsEnabled)
                 return { };
             range.consumeIncludingWhitespace();
             return PositionUnresolvedComponent { CSS::Keyword::YStart { } };
         case CSSValueYEnd:
-            if (!state.context.cssAxisRelativePositionKeywordsEnabled)
+            if (!allowedKeywords.contains(AllowedPositionKeywords::AxisRelative) || !state.context.cssAxisRelativePositionKeywordsEnabled)
                 return { };
             range.consumeIncludingWhitespace();
             return PositionUnresolvedComponent { CSS::Keyword::YEnd { } };
+        case CSSValueBlockStart:
+            if (!allowedKeywords.contains(AllowedPositionKeywords::FlowRelative) || !state.context.cssFlowRelativePositionKeywordsEnabled)
+                return { };
+            range.consumeIncludingWhitespace();
+            return PositionUnresolvedComponent { CSS::Keyword::BlockStart { } };
+        case CSSValueBlockEnd:
+            if (!allowedKeywords.contains(AllowedPositionKeywords::FlowRelative) || !state.context.cssFlowRelativePositionKeywordsEnabled)
+                return { };
+            range.consumeIncludingWhitespace();
+            return PositionUnresolvedComponent { CSS::Keyword::BlockEnd { } };
+        case CSSValueInlineStart:
+            if (!allowedKeywords.contains(AllowedPositionKeywords::FlowRelative) || !state.context.cssFlowRelativePositionKeywordsEnabled)
+                return { };
+            range.consumeIncludingWhitespace();
+            return PositionUnresolvedComponent { CSS::Keyword::InlineStart { } };
+        case CSSValueInlineEnd:
+            if (!allowedKeywords.contains(AllowedPositionKeywords::FlowRelative) || !state.context.cssFlowRelativePositionKeywordsEnabled)
+                return { };
+            range.consumeIncludingWhitespace();
+            return PositionUnresolvedComponent { CSS::Keyword::InlineEnd { } };
+        case CSSValueStart:
+            if (!allowedKeywords.contains(AllowedPositionKeywords::FlowRelative) || !state.context.cssFlowRelativePositionKeywordsEnabled)
+                return { };
+            range.consumeIncludingWhitespace();
+            return PositionUnresolvedComponent { CSS::Keyword::Start { } };
+        case CSSValueEnd:
+            if (!allowedKeywords.contains(AllowedPositionKeywords::FlowRelative) || !state.context.cssFlowRelativePositionKeywordsEnabled)
+                return { };
+            range.consumeIncludingWhitespace();
+            return PositionUnresolvedComponent { CSS::Keyword::End { } };
         case CSSValueCenter:
             range.consumeIncludingWhitespace();
             return PositionUnresolvedComponent { CSS::Keyword::Center { } };
@@ -176,7 +261,7 @@ static std::optional<PositionUnresolvedComponent> consumePositionUnresolvedCompo
 
 static std::optional<CSS::Position> positionUnresolvedFromOneComponent(PositionUnresolvedComponent&& component)
 {
-    // <position-one> = [ left | center | right | top | bottom | x-start | x-end | y-start | y-end | <length-percentage> ]
+    // <position-one> = [ left | center | right | top | bottom | x-start | x-end | y-start | y-end | block-start | block-end | inline-start | inline-end | <length-percentage> ]
 
     return WTF::switchOn(WTFMove(component),
         []<IsHorizontalOnlyComponent C>(C&& component) -> std::optional<CSS::Position> {
@@ -185,10 +270,49 @@ static std::optional<CSS::Position> positionUnresolvedFromOneComponent(PositionU
         []<IsVerticalOnlyComponent C>(C&& component) -> std::optional<CSS::Position> {
             return CSS::TwoComponentPositionHorizontalVertical { { CSS::Keyword::Center { } }, { WTFMove(component) } };
         },
+        []<IsBlockOnlyComponent C>(C&& component) -> std::optional<CSS::Position> {
+            return CSS::TwoComponentPositionBlockInline { { WTFMove(component) }, { CSS::Keyword::Center { } } };
+        },
+        []<IsInlineOnlyComponent C>(C&& component) -> std::optional<CSS::Position> {
+            return CSS::TwoComponentPositionBlockInline { { CSS::Keyword::Center { } }, { WTFMove(component) } };
+        },
+        []<IsStartEndOnlyComponent C>(C&&) -> std::optional<CSS::Position> {
+            // `start` and `end` are invalid for single component position values.
+            return { };
+        },
         [](CSS::Keyword::Center&&) -> std::optional<CSS::Position> {
             return CSS::TwoComponentPositionHorizontalVertical { { CSS::Keyword::Center { } }, { CSS::Keyword::Center { } } };
         },
         [](CSS::LengthPercentage<>&& component) -> std::optional<CSS::Position> {
+            return CSS::TwoComponentPositionHorizontalVertical { { WTFMove(component) }, { CSS::Keyword::Center { } } };
+        }
+    );
+}
+
+static std::optional<CSS::PositionXY> positionXYUnresolvedFromOneComponent(PositionUnresolvedComponent&& component)
+{
+    // Same as <position-one>, but without the flow relative keywords.
+
+    return WTF::switchOn(WTFMove(component),
+        []<IsHorizontalOnlyComponent C>(C&& component) -> std::optional<CSS::PositionXY> {
+            return CSS::TwoComponentPositionHorizontalVertical { { WTFMove(component) }, { CSS::Keyword::Center { } } };
+        },
+        []<IsVerticalOnlyComponent C>(C&& component) -> std::optional<CSS::PositionXY> {
+            return CSS::TwoComponentPositionHorizontalVertical { { CSS::Keyword::Center { } }, { WTFMove(component) } };
+        },
+        []<IsBlockOnlyComponent C>(C&&) -> std::optional<CSS::PositionXY> {
+            return { };
+        },
+        []<IsInlineOnlyComponent C>(C&&) -> std::optional<CSS::PositionXY> {
+            return { };
+        },
+        []<IsStartEndOnlyComponent C>(C&&) -> std::optional<CSS::PositionXY> {
+            return { };
+        },
+        [](CSS::Keyword::Center&&) -> std::optional<CSS::PositionXY> {
+            return CSS::TwoComponentPositionHorizontalVertical { { CSS::Keyword::Center { } }, { CSS::Keyword::Center { } } };
+        },
+        [](CSS::LengthPercentage<>&& component) -> std::optional<CSS::PositionXY> {
             return CSS::TwoComponentPositionHorizontalVertical { { WTFMove(component) }, { CSS::Keyword::Center { } } };
         }
     );
@@ -202,6 +326,11 @@ static std::optional<CSS::Position> positionUnresolvedFromTwoComponents(Position
     // |
     //   [ left | center | right | x-start | x-end | <length-percentage> ]
     //   [ top | center | bottom | y-start | y-end | <length-percentage> ]
+    // |
+    //   [ block-start | center | block-end ] &&
+    //   [ inline-start | center | inline-end ]
+    // |
+    //   [ start | center | end ]{2}
     // ]
 
     return WTF::switchOn(WTFMove(component1),
@@ -227,6 +356,39 @@ static std::optional<CSS::Position> positionUnresolvedFromTwoComponents(Position
                 }
             );
         },
+        [&]<IsBlockOnlyComponent C1>(C1&& component1) -> std::optional<CSS::Position> {
+            // `component2` must be in the set [ inline-start | center | inline-end ]
+            return WTF::switchOn(WTFMove(component2),
+                [&]<IsInlineSecondComponent C2>(C2&& component2) -> std::optional<CSS::Position> {
+                    return CSS::TwoComponentPositionBlockInline { { WTFMove(component1) }, { WTFMove(component2) } };
+                },
+                [](auto&&) -> std::optional<CSS::Position> {
+                    return { };
+                }
+            );
+        },
+        [&]<IsInlineOnlyComponent C1>(C1&& component1) -> std::optional<CSS::Position> {
+            // `component2` must be in the set [ block-start | center | block-end ]
+            return WTF::switchOn(WTFMove(component2),
+                [&]<IsBlockSecondComponent C2>(C2&& component2) -> std::optional<CSS::Position> {
+                    return CSS::TwoComponentPositionBlockInline { { WTFMove(component2) }, { WTFMove(component1) } };
+                },
+                [](auto&&) -> std::optional<CSS::Position> {
+                    return { };
+                }
+            );
+        },
+        [&]<IsStartEndOnlyComponent C1>(C1&& component1) -> std::optional<CSS::Position> {
+            // `component2` must be in the set [ start | center | end ]
+            return WTF::switchOn(WTFMove(component2),
+                [&]<IsStartEndSecondComponent C2>(C2&& component2) -> std::optional<CSS::Position> {
+                    return CSS::TwoComponentPositionStartEnd { { WTFMove(component1) }, { WTFMove(component2) } };
+                },
+                [](auto&&) -> std::optional<CSS::Position> {
+                    return { };
+                }
+            );
+        },
         [&](CSS::Keyword::Center&& component1) -> std::optional<CSS::Position> {
             // `component2` can be anything.
             return WTF::switchOn(WTFMove(component2),
@@ -235,6 +397,15 @@ static std::optional<CSS::Position> positionUnresolvedFromTwoComponents(Position
                 },
                 [&]<IsVerticalOnlyComponent C2>(C2&& component2) -> std::optional<CSS::Position> {
                     return CSS::TwoComponentPositionHorizontalVertical { { WTFMove(component1) }, { WTFMove(component2) } };
+                },
+                [&]<IsBlockOnlyComponent C2>(C2&& component2) -> std::optional<CSS::Position> {
+                    return CSS::TwoComponentPositionBlockInline { { WTFMove(component2) }, { WTFMove(component1) } };
+                },
+                [&]<IsInlineOnlyComponent C2>(C2&& component2) -> std::optional<CSS::Position> {
+                    return CSS::TwoComponentPositionBlockInline { { WTFMove(component1) }, { WTFMove(component2) } };
+                },
+                [&]<IsStartEndOnlyComponent C2>(C2&& component2) -> std::optional<CSS::Position> {
+                    return CSS::TwoComponentPositionStartEnd { { WTFMove(component1) }, { WTFMove(component2) } };
                 },
                 [&](CSS::Keyword::Center&& component2) -> std::optional<CSS::Position> {
                     return CSS::TwoComponentPositionHorizontalVertical { { WTFMove(component1) }, { WTFMove(component2) } };
@@ -258,6 +429,82 @@ static std::optional<CSS::Position> positionUnresolvedFromTwoComponents(Position
     );
 }
 
+static std::optional<CSS::PositionXY> positionXYUnresolvedFromTwoComponents(PositionUnresolvedComponent&& component1, PositionUnresolvedComponent&& component2)
+{
+    // Same as <position-two>, but without the flow relative keywords.
+
+    return WTF::switchOn(WTFMove(component1),
+        [&]<IsHorizontalOnlyComponent C1>(C1&& component1) -> std::optional<CSS::PositionXY> {
+            // `component2` must be in the set [ top | center | bottom | y-start | y-end | <length-percentage> ]
+            return WTF::switchOn(WTFMove(component2),
+                [&]<IsVerticalSecondComponent C2>(C2&& component2) -> std::optional<CSS::PositionXY> {
+                    return CSS::TwoComponentPositionHorizontalVertical { { WTFMove(component1) }, { WTFMove(component2) } };
+                },
+                [](auto&&) -> std::optional<CSS::PositionXY> {
+                    return { };
+                }
+            );
+        },
+        [&]<IsVerticalOnlyComponent C1>(C1&& component1) -> std::optional<CSS::PositionXY> {
+            // `component2` must be in the set [ left | center | right | x-start | x-end ] (NOTE: <length-percentage> is NOT allowed).
+            return WTF::switchOn(WTFMove(component2),
+                [&]<IsHorizontalSecondComponent C2>(C2&& component2) -> std::optional<CSS::PositionXY> {
+                    return CSS::TwoComponentPositionHorizontalVertical { { WTFMove(component2) }, { WTFMove(component1) } };
+                },
+                [](auto&&) -> std::optional<CSS::PositionXY> {
+                    return { };
+                }
+            );
+        },
+        [&]<IsBlockOnlyComponent C1>(C1&&) -> std::optional<CSS::PositionXY> {
+            return { };
+        },
+        [&]<IsInlineOnlyComponent C1>(C1&&) -> std::optional<CSS::PositionXY> {
+            return { };
+        },
+        [&]<IsStartEndOnlyComponent C1>(C1&&) -> std::optional<CSS::PositionXY> {
+            return { };
+        },
+        [&](CSS::Keyword::Center&& component1) -> std::optional<CSS::PositionXY> {
+            // `component2` can be anything.
+            return WTF::switchOn(WTFMove(component2),
+                [&]<IsHorizontalOnlyComponent C2>(C2&& component2) -> std::optional<CSS::PositionXY> {
+                    return CSS::TwoComponentPositionHorizontalVertical { { WTFMove(component2) }, { WTFMove(component1) } };
+                },
+                [&]<IsVerticalOnlyComponent C2>(C2&& component2) -> std::optional<CSS::PositionXY> {
+                    return CSS::TwoComponentPositionHorizontalVertical { { WTFMove(component1) }, { WTFMove(component2) } };
+                },
+                [&]<IsBlockOnlyComponent C2>(C2&&) -> std::optional<CSS::PositionXY> {
+                    return { };
+                },
+                [&]<IsInlineOnlyComponent C2>(C2&&) -> std::optional<CSS::PositionXY> {
+                    return { };
+                },
+                [&]<IsStartEndOnlyComponent C2>(C2&&) -> std::optional<CSS::PositionXY> {
+                    return { };
+                },
+                [&](CSS::Keyword::Center&& component2) -> std::optional<CSS::PositionXY> {
+                    return CSS::TwoComponentPositionHorizontalVertical { { WTFMove(component1) }, { WTFMove(component2) } };
+                },
+                [&](CSS::LengthPercentage<>&& component2) -> std::optional<CSS::PositionXY> {
+                    return CSS::TwoComponentPositionHorizontalVertical { { WTFMove(component1) }, { WTFMove(component2) } };
+                }
+            );
+        },
+        [&](CSS::LengthPercentage<>&& component1) -> std::optional<CSS::PositionXY> {
+            // `component2` must be in the set [ top | center | bottom | y-start | y-end | <length-percentage> ]
+            return WTF::switchOn(WTFMove(component2),
+                [&]<IsVerticalSecondComponent C2>(C2&& component2) -> std::optional<CSS::PositionXY> {
+                    return CSS::TwoComponentPositionHorizontalVertical { { WTFMove(component1) }, { WTFMove(component2) } };
+                },
+                [](auto&&) -> std::optional<CSS::PositionXY> {
+                    return { };
+                }
+            );
+        }
+    );
+}
+
 static std::optional<CSS::Position> positionUnresolvedFromThreeComponents(PositionUnresolvedComponent&& component1, PositionUnresolvedComponent&& component2, PositionUnresolvedComponent&& component3)
 {
     // Special case only for <bg-position> productions.
@@ -268,6 +515,18 @@ static std::optional<CSS::Position> positionUnresolvedFromThreeComponents(Positi
     // |
     //   [ center | left |  right | x-start | x-end ] &&
     //   [ [         top | bottom | y-start | y-end ] <length-percentage> ]
+    // |
+    //   [ [         block-start |  block-end ] <length-percentage> ] &&
+    //   [ center | inline-start | inline-end ]
+    // |
+    //   [ center |  block-start |  block-end ] &&
+    //   [ [        inline-start | inline-end ] <length-percentage> ]
+    // |
+    //   [ [        start | end ] <length-percentage> ]
+    //   [ center | start | end ]
+    // |
+    //   [ center | start | end ]
+    //   [ [        start | end ] <length-percentage> ]
     // ]
 
     return WTF::switchOn(WTFMove(component1),
@@ -345,12 +604,123 @@ static std::optional<CSS::Position> positionUnresolvedFromThreeComponents(Positi
                 }
             );
         },
+        [&]<IsBlockOnlyComponent C1>(C1&& component1) -> std::optional<CSS::Position> {
+            // `component2` must be in the set [ inline-start | inline-end | <length-percentage> ]
+            return WTF::switchOn(WTFMove(component2),
+                [&]<IsInlineOnlyComponent C2>(C2&& component2) -> std::optional<CSS::Position> {
+                    // `component3` must be <length-percentage>
+                    if (!WTF::holdsAlternative<CSS::LengthPercentage<>>(component3))
+                        return { };
+                    return CSS::ThreeComponentPositionBlockInlineLengthSecond {
+                        { { WTFMove(component1) } },
+                        { { WTFMove(component2), std::get<CSS::LengthPercentage<>>(component3) } },
+                    };
+                },
+                [&](CSS::LengthPercentage<>&& component2) -> std::optional<CSS::Position> {
+                    // `component3` must be in the set [ center | inline-start | inline-end ]
+                    return WTF::switchOn(WTFMove(component3),
+                        [&]<IsInlineOnlyComponent C3>(C3&& component3) -> std::optional<CSS::Position> {
+                            return CSS::ThreeComponentPositionBlockInlineLengthFirst {
+                                { { WTFMove(component1), WTFMove(component2) } },
+                                { { WTFMove(component3) } },
+                            };
+                        },
+                        [&](CSS::Keyword::Center&& component3) -> std::optional<CSS::Position> {
+                            return CSS::ThreeComponentPositionBlockInlineLengthFirst {
+                                { { WTFMove(component1), WTFMove(component2) } },
+                                { { WTFMove(component3) } },
+                            };
+                        },
+                        [](auto&&) -> std::optional<CSS::Position> {
+                            return { };
+                        }
+                    );
+                },
+                [](auto&&) -> std::optional<CSS::Position> {
+                    return { };
+                }
+            );
+        },
+        [&]<IsInlineOnlyComponent C1>(C1&& component1) -> std::optional<CSS::Position> {
+            // `component2` must be in the set [ block-start | block-end | <length-percentage> ]
+            return WTF::switchOn(WTFMove(component2),
+                [&]<IsBlockOnlyComponent C2>(C2&& component2) -> std::optional<CSS::Position> {
+                    // `component3` must be <length-percentage>
+                    if (!WTF::holdsAlternative<CSS::LengthPercentage<>>(component3))
+                        return { };
+                    return CSS::ThreeComponentPositionBlockInlineLengthFirst {
+                        { { WTFMove(component2), std::get<CSS::LengthPercentage<>>(component3) } },
+                        { { WTFMove(component1) } },
+                    };
+                },
+                [&](CSS::LengthPercentage<>&& component2) -> std::optional<CSS::Position> {
+                    // `component3` must be in the set [ center | block-start | block-end ]
+                    return WTF::switchOn(WTFMove(component3),
+                        [&]<IsBlockOnlyComponent C3>(C3&& component3) -> std::optional<CSS::Position> {
+                            return CSS::ThreeComponentPositionBlockInlineLengthSecond {
+                                { { WTFMove(component3) } },
+                                { { WTFMove(component1), WTFMove(component2) } },
+                            };
+                        },
+                        [&](CSS::Keyword::Center&& component3) -> std::optional<CSS::Position> {
+                            return CSS::ThreeComponentPositionBlockInlineLengthSecond {
+                                { { WTFMove(component3) } },
+                                { { WTFMove(component1), WTFMove(component2) } },
+                            };
+                        },
+                        [](auto&&) -> std::optional<CSS::Position> {
+                            return { };
+                        }
+                    );
+                },
+                [](auto&&) -> std::optional<CSS::Position> {
+                    return { };
+                }
+            );
+        },
+        [&]<IsStartEndOnlyComponent C1>(C1&& component1) -> std::optional<CSS::Position> {
+            // `component2` must be in the set [ start | end | <length-percentage> ]
+            return WTF::switchOn(WTFMove(component2),
+                [&]<IsStartEndOnlyComponent C2>(C2&& component2) -> std::optional<CSS::Position> {
+                    // `component3` must be <length-percentage>
+                    if (!WTF::holdsAlternative<CSS::LengthPercentage<>>(component3))
+                        return { };
+                    return CSS::ThreeComponentPositionStartEndLengthSecond {
+                        { { WTFMove(component1) } },
+                        { { WTFMove(component2), std::get<CSS::LengthPercentage<>>(component3) } },
+                    };
+                },
+                [&](CSS::LengthPercentage<>&& component2) -> std::optional<CSS::Position> {
+                    // `component3` must be in the set [ center | start | end ]
+                    return WTF::switchOn(WTFMove(component3),
+                        [&]<IsStartEndOnlyComponent C3>(C3&& component3) -> std::optional<CSS::Position> {
+                            return CSS::ThreeComponentPositionStartEndLengthFirst {
+                                { { WTFMove(component1), WTFMove(component2) } },
+                                { { WTFMove(component3) } },
+                            };
+                        },
+                        [&](CSS::Keyword::Center&& component3) -> std::optional<CSS::Position> {
+                            return CSS::ThreeComponentPositionStartEndLengthFirst {
+                                { { WTFMove(component1), WTFMove(component2) } },
+                                { { WTFMove(component3) } },
+                            };
+                        },
+                        [](auto&&) -> std::optional<CSS::Position> {
+                            return { };
+                        }
+                    );
+                },
+                [](auto&&) -> std::optional<CSS::Position> {
+                    return { };
+                }
+            );
+        },
         [&](CSS::Keyword::Center&& component1) -> std::optional<CSS::Position> {
             // `component3` must be <length-percentage>
             if (!WTF::holdsAlternative<CSS::LengthPercentage<>>(component3))
                 return { };
 
-            // `component2` must be in the set [ left | right | x-start | x-end | top | bottom | y-start | y-end ]
+            // `component2` must be in the set [ left | right | x-start | x-end | top | bottom | y-start | y-end | block-start | block-end inline-start | inline-end | start | end ]
             return WTF::switchOn(WTFMove(component2),
                 [&]<IsHorizontalOnlyComponent C2>(C2&& component2) -> std::optional<CSS::Position> {
                     return CSS::ThreeComponentPositionHorizontalVerticalLengthFirst {
@@ -360,6 +730,24 @@ static std::optional<CSS::Position> positionUnresolvedFromThreeComponents(Positi
                 },
                 [&]<IsVerticalOnlyComponent C2>(C2&& component2) -> std::optional<CSS::Position> {
                     return CSS::ThreeComponentPositionHorizontalVerticalLengthSecond {
+                        { { WTFMove(component1) } },
+                        { { WTFMove(component2), std::get<CSS::LengthPercentage<>>(component3) } },
+                    };
+                },
+                [&]<IsBlockOnlyComponent C2>(C2&& component2) -> std::optional<CSS::Position> {
+                    return CSS::ThreeComponentPositionBlockInlineLengthFirst {
+                        { { WTFMove(component2), std::get<CSS::LengthPercentage<>>(component3) } },
+                        { { WTFMove(component1) } },
+                    };
+                },
+                [&]<IsInlineOnlyComponent C2>(C2&& component2) -> std::optional<CSS::Position> {
+                    return CSS::ThreeComponentPositionBlockInlineLengthSecond {
+                        { { WTFMove(component1) } },
+                        { { WTFMove(component2), std::get<CSS::LengthPercentage<>>(component3) } },
+                    };
+                },
+                [&]<IsStartEndOnlyComponent C2>(C2&& component2) -> std::optional<CSS::Position> {
+                    return CSS::ThreeComponentPositionStartEndLengthSecond {
                         { { WTFMove(component1) } },
                         { { WTFMove(component2), std::get<CSS::LengthPercentage<>>(component3) } },
                     };
@@ -376,11 +764,144 @@ static std::optional<CSS::Position> positionUnresolvedFromThreeComponents(Positi
     );
 }
 
+static std::optional<CSS::PositionXY> positionXYUnresolvedFromThreeComponents(PositionUnresolvedComponent&& component1, PositionUnresolvedComponent&& component2, PositionUnresolvedComponent&& component3)
+{
+    // Same as <bg-position-three>, but without the flow relative keywords.
+
+    return WTF::switchOn(WTFMove(component1),
+        [&]<IsHorizontalOnlyComponent C1>(C1&& component1) -> std::optional<CSS::PositionXY> {
+            // `component2` must be in the set [ top | bottom | y-start | y-end | <length-percentage> ]
+            return WTF::switchOn(WTFMove(component2),
+                [&]<IsVerticalOnlyComponent C2>(C2&& component2) -> std::optional<CSS::PositionXY> {
+                    // `component3` must be <length-percentage>
+                    if (!WTF::holdsAlternative<CSS::LengthPercentage<>>(component3))
+                        return { };
+                    return CSS::ThreeComponentPositionHorizontalVerticalLengthSecond {
+                        { { WTFMove(component1) } },
+                        { { WTFMove(component2), std::get<CSS::LengthPercentage<>>(component3) } },
+                    };
+                },
+                [&](CSS::LengthPercentage<>&& component2) -> std::optional<CSS::PositionXY> {
+                    // `component3` must be in the set [ center | top | bottom | y-start | y-end ]
+                    return WTF::switchOn(WTFMove(component3),
+                        [&]<IsVerticalOnlyComponent C3>(C3&& component3) -> std::optional<CSS::PositionXY> {
+                            return CSS::ThreeComponentPositionHorizontalVerticalLengthFirst {
+                                { { WTFMove(component1), WTFMove(component2) } },
+                                { { WTFMove(component3) } },
+                            };
+                        },
+                        [&](CSS::Keyword::Center&& component3) -> std::optional<CSS::PositionXY> {
+                            return CSS::ThreeComponentPositionHorizontalVerticalLengthFirst {
+                                { { WTFMove(component1), WTFMove(component2) } },
+                                { { WTFMove(component3) } },
+                            };
+                        },
+                        [](auto&&) -> std::optional<CSS::PositionXY> {
+                            return { };
+                        }
+                    );
+                },
+                [](auto&&) -> std::optional<CSS::PositionXY> {
+                    return { };
+                }
+            );
+        },
+        [&]<IsVerticalOnlyComponent C1>(C1&& component1) -> std::optional<CSS::PositionXY> {
+            // `component2` must be in the set [ left | right | x-start | x-end | <length-percentage> ]
+            return WTF::switchOn(WTFMove(component2),
+                [&]<IsHorizontalOnlyComponent C2>(C2&& component2) -> std::optional<CSS::PositionXY> {
+                    // `component3` must be <length-percentage>
+                    if (!WTF::holdsAlternative<CSS::LengthPercentage<>>(component3))
+                        return { };
+                    return CSS::ThreeComponentPositionHorizontalVerticalLengthFirst {
+                        { { WTFMove(component2), std::get<CSS::LengthPercentage<>>(component3) } },
+                        { { WTFMove(component1) } },
+                    };
+                },
+                [&](CSS::LengthPercentage<>&& component2) -> std::optional<CSS::PositionXY> {
+                    // `component3` must be in the set [ center | left | right | x-start | x-end ]
+                    return WTF::switchOn(WTFMove(component3),
+                        [&]<IsHorizontalOnlyComponent C3>(C3&& component3) -> std::optional<CSS::PositionXY> {
+                            return CSS::ThreeComponentPositionHorizontalVerticalLengthSecond {
+                                { { WTFMove(component3) } },
+                                { { WTFMove(component1), WTFMove(component2) } },
+                            };
+                        },
+                        [&](CSS::Keyword::Center&& component3) -> std::optional<CSS::PositionXY> {
+                            return CSS::ThreeComponentPositionHorizontalVerticalLengthSecond {
+                                { { WTFMove(component3) } },
+                                { { WTFMove(component1), WTFMove(component2) } },
+                            };
+                        },
+                        [](auto&&) -> std::optional<CSS::PositionXY> {
+                            return { };
+                        }
+                    );
+                },
+                [](auto&&) -> std::optional<CSS::PositionXY> {
+                    return { };
+                }
+            );
+        },
+        [&]<IsBlockOnlyComponent C1>(C1&&) -> std::optional<CSS::PositionXY> {
+            return { };
+        },
+        [&]<IsInlineOnlyComponent C1>(C1&&) -> std::optional<CSS::PositionXY> {
+            return { };
+        },
+        [&]<IsStartEndOnlyComponent C1>(C1&&) -> std::optional<CSS::PositionXY> {
+            return { };
+        },
+        [&](CSS::Keyword::Center&& component1) -> std::optional<CSS::PositionXY> {
+            // `component3` must be <length-percentage>
+            if (!WTF::holdsAlternative<CSS::LengthPercentage<>>(component3))
+                return { };
+
+            // `component2` must be in the set [ left | right | x-start | x-end | top | bottom | y-start | y-end ]
+            return WTF::switchOn(WTFMove(component2),
+                [&]<IsHorizontalOnlyComponent C2>(C2&& component2) -> std::optional<CSS::PositionXY> {
+                    return CSS::ThreeComponentPositionHorizontalVerticalLengthFirst {
+                        { { WTFMove(component2), std::get<CSS::LengthPercentage<>>(component3) } },
+                        { { WTFMove(component1) } },
+                    };
+                },
+                [&]<IsVerticalOnlyComponent C2>(C2&& component2) -> std::optional<CSS::PositionXY> {
+                    return CSS::ThreeComponentPositionHorizontalVerticalLengthSecond {
+                        { { WTFMove(component1) } },
+                        { { WTFMove(component2), std::get<CSS::LengthPercentage<>>(component3) } },
+                    };
+                },
+                [&]<IsBlockOnlyComponent C2>(C2&&) -> std::optional<CSS::PositionXY> {
+                    return { };
+                },
+                [&]<IsInlineOnlyComponent C2>(C2&&) -> std::optional<CSS::PositionXY> {
+                    return { };
+                },
+                [&]<IsStartEndOnlyComponent C2>(C2&&) -> std::optional<CSS::PositionXY> {
+                    return { };
+                },
+                [](auto&&) -> std::optional<CSS::PositionXY> {
+                    return { };
+                }
+            );
+        },
+        [&](CSS::LengthPercentage<>&&) -> std::optional<CSS::PositionXY> {
+            // `<length-percentage>` is invalid for the first component of three component position values.
+            return { };
+        }
+    );
+}
+
 static std::optional<CSS::Position> positionUnresolvedFromFourComponents(PositionUnresolvedComponent&& component1, PositionUnresolvedComponent&& component2, PositionUnresolvedComponent&& component3, PositionUnresolvedComponent&& component4)
 {
     // <position-four> = [
     //   [ [ left | right | x-start | x-end ] <length-percentage> ] &&
     //   [ [ top | bottom | y-start | y-end ] <length-percentage> ]
+    // |
+    //   [ [ block-start | block-end ] <length-percentage> ] &&
+    //   [ [ inline-start | inline-end ] <length-percentage> ]
+    // |
+    //   [ [ start | end ] <length-percentage> ]{2}
     // ]
 
     // `component2` and `component4` must be <length-percentage>
@@ -416,6 +937,48 @@ static std::optional<CSS::Position> positionUnresolvedFromFourComponents(Positio
                 }
             );
         },
+        [&]<IsBlockOnlyComponent C1>(C1&& component1) -> std::optional<CSS::Position> {
+            // `component3` must be in the set [ inline-start | inline-end ]
+            return WTF::switchOn(WTFMove(component3),
+                [&]<IsInlineOnlyComponent C3>(C3&& component3) -> std::optional<CSS::Position> {
+                    return CSS::FourComponentPositionBlockInline {
+                        { { WTFMove(component1), std::get<CSS::LengthPercentage<>>(component2) } },
+                        { { WTFMove(component3), std::get<CSS::LengthPercentage<>>(component4) } },
+                    };
+                },
+                [](auto&&) -> std::optional<CSS::Position> {
+                    return { };
+                }
+            );
+        },
+        [&]<IsInlineOnlyComponent C1>(C1&& component1) -> std::optional<CSS::Position> {
+            // `component3` must be in the set [ block-start | block-end ]
+            return WTF::switchOn(WTFMove(component3),
+                [&]<IsBlockOnlyComponent C3>(C3&& component3) -> std::optional<CSS::Position> {
+                    return CSS::FourComponentPositionBlockInline {
+                        { { WTFMove(component3), std::get<CSS::LengthPercentage<>>(component4) } },
+                        { { WTFMove(component1), std::get<CSS::LengthPercentage<>>(component2) } },
+                    };
+                },
+                [](auto&&) -> std::optional<CSS::Position> {
+                    return { };
+                }
+            );
+        },
+        [&]<IsStartEndOnlyComponent C1>(C1&& component1) -> std::optional<CSS::Position> {
+            // `component3` must be in the set [ start | end ]
+            return WTF::switchOn(WTFMove(component3),
+                [&]<IsStartEndOnlyComponent C3>(C3&& component3) -> std::optional<CSS::Position> {
+                    return CSS::FourComponentPositionStartEnd {
+                        { { WTFMove(component1), std::get<CSS::LengthPercentage<>>(component2) } },
+                        { { WTFMove(component3), std::get<CSS::LengthPercentage<>>(component4) } },
+                    };
+                },
+                [](auto&&) -> std::optional<CSS::Position> {
+                    return { };
+                }
+            );
+        },
         [&](CSS::Keyword::Center&&) -> std::optional<CSS::Position> {
             // `center` is invalid for the first component of four component position values.
             return { };
@@ -427,15 +990,71 @@ static std::optional<CSS::Position> positionUnresolvedFromFourComponents(Positio
     );
 }
 
+static std::optional<CSS::PositionXY> positionXYUnresolvedFromFourComponents(PositionUnresolvedComponent&& component1, PositionUnresolvedComponent&& component2, PositionUnresolvedComponent&& component3, PositionUnresolvedComponent&& component4)
+{
+    // <position-four> = [
+    // `component2` and `component4` must be <length-percentage>
+    if (!WTF::holdsAlternative<CSS::LengthPercentage<>>(component2) || !WTF::holdsAlternative<CSS::LengthPercentage<>>(component4))
+        return { };
+
+    return WTF::switchOn(WTFMove(component1),
+        [&]<IsHorizontalOnlyComponent C1>(C1&& component1) -> std::optional<CSS::PositionXY> {
+            // `component3` must be in the set [ top | bottom | y-start | y-end ]
+            return WTF::switchOn(WTFMove(component3),
+                [&]<IsVerticalOnlyComponent C3>(C3&& component3) -> std::optional<CSS::PositionXY> {
+                    return CSS::FourComponentPositionHorizontalVertical {
+                        { { WTFMove(component1), std::get<CSS::LengthPercentage<>>(component2) } },
+                        { { WTFMove(component3), std::get<CSS::LengthPercentage<>>(component4) } },
+                    };
+                },
+                [](auto&&) -> std::optional<CSS::PositionXY> {
+                    return { };
+                }
+            );
+        },
+        [&]<IsVerticalOnlyComponent C1>(C1&& component1) -> std::optional<CSS::PositionXY> {
+            // `component3` must be in the set [ left | right | x-start | x-end ]
+            return WTF::switchOn(WTFMove(component3),
+                [&]<IsHorizontalOnlyComponent C3>(C3&& component3) -> std::optional<CSS::PositionXY> {
+                    return CSS::FourComponentPositionHorizontalVertical {
+                        { { WTFMove(component3), std::get<CSS::LengthPercentage<>>(component4) } },
+                        { { WTFMove(component1), std::get<CSS::LengthPercentage<>>(component2) } },
+                    };
+                },
+                [](auto&&) -> std::optional<CSS::PositionXY> {
+                    return { };
+                }
+            );
+        },
+        [&]<IsBlockOnlyComponent C1>(C1&&) -> std::optional<CSS::PositionXY> {
+            return { };
+        },
+        [&]<IsInlineOnlyComponent C1>(C1&&) -> std::optional<CSS::PositionXY> {
+            return { };
+        },
+        [&]<IsStartEndOnlyComponent C1>(C1&&) -> std::optional<CSS::PositionXY> {
+            return { };
+        },
+        [&](CSS::Keyword::Center&&) -> std::optional<CSS::PositionXY> {
+            // `center` is invalid for the first component of four component position values.
+            return { };
+        },
+        [&](CSS::LengthPercentage<>&&) -> std::optional<CSS::PositionXY> {
+            // `<length-percentage>` is invalid for the first component of four component position values.
+            return { };
+        }
+    );
+}
+
 std::optional<CSS::Position> consumePositionUnresolved(CSSParserTokenRange& range, CSS::PropertyParserState& state)
 {
     auto rangeCopy = range;
 
-    auto component1 = consumePositionUnresolvedComponent(rangeCopy, state);
+    auto component1 = consumePositionUnresolvedComponent(rangeCopy, state, { AllowedPositionKeywords::AxisRelative, AllowedPositionKeywords::FlowRelative });
     if (!component1)
         return { };
 
-    auto component2 = consumePositionUnresolvedComponent(rangeCopy, state);
+    auto component2 = consumePositionUnresolvedComponent(rangeCopy, state, { AllowedPositionKeywords::AxisRelative, AllowedPositionKeywords::FlowRelative });
     if (!component2) {
         auto position = positionUnresolvedFromOneComponent(WTFMove(*component1));
         if (!position)
@@ -444,7 +1063,7 @@ std::optional<CSS::Position> consumePositionUnresolved(CSSParserTokenRange& rang
         return position;
     }
 
-    auto component3 = consumePositionUnresolvedComponent(rangeCopy, state);
+    auto component3 = consumePositionUnresolvedComponent(rangeCopy, state, { AllowedPositionKeywords::AxisRelative, AllowedPositionKeywords::FlowRelative });
     if (!component3) {
         auto position = positionUnresolvedFromTwoComponents(WTFMove(*component1), WTFMove(*component2));
         if (!position)
@@ -453,7 +1072,7 @@ std::optional<CSS::Position> consumePositionUnresolved(CSSParserTokenRange& rang
         return position;
     }
 
-    auto component4 = consumePositionUnresolvedComponent(rangeCopy, state);
+    auto component4 = consumePositionUnresolvedComponent(rangeCopy, state, { AllowedPositionKeywords::AxisRelative, AllowedPositionKeywords::FlowRelative });
     if (!component4)
         return { };
 
@@ -464,15 +1083,53 @@ std::optional<CSS::Position> consumePositionUnresolved(CSSParserTokenRange& rang
     return position;
 }
 
+std::optional<CSS::PositionXY> consumePositionXYUnresolved(CSSParserTokenRange& range, CSS::PropertyParserState& state)
+{
+    auto rangeCopy = range;
+
+    auto component1 = consumePositionUnresolvedComponent(rangeCopy, state, { AllowedPositionKeywords::AxisRelative });
+    if (!component1)
+        return { };
+
+    auto component2 = consumePositionUnresolvedComponent(rangeCopy, state, { AllowedPositionKeywords::AxisRelative });
+    if (!component2) {
+        auto position = positionXYUnresolvedFromOneComponent(WTFMove(*component1));
+        if (!position)
+            return { };
+        range = rangeCopy;
+        return position;
+    }
+
+    auto component3 = consumePositionUnresolvedComponent(rangeCopy, state, { AllowedPositionKeywords::AxisRelative });
+    if (!component3) {
+        auto position = positionXYUnresolvedFromTwoComponents(WTFMove(*component1), WTFMove(*component2));
+        if (!position)
+            return { };
+        range = rangeCopy;
+        return position;
+    }
+
+    auto component4 = consumePositionUnresolvedComponent(rangeCopy, state, { AllowedPositionKeywords::AxisRelative });
+    if (!component4)
+        return { };
+
+    auto position = positionXYUnresolvedFromFourComponents(WTFMove(*component1), WTFMove(*component2), WTFMove(*component3), WTFMove(*component4));
+    if (!position)
+        return { };
+    range = rangeCopy;
+    return position;
+}
+
+
 std::optional<CSS::Position> consumeBackgroundPositionUnresolved(CSSParserTokenRange& range, CSS::PropertyParserState& state)
 {
     auto rangeCopy = range;
 
-    auto component1 = consumePositionUnresolvedComponent(rangeCopy, state);
+    auto component1 = consumePositionUnresolvedComponent(rangeCopy, state, { AllowedPositionKeywords::AxisRelative, AllowedPositionKeywords::FlowRelative });
     if (!component1)
         return { };
 
-    auto component2 = consumePositionUnresolvedComponent(rangeCopy, state);
+    auto component2 = consumePositionUnresolvedComponent(rangeCopy, state, { AllowedPositionKeywords::AxisRelative, AllowedPositionKeywords::FlowRelative });
     if (!component2) {
         auto position = positionUnresolvedFromOneComponent(WTFMove(*component1));
         if (!position)
@@ -481,7 +1138,7 @@ std::optional<CSS::Position> consumeBackgroundPositionUnresolved(CSSParserTokenR
         return position;
     }
 
-    auto component3 = consumePositionUnresolvedComponent(rangeCopy, state);
+    auto component3 = consumePositionUnresolvedComponent(rangeCopy, state, { AllowedPositionKeywords::AxisRelative, AllowedPositionKeywords::FlowRelative });
     if (!component3) {
         auto position = positionUnresolvedFromTwoComponents(WTFMove(*component1), WTFMove(*component2));
         if (!position)
@@ -490,7 +1147,7 @@ std::optional<CSS::Position> consumeBackgroundPositionUnresolved(CSSParserTokenR
         return position;
     }
 
-    auto component4 = consumePositionUnresolvedComponent(rangeCopy, state);
+    auto component4 = consumePositionUnresolvedComponent(rangeCopy, state, { AllowedPositionKeywords::AxisRelative, AllowedPositionKeywords::FlowRelative });
     if (!component4) {
         auto position = positionUnresolvedFromThreeComponents(WTFMove(*component1), WTFMove(*component2), WTFMove(*component3));
         if (!position)
@@ -506,8 +1163,57 @@ std::optional<CSS::Position> consumeBackgroundPositionUnresolved(CSSParserTokenR
     return position;
 }
 
+std::optional<CSS::PositionXY> consumeBackgroundPositionXYUnresolved(CSSParserTokenRange& range, CSS::PropertyParserState& state)
+{
+    auto rangeCopy = range;
+
+    auto component1 = consumePositionUnresolvedComponent(rangeCopy, state, { AllowedPositionKeywords::AxisRelative });
+    if (!component1)
+        return { };
+
+    auto component2 = consumePositionUnresolvedComponent(rangeCopy, state, { AllowedPositionKeywords::AxisRelative });
+    if (!component2) {
+        auto position = positionXYUnresolvedFromOneComponent(WTFMove(*component1));
+        if (!position)
+            return { };
+        range = rangeCopy;
+        return position;
+    }
+
+    auto component3 = consumePositionUnresolvedComponent(rangeCopy, state, { AllowedPositionKeywords::AxisRelative });
+    if (!component3) {
+        auto position = positionXYUnresolvedFromTwoComponents(WTFMove(*component1), WTFMove(*component2));
+        if (!position)
+            return { };
+        range = rangeCopy;
+        return position;
+    }
+
+    auto component4 = consumePositionUnresolvedComponent(rangeCopy, state, { AllowedPositionKeywords::AxisRelative });
+    if (!component4) {
+        auto position = positionXYUnresolvedFromThreeComponents(WTFMove(*component1), WTFMove(*component2), WTFMove(*component3));
+        if (!position)
+            return { };
+        range = rangeCopy;
+        return position;
+    }
+
+    auto position = positionXYUnresolvedFromFourComponents(WTFMove(*component1), WTFMove(*component2), WTFMove(*component3), WTFMove(*component4));
+    if (!position)
+        return { };
+    range = rangeCopy;
+    return position;
+}
+
 std::optional<CSS::PositionX> consumePositionXUnresolved(CSSParserTokenRange& range, CSS::PropertyParserState& state)
 {
+    // <position-x> = [
+    //   center | left | right | x-start | x-end | <length-percentage>
+    // |
+    //          [ left | right | x-start | x-end ] <length-percentage>
+    // ]
+    // https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position-x
+
     if (range.peek().type() == IdentToken) {
         switch (range.peek().id()) {
         case CSSValueLeft:
@@ -549,6 +1255,13 @@ std::optional<CSS::PositionX> consumePositionXUnresolved(CSSParserTokenRange& ra
 
 std::optional<CSS::PositionY> consumePositionYUnresolved(CSSParserTokenRange& range, CSS::PropertyParserState& state)
 {
+    // <position-y> = [
+    //   center | top | bottom | y-start | y-end | <length-percentage>
+    // |
+    //          [ top | bottom | y-start | y-end ] <length-percentage>
+    // ]
+    // https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position-y
+
     if (range.peek().type() == IdentToken) {
         switch (range.peek().id()) {
         case CSSValueTop:
@@ -588,15 +1301,59 @@ std::optional<CSS::PositionY> consumePositionYUnresolved(CSSParserTokenRange& ra
     return { };
 }
 
-std::optional<CSS::Position> consumeOneOrTwoComponentPositionUnresolved(CSSParserTokenRange& range, CSS::PropertyParserState& state)
+static std::optional<CSS::PositionLogical> consumePositionLogicalUnresolved(CSSParserTokenRange& range, CSS::PropertyParserState& state)
+{
+    // <position-block>/<position-inline> = [
+    //   center | start | end | <length-percentage>
+    // |
+    //          [ start | end ] <length-percentage>
+    // ]
+    // https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position-block
+
+    if (range.peek().type() == IdentToken) {
+        switch (range.peek().id()) {
+        case CSSValueStart:
+            range.consumeIncludingWhitespace();
+            if (auto lengthPercentage = MetaConsumer<CSS::LengthPercentage<>>::consume(range, state))
+                return CSS::PositionLogical { CSS::FourComponentPositionLogical { { CSS::Keyword::Start { }, WTFMove(*lengthPercentage) } } };
+            return CSS::PositionLogical { CSS::TwoComponentPositionLogical { CSS::Keyword::Start { } } };
+        case CSSValueEnd:
+            range.consumeIncludingWhitespace();
+            if (auto lengthPercentage = MetaConsumer<CSS::LengthPercentage<>>::consume(range, state))
+                return CSS::PositionLogical { CSS::FourComponentPositionLogical { { CSS::Keyword::End { }, WTFMove(*lengthPercentage) } } };
+            return CSS::PositionLogical { CSS::TwoComponentPositionLogical { CSS::Keyword::End { } } };
+        case CSSValueCenter:
+            range.consumeIncludingWhitespace();
+            return CSS::PositionLogical { CSS::TwoComponentPositionLogical { CSS::Keyword::Center { } } };
+        default:
+            return { };
+        }
+    }
+
+    if (auto lengthPercentage = MetaConsumer<CSS::LengthPercentage<>>::consume(range, state))
+        return CSS::PositionLogical { CSS::TwoComponentPositionLogical { WTFMove(*lengthPercentage) } };
+    return { };
+}
+
+std::optional<CSS::PositionLogical> consumePositionBlockUnresolved(CSSParserTokenRange& range, CSS::PropertyParserState& state)
+{
+    return consumePositionLogicalUnresolved(range, state);
+}
+
+std::optional<CSS::PositionLogical> consumePositionInlineUnresolved(CSSParserTokenRange& range, CSS::PropertyParserState& state)
+{
+    return consumePositionLogicalUnresolved(range, state);
+}
+
+std::optional<CSS::Position> consumeLegacyBackgroundPositionUnresolved(CSSParserTokenRange& range, CSS::PropertyParserState& state)
 {
     auto rangeCopy = range;
 
-    auto component1 = consumePositionUnresolvedComponent(rangeCopy, state);
+    auto component1 = consumePositionUnresolvedComponent(rangeCopy, state, { });
     if (!component1)
         return { };
 
-    auto component2 = consumePositionUnresolvedComponent(rangeCopy, state);
+    auto component2 = consumePositionUnresolvedComponent(rangeCopy, state, { });
     if (!component2) {
         auto position = positionUnresolvedFromOneComponent(WTFMove(*component1));
         if (!position)
@@ -606,6 +1363,30 @@ std::optional<CSS::Position> consumeOneOrTwoComponentPositionUnresolved(CSSParse
     }
 
     auto position = positionUnresolvedFromTwoComponents(WTFMove(*component1), WTFMove(*component2));
+    if (!position)
+        return { };
+    range = rangeCopy;
+    return position;
+}
+
+std::optional<CSS::PositionXY> consumeTransformOriginXY(CSSParserTokenRange& range, CSS::PropertyParserState& state)
+{
+    auto rangeCopy = range;
+
+    auto component1 = consumePositionUnresolvedComponent(rangeCopy, state, { });
+    if (!component1)
+        return { };
+
+    auto component2 = consumePositionUnresolvedComponent(rangeCopy, state, { });
+    if (!component2) {
+        auto position = positionXYUnresolvedFromOneComponent(WTFMove(*component1));
+        if (!position)
+            return { };
+        range = rangeCopy;
+        return position;
+    }
+
+    auto position = positionXYUnresolvedFromTwoComponents(WTFMove(*component1), WTFMove(*component2));
     if (!position)
         return { };
     range = rangeCopy;
@@ -698,6 +1479,20 @@ RefPtr<CSSValue> consumePositionY(CSSParserTokenRange& range, CSS::PropertyParse
 {
     if (auto positionY = consumePositionYUnresolved(range, state))
         return CSSPositionYValue::create(WTFMove(*positionY));
+    return nullptr;
+}
+
+RefPtr<CSSValue> consumePositionBlock(CSSParserTokenRange& range, CSS::PropertyParserState& state)
+{
+    if (auto positionLogical = consumePositionBlockUnresolved(range, state))
+        return CSSPositionLogicalValue::create(WTFMove(*positionLogical));
+    return nullptr;
+}
+
+RefPtr<CSSValue> consumePositionInline(CSSParserTokenRange& range, CSS::PropertyParserState& state)
+{
+    if (auto positionLogical = consumePositionInlineUnresolved(range, state))
+        return CSSPositionLogicalValue::create(WTFMove(*positionLogical));
     return nullptr;
 }
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Position.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Position.h
@@ -27,6 +27,7 @@
 #include "CSSPosition.h"
 #include "CSSPropertyParserOptions.h"
 #include <optional>
+#include <wtf/OptionSet.h>
 
 namespace WebCore {
 
@@ -42,6 +43,11 @@ namespace CSSPropertyParserHelpers {
 // MARK: <position> | <bg-position>
 // https://drafts.csswg.org/css-values/#position
 
+enum class AllowedPositionKeywords : uint8_t {
+    AxisRelative = 1 << 0,
+    FlowRelative = 1 << 1,
+};
+
 // MARK: <position> (CSSValue)
 RefPtr<CSSValue> consumePosition(CSSParserTokenRange&, CSS::PropertyParserState&);
 
@@ -51,12 +57,20 @@ RefPtr<CSSValue> consumePositionX(CSSParserTokenRange&, CSS::PropertyParserState
 // MARK: <position-y> (CSSValue)
 RefPtr<CSSValue> consumePositionY(CSSParserTokenRange&, CSS::PropertyParserState&);
 
+// MARK: <background-position-block> (CSSValue)
+RefPtr<CSSValue> consumePositionBlock(CSSParserTokenRange&, CSS::PropertyParserState&);
+
+// MARK: <background-position-inline> (CSSValue)
+RefPtr<CSSValue> consumePositionInline(CSSParserTokenRange&, CSS::PropertyParserState&);
+
 
 // MARK: <position> (unresolved)
 std::optional<CSS::Position> consumePositionUnresolved(CSSParserTokenRange&, CSS::PropertyParserState&);
+std::optional<CSS::PositionXY> consumePositionXYUnresolved(CSSParserTokenRange&, CSS::PropertyParserState&);
 
 // MARK: <bg-position> (unresolved)
 std::optional<CSS::Position> consumeBackgroundPositionUnresolved(CSSParserTokenRange&, CSS::PropertyParserState&);
+std::optional<CSS::PositionXY> consumeBackgroundPositionXYUnresolved(CSSParserTokenRange&, CSS::PropertyParserState&);
 
 // MARK: <position-x> (unresolved)
 std::optional<CSS::PositionX> consumePositionXUnresolved(CSSParserTokenRange&, CSS::PropertyParserState&);
@@ -64,16 +78,25 @@ std::optional<CSS::PositionX> consumePositionXUnresolved(CSSParserTokenRange&, C
 // MARK: <position-y> (unresolved)
 std::optional<CSS::PositionY> consumePositionYUnresolved(CSSParserTokenRange&, CSS::PropertyParserState&);
 
+// MARK: <position-block> (unresolved)
+std::optional<CSS::PositionLogical> consumePositionBlockUnresolved(CSSParserTokenRange&, CSS::PropertyParserState&);
+
+// MARK: <position-inline> (unresolved)
+std::optional<CSS::PositionLogical> consumePositionInlineUnresolved(CSSParserTokenRange&, CSS::PropertyParserState&);
+
 
 // MARK: Subset / Special case parsers.
 
-// NOTE: This is only used by the `<-webkit-radial-gradient()>` and `<transform-origin>` parsers.
-std::optional<CSS::Position> consumeOneOrTwoComponentPositionUnresolved(CSSParserTokenRange&, CSS::PropertyParserState&);
+// NOTE: This is only used by the `<-webkit-radial-gradient()>` parser. Does not include axis or flow relative keywords.
+std::optional<CSS::Position> consumeLegacyBackgroundPositionUnresolved(CSSParserTokenRange&, CSS::PropertyParserState&);
 
-// NOTE: This is only used by the `<horizontal-line-command>` parser
+// NOTE: This is only used by the `<transform-origin>` parser. Does not include axis or flow relative keywords.
+std::optional<CSS::PositionXY> consumeTransformOriginXY(CSSParserTokenRange&, CSS::PropertyParserState&);
+
+// NOTE: This is only used by the `<horizontal-line-command>` parser. Does not include flow relative keywords.
 std::optional<CSS::TwoComponentPositionHorizontal> consumeTwoComponentPositionHorizontalUnresolved(CSSParserTokenRange&, CSS::PropertyParserState&);
 
-// NOTE: This is only used by the `<vertical-line-command>` parser
+// NOTE: This is only used by the `<vertical-line-command>` parser. Does not include flow relative keywords.
 std::optional<CSS::TwoComponentPositionVertical> consumeTwoComponentPositionVerticalUnresolved(CSSParserTokenRange&, CSS::PropertyParserState&);
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/values/primitives/CSSPosition.cpp
+++ b/Source/WebCore/css/values/primitives/CSSPosition.cpp
@@ -63,7 +63,7 @@ static auto toTwoComponent(const ThreeComponentPositionVertical& component) -> T
     return WTF::switchOn(component.offset, [](auto keyword) -> TwoComponentPositionVertical { return { keyword }; });
 }
 
-std::pair<CSS::PositionX, CSS::PositionY> split(CSS::Position&& position)
+std::pair<CSS::PositionX, CSS::PositionY> split(CSS::PositionXY&& position)
 {
     // CSS::PositionX and CSS::PositionY don't utilize the three component variants, so the
     // non-length containing item must be converted to its two component variant.
@@ -77,6 +77,90 @@ std::pair<CSS::PositionX, CSS::PositionY> split(CSS::Position&& position)
         },
         [&](const ThreeComponentPositionHorizontalVerticalLengthSecond& components) -> std::pair<CSS::PositionX, CSS::PositionY> {
             return { CSS::PositionX(toTwoComponent(get<0>(components))), CSS::PositionY(get<1>(components)) };
+        }
+    );
+}
+
+PositionX resolveToPhysicalX(const PositionLogical& position, WritingMode writingMode)
+{
+    return WTF::switchOn(position.value,
+        [&](const TwoComponentPositionLogical& components) -> PositionX {
+            return WTF::switchOn(components.offset,
+                [&](Keyword::Start) -> PositionX {
+                    return writingMode.isAnyLeftToRight()
+                        ? TwoComponentPositionHorizontal { Keyword::Left { } }
+                        : TwoComponentPositionHorizontal { Keyword::Right { } };
+                },
+                [&](Keyword::End) -> PositionX {
+                    return writingMode.isAnyLeftToRight()
+                        ? TwoComponentPositionHorizontal { Keyword::Right { } }
+                        : TwoComponentPositionHorizontal { Keyword::Left { } };
+                },
+                [&](Keyword::Center) -> PositionX {
+                    return TwoComponentPositionHorizontal { Keyword::Center { } };
+                },
+                [&](const LengthPercentage<>& length) -> PositionX {
+                    return writingMode.isAnyLeftToRight()
+                        ? FourComponentPositionHorizontal { { Keyword::Left { }, length } }
+                        : FourComponentPositionHorizontal { { Keyword::Right { }, length } };
+                }
+            );
+        },
+        [&](const FourComponentPositionLogical& components) -> PositionX {
+            return WTF::switchOn(get<0>(components.offset),
+                [&](Keyword::Start) -> PositionX {
+                    return writingMode.isAnyLeftToRight()
+                        ? FourComponentPositionHorizontal { { Keyword::Left { }, get<1>(components.offset) } }
+                        : FourComponentPositionHorizontal { { Keyword::Right { }, get<1>(components.offset) } };
+                },
+                [&](Keyword::End) -> PositionX {
+                    return writingMode.isAnyLeftToRight()
+                        ? FourComponentPositionHorizontal { { Keyword::Right { }, get<1>(components.offset) } }
+                        : FourComponentPositionHorizontal { { Keyword::Left { }, get<1>(components.offset) } };
+                }
+            );
+        }
+    );
+}
+
+PositionY resolveToPhysicalY(const PositionLogical& position, WritingMode writingMode)
+{
+    return WTF::switchOn(position.value,
+        [&](const TwoComponentPositionLogical& components) -> PositionY {
+            return WTF::switchOn(components.offset,
+                [&](Keyword::Start) -> PositionY {
+                    return writingMode.isAnyTopToBottom()
+                        ? TwoComponentPositionVertical { Keyword::Top { } }
+                        : TwoComponentPositionVertical { Keyword::Bottom { } };
+                },
+                [&](Keyword::End) -> PositionY {
+                    return writingMode.isAnyTopToBottom()
+                        ? TwoComponentPositionVertical { Keyword::Bottom { } }
+                        : TwoComponentPositionVertical { Keyword::Top { } };
+                },
+                [&](Keyword::Center) -> PositionY {
+                    return TwoComponentPositionVertical { Keyword::Center { } };
+                },
+                [&](const LengthPercentage<>& length) -> PositionY {
+                    return writingMode.isAnyTopToBottom()
+                        ? FourComponentPositionVertical { { Keyword::Top { }, length } }
+                        : FourComponentPositionVertical { { Keyword::Bottom { }, length } };
+                }
+            );
+        },
+        [&](const FourComponentPositionLogical& components) -> PositionY {
+            return WTF::switchOn(get<0>(components.offset),
+                [&](Keyword::Start) -> PositionY {
+                    return writingMode.isAnyTopToBottom()
+                        ? FourComponentPositionVertical { { Keyword::Top { }, get<1>(components.offset) } }
+                        : FourComponentPositionVertical { { Keyword::Bottom { }, get<1>(components.offset) } };
+                },
+                [&](Keyword::End) -> PositionY {
+                    return writingMode.isAnyTopToBottom()
+                        ? FourComponentPositionVertical { { Keyword::Bottom { }, get<1>(components.offset) } }
+                        : FourComponentPositionVertical { { Keyword::Top { }, get<1>(components.offset) } };
+                }
+            );
         }
     );
 }

--- a/Source/WebCore/css/values/primitives/CSSPosition.h
+++ b/Source/WebCore/css/values/primitives/CSSPosition.h
@@ -27,6 +27,9 @@
 #include "CSSPrimitiveNumericTypes.h"
 
 namespace WebCore {
+
+class WritingMode;
+
 namespace CSS {
 
 // MARK: Two Component Types
@@ -44,6 +47,27 @@ struct TwoComponentPositionVertical {
     bool operator==(const TwoComponentPositionVertical&) const = default;
 };
 DEFINE_TYPE_WRAPPER_GET(TwoComponentPositionVertical, offset);
+
+struct TwoComponentPositionBlock {
+    Variant<Keyword::BlockStart, Keyword::Center, Keyword::BlockEnd> offset;
+
+    bool operator==(const TwoComponentPositionBlock&) const = default;
+};
+DEFINE_TYPE_WRAPPER_GET(TwoComponentPositionBlock, offset);
+
+struct TwoComponentPositionInline {
+    Variant<Keyword::InlineStart, Keyword::Center, Keyword::InlineEnd> offset;
+
+    bool operator==(const TwoComponentPositionInline&) const = default;
+};
+DEFINE_TYPE_WRAPPER_GET(TwoComponentPositionInline, offset);
+
+struct TwoComponentPositionLogical {
+    Variant<Keyword::Start, Keyword::End, Keyword::Center, LengthPercentage<>> offset;
+
+    bool operator==(const TwoComponentPositionLogical&) const = default;
+};
+DEFINE_TYPE_WRAPPER_GET(TwoComponentPositionLogical, offset);
 
 // MARK: Three Component Types
 
@@ -76,19 +100,58 @@ struct FourComponentPositionVertical {
 };
 DEFINE_TYPE_WRAPPER_GET(FourComponentPositionVertical, offset);
 
+struct FourComponentPositionBlock {
+    SpaceSeparatedTuple<Variant<Keyword::BlockStart, Keyword::BlockEnd>, LengthPercentage<>> offset;
+
+    bool operator==(const FourComponentPositionBlock&) const = default;
+};
+DEFINE_TYPE_WRAPPER_GET(FourComponentPositionBlock, offset);
+
+struct FourComponentPositionInline {
+    SpaceSeparatedTuple<Variant<Keyword::InlineStart, Keyword::InlineEnd>, LengthPercentage<>> offset;
+
+    bool operator==(const FourComponentPositionInline&) const = default;
+};
+DEFINE_TYPE_WRAPPER_GET(FourComponentPositionInline, offset);
+
+struct FourComponentPositionLogical {
+    SpaceSeparatedTuple<Variant<Keyword::Start, Keyword::End>, LengthPercentage<>> offset;
+
+    bool operator==(const FourComponentPositionLogical&) const = default;
+};
+DEFINE_TYPE_WRAPPER_GET(FourComponentPositionLogical, offset);
+
 using TwoComponentPositionHorizontalVertical               = SpaceSeparatedTuple<TwoComponentPositionHorizontal, TwoComponentPositionVertical>;
+using TwoComponentPositionBlockInline                      = SpaceSeparatedTuple<TwoComponentPositionBlock, TwoComponentPositionInline>;
+using TwoComponentPositionStartEnd                         = SpaceSeparatedTuple<TwoComponentPositionLogical, TwoComponentPositionLogical>;
 
 using ThreeComponentPositionHorizontalVerticalLengthFirst  = SpaceSeparatedTuple<FourComponentPositionHorizontal, ThreeComponentPositionVertical>;
 using ThreeComponentPositionHorizontalVerticalLengthSecond = SpaceSeparatedTuple<ThreeComponentPositionHorizontal, FourComponentPositionVertical>;
+using ThreeComponentPositionBlockInlineLengthFirst         = SpaceSeparatedTuple<FourComponentPositionBlock, TwoComponentPositionInline>;
+using ThreeComponentPositionBlockInlineLengthSecond        = SpaceSeparatedTuple<TwoComponentPositionBlock, FourComponentPositionInline>;
+using ThreeComponentPositionStartEndLengthFirst            = SpaceSeparatedTuple<FourComponentPositionLogical, TwoComponentPositionLogical>;
+using ThreeComponentPositionStartEndLengthSecond           = SpaceSeparatedTuple<TwoComponentPositionLogical, FourComponentPositionLogical>;
 
 using FourComponentPositionHorizontalVertical              = SpaceSeparatedTuple<FourComponentPositionHorizontal, FourComponentPositionVertical>;
+using FourComponentPositionBlockInline                     = SpaceSeparatedTuple<FourComponentPositionBlock, FourComponentPositionInline>;
+using FourComponentPositionStartEnd                        = SpaceSeparatedTuple<FourComponentPositionLogical, FourComponentPositionLogical>;
 
 struct Position {
     using Kind = Variant<
         TwoComponentPositionHorizontalVertical,
+        TwoComponentPositionBlockInline,
+        TwoComponentPositionStartEnd,
+
         ThreeComponentPositionHorizontalVerticalLengthFirst,
         ThreeComponentPositionHorizontalVerticalLengthSecond,
-        FourComponentPositionHorizontalVertical
+        ThreeComponentPositionBlockInlineLengthFirst,
+        ThreeComponentPositionBlockInlineLengthSecond,
+        ThreeComponentPositionStartEndLengthFirst,
+        ThreeComponentPositionStartEndLengthSecond,
+
+        FourComponentPositionHorizontalVertical,
+        FourComponentPositionBlockInline,
+        FourComponentPositionStartEnd
     >;
 
     template<typename T>
@@ -107,6 +170,31 @@ struct Position {
     Kind value;
 };
 DEFINE_TYPE_WRAPPER_GET(Position, value);
+
+struct PositionXY {
+    using Kind = Variant<
+        TwoComponentPositionHorizontalVertical,
+        ThreeComponentPositionHorizontalVerticalLengthFirst,
+        ThreeComponentPositionHorizontalVerticalLengthSecond,
+        FourComponentPositionHorizontalVertical
+    >;
+
+    template<typename T>
+    PositionXY(T&& value)
+        : value { std::forward<T>(value) }
+    {
+    }
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        return WTF::switchOn(value, std::forward<F>(f)...);
+    }
+
+    bool operator==(const PositionXY&) const = default;
+
+    Kind value;
+};
+DEFINE_TYPE_WRAPPER_GET(PositionXY, value);
 
 struct PositionX {
     using Kind = Variant<
@@ -154,19 +242,69 @@ struct PositionY {
 };
 DEFINE_TYPE_WRAPPER_GET(PositionY, value);
 
+struct PositionLogical {
+    using Kind = Variant<
+        TwoComponentPositionLogical,
+        FourComponentPositionLogical
+    >;
+
+    template<typename T>
+    PositionLogical(T&& value)
+        : value { std::forward<T>(value) }
+    {
+    }
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        return WTF::switchOn(value, std::forward<F>(f)...);
+    }
+
+    bool operator==(const PositionLogical&) const = default;
+
+    Kind value;
+};
+DEFINE_TYPE_WRAPPER_GET(PositionLogical, value);
+
 bool isCenterPosition(const Position&);
 
-std::pair<CSS::PositionX, CSS::PositionY> split(CSS::Position&&);
+// Resolves a logical position to a physical position (used by style builder).
+PositionX resolveToPhysicalX(const PositionLogical&, WritingMode);
+PositionY resolveToPhysicalY(const PositionLogical&, WritingMode);
+
+// Splits a position-xy into x and y components (used by shorthand parsers).
+std::pair<CSS::PositionX, CSS::PositionY> split(CSS::PositionXY&&);
+
+// MARK: Concept predicates.
+
+template<typename T> concept IsBlockInlineComponents =
+       std::same_as<T, CSS::TwoComponentPositionBlockInline>
+    || std::same_as<T, CSS::ThreeComponentPositionBlockInlineLengthFirst>
+    || std::same_as<T, CSS::ThreeComponentPositionBlockInlineLengthSecond>
+    || std::same_as<T, CSS::FourComponentPositionBlockInline>;
+
+template<typename T> concept IsStartEndComponents =
+       std::same_as<T, CSS::TwoComponentPositionStartEnd>
+    || std::same_as<T, CSS::ThreeComponentPositionStartEndLengthFirst>
+    || std::same_as<T, CSS::ThreeComponentPositionStartEndLengthSecond>
+    || std::same_as<T, CSS::FourComponentPositionStartEnd>;
 
 } // namespace CSS
 } // namespace WebCore
 
 DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::TwoComponentPositionHorizontal, 1)
 DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::TwoComponentPositionVertical, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::TwoComponentPositionBlock, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::TwoComponentPositionInline, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::TwoComponentPositionLogical, 1)
 DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::ThreeComponentPositionHorizontal, 1)
 DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::ThreeComponentPositionVertical, 1)
 DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::FourComponentPositionHorizontal, 1)
 DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::FourComponentPositionVertical, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::FourComponentPositionBlock, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::FourComponentPositionInline, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::FourComponentPositionLogical, 1)
 DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::Position, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::PositionXY, 1)
 DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::PositionX, 1)
 DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::PositionY, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::PositionLogical, 1)

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -596,6 +596,9 @@ inline LengthPoint BuilderConverter::convertPositionOrAuto(BuilderState& builder
 
 inline WebCore::Length BuilderConverter::convertPositionComponentX(BuilderState& builderState, const CSSValue& value)
 {
+    if (RefPtr positionLogicalValue = dynamicDowncast<CSSPositionLogicalValue>(value))
+        return Style::toPlatform(Style::toStyle(CSS::resolveToPhysicalX(positionLogicalValue->position(), builderState.style().writingMode()), builderState));
+
     RefPtr positionXValue = requiredDowncast<CSSPositionXValue>(builderState, value);
     if (!positionXValue)
         return { };
@@ -604,6 +607,9 @@ inline WebCore::Length BuilderConverter::convertPositionComponentX(BuilderState&
 
 inline WebCore::Length BuilderConverter::convertPositionComponentY(BuilderState& builderState, const CSSValue& value)
 {
+    if (RefPtr positionLogicalValue = dynamicDowncast<CSSPositionLogicalValue>(value))
+        return Style::toPlatform(Style::toStyle(CSS::resolveToPhysicalY(positionLogicalValue->position(), builderState.style().writingMode()), builderState));
+
     RefPtr positionYValue = requiredDowncast<CSSPositionYValue>(builderState, value);
     if (!positionYValue)
         return { };

--- a/Source/WebCore/style/values/primitives/StylePosition.cpp
+++ b/Source/WebCore/style/values/primitives/StylePosition.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "StylePosition.h"
 
+#include "BoxSides.h"
 #include "CalculationCategory.h"
 #include "CalculationTree.h"
 #include "LengthPoint.h"
@@ -114,6 +115,42 @@ template<typename... Args> static auto resolveKeyword(CSS::Keyword::YEnd, const 
         : resolveKeyword(CSS::Keyword::Top { }, state, std::forward<Args>(args)...);
 }
 
+template<typename... Args> static auto resolveKeyword(BoxSide boxSide, Args&&... args) -> LengthPercentage<>
+{
+    switch (boxSide) {
+    case BoxSide::Top:
+        return resolveKeyword(CSS::Keyword::Top { }, std::forward<Args>(args)...);
+    case BoxSide::Right:
+        return resolveKeyword(CSS::Keyword::Right { }, std::forward<Args>(args)...);
+    case BoxSide::Bottom:
+        return resolveKeyword(CSS::Keyword::Bottom { }, std::forward<Args>(args)...);
+    case BoxSide::Left:
+        return resolveKeyword(CSS::Keyword::Left { }, std::forward<Args>(args)...);
+    }
+    ASSERT_NOT_REACHED();
+    return 0_css_percentage;
+}
+
+template<typename... Args> static auto resolveKeyword(CSS::Keyword::BlockStart, const BuilderState& state, Args&&... args) -> LengthPercentage<>
+{
+    return resolveKeyword(mapSideLogicalToPhysical(state.style().writingMode(), LogicalBoxSide::BlockStart), state, std::forward<Args>(args)...);
+}
+
+template<typename... Args> static auto resolveKeyword(CSS::Keyword::BlockEnd, const BuilderState& state, Args&&... args) -> LengthPercentage<>
+{
+    return resolveKeyword(mapSideLogicalToPhysical(state.style().writingMode(), LogicalBoxSide::BlockEnd), state, std::forward<Args>(args)...);
+}
+
+template<typename... Args> static auto resolveKeyword(CSS::Keyword::InlineStart, const BuilderState& state, Args&&... args) -> LengthPercentage<>
+{
+    return resolveKeyword(mapSideLogicalToPhysical(state.style().writingMode(), LogicalBoxSide::InlineStart), state, std::forward<Args>(args)...);
+}
+
+template<typename... Args> static auto resolveKeyword(CSS::Keyword::InlineEnd, const BuilderState& state, Args&&... args) -> LengthPercentage<>
+{
+    return resolveKeyword(mapSideLogicalToPhysical(state.style().writingMode(), LogicalBoxSide::InlineEnd), state, std::forward<Args>(args)...);
+}
+
 // MARK: Horizontal/Vertical
 
 static auto resolve(const CSS::TwoComponentPositionHorizontal& value, const BuilderState& state) -> LengthPercentage<>
@@ -176,6 +213,106 @@ static auto resolve(const CSS::FourComponentPositionVertical& value, const Build
     );
 }
 
+// MARK: Block/Inline
+
+static auto resolve(const CSS::TwoComponentPositionBlock& value, const BuilderState& state) -> LengthPercentage<>
+{
+    return WTF::switchOn(value.offset,
+        [&](auto keyword) {
+            return resolveKeyword(keyword, state);
+        }
+    );
+}
+
+static auto resolve(const CSS::TwoComponentPositionInline& value, const BuilderState& state) -> LengthPercentage<>
+{
+    return WTF::switchOn(value.offset,
+        [&](auto keyword) {
+            return resolveKeyword(keyword, state);
+        }
+    );
+}
+
+static auto resolve(const CSS::FourComponentPositionBlock& value, const BuilderState& state) -> LengthPercentage<>
+{
+    return WTF::switchOn(get<0>(value.offset),
+        [&](auto keyword) {
+            return resolveKeyword(keyword, state, get<1>(value.offset));
+        }
+    );
+}
+
+static auto resolve(const CSS::FourComponentPositionInline& value, const BuilderState& state) -> LengthPercentage<>
+{
+    return WTF::switchOn(get<0>(value.offset),
+        [&](auto keyword) {
+            return resolveKeyword(keyword, state, get<1>(value.offset));
+        }
+    );
+}
+
+// MARK: Start/End
+
+static auto resolveMappingBlock(const CSS::TwoComponentPositionLogical& value, const BuilderState& state) -> LengthPercentage<>
+{
+    return WTF::switchOn(value.offset,
+        [&](CSS::Keyword::Start) {
+            return resolveKeyword(CSS::Keyword::BlockStart { }, state);
+        },
+        [&](CSS::Keyword::End) {
+            return resolveKeyword(CSS::Keyword::BlockEnd { }, state);
+        },
+        [&](CSS::Keyword::Center) {
+            return resolveKeyword(CSS::Keyword::Center { }, state);
+        },
+        [&](const CSS::LengthPercentage<>& value) {
+            return resolveKeyword(CSS::Keyword::BlockStart { }, state, value);
+        }
+    );
+}
+
+static auto resolveMappingInline(const CSS::TwoComponentPositionLogical& value, const BuilderState& state) -> LengthPercentage<>
+{
+    return WTF::switchOn(value.offset,
+        [&](CSS::Keyword::Start) {
+            return resolveKeyword(CSS::Keyword::InlineStart { }, state);
+        },
+        [&](CSS::Keyword::End) {
+            return resolveKeyword(CSS::Keyword::InlineEnd { }, state);
+        },
+        [&](CSS::Keyword::Center) {
+            return resolveKeyword(CSS::Keyword::Center { }, state);
+        },
+        [&](const CSS::LengthPercentage<>& value) {
+            return resolveKeyword(CSS::Keyword::InlineStart { }, state, value);
+        }
+    );
+}
+
+static auto resolveMappingBlock(const CSS::FourComponentPositionLogical& value, const BuilderState& state) -> LengthPercentage<>
+{
+    return WTF::switchOn(get<0>(value.offset),
+        [&](CSS::Keyword::Start) {
+            return resolveKeyword(CSS::Keyword::BlockStart { }, state, get<1>(value.offset));
+        },
+        [&](CSS::Keyword::End) {
+            return resolveKeyword(CSS::Keyword::BlockEnd { }, state, get<1>(value.offset));
+        }
+    );
+}
+
+static auto resolveMappingInline(const CSS::FourComponentPositionLogical& value, const BuilderState& state) -> LengthPercentage<>
+{
+    return WTF::switchOn(get<0>(value.offset),
+        [&](CSS::Keyword::Start) {
+            return resolveKeyword(CSS::Keyword::InlineStart { }, state, get<1>(value.offset));
+        },
+        [&](CSS::Keyword::End) {
+            return resolveKeyword(CSS::Keyword::InlineEnd { }, state, get<1>(value.offset));
+        }
+    );
+}
+
 auto ToStyle<CSS::TwoComponentPositionHorizontal>::operator()(const CSS::TwoComponentPositionHorizontal& value, const BuilderState& state) -> TwoComponentPositionHorizontal
 {
     return { resolve(value, state) };
@@ -201,6 +338,32 @@ auto ToStyle<CSS::Position>::operator()(const CSS::Position& position, const Bui
                 resolve(get<0>(components), state),
                 resolve(get<1>(components), state),
             };
+        },
+        [&]<CSS::IsBlockInlineComponents T>(const T& components) {
+            if (state.style().writingMode().isHorizontal()) {
+                return Position {
+                    resolve(get<1>(components), state),
+                    resolve(get<0>(components), state),
+                };
+            } else {
+                return Position {
+                    resolve(get<0>(components), state),
+                    resolve(get<1>(components), state),
+                };
+            }
+        },
+        [&]<CSS::IsStartEndComponents T>(const T& components) {
+            if (state.style().writingMode().isHorizontal()) {
+                return Position {
+                    resolveMappingInline(get<1>(components), state),
+                    resolveMappingBlock(get<0>(components), state),
+                };
+            } else {
+                return Position {
+                    resolveMappingBlock(get<0>(components), state),
+                    resolveMappingInline(get<1>(components), state),
+                };
+            }
         }
     );
 }


### PR DESCRIPTION
#### c40564f741a3735e9d0b9918cacf451d09d86018
<pre>
Add support for logical background-position shorthands
<a href="https://bugs.webkit.org/show_bug.cgi?id=292202">https://bugs.webkit.org/show_bug.cgi?id=292202</a>

Reviewed by NOBODY (OOPS!).

WIP

Still needed:
    - Ensure writing modes / direction actually produce the correct results at style building time.
    - Ensure writing modes / direction actually produce the correct results at computed style time.
    - Add support for background-position/background/etc shorthands.

* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-block-computed.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-block-computed.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-block-invalid.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-block-invalid.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-block-valid.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-block-valid.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-computed.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-computed.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-invalid.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-invalid.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-valid.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-valid.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-longhand-shorthand-overriding.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-longhand-shorthand-overriding.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-writing-mode.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-writing-mode.tentative.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSPositionValue.cpp:
* Source/WebCore/css/CSSPositionValue.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSProperty.h:
* Source/WebCore/css/CSSValue.cpp:
* Source/WebCore/css/CSSValue.h:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Position.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Position.h:
* Source/WebCore/css/values/primitives/CSSPosition.cpp:
* Source/WebCore/css/values/primitives/CSSPosition.h:
* Source/WebCore/style/StyleBuilderConverter.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c40564f741a3735e9d0b9918cacf451d09d86018

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101522 "12 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21188 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106683 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52161 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103562 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29683 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77327 "Found 7 new test failures: imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-computed.tentative.html imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-longhand-shorthand-overriding.tentative.html imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-writing-mode.tentative.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/css/css-values/position/position-computed.tentative.html imported/w3c/web-platform-tests/css/css-values/position/position-invalid.tentative.html imported/w3c/web-platform-tests/css/css-values/position/position-valid.tentative.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34352 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104529 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16599 "Exiting early after 10 failures. 20 tests run. 5 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91691 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57664 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16421 "Found 7 new test failures: imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-computed.tentative.html imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-longhand-shorthand-overriding.tentative.html imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-writing-mode.tentative.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-no-fallback-props-001.html imported/w3c/web-platform-tests/css/css-values/position/position-computed.tentative.html imported/w3c/web-platform-tests/css/css-values/position/position-invalid.tentative.html imported/w3c/web-platform-tests/css/css-values/position/position-valid.tentative.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9707 "Found 8 new test failures: imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-computed.tentative.html imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-longhand-shorthand-overriding.tentative.html imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-writing-mode.tentative.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-no-fallback-props-001.html imported/w3c/web-platform-tests/css/css-values/position/position-computed.tentative.html imported/w3c/web-platform-tests/css/css-values/position/position-invalid.tentative.html imported/w3c/web-platform-tests/css/css-values/position/position-valid.tentative.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51506 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94195 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86293 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9785 "Found 8 new test failures: imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-computed.tentative.html imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-longhand-shorthand-overriding.tentative.html imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-writing-mode.tentative.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-no-fallback-props-001.html imported/w3c/web-platform-tests/css/css-values/position/position-computed.tentative.html imported/w3c/web-platform-tests/css/css-values/position/position-invalid.tentative.html imported/w3c/web-platform-tests/css/css-values/position/position-valid.tentative.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109034 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100138 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28657 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21088 "Found 8 new test failures: imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-computed.tentative.html imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-longhand-shorthand-overriding.tentative.html imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-writing-mode.tentative.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-no-fallback-props-001.html imported/w3c/web-platform-tests/css/css-values/position/position-computed.tentative.html imported/w3c/web-platform-tests/css/css-values/position/position-invalid.tentative.html imported/w3c/web-platform-tests/css/css-values/position/position-valid.tentative.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86300 "Found 8 new test failures: imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-computed.tentative.html imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-longhand-shorthand-overriding.tentative.html imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-writing-mode.tentative.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-no-fallback-props-001.html imported/w3c/web-platform-tests/css/css-values/position/position-computed.tentative.html imported/w3c/web-platform-tests/css/css-values/position/position-invalid.tentative.html imported/w3c/web-platform-tests/css/css-values/position/position-valid.tentative.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29013 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87892 "Exiting early after 10 failures. 18 tests run. 4 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85862 "Found 101 new API test failures: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/javascript-dialogs, /TestWebKit:WebKit.DOMWindowExtensionCrashOnReload, /TestWebKit:WebKit.PageLoadBasic, /TestWebKit:WebKit.NewFirstVisuallyNonEmptyLayoutFails, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /TestWebKit:WebKit.InjectedBundleBasic, /TestWebKit:WebKit.PreventEmptyUserAgent, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/select-all/non-editable ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30596 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8310 "Found 8 new test failures: imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-inline-computed.tentative.html imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-longhand-shorthand-overriding.tentative.html imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-position-writing-mode.tentative.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-no-fallback-props-001.html imported/w3c/web-platform-tests/css/css-values/position/position-computed.tentative.html imported/w3c/web-platform-tests/css/css-values/position/position-invalid.tentative.html imported/w3c/web-platform-tests/css/css-values/position/position-valid.tentative.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22793 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28582 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33873 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/123757 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28393 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34396 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31713 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29952 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->