### PR TITLE
[JSC] Remove some Int52 overflow checks via strength reduction

### DIFF
--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -2028,7 +2028,7 @@ private:
             }
             break;
 
-        case Trunc:
+        case Trunc: {
             // Turn this: Trunc(int64Constant)
             // Into this: static_cast<int32_t>(int64Constant)
             if (m_value->child(0)->hasInt64()) {
@@ -2134,7 +2134,7 @@ private:
             case Add:
             case Sub:
             case BitOr:
-            case BitXor:
+            case BitXor: {
                 if (m_value->child(0)->child(1)->hasInt64()
                     && !(m_value->child(0)->child(1)->asInt64() & 0xffffffffll)) {
                     m_value->child(0) = m_value->child(0)->child(0);
@@ -2142,10 +2142,36 @@ private:
                     break;
                 }
                 break;
+            }
             default:
                 break;
             }
+
+            auto handleTruncOpExtension = [&]() {
+                // Turn this: Trunc(Op(@a, @b))
+                // Into this: Op(Trunc(@a), Trunc(@b))
+                switch (m_value->child(0)->opcode()) {
+                case Add:
+                case Sub:
+                case Mul:
+                case BitOr:
+                case BitAnd:
+                case BitXor: {
+                    auto* lhs = m_insertionSet.insert<Value>(m_index, Trunc, m_value->origin(), m_value->child(0)->child(0));
+                    auto* rhs = m_insertionSet.insert<Value>(m_index, Trunc, m_value->origin(), m_value->child(0)->child(1));
+                    replaceWithNew<Value>(m_value->child(0)->opcode(), m_value->origin(), lhs, rhs);
+                    return true;
+                }
+                default:
+                    return false;
+                }
+            };
+
+            if (handleTruncOpExtension())
+                break;
+
             break;
+        }
 
         case IToD:
             // Turn this: IToD(constant)
@@ -2324,6 +2350,8 @@ private:
         }
         case Equal:
             handleCommutativity();
+            if (handleCompareExt())
+                break;
 
             // Turn this: Equal(bool, 0)
             // Into this: BitXor(bool, 1)
@@ -2358,6 +2386,8 @@ private:
             
         case NotEqual:
             handleCommutativity();
+            if (handleCompareExt())
+                break;
 
             if (m_value->child(0)->returnsBool()) {
                 // Turn this: NotEqual(bool, 0)
@@ -2400,6 +2430,9 @@ private:
         case Below:
         case AboveEqual:
         case BelowEqual: {
+            if (handleCompareExt())
+                break;
+
             CanonicalizedComparison comparison = canonicalizeComparison(m_value);
             TriState result = TriState::Indeterminate;
             switch (comparison.opcode) {
@@ -3398,6 +3431,34 @@ private:
             std::swap(m_value->child(0), m_value->child(1));
             m_changed = true;
         }
+    }
+
+    bool handleCompareExt()
+    {
+        bool changed = false;
+
+        // Turn this Op(SExt32(@a), SExt32(@b))
+        // Into this: Op(@a, @b)
+        if (m_value->child(0)->opcode() == SExt32 && m_value->child(1)->opcode() == SExt32) {
+            m_value->child(0) = m_value->child(0)->child(0);
+            m_value->child(1) = m_value->child(1)->child(0);
+            changed = true;
+            // Continue folding.
+        }
+
+        // Turn this Op(ZExt32(@a), ZExt32(@b))
+        // Into this: Op(@a, @b)
+        if (m_value->child(0)->opcode() == ZExt32 && m_value->child(1)->opcode() == ZExt32) {
+            m_value->child(0) = m_value->child(0)->child(0);
+            m_value->child(1) = m_value->child(1)->child(0);
+            changed = true;
+            // Continue folding.
+        }
+
+        if (changed)
+            m_changed = true;
+
+        return changed;
     }
 
     // For Op==Add or Sub, turn any of these:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -2864,7 +2864,7 @@ void SpeculativeJIT::compileValueToInt32(Node* node)
 void SpeculativeJIT::compileUInt32ToNumber(Node* node)
 {
     if (doesOverflow(node->arithMode())) {
-        if (enableInt52()) {
+        if (node->hasInt52Result()) {
             SpeculateInt32Operand op1(this, node->child1());
             GPRTemporary result(this, Reuse, op1);
             zeroExtend32ToWord(op1.gpr(), result.gpr());

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -107,6 +107,187 @@ private:
         return false;
     }
 
+    static std::optional<std::tuple<int64_t, int64_t>> rangeInt52(Node* node, unsigned timeToLive = 5)
+    {
+        auto isInt52 = [](int64_t asInt64) {
+            if (asInt64 >= (static_cast<int64_t>(1) << (JSValue::numberOfInt52Bits - 1)))
+                return false;
+            if (asInt64 < -(static_cast<int64_t>(1) << (JSValue::numberOfInt52Bits - 1)))
+                return false;
+            return true;
+        };
+
+        if (!timeToLive)
+            return std::nullopt;
+
+        switch (node->op()) {
+        case Int52Constant: {
+            int64_t value = node->constant()->value().asAnyInt();
+            return std::tuple { value, value };
+        }
+
+        case UInt32ToNumber: {
+            return std::tuple { 0, UINT32_MAX };
+        }
+
+        case Int52Rep: {
+            switch (node->child1().useKind()) {
+            case Int32Use:
+                return std::tuple { INT32_MIN, INT32_MAX };
+            default:
+                return std::nullopt;
+            }
+        }
+
+        case GetByVal: {
+            ArrayMode arrayMode = node->arrayMode();
+            if (arrayMode.isOutOfBounds())
+                return std::nullopt;
+
+            switch (arrayMode.type()) {
+            case Array::Int8Array:
+                return std::tuple { INT8_MIN, INT8_MAX };
+            case Array::Uint8Array:
+            case Array::Uint8ClampedArray:
+                return std::tuple { 0, UINT8_MAX };
+            case Array::Int16Array:
+                return std::tuple { INT16_MIN, INT16_MAX };
+            case Array::Uint16Array:
+                return std::tuple { 0, UINT16_MAX };
+            case Array::Int32Array:
+                return std::tuple { INT32_MIN, INT32_MAX };
+            case Array::Uint32Array:
+                return std::tuple { 0, UINT32_MAX };
+            default:
+                return std::nullopt;
+            }
+        }
+
+        case ArithAdd: {
+            if (!node->isBinaryUseKind(Int52RepUse))
+                return std::nullopt;
+
+            auto lhs = rangeInt52(node->child1().node(), timeToLive - 1);
+            if (!lhs)
+                return std::nullopt;
+            auto [leftMinValue, leftMaxValue] = lhs.value();
+
+            auto rhs = rangeInt52(node->child2().node(), timeToLive - 1);
+            if (!rhs)
+                return std::nullopt;
+            auto [rightMinValue, rightMaxValue] = rhs.value();
+
+            auto value1 = CheckedInt64 { leftMinValue } + rightMinValue;
+            if (value1.hasOverflowed())
+                return std::nullopt;
+
+            auto value2 = CheckedInt64 { leftMaxValue } + rightMinValue;
+            if (value2.hasOverflowed())
+                return std::nullopt;
+
+            auto value3 = CheckedInt64 { leftMinValue } + rightMaxValue;
+            if (value3.hasOverflowed())
+                return std::nullopt;
+
+            auto value4 = CheckedInt64 { leftMaxValue } + rightMaxValue;
+            if (value4.hasOverflowed())
+                return std::nullopt;
+
+            auto minValue = std::min({ value1.value(), value2.value(), value3.value(), value4.value() });
+            auto maxValue = std::max({ value1.value(), value2.value(), value3.value(), value4.value() });
+            if (!isInt52(minValue))
+                return std::nullopt;
+            if (!isInt52(maxValue))
+                return std::nullopt;
+
+            return std::tuple { minValue, maxValue };
+        }
+
+        case ArithSub: {
+            if (!node->isBinaryUseKind(Int52RepUse))
+                return std::nullopt;
+
+            auto lhs = rangeInt52(node->child1().node(), timeToLive - 1);
+            if (!lhs)
+                return std::nullopt;
+            auto [leftMinValue, leftMaxValue] = lhs.value();
+
+            auto rhs = rangeInt52(node->child2().node(), timeToLive - 1);
+            if (!rhs)
+                return std::nullopt;
+            auto [rightMinValue, rightMaxValue] = rhs.value();
+
+            auto value1 = CheckedInt64 { leftMinValue } - rightMinValue;
+            if (value1.hasOverflowed())
+                return std::nullopt;
+
+            auto value2 = CheckedInt64 { leftMaxValue } - rightMinValue;
+            if (value2.hasOverflowed())
+                return std::nullopt;
+
+            auto value3 = CheckedInt64 { leftMinValue } - rightMaxValue;
+            if (value3.hasOverflowed())
+                return std::nullopt;
+
+            auto value4 = CheckedInt64 { leftMaxValue } - rightMaxValue;
+            if (value4.hasOverflowed())
+                return std::nullopt;
+
+            auto minValue = std::min({ value1.value(), value2.value(), value3.value(), value4.value() });
+            auto maxValue = std::max({ value1.value(), value2.value(), value3.value(), value4.value() });
+            if (!isInt52(minValue))
+                return std::nullopt;
+            if (!isInt52(maxValue))
+                return std::nullopt;
+
+            return std::tuple { minValue, maxValue };
+        }
+
+        case ArithMul: {
+            if (!node->isBinaryUseKind(Int52RepUse))
+                return std::nullopt;
+
+            auto lhs = rangeInt52(node->child1().node(), timeToLive - 1);
+            if (!lhs)
+                return std::nullopt;
+            auto [leftMinValue, leftMaxValue] = lhs.value();
+
+            auto rhs = rangeInt52(node->child2().node(), timeToLive - 1);
+            if (!rhs)
+                return std::nullopt;
+            auto [rightMinValue, rightMaxValue] = rhs.value();
+
+            auto value1 = CheckedInt64 { leftMinValue } * rightMinValue;
+            if (value1.hasOverflowed())
+                return std::nullopt;
+
+            auto value2 = CheckedInt64 { leftMaxValue } * rightMinValue;
+            if (value2.hasOverflowed())
+                return std::nullopt;
+
+            auto value3 = CheckedInt64 { leftMinValue } * rightMaxValue;
+            if (value3.hasOverflowed())
+                return std::nullopt;
+
+            auto value4 = CheckedInt64 { leftMaxValue } * rightMaxValue;
+            if (value4.hasOverflowed())
+                return std::nullopt;
+
+            auto minValue = std::min({ value1.value(), value2.value(), value3.value(), value4.value() });
+            auto maxValue = std::max({ value1.value(), value2.value(), value3.value(), value4.value() });
+            if (!isInt52(minValue))
+                return std::nullopt;
+            if (!isInt52(maxValue))
+                return std::nullopt;
+
+            return std::tuple { minValue, maxValue };
+        }
+
+        default:
+            return std::nullopt;
+        }
+    }
+
     void handleNode()
     {
         switch (m_node->op()) {
@@ -192,6 +373,16 @@ private:
                 convertToIdentityOverChild1();
                 break;
             }
+
+            if (m_node->isBinaryUseKind(Int52RepUse)) {
+                if (shouldCheckOverflow(m_node->arithMode())) {
+                    if (rangeInt52(m_node)) {
+                        m_node->setArithMode(Arith::Unchecked);
+                        m_changed = true;
+                        break;
+                    }
+                }
+            }
             break;
             
         case ValueMul:
@@ -235,6 +426,17 @@ private:
                     break;
                 }
             }
+
+
+            if (m_node->isBinaryUseKind(Int52RepUse)) {
+                if (m_node->arithMode() == Arith::CheckOverflow) {
+                    if (rangeInt52(m_node)) {
+                        m_node->setArithMode(Arith::Unchecked);
+                        m_changed = true;
+                        break;
+                    }
+                }
+            }
             break;
         }
         case ArithSub: {
@@ -251,6 +453,16 @@ private:
                             m_nodeIndex, m_node->origin, jsNumber(-value)));
                     m_changed = true;
                     break;
+                }
+            }
+
+            if (m_node->isBinaryUseKind(Int52RepUse)) {
+                if (shouldCheckOverflow(m_node->arithMode())) {
+                    if (rangeInt52(m_node)) {
+                        m_node->setArithMode(Arith::Unchecked);
+                        m_changed = true;
+                        break;
+                    }
                 }
             }
             break;

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -3917,7 +3917,7 @@ private:
     {
         LValue value = lowInt32(m_node->child1());
 
-        if (doesOverflow(m_node->arithMode())) {
+        if (m_node->hasInt52Result()) {
             setStrictInt52(m_out.zeroExtPtr(value));
             return;
         }


### PR DESCRIPTION
#### 73bbeb4a0bff794e399cfe52ce4eaff95751acbc
<pre>
[JSC] Remove some Int52 overflow checks via strength reduction
<a href="https://bugs.webkit.org/show_bug.cgi?id=292394">https://bugs.webkit.org/show_bug.cgi?id=292394</a>
<a href="https://rdar.apple.com/150477140">rdar://150477140</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compileUInt32ToNumber):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::rangeInt52):
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileUInt32ToNumber):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbe0744a88ce1cd1fa33d3aa87d430a83fc25825

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106908 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52384 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29920 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77469 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34499 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104757 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16785 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91886 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57807 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16610 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9904 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51735 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94422 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86468 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9981 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109264 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100360 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21267 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86449 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29244 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88087 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86017 "Found 102 new API test failures: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/javascript-dialogs, /TestWebKit:WebKit.DOMWindowExtensionCrashOnReload, /TestWebKit:WebKit.PageLoadBasic, /TestWebKit:WebKit.NewFirstVisuallyNonEmptyLayoutFails, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /TestWebKit:WebKit.InjectedBundleBasic, /TestWebKit:WebKit.PreventEmptyUserAgent, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/select-all/non-editable ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30775 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8498 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23046 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28811 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34101 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/123984 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28622 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34447 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31945 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30181 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->