### PR TITLE
[Writing Tools] Several Writing Tools tests are failing

### DIFF
--- a/Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift
@@ -629,7 +629,6 @@ class PlatformIntelligencePonderingTextEffect<Chunk>: PlatformIntelligenceTextEf
 
     func _add<Source>(to view: PlatformIntelligenceTextEffectView<Source>) async where Source : PlatformIntelligenceTextEffectViewSource, Source.Chunk == Chunk {
         guard let preview = await view.source.textPreview(for: self.chunk) else {
-            assertionFailure("Failed to generate text preview for pondering effect")
             return
         }
 


### PR DESCRIPTION
#### 44423b0ba8e1a667cd94d670c47ef7fae2608b17
<pre>
[Writing Tools] Several Writing Tools tests are failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=292379">https://bugs.webkit.org/show_bug.cgi?id=292379</a>
<a href="https://rdar.apple.com/150453007">rdar://150453007</a>

Reviewed by Aditya Keerthi.

Fix various tests; see per-function explanation below.

* Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift:

Remove an assertion that was wrong, since it is perfectly valid for a preview to not generate,
such as when the range is empty.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(TEST(WritingTools, APIWithBehaviorDefault)):
(TEST(WritingTools, APIWithBehaviorComplete)):
(TEST(WritingTools, ShowAffordance)):
(TEST(WritingTools, ShowAffordanceForMultipleLines)):
(TEST(WritingTools, ShowPanelWithNoSelection)):
(TEST(WritingTools, ShowPanelWithCaretSelection)):
(TEST(WritingTools, ShowPanelWithRangedSelection)):

These tests weren&apos;t failing, they just were not running. Get these tests to run properly by just
swizzling WT availability to pretend it&apos;s available.

(TEST(WritingTools, ShowToolWithRangedSelection)):
(TEST(WritingTools, ShowInvalidToolWithRangedSelection)):
(TEST(WritingTools, ContextMenuItemsNonEditable)):
(TEST(WritingTools, ContextMenuItemsEditable)):
(TEST(WritingTools, ContextMenuItemsEditableEmpty)):

These tests were failing for the same reasons, but just never had the guard in place.

(TEST(WritingTools, FocusWebViewAfterAnimation)):

This test was flakily failing due to the length of the animation, so expand the hard-coded delay.

(TEST(WritingTools, CompositionAnimationSizing)):

Ditto.

(TEST(WritingTools, IntelligenceTextEffectCoordinatorDelegate_RectsForProofreadingSuggestionsInRange)):

This was originally passing on macOS and failing on iOS. 294371@main made it pass on iOS, but accidentally
made it fail on macOS. Make it work on both platforms by just having specific expectations for each, which
is precedent from other API tests.

Canonical link: <a href="https://commits.webkit.org/294377@main">https://commits.webkit.org/294377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/655ee3997cce83befeefbdccd3cbd060443621e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21315 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11630 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/106805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52281 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103687 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29815 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/106805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/34438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104654 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/16700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/91794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/106805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/16526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/9811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51628 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/86393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/9888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109158 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28780 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/21192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29141 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/87995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/85947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/30699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/8412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/22943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16535 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28708 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33997 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28519 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31842 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30078 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->