### PR TITLE
Fix clang modules issues in WebPushDaemonConstants.h

### DIFF
--- a/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
@@ -35,6 +35,7 @@
 #import "PushClientConnectionMessages.h"
 #import "WebPushDaemonConstants.h"
 #import <wtf/darwin/XPCExtras.h>
+#import <wtf/text/ASCIILiteral.h>
 
 namespace WebKit::WebPushD { 
 
@@ -72,7 +73,7 @@ bool Connection::performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<IP
         if (xpc_dictionary_get_uint64(reply, WebPushD::protocolVersionKey) != WebPushD::protocolVersionValue)
             return completionHandler(nullptr);
 
-        auto data = xpcDictionaryGetData(reply, WebPushD::protocolEncodedMessageKey);
+        auto data = xpcDictionaryGetData(reply, ASCIILiteral::fromLiteralUnsafe(WebPushD::protocolEncodedMessageKey));
         auto decoder = IPC::Decoder::create(data, { });
 
         completionHandler(decoder.get());

--- a/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h
+++ b/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h
@@ -36,6 +36,7 @@
 #include <WebCore/PushSubscriptionData.h>
 #include <wtf/Expected.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/text/ASCIILiteral.h>
 
 namespace IPC {
 class Connection;
@@ -60,9 +61,9 @@ namespace WebPushD {
 
 struct ConnectionTraits {
     using MessageType = WebPushD::MessageType;
-    static constexpr auto protocolVersionKey { WebPushD::protocolVersionKey };
+    static constexpr auto protocolVersionKey = ASCIILiteral::fromLiteralUnsafe(WebPushD::protocolVersionKey);
     static constexpr uint64_t protocolVersionValue { WebPushD::protocolVersionValue };
-    static constexpr auto protocolEncodedMessageKey { WebPushD::protocolEncodedMessageKey };
+    static constexpr auto protocolEncodedMessageKey = ASCIILiteral::fromLiteralUnsafe(WebPushD::protocolEncodedMessageKey);
 };
 
 class Connection final : public Daemon::ConnectionToMachService<ConnectionTraits>, public IPC::MessageSender {

--- a/Source/WebKit/Shared/WebPushDaemonConstants.h
+++ b/Source/WebKit/Shared/WebPushDaemonConstants.h
@@ -27,21 +27,18 @@
 
 #ifdef __cplusplus
 
-#include <wtf/Seconds.h>
-#include <wtf/text/ASCIILiteral.h>
-
 namespace WebKit::WebPushD {
 
 // If an origin processes more than this many silent pushes, then it will be unsubscribed from push.
 constexpr unsigned maxSilentPushCount = 3;
 
 // getPendingPushMessage starts a timer with this time interval after returning a push message to the client. If the timer expires, then we increment the subscription's silent push count.
-static constexpr Seconds silentPushTimeoutForProduction { 30_s };
-static constexpr Seconds silentPushTimeoutForTesting { 1_s };
+constexpr double silentPushTimeoutForProductionSeconds = 30;
+constexpr double silentPushTimeoutForTestingSeconds = 1;
 
-constexpr auto protocolVersionKey = "protocol version"_s;
+constexpr auto protocolVersionKey = "protocol version";
 constexpr uint64_t protocolVersionValue = 5;
-constexpr auto protocolEncodedMessageKey = "encoded message"_s;
+constexpr auto protocolEncodedMessageKey = "encoded message";
 
 // FIXME: ConnectionToMachService traits requires we have a message type, so keep this placeholder here
 // until we can remove that requirement.

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -57,6 +57,7 @@
 #import <wtf/WorkQueue.h>
 #import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/darwin/XPCExtras.h>
+#import <wtf/text/ASCIILiteral.h>
 #import <wtf/text/MakeString.h>
 
 #if HAVE(MOBILE_KEY_BAG)
@@ -306,7 +307,7 @@ void WebPushDaemon::connectionEventHandler(xpc_object_t request)
         return;
     }
 
-    auto data = xpcDictionaryGetData(request, protocolEncodedMessageKey);
+    auto data = xpcDictionaryGetData(request, ASCIILiteral::fromLiteralUnsafe(protocolEncodedMessageKey));
     if (!data.data()) {
         RELEASE_LOG_ERROR(Push, "WebPushDaemon::connectionEventHandler - No encoded message data in xpc message");
         tryCloseRequestConnection(request);
@@ -676,7 +677,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 Seconds WebPushDaemon::silentPushTimeout() const
 {
-    return m_usingMockPushService ? silentPushTimeoutForTesting : silentPushTimeoutForProduction;
+    return Seconds { m_usingMockPushService ? silentPushTimeoutForTestingSeconds : silentPushTimeoutForProductionSeconds };
 }
 
 // This only needs to be called if the first entry in m_potentialSilentPushes was changed or removed.

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
@@ -41,6 +41,7 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/TZoneMallocInlines.h>
+#import <wtf/text/ASCIILiteral.h>
 
 namespace WebPushTool {
 
@@ -180,7 +181,7 @@ bool Connection::performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<IP
             return completionHandler(nullptr);
         }
 
-        auto data = xpcDictionaryGetData(reply, WebKit::WebPushD::protocolEncodedMessageKey);
+        auto data = xpcDictionaryGetData(reply, ASCIILiteral::fromLiteralUnsafe(WebKit::WebPushD::protocolEncodedMessageKey));
         auto decoder = IPC::Decoder::create(data, { });
         ASSERT(decoder);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -62,6 +62,7 @@
 #import <wtf/UniqueRef.h>
 #import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/darwin/XPCExtras.h>
+#import <wtf/text/ASCIILiteral.h>
 #import <wtf/text/Base64.h>
 #import <wtf/text/MakeString.h>
 
@@ -480,7 +481,7 @@ void WebPushXPCConnectionMessageSender::sendWithAsyncReplyWithoutUsingIPCConnect
         if (xpc_dictionary_get_uint64(reply, WebKit::WebPushD::protocolVersionKey) != WebKit::WebPushD::protocolVersionValue)
             RELEASE_ASSERT_NOT_REACHED();
 
-        auto data = xpcDictionaryGetData(reply, WebKit::WebPushD::protocolEncodedMessageKey);
+        auto data = xpcDictionaryGetData(reply, ASCIILiteral::fromLiteralUnsafe(WebKit::WebPushD::protocolEncodedMessageKey));
         TestDecoder decoder(data);
         decoder.ignoreHeader<M>();
         IPC::callReplyWithoutUsingConnection<M>(decoder, WTFMove(completionHandler));
@@ -1974,7 +1975,7 @@ TEST_F(WebPushDBuiltInTest, ImplicitSilentPushTimerCancelledOnShowingNotificatio
             ASSERT_TRUE(v->expectDecryptedMessage(@"null data", message.get()));
         }
 
-        [NSThread sleepForTimeInterval:(WebKit::WebPushD::silentPushTimeoutForTesting.seconds() + 0.5)];
+        [NSThread sleepForTimeInterval:(WebKit::WebPushD::silentPushTimeoutForTestingSeconds + 0.5)];
         ASSERT_TRUE(v->hasPushSubscription());
     }
 }
@@ -2011,7 +2012,7 @@ TEST_F(WebPushDBuiltInTest, ImplicitSilentPushTimerIgnoredForInspectedContexts)
         }
 
         // Should still be subscribed since we don't enforce the silent push timer while being inspected.
-        [NSThread sleepForTimeInterval:(WebKit::WebPushD::silentPushTimeoutForTesting.seconds() + 0.5)];
+        [NSThread sleepForTimeInterval:(WebKit::WebPushD::silentPushTimeoutForTestingSeconds + 0.5)];
         ASSERT_TRUE(v->hasPushSubscription());
     }
 }
@@ -3108,7 +3109,7 @@ TEST_F(WebPushDPushNotificationEventTest, Basic)
 
     // After the slew of above messages that were handled by service workers, silent push tracking should *not* have
     // kicked in, and therefore there should still be a push subscription.
-    [NSThread sleepForTimeInterval:(WebKit::WebPushD::silentPushTimeoutForTesting.seconds() + 0.5)];
+    [NSThread sleepForTimeInterval:(WebKit::WebPushD::silentPushTimeoutForTestingSeconds + 0.5)];
     EXPECT_TRUE(webViews().first()->hasPushSubscription());
 }
 


### PR DESCRIPTION
#### eece856ed103b9fd94b913721c76cce896e3be5b
<pre>
Fix clang modules issues in WebPushDaemonConstants.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=292364">https://bugs.webkit.org/show_bug.cgi?id=292364</a>
<a href="https://rdar.apple.com/150432989">rdar://150432989</a>

Reviewed by NOBODY (OOPS!).

This change removes dependencies on wtf headers from the exported
WebPushDaemonConstants.h header.

* Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm:
(WebKit::WebPushD::Connection::performSendWithAsyncReplyWithoutUsingIPCConnection const):
* Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h:
* Source/WebKit/Shared/WebPushDaemonConstants.h:
(): Deleted.
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::connectionEventHandler):
(WebPushD::WebPushDaemon::silentPushTimeout const):
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm:
(WebPushTool::Connection::performSendWithAsyncReplyWithoutUsingIPCConnection const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::WebPushXPCConnectionMessageSender::sendWithAsyncReplyWithoutUsingIPCConnection const):
(TestWebKitAPI::(WebPushDBuiltInTest, ImplicitSilentPushTimerCancelledOnShowingNotification)):
(TestWebKitAPI::(WebPushDBuiltInTest, ImplicitSilentPushTimerIgnoredForInspectedContexts)):
(TestWebKitAPI::(WebPushDPushNotificationEventTest, Basic)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eece856ed103b9fd94b913721c76cce896e3be5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101619 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106777 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52253 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103659 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29785 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77389 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34422 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104626 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16682 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91771 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57726 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16508 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9788 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51600 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86375 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9865 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109130 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28752 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21165 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86362 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29113 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87972 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85925 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30674 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8389 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/22904 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28680 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33969 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28491 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31814 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30050 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->