### PR TITLE
Strip StoragePartition from cookies returned by WKHTTPCookieStore API

### DIFF
--- a/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
@@ -186,6 +186,15 @@ void HTTPCookieStore::unregisterObserver(HTTPCookieStoreObserver& observer)
         networkProcess->send(Messages::WebCookieManager::StopObservingCookieChanges(m_sessionID), 0);
 }
 
+bool HTTPCookieStore::isOptInCookiePartitioningEnabled() const
+{
+#if ENABLE(OPT_IN_PARTITIONED_COOKIES)
+    if (RefPtr dataStore = m_owningDataStore.get())
+        return dataStore->isOptInCookiePartitioningEnabled();
+#endif
+    return false;
+}
+
 void HTTPCookieStore::cookiesDidChange()
 {
     for (Ref observer : m_observers)

--- a/Source/WebKit/UIProcess/API/APIHTTPCookieStore.h
+++ b/Source/WebKit/UIProcess/API/APIHTTPCookieStore.h
@@ -85,6 +85,8 @@ public:
 
     void filterAppBoundCookies(Vector<WebCore::Cookie>&&, CompletionHandler<void(Vector<WebCore::Cookie>&&)>&&);
 
+    bool isOptInCookiePartitioningEnabled() const;
+
 #if USE(SOUP)
     void replaceCookies(Vector<WebCore::Cookie>&&, CompletionHandler<void()>&&);
     void getAllCookies(CompletionHandler<void(const Vector<WebCore::Cookie>&)>&&);


### PR DESCRIPTION
#### d370e7c8f89ff1ab3b52f1394682524fdb2947c7
<pre>
Strip StoragePartition from cookies returned by WKHTTPCookieStore API
<a href="https://rdar.apple.com/147233516">rdar://147233516</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292351">https://bugs.webkit.org/show_bug.cgi?id=292351</a>

Reviewed by Alex Christensen.

The WKHTTPCookieStore API returns a NSHTTPCookie. When opt-in partitioned
cookies is enabled, a partitioned cookie can be set in either of a first or
third party context. As such, when a first party cookie is &quot;partitioned&quot;, its
NSHTTPCookie will contain the &quot;StoragePartition&quot; property.  This is internal
state that does not need to be exposed to an application that uses the
WKHTTPCookieStore API, and it can cause breakage in some situations.

This change clears the cookie property before the cookie is returned to the
application when the WKHTTPCookieStore API is used.

Adds a new API test.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
* Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp:
(API::HTTPCookieStore::isOptInCookiePartitioningEnabled const):
* Source/WebKit/UIProcess/API/APIHTTPCookieStore.h:
* Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm:
(clearCookiePartitionPropertyIfNeeded):
(-[WKHTTPCookieStore getAllCookies:]):
(-[WKHTTPCookieStore _getCookiesForURL:completionHandler:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm:
(TEST(WKHTTPCookieStore, PartitionedCookieShouldNotHavePartitionProperty)):

Canonical link: <a href="https://commits.webkit.org/300838@main">https://commits.webkit.org/300838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72aeddd5c3ef176b2f1f2f2364a64d591b77c4ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34325 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130703 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76064 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/83f4ec2b-7b30-498e-be98-7bbe7c5352e0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125790 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52222 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94249 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62537 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b5f79eda-335d-4c54-8baa-1fa3ed8ea634) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126867 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35333 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110845 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74850 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/042a9f07-f6fb-4243-b338-41de49d4fa5b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34295 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29006 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74176 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105066 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29229 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133395 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50866 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38739 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102714 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51240 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107065 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102541 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26106 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47885 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26137 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47724 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50719 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56483 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50193 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53539 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51867 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->