### PR TITLE
Two clicks required to resume playback at premierleague.com after returning from back-forward cache

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -578,6 +578,7 @@ public:
     RefPtr<VideoPlaybackQuality> getVideoPlaybackQuality() const;
 
     MediaPlayer::Preload preloadValue() const { return m_preload; }
+    MediaPlayer::Preload effectivePreloadValue() const;
     MediaElementSession* mediaSessionIfExists() const { return m_mediaSession.get(); }
     WEBCORE_EXPORT MediaElementSession& mediaSession() const;
 
@@ -1166,6 +1167,8 @@ private:
 
     bool limitedMatroskaSupportEnabled() const;
 
+    void maybeUpdatePlayerPreload() const;
+
     Timer m_progressEventTimer;
     Timer m_playbackProgressTimer;
     Timer m_scanTimer;
@@ -1478,6 +1481,8 @@ private:
     SoundStageSize m_soundStageSize { SoundStageSize::Auto };
 
     WeakHashSet<HTMLMediaElementClient> m_clients;
+
+    bool m_hasEverPreparedToPlay { false };
 };
 
 String convertEnumerationToString(HTMLMediaElement::AutoplayEventPlaybackState);

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -183,6 +183,9 @@ bool Quirks::needsAutoplayPlayPauseEvents() const
     if (!needsQuirks())
         return false;
 
+    if (m_quirksData.shouldDispatchPlayPauseEventsOnResume)
+        return true;
+
     Ref document = *m_document;
     if (allowedAutoplayQuirks(document).contains(AutoplayQuirk::SynthesizedPauseEvents))
         return true;
@@ -2514,6 +2517,9 @@ static void handlePremierLeagueQuirks(QuirksData& quirksData, const URL& quirksU
     UNUSED_PARAM(documentURL);
     // premierleague.com: rdar://123721211
     quirksData.shouldIgnorePlaysInlineRequirementQuirk = true;
+
+    // premierleague.com: rdar://68938833
+    quirksData.shouldDispatchPlayPauseEventsOnResume = true;
 }
 
 static void handleSFUSDQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -79,6 +79,7 @@ struct WEBCORE_EXPORT QuirksData {
     bool shouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraintsQuirk : 1 { false };
     bool shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeQuirk : 1 { false };
     bool shouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk : 1 { false };
+    bool shouldDispatchPlayPauseEventsOnResume : 1 { false };
 
     // Requires check at moment of use
     std::optional<bool> needsDisableDOMPasteAccessQuirk;


### PR DESCRIPTION
#### 88776c3efc3ff69c43417ac0aefce86864d3fe56
<pre>
Two clicks required to resume playback at premierleague.com after returning from back-forward cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=292349">https://bugs.webkit.org/show_bug.cgi?id=292349</a>
<a href="https://rdar.apple.com/68938833">rdar://68938833</a>

Reviewed by Jean Yves Avenard.

When a premierleague.com page with a video resumes from the back-forward cache, two
click are required to resume playback because the page&apos;s media controls state machine
believes it is already playing. Fix this by using the adding premierleague.com to
the existing `needsAutoplayPlayPauseEvents` quirk.

Additionally, video elements on the site have `preload=&quot;metadata&quot;` so when the MediaPlayer
is recreated we block media loading even if the video was playing when the page went into
the BF cache. Fix this by ignoring the `preload` attribute if an element has already
prepared to play.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::attributeChanged):
(WebCore::HTMLMediaElement::maybeUpdatePlayerPreload const):
(WebCore::HTMLMediaElement::effectivePreloadValue const):
(WebCore::HTMLMediaElement::loadResource):
(WebCore::HTMLMediaElement::mediaLoadingFailed):
(WebCore::HTMLMediaElement::prepareToPlay):
(WebCore::HTMLMediaElement::suspend):
(WebCore::HTMLMediaElement::resume):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::effectivePreloadForElement const):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsAutoplayPlayPauseEvents const):
(WebCore::handlePremierLeagueQuirks):
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/294392@main">https://commits.webkit.org/294392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/960eded686cf3e3db394ced382fc58fcd66d5504

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101633 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106791 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52267 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103673 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21609 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29800 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77398 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34429 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104640 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16691 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91781 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57735 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16517 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9798 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51614 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86384 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9875 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109144 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28766 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21178 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86371 "Found 1 new test failure: compositing/patterns/direct-pattern-compositing-size.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29127 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87982 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85934 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21874 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30687 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8399 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22925 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28694 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33983 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28505 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31828 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30064 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->