### PR TITLE
Remove unnecessary includes from WebFrameProxy.h

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp
@@ -29,6 +29,7 @@
 #include <WebCore/GtkUtilities.h>
 #include <WebCore/GtkVersioning.h>
 #include <WebCore/NotImplemented.h>
+#include <WebCore/ResourceError.h>
 #include <WebCore/SharedMemory.h>
 #include <fcntl.h>
 #include <gio/gunixfdlist.h>

--- a/Source/WebKit/UIProcess/FindStringCallbackAggregator.cpp
+++ b/Source/WebKit/UIProcess/FindStringCallbackAggregator.cpp
@@ -30,6 +30,7 @@
 #include "WebFrameProxy.h"
 #include "WebPageMessages.h"
 #include "WebPageProxy.h"
+#include "WebProcessProxy.h"
 
 namespace WebKit {
 

--- a/Source/WebKit/UIProcess/Gamepad/ios/UIGamepadProviderIOS.mm
+++ b/Source/WebKit/UIProcess/Gamepad/ios/UIGamepadProviderIOS.mm
@@ -31,6 +31,7 @@
 #import "UIKitSPI.h"
 #import "WKWebViewInternal.h"
 #import "WebPageProxy.h"
+#import "WebProcessProxy.h"
 
 namespace WebKit {
 

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -32,6 +32,7 @@
 #include "WebFrameMessages.h"
 #include "WebFrameProxy.h"
 #include "WebPageProxy.h"
+#include "WebProcessProxy.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -183,6 +183,11 @@ WebProcessProxy& WebFrameProxy::process() const
     return m_frameProcess->process();
 }
 
+Ref<WebProcessProxy> WebFrameProxy::protectedProcess() const
+{
+    return process();
+}
+
 ProcessID WebFrameProxy::processID() const
 {
     return process().processID();

--- a/Source/WebKit/UIProcess/gstreamer/WebPageProxyGStreamer.cpp
+++ b/Source/WebKit/UIProcess/gstreamer/WebPageProxyGStreamer.cpp
@@ -31,6 +31,7 @@
 #include "MessageSenderInlines.h"
 #include "WebPageMessages.h"
 #include "WebPageProxyInternals.h"
+#include "WebProcessProxy.h"
 
 namespace WebKit {
 

--- a/Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm
@@ -33,6 +33,7 @@
 #import "UIKitUtilities.h"
 #import "WKContentViewInteraction.h"
 #import "WebPageProxy.h"
+#import "WebPreferences.h"
 #import <WebCore/ColorCocoa.h>
 #import <pal/system/ios/UserInterfaceIdiom.h>
 #import <wtf/cocoa/VectorCocoa.h>

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -36,6 +36,7 @@
 #include "InjectedBundleNodeHandle.h"
 #include "InjectedBundleRangeHandle.h"
 #include "InjectedBundleScriptWorld.h"
+#include "Logging.h"
 #include "MessageSenderInlines.h"
 #include "NetworkConnectionToWebProcessMessages.h"
 #include "NetworkProcessConnection.h"


### PR DESCRIPTION
#### d563d572a779460fc3591bfdc3eb265a1f658c1b
<pre>
Remove unnecessary includes from WebFrameProxy.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=292354">https://bugs.webkit.org/show_bug.cgi?id=292354</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/UIProcess/FindStringCallbackAggregator.cpp:
* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::protectedProcess const):
* Source/WebKit/UIProcess/WebFrameProxy.h:
(WebKit::WebFrameProxy::protectedProcess const): Deleted.

Canonical link: <a href="https://commits.webkit.org/294375@main">https://commits.webkit.org/294375@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62d4ae9d4118c08db77784096d9a0a7be4eed41a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106794 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52270 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21612 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29804 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/77400 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34430 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104643 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/16694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/91784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57737 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/16520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51617 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/86387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/9878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109147 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28769 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/21182 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86374 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29130 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/87985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85937 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/30690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/8402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22928 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16534 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28697 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33986 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28508 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31831 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->