### PR TITLE
Web Extension content scripts stop receiving messages after back/forward navigation.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -94,7 +94,7 @@ const WebExtensionContext::UserContentControllerProxySet& WebExtensionContext::u
     return extensionController()->allNonPrivateUserContentControllers();
 }
 
-WebExtensionContext::WebProcessProxySet WebExtensionContext::processes(EventListenerTypeSet&& typeSet, ContentWorldTypeSet&& contentWorldTypeSet, Function<bool(WebPageProxy&, WebFrameProxy&)>&& predicate) const
+WebExtensionContext::WebProcessProxySet WebExtensionContext::processes(EventListenerTypeSet&& typeSet, ContentWorldTypeSet&& contentWorldTypeSet, Function<bool(WebProcessProxy&, WebPageProxy&, WebFrameProxy&)>&& predicate) const
 {
     if (!isLoaded())
         return { };
@@ -124,10 +124,10 @@ WebExtensionContext::WebProcessProxySet WebExtensionContext::processes(EventList
                 if (!hasAccessToPrivateData() && page->sessionID().isEphemeral())
                     continue;
 
-                if (predicate && !predicate(*page, frame))
+                Ref webProcess = frame->process();
+                if (predicate && !predicate(webProcess, *page, frame))
                     continue;
 
-                Ref webProcess = frame->process();
                 if (webProcess->canSendMessage())
                     result.add(webProcess);
             }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -598,7 +598,7 @@ public:
         return processes(WTFMove(typeSet), ContentWorldTypeSet { contentWorldType });
     }
 
-    HashSet<Ref<WebProcessProxy>> processes(EventListenerTypeSet&&, ContentWorldTypeSet&&, Function<bool(WebPageProxy&, WebFrameProxy&)>&& predicate = nullptr) const;
+    HashSet<Ref<WebProcessProxy>> processes(EventListenerTypeSet&&, ContentWorldTypeSet&&, Function<bool(WebProcessProxy&, WebPageProxy&, WebFrameProxy&)>&& predicate = nullptr) const;
 
     const UserContentControllerProxySet& userContentControllers() const;
 

--- a/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.mm
@@ -261,57 +261,57 @@
 
 - (void)_test_waitForDidStartProvisionalNavigation
 {
-    EXPECT_FALSE(self.navigationDelegate);
+    auto *oldNavigationDelegate = self.navigationDelegate;
 
     auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     self.navigationDelegate = navigationDelegate.get();
     [navigationDelegate waitForDidStartProvisionalNavigation];
 
-    self.navigationDelegate = nil;
+    self.navigationDelegate = oldNavigationDelegate;
 }
 
 - (void)_test_waitForDidFailProvisionalNavigation
 {
-    EXPECT_FALSE(self.navigationDelegate);
+    auto *oldNavigationDelegate = self.navigationDelegate;
 
     auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     self.navigationDelegate = navigationDelegate.get();
     [navigationDelegate waitForDidFailProvisionalNavigation];
 
-    self.navigationDelegate = nil;
+    self.navigationDelegate = oldNavigationDelegate;
 }
 
 - (void)_test_waitForDidFinishNavigationWithoutPresentationUpdate
 {
-    EXPECT_FALSE(self.navigationDelegate);
+    auto *oldNavigationDelegate = self.navigationDelegate;
 
     auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     self.navigationDelegate = navigationDelegate.get();
     [navigationDelegate waitForDidFinishNavigation];
 
-    self.navigationDelegate = nil;
+    self.navigationDelegate = oldNavigationDelegate;
 }
 
 - (void)_test_waitForDidFinishNavigationWithPreferences:(WKWebpagePreferences *)preferences
 {
-    EXPECT_FALSE(self.navigationDelegate);
+    auto *oldNavigationDelegate = self.navigationDelegate;
 
     auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     self.navigationDelegate = navigationDelegate.get();
     [navigationDelegate waitForDidFinishNavigationWithPreferences:preferences];
 
-    self.navigationDelegate = nil;
+    self.navigationDelegate = oldNavigationDelegate;
 }
 
 - (void)_test_waitForDidFinishNavigation
 {
-    EXPECT_FALSE(self.navigationDelegate);
+    auto *oldNavigationDelegate = self.navigationDelegate;
 
     auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     self.navigationDelegate = navigationDelegate.get();
     [navigationDelegate waitForDidFinishNavigation];
 
-    self.navigationDelegate = nil;
+    self.navigationDelegate = oldNavigationDelegate;
 
 #if PLATFORM(IOS_FAMILY)
     __block bool presentationUpdateHappened = false;
@@ -324,18 +324,18 @@
 
 - (void)_test_waitForDidSameDocumentNavigation
 {
-    EXPECT_FALSE(self.navigationDelegate);
+    auto *oldNavigationDelegate = self.navigationDelegate;
 
     auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     self.navigationDelegate = navigationDelegate.get();
     [navigationDelegate waitForDidSameDocumentNavigation];
 
-    self.navigationDelegate = nil;
+    self.navigationDelegate = oldNavigationDelegate;
 }
 
 - (void)_test_waitForDidFinishNavigationWhileIgnoringSSLErrors
 {
-    EXPECT_FALSE(self.navigationDelegate);
+    auto *oldNavigationDelegate = self.navigationDelegate;
 
     auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     navigationDelegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
@@ -344,7 +344,7 @@
     self.navigationDelegate = navigationDelegate.get();
     [navigationDelegate waitForDidFinishNavigation];
 
-    self.navigationDelegate = nil;
+    self.navigationDelegate = oldNavigationDelegate;
 
 #if PLATFORM(IOS_FAMILY)
     __block bool presentationUpdateHappened = false;
@@ -357,13 +357,14 @@
 
 - (_WKProcessTerminationReason)_test_waitForWebContentProcessDidTerminate
 {
-    EXPECT_FALSE(self.navigationDelegate);
+    auto *oldNavigationDelegate = self.navigationDelegate;
 
     auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     self.navigationDelegate = navigationDelegate.get();
     auto result = [navigationDelegate waitForWebContentProcessDidTerminate];
 
-    self.navigationDelegate = nil;
+    self.navigationDelegate = oldNavigationDelegate;
+
     return result;
 }
 


### PR DESCRIPTION
#### 705d5a3f9744ecfb8d5a0ccba1d525c26aacc5fe
<pre>
Web Extension content scripts stop receiving messages after back/forward navigation.
<a href="https://webkit.org/b/292378">https://webkit.org/b/292378</a>
<a href="https://rdar.apple.com/149063567">rdar://149063567</a>

Reviewed by Brian Weinstein.

The logic for fetching web processes for a tab when sending a message was sometimes returning two processes,
when only one was expected. Since the call site used `takeAny()`, it was random which process was picked,
and sometimes it was the wrong one.

Fix this by intersecting the set of active processes for the page with the set of processes we know are
listening for extension messages. This reliably finds the right process and ensures only one is returned.

Looking ahead to site isolation, we still need to support multiple processes, since different frames
can be in separate processes. So messaging a tab can legitimately involve multiple processes in the future,
where we previously assumed just one. This requires more complex IPC handling, but we already had to
solve this for `runtime.sendMessage`, so adapt that approach for `tabs.sendMessage` and `tabs.connect`.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsSendMessage): Handle multiple processes with EagerCallbackAggregator.
(WebKit::WebExtensionContext::tabsConnect): Handle multiple processes.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::processes const): Return the intersection of processes.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::processes const): Pass the process to the lambda.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, SendMessageBackAndForwardNavigation)): Added.
* Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.mm:
(-[WKWebView _test_waitForDidStartProvisionalNavigation]): Restore the previous delegate.
(-[WKWebView _test_waitForDidFailProvisionalNavigation]): Ditto.
(-[WKWebView _test_waitForDidFinishNavigationWithoutPresentationUpdate]): Ditto.
(-[WKWebView _test_waitForDidFinishNavigationWithPreferences:]): Ditto.
(-[WKWebView _test_waitForDidFinishNavigation]): Ditto.
(-[WKWebView _test_waitForDidSameDocumentNavigation]): Ditto.
(-[WKWebView _test_waitForDidFinishNavigationWhileIgnoringSSLErrors]): Ditto.
(-[WKWebView _test_waitForWebContentProcessDidTerminate]): Ditto.

Canonical link: <a href="https://commits.webkit.org/294395@main">https://commits.webkit.org/294395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9030a455d1aca7fd5818578c69d414ec8a38fa8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11631 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106806 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52282 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103688 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29816 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77408 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34439 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104655 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16705 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91796 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57745 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16531 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9813 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51629 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86398 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9890 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109159 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21193 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86383 "Found 1 new test failure: compositing/patterns/direct-pattern-compositing-size.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29142 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87997 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85948 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30703 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8414 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22944 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16544 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28709 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33998 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28520 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31843 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30079 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->