### PR TITLE
-[WKWebView _hasActiveNowPlayingSession] can return a stale value in some cases

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -712,7 +712,7 @@ void AudioContext::defaultDestinationWillBecomeConnected()
 void AudioContext::isActiveNowPlayingSessionChanged()
 {
     if (RefPtr document = this->document()) {
-        if (RefPtr page = document->protectedPage())
+        if (RefPtr page = document->page())
             page->hasActiveNowPlayingSessionChanged();
     }
 }

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -9871,7 +9871,7 @@ bool HTMLMediaElement::isActiveNowPlayingSession() const
 
 void HTMLMediaElement::isActiveNowPlayingSessionChanged()
 {
-    if (RefPtr page = protectedDocument()->protectedPage())
+    if (RefPtr page = protectedDocument()->page())
         page->hasActiveNowPlayingSessionChanged();
 }
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1269,7 +1269,7 @@ public:
 
     bool hasActiveNowPlayingSession() const { return m_hasActiveNowPlayingSession; }
     void hasActiveNowPlayingSessionChanged();
-    void activeNowPlayingSessionUpdateTimerFired();
+    void updateActiveNowPlayingSessionNow();
 
 #if PLATFORM(IOS_FAMILY)
     bool canShowWhileLocked() const { return m_canShowWhileLocked; }

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -286,6 +286,7 @@ void MediaSessionManagerCocoa::addSession(PlatformMediaSessionInterface& session
 void MediaSessionManagerCocoa::removeSession(PlatformMediaSessionInterface& session)
 {
     PlatformMediaSessionManager::removeSession(session);
+    session.setActiveNowPlayingSession(false);
 
     if (hasNoSession()) {
         m_nowPlayingManager->removeClient(*this);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7510,11 +7510,6 @@ void WebPageProxy::didChangeMainDocument(IPC::Connection& connection, FrameIdent
     m_isQuotaIncreaseDenied = false;
 
     m_speechRecognitionPermissionManager = nullptr;
-
-    if (frame && frame->isMainFrame()) {
-        if (RefPtr pageClient = this->pageClient())
-            pageClient->hasActiveNowPlayingSessionChanged(false);
-    }
 }
 
 void WebPageProxy::viewIsBecomingVisible()

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -634,6 +634,7 @@
 		9BBCA4DF265ACA5B00DFE723 /* CheckedPtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9BBCA4DE265ACA5B00DFE723 /* CheckedPtr.cpp */; };
 		9BD5111C1FE8E11600D2B630 /* AccessingPastedImage.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9BD5111B1FE8E11600D2B630 /* AccessingPastedImage.mm */; };
 		9BF00133267C4C5900DCFB3F /* CheckedRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9BF00132267C4C5900DCFB3F /* CheckedRef.cpp */; };
+		A109BF442DC2F9E2002967DB /* now-playing-session-test.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A109BF3C2DC2F9D3002967DB /* now-playing-session-test.html */; };
 		A1146A8D1D2D7115000FE710 /* ContentFiltering.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1146A8A1D2D704F000FE710 /* ContentFiltering.mm */; };
 		A11E7DA324A17D2500026745 /* ElementActionTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A11E7DA224A17C7D00026745 /* ElementActionTests.mm */; };
 		A12DDC021E837C2400CF6CAE /* RenderedImageWithOptionsPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = A12DDBFC1E836FF100CF6CAE /* RenderedImageWithOptionsPlugIn.mm */; };
@@ -1980,6 +1981,7 @@
 				A17C46D92C98E54B0023F3C7 /* no-autoplay-with-controls.html in Copy Resources */,
 				33B767682CC066E400E4314F /* notEncrypted.pdf in Copy Resources */,
 				A17C47DA2C98E5C20023F3C7 /* notify-resourceLoadObserver.html in Copy Resources */,
+				A109BF442DC2F9E2002967DB /* now-playing-session-test.html in Copy Resources */,
 				A17C47DB2C98E5C20023F3C7 /* now-playing.html in Copy Resources */,
 				A17C47DC2C98E5C20023F3C7 /* offscreen-iframe-of-media-document.html in Copy Resources */,
 				A17C47DD2C98E5C20023F3C7 /* offscreen-image.html in Copy Resources */,
@@ -3350,6 +3352,7 @@
 		9BDD95561F83683600D20C60 /* PasteRTFD.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PasteRTFD.mm; sourceTree = "<group>"; };
 		9BF00132267C4C5900DCFB3F /* CheckedRef.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CheckedRef.cpp; sourceTree = "<group>"; };
 		9BF356CC202D44F200F71160 /* mso-list.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "mso-list.html"; sourceTree = "<group>"; };
+		A109BF3C2DC2F9D3002967DB /* now-playing-session-test.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "now-playing-session-test.html"; sourceTree = "<group>"; };
 		A10F047C1E3AD29C00C95E19 /* NSFileManagerExtras.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NSFileManagerExtras.mm; sourceTree = "<group>"; };
 		A1146A8A1D2D704F000FE710 /* ContentFiltering.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ContentFiltering.mm; sourceTree = "<group>"; };
 		A1183D402C6C8F8600233D8B /* fullscreen-lifecycle-audio.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "fullscreen-lifecycle-audio.html"; sourceTree = "<group>"; };
@@ -5439,6 +5442,7 @@
 				F455DB8C2BAE37C100732E1B /* nested-frames.html */,
 				2E4838462169DD42002F4531 /* nested-lists.html */,
 				466C3842210637CE006A88DE /* notify-resourceLoadObserver.html */,
+				A109BF3C2DC2F9D3002967DB /* now-playing-session-test.html */,
 				CDB5DFFE21360ED800D3E189 /* now-playing.html */,
 				93E2D2751ED7D51700FA76F6 /* offscreen-iframe-of-media-document.html */,
 				F460BEE727A1F2D6007B87D9 /* offscreen-image.html */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlayingSession.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlayingSession.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,124 +32,210 @@
 #import <WebKit/WebKit.h>
 
 static NSString * const nowPlayingSessionKeyPath = @"_hasActiveNowPlayingSession";
-static bool hasActiveNowPlayingSessionChanged;
 
 @interface NowPlayingSessionObserver : NSObject
+- (void)waitForHasActiveNowPlayingSessionChanged;
 @end
 
-@implementation NowPlayingSessionObserver
+@implementation NowPlayingSessionObserver {
+    bool _hasActiveNowPlayingSessionChanged;
+}
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSString *, id> *)change context:(void *)context
 {
     ASSERT([keyPath isEqualToString:nowPlayingSessionKeyPath]);
     ASSERT([object isKindOfClass:WKWebView.class]);
-    hasActiveNowPlayingSessionChanged = true;
+    _hasActiveNowPlayingSessionChanged = true;
+}
+
+- (void)waitForHasActiveNowPlayingSessionChanged
+{
+    _hasActiveNowPlayingSessionChanged = false;
+    TestWebKitAPI::Util::run(&_hasActiveNowPlayingSessionChanged);
+}
+
+static RetainPtr<TestWKWebView> createWebView()
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
+#if PLATFORM(IOS_FAMILY)
+    [configuration setAllowsInlineMediaPlayback:YES];
+#endif
+    return adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
 }
 
 TEST(NowPlayingSession, NoSession)
 {
-    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320)]);
-    ASSERT_FALSE([webView _hasActiveNowPlayingSession]);
+    RetainPtr webView = createWebView();
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
 }
 
 TEST(NowPlayingSession, HasSession)
 {
-    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
-    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
-    ASSERT_FALSE([webView _hasActiveNowPlayingSession]);
+    RetainPtr webView = createWebView();
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
 
     RetainPtr observer = adoptNS([[NowPlayingSessionObserver alloc] init]);
     [webView addObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath options:NSKeyValueObservingOptionNew context:nil];
 
-    [webView loadTestPageNamed:@"large-video-test-now-playing"];
-    [webView waitForMessage:@"playing"];
+    [webView synchronouslyLoadTestPageNamed:@"now-playing-session-test"];
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
 
-    if (!hasActiveNowPlayingSessionChanged)
-        TestWebKitAPI::Util::run(&hasActiveNowPlayingSessionChanged);
-
-    ASSERT_TRUE([webView _hasActiveNowPlayingSession]);
+    [webView evaluateJavaScript:@"playInMainFrame()" completionHandler:nil];
+    [observer waitForHasActiveNowPlayingSessionChanged];
+    EXPECT_TRUE([webView _hasActiveNowPlayingSession]);
 
     [webView removeObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath];
 }
 
 TEST(NowPlayingSession, NavigateAfterHasSession)
 {
-    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
-    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
-    ASSERT_FALSE([webView _hasActiveNowPlayingSession]);
+    RetainPtr webView = createWebView();
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
 
     RetainPtr observer = adoptNS([[NowPlayingSessionObserver alloc] init]);
     [webView addObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath options:NSKeyValueObservingOptionNew context:nil];
 
-    [webView loadTestPageNamed:@"large-video-test-now-playing"];
-    [webView waitForMessage:@"playing"];
+    [webView synchronouslyLoadTestPageNamed:@"now-playing-session-test"];
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
 
-    if (!hasActiveNowPlayingSessionChanged)
-        TestWebKitAPI::Util::run(&hasActiveNowPlayingSessionChanged);
+    [webView evaluateJavaScript:@"playInMainFrame()" completionHandler:nil];
+    [observer waitForHasActiveNowPlayingSessionChanged];
+    EXPECT_TRUE([webView _hasActiveNowPlayingSession]);
 
-    ASSERT_TRUE([webView _hasActiveNowPlayingSession]);
+    [webView synchronouslyLoadTestPageNamed:@"simple"];
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
 
-    hasActiveNowPlayingSessionChanged = false;
-    [webView loadTestPageNamed:@"simple"];
+    [webView removeObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath];
+}
 
-    if (!hasActiveNowPlayingSessionChanged)
-        TestWebKitAPI::Util::run(&hasActiveNowPlayingSessionChanged);
+TEST(NowPlayingSession, RemoveVideoElementAfterHasSession)
+{
+    RetainPtr webView = createWebView();
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
 
-    ASSERT_FALSE([webView _hasActiveNowPlayingSession]);
+    RetainPtr observer = adoptNS([[NowPlayingSessionObserver alloc] init]);
+    [webView addObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath options:NSKeyValueObservingOptionNew context:nil];
+
+    [webView synchronouslyLoadTestPageNamed:@"now-playing-session-test"];
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
+
+    [webView evaluateJavaScript:@"playInMainFrame()" completionHandler:nil];
+    [observer waitForHasActiveNowPlayingSessionChanged];
+    EXPECT_TRUE([webView _hasActiveNowPlayingSession]);
+
+    [webView evaluateJavaScript:@"document.querySelector('video').remove()" completionHandler:nil];
+    [observer waitForHasActiveNowPlayingSessionChanged];
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
+
+    [webView removeObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath];
+}
+
+TEST(NowPlayingSession, NavigateAfterHasSessionAndPlayAgain)
+{
+    RetainPtr webView = createWebView();
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
+
+    RetainPtr observer = adoptNS([[NowPlayingSessionObserver alloc] init]);
+    [webView addObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath options:NSKeyValueObservingOptionNew context:nil];
+
+    [webView synchronouslyLoadTestPageNamed:@"now-playing-session-test"];
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
+
+    [webView evaluateJavaScript:@"playInMainFrame()" completionHandler:nil];
+    [observer waitForHasActiveNowPlayingSessionChanged];
+    EXPECT_TRUE([webView _hasActiveNowPlayingSession]);
+
+    [webView synchronouslyLoadTestPageNamed:@"now-playing-session-test"];
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
+
+    [webView evaluateJavaScript:@"playInMainFrame()" completionHandler:nil];
+    [observer waitForHasActiveNowPlayingSessionChanged];
+    EXPECT_TRUE([webView _hasActiveNowPlayingSession]);
 
     [webView removeObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath];
 }
 
 TEST(NowPlayingSession, NavigateToFragmentAfterHasSession)
 {
-    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
-    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
-    ASSERT_FALSE([webView _hasActiveNowPlayingSession]);
+    RetainPtr webView = createWebView();
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
 
     RetainPtr observer = adoptNS([[NowPlayingSessionObserver alloc] init]);
     [webView addObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath options:NSKeyValueObservingOptionNew context:nil];
 
-    [webView loadTestPageNamed:@"large-video-test-now-playing"];
-    [webView waitForMessage:@"playing"];
+    [webView synchronouslyLoadTestPageNamed:@"now-playing-session-test"];
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
 
-    if (!hasActiveNowPlayingSessionChanged)
-        TestWebKitAPI::Util::run(&hasActiveNowPlayingSessionChanged);
-
-    ASSERT_TRUE([webView _hasActiveNowPlayingSession]);
+    [webView evaluateJavaScript:@"playInMainFrame()" completionHandler:nil];
+    [observer waitForHasActiveNowPlayingSessionChanged];
+    EXPECT_TRUE([webView _hasActiveNowPlayingSession]);
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"#a" relativeToURL:[webView URL]]]];
     [webView _test_waitForDidSameDocumentNavigation];
-
-    ASSERT_TRUE([webView _hasActiveNowPlayingSession]);
+    EXPECT_TRUE([webView _hasActiveNowPlayingSession]);
 
     [webView removeObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath];
 }
 
-TEST(NowPlayingSession, LoadSubframeAfterHasSession)
+TEST(NowPlayingSession, HasSessionInSubframe)
 {
-    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
-    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
-    ASSERT_FALSE([webView _hasActiveNowPlayingSession]);
+    RetainPtr webView = createWebView();
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
 
     RetainPtr observer = adoptNS([[NowPlayingSessionObserver alloc] init]);
     [webView addObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath options:NSKeyValueObservingOptionNew context:nil];
 
-    [webView loadTestPageNamed:@"large-video-test-now-playing"];
-    [webView waitForMessage:@"playing"];
+    [webView synchronouslyLoadTestPageNamed:@"now-playing-session-test"];
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
 
-    if (!hasActiveNowPlayingSessionChanged)
-        TestWebKitAPI::Util::run(&hasActiveNowPlayingSessionChanged);
+    [webView evaluateJavaScript:@"playInSubframe()" completionHandler:nil];
+    [observer waitForHasActiveNowPlayingSessionChanged];
+    EXPECT_TRUE([webView _hasActiveNowPlayingSession]);
 
-    ASSERT_TRUE([webView _hasActiveNowPlayingSession]);
+    [webView removeObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath];
+}
 
-    [webView evaluateJavaScript:@"loadSubframe()" completionHandler:nil];
-    [webView waitForMessage:@"subframeLoaded"];
+TEST(NowPlayingSession, RemoveSubframeAfterHasSessionInSubframe)
+{
+    RetainPtr webView = createWebView();
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
 
-    ASSERT_TRUE([webView _hasActiveNowPlayingSession]);
+    RetainPtr observer = adoptNS([[NowPlayingSessionObserver alloc] init]);
+    [webView addObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath options:NSKeyValueObservingOptionNew context:nil];
+
+    [webView synchronouslyLoadTestPageNamed:@"now-playing-session-test"];
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
+
+    [webView evaluateJavaScript:@"playInSubframe()" completionHandler:nil];
+    [observer waitForHasActiveNowPlayingSessionChanged];
+    EXPECT_TRUE([webView _hasActiveNowPlayingSession]);
+
+    [webView evaluateJavaScript:@"document.querySelector('iframe').remove()" completionHandler:nil];
+    [observer waitForHasActiveNowPlayingSessionChanged];
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
+
+    [webView removeObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath];
+}
+
+TEST(NowPlayingSession, NavigateSubframeAfterHasSessionInSubframe)
+{
+    RetainPtr webView = createWebView();
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
+
+    RetainPtr observer = adoptNS([[NowPlayingSessionObserver alloc] init]);
+    [webView addObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath options:NSKeyValueObservingOptionNew context:nil];
+
+    [webView synchronouslyLoadTestPageNamed:@"now-playing-session-test"];
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
+
+    [webView evaluateJavaScript:@"playInSubframe()" completionHandler:nil];
+    [observer waitForHasActiveNowPlayingSessionChanged];
+    EXPECT_TRUE([webView _hasActiveNowPlayingSession]);
+
+    [webView evaluateJavaScript:@"document.querySelector('iframe').srcdoc = ''" completionHandler:nil];
+    [observer waitForHasActiveNowPlayingSessionChanged];
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
 
     [webView removeObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/now-playing-session-test.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/now-playing-session-test.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <script>
+        videoElementString = "<video autoplay loop playsinline width=480 height=320 src=large-video-with-audio.mp4>";
+
+        function playInMainFrame()
+        {
+            document.body.innerHTML = videoElementString;
+        }
+
+        function playInSubframe()
+        {
+            const iframe = document.createElement("iframe");
+            iframe.width = 480;
+            iframe.height = 320;
+            iframe.srcdoc = "<!DOCTYPE html>" + videoElementString;
+            document.body.appendChild(iframe);
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
#### 6ed528fbe80dcb4fa494d45510338ff387b14ed7
<pre>
-[WKWebView _hasActiveNowPlayingSession] can return a stale value in some cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=292360">https://bugs.webkit.org/show_bug.cgi?id=292360</a>
<a href="https://rdar.apple.com/150395491">rdar://150395491</a>

Reviewed by Jean-Yves Avenard.

When a PlatformMediaSession is removed from MediaSessionManagerCocoa,
MediaSessionManagerCocoa::scheduleSessionStatusUpdate() enqueues a task to update Now Playing info.
When updateNowPlayingInfo() identifies a new Now Playing session (or finds no Now Playing session),
it iterates over all PlatformMediaSessions and updates m_isActiveNowPlayingSession on each. If any
PlatformMediaSession::m_isActiveNowPlayingSession changes, PlatformMediaSession notifies its client
which should ultimately cause Page to recompute whether it has an active Now Playing session (via
Page::hasActiveNowPlayingSessionChanged()).

However, two problems could prevent this recomputation from occurring:
1. If the current Now Playing PlatformMediaSession is removed from MediaSessionManagerCocoa and no
   other Now Playing-eligible session exists, when MediaSessionManagerCocoa::updateNowPlayingInfo()
   iterates over all sessions it finds no session to update, preventing
   Page::hasActiveNowPlayingSessionChanged() from being called.
2. Even if a PlatformMediaSession is updated and it notifies its client, its client (e.g.,
   HTMLMediaElement) may be unable to call Page::hasActiveNowPlayingSessionChanged() because it has
   been disconnected from its frame.

Resolved (1) by calling PlatformMediaSession::setActiveNowPlayingSession(false) as soon as the
session is removed from MediaSessionManagerCocoa rather than waiting for updateNowPlayingInfo() to
be called. Resolved (2) by calling Page::updateActiveNowPlayingSessionNow() whenever the Page&apos;s
document changes. Something similar was previously done in WebPageProxy::didChangeMainDocument(),
but this was incorrect since it would lead to state becoming out-of-sync between a WebCore::Page
and its WebPageProxy.

Added new API tests.

* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::isActiveNowPlayingSessionChanged):
  Drive-by fix: fixed an incorrect use of protectedPage().

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::isActiveNowPlayingSessionChanged):
  Ditto.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::didChangeMainDocument):
  Called updateActiveNowPlayingSessionNow().
(WebCore::Page::updateActiveNowPlayingSessionNow):
  Renamed from activeNowPlayingSessionUpdateTimerFired().
(WebCore::Page::activeNowPlayingSessionUpdateTimerFired):
  Deleted.
* Source/WebCore/page/Page.h:

* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::removeSession):
  Called PlatformMediaSession::setActiveNowPlayingSession(false).

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didChangeMainDocument):
  Removed call to PageClient::hasActiveNowPlayingSessionChanged().

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlayingSession.mm:
(-[NowPlayingSessionObserver observeValueForKeyPath:ofObject:change:context:]):
(-[NowPlayingSessionObserver waitForHasActiveNowPlayingSessionChanged]):
(TEST(NowPlayingSession, NoSession)):
(TEST(NowPlayingSession, HasSession)):
(TEST(NowPlayingSession, NavigateAfterHasSession)):
(TEST(NowPlayingSession, RemoveVideoElementAfterHasSession)):
(TEST(NowPlayingSession, NavigateAfterHasSessionAndPlayAgain)):
(TEST(NowPlayingSession, NavigateToFragmentAfterHasSession)):
(TEST(NowPlayingSession, HasSessionInSubframe)):
(TEST(NowPlayingSession, RemoveSubframeAfterHasSessionInSubframe)):
(TEST(NowPlayingSession, NavigateSubframeAfterHasSessionInSubframe)):
(TEST(NowPlayingSession, LoadSubframeAfterHasSession)): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/now-playing-session-test.html: Added.
  Added new tests. Created a simplified test .html file and refactored existing tests.

Canonical link: <a href="https://commits.webkit.org/294437@main">https://commits.webkit.org/294437@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c7fddb0a43c7898c2ba59b6a76c0954ccf8af4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106917 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52393 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103799 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29930 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77478 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34505 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104766 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91894 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57816 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16618 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9912 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51744 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86475 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109273 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28892 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21275 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86458 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29253 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88095 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86028 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21906 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30784 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8505 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23055 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28820 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34110 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28631 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31954 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30190 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->