### PR TITLE
Leverage std::numbers more for some of our constants

### DIFF
--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -72,6 +72,7 @@
 #include "OperationResult.h"
 #include "PureNaN.h"
 #include <cmath>
+#include <numbers>
 #include <regex>
 #include <string>
 #include <wtf/FastTLS.h>
@@ -341,10 +342,6 @@ typedef B3Operand<int8_t> Int8Operand;
 
 #define MAKE_OPERAND(value) B3Operand<decltype(value)> { #value, value }
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846264338327950288
-#endif
-
 template<typename FloatType>
 void populateWithInterestingValues(Vector<B3Operand<FloatType>>& operands)
 {
@@ -362,8 +359,8 @@ void populateWithInterestingValues(Vector<B3Operand<FloatType>>& operands)
     operands.append({ "-1.1", static_cast<FloatType>(-1.1) });
     operands.append({ "2.", static_cast<FloatType>(2.) });
     operands.append({ "-2.", static_cast<FloatType>(-2.) });
-    operands.append({ "M_PI", static_cast<FloatType>(M_PI) });
-    operands.append({ "-M_PI", static_cast<FloatType>(-M_PI) });
+    operands.append({ "M_PI", static_cast<FloatType>(std::numbers::pi) });
+    operands.append({ "-M_PI", static_cast<FloatType>(-std::numbers::pi) });
     operands.append({ "min", std::numeric_limits<FloatType>::min() });
     operands.append({ "max", std::numeric_limits<FloatType>::max() });
     operands.append({ "lowest", std::numeric_limits<FloatType>::lowest() });

--- a/Source/JavaScriptCore/b3/testb3_3.cpp
+++ b/Source/JavaScriptCore/b3/testb3_3.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "testb3.h"
 
+#include <numbers>
+
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #if ENABLE(B3_JIT)
@@ -2757,7 +2759,7 @@ void testDoubleToFloatThroughPhi(float value)
     UpsilonValue* thenValue = thenCase->appendNew<UpsilonValue>(proc, Origin(), thenAdd);
     thenCase->appendNewControlValue(proc, Jump, Origin(), FrequentedBlock(tail));
 
-    Value* elseConst = elseCase->appendNew<ConstDoubleValue>(proc, Origin(), M_PI);
+    Value* elseConst = elseCase->appendNew<ConstDoubleValue>(proc, Origin(), std::numbers::pi);
     UpsilonValue* elseValue = elseCase->appendNew<UpsilonValue>(proc, Origin(), elseConst);
     elseCase->appendNewControlValue(proc, Jump, Origin(), FrequentedBlock(tail));
 
@@ -2769,7 +2771,7 @@ void testDoubleToFloatThroughPhi(float value)
 
     auto code = compileProc(proc);
     CHECK(isIdentical(invoke<float>(*code, 1L, std::bit_cast<int32_t>(value)), value + 42.5f));
-    CHECK(isIdentical(invoke<float>(*code, 0L, std::bit_cast<int32_t>(value)), static_cast<float>(M_PI)));
+    CHECK(isIdentical(invoke<float>(*code, 0L, std::bit_cast<int32_t>(value)), std::numbers::pi_v<float>));
 }
 
 void testReduceFloatToDoubleValidates()
@@ -4057,26 +4059,26 @@ void addArgTests(const TestConfig* config, Deque<RefPtr<SharedTask<void()>>>& ta
     RUN(testAddLoadTwice());
     RUN_TERNARY(testAddMulMulArgs, int64Operands(), int64Operands(), int64Operands());
     
-    RUN(testAddArgDouble(M_PI));
-    RUN(testAddArgsDouble(M_PI, 1));
-    RUN(testAddArgsDouble(M_PI, -M_PI));
-    RUN(testAddArgImmDouble(M_PI, 1));
-    RUN(testAddArgImmDouble(M_PI, 0));
-    RUN(testAddArgImmDouble(M_PI, negativeZero()));
+    RUN(testAddArgDouble(std::numbers::pi));
+    RUN(testAddArgsDouble(std::numbers::pi, 1));
+    RUN(testAddArgsDouble(std::numbers::pi, -std::numbers::pi));
+    RUN(testAddArgImmDouble(std::numbers::pi, 1));
+    RUN(testAddArgImmDouble(std::numbers::pi, 0));
+    RUN(testAddArgImmDouble(std::numbers::pi, negativeZero()));
     RUN(testAddArgImmDouble(0, 0));
     RUN(testAddArgImmDouble(0, negativeZero()));
     RUN(testAddArgImmDouble(negativeZero(), 0));
     RUN(testAddArgImmDouble(negativeZero(), negativeZero()));
-    RUN(testAddImmArgDouble(M_PI, 1));
-    RUN(testAddImmArgDouble(M_PI, 0));
-    RUN(testAddImmArgDouble(M_PI, negativeZero()));
+    RUN(testAddImmArgDouble(std::numbers::pi, 1));
+    RUN(testAddImmArgDouble(std::numbers::pi, 0));
+    RUN(testAddImmArgDouble(std::numbers::pi, negativeZero()));
     RUN(testAddImmArgDouble(0, 0));
     RUN(testAddImmArgDouble(0, negativeZero()));
     RUN(testAddImmArgDouble(negativeZero(), 0));
     RUN(testAddImmArgDouble(negativeZero(), negativeZero()));
-    RUN(testAddImmsDouble(M_PI, 1));
-    RUN(testAddImmsDouble(M_PI, 0));
-    RUN(testAddImmsDouble(M_PI, negativeZero()));
+    RUN(testAddImmsDouble(std::numbers::pi, 1));
+    RUN(testAddImmsDouble(std::numbers::pi, 0));
+    RUN(testAddImmsDouble(std::numbers::pi, negativeZero()));
     RUN(testAddImmsDouble(0, 0));
     RUN(testAddImmsDouble(0, negativeZero()));
     RUN(testAddImmsDouble(negativeZero(), negativeZero()));
@@ -4179,26 +4181,26 @@ void addArgTests(const TestConfig* config, Deque<RefPtr<SharedTask<void()>>>& ta
     RUN_BINARY(testMulArgsFloatWithUselessDoubleConversion, floatingPointOperands<float>(), floatingPointOperands<float>());
     RUN_BINARY(testMulArgsFloatWithEffectfulDoubleConversion, floatingPointOperands<float>(), floatingPointOperands<float>());
     
-    RUN(testDivArgDouble(M_PI));
-    RUN(testDivArgsDouble(M_PI, 1));
-    RUN(testDivArgsDouble(M_PI, -M_PI));
-    RUN(testDivArgImmDouble(M_PI, 1));
-    RUN(testDivArgImmDouble(M_PI, 0));
-    RUN(testDivArgImmDouble(M_PI, negativeZero()));
+    RUN(testDivArgDouble(std::numbers::pi));
+    RUN(testDivArgsDouble(std::numbers::pi, 1));
+    RUN(testDivArgsDouble(std::numbers::pi, -std::numbers::pi));
+    RUN(testDivArgImmDouble(std::numbers::pi, 1));
+    RUN(testDivArgImmDouble(std::numbers::pi, 0));
+    RUN(testDivArgImmDouble(std::numbers::pi, negativeZero()));
     RUN(testDivArgImmDouble(0, 0));
     RUN(testDivArgImmDouble(0, negativeZero()));
     RUN(testDivArgImmDouble(negativeZero(), 0));
     RUN(testDivArgImmDouble(negativeZero(), negativeZero()));
-    RUN(testDivImmArgDouble(M_PI, 1));
-    RUN(testDivImmArgDouble(M_PI, 0));
-    RUN(testDivImmArgDouble(M_PI, negativeZero()));
+    RUN(testDivImmArgDouble(std::numbers::pi, 1));
+    RUN(testDivImmArgDouble(std::numbers::pi, 0));
+    RUN(testDivImmArgDouble(std::numbers::pi, negativeZero()));
     RUN(testDivImmArgDouble(0, 0));
     RUN(testDivImmArgDouble(0, negativeZero()));
     RUN(testDivImmArgDouble(negativeZero(), 0));
     RUN(testDivImmArgDouble(negativeZero(), negativeZero()));
-    RUN(testDivImmsDouble(M_PI, 1));
-    RUN(testDivImmsDouble(M_PI, 0));
-    RUN(testDivImmsDouble(M_PI, negativeZero()));
+    RUN(testDivImmsDouble(std::numbers::pi, 1));
+    RUN(testDivImmsDouble(std::numbers::pi, 0));
+    RUN(testDivImmsDouble(std::numbers::pi, negativeZero()));
     RUN(testDivImmsDouble(0, 0));
     RUN(testDivImmsDouble(0, negativeZero()));
     RUN(testDivImmsDouble(negativeZero(), negativeZero()));

--- a/Source/JavaScriptCore/b3/testb3_6.cpp
+++ b/Source/JavaScriptCore/b3/testb3_6.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "testb3.h"
 
+#include <numbers>
+
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #if ENABLE(B3_JIT)
@@ -281,7 +283,7 @@ void testSelectDoubleCompareFloat(float a, float b)
             arguments[2],
             arguments[3]));
 
-    CHECK(isIdentical(compileAndRun<double>(proc, std::bit_cast<int32_t>(a), std::bit_cast<int32_t>(b), 42.1, -M_PI), a < b ? 42.1 : -M_PI));
+    CHECK(isIdentical(compileAndRun<double>(proc, std::bit_cast<int32_t>(a), std::bit_cast<int32_t>(b), 42.1, -std::numbers::pi), a < b ? 42.1 : -std::numbers::pi));
 }
 
 void testSelectFloatCompareFloat(float a, float b)

--- a/Source/JavaScriptCore/runtime/MathObject.cpp
+++ b/Source/JavaScriptCore/runtime/MathObject.cpp
@@ -24,6 +24,7 @@
 #include "IteratorOperations.h"
 #include "JSCInlines.h"
 #include "MathCommon.h"
+#include <numbers>
 #include <wtf/Assertions.h>
 #include <wtf/MathExtras.h>
 #include <wtf/PreciseSum.h>
@@ -85,7 +86,7 @@ void MathObject::finishCreation(VM& vm, JSGlobalObject* globalObject)
     putDirectWithoutTransition(vm, Identifier::fromString(vm, "LN10"_s), jsNumber(Math::log(10.0)), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
     putDirectWithoutTransition(vm, Identifier::fromString(vm, "LOG2E"_s), jsNumber(1.0 / Math::log(2.0)), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
     putDirectWithoutTransition(vm, Identifier::fromString(vm, "LOG10E"_s), jsNumber(0.4342944819032518), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
-    putDirectWithoutTransition(vm, Identifier::fromString(vm, "PI"_s), jsNumber(piDouble), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
+    putDirectWithoutTransition(vm, Identifier::fromString(vm, "PI"_s), jsNumber(std::numbers::pi), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
     putDirectWithoutTransition(vm, Identifier::fromString(vm, "SQRT1_2"_s), jsNumber(sqrt(0.5)), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
     putDirectWithoutTransition(vm, Identifier::fromString(vm, "SQRT2"_s), jsNumber(sqrt(2.0)), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();

--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -30,6 +30,7 @@
 #include <cmath>
 #include <float.h>
 #include <limits>
+#include <numbers>
 #include <stdint.h>
 #include <stdlib.h>
 #include <wtf/StdLibExtras.h>
@@ -39,45 +40,11 @@
 #include <machine/ieee.h>
 #endif
 
-#ifndef M_PI
-constexpr double piDouble = 3.14159265358979323846;
-constexpr float piFloat = 3.14159265358979323846f;
-#else
-constexpr double piDouble = M_PI;
-constexpr float piFloat = static_cast<float>(M_PI);
-#endif
+constexpr double piOverTwoDouble = std::numbers::pi / 2;
+constexpr float piOverTwoFloat = static_cast<float>(piOverTwoDouble);
 
-#ifndef M_PI_2
-constexpr double piOverTwoDouble = 1.57079632679489661923;
-constexpr float piOverTwoFloat = 1.57079632679489661923f;
-#else
-constexpr double piOverTwoDouble = M_PI_2;
-constexpr float piOverTwoFloat = static_cast<float>(M_PI_2);
-#endif
-
-#ifndef M_PI_4
-constexpr double piOverFourDouble = 0.785398163397448309616;
-constexpr float piOverFourFloat = 0.785398163397448309616f;
-#else
-constexpr double piOverFourDouble = M_PI_4;
-constexpr float piOverFourFloat = static_cast<float>(M_PI_4);
-#endif
-
-#ifndef M_SQRT2
-constexpr double sqrtOfTwoDouble = 1.41421356237309504880;
-constexpr float sqrtOfTwoFloat = 1.41421356237309504880f;
-#else
-constexpr double sqrtOfTwoDouble = M_SQRT2;
-constexpr float sqrtOfTwoFloat = static_cast<float>(M_SQRT2);
-#endif
-
-#ifndef M_E
-constexpr double eDouble = 2.71828182845904523536028747135266250;
-constexpr float eFloat = 2.71828182845904523536028747135266250f;
-#else
-constexpr double eDouble = M_E;
-constexpr float eFloat = static_cast<float>(M_E);
-#endif
+constexpr double piOverFourDouble = std::numbers::pi / 4;
+constexpr float piOverFourFloat = static_cast<float>(piOverFourDouble);
 
 #if OS(WINDOWS)
 
@@ -108,13 +75,13 @@ extern "C" inline double wtf_atan2(double x, double y)
 
 #endif // OS(WINDOWS)
 
-constexpr double radiansPerDegreeDouble = piDouble / 180.0;
-constexpr double degreesPerRadianDouble = 180.0 / piDouble;
+constexpr double radiansPerDegreeDouble = std::numbers::pi / 180.0;
+constexpr double degreesPerRadianDouble = 180.0 / std::numbers::pi;
 constexpr double gradientsPerDegreeDouble = 400.0 / 360.0;
 constexpr double degreesPerGradientDouble = 360.0 / 400.0;
 constexpr double turnsPerDegreeDouble = 1.0 / 360.0;
 constexpr double degreesPerTurnDouble = 360.0;
-constexpr double radiansPerTurnDouble = 2.0f * piDouble;
+constexpr double radiansPerTurnDouble = 2.0 * std::numbers::pi;
 
 constexpr double deg2rad(double d)  { return d * radiansPerDegreeDouble; }
 constexpr double rad2deg(double r)  { return r * degreesPerRadianDouble; }
@@ -125,13 +92,13 @@ constexpr double turn2deg(double t) { return t * degreesPerTurnDouble; }
 
 
 // Note that these differ from the casting the double values above in their rounding errors.
-constexpr float radiansPerDegreeFloat = piFloat / 180.0f;
-constexpr float degreesPerRadianFloat = 180.0f / piFloat;
+constexpr float radiansPerDegreeFloat = std::numbers::pi_v<float> / 180.0f;
+constexpr float degreesPerRadianFloat = 180.0f / std::numbers::pi_v<float>;
 constexpr float gradientsPerDegreeFloat= 400.0f / 360.0f;
 constexpr float degreesPerGradientFloat = 360.0f / 400.0f;
 constexpr float turnsPerDegreeFloat = 1.0f / 360.0f;
 constexpr float degreesPerTurnFloat = 360.0f;
-constexpr float radiansPerTurnFloat = 2.0f * piFloat;
+constexpr float radiansPerTurnFloat = 2.0f * std::numbers::pi_v<float>;
 
 constexpr float deg2rad(float d)  { return d * radiansPerDegreeFloat; }
 constexpr float rad2deg(float r)  { return r * degreesPerRadianFloat; }

--- a/Source/WebCore/Modules/webaudio/PannerNode.cpp
+++ b/Source/WebCore/Modules/webaudio/PannerNode.cpp
@@ -37,6 +37,7 @@
 #include "HRTFDatabaseLoader.h"
 #include "HRTFPanner.h"
 #include "ScriptExecutionContext.h"
+#include <numbers>
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -511,7 +512,7 @@ auto PannerNode::calculateAzimuthElevation(const FloatPoint3D& position, const F
         azimuth = 450.0 - azimuth;
 
     // Elevation
-    double elevation = 90.0 - 180.0 * acos(sourceListener.dot(up)) / piDouble;
+    double elevation = 90.0 - 180.0 * acos(sourceListener.dot(up)) / std::numbers::pi;
     fixNANs(elevation); // avoid illegal values
 
     if (elevation > 90.0)

--- a/Source/WebCore/Modules/webaudio/PeriodicWave.cpp
+++ b/Source/WebCore/Modules/webaudio/PeriodicWave.cpp
@@ -37,6 +37,7 @@
 #include "FFTFrame.h"
 #include "VectorMath.h"
 #include <algorithm>
+#include <numbers>
 #include <wtf/StdLibExtras.h>
 
 // The number of bands per octave. Each octave will have this many entries in the wave tables.
@@ -264,7 +265,7 @@ void PeriodicWave::generateBasicWaveform(Type shape)
     imagP[0] = 0;
 
     for (unsigned n = 1; n < halfSize; ++n) {
-        float piFactor = 2 / (n * piFloat);
+        float piFactor = 2 / (n * std::numbers::pi_v<float>);
 
         // All waveforms are odd functions with a positive slope at time 0. Hence
         // the coefficients for cos() are always 0.

--- a/Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp
+++ b/Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp
@@ -37,6 +37,7 @@
 #include <JavaScriptCore/Uint8Array.h>
 #include <algorithm>
 #include <complex>
+#include <numbers>
 #include <wtf/MainThread.h>
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -120,7 +121,7 @@ void applyWindow(std::span<float> p, size_t n)
     
     for (unsigned i = 0; i < n; ++i) {
         double x = static_cast<double>(i) / static_cast<double>(n);
-        double window = a0 - a1 * cos(2 * piDouble * x) + a2 * cos(4 * piDouble * x);
+        double window = a0 - a1 * cos(2 * std::numbers::pi * x) + a2 * cos(4 * std::numbers::pi * x);
         p[i] *= float(window);
     }
 }

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -40,6 +40,7 @@
 #include "XRReferenceSpaceType.h"
 #include "XRSessionMode.h"
 #include "XRVisibilityState.h"
+#include <numbers>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -167,7 +168,7 @@ private:
     std::optional<PlatformXR::RequestData> m_requestData;
 
     double m_minimumInlineFOV { 0.0 };
-    double m_maximumInlineFOV { piFloat };
+    double m_maximumInlineFOV { std::numbers::pi };
 
     // In meters.
     double m_minimumNearClipPlane { 0.1 };

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -49,6 +49,7 @@
 #include "Logging.h"
 #include "MediaQueryFeatures.h"
 #include "MediaQueryParser.h"
+#include <numbers>
 #include <wtf/SortedArrayMap.h>
 
 namespace WebCore {
@@ -61,8 +62,8 @@ static constexpr int maxExpressionDepth = 100;
 static std::optional<std::pair<Number, Type>> lookupConstantNumber(CSSValueID symbol)
 {
     static constexpr std::pair<CSSValueID, double> constantMappings[] {
-        { CSSValueE,                     eDouble                                  },
-        { CSSValuePi,                    piDouble                                 },
+        { CSSValueE,                     std::numbers::e                          },
+        { CSSValuePi,                    std::numbers::pi                         },
         { CSSValueInfinity,              std::numeric_limits<double>::infinity()  },
         { CSSValueNegativeInfinity, -1 * std::numeric_limits<double>::infinity()  },
         { CSSValueNaN,                   std::numeric_limits<double>::quiet_NaN() },

--- a/Source/WebCore/dom/PointerEvent.cpp
+++ b/Source/WebCore/dom/PointerEvent.cpp
@@ -30,6 +30,7 @@
 #include "MouseEventTypes.h"
 #include "Node.h"
 #include "PointerEventTypeNames.h"
+#include <numbers>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -102,7 +103,7 @@ auto PointerEvent::angleFromTilt(long tiltX, long tiltY) -> PointerEventAngle
     if (!tiltX && tiltY)
         azimuthAngle = tiltY > 0 ? piOverTwoDouble : 3 * piOverTwoDouble;
     else if (tiltX && !tiltY)
-        azimuthAngle = tiltX < 0 ? piDouble : azimuthAngle;
+        azimuthAngle = tiltX < 0 ? std::numbers::pi : azimuthAngle;
     else if (abs(tiltX) == 90 || abs(tiltY) == 90)
         azimuthAngle = 0;
     else {

--- a/Source/WebCore/html/canvas/CanvasPath.cpp
+++ b/Source/WebCore/html/canvas/CanvasPath.cpp
@@ -41,6 +41,7 @@
 #include "FloatRoundedRect.h"
 #include "FloatSize.h"
 #include <algorithm>
+#include <numbers>
 #include <wtf/MathExtras.h>
 #include <wtf/text/MakeString.h>
 
@@ -143,7 +144,7 @@ ExceptionOr<void> CanvasPath::arcTo(float x1, float y1, float x2, float y2, floa
 
 static void normalizeAngles(float& startAngle, float& endAngle, bool anticlockwise)
 {
-    constexpr auto twoPiFloat = 2 * piFloat;
+    constexpr auto twoPiFloat = 2 * std::numbers::pi_v<float>;
     float newStartAngle = fmodf(startAngle, twoPiFloat);
     if (newStartAngle < 0)
         newStartAngle += twoPiFloat;

--- a/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
+++ b/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
@@ -37,6 +37,7 @@
 #import <CoreText/CoreText.h>
 #import <QuartzCore/CALayer.h>
 #import <QuartzCore/CATransaction.h>
+#import <numbers>
 #import <wtf/MainThread.h>
 #import <wtf/MathExtras.h>
 #import <wtf/MemoryFootprint.h>
@@ -406,7 +407,7 @@ static void drawMemHistory(CGContextRef context, float x1, float y1, float y2, H
     drawGraphLabel(context, x1, y2, "Mem"_s);
 }
 
-static const float fullCircleInRadians = piFloat * 2;
+static const float fullCircleInRadians = std::numbers::pi_v<float> * 2;
 
 static void drawSlice(CGContextRef context, FloatPoint center, float& angle, float radius, size_t sliceSize, size_t totalSize, CGColorRef color)
 {

--- a/Source/WebCore/platform/DictationCaretAnimator.cpp
+++ b/Source/WebCore/platform/DictationCaretAnimator.cpp
@@ -33,6 +33,8 @@
 #include "Path.h"
 #include "RenderBlock.h"
 #include "VisibleSelection.h"
+#include <numbers>
+#include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -46,7 +48,7 @@ static constexpr KeyFrame keyframe(size_t i)
     constexpr auto updateRate = 40;
     i %= updateRate;
     constexpr float inverseFrameRate = 1.f / static_cast<float>(updateRate);
-    return KeyFrame { Seconds(i * inverseFrameRate), fabs(sinf(static_cast<float>(M_PI * i * inverseFrameRate))) };
+    return KeyFrame { Seconds(i * inverseFrameRate), fabs(sinf(std::numbers::pi_v<float> * i * inverseFrameRate)) };
 }
 
 constexpr auto tailBlurRadius(float cursorHeight)
@@ -175,7 +177,7 @@ void DictationCaretAnimator::start()
     // delta is the difference between `m_currentKeyframeIndex` and `m_currentKeyframeIndex - 1`
     m_currentKeyframeIndex = 1;
     m_lastUpdateTime = MonotonicTime::now();
-    m_initialScale = M_PI_2;
+    m_initialScale = piOverTwoDouble;
     didStart(m_lastUpdateTime, keyframeTimeDelta());
 
     resetGlowTail(m_client.localCaretRect());

--- a/Source/WebCore/platform/audio/Biquad.cpp
+++ b/Source/WebCore/platform/audio/Biquad.cpp
@@ -35,6 +35,7 @@
 #include "AudioUtilities.h"
 #include "DenormalDisabler.h"
 #include <algorithm>
+#include <numbers>
 #include <stdio.h>
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -281,7 +282,7 @@ void Biquad::setLowpassParams(size_t index, double cutoff, double resonance)
         // Compute biquad coefficients for lowpass filter
         resonance = pow(10.0, 0.05 * resonance);
 
-        double theta = piDouble * cutoff;
+        double theta = std::numbers::pi * cutoff;
         double alpha = sin(theta) / (2 * resonance);
         double cosw = cos(theta);
         double beta = (1 - cosw) / 2;
@@ -314,7 +315,7 @@ void Biquad::setHighpassParams(size_t index, double cutoff, double resonance)
         // Compute biquad coefficients for highpass filter
         resonance = pow(10.0, 0.05 * resonance);
 
-        double theta = piDouble * cutoff;
+        double theta = std::numbers::pi * cutoff;
         double alpha = sin(theta) / (2 * resonance);
         double cosw = cos(theta);
         double beta = (1 + cosw) / 2;
@@ -359,7 +360,7 @@ void Biquad::setLowShelfParams(size_t index, double frequency, double dbGain)
         // The z-transform is a constant gain.
         setNormalizedCoefficients(index, A * A, 0, 0, 1, 0, 0);
     } else if (frequency > 0) {
-        double w0 = piDouble * frequency;
+        double w0 = std::numbers::pi * frequency;
         double S = 1; // filter slope (1 is max value)
         double alpha = 0.5 * sin(w0) * sqrt((A + 1 / A) * (1 / S - 1) + 2);
         double k = cos(w0);
@@ -392,7 +393,7 @@ void Biquad::setHighShelfParams(size_t index, double frequency, double dbGain)
         // The z-transform is 1.
         setNormalizedCoefficients(index, 1, 0, 0, 1, 0, 0);
     } else if (frequency > 0) {
-        double w0 = piDouble * frequency;
+        double w0 = std::numbers::pi * frequency;
         double S = 1; // filter slope (1 is max value)
         double alpha = 0.5 * sin(w0) * sqrt((A + 1 / A) * (1 / S - 1) + 2);
         double k = cos(w0);
@@ -426,7 +427,7 @@ void Biquad::setPeakingParams(size_t index, double frequency, double Q, double d
 
     if (frequency > 0 && frequency < 1) {
         if (Q > 0) {
-            double w0 = piDouble * frequency;
+            double w0 = std::numbers::pi * frequency;
             double alpha = sin(w0) / (2 * Q);
             double k = cos(w0);
 
@@ -460,7 +461,7 @@ void Biquad::setAllpassParams(size_t index, double frequency, double Q)
 
     if (frequency > 0 && frequency < 1) {
         if (Q > 0) {
-            double w0 = piDouble * frequency;
+            double w0 = std::numbers::pi * frequency;
             double alpha = sin(w0) / (2 * Q);
             double k = cos(w0);
 
@@ -494,7 +495,7 @@ void Biquad::setNotchParams(size_t index, double frequency, double Q)
 
     if (frequency > 0 && frequency < 1) {
         if (Q > 0) {
-            double w0 = piDouble * frequency;
+            double w0 = std::numbers::pi * frequency;
             double alpha = sin(w0) / (2 * Q);
             double k = cos(w0);
 
@@ -527,7 +528,7 @@ void Biquad::setBandpassParams(size_t index, double frequency, double Q)
     Q = std::max(0.0, Q);
 
     if (frequency > 0 && frequency < 1) {
-        double w0 = piDouble * frequency;
+        double w0 = std::numbers::pi * frequency;
         if (Q > 0) {
             double alpha = sin(w0) / (2 * Q);
             double k = cos(w0);
@@ -587,7 +588,7 @@ void Biquad::getFrequencyResponse(unsigned nFrequencies, std::span<const float> 
             magResponse[k] = std::nanf("");
             phaseResponse[k] = std::nanf("");
         } else {
-            double omega = -piDouble * frequency[k];
+            double omega = -std::numbers::pi * frequency[k];
             std::complex<double> z = std::complex<double>(cos(omega), sin(omega));
             std::complex<double> numerator = b0 + (b1 + b2 * z) * z;
             std::complex<double> denominator = std::complex<double>(1, 0) + (a1 + a2 * z) * z;

--- a/Source/WebCore/platform/audio/DownSampler.cpp
+++ b/Source/WebCore/platform/audio/DownSampler.cpp
@@ -32,6 +32,7 @@
 
 #include "DownSampler.h"
 
+#include <numbers>
 #include <wtf/MathExtras.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -68,13 +69,13 @@ void DownSampler::initializeKernel()
     // after doing the main convolution using m_reducedKernel.
     for (int i = 1; i < n; i += 2) {
         // Compute the sinc() with offset.
-        double s = sincScaleFactor * piDouble * (i - halfSize);
+        double s = sincScaleFactor * std::numbers::pi * (i - halfSize);
         double sinc = !s ? 1.0 : sin(s) / s;
         sinc *= sincScaleFactor;
 
         // Compute Blackman window, matching the offset of the sinc().
         double x = static_cast<double>(i) / n;
-        double window = a0 - a1 * cos(2.0 * piDouble * x) + a2 * cos(4.0 * piDouble * x);
+        double window = a0 - a1 * cos(2.0 * std::numbers::pi * x) + a2 * cos(4.0 * std::numbers::pi * x);
 
         // Window the sinc() function.
         // Then store only the odd terms in the kernel.

--- a/Source/WebCore/platform/audio/DynamicsCompressorKernel.cpp
+++ b/Source/WebCore/platform/audio/DynamicsCompressorKernel.cpp
@@ -35,6 +35,7 @@
 #include "AudioUtilities.h"
 #include "DenormalDisabler.h"
 #include <algorithm>
+#include <numbers>
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -279,7 +280,7 @@ void DynamicsCompressorKernel::process(std::span<std::span<const float>> sourceC
         float desiredGain = m_detectorAverage;
 
         // Pre-warp so we get desiredGain after sin() warp below.
-        float scaledDesiredGain = asinf(desiredGain) / (0.5f * piFloat);
+        float scaledDesiredGain = asinf(desiredGain) / (0.5f * std::numbers::pi_v<float>);
 
         // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         // Deal with envelopes
@@ -411,7 +412,7 @@ void DynamicsCompressorKernel::process(std::span<std::span<const float>> sourceC
                 }
 
                 // Warp pre-compression gain to smooth out sharp exponential transition points.
-                float postWarpCompressorGain = sinf(0.5f * piFloat * compressorGain);
+                float postWarpCompressorGain = sinf(0.5f * std::numbers::pi_v<float> * compressorGain);
 
                 // Calculate total gain using master gain and effect blend.
                 float totalGain = dryMix + wetMix * masterLinearGain * postWarpCompressorGain;

--- a/Source/WebCore/platform/audio/FFTFrame.cpp
+++ b/Source/WebCore/platform/audio/FFTFrame.cpp
@@ -35,6 +35,7 @@
 #include "Logging.h"
 #include "VectorMath.h"
 #include <complex>
+#include <numbers>
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -142,32 +143,32 @@ void FFTFrame::interpolateFrequencyComponents(const FFTFrame& frame1, const FFTF
         lastPhase2 = phase2;
 
         // Unwrap phase deltas
-        if (deltaPhase1 > piDouble)
-            deltaPhase1 -= 2.0 * piDouble;
-        if (deltaPhase1 < -piDouble)
-            deltaPhase1 += 2.0 * piDouble;
-        if (deltaPhase2 > piDouble)
-            deltaPhase2 -= 2.0 * piDouble;
-        if (deltaPhase2 < -piDouble)
-            deltaPhase2 += 2.0 * piDouble;
+        if (deltaPhase1 > std::numbers::pi)
+            deltaPhase1 -= 2.0 * std::numbers::pi;
+        if (deltaPhase1 < -std::numbers::pi)
+            deltaPhase1 += 2.0 * std::numbers::pi;
+        if (deltaPhase2 > std::numbers::pi)
+            deltaPhase2 -= 2.0 * std::numbers::pi;
+        if (deltaPhase2 < -std::numbers::pi)
+            deltaPhase2 += 2.0 * std::numbers::pi;
 
         // Blend group-delays
         double deltaPhaseBlend;
 
-        if (deltaPhase1 - deltaPhase2 > piDouble)
-            deltaPhaseBlend = s1 * deltaPhase1 + s2 * (2.0 * piDouble + deltaPhase2);
-        else if (deltaPhase2 - deltaPhase1 > piDouble)
-            deltaPhaseBlend = s1 * (2.0 * piDouble + deltaPhase1) + s2 * deltaPhase2;
+        if (deltaPhase1 - deltaPhase2 > std::numbers::pi)
+            deltaPhaseBlend = s1 * deltaPhase1 + s2 * (2.0 * std::numbers::pi + deltaPhase2);
+        else if (deltaPhase2 - deltaPhase1 > std::numbers::pi)
+            deltaPhaseBlend = s1 * (2.0 * std::numbers::pi + deltaPhase1) + s2 * deltaPhase2;
         else
             deltaPhaseBlend = s1 * deltaPhase1 + s2 * deltaPhase2;
 
         phaseAccum += deltaPhaseBlend;
 
         // Unwrap
-        if (phaseAccum > piDouble)
-            phaseAccum -= 2.0 * piDouble;
-        if (phaseAccum < -piDouble)
-            phaseAccum += 2.0 * piDouble;
+        if (phaseAccum > std::numbers::pi)
+            phaseAccum -= 2.0 * std::numbers::pi;
+        if (phaseAccum < -std::numbers::pi)
+            phaseAccum += 2.0 * std::numbers::pi;
 
         std::complex<double> c = std::polar(mag, phaseAccum);
 
@@ -216,7 +217,7 @@ double FFTFrame::extractAverageGroupDelay()
 
     int halfSize = fftSize() / 2;
 
-    const double kSamplePhaseDelay = (2.0 * piDouble) / double(fftSize());
+    const double kSamplePhaseDelay = (2.0 * std::numbers::pi) / double(fftSize());
 
     // Calculate weighted average group delay
     for (int i = 0; i < halfSize; i++) {
@@ -228,10 +229,10 @@ double FFTFrame::extractAverageGroupDelay()
         lastPhase = phase;
 
         // Unwrap
-        if (deltaPhase < -piDouble)
-            deltaPhase += 2.0 * piDouble;
-        if (deltaPhase > piDouble)
-            deltaPhase -= 2.0 * piDouble;
+        if (deltaPhase < -std::numbers::pi)
+            deltaPhase += 2.0 * std::numbers::pi;
+        if (deltaPhase > std::numbers::pi)
+            deltaPhase -= 2.0 * std::numbers::pi;
 
         aveSum += mag * deltaPhase;
         weightSum += mag;
@@ -261,7 +262,7 @@ void FFTFrame::addConstantGroupDelay(double sampleFrameDelay)
     auto& realP = realData();
     auto& imagP = imagData();
 
-    const double kSamplePhaseDelay = (2.0 * piDouble) / double(fftSize());
+    const double kSamplePhaseDelay = (2.0 * std::numbers::pi) / double(fftSize());
 
     double phaseAdj = -sampleFrameDelay * kSamplePhaseDelay;
 

--- a/Source/WebCore/platform/audio/IIRFilter.cpp
+++ b/Source/WebCore/platform/audio/IIRFilter.cpp
@@ -33,6 +33,7 @@
 #include "VectorMath.h"
 #include <algorithm>
 #include <complex>
+#include <numbers>
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -145,7 +146,7 @@ void IIRFilter::getFrequencyResponse(unsigned length, std::span<const float> fre
             phaseResponse[k] = std::nanf("");
         } else {
             // zRecip = 1/z = exp(-j*frequency)
-            double omega = -piDouble * frequency[k];
+            double omega = -std::numbers::pi * frequency[k];
             auto zRecip = std::complex<double>(cos(omega), sin(omega));
 
             auto numerator = evaluatePolynomial(m_feedforward.span(), zRecip, m_feedforward.size() - 1);

--- a/Source/WebCore/platform/audio/SincResampler.cpp
+++ b/Source/WebCore/platform/audio/SincResampler.cpp
@@ -35,6 +35,7 @@
 #include "AudioBus.h"
 #include "AudioUtilities.h"
 #include "VectorMath.h"
+#include <numbers>
 #include <wtf/Algorithms.h>
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -192,13 +193,13 @@ void SincResampler::initializeKernel()
 
         for (int i = 0; i < n; ++i) {
             // Compute the sinc() with offset.
-            double s = sincScaleFactor * piDouble * (i - halfSize - subsampleOffset);
+            double s = sincScaleFactor * std::numbers::pi * (i - halfSize - subsampleOffset);
             double sinc = !s ? 1.0 : sin(s) / s;
             sinc *= sincScaleFactor;
 
             // Compute Blackman window, matching the offset of the sinc().
             double x = (i - subsampleOffset) / n;
-            double window = a0 - a1 * cos(2.0 * piDouble * x) + a2 * cos(4.0 * piDouble * x);
+            double window = a0 - a1 * cos(2.0 * std::numbers::pi * x) + a2 * cos(4.0 * std::numbers::pi * x);
 
             // Window the sinc() function and store at the correct offset.
             m_kernelStorage[i + offsetIndex * kernelSize] = sinc * window;

--- a/Source/WebCore/platform/audio/UpSampler.cpp
+++ b/Source/WebCore/platform/audio/UpSampler.cpp
@@ -32,6 +32,7 @@
 
 #include "UpSampler.h"
 
+#include <numbers>
 #include <wtf/MathExtras.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -64,12 +65,12 @@ void UpSampler::initializeKernel()
 
     for (int i = 0; i < n; ++i) {
         // Compute the sinc() with offset.
-        double s = piDouble * (i - halfSize - subsampleOffset);
+        double s = std::numbers::pi * (i - halfSize - subsampleOffset);
         double sinc = !s ? 1.0 : sin(s) / s;
 
         // Compute Blackman window, matching the offset of the sinc().
         double x = (i - subsampleOffset) / n;
-        double window = a0 - a1 * cos(2.0 * piDouble * x) + a2 * cos(4.0 * piDouble * x);
+        double window = a0 - a1 * cos(2.0 * std::numbers::pi * x) + a2 * cos(4.0 * std::numbers::pi * x);
 
         // Window the sinc() function.
         m_kernel[i] = sinc * window;

--- a/Source/WebCore/platform/calc/CalculationExecutor.h
+++ b/Source/WebCore/platform/calc/CalculationExecutor.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CalculationTree.h"
+#include <numbers>
 #include <numeric>
 #include <wtf/Forward.h>
 #include <wtf/MathExtras.h>
@@ -361,11 +362,11 @@ template<> struct OperatorExecutor<Cos> {
 template<> struct OperatorExecutor<Tan> {
     double operator()(double a)
     {
-        double x = std::fmod(a, piDouble * 2);
+        double x = std::fmod(a, std::numbers::pi * 2);
         // std::fmod can return negative values.
-        x = x < 0 ? piDouble * 2 + x : x;
+        x = x < 0 ? std::numbers::pi * 2 + x : x;
         ASSERT(!(x < 0));
-        ASSERT(!(x > piDouble * 2));
+        ASSERT(!(x > std::numbers::pi * 2));
         if (x == piOverTwoDouble)
             return std::numeric_limits<double>::infinity();
         if (x == 3 * piOverTwoDouble)

--- a/Source/WebCore/platform/graphics/FloatRoundedRect.cpp
+++ b/Source/WebCore/platform/graphics/FloatRoundedRect.cpp
@@ -32,6 +32,7 @@
 #include "FloatRoundedRect.h"
 
 #include <algorithm>
+#include <numbers>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
@@ -248,7 +249,7 @@ Region approximateAsRegion(const FloatRoundedRect& roundedRect, unsigned stepLen
     };
 
     auto subtractCornerRects = [&] (LayoutPoint corner, LayoutPoint ellipsisCenter, FloatSize axes, double fromAngle) {
-        double toAngle = fromAngle + piDouble / 2;
+        double toAngle = fromAngle + std::numbers::pi / 2;
 
         // Substract more rects for longer, more rounded arcs.
         auto arcLengthFactor = roundToInt(std::min(axes.width(), axes.height()));
@@ -276,21 +277,21 @@ Region approximateAsRegion(const FloatRoundedRect& roundedRect, unsigned stepLen
         auto corner = rect.minXMaxYCorner();
         auto axes = radii.bottomLeft();
         auto ellipsisCenter = LayoutPoint(corner.x() + axes.width(), corner.y() - axes.height());
-        subtractCornerRects(corner, ellipsisCenter, axes, piDouble / 2);
+        subtractCornerRects(corner, ellipsisCenter, axes, std::numbers::pi / 2);
     }
 
     {
         auto corner = rect.minXMinYCorner();
         auto axes = radii.topLeft();
         auto ellipsisCenter = LayoutPoint(corner.x() + axes.width(), corner.y() + axes.height());
-        subtractCornerRects(corner, ellipsisCenter, axes, piDouble);
+        subtractCornerRects(corner, ellipsisCenter, axes, std::numbers::pi);
     }
 
     {
         auto corner = rect.maxXMinYCorner();
         auto axes = radii.topRight();
         auto ellipsisCenter = LayoutPoint(corner.x() - axes.width(), corner.y() + axes.height());
-        subtractCornerRects(corner, ellipsisCenter, axes, piDouble * 3 / 2);
+        subtractCornerRects(corner, ellipsisCenter, axes, std::numbers::pi * 3 / 2);
     }
 
     return region;

--- a/Source/WebCore/platform/graphics/GeometryUtilities.cpp
+++ b/Source/WebCore/platform/graphics/GeometryUtilities.cpp
@@ -28,6 +28,7 @@
 #include "GeometryUtilities.h"
 
 #include "FloatQuad.h"
+#include <numbers>
 #include <wtf/MathExtras.h>
 #include <wtf/Vector.h>
 
@@ -213,7 +214,7 @@ static float angleBetweenVectors(const FloatSize& u, const FloatSize& v)
 
 RotatedRect rotatedBoundingRectWithMinimumAngleOfRotation(const FloatQuad& quad, std::optional<float> minRotationInRadians)
 {
-    constexpr auto twoPiFloat = 2 * piFloat;
+    constexpr auto twoPiFloat = 2 * std::numbers::pi_v<float>;
 
     auto minRotationAmount = minRotationInRadians.value_or(std::numeric_limits<float>::epsilon());
 

--- a/Source/WebCore/platform/graphics/PathSegmentData.cpp
+++ b/Source/WebCore/platform/graphics/PathSegmentData.cpp
@@ -28,6 +28,7 @@
 
 #include "AffineTransform.h"
 #include "GeometryUtilities.h"
+#include <numbers>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
@@ -340,7 +341,7 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, const PathBezierCurveTo& data)
 static float angleOfLine(const FloatPoint& p1, const FloatPoint& p2)
 {
     if (abs(p1.x() - p2.x()) < 0.00001)
-        return p1.y() - p2.y() >= 0 ? piFloat / 2 : 3 * piFloat / 2;
+        return p1.y() - p2.y() >= 0 ? std::numbers::pi_v<float> / 2 : 3 * std::numbers::pi_v<float> / 2;
     return atan2(p1.y() - p2.y(), p1.x() - p2.x());
 }
 
@@ -350,7 +351,7 @@ static FloatPoint calculateArcToEndPoint(const FloatPoint& currentPoint, const F
     float angle2 = angleOfLine(controlPoint1, controlPoint2);
     float angleBteweenLines = angle2 - angle1;
 
-    if (abs(angleBteweenLines) < 0.00001 || abs(angleBteweenLines) >= piFloat / 2)
+    if (abs(angleBteweenLines) < 0.00001 || abs(angleBteweenLines) >= std::numbers::pi_v<float> / 2)
         return controlPoint1;
 
     float adjacent = abs(radius / tan(angleBteweenLines / 2));
@@ -443,13 +444,13 @@ void PathArc::extendBoundingRect(const FloatPoint&, const FloatPoint&, FloatRect
     if (isInRange(float(0), startAngle, endAngle))
         x2 = circleRect.maxX();
 
-    if (isInRange(angleInClockwise(piFloat / 2, direction), startAngle, endAngle))
+    if (isInRange(angleInClockwise(std::numbers::pi_v<float> / 2, direction), startAngle, endAngle))
         y2 = circleRect.maxY();
 
-    if (isInRange(angleInClockwise(piFloat, direction), startAngle, endAngle))
+    if (isInRange(angleInClockwise(std::numbers::pi_v<float>, direction), startAngle, endAngle))
         x1 = circleRect.x();
 
-    if (isInRange(angleInClockwise(3 * piFloat / 2, direction), startAngle, endAngle))
+    if (isInRange(angleInClockwise(3 * std::numbers::pi_v<float> / 2, direction), startAngle, endAngle))
         y1 = circleRect.y();
 
     boundingRect.extend({ x1, y1 });

--- a/Source/WebCore/platform/graphics/PathUtilities.cpp
+++ b/Source/WebCore/platform/graphics/PathUtilities.cpp
@@ -34,6 +34,7 @@
 #include "FloatRoundedRect.h"
 #include "GeometryUtilities.h"
 #include <math.h>
+#include <numbers>
 #include <ranges>
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -186,7 +187,7 @@ static FloatPointGraph::Polygon walkGraphAndExtractPolygon(FloatPointGraph::Node
             float crossZ = nextVec.x() * currentVec.y() - nextVec.y() * currentVec.x();
 
             if (crossZ < 0)
-                angle = (2 * piFloat) - angle;
+                angle = (2 * std::numbers::pi_v<float>) - angle;
 
             if (!nextNode || angle > nextNodeAngle) {
                 nextNode = potentialNextNode;

--- a/Source/WebCore/platform/graphics/ShadowBlur.cpp
+++ b/Source/WebCore/platform/graphics/ShadowBlur.cpp
@@ -36,6 +36,7 @@
 #include "ImageBuffer.h"
 #include "PixelBuffer.h"
 #include "Timer.h"
+#include <numbers>
 #include <wtf/CheckedPtr.h>
 #include <wtf/Lock.h>
 #include <wtf/MathExtras.h>
@@ -255,7 +256,7 @@ static void calculateLobes(std::array<std::array<int, 2>, 3>& lobes, float blurR
         // However, shadows rendered according to that spec will extend a little further than m_blurRadius,
         // so we apply a fudge factor to bring the radius down slightly.
         float stdDev = blurRadius / 2;
-        const float gaussianKernelFactor = 3 / 4.f * sqrtf(2 * piFloat);
+        const float gaussianKernelFactor = 3 / 4.f * sqrtf(2 * std::numbers::pi_v<float>);
         const float fudgeFactor = 0.88f;
         diameter = std::max(2, static_cast<int>(floorf(stdDev * gaussianKernelFactor * fudgeFactor + 0.5f)));
     }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
@@ -37,6 +37,7 @@
 #import <AVFoundation/AVSampleBufferDisplayLayer.h>
 #import <QuartzCore/CALayer.h>
 #import <QuartzCore/CATransaction.h>
+#import <numbers>
 #import <pal/avfoundation/MediaTimeAVFoundation.h>
 #import <pal/spi/cocoa/AVFoundationSPI.h>
 #import <wtf/MainThread.h>
@@ -370,7 +371,7 @@ static inline CGAffineTransform transformationMatrixForVideoFrame(VideoFrame& vi
 #else
     int rotationAngle = static_cast<int>(videoFrame.rotation());
 #endif
-    auto videoTransform = CGAffineTransformMakeRotation(rotationAngle * M_PI / 180);
+    auto videoTransform = CGAffineTransformMakeRotation(rotationAngle * std::numbers::pi / 180);
     if (videoFrame.isMirrored())
         videoTransform = CGAffineTransformScale(videoTransform, -1, 1);
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -41,6 +41,7 @@
 #import "VideoFrameMetadata.h"
 #import "VideoLayerManagerObjC.h"
 #import "VideoTrackPrivateMediaStream.h"
+#import <numbers>
 #import <objc_runtime.h>
 #import <pal/avfoundation/MediaTimeAVFoundation.h>
 #import <pal/spi/cocoa/AVFoundationSPI.h>
@@ -49,7 +50,7 @@
 #import <wtf/MainThread.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/TZoneMallocInlines.h>
-#include <wtf/text/MakeString.h>
+#import <wtf/text/MakeString.h>
 
 #import "CoreVideoSoftLink.h"
 #import <pal/cf/CoreMediaSoftLink.h>
@@ -1094,7 +1095,7 @@ static inline CGAffineTransform videoTransformationMatrix(VideoFrame& videoFrame
     if (!width || !height)
         return CGAffineTransformIdentity;
 
-    auto videoTransform = CGAffineTransformMakeRotation(static_cast<int>(videoFrame.rotation()) * M_PI / 180);
+    auto videoTransform = CGAffineTransformMakeRotation(static_cast<int>(videoFrame.rotation()) * std::numbers::pi / 180);
     if (videoFrame.isMirrored())
         videoTransform = CGAffineTransformScale(videoTransform, -1, 1);
 

--- a/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
@@ -50,6 +50,7 @@
 #include "ShadowBlur.h"
 #include <algorithm>
 #include <cairo.h>
+#include <numbers>
 
 namespace WebCore {
 namespace Cairo {
@@ -1152,7 +1153,7 @@ void drawEllipse(GraphicsContextCairo& platformContext, const FloatRect& rect, c
     float xRadius = .5 * rect.width();
     cairo_translate(cr, rect.x() + xRadius, rect.y() + yRadius);
     cairo_scale(cr, xRadius, yRadius);
-    cairo_arc(cr, 0., 0., 1., 0., 2 * piFloat);
+    cairo_arc(cr, 0., 0., 1., 0., 2 * std::numbers::pi_v<float>);
     cairo_restore(cr);
 
     if (fillColor.isVisible()) {

--- a/Source/WebCore/platform/graphics/cairo/GradientCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GradientCairo.cpp
@@ -35,6 +35,7 @@
 #include "CairoUtilities.h"
 #include "ColorBlending.h"
 #include "GraphicsContextCairo.h"
+#include <numbers>
 #include <wtf/MathExtras.h>
 
 namespace WebCore {
@@ -60,10 +61,10 @@ static void setCornerColorRGBA(cairo_pattern_t* gradient, int id, GradientColorS
 }
 
 static constexpr double deg0 = 0;
-static constexpr double deg90 = piDouble / 2;
-static constexpr double deg180 = piDouble;
-static constexpr double deg270 = 3 * piDouble / 2;
-static constexpr double deg360 = 2 * piDouble;
+static constexpr double deg90 = std::numbers::pi / 2;
+static constexpr double deg180 = std::numbers::pi;
+static constexpr double deg270 = 3 * std::numbers::pi / 2;
+static constexpr double deg360 = 2 * std::numbers::pi;
 
 static double normalizeAngle(double angle)
 {
@@ -80,8 +81,8 @@ static void addConicSector(cairo_pattern_t *gradient, float cx, float cy, float 
 
     // Substract 90 degrees so angles start from top left.
     // Convert to radians and add angleRadians offset.
-    double angleStart = ((from.offset - angOffset) * 2 * piDouble) + angleRadians;
-    double angleEnd = ((to.offset - angOffset) * 2 * piDouble) + angleRadians;
+    double angleStart = ((from.offset - angOffset) * 2 * std::numbers::pi) + angleRadians;
+    double angleEnd = ((to.offset - angOffset) * 2 * std::numbers::pi) + angleRadians;
 
     // Calculate center offset depending on quadrant.
     //

--- a/Source/WebCore/platform/graphics/cairo/PathCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/PathCairo.cpp
@@ -33,6 +33,7 @@
 #include "FloatRect.h"
 #include "GraphicsContextCairo.h"
 #include "PathStream.h"
+#include <numbers>
 
 namespace WebCore {
 
@@ -221,7 +222,7 @@ void PathCairo::add(PathArcTo arcTo)
     orth_p1p0 = FloatPoint(-orth_p1p0.x(), -orth_p1p0.y());
     float sa = acos(orth_p1p0.x() / orth_p1p0_length);
     if (orth_p1p0.y() < 0.f)
-        sa = 2 * piDouble - sa;
+        sa = 2 * std::numbers::pi - sa;
 
     // clockwise logic
     auto direction = RotationDirection::Clockwise;
@@ -232,10 +233,10 @@ void PathCairo::add(PathArcTo arcTo)
     float orth_p1p2_length = sqrtf(orth_p1p2.x() * orth_p1p2.x() + orth_p1p2.y() * orth_p1p2.y());
     float ea = acos(orth_p1p2.x() / orth_p1p2_length);
     if (orth_p1p2.y() < 0)
-        ea = 2 * piDouble - ea;
-    if ((sa > ea) && ((sa - ea) < piDouble))
+        ea = 2 * std::numbers::pi - ea;
+    if ((sa > ea) && ((sa - ea) < std::numbers::pi))
         direction = RotationDirection::Counterclockwise;
-    if ((sa < ea) && ((ea - sa) > piDouble))
+    if ((sa < ea) && ((ea - sa) > std::numbers::pi))
         direction = RotationDirection::Counterclockwise;
 
     cairo_line_to(platformPath(), t_p1p0.x(), t_p1p0.y());
@@ -254,7 +255,7 @@ void PathCairo::add(PathArc arc)
     const float endAngle = arc.endAngle;
     const RotationDirection direction = arc.direction;
     float sweep = endAngle - startAngle;
-    const float twoPI = 2 * piFloat;
+    constexpr float twoPI = 2 * std::numbers::pi_v<float>;
     if ((sweep <= -twoPI || sweep >= twoPI)
         && ((direction == RotationDirection::Counterclockwise && (endAngle < startAngle)) || (direction == RotationDirection::Clockwise && (startAngle < endAngle)))) {
         if (direction == RotationDirection::Clockwise)
@@ -305,7 +306,7 @@ void PathCairo::add(PathEllipseInRect ellipseInRect)
     float xRadius = .5 * ellipseInRect.rect.width();
     cairo_translate(cr, ellipseInRect.rect.x() + xRadius, ellipseInRect.rect.y() + yRadius);
     cairo_scale(cr, xRadius, yRadius);
-    cairo_arc(cr, 0., 0., 1., 0., 2 * piDouble);
+    cairo_arc(cr, 0., 0., 1., 0., 2 * std::numbers::pi);
     cairo_restore(cr);
 
     m_elementsStream = nullptr;

--- a/Source/WebCore/platform/graphics/cg/GradientCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GradientCG.cpp
@@ -32,7 +32,7 @@
 #include "GradientRendererCG.h"
 #include "GraphicsContextCG.h"
 #include <pal/spi/cg/CoreGraphicsSPI.h>
-
+#include <wtf/MathExtras.h>
 namespace WebCore {
 
 void Gradient::stopsChanged()
@@ -163,7 +163,7 @@ void Gradient::paint(CGContextRef platformContext)
 #if HAVE(CORE_GRAPHICS_CONIC_GRADIENTS)
             CGContextSaveGState(platformContext);
             CGContextTranslateCTM(platformContext, data.point0.x(), data.point0.y());
-            CGContextRotateCTM(platformContext, (CGFloat)-M_PI_2);
+            CGContextRotateCTM(platformContext, (CGFloat)-piOverTwoDouble);
             CGContextTranslateCTM(platformContext, -data.point0.x(), -data.point0.y());
             m_platformRenderer->drawConicGradient(platformContext, data.point0, data.angleRadians);
             CGContextRestoreGState(platformContext);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -35,6 +35,7 @@
 #include "Logging.h"
 #include "MediaPlayer.h"
 #include "NotImplemented.h"
+#include <numbers>
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
@@ -144,7 +145,7 @@ bool Recorder::updateStateForTranslate(float x, float y)
 
 bool Recorder::updateStateForRotate(float angleInRadians)
 {
-    if (WTF::areEssentiallyEqual(0.f, fmodf(angleInRadians, piFloat * 2.f)))
+    if (WTF::areEssentiallyEqual(0.f, fmodf(angleInRadians, std::numbers::pi_v<float> * 2.f)))
         return false;
     currentState().rotate(angleInRadians);
     return true;

--- a/Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp
@@ -28,6 +28,7 @@
 
 #include "FEGaussianBlurSoftwareApplier.h"
 #include "Filter.h"
+#include <numbers>
 #include <wtf/text/TextStream.h>
 
 #if USE(SKIA)
@@ -83,7 +84,7 @@ bool FEGaussianBlur::setEdgeMode(EdgeModeType edgeMode)
 
 static inline float gaussianKernelFactor()
 {
-    return 3 / 4.f * sqrtf(2 * piFloat);
+    return 3 / 4.f * sqrtf(2 * std::numbers::pi_v<float>);
 }
 
 static int clampedToKernelSize(float value)

--- a/Source/WebCore/platform/graphics/skia/PathSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PathSkia.cpp
@@ -30,6 +30,7 @@
 #include "GraphicsContextSkia.h"
 #include "NotImplemented.h"
 #include "PathStream.h"
+#include <numbers>
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkPathUtils.h>
@@ -126,13 +127,13 @@ void PathSkia::addEllipse(const FloatPoint& center, float radiusX, float radiusY
     SkRect oval = { x - radiusXScalar, y - radiusYScalar, x + radiusXScalar, y + radiusYScalar };
 
     if (direction == RotationDirection::Clockwise && startAngle > endAngle)
-        endAngle = startAngle + (2 * piFloat - fmodf(startAngle - endAngle, 2 * piFloat));
+        endAngle = startAngle + (2 * std::numbers::pi_v<float> - fmodf(startAngle - endAngle, 2 * std::numbers::pi_v<float>));
     else if (direction == RotationDirection::Counterclockwise && startAngle < endAngle)
-        endAngle = startAngle - (2 * piFloat - fmodf(endAngle - startAngle, 2 * piFloat));
+        endAngle = startAngle - (2 * std::numbers::pi_v<float> - fmodf(endAngle - startAngle, 2 * std::numbers::pi_v<float>));
 
     auto sweepAngle = endAngle - startAngle;
-    SkScalar startDegrees = SkFloatToScalar(startAngle * 180 / piFloat);
-    SkScalar sweepDegrees = SkFloatToScalar(sweepAngle * 180 / piFloat);
+    SkScalar startDegrees = SkFloatToScalar(startAngle * 180 / std::numbers::pi_v<float>);
+    SkScalar sweepDegrees = SkFloatToScalar(sweepAngle * 180 / std::numbers::pi_v<float>);
 
     // SkPath::arcTo can't handle the sweepAngle that is equal to 360, so in those
     // cases we add two arcs with sweepAngle = 180. SkPath::addOval can handle sweepAngle

--- a/Source/WebCore/platform/graphics/transforms/AffineTransform.cpp
+++ b/Source/WebCore/platform/graphics/transforms/AffineTransform.cpp
@@ -35,6 +35,7 @@
 #include "IntRect.h"
 #include "Region.h"
 #include "TransformationMatrix.h"
+#include <numbers>
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
@@ -408,18 +409,18 @@ void AffineTransform::blend(const AffineTransform& from, double progress, Compos
     if ((srA.scaleX < 0 && srB.scaleY < 0) || (srA.scaleY < 0 &&  srB.scaleX < 0)) {
         srA.scaleX = -srA.scaleX;
         srA.scaleY = -srA.scaleY;
-        srA.angle += srA.angle < 0 ? piDouble : -piDouble;
+        srA.angle += srA.angle < 0 ? std::numbers::pi : -std::numbers::pi;
     }
 
     // Don't rotate the long way around.
-    srA.angle = fmod(srA.angle, 2 * piDouble);
-    srB.angle = fmod(srB.angle, 2 * piDouble);
+    srA.angle = fmod(srA.angle, 2 * std::numbers::pi);
+    srB.angle = fmod(srB.angle, 2 * std::numbers::pi);
 
-    if (std::abs(srA.angle - srB.angle) > piDouble) {
+    if (std::abs(srA.angle - srB.angle) > std::numbers::pi) {
         if (srA.angle > srB.angle)
-            srA.angle -= piDouble * 2;
+            srA.angle -= std::numbers::pi * 2;
         else
-            srB.angle -= piDouble * 2;
+            srB.angle -= std::numbers::pi * 2;
     }
     
     srA.scaleX += progress * (srB.scaleX - srA.scaleX);

--- a/Source/WebCore/platform/ios/WebCoreMotionManager.mm
+++ b/Source/WebCore/platform/ios/WebCoreMotionManager.mm
@@ -33,6 +33,7 @@
 #import "WebCoreObjCExtras.h"
 #import "WebCoreThreadRun.h"
 #import <CoreLocation/CoreLocation.h>
+#import <numbers>
 #import <objc/objc-runtime.h>
 #import <pal/spi/cocoa/CoreMotionSPI.h>
 #import <wtf/MathExtras.h>
@@ -289,27 +290,27 @@ static const double kGravity = 9.80665;
         } else if (R[8] < 0) {
             zRot = atan2(R[1], -R[4]);
             xRot = -asin(R[7]);
-            xRot += (xRot >= 0) ? -M_PI : M_PI;
+            xRot += (xRot >= 0) ? -std::numbers::pi : std::numbers::pi;
             yRot = atan2(R[6], -R[8]);
         } else {
             if (R[6] > 0) {
                 zRot = atan2(-R[1], R[4]);
                 xRot = asin(R[7]);
-                yRot = -M_PI_2;
+                yRot = -piOverTwoDouble;
             } else if (R[6] < 0) {
                 zRot = atan2(R[1], -R[4]);
                 xRot = -asin(R[7]);
-                xRot += (xRot >= 0) ? -M_PI : M_PI;
-                yRot = -M_PI_2;
+                xRot += (xRot >= 0) ? -std::numbers::pi : std::numbers::pi;
+                yRot = -piOverTwoDouble;
             } else {
                 zRot = atan2(R[3], R[0]);
-                xRot = (R[7] > 0) ? M_PI_2 : -M_PI_2;
+                xRot = (R[7] > 0) ? piOverTwoDouble : -piOverTwoDouble;
                 yRot = 0;
             }
         }
 
         // Rotation around the Z axis (pointing up. normalized to [0, 360] deg).
-        double alpha = rad2deg(zRot > 0 ? zRot : (M_PI * 2 + zRot));
+        double alpha = rad2deg(zRot > 0 ? zRot : (std::numbers::pi * 2 + zRot));
         // Rotation around the X axis (top to bottom).
         double beta  = rad2deg(xRot);
         // Rotation around the Y axis (side to side).

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
@@ -42,6 +42,7 @@
 #include <CoreAudio/CoreAudioTypes.h>
 #include <CoreMedia/CMTime.h>
 #include <mutex>
+#include <numbers>
 #include <wtf/Locker.h>
 #include <wtf/MediaTime.h>
 
@@ -456,7 +457,7 @@ void MediaRecorderPrivateEncoder::appendVideoFrame(MediaTime sampleTime, Ref<Vid
         m_firstVideoFrameProcessed = true;
 
         if (frame->rotation() != VideoFrame::Rotation::None || frame->isMirrored()) {
-            m_videoTransform = CGAffineTransformMakeRotation(static_cast<int>(frame->rotation()) * M_PI / 180);
+            m_videoTransform = CGAffineTransformMakeRotation(static_cast<int>(frame->rotation()) * std::numbers::pi / 180);
             if (frame->isMirrored())
                 m_videoTransform = CGAffineTransformScale(*m_videoTransform, -1, 1);
         }

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
@@ -28,11 +28,12 @@
 #include "GStreamerCaptureDeviceManager.h"
 #include "MockRealtimeMediaSourceCenter.h"
 #include <gst/app/gstappsrc.h>
+#include <numbers>
 #include <wtf/IndexedRange.h>
 
 namespace WebCore {
 
-static constexpr double s_Tau = 2 * M_PI;
+static constexpr double s_Tau = 2 * std::numbers::pi;
 static constexpr double s_BipBopDuration = 0.07;
 static constexpr double s_BipBopVolume = 0.5;
 static constexpr double s_BipFrequency = 1500;

--- a/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
@@ -44,6 +44,7 @@
 #import <AVFoundation/AVAudioBuffer.h>
 #import <AudioToolbox/AudioConverter.h>
 #import <CoreAudio/CoreAudioTypes.h>
+#import <numbers>
 #import <wtf/IndexedRange.h>
 #import <wtf/RunLoop.h>
 #import <wtf/StdLibExtras.h>
@@ -62,7 +63,7 @@ static inline size_t alignTo16Bytes(size_t size)
     return (size + 15) & ~15;
 }
 
-static constexpr double Tau = 2 * M_PI;
+static constexpr double Tau = 2 * std::numbers::pi;
 static constexpr double BipBopDuration = 0.07;
 static constexpr double BipBopVolume = 0.5;
 static constexpr double BipFrequency = 1500;

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -46,6 +46,7 @@
 #include "ThreadGlobalData.h"
 #include "VideoFrame.h"
 #include <math.h>
+#include <numbers>
 #include <wtf/NativePromise.h>
 #include <wtf/UUID.h>
 #include <wtf/text/MakeString.h>
@@ -473,16 +474,16 @@ void MockRealtimeVideoSource::drawAnimation(GraphicsContext& context)
 
     m_path.clear();
     m_path.moveTo(location);
-    m_path.addArc(location, radius, 0, 2 * piFloat, RotationDirection::Counterclockwise);
+    m_path.addArc(location, radius, 0, 2 * std::numbers::pi_v<float>, RotationDirection::Counterclockwise);
     m_path.closeSubpath();
     context.setFillColor(Color::white);
     context.setFillRule(WindRule::NonZero);
     context.fillPath(m_path);
 
-    float endAngle = piFloat * (((fmod(m_frameNumber, frameRate()) + 0.5) * (2.0 / frameRate())) + 1);
+    float endAngle = std::numbers::pi_v<float> * (((fmod(m_frameNumber, frameRate()) + 0.5) * (2.0 / frameRate())) + 1);
     m_path.clear();
     m_path.moveTo(location);
-    m_path.addArc(location, radius, 1.5 * piFloat, endAngle, RotationDirection::Counterclockwise);
+    m_path.addArc(location, radius, 1.5 * std::numbers::pi_v<float>, endAngle, RotationDirection::Counterclockwise);
     m_path.closeSubpath();
     context.setFillColor(Color::gray);
     context.setFillRule(WindRule::NonZero);

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -85,10 +85,12 @@
 #import "WebCoreThreadRun.h"
 #import <CoreGraphics/CoreGraphics.h>
 #import <CoreImage/CoreImage.h>
+#import <numbers>
 #import <objc/runtime.h>
 #import <pal/spi/cf/CoreTextSPI.h>
 #import <pal/spi/ios/UIKitSPI.h>
 #import <pal/system/ios/UserInterfaceIdiom.h>
+#import <wtf/MathExtras.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/ObjCRuntimeExtras.h>
 #import <wtf/StdLibExtras.h>
@@ -1312,7 +1314,7 @@ static void paintAttachmentProgress(GraphicsContext& context, AttachmentLayout& 
     Path progressPath;
     progressPath.moveTo(center);
     progressPath.addLineTo(FloatPoint(center.x(), info.progressRect.y()));
-    progressPath.addArc(center, info.progressRect.width() / 2, -M_PI_2, info.progress * 2 * M_PI - M_PI_2, RotationDirection::Counterclockwise);
+    progressPath.addArc(center, info.progressRect.width() / 2, -piOverTwoDouble, info.progress * 2 * std::numbers::pi - piOverTwoDouble, RotationDirection::Counterclockwise);
     progressPath.closeSubpath();
     context.fillPath(progressPath);
 }

--- a/Source/WebCore/rendering/mathml/MathOperator.cpp
+++ b/Source/WebCore/rendering/mathml/MathOperator.cpp
@@ -31,6 +31,7 @@
 
 #include "RenderStyleInlines.h"
 #include "StyleInheritedData.h"
+#include <numbers>
 #include <wtf/StdLibExtras.h>
 
 static const unsigned kRadicalOperator = 0x221A;
@@ -242,7 +243,7 @@ void MathOperator::calculateDisplayStyleLargeOperator(const RenderStyle& style)
         return;
 
     // The value of displayOperatorMinHeight is sometimes too small, so we ensure that it is at least \sqrt{2} times the size of the base glyph.
-    float displayOperatorMinHeight = std::max(heightForGlyph(baseGlyph) * sqrtOfTwoFloat, baseGlyph.font->mathData()->getMathConstant(*baseGlyph.font, OpenTypeMathData::DisplayOperatorMinHeight));
+    float displayOperatorMinHeight = std::max(heightForGlyph(baseGlyph) * std::numbers::sqrt2_v<float>, baseGlyph.font->mathData()->getMathConstant(*baseGlyph.font, OpenTypeMathData::DisplayOperatorMinHeight));
 
     Vector<Glyph> sizeVariants;
     Vector<OpenTypeMathData::AssemblyPart> assemblyParts;

--- a/Source/WebCore/rendering/mathml/RenderMathMLMenclose.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLMenclose.cpp
@@ -35,6 +35,7 @@
 #include "RenderBoxInlines.h"
 #include "RenderBoxModelObjectInlines.h"
 #include "RoundedRect.h"
+#include <numbers>
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -145,10 +146,10 @@ RenderMathMLMenclose::SpaceAroundContent RenderMathMLMenclose::spaceAroundConten
     // - We add extra margin of \xi_8
     // Then for example the top space is \sqrt{2}contentHeight/2 - contentHeight/2 + \xi_8/2 + \xi_8.
     if (hasNotation(MathMLMencloseElement::Circle)) {
-        LayoutUnit extraSpace { (contentWidth * (sqrtOfTwoFloat - 1) + 3 * thickness) / 2 };
+        LayoutUnit extraSpace { (contentWidth * (std::numbers::sqrt2_v<float> - 1) + 3 * thickness) / 2 };
         space.left = std::max(space.left, extraSpace);
         space.right = std::max(space.right, extraSpace);
-        extraSpace = (contentHeight * (sqrtOfTwoFloat - 1) + 3 * thickness) / 2;
+        extraSpace = (contentHeight * (std::numbers::sqrt2_v<float> - 1) + 3 * thickness) / 2;
         space.top = std::max(space.top, extraSpace);
         space.bottom = std::max(space.bottom, extraSpace);
     }
@@ -356,8 +357,8 @@ void RenderMathMLMenclose::paint(PaintInfo& info, const LayoutPoint& paintOffset
     // - The height is \xi_8/2 + contentHeight * \sqrt{2} + \xi_8/2
     if (hasNotation(MathMLMencloseElement::Circle)) {
         LayoutRect ellipseRect;
-        ellipseRect.setWidth(m_contentRect.width() * sqrtOfTwoFloat + thickness);
-        ellipseRect.setHeight(m_contentRect.height() * sqrtOfTwoFloat + thickness);
+        ellipseRect.setWidth(m_contentRect.width() * std::numbers::sqrt2_v<float> + thickness);
+        ellipseRect.setHeight(m_contentRect.height() * std::numbers::sqrt2_v<float> + thickness);
         ellipseRect.setX(m_contentRect.x() - (ellipseRect.width() - m_contentRect.width()) / 2);
         ellipseRect.setY(m_contentRect.y() - (ellipseRect.height() - m_contentRect.height()) / 2);
         Path path;

--- a/Source/WebCore/rendering/svg/SVGLayerTransformComputation.h
+++ b/Source/WebCore/rendering/svg/SVGLayerTransformComputation.h
@@ -24,6 +24,7 @@
 #include "RenderLayerModelObject.h"
 #include "RenderSVGViewportContainer.h"
 #include "TransformState.h"
+#include <numbers>
 #include <wtf/MathExtras.h>
 
 namespace WebCore {
@@ -123,7 +124,7 @@ public:
         ctm.scale(m_renderer->document().deviceScaleFactor());
         if (!m_renderer->document().isSVGDocument())
             ctm.scale(m_renderer->style().usedZoom());
-        return narrowPrecisionToFloat(std::hypot(ctm.xScale(), ctm.yScale()) / sqrtOfTwoDouble);
+        return narrowPrecisionToFloat(std::hypot(ctm.xScale(), ctm.yScale()) / std::numbers::sqrt2);
     }
 
 private:

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -57,6 +57,7 @@
 #include "SVGResourcesCache.h"
 #include "TransformOperationData.h"
 #include "TransformState.h"
+#include <numbers>
 
 namespace WebCore {
 
@@ -568,12 +569,12 @@ FloatRect SVGRenderSupport::calculateApproximateStrokeBoundingBox(const RenderEl
             auto& style = renderer.style();
             if (renderer.shapeType() == Renderer::ShapeType::Path && style.joinStyle() == LineJoin::Miter) {
                 const float miter = style.strokeMiterLimit();
-                if (miter < sqrtOfTwoDouble && style.capStyle() == LineCap::Square)
-                    delta *= sqrtOfTwoDouble;
+                if (miter < std::numbers::sqrt2 && style.capStyle() == LineCap::Square)
+                    delta *= std::numbers::sqrt2;
                 else
                     delta *= std::max(miter, 1.0f);
             } else if (style.capStyle() == LineCap::Square)
-                delta *= sqrtOfTwoDouble;
+                delta *= std::numbers::sqrt2;
             break;
         }
         }

--- a/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
@@ -41,6 +41,7 @@
 #include "SVGLengthContext.h"
 #include "SVGResources.h"
 #include "SVGResourcesCache.h"
+#include <numbers>
 #include <wtf/MathExtras.h>
 
 namespace WebCore {
@@ -207,7 +208,7 @@ static AffineTransform& currentContentTransformation()
 float SVGRenderingContext::calculateScreenFontSizeScalingFactor(const RenderObject& renderer)
 {
     AffineTransform ctm = calculateTransformationToOutermostCoordinateSystem(renderer);
-    return narrowPrecisionToFloat(std::hypot(ctm.xScale(), ctm.yScale()) / sqrtOfTwoDouble);
+    return narrowPrecisionToFloat(std::hypot(ctm.xScale(), ctm.yScale()) / std::numbers::sqrt2);
 }
 
 AffineTransform SVGRenderingContext::calculateTransformationToOutermostCoordinateSystem(const RenderObject& renderer)

--- a/Source/WebCore/style/values/shapes/StyleCircleFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleCircleFunction.cpp
@@ -30,6 +30,7 @@
 #include "Path.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
+#include <numbers>
 #include <wtf/TinyLRUCache.h>
 
 namespace WebCore {
@@ -69,7 +70,7 @@ float resolveRadius(const Circle& value, FloatSize boxSize, FloatPoint center)
 {
     return WTF::switchOn(value.radius,
         [&](const Circle::Length& length) -> float {
-            return evaluate(length, boxSize.diagonalLength() / sqrtOfTwoFloat);
+            return evaluate(length, boxSize.diagonalLength() / std::numbers::sqrt2_v<float>);
         },
         [&](const Circle::Extent& extent) -> float {
             return WTF::switchOn(extent,

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -33,6 +33,7 @@
 #include "RenderView.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGSVGElement.h"
+#include <numbers>
 #include <wtf/MathExtras.h>
 
 namespace WebCore {
@@ -92,7 +93,7 @@ static inline float dimensionForLengthMode(SVGLengthMode mode, FloatSize viewpor
     case SVGLengthMode::Height:
         return viewportSize.height();
     case SVGLengthMode::Other:
-        return viewportSize.diagonalLength() / sqrtOfTwoFloat;
+        return viewportSize.diagonalLength() / std::numbers::sqrt2_v<float>;
     }
     ASSERT_NOT_REACHED();
     return 0;

--- a/Source/WebCore/svg/SVGPathParser.cpp
+++ b/Source/WebCore/svg/SVGPathParser.cpp
@@ -30,6 +30,7 @@
 #include "SVGPathSource.h"
 #include "SVGPathStringBuilder.h"
 #include "SVGPathUtilities.h"
+#include <numbers>
 #include <wtf/MathExtras.h>
 
 static const float gOneOverThree = 1 / 3.f;
@@ -455,9 +456,9 @@ bool SVGPathParser::decomposeArcToCubic(float angle, float rx, float ry, const F
 
     float thetaArc = theta2 - theta1;
     if (thetaArc < 0 && sweepFlag)
-        thetaArc += 2 * piFloat;
+        thetaArc += 2 * std::numbers::pi_v<float>;
     else if (thetaArc > 0 && !sweepFlag)
-        thetaArc -= 2 * piFloat;
+        thetaArc -= 2 * std::numbers::pi_v<float>;
 
     pointTransform.makeIdentity();
     pointTransform.rotate(angle);

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
@@ -30,6 +30,7 @@
 #include "SVGFilterElement.h"
 #include "SVGFilterPrimitiveGraph.h"
 #include "SVGFilterPrimitiveStandardAttributes.h"
+#include <numbers>
 
 namespace WebCore {
 
@@ -244,7 +245,7 @@ FloatPoint3D SVGFilter::resolvedPoint3D(const FloatPoint3D& point) const
     resolvedPoint.setY(m_targetBoundingBox.y() + point.y() * m_targetBoundingBox.height());
 
     // https://www.w3.org/TR/SVG/filters.html#fePointLightZAttribute and https://www.w3.org/TR/SVG/coords.html#Units_viewport_percentage
-    resolvedPoint.setZ(point.z() * euclidianDistance(m_targetBoundingBox.minXMinYCorner(), m_targetBoundingBox.maxXMaxYCorner()) / sqrtOfTwoFloat);
+    resolvedPoint.setZ(point.z() * euclidianDistance(m_targetBoundingBox.minXMinYCorner(), m_targetBoundingBox.maxXMaxYCorner()) / std::numbers::sqrt2_v<float>);
 
     return resolvedPoint;
 }

--- a/Source/WebCore/testing/cocoa/WebViewVisualIdentificationOverlay.mm
+++ b/Source/WebCore/testing/cocoa/WebViewVisualIdentificationOverlay.mm
@@ -31,6 +31,7 @@
 #import "Color.h"
 #import "WebCoreCALayerExtras.h"
 #import <CoreText/CoreText.h>
+#import <wtf/MathExtras.h>
 #import <wtf/WeakObjCPtr.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -169,7 +170,7 @@ static void drawPattern(void *overlayPtr, CGContextRef ctx)
 
     CGSize textSize = [_kind sizeWithAttributes:@{ (id)kCTFontAttributeName : (id)createIdentificationFont().get() }];
     CGSize patternSize = CGSizeMake(textSize.width + horizontalMargin, (textSize.height + verticalMargin) * 2);
-    auto pattern = adoptCF(CGPatternCreate(self, layer.bounds, CGAffineTransformMakeRotation(M_PI_4), patternSize.width, patternSize.height, kCGPatternTilingNoDistortion, true, &callbacks));
+    auto pattern = adoptCF(CGPatternCreate(self, layer.bounds, CGAffineTransformMakeRotation(piOverFourDouble), patternSize.width, patternSize.height, kCGPatternTilingNoDistortion, true, &callbacks));
     CGFloat alpha = 0.5;
     CGContextSetFillPattern(ctx, pattern.get(), &alpha);
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTouchEventGenerator.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTouchEventGenerator.mm
@@ -30,6 +30,7 @@
 
 #import "UIKitSPI.h"
 #import <mach/mach_time.h>
+#import <numbers>
 #import <pal/spi/cocoa/IOKitSPI.h>
 #import <wtf/Assertions.h>
 #import <wtf/IndexedRange.h>
@@ -73,7 +74,7 @@ static CFTimeInterval secondsSinceAbsoluteTime(CFAbsoluteTime startTime)
 
 static double simpleCurveInterpolation(double a, double b, double t)
 {
-    return a + (b - a) * sin(sin(t * M_PI / 2) * t * M_PI / 2);
+    return a + (b - a) * sin(sin(t * std::numbers::pi / 2) * t * std::numbers::pi / 2);
 }
 
 static CGPoint calculateNextCurveLocation(CGPoint a, CGPoint b, CFTimeInterval t)

--- a/Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm
+++ b/Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm
@@ -41,6 +41,7 @@
 #import <WebCore/WebEvent.h>
 #import <WebKit/UIKitSPI.h>
 #import <algorithm>
+#import <numbers>
 #import <wtf/RetainPtr.h>
 #import <wtf/WeakObjCPtr.h>
 
@@ -316,7 +317,7 @@ static NSString * const scrollToExtentWithAnimationKey = @"ScrollToExtentAnimati
 
         // See also: _smoothDecelerationAnimation() in UIKit.
         auto animation = [CASpringAnimation animationWithKeyPath:@"position"];
-        static constexpr auto angularFrequency = 2 * M_PI / 0.6;
+        static constexpr auto angularFrequency = 2 * std::numbers::pi / 0.6;
         animation.mass = 1;
         animation.stiffness = angularFrequency * angularFrequency;
         animation.damping = 2 * angularFrequency;

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
@@ -38,6 +38,7 @@
 #import "WebPageProxy.h"
 #import <UIKit/UIKit.h>
 #import <WebCore/LocalizedStrings.h>
+#import <numbers>
 #import <pal/system/ios/UserInterfaceIdiom.h>
 
 using namespace WebKit;
@@ -856,7 +857,7 @@ static const CGFloat groupHeaderCollapseButtonTransitionDuration = 0.3f;
 
     auto animations = [protectedSelf = retainPtr(self)] {
         auto layoutDirectionMultipler = ([UIView userInterfaceLayoutDirectionForSemanticContentAttribute:[protectedSelf semanticContentAttribute]] == UIUserInterfaceLayoutDirectionLeftToRight) ? -1.0f : 1.0f;
-        auto transform = protectedSelf->_collapsed ? CGAffineTransformMakeRotation(layoutDirectionMultipler * M_PI / 2) : CGAffineTransformIdentity;
+        auto transform = protectedSelf->_collapsed ? CGAffineTransformMakeRotation(layoutDirectionMultipler * std::numbers::pi / 2) : CGAffineTransformIdentity;
         [protectedSelf->_collapseIndicatorView setTransform:transform];
     };
 

--- a/Source/WebKitLegacy/ios/WebView/WebPDFViewIOS.mm
+++ b/Source/WebKitLegacy/ios/WebView/WebPDFViewIOS.mm
@@ -48,6 +48,7 @@
 #import <WebKitLegacy/WebFrameView.h>
 #import <WebKitLegacy/WebNSViewExtras.h>
 #import <WebKitLegacy/WebViewPrivate.h>
+#import <numbers>
 #import <wtf/Assertions.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/StdLibExtras.h>
@@ -262,7 +263,7 @@ static RetainPtr<CGColorRef> createCGColorWithDeviceWhite(CGFloat white, CGFloat
         
         CGPDFPageRef page = CGPDFDocumentGetPage(_PDFDocument, i);
         CGRect boxRect = CGPDFPageGetBoxRect(page, kCGPDFCropBox);
-        CGFloat rotation = CGPDFPageGetRotationAngle(page) * (M_PI / 180);
+        CGFloat rotation = CGPDFPageGetRotationAngle(page) * (std::numbers::pi / 180);
         if (rotation != 0) {
             boxRect = CGRectApplyAffineTransform(boxRect, CGAffineTransformMakeRotation(rotation));
             boxRect.size.width = roundf(boxRect.size.width);

--- a/Source/WebKitLegacy/ios/WebView/WebPDFViewPlaceholder.mm
+++ b/Source/WebKitLegacy/ios/WebView/WebPDFViewPlaceholder.mm
@@ -47,6 +47,7 @@
 #import <WebKitLegacy/WebNSViewExtras.h>
 #import <WebKitLegacy/WebPDFDocumentExtras.h>
 #import <WebKitLegacy/WebViewPrivate.h>
+#import <numbers>
 #import <wtf/MonotonicTime.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/Vector.h>
@@ -346,7 +347,7 @@ static const float PAGE_HEIGHT_INSET = 4.0f * 2.0f;
         return CGRectZero;
 
     CGRect bounds = CGPDFPageGetBoxRect(page, kCGPDFCropBox);
-    CGFloat rotation = CGPDFPageGetRotationAngle(page) * (M_PI / 180.0f);
+    CGFloat rotation = CGPDFPageGetRotationAngle(page) * (std::numbers::pi / 180.0f);
     if (rotation != 0)
         bounds = CGRectApplyAffineTransform(bounds, CGAffineTransformMakeRotation(rotation));
 

--- a/Source/WebKitLegacy/mac/WebView/WebWindowAnimation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebWindowAnimation.mm
@@ -28,6 +28,7 @@
 #import "WebWindowAnimation.h"
 
 #import <WebCore/FloatConversion.h>
+#import <numbers>
 #import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <wtf/Assertions.h>
 #import <wtf/MathExtras.h>
@@ -96,7 +97,7 @@ using WebCore::narrowPrecisionToFloat;
 
 - (float)currentValue
 {
-    return narrowPrecisionToFloat(0.5 - 0.5 * cos(piDouble * (1 - [self currentProgress])));
+    return narrowPrecisionToFloat(0.5 - 0.5 * cos(std::numbers::pi * (1 - [self currentProgress])));
 }
 
 - (NSRect)currentFrame

--- a/Tools/TestWebKitAPI/Tests/WTF/AtomString.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/AtomString.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 
+#include <numbers>
 #include <wtf/text/AtomString.h>
 
 namespace TestWebKitAPI {
@@ -78,8 +79,8 @@ TEST(WTF, AtomStringNumberDouble)
     EXPECT_STREQ("-1.7976931348623157e+308", testAtomStringNumber(Limits::lowest()));
     EXPECT_STREQ("1.7976931348623157e+308", testAtomStringNumber(Limits::max()));
 
-    EXPECT_STREQ("3.141592653589793", testAtomStringNumber(piDouble));
-    EXPECT_STREQ("3.1415927410125732", testAtomStringNumber(piFloat));
+    EXPECT_STREQ("3.141592653589793", testAtomStringNumber(std::numbers::pi));
+    EXPECT_STREQ("3.1415927410125732", testAtomStringNumber(std::numbers::pi_v<float>));
     EXPECT_STREQ("1.5707963267948966", testAtomStringNumber(piOverTwoDouble));
     EXPECT_STREQ("1.5707963705062866", testAtomStringNumber(piOverTwoFloat));
     EXPECT_STREQ("0.7853981633974483", testAtomStringNumber(piOverFourDouble));

--- a/Tools/TestWebKitAPI/Tests/WTF/MediaTime.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/MediaTime.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 
 #include <limits>
+#include <numbers>
 #include <wtf/Expected.h>
 #include <wtf/MathExtras.h>
 #include <wtf/MediaTime.h>
@@ -193,7 +194,7 @@ TEST(WTF, MediaTime)
     EXPECT_EQ(MediaTime(3, 2).toDouble(), 1.5);
     EXPECT_EQ(MediaTime(1, 1 << 16).toFloat(), 1 / pow(2.0f, 16.0f));
     EXPECT_EQ(MediaTime(1, 1 << 30).toDouble(), 1 / pow(2.0, 30.0));
-    EXPECT_EQ(MediaTime::createWithDouble(piDouble, 1 << 30), MediaTime(3373259426U, 1 << 30));
+    EXPECT_EQ(MediaTime::createWithDouble(std::numbers::pi, 1 << 30), MediaTime(3373259426U, 1 << 30));
 
     EXPECT_EQ(MediaTime::createWithFloat(std::numeric_limits<float>::infinity()), MediaTime::positiveInfiniteTime());
     EXPECT_EQ(MediaTime::createWithFloat(-std::numeric_limits<float>::infinity()), MediaTime::negativeInfiniteTime());

--- a/Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp
@@ -27,6 +27,7 @@
 
 #include "Test.h"
 #include <limits>
+#include <numbers>
 #include <sstream>
 #include <wtf/MathExtras.h>
 #include <wtf/text/CString.h>
@@ -100,8 +101,8 @@ TEST(WTF, StringNumberFixedPrecision)
     EXPECT_STREQ("-1.79769e+308", testStringNumberFixedPrecision(Limits::lowest()));
     EXPECT_STREQ("1.79769e+308", testStringNumberFixedPrecision(Limits::max()));
 
-    EXPECT_STREQ("3.14159", testStringNumberFixedPrecision(piDouble));
-    EXPECT_STREQ("3.14159", testStringNumberFixedPrecision(piFloat));
+    EXPECT_STREQ("3.14159", testStringNumberFixedPrecision(std::numbers::pi));
+    EXPECT_STREQ("3.14159", testStringNumberFixedPrecision(std::numbers::pi_v<float>));
     EXPECT_STREQ("1.5708", testStringNumberFixedPrecision(piOverTwoDouble));
     EXPECT_STREQ("1.5708", testStringNumberFixedPrecision(piOverTwoFloat));
     EXPECT_STREQ("0.785398", testStringNumberFixedPrecision(piOverFourDouble));
@@ -149,8 +150,8 @@ TEST(WTF, StringNumberFixedWidth)
     EXPECT_STREQ("", testStringNumberFixedWidth(Limits::lowest()));
     EXPECT_STREQ("", testStringNumberFixedWidth(Limits::max()));
 
-    EXPECT_STREQ("3.141593", testStringNumberFixedWidth(piDouble));
-    EXPECT_STREQ("3.141593", testStringNumberFixedWidth(piFloat));
+    EXPECT_STREQ("3.141593", testStringNumberFixedWidth(std::numbers::pi));
+    EXPECT_STREQ("3.141593", testStringNumberFixedWidth(std::numbers::pi_v<float>));
     EXPECT_STREQ("1.570796", testStringNumberFixedWidth(piOverTwoDouble));
     EXPECT_STREQ("1.570796", testStringNumberFixedWidth(piOverTwoFloat));
     EXPECT_STREQ("0.785398", testStringNumberFixedWidth(piOverFourDouble));
@@ -196,8 +197,8 @@ TEST(WTF, StringNumber)
     EXPECT_STREQ("-1.7976931348623157e+308", testStringNumber(Limits::lowest()));
     EXPECT_STREQ("1.7976931348623157e+308", testStringNumber(Limits::max()));
 
-    EXPECT_STREQ("3.141592653589793", testStringNumber(piDouble));
-    EXPECT_STREQ("3.1415927410125732", testStringNumber(piFloat));
+    EXPECT_STREQ("3.141592653589793", testStringNumber(std::numbers::pi));
+    EXPECT_STREQ("3.1415927410125732", testStringNumber(std::numbers::pi_v<float>));
     EXPECT_STREQ("1.5707963267948966", testStringNumber(piOverTwoDouble));
     EXPECT_STREQ("1.5707963705062866", testStringNumber(piOverTwoFloat));
     EXPECT_STREQ("0.7853981633974483", testStringNumber(piOverFourDouble));

--- a/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
@@ -32,7 +32,9 @@
 #include <WebCore/DisplayListRecorderImpl.h>
 #include <WebCore/GraphicsContext.h>
 #include <WebCore/ImageBuffer.h>
+#include <numbers>
 #include <wtf/MathExtras.h>
+
 #if PLATFORM(COCOA)
 #include <WebCore/GraphicsContextCG.h>
 #endif
@@ -410,9 +412,9 @@ struct TrivialRotate {
         c.rotate(1.f);
         c.rotate(0.f);
         c.rotate(2.f);
-        c.rotate(piFloat * 2.f);
-        c.rotate(7.f * piFloat * 2.f);
-        c.rotate(-2.f * piFloat * 2.f);
+        c.rotate(std::numbers::pi_v<float> * 2.f);
+        c.rotate(7.f * std::numbers::pi_v<float> * 2.f);
+        c.rotate(-2.f * std::numbers::pi_v<float> * 2.f);
         c.drawRect({ 0, 0, 1, 1 });
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/cg/BifurcatedGraphicsContextTestsCG.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cg/BifurcatedGraphicsContextTestsCG.cpp
@@ -35,6 +35,7 @@
 #include <WebCore/FontCascade.h>
 #include <WebCore/GradientImage.h>
 #include <WebCore/GraphicsContextCG.h>
+#include <numbers>
 
 namespace TestWebKitAPI {
 using namespace WebCore;
@@ -241,7 +242,7 @@ TEST(BifurcatedGraphicsContextTests, TransformedClip)
         EXPECT_EQ(primaryContext.clipBounds(), secondaryContext.clipBounds());
         EXPECT_EQ(primaryContext.clipBounds(), FloatRect(0, 0, 10, 10));
 
-        ctx.rotate(M_PI / 6);
+        ctx.rotate(std::numbers::pi / 6);
 
         EXPECT_EQ(primaryContext.clipBounds(), secondaryContext.clipBounds());
         EXPECT_EQ(primaryContext.clipBounds(), FloatRect(0, -5, 14, 14));

--- a/Tools/WebKitTestRunner/ios/HIDEventGenerator.mm
+++ b/Tools/WebKitTestRunner/ios/HIDEventGenerator.mm
@@ -30,9 +30,11 @@
 #import "GeneratedTouchesDebugWindow.h"
 #import "UIKitSPIForTesting.h"
 #import <mach/mach_time.h>
+#import <numbers>
 #import <pal/spi/cocoa/IOKitSPI.h>
 #import <wtf/Assertions.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/MathExtras.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/Vector.h>
 
@@ -185,7 +187,7 @@ static double linearInterpolation(double a, double b, double t)
 
 static double simpleCurveInterpolation(double a, double b, double t)
 {
-    return (a + (b - a) * sin(sin(t * M_PI / 2) * t * M_PI / 2));
+    return (a + (b - a) * sin(sin(t * std::numbers::pi / 2) * t * std::numbers::pi / 2));
 }
 
 
@@ -712,8 +714,8 @@ static InterpolationType interpolationFromString(NSString *string)
     // data. It does not mention that the azimuth angle is offset from a full rotation.
     // Also, UIKit and IOHID interpret the altitude as different adjacent angles.
     _activePoints[0].pathPressure = pressure * 500;
-    _activePoints[0].azimuthAngle = M_PI * 2 - azimuthAngle;
-    _activePoints[0].altitudeAngle = M_PI_2 - altitudeAngle;
+    _activePoints[0].azimuthAngle = std::numbers::pi * 2 - azimuthAngle;
+    _activePoints[0].altitudeAngle = piOverTwoDouble - altitudeAngle;
 
     auto eventRef = adoptCF([self _createIOHIDEventType:StylusEventTouched]);
     [self _sendHIDEvent:eventRef.get()];
@@ -726,8 +728,8 @@ static InterpolationType interpolationFromString(NSString *string)
     _activePoints[0].isStylus = YES;
     // See notes above for details on these calculations.
     _activePoints[0].pathPressure = pressure * 500;
-    _activePoints[0].azimuthAngle = M_PI * 2 - azimuthAngle;
-    _activePoints[0].altitudeAngle = M_PI_2 - altitudeAngle;
+    _activePoints[0].azimuthAngle = std::numbers::pi * 2 - azimuthAngle;
+    _activePoints[0].altitudeAngle = piOverTwoDouble - altitudeAngle;
 
     auto eventRef = adoptCF([self _createIOHIDEventType:StylusEventMoved]);
     [self _sendHIDEvent:eventRef.get()];


### PR DESCRIPTION
#### 91bbe4c98b2aff226120fb71c98b32b62130f157
<pre>
Leverage std::numbers more for some of our constants
<a href="https://bugs.webkit.org/show_bug.cgi?id=292372">https://bugs.webkit.org/show_bug.cgi?id=292372</a>

Reviewed by Sam Weinig.

This avoids duplicating them in wtf/MathExtras.h.

* Source/JavaScriptCore/b3/testb3.h:
(populateWithInterestingValues):
* Source/JavaScriptCore/b3/testb3_3.cpp:
(testDoubleToFloatThroughPhi):
(addArgTests):
* Source/JavaScriptCore/b3/testb3_6.cpp:
(testSelectDoubleCompareFloat):
* Source/JavaScriptCore/runtime/MathObject.cpp:
(JSC::MathObject::finishCreation):
* Source/WTF/wtf/MathExtras.h:
* Source/WebCore/Modules/webaudio/PannerNode.cpp:
(WebCore::PannerNode::calculateAzimuthElevation):
* Source/WebCore/Modules/webaudio/PeriodicWave.cpp:
(WebCore::PeriodicWave::generateBasicWaveform):
* Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp:
* Source/WebCore/Modules/webxr/WebXRSession.h:
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
(WebCore::CSSCalc::lookupConstantNumber):
* Source/WebCore/dom/PointerEvent.cpp:
(WebCore::PointerEvent::angleFromTilt):
* Source/WebCore/html/canvas/CanvasPath.cpp:
(WebCore::normalizeAngles):
* Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm:
* Source/WebCore/platform/DictationCaretAnimator.cpp:
(WebCore::keyframe):
* Source/WebCore/platform/audio/Biquad.cpp:
(WebCore::Biquad::setLowpassParams):
(WebCore::Biquad::setHighpassParams):
(WebCore::Biquad::setLowShelfParams):
(WebCore::Biquad::setHighShelfParams):
(WebCore::Biquad::setPeakingParams):
(WebCore::Biquad::setAllpassParams):
(WebCore::Biquad::setNotchParams):
(WebCore::Biquad::setBandpassParams):
(WebCore::Biquad::getFrequencyResponse):
* Source/WebCore/platform/audio/DownSampler.cpp:
(WebCore::DownSampler::initializeKernel):
* Source/WebCore/platform/audio/DynamicsCompressorKernel.cpp:
(WebCore::DynamicsCompressorKernel::process):
* Source/WebCore/platform/audio/FFTFrame.cpp:
(WebCore::FFTFrame::interpolateFrequencyComponents):
(WebCore::FFTFrame::extractAverageGroupDelay):
(WebCore::FFTFrame::addConstantGroupDelay):
* Source/WebCore/platform/audio/IIRFilter.cpp:
(WebCore::IIRFilter::getFrequencyResponse):
* Source/WebCore/platform/audio/SincResampler.cpp:
(WebCore::SincResampler::initializeKernel):
* Source/WebCore/platform/audio/UpSampler.cpp:
(WebCore::UpSampler::initializeKernel):
* Source/WebCore/platform/calc/CalculationExecutor.h:
(WebCore::Calculation::OperatorExecutor&lt;Tan&gt;::operator()):
* Source/WebCore/platform/graphics/FloatRoundedRect.cpp:
(WebCore::approximateAsRegion):
* Source/WebCore/platform/graphics/GeometryUtilities.cpp:
(WebCore::rotatedBoundingRectWithMinimumAngleOfRotation):
* Source/WebCore/platform/graphics/PathSegmentData.cpp:
(WebCore::angleOfLine):
(WebCore::calculateArcToEndPoint):
(WebCore::PathArc::extendBoundingRect const):
* Source/WebCore/platform/graphics/PathUtilities.cpp:
(WebCore::walkGraphAndExtractPolygon):
* Source/WebCore/platform/graphics/ShadowBlur.cpp:
(WebCore::calculateLobes):
* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm:
(WebCore::transformationMatrixForVideoFrame):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::videoTransformationMatrix):
* Source/WebCore/platform/graphics/cairo/CairoOperations.cpp:
(WebCore::Cairo::drawEllipse):
* Source/WebCore/platform/graphics/cairo/GradientCairo.cpp:
(WebCore::addConicSector):
* Source/WebCore/platform/graphics/cairo/PathCairo.cpp:
(WebCore::PathCairo::add):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::updateStateForRotate):
* Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp:
(WebCore::gaussianKernelFactor):
* Source/WebCore/platform/graphics/skia/PathSkia.cpp:
(WebCore::PathSkia::addEllipse):
* Source/WebCore/platform/graphics/transforms/AffineTransform.cpp:
(WebCore::AffineTransform::blend):
* Source/WebCore/platform/ios/WebCoreMotionManager.mm:
(-[WebCoreMotionManager sendMotionData:withHeading:]):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp:
(WebCore::MediaRecorderPrivateEncoder::appendVideoFrame):
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp:
* Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm:
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::drawAnimation):
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::paintAttachmentProgress):
* Source/WebCore/rendering/mathml/MathOperator.cpp:
(WebCore::MathOperator::calculateDisplayStyleLargeOperator):
* Source/WebCore/rendering/mathml/RenderMathMLMenclose.cpp:
(WebCore::RenderMathMLMenclose::spaceAroundContent const):
(WebCore::RenderMathMLMenclose::paint):
* Source/WebCore/rendering/svg/SVGLayerTransformComputation.h:
(WebCore::SVGLayerTransformComputation::calculateScreenFontSizeScalingFactor const):
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::calculateApproximateStrokeBoundingBox):
* Source/WebCore/rendering/svg/SVGRenderingContext.cpp:
(WebCore::SVGRenderingContext::calculateScreenFontSizeScalingFactor):
* Source/WebCore/style/values/shapes/StyleCircleFunction.cpp:
(WebCore::Style::resolveRadius):
* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::dimensionForLengthMode):
* Source/WebCore/svg/SVGPathParser.cpp:
(WebCore::SVGPathParser::decomposeArcToCubic):
* Source/WebCore/svg/graphics/filters/SVGFilter.cpp:
(WebCore::SVGFilter::resolvedPoint3D const):
* Source/WebKit/UIProcess/API/Cocoa/_WKTouchEventGenerator.mm:
(simpleCurveInterpolation):
* Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm:
(-[WKKeyboardScrollingAnimator beginWithEvent:]):
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm:
(-[WKSelectPickerGroupHeaderView setCollapsed:animated:]):
* Source/WebKitLegacy/ios/WebView/WebPDFViewIOS.mm:
(-[WebPDFView _computePageRects]):
* Source/WebKitLegacy/ios/WebView/WebPDFViewPlaceholder.mm:
(-[WebPDFViewPlaceholder _getPDFPageBounds:]):
* Source/WebKitLegacy/mac/WebView/WebWindowAnimation.mm:
(-[WebWindowScaleAnimation currentValue]):
* Tools/TestWebKitAPI/Tests/WTF/AtomString.cpp:
(TestWebKitAPI::TEST(WTF, AtomStringNumberDouble)):
* Tools/TestWebKitAPI/Tests/WTF/MediaTime.cpp:
(TestWebKitAPI::TEST(WTF, MediaTime)):
* Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp:
(TestWebKitAPI::TEST(WTF, StringNumberFixedPrecision)):
(TestWebKitAPI::TEST(WTF, StringNumberFixedWidth)):
(TestWebKitAPI::TEST(WTF, StringNumber)):
* Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp:
* Tools/TestWebKitAPI/Tests/WebCore/cg/BifurcatedGraphicsContextTestsCG.cpp:
(TestWebKitAPI::TEST(BifurcatedGraphicsContextTests, TransformedClip)):
* Tools/WebKitTestRunner/ios/HIDEventGenerator.mm:
(simpleCurveInterpolation):
(-[HIDEventGenerator stylusDownAtPoint:azimuthAngle:altitudeAngle:pressure:]):

Canonical link: <a href="https://commits.webkit.org/294398@main">https://commits.webkit.org/294398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2503903b99226532db46238eeb9a3fa802b413da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106827 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52303 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21645 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29837 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/77425 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34453 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104676 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16726 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91814 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57762 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16552 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9831 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51652 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94341 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86418 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9908 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109181 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100279 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28802 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/21211 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86402 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29163 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88015 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85967 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21878 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30718 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8432 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22965 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28730 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34019 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/123903 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28541 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34428 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31864 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30100 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->