### PR TITLE
WebCore::RenderObject::repaintUsingContainer ASSERT due to layer being nullptr

### DIFF
--- a/LayoutTests/compositing/compositing-deleted-object-assert-expected.txt
+++ b/LayoutTests/compositing/compositing-deleted-object-assert-expected.txt
@@ -1,0 +1,1 @@
+Test PASS if no crash

--- a/LayoutTests/compositing/compositing-deleted-object-assert.html
+++ b/LayoutTests/compositing/compositing-deleted-object-assert.html
@@ -1,0 +1,24 @@
+<style>
+    #htmlvar00006 { 0px; transform: translate(78px, -1px) }
+    .class4 { outline-style: inset; }
+    body { will-change: opacity, }
+</style>
+
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+        
+    function jsfuzzer() {
+        htmlvar00004 = document.getElementById("htmlvar00004"); //HTMLAnchorElement
+        try { var00010 = document.head; } catch(e) { }
+        try { svgvar00001.remove(); } catch(e) { }
+        try { htmlvar00004.replaceWith(var00010); } catch(e) { }
+}
+</script>
+
+<body onload=jsfuzzer()>
+    <svg id="svgvar00001" style="break-inside: floating; background: url(data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7) top; onmousedown="eventhandler3()">
+    <a id="htmlvar00004" />
+    <dl id="htmlvar00006" style="animation-direction: initial; -webkit-transition-duration: 1s; srclang="sv">
+    <dt class="class4" manifest="S8H,&#x27;wbI&amp;|!&amp;yw">
+    <p> Test PASS if no crash </p>

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1047,9 +1047,10 @@ void RenderObject::repaintUsingContainer(SingleThreadWeakPtr<const RenderLayerMo
     }
 
     if (view().usesCompositing()) {
-        ASSERT(repaintContainer->isComposited());
-        if (CheckedPtr layer = repaintContainer->layer())
+        if (CheckedPtr layer = repaintContainer->layer()) {
+            ASSERT(repaintContainer->isComposited());
             layer->setBackingNeedsRepaintInRect(r, shouldClipToLayer ? GraphicsLayer::ClipToLayer : GraphicsLayer::DoNotClipToLayer);
+        }
     }
 }
 


### PR DESCRIPTION
#### 6d1ec4adb0c97de33168b134bdca12ca90e7702d
<pre>
WebCore::RenderObject::repaintUsingContainer ASSERT due to layer being nullptr
<a href="https://bugs.webkit.org/show_bug.cgi?id=292353">https://bugs.webkit.org/show_bug.cgi?id=292353</a>
<a href="https://rdar.apple.com/148249823">rdar://148249823</a>

Reviewed by NOBODY (OOPS!).

The ASSERT was triggered by repaintContainer-&gt;isComposited() being false. This
function returns false because hasLayer() returns false, which is correct since
the layer has been set to nullptr when the object in that layer was removed. The
fix is to move the ASSERT after the if condition to check if the layer is valid
and not nullptr.

* LayoutTests/compositing/compositing-deleted-object-assert-expected.txt: Added.
* LayoutTests/compositing/compositing-deleted-object-assert.html: Added.
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::repaintUsingContainer const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d1ec4adb0c97de33168b134bdca12ca90e7702d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106745 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52220 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103627 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29778 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77366 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34393 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16651 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91740 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57703 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16476 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9757 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51568 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86344 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9834 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109098 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28720 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21158 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86341 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29081 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87941 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85903 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30647 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8358 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/22858 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28648 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33937 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28459 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31782 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30018 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->