### PR TITLE
Check std::optional in PositionedLayoutConstraints::captureGridArea

### DIFF
--- a/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
@@ -159,11 +159,18 @@ void PositionedLayoutConstraints::captureGridArea(const RenderBox& renderer)
         return;
 
     if (LogicalBoxAxis::Inline == m_containingAxis) {
-        m_containingRange = gridContainer->gridAreaColumnRangeForOutOfFlow(renderer);
-        m_marginPercentageBasis = m_containingRange.size();
+        auto range = gridContainer->gridAreaColumnRangeForOutOfFlow(renderer);
+        if (!range)
+            return;
+        m_containingRange = *range;
+        m_marginPercentageBasis = range->size();
     } else {
-        m_containingRange = gridContainer->gridAreaRowRangeForOutOfFlow(renderer);
-        m_marginPercentageBasis = gridContainer->gridAreaColumnRangeForOutOfFlow(renderer).size();
+        auto range = gridContainer->gridAreaRowRangeForOutOfFlow(renderer);
+        if (range)
+            m_containingRange = *range;
+        auto columnRange = gridContainer->gridAreaColumnRangeForOutOfFlow(renderer);
+        if (columnRange)
+            m_marginPercentageBasis = columnRange->size();
     }
 
     if (!startIsBefore()) {

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -2331,21 +2331,24 @@ LayoutUnit RenderGrid::logicalOffsetForOutOfFlowGridItem(const RenderBox& gridIt
     return trackBreadth - offset - gridItemBreadth;
 }
 
-LayoutRange RenderGrid::gridAreaRowRangeForOutOfFlow(const RenderBox& gridItem) const
+std::optional<LayoutRange> RenderGrid::gridAreaRowRangeForOutOfFlow(const RenderBox& gridItem) const
 {
     ASSERT(gridItem.isOutOfFlowPositioned());
     auto areaSize = GridLayoutFunctions::overridingContainingBlockContentSizeForGridItem(gridItem, GridTrackSizingDirection::ForRows);
+    if (!areaSize)
+        return std::nullopt;
     LayoutRange range(borderBefore(), areaSize->value());
     if (auto line = m_outOfFlowItemRow.get(&gridItem))
         range.moveTo(m_rowPositions[line.value()]);
     return range;
 }
 
-LayoutRange RenderGrid::gridAreaColumnRangeForOutOfFlow(const RenderBox& gridItem) const
+std::optional<LayoutRange> RenderGrid::gridAreaColumnRangeForOutOfFlow(const RenderBox& gridItem) const
 {
     ASSERT(gridItem.isOutOfFlowPositioned());
     auto areaSize = GridLayoutFunctions::overridingContainingBlockContentSizeForGridItem(gridItem, GridTrackSizingDirection::ForColumns);
-    ASSERT(areaSize);
+    if (!areaSize)
+        return std::nullopt;
     LayoutRange range(borderStart(), areaSize->value());
     if (auto line = m_outOfFlowItemColumn.get(&gridItem))
         range.moveTo(m_columnPositions[line.value()]);
@@ -2354,11 +2357,12 @@ LayoutRange RenderGrid::gridAreaColumnRangeForOutOfFlow(const RenderBox& gridIte
 
 std::pair<LayoutUnit, LayoutUnit> RenderGrid::gridAreaPositionForOutOfFlowGridItem(const RenderBox& gridItem, GridTrackSizingDirection direction) const
 {
-    LayoutRange range = direction == GridTrackSizingDirection::ForColumns
+    std::optional<LayoutRange> range = direction == GridTrackSizingDirection::ForColumns
         ? gridAreaColumnRangeForOutOfFlow(gridItem)
         : gridAreaRowRangeForOutOfFlow(gridItem);
-    range.moveBy(logicalOffsetForOutOfFlowGridItem(gridItem, direction, range.size()));
-    return { range.min(), range.max() };
+    ASSERT(range);
+    range->moveBy(logicalOffsetForOutOfFlowGridItem(gridItem, direction, range->size()));
+    return { range->min(), range->max() };
 }
 
 std::pair<LayoutUnit, LayoutUnit> RenderGrid::gridAreaPositionForInFlowGridItem(const RenderBox& gridItem, GridTrackSizingDirection direction) const

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -224,8 +224,8 @@ private:
 
     LayoutUnit gridAreaBreadthForOutOfFlowGridItem(const RenderBox&, GridTrackSizingDirection);
     LayoutUnit logicalOffsetForOutOfFlowGridItem(const RenderBox&, GridTrackSizingDirection, LayoutUnit) const;
-    LayoutRange gridAreaRowRangeForOutOfFlow(const RenderBox& gridItem) const;
-    LayoutRange gridAreaColumnRangeForOutOfFlow(const RenderBox& gridItem) const;
+    std::optional<LayoutRange> gridAreaRowRangeForOutOfFlow(const RenderBox& gridItem) const;
+    std::optional<LayoutRange> gridAreaColumnRangeForOutOfFlow(const RenderBox& gridItem) const;
     std::pair<LayoutUnit, LayoutUnit> gridAreaPositionForOutOfFlowGridItem(const RenderBox&, GridTrackSizingDirection) const;
     std::pair<LayoutUnit, LayoutUnit> gridAreaPositionForInFlowGridItem(const RenderBox&, GridTrackSizingDirection) const;
     std::pair<LayoutUnit, LayoutUnit> gridAreaPositionForGridItem(const RenderBox&, GridTrackSizingDirection) const;


### PR DESCRIPTION
#### c19355793d72b813caeaa43c52103b7a187426c4
<pre>
Check std::optional in PositionedLayoutConstraints::captureGridArea
<a href="https://bugs.webkit.org/show_bug.cgi?id=292341">https://bugs.webkit.org/show_bug.cgi?id=292341</a>
<a href="https://rdar.apple.com/150376870">rdar://150376870</a>

Reviewed by Alan Baradlay.

Add checks for omitted containing block grid area info.

* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::captureGridArea):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::gridAreaRowRangeForOutOfFlow const):
(WebCore::RenderGrid::gridAreaColumnRangeForOutOfFlow const):
(WebCore::RenderGrid::gridAreaPositionForOutOfFlowGridItem const):
* Source/WebCore/rendering/RenderGrid.h:

Canonical link: <a href="https://commits.webkit.org/294367@main">https://commits.webkit.org/294367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/642ff23419fe0cbe3aa08273a85ee601542e684c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21223 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106713 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52188 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103595 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29717 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77342 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34367 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104562 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16624 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91710 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57680 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16447 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9727 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51535 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86318 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9804 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109064 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28688 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21111 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86317 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87911 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85879 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21860 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30619 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8329 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22820 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28616 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33905 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28427 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31750 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29986 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->