### PR TITLE
Leverage std::ranges in more places

### DIFF
--- a/Source/WTF/benchmarks/ConditionSpeedTest.cpp
+++ b/Source/WTF/benchmarks/ConditionSpeedTest.cpp
@@ -31,6 +31,7 @@
 #include "ToyLocks.h"
 #include <condition_variable>
 #include <mutex>
+#include <ranges>
 #include <thread>
 #include <type_traits>
 #include <unistd.h>
@@ -161,7 +162,7 @@ void runTest(
         thread->waitForCompletion();
 
     RELEASE_ASSERT(numProducers * numMessagesPerProducer == received.size());
-    std::sort(received.begin(), received.end());
+    std::ranges::sort(received);
     for (unsigned messageIndex = 0; messageIndex < numMessagesPerProducer; ++messageIndex) {
         for (unsigned producerIndex = 0; producerIndex < numProducers; ++producerIndex)
             RELEASE_ASSERT(messageIndex == received[messageIndex * numProducers + producerIndex]);

--- a/Source/WTF/wtf/Dominators.h
+++ b/Source/WTF/wtf/Dominators.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <ranges>
 #include <wtf/BitSet.h>
 #include <wtf/CommaPrinter.h>
 #include <wtf/FastBitVector.h>
@@ -373,7 +374,7 @@ private:
             m_postorderNumbers.fill(0, m_graph.numNodes());
             for (unsigned i = 0; i < m_reversePostorderedNodes.size(); i ++)
                 m_postorderNumbers[m_reversePostorderedNodes[i]] = i;
-            std::reverse(m_reversePostorderedNodes.begin(), m_reversePostorderedNodes.end());
+            std::ranges::reverse(m_reversePostorderedNodes);
         }
 
         uint16_t intersect(uint16_t a, uint16_t b)

--- a/Source/WTF/wtf/FastMalloc.cpp
+++ b/Source/WTF/wtf/FastMalloc.cpp
@@ -491,7 +491,7 @@ void MallocCallTracker::dumpStats()
             stackHashes.append(key);
 
         // Sort by reverse total size.
-        std::sort(stackHashes.begin(), stackHashes.end(), [&] (unsigned a, unsigned b) {
+        std::ranges::sort(stackHashes, [&] (unsigned a, unsigned b) {
             const auto& aSiteTotals = callSiteToMallocData.get(a);
             const auto& bSiteTotals = callSiteToMallocData.get(b);
 

--- a/Source/WTF/wtf/IndexSparseSet.h
+++ b/Source/WTF/wtf/IndexSparseSet.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <ranges>
 #include <wtf/Vector.h>
 
 namespace WTF {
@@ -212,8 +213,8 @@ auto IndexSparseSet<EntryType, EntryTypeTraits, OverflowHandler>::get(unsigned v
 template<typename EntryType, typename EntryTypeTraits, typename OverflowHandler>
 void IndexSparseSet<EntryType, EntryTypeTraits, OverflowHandler>::sort()
 {
-    std::sort(
-        m_values.begin(), m_values.end(),
+    std::ranges::sort(
+        m_values,
         [&] (const EntryType& a, const EntryType& b) {
             return EntryTypeTraits::key(a) < EntryTypeTraits::key(b);
         });

--- a/Source/WTF/wtf/InterferenceGraph.h
+++ b/Source/WTF/wtf/InterferenceGraph.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <ranges>
 #include <wtf/BitVector.h>
 #include <wtf/HashSet.h>
 #include <wtf/HashTraits.h>
@@ -473,8 +474,8 @@ public:
             for (IndexType value : iterableB)
                 valuesB.append(value);
             RELEASE_ASSERT(m_values.size() == valuesB.size());
-            std::sort(m_values.begin(), m_values.end());
-            std::sort(valuesB.begin(), valuesB.end());
+            std::ranges::sort(m_values);
+            std::ranges::sort(valuesB));
             for (unsigned i = 0; i < m_values.size(); ++i)
                 RELEASE_ASSERT(m_values[i] == valuesB[i]);
         }

--- a/Source/WTF/wtf/ListDump.h
+++ b/Source/WTF/wtf/ListDump.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <ranges>
 #include <wtf/CommaPrinter.h>
 #include <wtf/PrintStream.h>
 #include <wtf/StringPrintStream.h>
@@ -112,7 +113,7 @@ CString sortedListDump(const T& list, const Comparator& comparator, ASCIILiteral
 {
     Vector<typename T::ValueType> myList;
     myList.appendRange(list.begin(), list.end());
-    std::sort(myList.begin(), myList.end(), comparator);
+    std::ranges::sort(myList, comparator);
     StringPrintStream out;
     CommaPrinter commaPrinter(comma);
     for (unsigned i = 0; i < myList.size(); ++i)
@@ -138,7 +139,7 @@ CString sortedMapDump(const T& map, const Comparator& comparator, ASCIILiteral a
     Vector<typename T::KeyType> keys;
     for (auto iter = map.begin(); iter != map.end(); ++iter)
         keys.append(iter->key);
-    std::sort(keys.begin(), keys.end(), comparator);
+    std::ranges::sort(keys, comparator);
     StringPrintStream out;
     CommaPrinter commaPrinter(comma);
     for (unsigned i = 0; i < keys.size(); ++i)

--- a/Source/WTF/wtf/ListHashSet.h
+++ b/Source/WTF/wtf/ListHashSet.h
@@ -382,8 +382,8 @@ template<typename T, typename U>
 inline ListHashSet<T, U>::ListHashSet(const ListHashSet& other)
     : ListHashSet<T, U>()
 {
-    for (auto it = other.begin(), end = other.end(); it != end; ++it)
-        add(*it);
+    for (auto& item : other)
+        add(item);
 }
 
 template<typename T, typename U>

--- a/Source/WTF/wtf/Liveness.h
+++ b/Source/WTF/wtf/Liveness.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <ranges>
 #include <wtf/BitVector.h>
 #include <wtf/IndexSparseSet.h>
 #include <wtf/StdLibExtras.h>
@@ -275,7 +276,7 @@ protected:
                     liveAtTail.append(index);
                 });
             
-            std::sort(liveAtTail.begin(), liveAtTail.end());
+            std::ranges::sort(liveAtTail);
             removeRepeatedElements(liveAtTail);
         }
 

--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -29,6 +29,7 @@
 #include <algorithm>
 #include <atomic>
 #include <functional>
+#include <ranges>
 #include <wtf/Logging.h>
 #include <wtf/MemoryFootprint.h>
 #include <wtf/NeverDestroyed.h>
@@ -215,7 +216,7 @@ void MemoryPressureHandler::setMemoryFootprintNotificationThresholds(Vector<size
     if (thresholds.isEmpty() || !handler)
         return;
 
-    std::sort(thresholds.begin(), thresholds.end(), std::greater<>());
+    std::ranges::sort(thresholds, std::greater<>());
     m_memoryFootprintNotificationThresholds = WTFMove(thresholds);
     m_memoryFootprintNotificationHandler = WTFMove(handler);
 }

--- a/Source/WTF/wtf/NaturalLoops.h
+++ b/Source/WTF/wtf/NaturalLoops.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <ranges>
 #include <wtf/DataLog.h>
 #include <wtf/Dominators.h>
 
@@ -260,8 +261,8 @@ public:
             
                 Vector<const NaturalLoop<Graph>*> fancyLoopsOf = loopsOf(block);
             
-                std::sort(simpleLoopsOf.begin(), simpleLoopsOf.end());
-                std::sort(fancyLoopsOf.begin(), fancyLoopsOf.end());
+                std::ranges::sort(simpleLoopsOf);
+                std::ranges::sort(fancyLoopsOf);
             
                 RELEASE_ASSERT(simpleLoopsOf == fancyLoopsOf);
             }

--- a/Source/WTF/wtf/ParkingLot.cpp
+++ b/Source/WTF/wtf/ParkingLot.cpp
@@ -27,6 +27,7 @@
 #include <wtf/ParkingLot.h>
 
 #include <mutex>
+#include <ranges>
 #include <wtf/DataLog.h>
 #include <wtf/FixedVector.h>
 #include <wtf/HashFunctions.h>
@@ -312,7 +313,7 @@ Vector<Bucket*> lockHashtable()
         }
 
         // Now lock the buckets in the right order.
-        std::sort(buckets.begin(), buckets.end());
+        std::ranges::sort(buckets);
         for (Bucket* bucket : buckets)
             bucket->lock.lock();
 

--- a/Source/WTF/wtf/RefTrackerMixin.cpp
+++ b/Source/WTF/wtf/RefTrackerMixin.cpp
@@ -20,6 +20,8 @@
 #include "config.h"
 #include "RefTrackerMixin.h"
 
+#include <ranges>
+
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WTF {
@@ -55,7 +57,7 @@ void RefTracker::logAllLiveReferences()
     Locker locker(lock);
     auto keysIterator = map.keys();
     auto keys = std::vector<void*> { keysIterator.begin(), keysIterator.end() };
-    std::sort(keys.begin(), keys.end());
+    std::ranges::sort(keys);
     for (auto& k : keys) {
         auto* v = map.get(k);
         if (!v)

--- a/Source/WTF/wtf/SortedArrayMap.h
+++ b/Source/WTF/wtf/SortedArrayMap.h
@@ -26,6 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
+#include <ranges>
 #include <wtf/IndexedRange.h>
 #include <wtf/text/StringView.h>
 
@@ -161,7 +162,7 @@ template<ASCIISubset subset, typename CharacterType> constexpr std::make_unsigne
 template<ASCIISubset subset> constexpr ComparableASCIISubsetLiteral<subset>::ComparableASCIISubsetLiteral(ASCIILiteral inputLiteral)
     : literal { inputLiteral }
 {
-    ASSERT_UNDER_CONSTEXPR_CONTEXT(std::all_of(literal.span().begin(), literal.span().end(), [] (char character) {
+    ASSERT_UNDER_CONSTEXPR_CONTEXT(std::ranges::all_of(literal.span(), [](char character) {
         return isInSubset<subset>(character);
     }));
 }
@@ -169,7 +170,7 @@ template<ASCIISubset subset> constexpr ComparableASCIISubsetLiteral<subset>::Com
 template<typename ArrayType> constexpr SortedArrayMap<ArrayType>::SortedArrayMap(const ArrayType& array)
     : m_array { array }
 {
-    ASSERT_UNDER_CONSTEXPR_CONTEXT(std::is_sorted(std::begin(array), std::end(array), [] (auto& a, auto b) {
+    ASSERT_UNDER_CONSTEXPR_CONTEXT(std::is_sorted(std::begin(array), std::end(array), [](auto& a, auto b) {
         return a.first < b.first;
     }));
 }
@@ -182,13 +183,13 @@ template<typename ArrayType> template<typename KeyArgument> inline auto SortedAr
         return nullptr;
     decltype(std::begin(m_array)) iterator;
     if (std::size(m_array) < binarySearchThreshold) {
-        iterator = std::find_if(std::begin(m_array), std::end(m_array), [&parsedKey] (auto& pair) {
+        iterator = std::find_if(std::begin(m_array), std::end(m_array), [&parsedKey](auto& pair) {
             return pair.first == *parsedKey;
         });
         if (iterator == std::end(m_array))
             return nullptr;
     } else {
-        iterator = std::lower_bound(std::begin(m_array), std::end(m_array), *parsedKey, [] (auto& pair, auto& value) {
+        iterator = std::lower_bound(std::begin(m_array), std::end(m_array), *parsedKey, [](auto& pair, auto& value) {
             return pair.first < value;
         });
         if (iterator == std::end(m_array) || !(iterator->first == *parsedKey))

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -28,6 +28,7 @@
 #include <wtf/URL.h>
 
 #include "URLParser.h"
+#include <ranges>
 #include <stdio.h>
 #include <unicode/uidna.h>
 #include <wtf/FileSystem.h>
@@ -1291,8 +1292,8 @@ Vector<KeyValuePair<String, String>> differingQueryParameters(const URL& firstUR
         return compare(a, b) < 0;
     };
     
-    std::sort(firstQueryParameters.begin(), firstQueryParameters.end(), comparesLessThan);
-    std::sort(secondQueryParameters.begin(), secondQueryParameters.end(), comparesLessThan);
+    std::ranges::sort(firstQueryParameters, comparesLessThan);
+    std::ranges::sort(secondQueryParameters, comparesLessThan);
     size_t totalFirstQueryParameters = firstQueryParameters.size();
     size_t totalSecondQueryParameters = secondQueryParameters.size();
     size_t indexInFirstQueryParameters = 0;

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -23,6 +23,7 @@
 #include <initializer_list>
 #include <limits>
 #include <optional>
+#include <ranges>
 #include <span>
 #include <string.h>
 #include <type_traits>
@@ -2118,7 +2119,7 @@ inline Vector<typename CopyOrMoveToVectorResult<Collection>::Type> moveToVector(
 
 template<typename T, size_t inlineCapacity = 0> static bool insertInUniquedSortedVector(Vector<T, inlineCapacity>& vector, const T& value)
 {
-    auto it = std::lower_bound(vector.begin(), vector.end(), value);
+    auto it = std::ranges::lower_bound(vector, value);
     if (UNLIKELY(it != vector.end() && *it == value))
         return false;
     vector.insert(it - vector.begin(), value);

--- a/Source/WTF/wtf/text/TextBreakIterator.h
+++ b/Source/WTF/wtf/text/TextBreakIterator.h
@@ -23,6 +23,7 @@
 
 #include <mutex>
 #include <optional>
+#include <ranges>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Variant.h>
 #include <wtf/text/StringView.h>
@@ -153,7 +154,7 @@ private:
     TextBreakIterator take(StringView string, std::span<const UChar> priorContext, TextBreakIterator::Mode mode, TextBreakIterator::ContentAnalysis contentAnalysis, const AtomString& locale)
     {
         ASSERT(isMainThread());
-        auto iter = std::find_if(m_unused.begin(), m_unused.end(), [&](TextBreakIterator& candidate) {
+        auto iter = std::ranges::find_if(m_unused, [&](TextBreakIterator& candidate) {
             return candidate.mode() == mode && candidate.contentAnalysis() == contentAnalysis && candidate.locale() == locale;
         });
         if (iter == m_unused.end())

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.cpp
@@ -34,6 +34,7 @@
 #include "JSMediaKeyStatusMap.h"
 #include "MediaKeySession.h"
 #include "SharedBuffer.h"
+#include <ranges>
 #include <wtf/StdLibExtras.h>
 
 namespace WebCore {
@@ -70,8 +71,7 @@ bool MediaKeyStatusMap::has(const BufferSource& keyId)
         return false;
 
     auto& statuses = m_session->statuses();
-    return std::any_of(statuses.begin(), statuses.end(),
-        [&keyId] (auto& it) { return keyIdsMatch(it.first, keyId); });
+    return std::ranges::any_of(statuses, [&keyId] (auto& it) { return keyIdsMatch(it.first, keyId); });
 }
 
 JSC::JSValue MediaKeyStatusMap::get(JSC::JSGlobalObject& state, const BufferSource& keyId)
@@ -80,8 +80,7 @@ JSC::JSValue MediaKeyStatusMap::get(JSC::JSGlobalObject& state, const BufferSour
         return JSC::jsUndefined();
 
     auto& statuses = m_session->statuses();
-    auto it = std::find_if(statuses.begin(), statuses.end(),
-        [&keyId] (auto& it) { return keyIdsMatch(it.first, keyId); });
+    auto it = std::ranges::find_if(statuses, [&keyId] (auto& it) { return keyIdsMatch(it.first, keyId); });
 
     if (it == statuses.end())
         return JSC::jsUndefined();

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
@@ -40,6 +40,7 @@
 #include "Logging.h"
 #include "MediaKeySession.h"
 #include "SharedBuffer.h"
+#include <ranges>
 #include <wtf/Logger.h>
 #include <wtf/LoggerHelper.h>
 
@@ -174,7 +175,7 @@ void MediaKeys::attemptToResumePlaybackOnClients()
 
 bool MediaKeys::hasOpenSessions() const
 {
-    return std::any_of(m_sessions.begin(), m_sessions.end(),
+    return std::ranges::any_of(m_sessions,
         [](auto& session) {
             return !session->isClosed();
         });

--- a/Source/WebCore/Modules/fetch/FetchHeaders.cpp
+++ b/Source/WebCore/Modules/fetch/FetchHeaders.cpp
@@ -30,6 +30,7 @@
 #include "FetchHeaders.h"
 
 #include "HTTPParsers.h"
+#include <ranges>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
@@ -290,14 +291,14 @@ std::optional<KeyValuePair<String, String>> FetchHeaders::Iterator::next()
         });
         if (hasSetCookie)
             m_keys.append(String());
-        std::sort(m_keys.begin(), m_keys.end(), compareIteratorKeys);
+        std::ranges::sort(m_keys, compareIteratorKeys);
 
         // We adjust the current index to work with Set-Cookie headers.
         // This relies on the fact that `m_currentIndex + m_setCookieIndex`
         // gives you the current total index into the iteration.
         m_currentIndex += m_setCookieIndex;
         if (hasSetCookie) {
-            size_t setCookieKeyIndex = std::lower_bound(m_keys.begin(), m_keys.end(), String(), compareIteratorKeys) - m_keys.begin();
+            size_t setCookieKeyIndex = std::ranges::lower_bound(m_keys, String(), compareIteratorKeys) - m_keys.begin();
             if (m_currentIndex < setCookieKeyIndex)
                 m_setCookieIndex = 0;
             else {

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
@@ -41,6 +41,7 @@
 #include "Node.h"
 #include "ScriptExecutionContext.h"
 #include <JavaScriptCore/HeapInlines.h>
+#include <ranges>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -49,7 +50,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(IDBDatabase);
 
 static Vector<String> sortAndRemoveDuplicates(Vector<String>&& vector)
 {
-    std::sort(vector.begin(), vector.end(), WTF::codePointCompareLessThan);
+    std::ranges::sort(vector, WTF::codePointCompareLessThan);
     removeRepeatedElements(vector);
     return WTFMove(vector);
 }

--- a/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
@@ -40,6 +40,7 @@
 #include "MediaImage.h"
 #include "MediaMetadataInit.h"
 #include "SpaceSplitString.h"
+#include <ranges>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 #include <wtf/text/StringToIntegerConversion.h>
@@ -245,7 +246,7 @@ void MediaMetadata::refreshArtworkImage()
         return { imageDimensionsScore(size.width(), size.height(), s_minimumSize, s_idealSize), m_metadata.artwork[index].src };
     });
 
-    std::sort(artworks.begin(), artworks.end(), [](const Pair& a1, const Pair& a2) {
+    std::ranges::sort(artworks, [](const Pair& a1, const Pair& a2) {
         return a1.score > a2.score;
     });
 

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -54,6 +54,7 @@
 #include "UserGestureIndicator.h"
 #include "UserMediaController.h"
 #include "UserMediaRequest.h"
+#include <ranges>
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -340,7 +341,7 @@ static inline bool exposeSpeakersWithoutMicrophoneAccess(const Document& documen
 
 static inline bool haveMicrophoneDevice(const Vector<CaptureDeviceWithCapabilities>& devices, const String& deviceId)
 {
-    return std::any_of(devices.begin(), devices.end(), [&deviceId](auto& deviceWithCapabilities) {
+    return std::ranges::any_of(devices, [&deviceId](auto& deviceWithCapabilities) {
         auto& device = deviceWithCapabilities.device;
         return device.persistentId() == deviceId && device.type() == CaptureDevice::DeviceType::Microphone;
     });

--- a/Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp
@@ -33,6 +33,7 @@
 #include <JavaScriptCore/JSCJSValue.h>
 #include <JavaScriptCore/JSString.h>
 #include <JavaScriptCore/RegExpObject.h>
+#include <ranges>
 
 namespace WebCore {
 using namespace JSC;
@@ -85,7 +86,7 @@ bool URLPatternComponent::matchSpecialSchemeProtocol(ScriptExecutionContext& con
         return false;
     auto protocolRegex = JSC::RegExpObject::create(vm, contextObject->regExpStructure(), m_regularExpression.get(), true);
 
-    auto isSchemeMatch = std::find_if(specialSchemeList.begin(), specialSchemeList.end(), [context = Ref { context }, &vm, &protocolRegex](const String& scheme) {
+    auto isSchemeMatch = std::ranges::find_if(specialSchemeList, [context = Ref { context }, &vm, &protocolRegex](const String& scheme) {
         auto maybeMatch = protocolRegex->exec(context->globalObject(), JSC::jsString(vm, scheme));
         return !maybeMatch.isNull();
     });

--- a/Source/WebCore/Modules/url-pattern/URLPatternParser.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternParser.cpp
@@ -28,6 +28,7 @@
 
 #include "URLPatternCanonical.h"
 #include "URLPatternTokenizer.h"
+#include <ranges>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
@@ -314,7 +315,7 @@ static String escapeRegexStringForCharacters(std::span<const CharacterType> char
     result.reserveCapacity(characters.size());
 
     for (auto character : characters) {
-        if (std::find(regexEscapeCharacters.begin(), regexEscapeCharacters.end(), character) != regexEscapeCharacters.end())
+        if (std::ranges::find(regexEscapeCharacters, character) != regexEscapeCharacters.end())
             result.append('\\');
 
         result.append(character);
@@ -512,7 +513,7 @@ static String escapePatternStringForCharacters(std::span<const CharacterType> ch
     result.reserveCapacity(characters.size());
 
     for (auto character : characters) {
-        if (std::find(escapeCharacters.begin(), escapeCharacters.end(), character) != escapeCharacters.end())
+        if (std::ranges::find(escapeCharacters, character) != escapeCharacters.end())
             result.append('\\');
 
         result.append(character);

--- a/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
@@ -28,6 +28,7 @@
 
 #include "EncodingTables.h"
 #include <mutex>
+#include <ranges>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CodePointIterator.h>
 #include <wtf/text/MakeString.h>
@@ -863,7 +864,7 @@ static std::optional<char32_t> gb18030RangesCodePoint(uint32_t pointer)
         return std::nullopt;
     if (pointer == 7457)
         return 0xE7C7;
-    auto upperBound = std::upper_bound(gb18030Ranges().begin(), gb18030Ranges().end(), makeFirstAdapter(pointer), CompareFirst { });
+    auto upperBound = std::ranges::upper_bound(gb18030Ranges(), makeFirstAdapter(pointer), CompareFirst { });
     ASSERT(upperBound != gb18030Ranges().begin());
     uint32_t offset = (upperBound - 1)->first;
     char32_t codePointOffset = (upperBound - 1)->second;
@@ -875,7 +876,7 @@ static uint32_t gb18030RangesPointer(char32_t codePoint)
 {
     if (codePoint == 0xE7C7)
         return 7457;
-    auto upperBound = std::upper_bound(gb18030Ranges().begin(), gb18030Ranges().end(), makeSecondAdapter(codePoint), CompareSecond { });
+    auto upperBound = std::ranges::upper_bound(gb18030Ranges(), makeSecondAdapter(codePoint), CompareSecond { });
     ASSERT(upperBound != gb18030Ranges().begin());
     uint32_t pointerOffset = (upperBound - 1)->first;
     char32_t offset = (upperBound - 1)->second;

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -120,6 +120,7 @@
 #include "TypedElementDescendantIteratorInlines.h"
 #include "VisibleUnits.h"
 #include <algorithm>
+#include <ranges>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Scope.h>
 #include <wtf/StdLibExtras.h>
@@ -2330,7 +2331,7 @@ bool AccessibilityRenderObject::inheritsPresentationalRole() const
         // If native tag of the parent element matches an acceptable name, then return
         // based on its presentational status.
         auto& name = node->tagQName();
-        if (std::any_of(parentTags.begin(), parentTags.end(), [&name] (auto* possibleName) { return possibleName->get() == name; }))
+        if (std::ranges::any_of(parentTags, [&name](auto* possibleName) { return possibleName->get() == name; }))
             return parent->roleValue() == AccessibilityRole::Presentational;
     }
 

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -43,6 +43,7 @@
 #include "ViewTimeline.h"
 #include "WebAnimation.h"
 #include "WebAnimationTypes.h"
+#include <ranges>
 #include <wtf/HashSet.h>
 #include <wtf/Ref.h>
 #include <wtf/text/TextStream.h>
@@ -216,7 +217,7 @@ void AnimationTimelinesController::updateAnimationsAndSendEvents(ReducedResoluti
         auto events = documentTimeline->prepareForPendingAnimationEventsDispatch();
 
         // 6. Perform a stable sort of the animation events in events to dispatch as follows.
-        std::stable_sort(events.begin(), events.end(), [] (const Ref<AnimationEventBase>& lhs, const Ref<AnimationEventBase>& rhs) {
+        std::ranges::stable_sort(events, [](auto& lhs, auto& rhs) {
             return compareAnimationEventsByCompositeOrder(lhs.get(), rhs.get());
         });
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -79,6 +79,7 @@
 #include "TranslateTransformOperation.h"
 #include "ViewTimeline.h"
 #include <JavaScriptCore/Exception.h>
+#include <ranges>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/UUID.h>
 #include <wtf/text/TextStream.h>
@@ -473,7 +474,7 @@ static inline ExceptionOr<KeyframeEffect::KeyframeLikeObject> processKeyframeLik
 
     // 5. Sort animation properties in ascending order by the Unicode codepoints that define each property name.
     auto sortPropertiesInAscendingOrder = [](auto& properties) {
-        std::sort(properties.begin(), properties.end(), [](auto& lhs, auto& rhs) {
+        std::ranges::sort(properties, [](auto& lhs, auto& rhs) {
             return codePointCompareLessThan(lhs.string().string(), rhs.string().string());
         });
     };
@@ -660,7 +661,7 @@ static inline ExceptionOr<void> processPropertyIndexedKeyframes(JSGlobalObject& 
     }
 
     // 3. Sort processed keyframes by the computed keyframe offset of each keyframe in increasing order.
-    std::sort(parsedKeyframes.begin(), parsedKeyframes.end(), [](auto& lhs, auto& rhs) {
+    std::ranges::sort(parsedKeyframes, [](auto& lhs, auto& rhs) {
         if (!std::isnan(lhs.computedOffset) && !std::isnan(rhs.computedOffset))
             return lhs.computedOffset < rhs.computedOffset;
         // This will sort nullopt values prior to other values.

--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -40,6 +40,7 @@
 #include "TranslateTransformOperation.h"
 #include "WebAnimation.h"
 #include "WebAnimationUtilities.h"
+#include <ranges>
 #include <wtf/PointerComparison.h>
 
 namespace WebCore {
@@ -130,7 +131,7 @@ void KeyframeEffectStack::ensureEffectsAreSorted()
     if (m_isSorted || m_effects.size() < 2)
         return;
 
-    std::stable_sort(m_effects.begin(), m_effects.end(), [](auto& lhs, auto& rhs) {
+    std::ranges::stable_sort(m_effects, [](auto& lhs, auto& rhs) {
         RELEASE_ASSERT(lhs.get());
         RELEASE_ASSERT(rhs.get());
         

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
@@ -48,6 +48,7 @@
 #include "Settings.h"
 #include <wtf/URL.h>
 #include "UserContentController.h"
+#include <ranges>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
@@ -144,7 +145,7 @@ auto ContentExtensionsBackend::actionsFromContentRuleList(const ContentExtension
         vector.appendContainerWithMapping(universalActions, [](uint64_t actionLocation) {
             return static_cast<uint32_t>(actionLocation);
         });
-        std::sort(vector.begin(), vector.end());
+        std::ranges::sort(vector);
 
         // Add actions in reverse order to properly deal with IgnorePreviousRules.
         for (auto i = vector.size(); i; i--) {
@@ -414,7 +415,7 @@ void applyResultsToRequest(ContentRuleListResults&& results, Page* page, Resourc
         request.upgradeInsecureRequest();
     }
 
-    std::sort(results.summary.modifyHeadersActions.begin(), results.summary.modifyHeadersActions.end(),
+    std::ranges::sort(results.summary.modifyHeadersActions,
         [] (const ModifyHeadersAction& a, const ModifyHeadersAction& b) {
         return a.priority > b.priority;
     });

--- a/Source/WebCore/contentextensions/DFA.cpp
+++ b/Source/WebCore/contentextensions/DFA.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(CONTENT_EXTENSIONS)
 
 #include "DFAMinimizer.h"
+#include <ranges>
 #include <wtf/DataLog.h>
 
 namespace WebCore {
@@ -106,7 +107,7 @@ static void printTransitions(const DFA& dfa, unsigned sourceNodeId)
         dataLogF("        %d -> %d [label=\"", sourceNodeId, transitionPerTarget.key);
 
         Vector<uint16_t> incomingCharacters = transitionPerTarget.value;
-        std::sort(incomingCharacters.begin(), incomingCharacters.end());
+        std::ranges::sort(incomingCharacters);
 
         char rangeStart = incomingCharacters.first();
         char rangeEnd = rangeStart;

--- a/Source/WebCore/contentextensions/HashableActionList.h
+++ b/Source/WebCore/contentextensions/HashableActionList.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <ranges>
 #include <wtf/Hasher.h>
 #include <wtf/Vector.h>
 
@@ -44,7 +45,7 @@ struct HashableActionList {
         : actions(otherActions)
         , state(Valid)
     {
-        std::sort(actions.begin(), actions.end());
+        std::ranges::sort(actions);
         SuperFastHash hasher;
         hasher.addCharactersAssumingAligned(reinterpret_cast<const UChar*>(actions.data()), actions.size() * sizeof(uint64_t) / sizeof(UChar));
         hash = hasher.hash();

--- a/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -41,6 +41,7 @@
 #include "StyleBuilderConverter.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StyleProperties.h"
+#include <ranges>
 
 namespace WebCore {
 
@@ -505,9 +506,9 @@ CSSSegmentedFontFace* CSSFontFaceSet::fontFace(FontSelectionRequest request, con
             return face.get().fontSelectionCapabilities();
         });
         FontSelectionAlgorithm fontSelectionAlgorithm(request, capabilities);
-        std::stable_sort(candidateFontFaces.begin(), candidateFontFaces.end(), [&fontSelectionAlgorithm](const CSSFontFace& first, const CSSFontFace& second) {
-            auto firstCapabilities = first.fontSelectionCapabilities();
-            auto secondCapabilities = second.fontSelectionCapabilities();
+        std::ranges::stable_sort(candidateFontFaces, [&fontSelectionAlgorithm](auto& first, auto& second) {
+            auto firstCapabilities = first.get().fontSelectionCapabilities();
+            auto secondCapabilities = second.get().fontSelectionCapabilities();
             
             auto widthDistanceFirst = fontSelectionAlgorithm.widthDistance(firstCapabilities).distance;
             auto widthDistanceSecond = fontSelectionAlgorithm.widthDistance(secondCapabilities).distance;

--- a/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
@@ -35,6 +35,7 @@
 #include "CSSUnits.h"
 #include "ContainerQueryFeatures.h"
 #include "MediaQueryFeatures.h"
+#include <ranges>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
@@ -241,7 +242,7 @@ static Vector<ChildRepresentation, 16> generateSortedChildrenMap(const Children&
     for (size_t i = 0; i < children.size(); ++i)
         sortedChildrenMap.append(ChildRepresentation { .index = i, .sortPriority = sortPriority(children[i]) });
 
-    std::stable_sort(sortedChildrenMap.begin(), sortedChildrenMap.end(), [](const auto& first, const auto& second) -> bool {
+    std::ranges::stable_sort(sortedChildrenMap, [](auto& first, auto& second) {
         return first.sortPriority < second.sortPriority;
     });
 

--- a/Source/WebCore/css/typedom/CSSNumericValue.cpp
+++ b/Source/WebCore/css/typedom/CSSNumericValue.cpp
@@ -52,6 +52,7 @@
 #include "CSSUnitValue.h"
 #include "CalculationCategory.h"
 #include "ExceptionOr.h"
+#include <ranges>
 #include <wtf/Algorithms.h>
 #include <wtf/FixedVector.h>
 #include <wtf/StdLibExtras.h>
@@ -417,7 +418,7 @@ ExceptionOr<Ref<CSSMathSum>> CSSNumericValue::toSum(FixedVector<String>&& units)
     }
 
     if (parsedUnits.isEmpty()) {
-        std::sort(values.begin(), values.end(), [](auto& a, auto& b) {
+        std::ranges::sort(values, [](auto& a, auto& b) {
             return is_lt(compareSpans(downcast<CSSUnitValue>(a)->unitSerialization().span(), downcast<CSSUnitValue>(b)->unitSerialization().span()));
         });
         return CSSMathSum::create(WTFMove(values));

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
@@ -35,6 +35,7 @@
 #include "RenderStyleInlines.h"
 #include "StylePropertyShorthand.h"
 #include "StyleScope.h"
+#include <ranges>
 #include <wtf/KeyValuePair.h>
 
 namespace WebCore {
@@ -116,7 +117,7 @@ Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> ComputedStylePropertyMap
         });
     }
 
-    std::sort(values.begin(), values.end(), [](const auto& a, const auto& b) {
+    std::ranges::sort(values, [](const auto& a, const auto& b) {
         const auto& nameA = a.key;
         const auto& nameB = b.key;
         if (nameA.startsWith("--"_s))

--- a/Source/WebCore/dom/DOMStringList.cpp
+++ b/Source/WebCore/dom/DOMStringList.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "DOMStringList.h"
 
+#include <ranges>
+
 namespace WebCore {
 
 String DOMStringList::item(unsigned index) const
@@ -47,7 +49,7 @@ bool DOMStringList::contains(const String& string) const
 
 void DOMStringList::sort()
 {
-    std::sort(m_strings.begin(), m_strings.end(), WTF::codePointCompareLessThan);
+    std::ranges::sort(m_strings, WTF::codePointCompareLessThan);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -334,6 +334,7 @@
 #include <JavaScriptCore/ScriptCallStack.h>
 #include <JavaScriptCore/VM.h>
 #include <ctime>
+#include <ranges>
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/HexNumber.h>
 #include <wtf/Language.h>
@@ -10514,7 +10515,7 @@ Vector<RefPtr<WebAnimation>> Document::matchingAnimations(NOESCAPE const Functio
             animations.append(animation);
     }
 
-    std::stable_sort(animations.begin(), animations.end(), [](auto& lhs, auto& rhs) {
+    std::ranges::stable_sort(animations, [](auto& lhs, auto& rhs) {
         return compareAnimationsByCompositeOrder(*lhs, *rhs);
     });
 

--- a/Source/WebCore/dom/MutationObserver.cpp
+++ b/Source/WebCore/dom/MutationObserver.cpp
@@ -42,6 +42,7 @@
 #include "MutationRecord.h"
 #include "WindowEventLoop.h"
 #include <algorithm>
+#include <ranges>
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RobinHoodHashSet.h>
@@ -245,7 +246,7 @@ void MutationObserver::notifyMutationObservers(WindowEventLoop& eventLoop)
         // 2. Let notify list be a copy of unit of related similar-origin browsing contexts' list of MutationObserver objects.
         auto notifyList = copyToVector(eventLoop.activeMutationObservers());
         eventLoop.activeMutationObservers().clear();
-        std::sort(notifyList.begin(), notifyList.end(), [](auto& lhs, auto& rhs) {
+        std::ranges::sort(notifyList, [](auto& lhs, auto& rhs) {
             return lhs->m_priority < rhs->m_priority;
         });
 

--- a/Source/WebCore/dom/RadioButtonGroups.cpp
+++ b/Source/WebCore/dom/RadioButtonGroups.cpp
@@ -23,6 +23,7 @@
 
 #include "HTMLInputElement.h"
 #include "Range.h"
+#include <ranges>
 #include <wtf/HashSet.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
@@ -67,7 +68,7 @@ Vector<Ref<HTMLInputElement>> RadioButtonGroup::members() const
     auto sortedMembers = WTF::map(m_members, [](auto& element) -> Ref<HTMLInputElement> {
         return element;
     });
-    std::sort(sortedMembers.begin(), sortedMembers.end(), [](auto& a, auto& b) {
+    std::ranges::sort(sortedMembers, [](auto& a, auto& b) {
         return is_lt(treeOrder<ComposedTree>(a, b));
     });
     return sortedMembers;

--- a/Source/WebCore/html/HTMLDocument.cpp
+++ b/Source/WebCore/html/HTMLDocument.cpp
@@ -78,6 +78,7 @@
 #include "Quirks.h"
 #include "ScriptController.h"
 #include "StyleResolver.h"
+#include <ranges>
 #include <wtf/RobinHoodHashSet.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
@@ -143,7 +144,7 @@ Vector<AtomString> HTMLDocument::supportedPropertyNames() const
     // The specification says these should be sorted in document order but this would be expensive
     // and other browser engines do not comply with this part of the specification. For now, just
     // do an alphabetical sort to get consistent results.
-    std::sort(properties.begin(), properties.end(), WTF::codePointCompareLessThan);
+    std::ranges::sort(properties, WTF::codePointCompareLessThan);
     return properties;
 }
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -141,6 +141,7 @@
 #include <JavaScriptCore/Uint8Array.h>
 #include <limits>
 #include <pal/SessionID.h>
+#include <ranges>
 #include <wtf/Algorithms.h>
 #include <wtf/JSONValues.h>
 #include <wtf/Language.h>
@@ -847,7 +848,7 @@ WeakPtr<PlatformMediaSessionInterface> HTMLMediaElement::selectBestMediaSession(
     if (!candidateSessions.size())
         return nullptr;
 
-    std::sort(candidateSessions.begin(), candidateSessions.end(), preferMediaControlsForCandidateSessionOverOtherCandidateSession);
+    std::ranges::sort(candidateSessions, preferMediaControlsForCandidateSessionOverOtherCandidateSession);
     auto strongestSessionCandidate = candidateSessions.first();
     if (!strongestSessionCandidate.isVisibleInViewportOrFullscreen && !strongestSessionCandidate.isPlayingAudio && atLeastOneNonCandidateMayBeConfusedForMainContent)
         return nullptr;
@@ -2070,7 +2071,7 @@ void HTMLMediaElement::updateActiveTextTrackCues(const MediaTime& movieTime)
                 currentCues.append(cue);
         }
         if (currentCues.size() > 1)
-            std::sort(currentCues.begin(), currentCues.end(), &compareCueInterval);
+            std::ranges::sort(currentCues, &compareCueInterval);
     }
 
     CueList previousCues;
@@ -2135,7 +2136,7 @@ void HTMLMediaElement::updateActiveTextTrackCues(const MediaTime& movieTime)
     }
 
     MediaTime nextInterestingTime = MediaTime::invalidTime();
-    if (auto nearestEndingCue = std::min_element(currentCues.begin(), currentCues.end(), compareCueIntervalEndTime))
+    if (auto nearestEndingCue = std::ranges::min_element(currentCues, compareCueIntervalEndTime))
         nextInterestingTime = nearestEndingCue->data()->endMediaTime();
 
     std::optional<CueInterval> nextCue = m_cueData->cueTree.nextIntervalAfter(movieTime);
@@ -2221,7 +2222,7 @@ void HTMLMediaElement::updateActiveTextTrackCues(const MediaTime& movieTime)
 
     // 12 - Sort the tasks in events in ascending time order (tasks with earlier
     // times first).
-    std::sort(eventTasks.begin(), eventTasks.end(), eventTimeCueCompare);
+    std::ranges::sort(eventTasks, eventTimeCueCompare);
 
     for (auto& eventTask : eventTasks) {
         auto& [eventTime, eventCue] = eventTask;
@@ -2246,7 +2247,7 @@ void HTMLMediaElement::updateActiveTextTrackCues(const MediaTime& movieTime)
 
     // 14 - Sort affected tracks in the same order as the text tracks appear in
     // the media element's list of text tracks, and remove duplicates.
-    std::sort(affectedTracks.begin(), affectedTracks.end(), trackIndexCompare);
+    std::ranges::sort(affectedTracks, trackIndexCompare);
 
     // 15 - For each text track in affected tracks, in the list order, queue a
     // task to fire a simple event named cuechange at the TextTrack object, and, ...

--- a/Source/WebCore/html/LinkIconCollector.cpp
+++ b/Source/WebCore/html/LinkIconCollector.cpp
@@ -31,6 +31,7 @@
 #include "HTMLHeadElement.h"
 #include "HTMLLinkElement.h"
 #include "LinkIconType.h"
+#include <ranges>
 #include <wtf/text/StringToIntegerConversion.h>
 
 namespace WebCore {
@@ -111,7 +112,7 @@ auto LinkIconCollector::iconsOfTypes(OptionSet<LinkIconType> iconTypes) -> Vecto
         icons.append({ url, iconType, linkElement->type(), iconSize, WTFMove(attributes) });
     }
 
-    std::sort(icons.begin(), icons.end(), [](auto& a, auto& b) {
+    std::ranges::sort(icons, [](auto& a, auto& b) {
         return compareIcons(a, b) < 0;
     });
 

--- a/Source/WebCore/html/RangeInputType.cpp
+++ b/Source/WebCore/html/RangeInputType.cpp
@@ -55,6 +55,7 @@
 #include "StepRange.h"
 #include "UserAgentParts.h"
 #include <limits>
+#include <ranges>
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -400,7 +401,7 @@ void RangeInputType::updateTickMarkValues()
         m_tickMarkValues.append(parseToNumber(optionValue, Decimal::nan()));
     }
     m_tickMarkValues.shrinkToFit();
-    std::sort(m_tickMarkValues.begin(), m_tickMarkValues.end());
+    std::ranges::sort(m_tickMarkValues);
 }
 
 std::optional<Decimal> RangeInputType::findClosestTickMarkValue(const Decimal& value)

--- a/Source/WebCore/html/URLSearchParams.cpp
+++ b/Source/WebCore/html/URLSearchParams.cpp
@@ -26,6 +26,7 @@
 #include "URLSearchParams.h"
 
 #include "DOMURL.h"
+#include <ranges>
 #include <wtf/URLParser.h>
 
 namespace WebCore {
@@ -81,7 +82,7 @@ bool URLSearchParams::has(const String& name, const String& value) const
 
 void URLSearchParams::sort()
 {
-    std::stable_sort(m_pairs.begin(), m_pairs.end(), [] (const auto& a, const auto& b) {
+    std::ranges::stable_sort(m_pairs, [] (const auto& a, const auto& b) {
         return WTF::codePointCompareLessThan(a.key, b.key);
     });
     updateURL();

--- a/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
@@ -35,6 +35,7 @@
 #include "CSSSerializationContext.h"
 #include "Element.h"
 #include "HTMLParserIdioms.h"
+#include <ranges>
 #include <wtf/ListHashSet.h>
 #include <wtf/URL.h>
 #include <wtf/text/ParsingUtilities.h>
@@ -271,7 +272,7 @@ static ImageCandidate pickBestImageCandidate(float deviceScaleFactor, Vector<Ima
             candidate.density = DefaultDensityValue;
     }
 
-    std::stable_sort(imageCandidates.begin(), imageCandidates.end(), compareByDensity);
+    std::ranges::stable_sort(imageCandidates, compareByDensity);
 
     unsigned i;
     for (i = 0; i < imageCandidates.size() - 1; ++i) {

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
@@ -58,6 +58,7 @@
 #include "TextTrackList.h"
 #include "UserAgentParts.h"
 #include "VTTRegionList.h"
+#include <ranges>
 #include <wtf/Language.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -174,7 +175,7 @@ void MediaControlTextTrackContainerElement::updateDisplay()
     // Sort the active cues for the appropriate display order. For example, for roll-up
     // or paint-on captions, we need to add the cues in reverse chronological order,
     // so that the newest captions appear at the bottom.
-    std::sort(activeCues.begin(), activeCues.end(), &compareCueIntervalForDisplay);
+    std::ranges::sort(activeCues, &compareCueIntervalForDisplay);
 
     if (mediaElement->closedCaptionsVisible()) {
         // 10. For each text track cue in cues that has not yet had

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp
@@ -35,6 +35,7 @@
 #include "LayoutState.h"
 #include "LengthFunctions.h"
 #include "RenderStyleInlines.h"
+#include <ranges>
 #include <wtf/FixedVector.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -192,7 +193,7 @@ FlexLayout::LogicalFlexItems FlexFormattingContext::convertFlexItemsToLogicalSpa
         if (!flexItemsNeedReordering)
             return;
 
-        std::stable_sort(flexItemList.begin(), flexItemList.end(), [&] (auto& a, auto& b) {
+        std::ranges::stable_sort(flexItemList, [&](auto& a, auto& b) {
             return a.logicalOrder < b.logicalOrder;
         });
     };

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp
@@ -29,6 +29,7 @@
 #include "InlineLineBuilder.h"
 #include "RenderStyleInlines.h"
 #include <limits>
+#include <ranges>
 #include <wtf/MathExtras.h>
 #include <wtf/PriorityQueue.h>
 
@@ -582,7 +583,7 @@ std::optional<Vector<LayoutUnit>> InlineContentConstrainer::prettifyRange(Inline
     // try to build a valid line using hyphenation from the beginning.
     if (!lastValidStateIndex.has_value()) {
         auto newEntry = layoutSingleLineForPretty({ breakOpportunities[0], range.endIndex() }, idealLineWidth, state[0], 0);
-        auto it = std::find(breakOpportunities.begin(), breakOpportunities.end(), newEntry.lineEnd.index);
+        auto it = std::ranges::find(breakOpportunities, newEntry.lineEnd.index);
         if (it == breakOpportunities.end())
             return { };
         lastValidStateIndex = std::distance(breakOpportunities.begin(), it);
@@ -610,7 +611,7 @@ std::optional<Vector<LayoutUnit>> InlineContentConstrainer::prettifyRange(Inline
         if (firstStartIndex>lastValidStateIndex.value()) {
             // If hyphenation does not create a valid solution, we should return early.
             auto newEntry = layoutSingleLineForPretty({ state[lastValidStateIndex.value()].lineEnd.index, range.endIndex() }, idealLineWidth, state[lastValidStateIndex.value()], lastValidStateIndex.value());
-            auto it = std::find(breakOpportunities.begin(), breakOpportunities.end(), newEntry.lineEnd.index);
+            auto it = std::ranges::find(breakOpportunities, newEntry.lineEnd.index);
             if (it == breakOpportunities.end())
                 return { };
             lastValidStateIndex = std::distance(breakOpportunities.begin(), it);

--- a/Source/WebCore/layout/formattingContexts/table/TableLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableLayout.cpp
@@ -30,6 +30,7 @@
 #include "LayoutBoxGeometry.h"
 #include "RenderStyleInlines.h"
 #include "TableFormattingGeometry.h"
+#include <ranges>
 
 namespace WebCore {
 namespace Layout {
@@ -159,7 +160,7 @@ static Vector<LayoutUnit> distributeAvailableSpace(const TableGrid& grid, Layout
         // we can resolve overlapping spans starting with the shorter ones e.g.
         // <td colspan=4>#a</td><td>#b</td>
         // <td colspan=2>#c</td><td colspan=3>#d</td>
-        std::sort(spanningCells.begin(), spanningCells.end(), [&] (auto& a, auto& b) {
+        std::ranges::sort(spanningCells, [&](auto& a, auto& b) {
             return SpanType::spanCount(grid.slot(a.position)->cell()) < SpanType::spanCount(grid.slot(b.position)->cell());
         });
 

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLogicalOrderTraversal.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLogicalOrderTraversal.cpp
@@ -28,6 +28,7 @@
 
 #include "InlineIteratorLineBox.h"
 #include <algorithm>
+#include <ranges>
 
 namespace WebCore {
 namespace InlineIterator {
@@ -44,7 +45,7 @@ static TextLogicalOrderCache makeTextLogicalOrderCacheIfNeeded(const RenderText&
     if (cache->boxes.isEmpty())
         return nullptr;
 
-    std::sort(cache->boxes.begin(), cache->boxes.end(), [&](auto& a, auto& b) {
+    std::ranges::sort(cache->boxes, [&](auto& a, auto& b) {
         return a->start() < b->start();
     });
 

--- a/Source/WebCore/loader/CrossOriginAccessControl.cpp
+++ b/Source/WebCore/loader/CrossOriginAccessControl.cpp
@@ -41,6 +41,7 @@
 #include "SecurityOrigin.h"
 #include "SecurityPolicy.h"
 #include <mutex>
+#include <ranges>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RuntimeApplicationChecks.h>
 #include <wtf/text/AtomString.h>
@@ -107,7 +108,7 @@ ResourceRequest createAccessControlPreflightRequest(const ResourceRequest& reque
                 unsafeHeaders.append(headerField.key.convertToASCIILowercase());
         }
 
-        std::sort(unsafeHeaders.begin(), unsafeHeaders.end(), WTF::codePointCompareLessThan);
+        std::ranges::sort(unsafeHeaders, WTF::codePointCompareLessThan);
 
         StringBuilder headerBuffer;
 

--- a/Source/WebCore/loader/appcache/ApplicationCache.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCache.cpp
@@ -31,6 +31,7 @@
 #include "ApplicationCacheStorage.h"
 #include "ResourceRequest.h"
 #include <algorithm>
+#include <ranges>
 #include <stdio.h>
 #include <wtf/text/CString.h>
 
@@ -144,7 +145,7 @@ void ApplicationCache::setFallbackURLs(const FallbackURLVector& fallbackURLs)
     ASSERT(m_fallbackURLs.isEmpty());
     m_fallbackURLs = fallbackURLs;
     // FIXME: What's the right behavior if we have 2 or more identical namespace URLs?
-    std::stable_sort(m_fallbackURLs.begin(), m_fallbackURLs.end(), fallbackURLLongerThan);
+    std::ranges::stable_sort(m_fallbackURLs, fallbackURLLongerThan);
 }
 
 bool ApplicationCache::urlMatchesFallbackNamespace(const URL& url, URL* fallbackURL)

--- a/Source/WebCore/page/CaptionUserPreferences.cpp
+++ b/Source/WebCore/page/CaptionUserPreferences.cpp
@@ -42,6 +42,7 @@
 #include "UserStyleSheet.h"
 #include "UserStyleSheetTypes.h"
 #include <JavaScriptCore/JSObjectInlines.h>
+#include <ranges>
 #include <wtf/Language.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/unicode/Collator.h>
@@ -272,7 +273,7 @@ Vector<RefPtr<TextTrack>> CaptionUserPreferences::sortedTrackListForMenu(TextTra
 
     Collator collator;
 
-    std::sort(tracksForMenu.begin(), tracksForMenu.end(), [&] (auto& a, auto& b) {
+    std::ranges::sort(tracksForMenu, [&](auto& a, auto& b) {
         return collator.collate(trackDisplayName(a.get()), trackDisplayName(b.get())) < 0;
     });
 
@@ -316,7 +317,7 @@ Vector<RefPtr<AudioTrack>> CaptionUserPreferences::sortedTrackListForMenu(AudioT
 
     Collator collator;
 
-    std::sort(tracksForMenu.begin(), tracksForMenu.end(), [&] (auto& a, auto& b) {
+    std::ranges::sort(tracksForMenu, [&](auto& a, auto& b) {
         return collator.collate(trackDisplayName(a.get()), trackDisplayName(b.get())) < 0;
     });
 

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
@@ -40,6 +40,7 @@
 #include "UserAgentParts.h"
 #include "UserStyleSheetTypes.h"
 #include <algorithm>
+#include <ranges>
 #include <wtf/Language.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RetainPtr.h>
@@ -843,7 +844,7 @@ Vector<RefPtr<AudioTrack>> CaptionUserPreferencesMediaAF::sortedTrackListForMenu
 
     Collator collator;
 
-    std::sort(tracksForMenu.begin(), tracksForMenu.end(), [&] (auto& a, auto& b) {
+    std::ranges::sort(tracksForMenu, [&] (auto& a, auto& b) {
         if (auto trackDisplayComparison = collator.collate(trackDisplayName(*a), trackDisplayName(*b)))
             return trackDisplayComparison < 0;
 
@@ -959,7 +960,7 @@ Vector<RefPtr<TextTrack>> CaptionUserPreferencesMediaAF::sortedTrackListForMenu(
     if (tracksForMenu.isEmpty())
         return tracksForMenu;
 
-    std::sort(tracksForMenu.begin(), tracksForMenu.end(), textTrackCompare);
+    std::ranges::sort(tracksForMenu, textTrackCompare);
 
     if (requestingCaptionsOrDescriptionsOrSubtitles) {
         tracksForMenu.insert(0, &TextTrack::captionMenuOffItem());

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -69,6 +69,7 @@
 #include "TextIterator.h"
 #include "TypedElementDescendantIteratorInlines.h"
 #include "VisibilityAdjustment.h"
+#include <ranges>
 #include <wtf/HashMap.h>
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -541,7 +542,7 @@ static Vector<Vector<String>> selectorsForTarget(Element& element, ElementSelect
             selectors.append(WTFMove(selector));
     }
 
-    std::sort(selectors.begin(), selectors.end(), [](auto& first, auto& second) {
+    std::ranges::sort(selectors, [](auto& first, auto& second) {
         return first.length() < second.length();
     });
 
@@ -1960,7 +1961,7 @@ uint64_t ElementTargetingController::numberOfVisibilityAdjustmentRects()
     }
 
     // Sort by area in descending order so that we don't double-count fully overlapped elements.
-    std::sort(clientRects.begin(), clientRects.end(), [](auto first, auto second) {
+    std::ranges::sort(clientRects, [](auto first, auto second) {
         return first.area() > second.area();
     });
 

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -48,6 +48,7 @@
 #include "RenderView.h"
 #include "WebCoreOpaqueRootInlines.h"
 #include <JavaScriptCore/AbstractSlotVisitorInlines.h>
+#include <ranges>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
@@ -162,7 +163,7 @@ IntersectionObserver::IntersectionObserver(Document& document, Ref<IntersectionO
             m_implicitRootDocument = localFrame->document();
     }
 
-    std::sort(m_thresholds.begin(), m_thresholds.end());
+    std::ranges::sort(m_thresholds);
     
     LOG_WITH_STREAM(IntersectionObserver, stream << "Created IntersectionObserver " << this << " root " << root << " root margin " << m_rootMargin << " scroll margin " << m_scrollMargin << " thresholds " << m_thresholds);
 }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -197,6 +197,7 @@
 #include "WindowFeatures.h"
 #include "WorkerOrWorkletScriptController.h"
 #include <JavaScriptCore/VM.h>
+#include <ranges>
 #include <wtf/FileSystem.h>
 #include <wtf/RefCountedLeakCounter.h>
 #include <wtf/StdLibExtras.h>
@@ -1344,7 +1345,7 @@ static void replaceRanges(Page& page, const Vector<FindReplacementRange>& ranges
     // Likewise, iterate backwards (in document and frame order) through editing containers that contain text matches,
     // so that we're consistent with our backwards iteration behavior per editing container when replacing text.
     auto containerNodesInOrderOfReplacement = copyToVector(rangesByContainerNode.keys());
-    std::sort(containerNodesInOrderOfReplacement.begin(), containerNodesInOrderOfReplacement.end(), [frameToTraversalIndexMap] (auto& firstNode, auto& secondNode) {
+    std::ranges::sort(containerNodesInOrderOfReplacement, [frameToTraversalIndexMap](auto& firstNode, auto& secondNode) {
         if (firstNode == secondNode)
             return false;
 

--- a/Source/WebCore/page/PageColorSampler.cpp
+++ b/Source/WebCore/page/PageColorSampler.cpp
@@ -54,6 +54,7 @@
 #include "Settings.h"
 #include "Styleable.h"
 #include "WebAnimation.h"
+#include <ranges>
 #include <wtf/HashCountedSet.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/OptionSet.h>
@@ -358,7 +359,7 @@ Variant<PredominantColorType, Color> PageColorSampler::predominantColor(Page& pa
     for (auto& [color, count] : colorDistribution)
         colorsByDescendingFrequency.append({ color, count });
 
-    std::stable_sort(colorsByDescendingFrequency.begin(), colorsByDescendingFrequency.end(), [](auto& a, auto& b) {
+    std::ranges::stable_sort(colorsByDescendingFrequency, [](auto& a, auto& b) {
         return a.second > b.second;
     });
 

--- a/Source/WebCore/page/Performance.cpp
+++ b/Source/WebCore/page/Performance.cpp
@@ -51,6 +51,7 @@
 #include "PerformanceUserTiming.h"
 #include "ResourceResponse.h"
 #include "ScriptExecutionContext.h"
+#include <ranges>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -156,7 +157,7 @@ Vector<Ref<PerformanceEntry>> Performance::getEntries() const
     if (m_firstContentfulPaint)
         entries.append(*m_firstContentfulPaint);
 
-    std::sort(entries.begin(), entries.end(), PerformanceEntry::startTimeCompareLessThan);
+    std::ranges::sort(entries, PerformanceEntry::startTimeCompareLessThan);
     return entries;
 }
 
@@ -180,7 +181,7 @@ Vector<Ref<PerformanceEntry>> Performance::getEntriesByType(const String& entryT
             entries.appendVector(m_userTiming->getMeasures());
     }
 
-    std::sort(entries.begin(), entries.end(), PerformanceEntry::startTimeCompareLessThan);
+    std::ranges::sort(entries, PerformanceEntry::startTimeCompareLessThan);
     return entries;
 }
 
@@ -208,7 +209,7 @@ Vector<Ref<PerformanceEntry>> Performance::getEntriesByName(const String& name, 
             entries.appendVector(m_userTiming->getMeasures(name));
     }
 
-    std::sort(entries.begin(), entries.end(), PerformanceEntry::startTimeCompareLessThan);
+    std::ranges::sort(entries, PerformanceEntry::startTimeCompareLessThan);
     return entries;
 }
 

--- a/Source/WebCore/page/PerformanceObserverEntryList.cpp
+++ b/Source/WebCore/page/PerformanceObserverEntryList.cpp
@@ -27,6 +27,7 @@
 #include "PerformanceObserverEntryList.h"
 
 #include "PerformanceEntry.h"
+#include <ranges>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -43,7 +44,7 @@ PerformanceObserverEntryList::PerformanceObserverEntryList(Vector<Ref<Performanc
 {
     ASSERT(!m_entries.isEmpty());
 
-    std::stable_sort(m_entries.begin(), m_entries.end(), PerformanceEntry::startTimeCompareLessThan);
+    std::ranges::stable_sort(m_entries, PerformanceEntry::startTimeCompareLessThan);
 }
 
 Vector<Ref<PerformanceEntry>> PerformanceObserverEntryList::getEntriesByType(const String& entryType) const

--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
@@ -36,6 +36,7 @@
 #include "RenderView.h"
 #include "ScrollableArea.h"
 #include "StyleScrollSnapPoints.h"
+#include <ranges>
 
 namespace WebCore {
 
@@ -399,13 +400,13 @@ void updateSnapOffsetsForScrollableArea(ScrollableArea& scrollableArea, const Re
 
     Vector<SnapOffset<LayoutUnit>> horizontalSnapOffsets = copyToVector(horizontalSnapOffsetsMap.values());
     if (!horizontalSnapOffsets.isEmpty()) {
-        std::sort(horizontalSnapOffsets.begin(), horizontalSnapOffsets.end(), compareSnapOffsets);
+        std::ranges::sort(horizontalSnapOffsets, compareSnapOffsets);
         LOG_WITH_STREAM(ScrollSnap, stream << " => Computed horizontal scroll snap offsets: " << horizontalSnapOffsets);
     }
 
     Vector<SnapOffset<LayoutUnit>> verticalSnapOffsets = copyToVector(verticalSnapOffsetsMap.values());
     if (!verticalSnapOffsets.isEmpty()) {
-        std::sort(verticalSnapOffsets.begin(), verticalSnapOffsets.end(), compareSnapOffsets);
+        std::ranges::sort(verticalSnapOffsets, compareSnapOffsets);
         LOG_WITH_STREAM(ScrollSnap, stream << " => Computed vertical scroll snap offsets: " << verticalSnapOffsets);
     }
 

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(ASYNC_SCROLLING)
 
 #include "ScrollingStateTree.h"
+#include <ranges>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
@@ -472,7 +473,7 @@ void ScrollingStateFrameScrollingNode::dumpProperties(TextStream& ts, OptionSet<
     auto& synchronousDispatchRegionMap = m_eventTrackingRegions.eventSpecificSynchronousDispatchRegions;
     if (!synchronousDispatchRegionMap.isEmpty()) {
         auto eventRegionNames = copyToVector(synchronousDispatchRegionMap.keys());
-        std::sort(eventRegionNames.begin(), eventRegionNames.end());
+        std::ranges::sort(eventRegionNames);
         for (const auto& name : eventRegionNames) {
             const auto& region = synchronousDispatchRegionMap.get(name);
             TextStream::GroupScope scope(ts);

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -53,6 +53,7 @@
 #include "Text.h"
 #include "TextIterator.h"
 #include "WritingMode.h"
+#include <ranges>
 #include <unicode/uchar.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
@@ -610,9 +611,10 @@ RenderedText extractRenderedText(Element& element)
         return true;
     }();
 
-    std::sort(allTokensAndOffsets.begin(), allTokensAndOffsets.end(), [&](auto& a, auto& b) {
-        return ascendingOrder ? a.offset < b.offset : a.offset > b.offset;
-    });
+    if (ascendingOrder)
+        std::ranges::sort(allTokensAndOffsets, [&](auto& a, auto& b) { return a.offset < b.offset; });
+    else
+        std::ranges::sort(allTokensAndOffsets, [&](auto& a, auto& b) { return a.offset > b.offset; });
 
     bool hasLargeReplacedDescendant = false;
     StringBuilder textWithReplacedContent;

--- a/Source/WebCore/platform/MIMETypeRegistry.cpp
+++ b/Source/WebCore/platform/MIMETypeRegistry.cpp
@@ -30,6 +30,7 @@
 #include "DeprecatedGlobalSettings.h"
 #include "MediaPlayer.h"
 #include "ThreadGlobalData.h"
+#include <ranges>
 #include <wtf/FixedVector.h>
 #include <wtf/HashMap.h>
 #include <wtf/MainThread.h>
@@ -156,7 +157,7 @@ constexpr ComparableCaseFoldingASCIILiteral supportedImageMIMETypeArray[] = {
 template<ASCIISubset subset, unsigned size> static FixedVector<ASCIILiteral> makeFixedVector(const ComparableASCIISubsetLiteral<subset> (&array)[size])
 {
     FixedVector<ASCIILiteral> result(std::size(array));
-    std::transform(std::begin(array), std::end(array), result.begin(), [] (auto literal) {
+    std::ranges::transform(array, result.begin(), [](auto literal) {
         return literal.literal;
     });
     return result;

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
@@ -29,6 +29,7 @@
 #include "Logging.h"
 #include "ScrollExtents.h"
 #include "ScrollingEffectsController.h"
+#include <ranges>
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
@@ -103,7 +104,7 @@ bool ScrollSnapAnimatorState::preserveCurrentTargetForAxis(ScrollEventAxis axis,
 {
     auto snapOffsets = snapOffsetsForAxis(axis);
     
-    auto found = std::find_if(snapOffsets.begin(), snapOffsets.end(), [boxID](SnapOffset<LayoutUnit> p) -> bool {
+    auto found = std::ranges::find_if(snapOffsets, [boxID](SnapOffset<LayoutUnit> p) -> bool {
         return *p.snapTargetID == boxID;
     });
     if (found == snapOffsets.end()) {
@@ -166,13 +167,13 @@ static ElementIdentifier chooseBoxToResnapTo(const UncheckedKeyHashSet<ElementId
 {
     ASSERT(snappedBoxes.size());
 
-    auto found = std::find_if(horizontalOffsets.begin(), horizontalOffsets.end(), [&snappedBoxes](SnapOffset<LayoutUnit> p) -> bool {
+    auto found = std::ranges::find_if(horizontalOffsets, [&snappedBoxes](SnapOffset<LayoutUnit> p) -> bool {
         return snappedBoxes.contains(*p.snapTargetID) && p.isFocused;
     });
     if (found != horizontalOffsets.end())
         return *found->snapTargetID;
     
-    found = std::find_if(verticalOffsets.begin(), verticalOffsets.end(), [&snappedBoxes](SnapOffset<LayoutUnit> p) -> bool {
+    found = std::ranges::find_if(verticalOffsets, [&snappedBoxes](SnapOffset<LayoutUnit> p) -> bool {
         return snappedBoxes.contains(*p.snapTargetID) && p.isFocused;
     });
     if (found != verticalOffsets.end())

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -31,6 +31,7 @@
 #include "Logging.h"
 #include "NowPlayingInfo.h"
 #include "PlatformMediaSession.h"
+#include <ranges>
 #include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(COCOA)
@@ -229,7 +230,7 @@ void PlatformMediaSessionManager::addSession(PlatformMediaSessionInterface& sess
 
 bool PlatformMediaSessionManager::hasNoSession() const
 {
-    return m_sessions.isEmpty() || std::all_of(m_sessions.begin(), m_sessions.end(), std::logical_not<void>());
+    return m_sessions.isEmpty() || std::ranges::all_of(m_sessions, std::logical_not<void>());
 }
 
 void PlatformMediaSessionManager::removeSession(PlatformMediaSessionInterface& session)

--- a/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
+++ b/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
@@ -40,6 +40,7 @@
 #include "SharedBuffer.h"
 #include <algorithm>
 #include <iterator>
+#include <ranges>
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>
@@ -285,7 +286,7 @@ Vector<AtomString> CDMPrivateClearKey::supportedInitDataTypes() const
 
 static bool containsPersistentLicenseType(const Vector<CDMSessionType>& types)
 {
-    return std::any_of(types.begin(), types.end(),
+    return std::ranges::any_of(types,
         [] (auto& sessionType) { return sessionType == CDMSessionType::PersistentLicense; });
 }
 

--- a/Source/WebCore/platform/graphics/FloatSegment.h
+++ b/Source/WebCore/platform/graphics/FloatSegment.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <algorithm>
+#include <ranges>
 #include <wtf/Vector.h>
 
 namespace WTF {
@@ -55,7 +56,7 @@ struct FloatSegment {
 // return differenceWithDilation({ 0, totalWidth }, intersections);
 inline Vector<FloatSegment> differenceWithDilation(FloatSegment a, Vector<FloatSegment>&& bs, float dilationAmount)
 {
-    std::sort(bs.begin(), bs.end(), [](auto&& a, auto&& b) {
+    std::ranges::sort(bs, [](auto&& a, auto&& b) {
         return a.begin < b.begin;
     });
 

--- a/Source/WebCore/platform/graphics/GradientColorStops.h
+++ b/Source/WebCore/platform/graphics/GradientColorStops.h
@@ -28,6 +28,7 @@
 #include "GradientColorStop.h"
 #include <algorithm>
 #include <optional>
+#include <ranges>
 #include <wtf/Forward.h>
 #include <wtf/Vector.h>
 
@@ -71,7 +72,7 @@ public:
         if (m_isSorted)
             return;
 
-        std::stable_sort(m_stops.begin(), m_stops.end(), [] (auto& a, auto& b) {
+        std::ranges::stable_sort(m_stops, [](auto& a, auto& b) {
             return a.offset < b.offset;
         });
         m_isSorted = true;
@@ -111,7 +112,7 @@ private:
 #if ASSERT_ENABLED
     bool validateIsSorted() const
     {
-        return std::is_sorted(m_stops.begin(), m_stops.end(), [] (auto& a, auto& b) {
+        return std::ranges::is_sorted(m_stops, [](auto& a, auto& b) {
             return a.offset < b.offset;
         });
     }

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -33,6 +33,7 @@
 #include "MediaSourcePrivateClient.h"
 #include "PlatformTimeRanges.h"
 #include "SourceBufferPrivate.h"
+#include <ranges>
 #include <wtf/Threading.h>
 
 namespace WebCore {
@@ -146,7 +147,7 @@ bool MediaSourcePrivate::hasAudio() const
 {
     ASSERT(m_dispatcher->isCurrent() || Thread::mayBeGCThread());
 
-    return std::any_of(m_activeSourceBuffers.begin(), m_activeSourceBuffers.end(), [] (SourceBufferPrivate* sourceBuffer) {
+    return std::ranges::any_of(m_activeSourceBuffers, [](auto* sourceBuffer) {
         return sourceBuffer->hasAudio();
     });
 }
@@ -155,7 +156,7 @@ bool MediaSourcePrivate::hasVideo() const
 {
     assertIsCurrent(m_dispatcher);
 
-    return std::any_of(m_activeSourceBuffers.begin(), m_activeSourceBuffers.end(), [] (SourceBufferPrivate* sourceBuffer) {
+    return std::ranges::any_of(m_activeSourceBuffers, [](auto* sourceBuffer) {
         return sourceBuffer->hasVideo();
     });
 }

--- a/Source/WebCore/platform/graphics/PathUtilities.cpp
+++ b/Source/WebCore/platform/graphics/PathUtilities.cpp
@@ -34,6 +34,7 @@
 #include "FloatRoundedRect.h"
 #include "GeometryUtilities.h"
 #include <math.h>
+#include <ranges>
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -136,7 +137,7 @@ static bool addIntersectionPoints(Vector<FloatPointGraph::Polygon>& polys, Float
             intersectionPoints.append(graph.findOrCreateNode(intersectionPoint));
         }
 
-        std::sort(intersectionPoints.begin(), intersectionPoints.end(), [edgeA](auto* a, auto* b) {
+        std::ranges::sort(intersectionPoints, [edgeA](auto* a, auto* b) {
             return FloatPoint(*edgeA.first - *b).lengthSquared() > FloatPoint(*edgeA.first - *a).lengthSquared();
         });
 
@@ -263,10 +264,10 @@ static Vector<FloatPointGraph::Polygon> polygonsForRect(const Vector<FloatRect>&
 {
     Vector<FloatRect> sortedRects = rects;
     // FIXME: Replace it with 2 dimensional sort.
-    std::sort(sortedRects.begin(), sortedRects.end(), [](FloatRect a, FloatRect b) {
+    std::ranges::sort(sortedRects, [](FloatRect a, FloatRect b) {
         return a.x() < b.x();
     });
-    std::sort(sortedRects.begin(), sortedRects.end(), [](FloatRect a, FloatRect b) {
+    std::ranges::sort(sortedRects, [](FloatRect a, FloatRect b) {
         return a.y() < b.y();
     });
 

--- a/Source/WebCore/platform/graphics/TrackBuffer.cpp
+++ b/Source/WebCore/platform/graphics/TrackBuffer.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(MEDIA_SOURCE)
 
 #include "Logging.h"
+#include <ranges>
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -87,7 +88,7 @@ bool TrackBuffer::updateMinimumUpcomingPresentationTime()
         return false;
     }
 
-    auto minPts = std::min_element(m_decodeQueue.begin(), m_decodeQueue.end(), [](auto& left, auto& right) -> bool {
+    auto minPts = std::ranges::min_element(m_decodeQueue, [](auto& left, auto& right) -> bool {
         return left.second->presentationTime() < right.second->presentationTime();
     });
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
@@ -38,6 +38,7 @@
 #import "SourceBufferPrivateAVFObjC.h"
 #import "VideoMediaSampleRenderer.h"
 #import <objc/runtime.h>
+#import <ranges>
 #import <wtf/Algorithms.h>
 #import <wtf/NativePromise.h>
 #import <wtf/SoftLinking.h>
@@ -174,7 +175,7 @@ void MediaSourcePrivateAVFObjC::keyAdded()
 
 bool MediaSourcePrivateAVFObjC::hasSelectedVideo() const
 {
-    return std::any_of(m_activeSourceBuffers.begin(), m_activeSourceBuffers.end(), [] (auto* sourceBuffer) {
+    return std::ranges::any_of(m_activeSourceBuffers, [] (auto* sourceBuffer) {
         return downcast<SourceBufferPrivateAVFObjC>(sourceBuffer)->hasSelectedVideo();
     });
 }

--- a/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
@@ -32,6 +32,7 @@
 #include "FontMetricsNormalization.h"
 
 #include <pal/system/ios/UserInterfaceIdiom.h>
+#include <ranges>
 #include <wtf/cf/TypeCastsCF.h>
 
 namespace WebCore {
@@ -311,10 +312,10 @@ std::optional<SystemFontKind> SystemFontDatabaseCoreText::matchSystemFontUse(con
             kCTUIFontTextStyleTitle0,
             kCTUIFontTextStyleTitle4,
         };
-        std::sort(m_textStyles.begin(), m_textStyles.end(), compareAsPointer);
+        std::ranges::sort(m_textStyles, compareAsPointer);
     }
 
-    if (std::binary_search(m_textStyles.begin(), m_textStyles.end(), string, compareAsPointer))
+    if (std::ranges::binary_search(m_textStyles, string, compareAsPointer))
         return SystemFontKind::TextStyle;
 
     return std::nullopt;

--- a/Source/WebCore/platform/ios/LegacyTileGrid.mm
+++ b/Source/WebCore/platform/ios/LegacyTileGrid.mm
@@ -37,8 +37,9 @@
 #import <functional>
 #import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
+#import <ranges>
 #import <wtf/MemoryPressureHandler.h>
-#include <wtf/TZoneMallocInlines.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -134,9 +135,9 @@ bool LegacyTileGrid::dropDistantTiles(unsigned tilesNeeded, double shortestDista
         if (distance <= shortestDistance)
             continue;
         toRemove.append(std::make_pair(distance, index));
-        std::push_heap(toRemove.begin(), toRemove.end(), isFartherAway<TileIndex>);
+        std::ranges::push_heap(toRemove, isFartherAway<TileIndex>);
         if (toRemove.size() > tilesToRemoveCount) {
-            std::pop_heap(toRemove.begin(), toRemove.end(), isFartherAway<TileIndex>);
+            std::ranges::pop_heap(toRemove, isFartherAway<TileIndex>);
             toRemove.removeLast();
         }
     }

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
@@ -39,6 +39,7 @@
 #include "Logging.h"
 #include "MediaDeviceHashSalts.h"
 #include "MediaStreamPrivate.h"
+#include <ranges>
 #include <wtf/CallbackAggregator.h>
 #include <wtf/HexNumber.h>
 #include <wtf/SHA1.h>
@@ -352,7 +353,7 @@ Expected<RealtimeMediaSourceCenter::ValidDevices, MediaConstraintType> RealtimeM
 
     Vector<CaptureDevice> audioDevices;
     if (!audioDeviceInfo.isEmpty()) {
-        std::stable_sort(audioDeviceInfo.begin(), audioDeviceInfo.end(), sortBasedOnFitnessScore);
+        std::ranges::stable_sort(audioDeviceInfo, sortBasedOnFitnessScore);
         audioDevices = WTF::map(audioDeviceInfo, [] (auto& info) {
             return info.device;
         });
@@ -360,7 +361,7 @@ Expected<RealtimeMediaSourceCenter::ValidDevices, MediaConstraintType> RealtimeM
 
     Vector<CaptureDevice> videoDevices;
     if (!videoDeviceInfo.isEmpty()) {
-        std::stable_sort(videoDeviceInfo.begin(), videoDeviceInfo.end(), sortBasedOnFitnessScore);
+        std::ranges::stable_sort(videoDeviceInfo, sortBasedOnFitnessScore);
         videoDevices = WTF::map(videoDeviceInfo, [] (auto& info) {
             return info.device;
         });

--- a/Source/WebCore/platform/mediastream/VideoPreset.h
+++ b/Source/WebCore/platform/mediastream/VideoPreset.h
@@ -29,6 +29,7 @@
 
 #include "ImageBuffer.h"
 #include "RealtimeMediaSource.h"
+#include <ranges>
 #include <wtf/Lock.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/RunLoop.h>
@@ -118,7 +119,7 @@ inline double VideoPreset::maxFrameRate() const
 
 inline void VideoPreset::sortFrameRateRanges()
 {
-    std::sort(m_data.frameRateRanges.begin(), m_data.frameRateRanges.end(),
+    std::ranges::sort(m_data.frameRateRanges,
         [&] (const auto& a, const auto& b) -> bool {
             return a.minimum < b.minimum;
     });

--- a/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.mm
+++ b/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.mm
@@ -35,6 +35,7 @@
 #import "RealtimeMediaSourceCenter.h"
 #import <AVFoundation/AVAudioSession.h>
 #import <pal/spi/cocoa/AVFoundationSPI.h>
+#import <ranges>
 #import <wtf/Assertions.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/MainThread.h>
@@ -310,12 +311,12 @@ void AVAudioSessionCaptureDeviceManager::setAudioCaptureDevices(Vector<AVAudioSe
         }
     }
 
-    std::sort(newCaptureDevices.begin(), newCaptureDevices.end(), [] (auto& first, auto& second) -> bool {
+    std::ranges::sort(newCaptureDevices, [] (auto& first, auto& second) -> bool {
         return first.isDefault() && !second.isDefault();
     });
     m_captureDevices = WTFMove(newCaptureDevices);
 
-    std::sort(newSpeakerDevices.begin(), newSpeakerDevices.end(), [] (auto& first, auto& second) -> bool {
+    std::ranges::sort(newSpeakerDevices, [] (auto& first, auto& second) -> bool {
         return first.isDefault() && !second.isDefault();
     });
     m_speakerDevices = WTFMove(newSpeakerDevices);

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp
@@ -35,6 +35,7 @@
 #include <AudioUnit/AudioUnit.h>
 #include <CoreMedia/CMSync.h>
 #include <pal/spi/cf/CoreAudioSPI.h>
+#include <ranges>
 #include <wtf/Assertions.h>
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
@@ -245,7 +246,7 @@ std::optional<CoreAudioCaptureDevice> CoreAudioCaptureDeviceManager::coreAudioDe
 
 static inline bool hasDevice(const Vector<CoreAudioCaptureDevice>& devices, uint32_t deviceID, CaptureDevice::DeviceType deviceType)
 {
-    return std::any_of(devices.begin(), devices.end(), [&deviceID, deviceType](auto& device) {
+    return std::ranges::any_of(devices, [&deviceID, deviceType](auto& device) {
         return device.deviceID() == deviceID && device.type() == deviceType;
     });
 }
@@ -338,7 +339,7 @@ void CoreAudioCaptureDeviceManager::refreshAudioCaptureDevices(NotifyIfDevicesHa
     if (!haveDeviceChanges)
         return;
 
-    std::sort(audioDevices.begin(), audioDevices.end(), [] (auto& first, auto& second) -> bool {
+    std::ranges::sort(audioDevices, [] (auto& first, auto& second) -> bool {
         return first.isDefault() && !second.isDefault();
     });
     m_coreAudioCaptureDevices = WTFMove(audioDevices);

--- a/Source/WebCore/platform/text/SuffixTree.h
+++ b/Source/WebCore/platform/text/SuffixTree.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <ranges>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
@@ -90,7 +91,7 @@ private:
 
         auto find(int codeWord)
         {
-            return std::find_if(m_children.begin(), m_children.end(), [codeWord](auto& entry) {
+            return std::ranges::find_if(m_children, [codeWord](auto& entry) {
                 return entry.codeWord == codeWord;
             });
         }

--- a/Source/WebCore/plugins/DOMPlugin.cpp
+++ b/Source/WebCore/plugins/DOMPlugin.cpp
@@ -21,6 +21,7 @@
 
 #include "DOMMimeType.h"
 #include "Navigator.h"
+#include <ranges>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/AtomString.h>
 
@@ -38,7 +39,7 @@ static Vector<Ref<DOMMimeType>> makeMimeTypes(Navigator& navigator, const Plugin
     auto types = info.mimes.map([&](auto& type) {
         return DOMMimeType::create(navigator, type, self);
     });
-    std::sort(types.begin(), types.end(), [](const Ref<DOMMimeType>& a, const Ref<DOMMimeType>& b) {
+    std::ranges::sort(types, [](const Ref<DOMMimeType>& a, const Ref<DOMMimeType>& b) {
         return codePointCompareLessThan(a->type(), b->type());
     });
 

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -36,6 +36,7 @@
 #include "RenderGrid.h"
 #include "RenderStyleConstants.h"
 #include "StyleSelfAlignmentData.h"
+#include <ranges>
 #include <wtf/StdMap.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
@@ -768,7 +769,7 @@ static void distributeItemIncurredIncreases(Vector<WeakPtr<GridTrack>>& tracks, 
     if (variant == TrackSizeComputationVariant::NotCrossingFlexibleTracks) {
         // We have to sort tracks according to their growth potential. This is necessary even when distributing beyond growth limits,
         // because there might be tracks with growth limit caps (like the ones with fit-content()) which cannot indefinitely grow over the limits.
-        std::sort(tracks.begin(), tracks.end(), sortByGridTrackGrowthPotential);
+        std::ranges::sort(tracks, sortByGridTrackGrowthPotential);
         for (uint32_t i = 0; i < tracksSize; ++i) {
             ASSERT(!getSizeDistributionWeight<variant>(*tracks[i]));
             distributeItemIncurredIncreaseToTrack<phase, limit>(*tracks[i], freeSpace, tracksSize - i);

--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -39,6 +39,7 @@
 #include "RenderedDocumentMarker.h"
 #include "TextBoxSelectableRange.h"
 #include <algorithm>
+#include <ranges>
 #include <wtf/HashSet.h>
 
 namespace WebCore {
@@ -67,7 +68,7 @@ Vector<MarkedText> MarkedText::subdivide(const Vector<MarkedText>& markedTexts, 
     }
 
     // 2. Sort offsets such that begin offsets are in paint order and end offsets are in reverse paint order.
-    std::sort(offsets.begin(), offsets.end(), [] (const Offset& a, const Offset& b) {
+    std::ranges::sort(offsets, [] (const Offset& a, const Offset& b) {
         return a.value < b.value || (a.value == b.value && a.kind == b.kind && a.kind == Offset::Begin && a.markedText->type < b.markedText->type)
         || (a.value == b.value && a.kind == b.kind && a.kind == Offset::End && a.markedText->type > b.markedText->type);
     });
@@ -101,7 +102,7 @@ Vector<MarkedText> MarkedText::subdivide(const Vector<MarkedText>& markedTexts, 
     }
     // Fix up; sort the marked texts so that they are in paint order.
     if (overlapStrategy == OverlapStrategy::None)
-        std::sort(result.begin(), result.end(), [] (const MarkedText& a, const MarkedText& b) { return a.startOffset < b.startOffset || (a.startOffset == b.startOffset && a.type < b.type); });
+        std::ranges::sort(result, [] (const MarkedText& a, const MarkedText& b) { return a.startOffset < b.startOffset || (a.startOffset == b.startOffset && a.type < b.type); });
     return result;
 }
 

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -38,6 +38,7 @@
 #include "RenderObjectInlines.h"
 #include "RenderStyleInlines.h"
 #include "RenderView.h"
+#include <ranges>
 #include <wtf/Scope.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -97,7 +98,7 @@ public:
                     // Only copy+sort the values once per layout even if the iterator is reset.
                     if (static_cast<size_t>(m_ordinalValues.size()) != m_sortedOrdinalValues.size()) {
                         m_sortedOrdinalValues = copyToVector(m_ordinalValues);
-                        std::sort(m_sortedOrdinalValues.begin(), m_sortedOrdinalValues.end());
+                        std::ranges::sort(m_sortedOrdinalValues);
                     }
                     m_currentOrdinal = m_forward ? m_sortedOrdinalValues[m_ordinalIteration - 1] : m_sortedOrdinalValues[m_sortedOrdinalValues.size() - m_ordinalIteration];
                 }

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -46,6 +46,7 @@
 #include "Settings.h"
 #include "StyleProperties.h"
 #include "TransformState.h"
+#include <ranges>
 #include <wtf/StackStats.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -1256,7 +1257,7 @@ void RenderTableCell::collectBorderValues(RenderTable::CollapsedBorderValues& bo
 
 void RenderTableCell::sortBorderValues(RenderTable::CollapsedBorderValues& borderValues)
 {
-    std::sort(borderValues.begin(), borderValues.end(), compareBorders);
+    std::ranges::sort(borderValues, compareBorders);
 }
 
 void RenderTableCell::paintCollapsedBorders(PaintInfo& paintInfo, const LayoutPoint& paintOffset)


### PR DESCRIPTION
#### 48158ba01cc1850ee7799a8d504242553f7ade0e
<pre>
Leverage std::ranges in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=292357">https://bugs.webkit.org/show_bug.cgi?id=292357</a>

Reviewed by Geoffrey Garen and Sam Weinig.

Leverage std::ranges in more places to simplify our code a bit.

* Source/WTF/benchmarks/ConditionSpeedTest.cpp:
* Source/WTF/wtf/Dominators.h:
(WTF::Dominators::IterativeDominance::computeReversePostorder):
* Source/WTF/wtf/FastMalloc.cpp:
(WTF::MallocCallTracker::dumpStats):
* Source/WTF/wtf/IndexSparseSet.h:
(WTF::OverflowHandler&gt;::sort):
* Source/WTF/wtf/InterferenceGraph.h:
(WTF::InstrumentedIterableInterferenceGraph::Iterable::Iterable):
(WTF::InstrumentedIterableInterferenceGraph::Iterable::begin const): Deleted.
(WTF::InstrumentedIterableInterferenceGraph::Iterable::end const): Deleted.
(WTF::InstrumentedIterableInterferenceGraph::operator[] const): Deleted.
* Source/WTF/wtf/ListDump.h:
(WTF::sortedListDump):
(WTF::sortedMapDump):
* Source/WTF/wtf/ListHashSet.h:
(WTF::U&gt;::ListHashSet):
* Source/WTF/wtf/Liveness.h:
(WTF::Liveness::compute):
* Source/WTF/wtf/MemoryPressureHandler.cpp:
(WTF::MemoryPressureHandler::setMemoryFootprintNotificationThresholds):
* Source/WTF/wtf/NaturalLoops.h:
(WTF::NaturalLoops::NaturalLoops):
* Source/WTF/wtf/ParkingLot.cpp:
* Source/WTF/wtf/RefTrackerMixin.cpp:
(WTF::RefTracker::logAllLiveReferences):
* Source/WTF/wtf/SortedArrayMap.h:
* Source/WTF/wtf/URL.cpp:
(WTF::differingQueryParameters):
* Source/WTF/wtf/Vector.h:
(WTF::insertInUniquedSortedVector):
* Source/WTF/wtf/text/TextBreakIterator.h:
(WTF::TextBreakIteratorCache::take):
* Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.cpp:
(WebCore::MediaKeyStatusMap::has):
(WebCore::MediaKeyStatusMap::get):
* Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp:
(WebCore::MediaKeys::hasOpenSessions const):
* Source/WebCore/Modules/fetch/FetchHeaders.cpp:
(WebCore::FetchHeaders::Iterator::next):
* Source/WebCore/Modules/indexeddb/IDBDatabase.cpp:
(WebCore::sortAndRemoveDuplicates):
* Source/WebCore/Modules/mediasession/MediaMetadata.cpp:
(WebCore::MediaMetadata::refreshArtworkImage):
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::haveMicrophoneDevice):
* Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp:
(WebCore::URLPatternUtilities::URLPatternComponent::matchSpecialSchemeProtocol const):
* Source/WebCore/Modules/url-pattern/URLPatternParser.cpp:
(WebCore::URLPatternUtilities::escapeRegexStringForCharacters):
(WebCore::URLPatternUtilities::escapePatternStringForCharacters):
* Source/WebCore/PAL/pal/text/TextCodecCJK.cpp:
(PAL::gb18030RangesCodePoint):
(PAL::gb18030RangesPointer):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::inheritsPresentationalRole const):
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::updateAnimationsAndSendEvents):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::processKeyframeLikeObject):
(WebCore::processPropertyIndexedKeyframes):
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::ensureEffectsAreSorted):
* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::actionsFromContentRuleList const):
(WebCore::ContentExtensions::applyResultsToRequest):
* Source/WebCore/contentextensions/DFA.cpp:
(WebCore::ContentExtensions::printTransitions):
* Source/WebCore/contentextensions/HashableActionList.h:
(WebCore::ContentExtensions::HashableActionList::HashableActionList):
* Source/WebCore/css/CSSFontFaceSet.cpp:
(WebCore::CSSFontFaceSet::fontFace):
* Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp:
(WebCore::CSSCalc::generateSortedChildrenMap):
* Source/WebCore/css/typedom/CSSNumericValue.cpp:
(WebCore::CSSNumericValue::toSum):
* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp:
(WebCore::ComputedStylePropertyMapReadOnly::entries const):
* Source/WebCore/dom/DOMStringList.cpp:
(WebCore::DOMStringList::sort):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::matchingAnimations):
* Source/WebCore/dom/MutationObserver.cpp:
(WebCore::MutationObserver::notifyMutationObservers):
* Source/WebCore/dom/RadioButtonGroups.cpp:
(WebCore::RadioButtonGroup::members const):
* Source/WebCore/html/HTMLDocument.cpp:
(WebCore::HTMLDocument::supportedPropertyNames const):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::selectBestMediaSession):
(WebCore::HTMLMediaElement::updateActiveTextTrackCues):
* Source/WebCore/html/LinkIconCollector.cpp:
(WebCore::LinkIconCollector::iconsOfTypes):
* Source/WebCore/html/RangeInputType.cpp:
(WebCore::RangeInputType::updateTickMarkValues):
* Source/WebCore/html/URLSearchParams.cpp:
(WebCore::URLSearchParams::sort):
* Source/WebCore/html/parser/HTMLSrcsetParser.cpp:
(WebCore::pickBestImageCandidate):
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
(WebCore::MediaControlTextTrackContainerElement::updateDisplay):
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp:
(WebCore::Layout::FlexFormattingContext::convertFlexItemsToLogicalSpace):
* Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp:
(WebCore::Layout::InlineContentConstrainer::prettifyRange):
* Source/WebCore/layout/formattingContexts/table/TableLayout.cpp:
(WebCore::Layout::distributeAvailableSpace):
* Source/WebCore/layout/integration/inline/InlineIteratorLogicalOrderTraversal.cpp:
(WebCore::InlineIterator::makeTextLogicalOrderCacheIfNeeded):
* Source/WebCore/loader/CrossOriginAccessControl.cpp:
(WebCore::createAccessControlPreflightRequest):
* Source/WebCore/loader/appcache/ApplicationCache.cpp:
(WebCore::ApplicationCache::setFallbackURLs):
* Source/WebCore/page/CaptionUserPreferences.cpp:
(WebCore::CaptionUserPreferences::sortedTrackListForMenu):
* Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp:
(WebCore::CaptionUserPreferencesMediaAF::sortedTrackListForMenu):
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::selectorsForTarget):
(WebCore::ElementTargetingController::numberOfVisibilityAdjustmentRects):
* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::IntersectionObserver):
* Source/WebCore/page/Page.cpp:
(WebCore::replaceRanges):
* Source/WebCore/page/PageColorSampler.cpp:
(WebCore::PageColorSampler::predominantColor):
* Source/WebCore/page/Performance.cpp:
(WebCore::Performance::getEntries const):
(WebCore::Performance::getEntriesByType const):
(WebCore::Performance::getEntriesByName const):
* Source/WebCore/page/PerformanceObserverEntryList.cpp:
(WebCore::PerformanceObserverEntryList::PerformanceObserverEntryList):
* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp:
(WebCore::updateSnapOffsetsForScrollableArea):
* Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp:
(WebCore::ScrollingStateFrameScrollingNode::dumpProperties const):
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractRenderedText):
* Source/WebCore/platform/MIMETypeRegistry.cpp:
(WebCore::makeFixedVector):
* Source/WebCore/platform/ScrollSnapAnimatorState.cpp:
(WebCore::ScrollSnapAnimatorState::preserveCurrentTargetForAxis):
(WebCore::chooseBoxToResnapTo):
* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::hasNoSession const):
* Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp:
(WebCore::containsPersistentLicenseType):
* Source/WebCore/platform/graphics/FloatSegment.h:
(WebCore::differenceWithDilation):
* Source/WebCore/platform/graphics/GradientColorStops.h:
(WebCore::GradientColorStops::sort):
(WebCore::GradientColorStops::validateIsSorted const):
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::hasAudio const):
(WebCore::MediaSourcePrivate::hasVideo const):
* Source/WebCore/platform/graphics/PathUtilities.cpp:
(WebCore::addIntersectionPoints):
(WebCore::polygonsForRect):
* Source/WebCore/platform/graphics/TrackBuffer.cpp:
(WebCore::TrackBuffer::updateMinimumUpcomingPresentationTime):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::hasSelectedVideo const):
* Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp:
(WebCore::SystemFontDatabaseCoreText::matchSystemFontUse):
* Source/WebCore/platform/ios/LegacyTileGrid.mm:
(WebCore::LegacyTileGrid::dropDistantTiles):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp:
(WebCore::RealtimeMediaSourceCenter::validateRequestConstraintsAfterEnumeration):
* Source/WebCore/platform/mediastream/VideoPreset.h:
(WebCore::VideoPreset::sortFrameRateRanges):
* Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.mm:
(WebCore::AVAudioSessionCaptureDeviceManager::setAudioCaptureDevices):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp:
(WebCore::hasDevice):
(WebCore::CoreAudioCaptureDeviceManager::refreshAudioCaptureDevices):
* Source/WebCore/platform/text/SuffixTree.h:
(WebCore::SuffixTree::Node::find):
* Source/WebCore/plugins/DOMPlugin.cpp:
(WebCore::makeMimeTypes):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::distributeItemIncurredIncreases):
* Source/WebCore/rendering/MarkedText.cpp:
(WebCore::MarkedText::subdivide):
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp:
(WebCore::FlexBoxIterator::next):
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::sortBorderValues):

Canonical link: <a href="https://commits.webkit.org/294387@main">https://commits.webkit.org/294387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bae4f02bfa97f3377b54d088d0647af9c2faac2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101650 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11633 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106808 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52284 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103690 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29818 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/77410 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34445 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91799 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57747 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16536 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9816 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51631 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94322 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86403 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9893 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109161 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100260 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28783 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/21196 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86386 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29144 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85951 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21872 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30706 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8417 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22946 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28711 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34000 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/123884 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28522 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34422 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31845 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30081 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->