### PR TITLE
[Page color sampling] Avoid color-extending small fixed elements on the left/right sides of the viewport

### DIFF
--- a/LayoutTests/fast/page-color-sampling/page-color-sampling-skips-small-elements-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/page-color-sampling-skips-small-elements-expected.txt
@@ -1,0 +1,6 @@
+PASS edgeColors.top is null
+PASS edgeColors.left is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/page-color-sampling/page-color-sampling-skips-small-elements.html
+++ b/LayoutTests/fast/page-color-sampling/page-color-sampling-skips-small-elements.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body, html {
+            width: 100%;
+            margin: 0;
+            font-family: system-ui;
+        }
+
+        .left {
+            position: fixed;
+            top: calc(50% - 10px);
+            height: 100px;
+            width: 20px;
+            background: red;
+            border-top-right-radius: 6px;
+            border-bottom-right-radius: 6px;
+        }
+
+        .tall {
+            width: 10px;
+            height: 5000px;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(100, 100, 0, 0);
+        await UIHelper.ensurePresentationUpdate();
+        edgeColors = await UIHelper.fixedContainerEdgeColors();
+        shouldBeNull("edgeColors.top");
+        shouldBeNull("edgeColors.left");
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+<div class="left"></div>
+<div class="tall"></div>
+</body>
+</html>


### PR DESCRIPTION
#### bec2413d0d7f2af55ceac430718fa409f873f488
<pre>
[Page color sampling] Avoid color-extending small fixed elements on the left/right sides of the viewport
<a href="https://bugs.webkit.org/show_bug.cgi?id=292375">https://bugs.webkit.org/show_bug.cgi?id=292375</a>
<a href="https://rdar.apple.com/148934011">rdar://148934011</a>

Reviewed by Aditya Keerthi.

Avoid surfacing small fixed elements (more specifically, elements whose bounds don&apos;t overlap with
most of the viewport edge) when sampling the left/right edges of the viewport; limit this to only
left/right edges for now to mitigate risk.

* LayoutTests/fast/page-color-sampling/page-color-sampling-skips-small-elements-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/page-color-sampling-skips-small-elements.html: Added.

Add a layout test to exercise this change.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):

Pull out logic to compute the rect along with given `BoxSide` of a `LayoutRect`, with a thickness
equal to `sampleRectThickness` into a separate lambda.

Canonical link: <a href="https://commits.webkit.org/294382@main">https://commits.webkit.org/294382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa7e946c745210a957ab9f29385b0f30cb762f12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106799 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52275 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103681 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29809 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77402 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34431 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104648 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57739 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16522 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9802 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51622 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86389 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9879 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109152 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28774 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21186 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86376 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29135 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85939 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21870 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30694 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8403 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22937 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28702 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33991 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28513 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31836 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30072 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->