### PR TITLE
[Grid] Properly handle calc values when computing auto track sizes in computeAutoRepeatTracksCount.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-auto-fit-with-calc-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-auto-fit-with-calc-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-auto-fit-with-calc.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-auto-fit-with-calc.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html> 
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#auto-repeat">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<style>
+  .grid {
+    display: grid;
+    width: 100px;
+    grid-template-columns: repeat(auto-fit, minmax(calc(100% - 10px), calc(100% - 100px)));
+    background-color: green;
+  }
+</style>
+</head>
+  <body>
+    <p>Test passes if there is a filled green square.</p>
+    <div class="grid">
+      <div style="height: 50px;"></div>
+      <div style="height: 50px;"></div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
#### 417c5cd1cddf38bcb6268923a17f9b35cde9fd11
<pre>
[Grid] Properly handle calc values when computing auto track sizes in computeAutoRepeatTracksCount.
<a href="https://rdar.apple.com/146466356">rdar://146466356</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=288819">https://bugs.webkit.org/show_bug.cgi?id=288819</a>

Reviewed by Alan Baradlay.

RenderGrid::computeAutoRepeatTracksAccount is supposed to determine the
number of auto-repeat tracks according to the following:

<a href="https://drafts.csswg.org/css-grid-2/#auto-repeat">https://drafts.csswg.org/css-grid-2/#auto-repeat</a>

During this process we are supposed to &quot;floor the max track sizing
function by the min track sizing function,&quot; if both are definite. The
code that handles this does not consider calcu values at all which
results in hitting an ASSERT in Length when attempting to get the value,
which can even result in incorrect geometry. Fix this by using
valueForLength to properly compute these values.

Also slightly rewrite this part of the code so that it reads more
closely to the spec.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-auto-fit-with-calc-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-auto-fit-with-calc.html: Added.
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::computeAutoRepeatTracksCount const):

Canonical link: <a href="https://commits.webkit.org/294374@main">https://commits.webkit.org/294374@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f07dc132a9ff21a840247290d7c07a8209ccdf04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106728 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52203 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103610 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29733 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77354 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34380 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104577 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16635 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91726 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57691 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16460 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9743 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51550 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9820 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109079 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28703 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86328 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29064 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87927 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85890 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21865 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30634 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8344 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22837 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28631 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33920 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28442 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31765 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30001 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->