### PR TITLE
Unreviewed, reverting 294351@main (ea48344d7169)

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-291988b-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-291988b-expected.txt
@@ -1,1 +1,1 @@
-CONSOLE MESSAGE: Pass
+Pass

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-291988b.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-291988b.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <style>
   :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
 </style>
@@ -27998,7 +27999,6 @@ device0.queue.submit([commandBuffer23, commandBuffer25]);
 try {
 device0.queue.writeBuffer(buffer23, 12, new DataView(new ArrayBuffer(15688)), 57, 4);
 } catch {}
-await gc();
 videoFrame0.close();
 videoFrame1.close();
 videoFrame2.close();
@@ -28021,6 +28021,8 @@ videoFrame23.close();
 videoFrame24.close();
 videoFrame25.close();
 videoFrame26.close();
+await gc();
+
 }
 
 onload = async () => {
@@ -28068,8 +28070,9 @@ onload = async () => {
       
     }
   }
-  log('Pass');
+  console.debug('Pass');
   globalThis.testRunner?.dumpAsText();
   globalThis.testRunner?.notifyDone();
 };
 </script>
+Pass

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2418,5 +2418,3 @@ fast/forms/color/input-color-swatch-overlay-appearance.html [ Pass ]
 webkit.org/b/291459 [ Release ] imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-018.html [ Pass Failure ]
 
 webkit.org/b/291785 [ Release ] security/decode-buffer-size.html [ Timeout ]
-
-webkit.org/b/292337 fast/webgpu/nocrash/fuzz-291988b.html [ Skip ]


### PR DESCRIPTION
#### bdd63eee79501b7e51ae72d799f713223c322fe0
<pre>
Unreviewed, reverting 294351@main (ea48344d7169)
<a href="https://bugs.webkit.org/show_bug.cgi?id=292337">https://bugs.webkit.org/show_bug.cgi?id=292337</a>
<a href="https://rdar.apple.com/150378994">rdar://150378994</a>

REGRESSION(294277@main)[MacOS wk2] fast/webgpu/nocrash/fuzz-291988b.html is constant failure

Reverted change:

    [Gardening]: REGRESSION(294277@main)[MacOS wk2] fast/webgpu/nocrash/fuzz-291988b.html is constant failure
    <a href="https://bugs.webkit.org/show_bug.cgi?id=292337">https://bugs.webkit.org/show_bug.cgi?id=292337</a>
    <a href="https://rdar.apple.com/150378994">rdar://150378994</a>
    294351@main (ea48344d7169)

Canonical link: <a href="https://commits.webkit.org/294360@main">https://commits.webkit.org/294360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d481aa96eb9277215baad4d310da6ac533c3c4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106711 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52186 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29715 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77339 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34365 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16626 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91707 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57677 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16449 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/9724 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51533 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86320 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109062 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28686 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/21109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86315 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29047 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87908 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85877 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30617 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8326 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22818 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16527 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28614 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28425 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31748 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29984 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->