### PR TITLE
Bucket the physical and logical properties of logical property groups separately for more efficient classification

### DIFF
--- a/Source/WebCore/css/CSSProperty.h
+++ b/Source/WebCore/css/CSSProperty.h
@@ -79,7 +79,7 @@ public:
     static CSSPropertyID unresolvePhysicalProperty(CSSPropertyID, WritingMode);
     static bool isInheritedProperty(CSSPropertyID);
     static Vector<String> aliasesForProperty(CSSPropertyID);
-    static bool isDirectionAwareProperty(CSSPropertyID);
+    static bool isDirectionAwareProperty(CSSPropertyID propertyID) { return isLogicalPropertyGroupLogicalProperty(propertyID); }
     static bool isInLogicalPropertyGroup(CSSPropertyID);
     static bool areInSameLogicalPropertyGroupWithDifferentMappingLogic(CSSPropertyID, CSSPropertyID);
     static bool isDescriptorOnly(CSSPropertyID);

--- a/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyNames.gperf
+++ b/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyNames.gperf
@@ -218,10 +218,10 @@ constexpr ASCIILiteral propertyNameStrings[numCSSProperties] = {
     "test-using-shared-rule-exported"_s,
     "test-using-shared-rule-with-override-function"_s,
     "test-sink-priority"_s,
-    "test-logical-property-group-logical-block"_s,
-    "test-logical-property-group-logical-inline"_s,
     "test-logical-property-group-physical-horizontal"_s,
     "test-logical-property-group-physical-vertical"_s,
+    "test-logical-property-group-logical-block"_s,
+    "test-logical-property-group-logical-inline"_s,
     "font"_s,
     "test-shorthand-one"_s,
     "test-shorthand-two"_s,
@@ -336,10 +336,10 @@ test-using-shared-rule, CSSPropertyID::CSSPropertyTestUsingSharedRule
 test-using-shared-rule-exported, CSSPropertyID::CSSPropertyTestUsingSharedRuleExported
 test-using-shared-rule-with-override-function, CSSPropertyID::CSSPropertyTestUsingSharedRuleWithOverrideFunction
 test-sink-priority, CSSPropertyID::CSSPropertyTestSinkPriority
-test-logical-property-group-logical-block, CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalBlock
-test-logical-property-group-logical-inline, CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalInline
 test-logical-property-group-physical-horizontal, CSSPropertyID::CSSPropertyTestLogicalPropertyGroupPhysicalHorizontal
 test-logical-property-group-physical-vertical, CSSPropertyID::CSSPropertyTestLogicalPropertyGroupPhysicalVertical
+test-logical-property-group-logical-block, CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalBlock
+test-logical-property-group-logical-inline, CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalInline
 font, CSSPropertyID::CSSPropertyFont
 test-shorthand-one, CSSPropertyID::CSSPropertyTestShorthandOne
 test-shorthand-two, CSSPropertyID::CSSPropertyTestShorthandTwo
@@ -560,10 +560,10 @@ constexpr bool isInheritedPropertyTable[cssPropertyIDEnumValueCount] = {
     false, // CSSPropertyID::CSSPropertyTestUsingSharedRuleExported
     false, // CSSPropertyID::CSSPropertyTestUsingSharedRuleWithOverrideFunction
     false, // CSSPropertyID::CSSPropertyTestSinkPriority
-    false, // CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalBlock
-    false, // CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalInline
     false, // CSSPropertyID::CSSPropertyTestLogicalPropertyGroupPhysicalHorizontal
     false, // CSSPropertyID::CSSPropertyTestLogicalPropertyGroupPhysicalVertical
+    false, // CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalBlock
+    false, // CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalInline
     false, // CSSPropertyID::CSSPropertyFont
     false, // CSSPropertyID::CSSPropertyTestShorthandOne
     false, // CSSPropertyID::CSSPropertyTestShorthandTwo
@@ -663,10 +663,10 @@ bool CSSProperty::allowsNumberOrIntegerInput(CSSPropertyID id)
     case CSSPropertyID::CSSPropertyTestUnboundedRepetitionWithSpacesWithMinSingleItemOpt:
     case CSSPropertyID::CSSPropertyTestUsingSharedRule:
     case CSSPropertyID::CSSPropertyTestSinkPriority:
-    case CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalBlock:
-    case CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalInline:
     case CSSPropertyID::CSSPropertyTestLogicalPropertyGroupPhysicalHorizontal:
     case CSSPropertyID::CSSPropertyTestLogicalPropertyGroupPhysicalVertical:
+    case CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalBlock:
+    case CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalInline:
         return true;
     default:
         return false;
@@ -676,17 +676,6 @@ bool CSSProperty::allowsNumberOrIntegerInput(CSSPropertyID id)
 bool CSSProperty::disablesNativeAppearance(CSSPropertyID id)
 {
     switch (id) {
-        return true;
-    default:
-        return false;
-    }
-}
-
-bool CSSProperty::isDirectionAwareProperty(CSSPropertyID id)
-{
-    switch (id) {
-    case CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalBlock:
-    case CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalInline:
         return true;
     default:
         return false;

--- a/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyNames.h
+++ b/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyNames.h
@@ -107,10 +107,10 @@ enum CSSPropertyID : uint16_t {
     CSSPropertyTestUsingSharedRuleExported = 93,
     CSSPropertyTestUsingSharedRuleWithOverrideFunction = 94,
     CSSPropertyTestSinkPriority = 95,
-    CSSPropertyTestLogicalPropertyGroupLogicalBlock = 96,
-    CSSPropertyTestLogicalPropertyGroupLogicalInline = 97,
-    CSSPropertyTestLogicalPropertyGroupPhysicalHorizontal = 98,
-    CSSPropertyTestLogicalPropertyGroupPhysicalVertical = 99,
+    CSSPropertyTestLogicalPropertyGroupPhysicalHorizontal = 96,
+    CSSPropertyTestLogicalPropertyGroupPhysicalVertical = 97,
+    CSSPropertyTestLogicalPropertyGroupLogicalBlock = 98,
+    CSSPropertyTestLogicalPropertyGroupLogicalInline = 99,
     CSSPropertyFont = 100,
     CSSPropertyTestShorthandOne = 101,
     CSSPropertyTestShorthandTwo = 102,
@@ -132,8 +132,12 @@ constexpr auto firstHighPriorityProperty = CSSPropertyID::CSSPropertyTestHighPri
 constexpr auto lastHighPriorityProperty = CSSPropertyID::CSSPropertyTestHighPriority;
 constexpr auto firstLowPriorityProperty = CSSPropertyID::CSSPropertyFirstTestDescriptorForFirstDescriptor;
 constexpr auto lastLowPriorityProperty = CSSPropertyID::CSSPropertyTestSinkPriority;
-constexpr auto firstLogicalGroupProperty = CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalBlock;
-constexpr auto lastLogicalGroupProperty = CSSPropertyID::CSSPropertyTestLogicalPropertyGroupPhysicalVertical;
+constexpr auto firstLogicalGroupPhysicalProperty = CSSPropertyID::CSSPropertyTestLogicalPropertyGroupPhysicalHorizontal;
+constexpr auto lastLogicalGroupPhysicalProperty = CSSPropertyID::CSSPropertyTestLogicalPropertyGroupPhysicalVertical;
+constexpr auto firstLogicalGroupLogicalProperty = CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalBlock;
+constexpr auto lastLogicalGroupLogicalProperty = CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalInline;
+constexpr auto firstLogicalGroupProperty = firstLogicalGroupPhysicalProperty;
+constexpr auto lastLogicalGroupProperty = lastLogicalGroupLogicalProperty;
 constexpr auto firstShorthandProperty = CSSPropertyID::CSSPropertyFont;
 constexpr auto lastShorthandProperty = CSSPropertyID::CSSPropertyTestShorthandTwo;
 constexpr uint16_t numCSSPropertyLonghands = firstShorthandProperty - firstCSSProperty;
@@ -184,11 +188,31 @@ constexpr AllLonghandCSSPropertiesRange allLonghandCSSProperties() { return { };
 
 constexpr bool isLonghand(CSSPropertyID property)
 {
-    return static_cast<uint16_t>(property) >= firstCSSProperty && static_cast<uint16_t>(property) < static_cast<uint16_t>(firstShorthandProperty);
+    return static_cast<uint16_t>(property) >= firstCSSProperty 
+        && static_cast<uint16_t>(property) < static_cast<uint16_t>(firstShorthandProperty);
 }
 constexpr bool isShorthand(CSSPropertyID property)
 {
-    return static_cast<uint16_t>(property) >= static_cast<uint16_t>(firstShorthandProperty) && static_cast<uint16_t>(property) <= static_cast<uint16_t>(lastShorthandProperty);
+    return static_cast<uint16_t>(property) >= static_cast<uint16_t>(firstShorthandProperty) 
+        && static_cast<uint16_t>(property) <= static_cast<uint16_t>(lastShorthandProperty);
+}
+
+constexpr bool isLogicalPropertyGroupProperty(CSSPropertyID property)
+{
+    return static_cast<uint16_t>(property) >= static_cast<uint16_t>(firstLogicalGroupPhysicalProperty) 
+        && static_cast<uint16_t>(property) <= static_cast<uint16_t>(lastLogicalGroupLogicalProperty);
+}
+
+constexpr bool isLogicalPropertyGroupPhysicalProperty(CSSPropertyID property)
+{
+    return static_cast<uint16_t>(property) >= static_cast<uint16_t>(firstLogicalGroupPhysicalProperty) 
+        && static_cast<uint16_t>(property) <= static_cast<uint16_t>(lastLogicalGroupPhysicalProperty);
+}
+
+constexpr bool isLogicalPropertyGroupLogicalProperty(CSSPropertyID property)
+{
+    return static_cast<uint16_t>(property) >= static_cast<uint16_t>(firstLogicalGroupLogicalProperty) 
+        && static_cast<uint16_t>(property) <= static_cast<uint16_t>(lastLogicalGroupLogicalProperty);
 }
 
 WTF::TextStream& operator<<(WTF::TextStream&, CSSPropertyID);

--- a/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyParsing.cpp
+++ b/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyParsing.cpp
@@ -3203,10 +3203,10 @@ RefPtr<CSSValue> CSSPropertyParsing::parseStyleProperty(CSSParserTokenRange& ran
     case CSSPropertyID::CSSPropertyTestProperty:
     case CSSPropertyID::CSSPropertyTestSettingsOne:
     case CSSPropertyID::CSSPropertyTestSinkPriority:
-    case CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalBlock:
-    case CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalInline:
     case CSSPropertyID::CSSPropertyTestLogicalPropertyGroupPhysicalHorizontal:
     case CSSPropertyID::CSSPropertyTestLogicalPropertyGroupPhysicalVertical:
+    case CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalBlock:
+    case CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalInline:
         return CSSPrimitiveValueResolver<CSS::Number<>>::consumeAndResolve(range, state);
     case CSSPropertyID::CSSPropertyTestBoundedRepetitionWithCommas:
         return consumeTestBoundedRepetitionWithCommas(range, state);

--- a/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleBuilderGenerated.cpp
+++ b/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleBuilderGenerated.cpp
@@ -2362,10 +2362,6 @@ void BuilderGenerated::applyProperty(CSSPropertyID id, BuilderState& builderStat
             break;
         }
         break;
-    case CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalBlock:
-        break;
-    case CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalInline:
-        break;
     case CSSPropertyID::CSSPropertyTestLogicalPropertyGroupPhysicalHorizontal:
         switch (valueType) {
         case ApplyValueType::Initial:
@@ -2391,6 +2387,10 @@ void BuilderGenerated::applyProperty(CSSPropertyID id, BuilderState& builderStat
             BuilderFunctions::applyValueTestLogicalPropertyGroupPhysicalVertical(builderState, value);
             break;
         }
+        break;
+    case CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalBlock:
+        break;
+    case CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalInline:
         break;
     case CSSPropertyID::CSSPropertyFont:
         ASSERT(isShorthand(id));

--- a/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleInterpolationWrapperMap.cpp
+++ b/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleInterpolationWrapperMap.cpp
@@ -125,10 +125,10 @@ WrapperMap::WrapperMap()
         new DiscreteWrapper(CSSPropertyID::CSSPropertyTestUsingSharedRuleExported, &RenderStyle::testUsingSharedRuleExported, &RenderStyle::setTestUsingSharedRuleExported), // CSSPropertyID::CSSPropertyTestUsingSharedRuleExported
         new DiscreteWrapper(CSSPropertyID::CSSPropertyTestUsingSharedRuleWithOverrideFunction, &RenderStyle::testUsingSharedRuleWithOverrideFunction, &RenderStyle::setTestUsingSharedRuleWithOverrideFunction), // CSSPropertyID::CSSPropertyTestUsingSharedRuleWithOverrideFunction
         new DiscreteWrapper(CSSPropertyID::CSSPropertyTestSinkPriority, &RenderStyle::testSinkPriority, &RenderStyle::setTestSinkPriority), // CSSPropertyID::CSSPropertyTestSinkPriority
-        nullptr, // CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalBlock - logical, handled via resolution to physical
-        nullptr, // CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalInline - logical, handled via resolution to physical
         new DiscreteWrapper(CSSPropertyID::CSSPropertyTestLogicalPropertyGroupPhysicalHorizontal, &RenderStyle::testLogicalPropertyGroupPhysicalHorizontal, &RenderStyle::setTestLogicalPropertyGroupPhysicalHorizontal), // CSSPropertyID::CSSPropertyTestLogicalPropertyGroupPhysicalHorizontal
         new DiscreteWrapper(CSSPropertyID::CSSPropertyTestLogicalPropertyGroupPhysicalVertical, &RenderStyle::testLogicalPropertyGroupPhysicalVertical, &RenderStyle::setTestLogicalPropertyGroupPhysicalVertical), // CSSPropertyID::CSSPropertyTestLogicalPropertyGroupPhysicalVertical
+        nullptr, // CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalBlock - logical, handled via resolution to physical
+        nullptr, // CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalInline - logical, handled via resolution to physical
         nullptr, // CSSPropertyID::CSSPropertyFont - shorthand, will perform fix-up below
         nullptr, // CSSPropertyID::CSSPropertyTestShorthandOne - shorthand, will perform fix-up below
         nullptr, // CSSPropertyID::CSSPropertyTestShorthandTwo - shorthand, will perform fix-up below


### PR DESCRIPTION
#### 82db23e607b394de2ecf2ca89fb24740675847b9
<pre>
Bucket the physical and logical properties of logical property groups separately for more efficient classification
<a href="https://bugs.webkit.org/show_bug.cgi?id=292374">https://bugs.webkit.org/show_bug.cgi?id=292374</a>

Reviewed by Antti Koivisto.

Re-orders the CSSPropertyID enum so that there are separate buckets for
the physical and logical properties of logical property groups. This allows
us to simplify the check `isDirectionAwareProperty` to just two comparisons
and makes resolving said direction aware properties more efficient as now
the switch statement is on a contiguous range of values.

CSSPropertyID is now sorted into the following buckets:

  - Invalid
  - Custom
  - Top
  - High
  - Low
  - Physical
  - Logical
  - Shorthand

* Source/WebCore/css/CSSProperty.h:
* Source/WebCore/css/scripts/process-css-properties.py:
* Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyNames.gperf:
* Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyNames.h:
* Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyParsing.cpp:
* Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleBuilderGenerated.cpp:
* Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleInterpolationWrapperMap.cpp:

Canonical link: <a href="https://commits.webkit.org/294394@main">https://commits.webkit.org/294394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c73d50a0a197188a4c7dd225b1121855284b59c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106798 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52274 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21616 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29808 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77406 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34432 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104647 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91787 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57743 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16521 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9804 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51621 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86388 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109151 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28773 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86381 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29134 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87988 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85946 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21876 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30692 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8405 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22935 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28701 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33990 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28512 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31835 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30071 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->