### PR TITLE
Remove a dependency on wtf from WebKit exported headers

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristic.cpp
+++ b/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristic.cpp
@@ -75,15 +75,15 @@ double FullscreenTouchSecheuristic::distanceScore(const CGPoint& nextLocation, c
         m_parameters.yWeight * pow(m_size.height, 2));
     double scaledDistance = distance / sizeFactor;
     if (scaledDistance <= m_parameters.gammaCutoff)
-        return scaledDistance * (m_parameters.rampUpSpeed / deltaTime);
+        return scaledDistance * (Seconds { m_parameters.rampUpSpeedSeconds } / deltaTime);
 
     double exponentialDistance = m_parameters.gammaCutoff + pow((scaledDistance - m_parameters.gammaCutoff) / (1 - m_parameters.gammaCutoff), m_parameters.gamma);
-    return exponentialDistance * (m_parameters.rampUpSpeed / deltaTime);
+    return exponentialDistance * (Seconds { m_parameters.rampUpSpeedSeconds } / deltaTime);
 }
 
 double FullscreenTouchSecheuristic::attenuationFactor(Seconds delta)
 {
-    double normalizedTimeDelta = delta / m_parameters.rampDownSpeed;
+    double normalizedTimeDelta = delta / Seconds { m_parameters.rampDownSpeedSeconds };
     return std::max(std::min(normalizedTimeDelta * m_weight, 1.0), 0.0);
 }
 

--- a/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristic.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristic.h
@@ -28,6 +28,7 @@
 #ifdef __cplusplus
 
 #include <WebKit/FullscreenTouchSecheuristicParameters.h>
+#include <wtf/Seconds.h>
 
 namespace WebKit {
 
@@ -40,8 +41,8 @@ public:
     void setParameters(const FullscreenTouchSecheuristicParameters& parameters) { m_parameters = parameters; }
     double requiredScore() const { return m_parameters.requiredScore; }
 
-    void setRampUpSpeed(Seconds speed) { m_parameters.rampUpSpeed = speed; }
-    void setRampDownSpeed(Seconds speed) { m_parameters.rampDownSpeed = speed; }
+    void setRampUpSpeed(Seconds speed) { m_parameters.rampUpSpeedSeconds = speed.seconds(); }
+    void setRampDownSpeed(Seconds speed) { m_parameters.rampDownSpeedSeconds = speed.seconds(); }
     void setXWeight(double weight) { m_parameters.xWeight = weight; }
     void setYWeight(double weight) { m_parameters.yWeight = weight; }
     void setSize(CGSize size) { m_size = size; }

--- a/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristicParameters.cpp
+++ b/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristicParameters.cpp
@@ -31,8 +31,8 @@ namespace WebKit {
 FullscreenTouchSecheuristicParameters FullscreenTouchSecheuristicParameters::iosParameters()
 {
     return {
-        .rampUpSpeed = 0.25_s,
-        .rampDownSpeed = 1_s,
+        .rampUpSpeedSeconds = 0.25,
+        .rampDownSpeedSeconds = 1,
         .xWeight = 0,
         .yWeight = 1,
         .gamma = 0.1,

--- a/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristicParameters.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristicParameters.h
@@ -28,13 +28,12 @@
 #ifdef __cplusplus
 
 #include <WebKit/WKDeclarationSpecifiers.h>
-#include <wtf/Seconds.h>
 
 namespace WebKit {
 
 struct FullscreenTouchSecheuristicParameters {
-    Seconds rampUpSpeed;
-    Seconds rampDownSpeed;
+    double rampUpSpeedSeconds;
+    double rampDownSpeedSeconds;
     double xWeight;
     double yWeight;
     double gamma;


### PR DESCRIPTION
#### 491eba59763fdc38b76e2440f9710694988f70b1
<pre>
Remove a dependency on wtf from WebKit exported headers
<a href="https://bugs.webkit.org/show_bug.cgi?id=292365">https://bugs.webkit.org/show_bug.cgi?id=292365</a>
<a href="https://rdar.apple.com/150433321">rdar://150433321</a>

Reviewed by NOBODY (OOPS!).

Removes dependencies on wtf headers from the exported header
FullscreenTouchSecheuristicParameters.h

* Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristic.cpp:
(WebKit::FullscreenTouchSecheuristic::distanceScore):
(WebKit::FullscreenTouchSecheuristic::attenuationFactor):
* Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristic.h:
(WebKit::FullscreenTouchSecheuristic::setRampUpSpeed):
(WebKit::FullscreenTouchSecheuristic::setRampDownSpeed):
* Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristicParameters.cpp:
(WebKit::FullscreenTouchSecheuristicParameters::iosParameters):
* Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristicParameters.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/491eba59763fdc38b76e2440f9710694988f70b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101620 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11602 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106778 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52254 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29786 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77390 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34418 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104627 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16679 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91768 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57727 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16505 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51601 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86372 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9862 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109131 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28753 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21164 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86363 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29114 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87969 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85926 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30678 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8386 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/22905 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28681 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33970 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28492 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31815 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30051 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->