### PR TITLE
[GStreamer][WebRTC] Propagate rid and mid attributes to incoming stream caps

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2429,7 +2429,10 @@ webkit.org/b/286481 imported/w3c/web-platform-tests/webrtc/protocol/rtp-demuxing
 imported/w3c/web-platform-tests/webrtc/protocol/missing-fields.html [ Failure ]
 
 # Simulcast support is not complete yet.
-webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/simulcast [ Skip ]
+imported/w3c/web-platform-tests/webrtc/simulcast [ Pass ]
+imported/w3c/web-platform-tests/webrtc/simulcast/negotiation-encodings.https.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/simulcast/setParameters-encodings.https.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/simulcast/setParameters-maxFramerate.https.html [ Failure ]
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/protocol/simulcast-answer.html [ Skip ]
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/protocol/simulcast-offer.html [ Skip ]
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/simulcast/av1.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/simulcast/av1.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS AV1 simulcast setup with two streams
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/simulcast/vp9-scalability-mode.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/simulcast/vp9-scalability-mode.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS VP9 simulcast setup with two streams and L1T2 set
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/simulcast/vp9.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/simulcast/vp9.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS VP9 simulcast setup with two streams
+

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -187,6 +187,30 @@ bool GStreamerMediaEndpoint::initializePipeline()
         return false;
     }
 
+    g_signal_connect_swapped(rtpBin.get(), "element-added", G_CALLBACK(+[](GStreamerMediaEndpoint* self, GstElement* element) {
+        GUniquePtr<char> elementName(gst_element_get_name(element));
+        auto view = StringView::fromLatin1(elementName.get());
+        if (!view.startsWith("rtpptdemux"_s))
+            return;
+
+        auto pad = adoptGRef(gst_element_get_static_pad(element, "sink"));
+        gst_pad_add_probe(pad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_BUFFER), [](GstPad*, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
+            auto self = reinterpret_cast<GStreamerMediaEndpoint*>(userData);
+            auto buffer = GST_PAD_PROBE_INFO_BUFFER(info);
+            GstMappedRtpBuffer rtpBuffer(buffer, GST_MAP_READ);
+            if (!rtpBuffer) [[unlikely]]
+                return GST_PAD_PROBE_OK;
+
+            uint32_t ssrc = gst_rtp_buffer_get_ssrc(rtpBuffer.mappedData());
+            self->m_inputBuffers.add(ssrc, GRefPtr<GstBuffer>(buffer));
+            return GST_PAD_PROBE_REMOVE;
+        }, self, nullptr);
+
+        g_signal_connect(element, "new-payload-type", G_CALLBACK(+[](GstElement* ptDemux, unsigned, GstPad* pad, GStreamerMediaEndpoint* self) {
+            self->updatePtDemuxSrcPadCaps(ptDemux, pad);
+        }), self);
+    }), this);
+
     if (gstObjectHasProperty(rtpBin.get(), "add-reference-timestamp-meta"_s)) {
         auto disableCaptureTimeTracking = StringView::fromLatin1(g_getenv("WEBKIT_GST_DISABLE_WEBRTC_CAPTURE_TIME_TRACKING"));
         if (disableCaptureTimeTracking.isEmpty() || disableCaptureTimeTracking == "0"_s)
@@ -1378,12 +1402,16 @@ void GStreamerMediaEndpoint::connectIncomingTrack(WebRTCTrackData& data)
 {
     ASSERT(isMainThread());
 
-    GRefPtr<GstWebRTCRTPTransceiver> rtcTransceiver(data.transceiver);
-    auto trackId = data.trackId;
+    // NOTE: Here ideally we should match WebKit-side transceivers with data.transceiver but we
+    // cannot because in some situations (simulcast, mostly), we can end-up with multiple webrtcbin
+    // src pads associated to the same transceiver.
     auto transceiver = m_peerConnectionBackend.existingTransceiver([&](auto& backend) -> bool {
-        return backend.rtcTransceiver() == rtcTransceiver.get();
+        GUniqueOutPtr<char> mid;
+        g_object_get(backend.rtcTransceiver(), "mid", &mid.outPtr(), nullptr);
+        return data.mid == StringView::fromLatin1(mid.get());
     });
     if (!transceiver) {
+        GRefPtr<GstWebRTCRTPTransceiver> rtcTransceiver(data.transceiver);
         unsigned mLineIndex;
         g_object_get(rtcTransceiver.get(), "mlineindex", &mLineIndex, nullptr);
         GUniqueOutPtr<GstWebRTCSessionDescription> description;
@@ -1393,6 +1421,7 @@ void GStreamerMediaEndpoint::connectIncomingTrack(WebRTCTrackData& data)
             GST_WARNING_OBJECT(m_pipeline.get(), "SDP media for transceiver %u not found, skipping incoming track setup", mLineIndex);
             return;
         }
+        const auto& trackId = data.trackId;
         transceiver = &m_peerConnectionBackend.newRemoteTransceiver(makeUnique<GStreamerRtpTransceiverBackend>(WTFMove(rtcTransceiver)), data.type, trackId.isolatedCopy());
     }
 
@@ -2485,6 +2514,66 @@ std::optional<bool> GStreamerMediaEndpoint::canTrickleIceCandidates() const
             return true;
     }
     return false;
+}
+
+
+void GStreamerMediaEndpoint::updatePtDemuxSrcPadCaps(GstElement* ptDemux, GstPad* pad)
+{
+    GUniqueOutPtr<GstWebRTCSessionDescription> description;
+    g_object_get(m_webrtcBin.get(), "current-remote-description", &description.outPtr(), nullptr);
+    if (!description)
+        return;
+
+    auto currentCaps = adoptGRef(gst_pad_get_current_caps(pad));
+
+    auto sinkPad = adoptGRef(gst_element_get_static_pad(ptDemux, "sink"));
+    auto sinkCaps = adoptGRef(gst_pad_get_current_caps(sinkPad.get()));
+    const auto structure = gst_caps_get_structure(sinkCaps.get(), 0);
+    auto ssrc = gstStructureGet<unsigned>(structure, "ssrc"_s);
+    if (!ssrc)
+        return;
+
+    auto buffer = m_inputBuffers.take(*ssrc);
+    if (!buffer)
+        return;
+
+    GstMappedRtpBuffer rtpBuffer(buffer, GST_MAP_READ);
+    if (!rtpBuffer) [[unlikely]]
+        return;
+
+    auto caps = extractMidAndRidFromRTPBuffer(rtpBuffer, description->sdp);
+    if (!caps) {
+        GST_DEBUG_OBJECT(pipeline(), "mid attribute not found in buffer %" GST_PTR_FORMAT, buffer.get());
+        return;
+    }
+
+    // Propagate several caps fields from the previous caps to the new caps.
+    auto s = gst_caps_get_structure(caps.get(), 0);
+    auto s2 = gst_caps_get_structure(currentCaps.get(), 0);
+    for (int j = 0; j < gst_structure_n_fields(s2); j++) {
+        const char* name = gst_structure_nth_field_name(s2, j);
+        if (!g_str_equal(name, "media") && !g_str_equal(name, "payload") && !g_str_equal(name, "clock-rate") && !g_str_equal(name, "encoding-name"))
+            continue;
+        gst_structure_set_value(s, name, gst_structure_get_value(s2, name));
+    }
+
+    // Remove "ssrc-*" attributes matching other SSRCs.
+    gstStructureFilterAndMapInPlace(s, [&](auto id, auto) -> bool {
+        auto idString = gstIdToString(id);
+        if (!idString.startsWith("ssrc-"_s))
+            return true;
+
+        auto value = parseInteger<unsigned>(idString.substring(5));
+        if (!value)
+            return true;
+
+        return *value == *ssrc;
+    });
+
+    gst_caps_set_simple(caps.get(), "ssrc", G_TYPE_UINT, *ssrc, nullptr);
+
+    GST_DEBUG_OBJECT(pipeline(), "mid and rid attribute set from buffer on caps %" GST_PTR_FORMAT, caps.get());
+    gst_pad_set_caps(pad, caps.get());
 }
 
 void GStreamerMediaEndpoint::startRTCLogs()

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
@@ -234,6 +234,11 @@ private:
     NetSimOptions m_sinkNetSimOptions;
 
     GUniquePtr<GstSDPMessage> completeSDPAnswer(const String&, const GstSDPMessage*);
+
+    void updatePtDemuxSrcPadCaps(GstElement*, GstPad*);
+
+    // This stores only the first received buffer for each SSRC.
+    HashMap<uint32_t, GRefPtr<GstBuffer>> m_inputBuffers;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
@@ -347,6 +347,8 @@ String sdpAsString(const GstSDPMessage*);
 
 bool sdpMediaHasRTPHeaderExtension(const GstSDPMedia*, const String&);
 
+WARN_UNUSED_RETURN GRefPtr<GstCaps> extractMidAndRidFromRTPBuffer(const GstMappedRtpBuffer&, const GstSDPMessage*);
+
 } // namespace WebCore
 
 #endif // ENABLE(WEB_RTC) && USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCCommon.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCCommon.h
@@ -30,6 +30,7 @@ using WebRTCTrackData = struct _WebRTCTrackData {
     RealtimeMediaSource::Type type;
     GRefPtr<GstCaps> caps;
     unsigned ssrc;
+    String mid;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### e2ef134aedd82648216d0fc83f0e7558eff0ccc8
<pre>
[GStreamer][WebRTC] Propagate rid and mid attributes to incoming stream caps
<a href="https://bugs.webkit.org/show_bug.cgi?id=292377">https://bugs.webkit.org/show_bug.cgi?id=292377</a>

Reviewed by Xabier Rodriguez-Calvar.

The simulcast tests were failing because the receiving PeerConnection was emitting
only one track event instead of 2, even though webrtcbin created 2 src pads, their transceivers were
duplicated, so we couldn&apos;t find a RealtimeIncomingSource match for the second expected track event.
This is a known bug of webrtcbin.

The mid and rid attributes are embedded in RTP buffers using header extensions. When a new payload
type is detected by rtpptdemux we now look for those attributes in the first buffer received on the
demuxer sink pad and add them to the caps emitted downstream. Then when we process pending track
events from the IncomingTrackProcessor, we use the webrtcbin transceiver matching with the mid in
order to find the RealtimeIncomingSource to use and link to.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/simulcast/av1.https-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/simulcast/vp9-scalability-mode.https-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/simulcast/vp9.https-expected.txt: Added.
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::initializePipeline):
(WebCore::GStreamerMediaEndpoint::connectIncomingTrack):
(WebCore::GStreamerMediaEndpoint::updatePtDemuxSrcPadCaps):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::extractMidAndRidFromRTPBuffer):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp:
(WebCore::GStreamerIncomingTrackProcessor::configure):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCCommon.h:

Canonical link: <a href="https://commits.webkit.org/294665@main">https://commits.webkit.org/294665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3e30464bca7174f73eed2b9e23a123e3f1f21f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107787 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53263 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104665 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30801 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/78065 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35041 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105632 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17515 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/92622 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58400 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17355 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10653 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52620 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87165 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10721 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110162 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29758 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21940 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87043 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30122 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88818 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86650 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22050 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31476 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/9203 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24013 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29686 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34998 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29497 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32820 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31056 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->