### PR TITLE
Start adopting C++20's [[likely]] / [[unlikely]] in WTF/

### DIFF
--- a/Source/WTF/benchmarks/ToyLocks.h
+++ b/Source/WTF/benchmarks/ToyLocks.h
@@ -190,7 +190,7 @@ public:
     
     void lock()
     {
-        if (LIKELY(m_state.compareExchangeWeak(0, isLockedBit, std::memory_order_acquire)))
+        if (m_state.compareExchangeWeak(0, isLockedBit, std::memory_order_acquire)) [[likely]]
             return;
         
         lockSlow();
@@ -198,7 +198,7 @@ public:
     
     void unlock()
     {
-        if (LIKELY(m_state.compareExchangeWeak(isLockedBit, 0, std::memory_order_release)))
+        if (m_state.compareExchangeWeak(isLockedBit, 0, std::memory_order_release)) [[likely]]
             return;
         
         unlockSlow();
@@ -267,7 +267,7 @@ public:
     
     void lock()
     {
-        if (LIKELY(m_state.compareExchangeWeak(Unlocked, Locked, std::memory_order_acquire)))
+        if (m_state.compareExchangeWeak(Unlocked, Locked, std::memory_order_acquire)) [[likely]]
             return;
         
         lockSlow();
@@ -275,7 +275,7 @@ public:
     
     void unlock()
     {
-        if (LIKELY(m_state.compareExchangeWeak(Locked, Unlocked, std::memory_order_release)))
+        if (m_state.compareExchangeWeak(Locked, Unlocked, std::memory_order_release)) [[likely]]
             return;
         
         unlockSlow();
@@ -336,7 +336,7 @@ public:
     
     void lock()
     {
-        if (LIKELY(m_state.compareExchangeWeak(Unlocked, Locked, std::memory_order_acquire)))
+        if (m_state.compareExchangeWeak(Unlocked, Locked, std::memory_order_acquire)) [[likely]]
             return;
         
         lockSlow();
@@ -344,7 +344,7 @@ public:
     
     void unlock()
     {
-        if (LIKELY(m_state.compareExchangeWeak(Locked, Unlocked, std::memory_order_release)))
+        if (m_state.compareExchangeWeak(Locked, Unlocked, std::memory_order_release)) [[likely]]
             return;
         
         unlockSlow();
@@ -406,7 +406,7 @@ public:
     
     void lock()
     {
-        if (LIKELY(m_state.compareExchangeWeak(0, isLockedBit, std::memory_order_acquire)))
+        if (m_state.compareExchangeWeak(0, isLockedBit, std::memory_order_acquire)) [[likely]]
             return;
 
         lockSlow();
@@ -414,7 +414,7 @@ public:
 
     void unlock()
     {
-        if (LIKELY(m_state.compareExchangeWeak(isLockedBit, 0, std::memory_order_release)))
+        if (m_state.compareExchangeWeak(isLockedBit, 0, std::memory_order_release)) [[likely]]
             return;
 
         unlockSlow();

--- a/Source/WTF/wtf/ASCIICType.h
+++ b/Source/WTF/wtf/ASCIICType.h
@@ -244,7 +244,9 @@ template<typename CharacterType> constexpr bool isASCIIAlphaCaselessEqual(Charac
     //   - a control character such as "\n"
     // FIXME: Would be nice to make both the function name and expectedASCIILowercaseLetter argument name clearer.
     ASSERT(toASCIILowerUnchecked(expectedASCIILowercaseLetter) == expectedASCIILowercaseLetter);
-    return LIKELY(toASCIILowerUnchecked(inputCharacter) == static_cast<CharacterType>(expectedASCIILowercaseLetter));
+    if (toASCIILowerUnchecked(inputCharacter) == static_cast<CharacterType>(expectedASCIILowercaseLetter)) [[likely]]
+        return true;
+    return false;
 }
 
 template<typename CharacterType> constexpr bool isASCIIDigitOrPunctuation(CharacterType character)

--- a/Source/WTF/wtf/BloomFilter.h
+++ b/Source/WTF/wtf/BloomFilter.h
@@ -214,9 +214,9 @@ inline void CountingBloomFilter<keyBits>::add(unsigned hash)
 {
     auto& first = firstBucket(hash);
     auto& second = secondBucket(hash);
-    if (LIKELY(first < maximumCount()))
+    if (first < maximumCount()) [[likely]]
         ++first;
-    if (LIKELY(second < maximumCount()))
+    if (second < maximumCount()) [[likely]]
         ++second;
 }
 
@@ -228,9 +228,9 @@ inline void CountingBloomFilter<keyBits>::remove(unsigned hash)
     ASSERT(first);
     ASSERT(second);
     // In case of an overflow, the bucket sticks in the table until clear().
-    if (LIKELY(first < maximumCount()))
+    if (first < maximumCount()) [[likely]]
         --first;
-    if (LIKELY(second < maximumCount()))
+    if (second < maximumCount()) [[likely]]
         --second;
 }
     

--- a/Source/WTF/wtf/BumpPointerAllocator.h
+++ b/Source/WTF/wtf/BumpPointerAllocator.h
@@ -161,7 +161,7 @@ private:
             if (!pool) {
                 // We've run to the end; allocate a new pool.
                 pool = BumpPointerPool::create(previousPool->m_remainingCapacity, size);
-                if (UNLIKELY(!pool))
+                if (!pool) [[unlikely]]
                     return nullptr;
                 previousPool->m_next = pool;
                 pool->m_previous = previousPool;

--- a/Source/WTF/wtf/CheckedArithmetic.h
+++ b/Source/WTF/wtf/CheckedArithmetic.h
@@ -734,21 +734,21 @@ public:
     // Boolean operators
     bool operator!() const
     {
-        if (UNLIKELY(this->hasOverflowed()))
+        if (this->hasOverflowed()) [[unlikely]]
             this->crash();
         return !m_value;
     }
 
     explicit operator bool() const
     {
-        if (UNLIKELY(this->hasOverflowed()))
+        if (this->hasOverflowed()) [[unlikely]]
             this->crash();
         return m_value;
     }
 
     operator T() const
     {
-        if (UNLIKELY(this->hasOverflowed()))
+        if (this->hasOverflowed()) [[unlikely]]
             this->crash();
         return m_value;
     }
@@ -757,7 +757,7 @@ public:
     template<typename U = T>
     U value() const
     {
-        if (UNLIKELY(this->hasOverflowed()))
+        if (this->hasOverflowed()) [[unlikely]]
             this->crash();
         return static_cast<U>(m_value);
     }
@@ -851,40 +851,40 @@ private:
 
 template <typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator+(Checked<U, OverflowHandler> lhs, Checked<V, OverflowHandler> rhs)
 {
-    if (UNLIKELY(lhs.hasOverflowed() || rhs.hasOverflowed()))
+    if (lhs.hasOverflowed() || rhs.hasOverflowed()) [[unlikely]]
         return ResultOverflowed;
     typename Result<U, V>::ResultType result = 0;
-    if (UNLIKELY(!safeAdd<OverflowHandler>(lhs.value(), rhs.value(), result)))
+    if (!safeAdd<OverflowHandler>(lhs.value(), rhs.value(), result)) [[unlikely]]
         return ResultOverflowed;
     return result;
 }
 
 template <typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator-(Checked<U, OverflowHandler> lhs, Checked<V, OverflowHandler> rhs)
 {
-    if (UNLIKELY(lhs.hasOverflowed() || rhs.hasOverflowed()))
+    if (lhs.hasOverflowed() || rhs.hasOverflowed()) [[unlikely]]
         return ResultOverflowed;
     typename Result<U, V>::ResultType result = 0;
-    if (UNLIKELY(!safeSub<OverflowHandler>(lhs.value(), rhs.value(), result)))
+    if (!safeSub<OverflowHandler>(lhs.value(), rhs.value(), result)) [[unlikely]]
         return ResultOverflowed;
     return result;
 }
 
 template <typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator*(Checked<U, OverflowHandler> lhs, Checked<V, OverflowHandler> rhs)
 {
-    if (UNLIKELY(lhs.hasOverflowed() || rhs.hasOverflowed()))
+    if (lhs.hasOverflowed() || rhs.hasOverflowed()) [[unlikely]]
         return ResultOverflowed;
     typename Result<U, V>::ResultType result = 0;
-    if (UNLIKELY(!safeMultiply<OverflowHandler>(lhs.value(), rhs.value(), result)))
+    if (!safeMultiply<OverflowHandler>(lhs.value(), rhs.value(), result)) [[unlikely]]
         return ResultOverflowed;
     return result;
 }
 
 template <typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator/(Checked<U, OverflowHandler> lhs, Checked<V, OverflowHandler> rhs)
 {
-    if (UNLIKELY(lhs.hasOverflowed() || rhs.hasOverflowed()))
+    if (lhs.hasOverflowed() || rhs.hasOverflowed()) [[unlikely]]
         return ResultOverflowed;
     typename Result<U, V>::ResultType result = 0;
-    if (UNLIKELY(!safeDivide<OverflowHandler>(lhs.value(), rhs.value(), result)))
+    if (!safeDivide<OverflowHandler>(lhs.value(), rhs.value(), result)) [[unlikely]]
         return ResultOverflowed;
     return result;
 }

--- a/Source/WTF/wtf/CheckedPtr.h
+++ b/Source/WTF/wtf/CheckedPtr.h
@@ -175,13 +175,13 @@ private:
 
     ALWAYS_INLINE void refIfNotNull()
     {
-        if (T* ptr = PtrTraits::unwrap(m_ptr); LIKELY(ptr))
+        if (T* ptr = PtrTraits::unwrap(m_ptr); ptr) [[likely]]
             ptr->incrementCheckedPtrCount();
     }
 
     ALWAYS_INLINE void derefIfNotNull()
     {
-        if (T* ptr = PtrTraits::unwrap(m_ptr); LIKELY(ptr))
+        if (T* ptr = PtrTraits::unwrap(m_ptr); ptr) [[likely]]
             ptr->decrementCheckedPtrCount();
     }
 

--- a/Source/WTF/wtf/CountingLock.h
+++ b/Source/WTF/wtf/CountingLock.h
@@ -89,13 +89,13 @@ public:
 
     void lock()
     {
-        if (UNLIKELY(!ExclusiveAlgorithm::lockFast(m_word)))
+        if (!ExclusiveAlgorithm::lockFast(m_word)) [[unlikely]]
             lockSlow();
     }
     
     void unlock()
     {
-        if (UNLIKELY(!ExclusiveAlgorithm::unlockFast(m_word)))
+        if (!ExclusiveAlgorithm::unlockFast(m_word)) [[unlikely]]
             unlockSlow();
     }
     

--- a/Source/WTF/wtf/DataLog.h
+++ b/Source/WTF/wtf/DataLog.h
@@ -55,35 +55,35 @@ void dataLogLn(const Types&... values)
 #define dataLogIf(shouldLog, ...) do { \
         using ShouldLogType = std::decay_t<decltype(shouldLog)>; \
         static_assert(std::is_same_v<ShouldLogType, bool> || std::is_enum_v<ShouldLogType>, "You probably meant to pass a bool or enum as dataLogIf's first parameter"); \
-        if (UNLIKELY(shouldLog)) \
+        if (shouldLog) [[unlikely]] \
             dataLog(__VA_ARGS__); \
     } while (0)
 
 #define dataLogLnIf(shouldLog, ...) do { \
         using ShouldLogType = std::decay_t<decltype(shouldLog)>; \
         static_assert(std::is_same_v<ShouldLogType, bool> || std::is_enum_v<ShouldLogType>, "You probably meant to pass a bool or enum as dataLogLnIf's first parameter"); \
-        if (UNLIKELY(shouldLog)) \
+        if (shouldLog) [[unlikely]] \
             dataLogLn(__VA_ARGS__); \
     } while (0)
 
 #define dataLogFIf(shouldLog, ...) do { \
         using ShouldLogType = std::decay_t<decltype(shouldLog)>; \
         static_assert(std::is_same_v<ShouldLogType, bool> || std::is_enum_v<ShouldLogType>, "You probably meant to pass a bool or enum as dataLogIf's first parameter"); \
-        if (UNLIKELY(shouldLog)) \
+        if (shouldLog) [[unlikely]] \
             dataLogF(__VA_ARGS__); \
     } while (0)
 
 #define dataLogFVIf(shouldLog, ...) do { \
         using ShouldLogType = std::decay_t<decltype(shouldLog)>; \
         static_assert(std::is_same_v<ShouldLogType, bool> || std::is_enum_v<ShouldLogType>, "You probably meant to pass a bool or enum as dataLogIf's first parameter"); \
-        if (UNLIKELY(shouldLog)) \
+        if (shouldLog) [[unlikely]] \
             dataLogFV(__VA_ARGS__); \
     } while (0)
 
 #define dataLogFStringIf(shouldLog, ...) do { \
         using ShouldLogType = std::decay_t<decltype(shouldLog)>; \
         static_assert(std::is_same_v<ShouldLogType, bool> || std::is_enum_v<ShouldLogType>, "You probably meant to pass a bool or enum as dataLogIf's first parameter"); \
-        if (UNLIKELY(shouldLog)) \
+        if (shouldLog) [[unlikely]] \
             dataLogFString(__VA_ARGS__); \
     } while (0)
 

--- a/Source/WTF/wtf/Dominators.h
+++ b/Source/WTF/wtf/Dominators.h
@@ -51,7 +51,7 @@ public:
         : m_graph(graph)
         , m_data(graph.template newMap<BlockData>())
     {
-        if (LIKELY(m_graph.numNodes() <= maxNodesForIterativeDominance)) {
+        if (m_graph.numNodes() <= maxNodesForIterativeDominance) [[likely]] {
             IterativeDominance iterativeDominance(m_graph);
             iterativeDominance.compute();
 

--- a/Source/WTF/wtf/FastBitVector.h
+++ b/Source/WTF/wtf/FastBitVector.h
@@ -500,7 +500,7 @@ public:
     template<typename OtherWords>
     FastBitVector& operator=(const FastBitVectorImpl<OtherWords>& other)
     {
-        if (UNLIKELY(numBits() != other.numBits()))
+        if (numBits() != other.numBits()) [[unlikely]]
             resize(other.numBits());
         
         for (unsigned i = arrayLength(); i--;)

--- a/Source/WTF/wtf/FastMalloc.cpp
+++ b/Source/WTF/wtf/FastMalloc.cpp
@@ -79,7 +79,7 @@ void fastSetMaxSingleAllocationSize(size_t size)
 #endif // ASSERT_ENABLED
 
 #define FAIL_IF_EXCEEDS_LIMIT(size) do { \
-        if (UNLIKELY((size) > maxSingleAllocationSize)) \
+        if ((size) > maxSingleAllocationSize) [[unlikely]] \
             return nullptr; \
     } while (false)
 
@@ -162,7 +162,7 @@ void* fastAlignedMalloc(size_t alignment, size_t size)
 {
     ASSERT_IS_WITHIN_LIMIT(size);
     void* p = _aligned_malloc(size, alignment);
-    if (UNLIKELY(!p))
+    if (!p) [[unlikely]]
         CRASH();
     return p;
 }
@@ -184,7 +184,7 @@ void* fastAlignedMalloc(size_t alignment, size_t size)
 {
     ASSERT_IS_WITHIN_LIMIT(size);
     void* p = aligned_alloc(alignment, size);
-    if (UNLIKELY(!p))
+    if (!p) [[unlikely]]
         CRASH();
     return p;
 }

--- a/Source/WTF/wtf/FixedBitVector.h
+++ b/Source/WTF/wtf/FixedBitVector.h
@@ -93,7 +93,7 @@ private:
 
 ALWAYS_INLINE bool FixedBitVector::concurrentTestAndSet(size_t bitIndex, Dependency dependency)
 {
-    if (UNLIKELY(bitIndex >= size()))
+    if (bitIndex >= size()) [[unlikely]]
         return false;
 
     WordType mask = one << (bitIndex % wordSize);
@@ -111,7 +111,7 @@ ALWAYS_INLINE bool FixedBitVector::concurrentTestAndSet(size_t bitIndex, Depende
 
 ALWAYS_INLINE bool FixedBitVector::concurrentTestAndClear(size_t bitIndex, Dependency dependency)
 {
-    if (UNLIKELY(bitIndex >= size()))
+    if (bitIndex >= size()) [[unlikely]]
         return false;
 
     WordType mask = one << (bitIndex % wordSize);
@@ -129,7 +129,7 @@ ALWAYS_INLINE bool FixedBitVector::concurrentTestAndClear(size_t bitIndex, Depen
 
 ALWAYS_INLINE bool FixedBitVector::testAndSet(size_t bitIndex)
 {
-    if (UNLIKELY(bitIndex >= size()))
+    if (bitIndex >= size()) [[unlikely]]
         return false;
 
     WordType mask = one << (bitIndex % wordSize);
@@ -142,7 +142,7 @@ ALWAYS_INLINE bool FixedBitVector::testAndSet(size_t bitIndex)
 
 ALWAYS_INLINE bool FixedBitVector::testAndClear(size_t bitIndex)
 {
-    if (UNLIKELY(bitIndex >= size()))
+    if (bitIndex >= size()) [[unlikely]]
         return false;
 
     WordType mask = one << (bitIndex % wordSize);
@@ -155,7 +155,7 @@ ALWAYS_INLINE bool FixedBitVector::testAndClear(size_t bitIndex)
 
 ALWAYS_INLINE bool FixedBitVector::test(size_t bitIndex)
 {
-    if (UNLIKELY(bitIndex >= size()))
+    if (bitIndex >= size()) [[unlikely]]
         return false;
 
     WordType mask = one << (bitIndex % wordSize);

--- a/Source/WTF/wtf/HashTraits.h
+++ b/Source/WTF/wtf/HashTraits.h
@@ -182,7 +182,7 @@ template<typename T, typename Deleter> struct HashTraits<std::unique_ptr<T, Dele
 
         // The null case happens if a caller uses std::move() to remove the pointer before calling remove()
         // with an iterator. This is very uncommon.
-        if (LIKELY(pointer))
+        if (pointer) [[likely]]
             Deleter()(pointer);
     }
 };

--- a/Source/WTF/wtf/JSONValues.cpp
+++ b/Source/WTF/wtf/JSONValues.cpp
@@ -275,7 +275,7 @@ bool decodeString(std::span<const CodeUnit> data, StringBuilder& output)
             output.append(c);
             continue;
         }
-        if (UNLIKELY(data.empty()))
+        if (data.empty()) [[unlikely]]
             return false;
         c = consume(data);
         switch (c) {
@@ -302,13 +302,13 @@ bool decodeString(std::span<const CodeUnit> data, StringBuilder& output)
             c = '\v';
             break;
         case 'x':
-            if (UNLIKELY(data.size() < 2))
+            if (data.size() < 2) [[unlikely]]
                 return false;
             c = toASCIIHexValue(data[0], data[1]);
             skip(data, 2);
             break;
         case 'u':
-            if (UNLIKELY(data.size() < 4))
+            if (data.size() < 4) [[unlikely]]
                 return false;
             c = toASCIIHexValue(data[0], data[1]) << 8 | toASCIIHexValue(data[2], data[3]);
             skip(data, 4);

--- a/Source/WTF/wtf/LazyRef.h
+++ b/Source/WTF/wtf/LazyRef.h
@@ -68,7 +68,7 @@ public:
     {
         ASSERT(m_pointer);
         ASSERT(!(m_pointer & initializingTag));
-        if (UNLIKELY(m_pointer & lazyTag)) {
+        if (m_pointer & lazyTag) [[unlikely]] {
             FuncType func = *std::bit_cast<FuncType*>(m_pointer & ~(lazyTag | initializingTag));
             return *func(owner, *this);
         }

--- a/Source/WTF/wtf/LazyUniqueRef.h
+++ b/Source/WTF/wtf/LazyUniqueRef.h
@@ -68,7 +68,7 @@ public:
     {
         ASSERT(m_pointer);
         ASSERT(!(m_pointer & initializingTag));
-        if (UNLIKELY(m_pointer & lazyTag)) {
+        if (m_pointer & lazyTag) [[unlikely]] {
             FuncType func = *std::bit_cast<FuncType*>(m_pointer & ~(lazyTag | initializingTag));
             return *func(owner, *this);
         }

--- a/Source/WTF/wtf/Lock.h
+++ b/Source/WTF/wtf/Lock.h
@@ -66,7 +66,7 @@ public:
 
     void lock() WTF_ACQUIRES_LOCK()
     {
-        if (UNLIKELY(!DefaultLockAlgorithm::lockFastAssumingZero(m_byte)))
+        if (!DefaultLockAlgorithm::lockFastAssumingZero(m_byte)) [[unlikely]]
             lockSlow();
     }
 
@@ -93,7 +93,7 @@ public:
     // guarantees that long critical sections always get a fair lock.
     void unlock() WTF_RELEASES_LOCK()
     {
-        if (UNLIKELY(!DefaultLockAlgorithm::unlockFastAssumingZero(m_byte)))
+        if (!DefaultLockAlgorithm::unlockFastAssumingZero(m_byte)) [[unlikely]]
             unlockSlow();
     }
 
@@ -104,13 +104,13 @@ public:
     // want.
     void unlockFairly() WTF_RELEASES_LOCK()
     {
-        if (UNLIKELY(!DefaultLockAlgorithm::unlockFastAssumingZero(m_byte)))
+        if (!DefaultLockAlgorithm::unlockFastAssumingZero(m_byte)) [[unlikely]]
             unlockFairlySlow();
     }
     
     void safepoint()
     {
-        if (UNLIKELY(!DefaultLockAlgorithm::safepointFast(m_byte)))
+        if (!DefaultLockAlgorithm::safepointFast(m_byte)) [[unlikely]]
             safepointSlow();
     }
 

--- a/Source/WTF/wtf/LockAlgorithm.h
+++ b/Source/WTF/wtf/LockAlgorithm.h
@@ -68,7 +68,7 @@ public:
     
     static void lock(Atomic<LockType>& lock)
     {
-        if (UNLIKELY(!lockFast(lock)))
+        if (!lockFast(lock)) [[unlikely]]
             lockSlow(lock);
     }
     
@@ -103,13 +103,13 @@ public:
     
     static void unlock(Atomic<LockType>& lock)
     {
-        if (UNLIKELY(!unlockFast(lock)))
+        if (!unlockFast(lock)) [[unlikely]]
             unlockSlow(lock, Unfair);
     }
     
     static void unlockFairly(Atomic<LockType>& lock)
     {
-        if (UNLIKELY(!unlockFast(lock)))
+        if (!unlockFast(lock)) [[unlikely]]
             unlockSlow(lock, Fair);
     }
     
@@ -121,7 +121,7 @@ public:
     
     static void safepoint(Atomic<LockType>& lock)
     {
-        if (UNLIKELY(!safepointFast(lock)))
+        if (!safepointFast(lock)) [[unlikely]]
             safepointSlow(lock);
     }
     

--- a/Source/WTF/wtf/MetaAllocator.cpp
+++ b/Source/WTF/wtf/MetaAllocator.cpp
@@ -71,7 +71,7 @@ void MetaAllocator::release(const Locker<Lock>&, MetaAllocatorHandle& handle)
         addFreeSpaceFromReleasedHandle(start.retagged<FreeSpacePtrTag>(), sizeInBytes);
     }
 
-    if (UNLIKELY(!!m_tracker))
+    if (!!m_tracker) [[unlikely]]
         m_tracker->release(handle);
 }
 
@@ -192,7 +192,7 @@ RefPtr<MetaAllocatorHandle> MetaAllocator::allocate(const Locker<Lock>&, size_t 
 
     auto handle = adoptRef(*new MetaAllocatorHandle(*this, start.retagged<HandleMemoryPtrTag>(), sizeInBytes));
 
-    if (UNLIKELY(!!m_tracker))
+    if (!!m_tracker) [[unlikely]]
         m_tracker->notify(*handle.ptr());
 
     return handle;

--- a/Source/WTF/wtf/NativePromise.h
+++ b/Source/WTF/wtf/NativePromise.h
@@ -731,7 +731,7 @@ private:
 
             ASSERT(!promise.isNothing());
 
-            if (UNLIKELY(!m_targetQueue || (promise.m_dispatchMode == PromiseDispatchMode::RunSynchronouslyOnTarget && m_targetQueue->isCurrent()))) {
+            if (!m_targetQueue || (promise.m_dispatchMode == PromiseDispatchMode::RunSynchronouslyOnTarget && m_targetQueue->isCurrent())) [[unlikely]] {
                 if (m_disconnected) {
                     PROMISE_LOG("ThenCallback disconnected from ", promise, " aborting [callback:", (const void*)this, " callSite:", m_logSiteIdentifier, "]");
                     return;

--- a/Source/WTF/wtf/PrintStream.cpp
+++ b/Source/WTF/wtf/PrintStream.cpp
@@ -77,7 +77,7 @@ void printInternal(PrintStream& out, const char* string)
 
 static void printExpectedCStringHelper(PrintStream& out, const char* type, Expected<CString, UTF8ConversionError> expectedCString)
 {
-    if (UNLIKELY(!expectedCString)) {
+    if (!expectedCString) [[unlikely]] {
         if (expectedCString.error() == UTF8ConversionError::OutOfMemory) {
             printInternal(out, "(Out of memory while converting ");
             printInternal(out, type);

--- a/Source/WTF/wtf/PriorityQueue.h
+++ b/Source/WTF/wtf/PriorityQueue.h
@@ -120,7 +120,7 @@ protected:
     {
         while (leftChildOf(location) < m_buffer.size()) {
             size_t higherPriorityChild;
-            if (LIKELY(rightChildOf(location) < m_buffer.size()))
+            if (rightChildOf(location) < m_buffer.size()) [[likely]]
                 higherPriorityChild = isHigherPriority(m_buffer[leftChildOf(location)], m_buffer[rightChildOf(location)]) ? leftChildOf(location) : rightChildOf(location);
             else
                 higherPriorityChild = leftChildOf(location);

--- a/Source/WTF/wtf/PtrTag.h
+++ b/Source/WTF/wtf/PtrTag.h
@@ -170,7 +170,7 @@ WTF_EXPORT_PRIVATE const char* tagForPtr(const void*);
 
 constexpr bool enablePtrTagDebugAssert = true;
 #define REPORT_BAD_TAG(success, ptr, expectedTag) do { \
-        if (UNLIKELY(!success)) \
+        if (!success) [[unlikely]] \
             reportBadTag(reinterpret_cast<const void*>(ptr), expectedTag); \
     } while (false)
 #else

--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -45,7 +45,7 @@ inline void adopted(const void*) { }
 template<typename T> struct DefaultRefDerefTraits {
     static ALWAYS_INLINE T* refIfNotNull(T* ptr)
     {
-        if (LIKELY(ptr))
+        if (ptr) [[likely]]
             ptr->ref();
         return ptr;
     }
@@ -58,7 +58,7 @@ template<typename T> struct DefaultRefDerefTraits {
 
     static ALWAYS_INLINE void derefIfNotNull(T* ptr)
     {
-        if (LIKELY(ptr))
+        if (ptr) [[likely]]
             ptr->deref();
     }
 };

--- a/Source/WTF/wtf/RefTrackerMixin.h
+++ b/Source/WTF/wtf/RefTrackerMixin.h
@@ -69,7 +69,7 @@ struct RefTrackerMixin final {
     {
         RELEASE_ASSERT(!originalThis);
         originalThis = this;
-        if (UNLIKELY(T::enabled()))
+        if (T::enabled()) [[unlikely]]
             T::refTrackerSingleton().reportLive(static_cast<void*>(this));
     }
 
@@ -77,7 +77,7 @@ struct RefTrackerMixin final {
     {
         RELEASE_ASSERT(!originalThis);
         originalThis = this;
-        if (UNLIKELY(T::enabled()))
+        if (T::enabled()) [[unlikely]]
             T::refTrackerSingleton().reportLive(static_cast<void*>(this));
     }
 
@@ -85,14 +85,14 @@ struct RefTrackerMixin final {
     {
         RELEASE_ASSERT(!originalThis);
         originalThis = this;
-        if (UNLIKELY(T::enabled()))
+        if (T::enabled()) [[unlikely]]
             T::refTrackerSingleton().reportLive(static_cast<void*>(this));
     }
 
     ALWAYS_INLINE ~RefTrackerMixin()
     {
         RELEASE_ASSERT(originalThis == this);
-        if (UNLIKELY(T::enabled()))
+        if (T::enabled()) [[unlikely]]
             T::refTrackerSingleton().reportDead(static_cast<void*>(this));
     }
 

--- a/Source/WTF/wtf/SequenceLocked.h
+++ b/Source/WTF/wtf/SequenceLocked.h
@@ -56,14 +56,14 @@ public:
             // Acquire barrier ensures that no loads are reordered
             // above the first load of the sequence counter.
             uint64_t versionBefore = m_version.load(std::memory_order_acquire);
-            if (UNLIKELY((versionBefore & 1) == 1))
+            if ((versionBefore & 1) == 1) [[unlikely]]
                 continue;
             relaxedCopyFromAtomic(asMutableByteSpan(result), std::span { m_storage });
             // Another acquire fence ensures that the load of 'm_version' below is
             // strictly ordered after the RelaxedCopyToAtomic call above.
             std::atomic_thread_fence(std::memory_order_acquire);
             uint64_t versionAfter = m_version.load(std::memory_order_relaxed);
-            if (LIKELY(versionBefore == versionAfter))
+            if (versionBefore == versionAfter) [[likely]]
                 break;
         }
         return result;

--- a/Source/WTF/wtf/SequesteredImmortalHeap.h
+++ b/Source/WTF/wtf/SequesteredImmortalHeap.h
@@ -152,7 +152,7 @@ private:
     {
         uintptr_t allocation = m_allocHead;
         uintptr_t newHead = headIncrementedBy(bytes);
-        if (LIKELY(newHead < m_allocBound)) {
+        if (newHead < m_allocBound) [[likely]] {
             m_allocHead = newHead;
             return reinterpret_cast<void*>(allocation);
         }
@@ -163,7 +163,7 @@ private:
     {
         uintptr_t allocation = WTF::roundUpToMultipleOf<minHeadAlignment>(m_allocHead);
         uintptr_t newHead = headIncrementedBy((allocation - m_allocHead) + bytes);
-        if (LIKELY(newHead < m_allocBound)) {
+        if (newHead < m_allocBound) [[likely]] {
             m_allocHead = newHead;
             return reinterpret_cast<void*>(allocation);
         }
@@ -274,7 +274,7 @@ public:
     {
         void* p = mmap(nullptr, bytes, PROT_READ | PROT_WRITE,
             MAP_PRIVATE | MAP_ANON, -1, 0);
-        if (UNLIKELY(p == MAP_FAILED)) {
+        if (p == MAP_FAILED) [[unlikely]] {
             if constexpr (mode == AllocationFailureMode::ReturnNull)
                 return nullptr;
             RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WTF/wtf/SequesteredMalloc.cpp
+++ b/Source/WTF/wtf/SequesteredMalloc.cpp
@@ -53,7 +53,7 @@ void sequesteredArenaSetMaxSingleAllocationSize(size_t size)
 #endif // ASSERT_ENABLED
 
 #define FAIL_IF_EXCEEDS_LIMIT(size) do { \
-        if (UNLIKELY((size) > maxSingleSequesteredArenaAllocationSize)) \
+        if ((size) > maxSingleSequesteredArenaAllocationSize) [[unlikely]] \
             return nullptr; \
     } while (false)
 #else // !ASSERT_ENABLED

--- a/Source/WTF/wtf/SmallSet.h
+++ b/Source/WTF/wtf/SmallSet.h
@@ -145,7 +145,7 @@ public:
         }
 
         // If we're more than 3/4ths full we grow.
-        if (UNLIKELY(m_size * 4 >= m_capacity * 3)) {
+        if (m_size * 4 >= m_capacity * 3) [[unlikely]] {
             grow(m_capacity * 2);
             ASSERT(!(m_capacity & (m_capacity - 1)));
         }

--- a/Source/WTF/wtf/StackCheck.h
+++ b/Source/WTF/wtf/StackCheck.h
@@ -73,7 +73,7 @@ public:
                 m_checker.m_lastCheckpointStackTrace = StackTrace::captureStackTrace(INT_MAX);
             }
 
-            if (UNLIKELY(stackBetweenCheckpoints <= 0 || stackBetweenCheckpoints >= static_cast<ptrdiff_t>(m_checker.m_reservedZone)))
+            if (stackBetweenCheckpoints <= 0 || stackBetweenCheckpoints >= static_cast<ptrdiff_t>(m_checker.m_reservedZone)) [[unlikely]]
                 reportVerificationFailureAndCrash();
 #endif
         }

--- a/Source/WTF/wtf/ThreadSafeRefCounted.h
+++ b/Source/WTF/wtf/ThreadSafeRefCounted.h
@@ -72,7 +72,7 @@ protected:
     {
         ASSERT(m_refCount);
 
-        if (UNLIKELY(!--m_refCount)) {
+        if (!--m_refCount) [[unlikely]] {
             // Setting m_refCount to 1 here prevents double delete within the destructor but not from another thread
             // since such a thread could have ref'ed this object long after it had been deleted. See webkit.org/b/201576.
             m_refCount = 1;

--- a/Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h
+++ b/Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h
@@ -69,7 +69,7 @@ protected:
     {
         ASSERT(m_refCount);
 
-        if (UNLIKELY(!--m_refCount)) {
+        if (!--m_refCount) [[unlikely]] {
             // Setting m_refCount to 1 here prevents double delete within the destructor but not from another thread
             // since such a thread could have ref'ed this object long after it had been deleted. See webkit.org/b/201576.
             m_refCount = 1;

--- a/Source/WTF/wtf/ThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/ThreadSafeWeakPtr.h
@@ -74,7 +74,7 @@ public:
         {
             Locker locker { m_lock };
             ASSERT_WITH_SECURITY_IMPLICATION(m_object);
-            if (LIKELY(--m_strongReferenceCount))
+            if (--m_strongReferenceCount) [[likely]]
                 return;
             object = static_cast<T*>(std::exchange(m_object, nullptr));
             // We need to take a weak ref so `this` survives until the `delete object` below.
@@ -185,14 +185,14 @@ private:
 struct ThreadSafeWeakPtrControlBlockRefDerefTraits {
     static ALWAYS_INLINE ThreadSafeWeakPtrControlBlock* refIfNotNull(ThreadSafeWeakPtrControlBlock* ptr)
     {
-        if (LIKELY(ptr))
+        if (ptr) [[likely]]
             return ptr->weakRef();
         return nullptr;
     }
 
     static ALWAYS_INLINE void derefIfNotNull(ThreadSafeWeakPtrControlBlock* ptr)
     {
-        if (LIKELY(ptr))
+        if (ptr) [[likely]]
             ptr->weakDeref();
     }
 };
@@ -282,7 +282,7 @@ protected:
         // that seems unlikely since this is a one-way street. Once we add a controlBlock we don't go back
         // to strong only.
         uintptr_t bits = m_bits.loadRelaxed();
-        if (LIKELY(!isStrongOnly(bits)))
+        if (!isStrongOnly(bits)) [[likely]]
             return *std::bit_cast<ThreadSafeWeakPtrControlBlock*>(bits);
 
         auto* controlBlock = new ThreadSafeWeakPtrControlBlock(this);

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -436,10 +436,10 @@ inline Thread& Thread::currentSingleton()
     //    Thread::initializeTLSKey() is initially called from initialize(), ensuring
     //    this is initially called in a std::call_once locked context.
 #if !HAVE(FAST_TLS) && !OS(WINDOWS)
-    if (UNLIKELY(Thread::s_key == InvalidThreadSpecificKey))
+    if (Thread::s_key == InvalidThreadSpecificKey) [[unlikely]]
         WTF::initialize();
 #endif
-    if (SUPPRESS_UNCOUNTED_LOCAL auto* thread = currentMayBeNull(); LIKELY(thread))
+    if (SUPPRESS_UNCOUNTED_LOCAL auto* thread = currentMayBeNull(); thread) [[likely]]
         return *thread;
     return initializeCurrentTLS();
 }

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -620,7 +620,7 @@ static String percentEncodeCharacters(const StringType& input, bool(*shouldEncod
     };
 
     for (size_t i = 0; i < input.length(); ++i) {
-        if (UNLIKELY(shouldEncode(input[i])))
+        if (shouldEncode(input[i])) [[unlikely]]
             return encode(input);
     }
     if constexpr (std::is_same_v<StringType, StringView>)

--- a/Source/WTF/wtf/ValueOrReference.h
+++ b/Source/WTF/wtf/ValueOrReference.h
@@ -36,7 +36,7 @@ namespace WTF {
 //
 // ValueOrReference<String> append(const String& string LIFETIME_BOUND, std::optional<String&> suffix)
 // {
-//     if (LIKELY(!suffix))
+//     if (!suffix) [[likely]]
 //         return string; // existing reference -- ValueOrReference<T> avoids a copy
 //     return makeString(string, suffix.value()); // temporary -- ValueOrReference<T> holds T
 // }

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -348,7 +348,7 @@ public:
             newBuffer = static_cast<T*>(Malloc::malloc(sizeToAllocate));
         else {
             newBuffer = static_cast<T*>(Malloc::tryMalloc(sizeToAllocate));
-            if (UNLIKELY(!newBuffer))
+            if (!newBuffer) [[unlikely]]
                 return false;
         }
         m_capacity = sizeToAllocate / sizeof(T);
@@ -846,13 +846,13 @@ public:
 
     T& at(size_t i) LIFETIME_BOUND
     {
-        if (UNLIKELY(i >= size()))
+        if (i >= size()) [[unlikely]]
             OverflowHandler::overflowed();
         return Base::buffer()[i];
     }
     const T& at(size_t i) const LIFETIME_BOUND
     {
-        if (UNLIKELY(i >= size()))
+        if (i >= size()) [[unlikely]]
             OverflowHandler::overflowed();
         return Base::buffer()[i];
     }
@@ -947,7 +947,7 @@ public:
 
     void removeLast()
     {
-        if (UNLIKELY(isEmpty()))
+        if (isEmpty()) [[unlikely]]
             OverflowHandler::overflowed();
         shrink(size() - 1); 
     }
@@ -1262,7 +1262,7 @@ NEVER_INLINE T* Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>:
     if (ptr < begin() || ptr >= end()) {
         bool success = expandCapacity<action>(newMinCapacity);
         if constexpr (action == FailureAction::Report) {
-            if (UNLIKELY(!success))
+            if (!success) [[unlikely]]
                 return nullptr;
         }
         UNUSED_PARAM(success);
@@ -1271,7 +1271,7 @@ NEVER_INLINE T* Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>:
     size_t index = ptr - begin();
     bool success = expandCapacity<action>(newMinCapacity);
     if constexpr (action == FailureAction::Report) {
-        if (UNLIKELY(!success))
+        if (!success) [[unlikely]]
             return nullptr;
     }
     UNUSED_PARAM(success);
@@ -1285,7 +1285,7 @@ inline U* Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::expan
     static_assert(action == FailureAction::Crash || action == FailureAction::Report);
     bool success = expandCapacity<action>(newMinCapacity);
     if constexpr (action == FailureAction::Report) {
-        if (UNLIKELY(!success))
+        if (!success) [[unlikely]]
             return nullptr;
     }
     UNUSED_PARAM(success);
@@ -1332,7 +1332,7 @@ bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::growImpl(s
     if (size > capacity()) {
         bool success = expandCapacity<failureAction>(size);
         if constexpr (failureAction == FailureAction::Report) {
-            if (UNLIKELY(!success))
+            if (!success) [[unlikely]]
                 return false;
         }
     }
@@ -1403,7 +1403,7 @@ bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::reserveCap
 
     bool success = Base::template allocateBuffer<action>(newCapacity);
     if constexpr (action == FailureAction::Report) {
-        if (UNLIKELY(!success)) {
+        if (!success) [[unlikely]] {
             asanSetInitialBufferSizeTo(size());
             return false;
         }
@@ -1492,7 +1492,7 @@ ALWAYS_INLINE bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Mallo
     if (newSize > capacity()) {
         dataPtr = expandCapacity<action>(newSize, dataPtr);
         if constexpr (action == FailureAction::Report) {
-            if (UNLIKELY(!dataPtr))
+            if (!dataPtr) [[unlikely]]
                 return false;
         }
         ASSERT(begin());
@@ -1565,7 +1565,7 @@ bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::appendSlow
     auto ptr = const_cast<std::remove_cvref_t<U>*>(std::addressof(value));
     ptr = expandCapacity<action>(size() + 1, ptr);
     if constexpr (action == FailureAction::Report) {
-        if (UNLIKELY(!ptr))
+        if (!ptr) [[unlikely]]
             return false;
     }
     ASSERT(begin());
@@ -1585,7 +1585,7 @@ bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::constructA
 
     bool success = expandCapacity<action>(size() + 1);
     if constexpr (action == FailureAction::Report) {
-        if (UNLIKELY(!success))
+        if (!success) [[unlikely]]
             return false;
     }
     UNUSED_PARAM(success);
@@ -2120,7 +2120,7 @@ inline Vector<typename CopyOrMoveToVectorResult<Collection>::Type> moveToVector(
 template<typename T, size_t inlineCapacity = 0> static bool insertInUniquedSortedVector(Vector<T, inlineCapacity>& vector, const T& value)
 {
     auto it = std::ranges::lower_bound(vector, value);
-    if (UNLIKELY(it != vector.end() && *it == value))
+    if (it != vector.end() && *it == value) [[unlikely]]
         return false;
     vector.insert(it - vector.begin(), value);
     return true;

--- a/Source/WTF/wtf/WeakHashMap.h
+++ b/Source/WTF/wtf/WeakHashMap.h
@@ -325,7 +325,7 @@ public:
             return true;
 
         auto onlyContainsNullReferences = begin() == end();
-        if (UNLIKELY(onlyContainsNullReferences))
+        if (onlyContainsNullReferences) [[unlikely]]
             const_cast<WeakHashMap&>(*this).clear();
         return onlyContainsNullReferences;
     }

--- a/Source/WTF/wtf/WeakListHashSet.h
+++ b/Source/WTF/wtf/WeakListHashSet.h
@@ -269,7 +269,7 @@ public:
             return true;
 
         auto onlyContainsNullReferences = begin() == end();
-        if (UNLIKELY(onlyContainsNullReferences))
+        if (onlyContainsNullReferences) [[unlikely]]
             const_cast<WeakListHashSet&>(*this).clear();
         return onlyContainsNullReferences;
     }

--- a/Source/WTF/wtf/WordLock.h
+++ b/Source/WTF/wtf/WordLock.h
@@ -53,7 +53,7 @@ public:
 
     void lock()
     {
-        if (LIKELY(m_word.compareExchangeWeak(0, isLockedBit, std::memory_order_acquire))) {
+        if (m_word.compareExchangeWeak(0, isLockedBit, std::memory_order_acquire)) [[likely]] {
             // WordLock acquired!
             return;
         }
@@ -63,7 +63,7 @@ public:
 
     void unlock()
     {
-        if (LIKELY(m_word.compareExchangeWeak(isLockedBit, 0, std::memory_order_release))) {
+        if (m_word.compareExchangeWeak(isLockedBit, 0, std::memory_order_release)) [[likely]] {
             // WordLock released, and nobody was waiting!
             return;
         }

--- a/Source/WTF/wtf/cf/URLCF.cpp
+++ b/Source/WTF/wtf/cf/URLCF.cpp
@@ -55,7 +55,7 @@ RetainPtr<CFURLRef> URL::createCFURL() const
         return nullptr;
 
     RetainPtr<CFURLRef> result;
-    if (LIKELY(m_string.is8Bit() && m_string.containsOnlyASCII())) {
+    if (m_string.is8Bit() && m_string.containsOnlyASCII()) [[likely]] {
         auto characters = m_string.span8();
         result = adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, characters.data(), characters.size(), kCFStringEncodingUTF8, nullptr, true));
     } else {

--- a/Source/WTF/wtf/darwin/OSLogPrintStream.mm
+++ b/Source/WTF/wtf/darwin/OSLogPrintStream.mm
@@ -60,7 +60,7 @@ void OSLogPrintStream::vprintf(const char* format, va_list argList)
     va_copy(backup, argList);
 ALLOW_NONLITERAL_FORMAT_BEGIN
     size_t bytesWritten = vsnprintf(m_string.mutableSpanIncludingNullTerminator().subspan(offset).data(), freeBytes, format, argList);
-    if (UNLIKELY(bytesWritten >= freeBytes)) {
+    if (bytesWritten >= freeBytes) [[unlikely]] {
         size_t newLength = std::max(bytesWritten + m_string.length(), m_string.length() * 2);
         m_string.grow(newLength);
         freeBytes = newLength - offset;

--- a/Source/WTF/wtf/glib/SocketConnection.cpp
+++ b/Source/WTF/wtf/glib/SocketConnection.cpp
@@ -174,12 +174,12 @@ void SocketConnection::sendMessage(const char* messageName, GVariant* parameters
     size_t parametersSize = parameters ? g_variant_get_size(parameters) : 0;
     CheckedSize messageNameLength = strlen(messageName);
     messageNameLength++;
-    if (UNLIKELY(messageNameLength.hasOverflowed())) {
+    if (messageNameLength.hasOverflowed()) [[unlikely]] {
         g_warning("Trying to send message with invalid too long name");
         return;
     }
     CheckedUint32 bodySize = messageNameLength + parametersSize;
-    if (UNLIKELY(bodySize.hasOverflowed())) {
+    if (bodySize.hasOverflowed()) [[unlikely]] {
         g_warning("Trying to send message '%s' with invalid too long body", messageName);
         return;
     }

--- a/Source/WTF/wtf/playstation/OSAllocatorPlayStation.cpp
+++ b/Source/WTF/wtf/playstation/OSAllocatorPlayStation.cpp
@@ -134,7 +134,7 @@ bool OSAllocator::tryProtect(void* address, size_t bytes, bool readable, bool wr
 
 void OSAllocator::protect(void* address, size_t bytes, bool readable, bool writable)
 {
-    if (bool result = tryProtect(address, bytes, readable, writable); UNLIKELY(!result)) {
+    if (bool result = tryProtect(address, bytes, readable, writable); !result) [[unlikely]] {
         dataLogLn("mprotect failed: ", safeStrerror(errno).data());
         RELEASE_ASSERT_NOT_REACHED();
     }

--- a/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
+++ b/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
@@ -281,7 +281,7 @@ bool OSAllocator::tryProtect(void* address, size_t bytes, bool readable, bool wr
 
 void OSAllocator::protect(void* address, size_t bytes, bool readable, bool writable)
 {
-    if (bool result = tryProtect(address, bytes, readable, writable); UNLIKELY(!result)) {
+    if (bool result = tryProtect(address, bytes, readable, writable); !result) [[unlikely]] {
         dataLogLn("mprotect failed: ", safeStrerror(errno).data());
         RELEASE_ASSERT_NOT_REACHED();
     }

--- a/Source/WTF/wtf/text/AtomString.cpp
+++ b/Source/WTF/wtf/text/AtomString.cpp
@@ -39,7 +39,7 @@ template<AtomString::CaseConvertType type>
 ALWAYS_INLINE AtomString AtomString::convertASCIICase() const
 {
     StringImpl* impl = this->impl();
-    if (UNLIKELY(!impl))
+    if (!impl) [[unlikely]]
         return nullAtom();
 
     // Convert short strings without allocating a new StringImpl, since
@@ -67,7 +67,7 @@ SlowPath:
     }
 
     Ref<StringImpl> convertedString = type == CaseConvertType::Lower ? impl->convertToASCIILowercase() : impl->convertToASCIIUppercase();
-    if (LIKELY(convertedString.ptr() == impl))
+    if (convertedString.ptr() == impl) [[likely]]
         return *this;
 
     AtomString result;
@@ -152,7 +152,7 @@ static inline StringBuilder replaceUnpairedSurrogatesWithReplacementCharacterInt
 AtomString replaceUnpairedSurrogatesWithReplacementCharacter(AtomString&& string)
 {
     // Fast path for the case where there are no unpaired surrogates.
-    if (LIKELY(!hasUnpairedSurrogate(string)))
+    if (!hasUnpairedSurrogate(string)) [[likely]]
         return WTFMove(string);
     return replaceUnpairedSurrogatesWithReplacementCharacterInternal(string).toAtomString();
 }
@@ -160,7 +160,7 @@ AtomString replaceUnpairedSurrogatesWithReplacementCharacter(AtomString&& string
 String replaceUnpairedSurrogatesWithReplacementCharacter(String&& string)
 {
     // Fast path for the case where there are no unpaired surrogates.
-    if (LIKELY(!hasUnpairedSurrogate(string)))
+    if (!hasUnpairedSurrogate(string)) [[likely]]
         return WTFMove(string);
     return replaceUnpairedSurrogatesWithReplacementCharacterInternal(string).toString();
 }

--- a/Source/WTF/wtf/text/StringBuilder.cpp
+++ b/Source/WTF/wtf/text/StringBuilder.cpp
@@ -142,7 +142,7 @@ std::span<UChar> StringBuilder::extendBufferForAppendingWithUpconvert(unsigned r
 {
     if (is8Bit()) {
         allocateBuffer<UChar>(span8(), expandedCapacity(capacity(), requiredLength));
-        if (UNLIKELY(hasOverflowed()))
+        if (hasOverflowed()) [[unlikely]]
             return { };
         return spanConstCast<UChar>(m_buffer->span16().subspan(std::exchange(m_length, requiredLength)));
     }

--- a/Source/WTF/wtf/text/StringBuilderInternals.h
+++ b/Source/WTF/wtf/text/StringBuilderInternals.h
@@ -35,7 +35,7 @@ template<typename AllocationCharacterType, typename CurrentCharacterType> void S
 {
     std::span<AllocationCharacterType> newBufferCharacters;
     auto buffer = StringImpl::tryCreateUninitialized(requiredCapacity, newBufferCharacters);
-    if (UNLIKELY(!buffer)) {
+    if (!buffer) [[unlikely]] {
         didOverflow();
         return;
     }
@@ -55,7 +55,7 @@ template<typename CharacterType> void StringBuilder::reallocateBuffer(unsigned r
         if (m_buffer->hasOneRef()) {
             CharacterType* bufferCharacters;
             auto buffer = StringImpl::tryReallocate(m_buffer.releaseNonNull(), requiredCapacity, bufferCharacters);
-            if (UNLIKELY(!buffer)) {
+            if (!buffer) [[unlikely]] {
                 didOverflow();
                 return;
             }
@@ -86,7 +86,7 @@ template<typename CharacterType> std::span<CharacterType> StringBuilder::extendB
     if (!requiredLength || hasOverflowed())
         return { };
     reallocateBuffer(expandedCapacity(capacity(), requiredLength));
-    if (UNLIKELY(hasOverflowed()))
+    if (hasOverflowed()) [[unlikely]]
         return { };
     return spanConstCast<CharacterType>(m_buffer->span<CharacterType>().subspan(std::exchange(m_length, requiredLength)));
 }

--- a/Source/WTF/wtf/text/StringBuilderJSON.h
+++ b/Source/WTF/wtf/text/StringBuilderJSON.h
@@ -23,9 +23,9 @@ ALWAYS_INLINE static void appendEscapedJSONStringContent(std::span<OutputCharact
 {
     for (; !input.empty(); skip(input, 1)) {
         auto character = input.front();
-        if (LIKELY(character <= 0xFF)) {
+        if (character <= 0xFF) [[likely]] {
             auto escaped = escapedFormsForJSON[character];
-            if (LIKELY(!escaped)) {
+            if (!escaped) [[likely]] {
                 consume(output) = character;
                 continue;
             }
@@ -33,7 +33,7 @@ ALWAYS_INLINE static void appendEscapedJSONStringContent(std::span<OutputCharact
             output[0] = '\\';
             output[1] = escaped;
             skip(output, 2);
-            if (UNLIKELY(escaped == 'u')) {
+            if (escaped == 'u') [[unlikely]] {
                 output[0] = '0';
                 output[1] = '0';
                 output[2] = upperNibbleToLowercaseASCIIHexDigit(character);
@@ -43,7 +43,7 @@ ALWAYS_INLINE static void appendEscapedJSONStringContent(std::span<OutputCharact
             continue;
         }
 
-        if (LIKELY(!U16_IS_SURROGATE(character))) {
+        if (!U16_IS_SURROGATE(character)) [[likely]] {
             consume(output) = character;
             continue;
         }

--- a/Source/WTF/wtf/text/StringHasherInlines.h
+++ b/Source/WTF/wtf/text/StringHasherInlines.h
@@ -33,7 +33,7 @@ template<typename T, typename Converter>
 unsigned StringHasher::computeHashAndMaskTop8Bits(std::span<const T> data)
 {
 #if ENABLE(WYHASH_STRING_HASHER)
-    if (LIKELY(data.size() <= smallStringThreshold))
+    if (data.size() <= smallStringThreshold) [[likely]]
         return SuperFastHash::computeHashAndMaskTop8Bits<T, Converter>(data);
     return WYHash::computeHashAndMaskTop8Bits<T, Converter>(data);
 #else
@@ -46,7 +46,7 @@ constexpr unsigned StringHasher::computeLiteralHashAndMaskTop8Bits(const T (&cha
 {
     constexpr unsigned characterCountWithoutNull = characterCount - 1;
 #if ENABLE(WYHASH_STRING_HASHER)
-    if constexpr (LIKELY(characterCountWithoutNull <= smallStringThreshold))
+    if constexpr (characterCountWithoutNull <= smallStringThreshold)
         return SuperFastHash::computeHashAndMaskTop8Bits<T>(std::span { characters, characterCountWithoutNull });
     return WYHash::computeHashAndMaskTop8Bits<T>(std::span { characters, characterCountWithoutNull });
 #else

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -354,7 +354,7 @@ Ref<StringImpl> StringImpl::convertToLowercaseWithoutLocale()
     if (is8Bit()) {
         for (unsigned i = 0; i < m_length; ++i) {
             LChar character = m_data8[i];
-            if (UNLIKELY(!isASCII(character) || isASCIIUpper(character)))
+            if (!isASCII(character) || isASCIIUpper(character)) [[unlikely]]
                 return convertToLowercaseWithoutLocaleStartingAtFailingIndex8Bit(i);
         }
 
@@ -366,7 +366,7 @@ Ref<StringImpl> StringImpl::convertToLowercaseWithoutLocale()
 
     for (unsigned i = 0; i < m_length; ++i) {
         UChar character = m_data16[i];
-        if (UNLIKELY(isASCIIUpper(character)))
+        if (isASCIIUpper(character)) [[unlikely]]
             noUpper = false;
         ored |= character;
     }
@@ -442,7 +442,7 @@ Ref<StringImpl> StringImpl::convertToUppercaseWithoutLocale()
     if (is8Bit()) {
         for (unsigned i = 0; i < m_length; ++i) {
             LChar character = m_data8[i];
-            if (UNLIKELY(!isASCII(character) || isASCIILower(character)))
+            if (!isASCII(character) || isASCIILower(character)) [[unlikely]]
                 return convertToUppercaseWithoutLocaleStartingAtFailingIndex8Bit(i);
         }
         return *this;
@@ -480,11 +480,11 @@ Ref<StringImpl> StringImpl::convertToUppercaseWithoutLocaleStartingAtFailingInde
     //  2. Lower case sharp-S converts to "SS" (two characters)
     for (unsigned i = 0; i < m_length; ++i) {
         LChar character = m_data8[i];
-        if (UNLIKELY(character == smallLetterSharpS))
+        if (character == smallLetterSharpS) [[unlikely]]
             ++numberSharpSCharacters;
         ASSERT(u_toupper(character) <= 0xFFFF);
         UChar upper = u_toupper(character);
-        if (UNLIKELY(!isLatin1(upper))) {
+        if (!isLatin1(upper)) [[unlikely]] {
             // Since this upper-cased character does not fit in an 8-bit string, we need to take the 16-bit path.
             return convertToUppercaseWithoutLocaleUpconvert();
         }
@@ -646,7 +646,7 @@ Ref<StringImpl> StringImpl::foldCase()
         unsigned failingIndex;
         for (unsigned i = 0; i < m_length; ++i) {
             auto character = m_data8[i];
-            if (UNLIKELY(!isASCII(character) || isASCIIUpper(character))) {
+            if (!isASCII(character) || isASCIIUpper(character)) [[unlikely]] {
                 failingIndex = i;
                 goto SlowPath;
             }
@@ -685,7 +685,7 @@ SlowPath:
         unsigned ored = 0;
         for (unsigned i = 0; i < m_length; ++i) {
             UChar character = m_data16[i];
-            if (UNLIKELY(isASCIIUpper(character)))
+            if (isASCIIUpper(character)) [[unlikely]]
                 noUpper = false;
             ored |= character;
         }
@@ -919,7 +919,7 @@ size_t StringImpl::reverseFind(std::span<const LChar> matchString, size_t start)
 size_t StringImpl::find(StringView matchString)
 {
     // Check for null string to match against
-    if (UNLIKELY(!matchString))
+    if (!matchString) [[unlikely]]
         return notFound;
     unsigned matchLength = matchString.length();
 
@@ -940,7 +940,7 @@ size_t StringImpl::find(StringView matchString)
         return notFound;
 
     // Check for empty string to match against
-    if (UNLIKELY(!matchLength))
+    if (!matchLength) [[unlikely]]
         return 0;
 
     if (is8Bit()) {
@@ -958,7 +958,7 @@ size_t StringImpl::find(StringView matchString)
 size_t StringImpl::find(StringView matchString, size_t start)
 {
     // Check for null or empty string to match against
-    if (UNLIKELY(!matchString))
+    if (!matchString) [[unlikely]]
         return notFound;
 
     return findCommon(StringView { *this }, matchString, start);

--- a/Source/WTF/wtf/text/StringSearch.h
+++ b/Source/WTF/wtf/text/StringSearch.h
@@ -57,7 +57,7 @@ public:
         if (matchLength > string.length())
             return notFound;
 
-        if (UNLIKELY(!matchLength))
+        if (!matchLength) [[unlikely]]
             return 0;
 
         if (string.is8Bit()) {

--- a/Source/WTF/wtf/text/StringToIntegerConversion.h
+++ b/Source/WTF/wtf/text/StringToIntegerConversion.h
@@ -78,7 +78,7 @@ template<typename IntegralType, typename CharacterType> std::optional<IntegralTy
             value += digitValue;
     } while (!data.empty() && isCharacterAllowedInBase(data.front(), base));
 
-    if (UNLIKELY(value.hasOverflowed()))
+    if (value.hasOverflowed()) [[unlikely]]
         return std::nullopt;
 
     if (policy == TrailingJunkPolicy::Disallow) {

--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -124,7 +124,7 @@ size_t StringView::find(AdaptiveStringSearcherTables& tables, StringView matchSt
     if (!matchLength)
         return start;
 
-    if (UNLIKELY(subjectLength > INT32_MAX || matchLength > INT32_MAX))
+    if (subjectLength > INT32_MAX || matchLength > INT32_MAX) [[unlikely]]
         return find(matchString, start);
 
     if (is8Bit()) {
@@ -301,7 +301,7 @@ template<typename CharacterType>
 static AtomString convertASCIILowercaseAtom(std::span<const CharacterType> input)
 {
     for (auto character : input) {
-        if (UNLIKELY(isASCIIUpper(character)))
+        if (isASCIIUpper(character)) [[unlikely]]
             return makeAtomString(asASCIILowercase(input));
     }
     // Fast path when the StringView is already all lowercase.

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -305,14 +305,14 @@ inline StringView::StringView()
 
 inline String StringViewWithUnderlyingString::toString() const
 {
-    if (LIKELY(view.length() == underlyingString.length()))
+    if (view.length() == underlyingString.length()) [[likely]]
         return underlyingString;
     return view.toString();
 }
 
 inline AtomString StringViewWithUnderlyingString::toAtomString() const
 {
-    if (LIKELY(view.length() == underlyingString.length()))
+    if (view.length() == underlyingString.length()) [[likely]]
         return AtomString { underlyingString };
     return view.toAtomString();
 }

--- a/Source/WTF/wtf/text/WYHash.h
+++ b/Source/WTF/wtf/text/WYHash.h
@@ -270,7 +270,7 @@ private:
     template<typename T, typename Read8Functor>
     ALWAYS_INLINE static constexpr void handleGreaterThan8CharactersCase(T*& p, unsigned& i, NOESCAPE const Read8Functor& wyr8, uint64_t& seed, uint64_t see1, uint64_t see2)
     {
-        if (UNLIKELY(i > 24)) {
+        if (i > 24) [[unlikely]] {
             do {
                 consume24Characters(p, wyr8, seed, see1, see2);
                 p += 24;
@@ -278,7 +278,7 @@ private:
             } while (LIKELY(i > 24));
             seed ^= see1 ^ see2;
         }
-        while (UNLIKELY(i > 8)) {
+        while (i > 8) [[unlikely]] {
             seed = wymix(wyr8(p) ^ secret[1], wyr8(p + 4) ^ seed);
             i -= 8;
             p += 8;
@@ -302,13 +302,13 @@ private:
         const uint64_t byteCount = static_cast<uint64_t>(p.size()) << 1;
         uint64_t seed = initSeed();
 
-        if (LIKELY(p.size() <= 8)) {
-            if (LIKELY(p.size() >= 2)) {
+        if (p.size() <= 8) [[likely]] {
+            if (p.size() >= 2) [[likely]] {
                 const uint64_t offset = ((byteCount >> 3) << 2) >> 1;
                 a = (wyr4(p.data()) << 32) | wyr4(p.data() + offset);
                 auto* p2 = p.data() + p.size() - 2;
                 b = (wyr4(p2) << 32) | wyr4(p2 - offset);
-            } else if (LIKELY(p.size() > 0)) {
+            } else if (p.size() > 0) [[likely]] {
                 a = wyr3(p.data());
                 b = 0;
             } else {

--- a/Source/WTF/wtf/win/OSAllocatorWin.cpp
+++ b/Source/WTF/wtf/win/OSAllocatorWin.cpp
@@ -153,7 +153,7 @@ bool OSAllocator::tryProtect(void* address, size_t bytes, bool readable, bool wr
 
 void OSAllocator::protect(void* address, size_t bytes, bool readable, bool writable)
 {
-    if (bool result = tryProtect(address, bytes, readable, writable); UNLIKELY(!result)) {
+    if (bool result = tryProtect(address, bytes, readable, writable); !result) [[unlikely]] {
         dataLogLn("mprotect failed: ", static_cast<int>(GetLastError()));
         RELEASE_ASSERT_NOT_REACHED();
     }


### PR DESCRIPTION
#### f8fff5fe6aeb98af29bb80a3b9c4c6edf1577b87
<pre>
Start adopting C++20&apos;s [[likely]] / [[unlikely]] in WTF/
<a href="https://bugs.webkit.org/show_bug.cgi?id=292387">https://bugs.webkit.org/show_bug.cgi?id=292387</a>

Reviewed by Yusuke Suzuki.

Start adopting C++20&apos;s [[likely]] / [[unlikely]] in WTF/. It is now part of the C++
language and has several benefits over our macros. In particular, those annotations
can be used for `switch` cases and `else` statements.

* Source/WTF/benchmarks/ToyLocks.h:
* Source/WTF/wtf/ASCIICType.h:
(WTF::isASCIIAlphaCaselessEqual):
* Source/WTF/wtf/BloomFilter.h:
(WTF::CountingBloomFilter&lt;keyBits&gt;::add):
(WTF::CountingBloomFilter&lt;keyBits&gt;::remove):
* Source/WTF/wtf/BumpPointerAllocator.h:
(WTF::BumpPointerPool::ensureCapacityCrossPool):
* Source/WTF/wtf/CheckedArithmetic.h:
(WTF::Checked::operator! const):
(WTF::Checked::operator bool const):
(WTF::Checked::operator T const):
(WTF::Checked::value const):
(WTF::operator+):
(WTF::operator-):
(WTF::operator*):
(WTF::operator/):
* Source/WTF/wtf/CheckedPtr.h:
(WTF::CheckedPtr::refIfNotNull):
(WTF::CheckedPtr::derefIfNotNull):
* Source/WTF/wtf/CountingLock.h:
* Source/WTF/wtf/DataLog.h:
* Source/WTF/wtf/Dominators.h:
(WTF::Dominators::Dominators):
* Source/WTF/wtf/FastBitVector.h:
(WTF::FastBitVector::operator=):
* Source/WTF/wtf/FastMalloc.cpp:
(WTF::fastAlignedMalloc):
* Source/WTF/wtf/FixedBitVector.h:
(WTF::FixedBitVector::concurrentTestAndSet):
(WTF::FixedBitVector::concurrentTestAndClear):
(WTF::FixedBitVector::testAndSet):
(WTF::FixedBitVector::testAndClear):
(WTF::FixedBitVector::test):
* Source/WTF/wtf/HashTraits.h:
* Source/WTF/wtf/JSONValues.cpp:
* Source/WTF/wtf/LazyRef.h:
(WTF::LazyRef::get):
* Source/WTF/wtf/LazyUniqueRef.h:
(WTF::LazyUniqueRef::get):
* Source/WTF/wtf/Lock.h:
* Source/WTF/wtf/LockAlgorithm.h:
(WTF::LockAlgorithm::lock):
(WTF::LockAlgorithm::unlock):
(WTF::LockAlgorithm::unlockFairly):
(WTF::LockAlgorithm::safepoint):
* Source/WTF/wtf/MetaAllocator.cpp:
(WTF::MetaAllocator::release):
(WTF::MetaAllocator::allocate):
* Source/WTF/wtf/NativePromise.h:
* Source/WTF/wtf/PrintStream.cpp:
(WTF::printExpectedCStringHelper):
* Source/WTF/wtf/PriorityQueue.h:
* Source/WTF/wtf/PtrTag.h:
* Source/WTF/wtf/Ref.h:
(WTF::DefaultRefDerefTraits::refIfNotNull):
(WTF::DefaultRefDerefTraits::derefIfNotNull):
* Source/WTF/wtf/RefTrackerMixin.h:
* Source/WTF/wtf/SequenceLocked.h:
(WTF::SequenceLocked::load const):
* Source/WTF/wtf/SequesteredAllocator.h:
* Source/WTF/wtf/SequesteredImmortalHeap.h:
(WTF::SequesteredImmortalAllocator::allocateImpl):
(WTF::SequesteredImmortalAllocator::alignedAllocateImpl):
* Source/WTF/wtf/SequesteredMalloc.cpp:
* Source/WTF/wtf/SmallSet.h:
* Source/WTF/wtf/StackCheck.h:
(WTF::StackCheck::Scope::Scope):
* Source/WTF/wtf/ThreadSafeRefCounted.h:
(WTF::ThreadSafeRefCountedBase::derefBaseWithoutDeletionCheck const):
* Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h:
(WTF::ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase::derefBaseWithoutDeletionCheck const):
* Source/WTF/wtf/ThreadSafeWeakPtr.h:
(WTF::ThreadSafeWeakPtrControlBlock::strongDeref const):
(WTF::ThreadSafeWeakPtrControlBlockRefDerefTraits::refIfNotNull):
(WTF::ThreadSafeWeakPtrControlBlockRefDerefTraits::derefIfNotNull):
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::controlBlock const):
* Source/WTF/wtf/Threading.h:
(WTF::Thread::currentSingleton):
* Source/WTF/wtf/URL.cpp:
(WTF::percentEncodeCharacters):
* Source/WTF/wtf/URLParser.cpp:
(WTF::URLParser::advance):
(WTF::URLParser::appendToASCIIBuffer):
(WTF::URLParser::utf8PercentEncode):
(WTF::URLParser::utf8QueryEncode):
(WTF::URLParser::encodeNonUTF8Query):
(WTF::URLParser::parsedDataView):
(WTF::URLParser::currentPosition):
(WTF::URLParser::URLParser):
(WTF::URLParser::parse):
(WTF::URLParser::parseAuthority):
(WTF::URLParser::parseIPv4Piece):
(WTF::URLParser::parseIPv4Host):
(WTF::URLParser::parseIPv6Host):
(WTF::URLParser::domainToASCII):
(WTF::URLParser::parsePort):
(WTF::dnsNameEndsInNumber):
(WTF::URLParser::parseHostAndPort):
(WTF::URLParser::internationalDomainNameTranscoder):
* Source/WTF/wtf/ValueOrReference.h:
* Source/WTF/wtf/Vector.h:
(WTF::VectorBufferBase::allocateBuffer):
(WTF::Vector::removeLast):
(WTF::Malloc&gt;::expandCapacity):
(WTF::Malloc&gt;::growImpl):
(WTF::Malloc&gt;::reserveCapacity):
(WTF::Malloc&gt;::append):
(WTF::Malloc&gt;::appendSlowCase):
(WTF::Malloc&gt;::constructAndAppendSlowCase):
(WTF::insertInUniquedSortedVector):
* Source/WTF/wtf/WeakHashMap.h:
* Source/WTF/wtf/WeakListHashSet.h:
* Source/WTF/wtf/WordLock.h:
* Source/WTF/wtf/cf/URLCF.cpp:
(WTF::URL::createCFURL const):
* Source/WTF/wtf/darwin/OSLogPrintStream.mm:
(WTF::OSLogPrintStream::vprintf):
* Source/WTF/wtf/glib/SocketConnection.cpp:
(WTF::SocketConnection::sendMessage):
* Source/WTF/wtf/playstation/OSAllocatorPlayStation.cpp:
(WTF::OSAllocator::protect):
* Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp:
(WTF::OSAllocator::protect):
* Source/WTF/wtf/text/AtomString.cpp:
(WTF::AtomString::convertASCIICase const):
(WTF::replaceUnpairedSurrogatesWithReplacementCharacter):
* Source/WTF/wtf/text/StringBuilder.cpp:
(WTF::StringBuilder::extendBufferForAppendingWithUpconvert):
* Source/WTF/wtf/text/StringBuilderInternals.h:
(WTF::StringBuilder::allocateBuffer):
(WTF::StringBuilder::reallocateBuffer):
(WTF::StringBuilder::extendBufferForAppendingSlowCase):
* Source/WTF/wtf/text/StringBuilderJSON.h:
(WTF::appendEscapedJSONStringContent):
* Source/WTF/wtf/text/StringHasherInlines.h:
(WTF::StringHasher::computeHashAndMaskTop8Bits):
(WTF::StringHasher::computeLiteralHashAndMaskTop8Bits):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::convertToLowercaseWithoutLocale):
(WTF::StringImpl::convertToUppercaseWithoutLocale):
(WTF::StringImpl::convertToUppercaseWithoutLocaleStartingAtFailingIndex8Bit):
(WTF::StringImpl::foldCase):
(WTF::StringImpl::find):
* Source/WTF/wtf/text/StringSearch.h:
(WTF::BoyerMooreHorspoolTable::find const):
* Source/WTF/wtf/text/StringToIntegerConversion.h:
(WTF::parseInteger):
* Source/WTF/wtf/text/StringView.cpp:
(WTF::StringView::find const):
(WTF::convertASCIILowercaseAtom):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringViewWithUnderlyingString::toString const):
(WTF::StringViewWithUnderlyingString::toAtomString const):
* Source/WTF/wtf/text/WYHash.h:
(WTF::WYHash::handleGreaterThan8CharactersCase):
(WTF::WYHash::hash):
* Source/WTF/wtf/win/OSAllocatorWin.cpp:
(WTF::OSAllocator::protect):

Canonical link: <a href="https://commits.webkit.org/294408@main">https://commits.webkit.org/294408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46a846107b25bda77af86333649f37daf53ee9ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101685 "219 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11668 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106843 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52319 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29853 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77437 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34460 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104692 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16735 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91830 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57774 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16561 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9847 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51668 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94357 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86425 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109197 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100295 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28818 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21221 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86422 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88031 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85996 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21882 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30731 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8447 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22981 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28746 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34035 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/123919 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28557 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34430 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31880 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30116 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->