### PR TITLE
CoreIPCCFDictionary::createCFDictionary() doesn't validate key/value type

### DIFF
--- a/Source/WebKit/Shared/cf/CoreIPCCFDictionary.h
+++ b/Source/WebKit/Shared/cf/CoreIPCCFDictionary.h
@@ -33,10 +33,21 @@
 namespace WebKit {
 
 class CoreIPCCFType;
+class CoreIPCCFArray;
+class CoreIPCBoolean;
+class CoreIPCCFCharacterSet;
+class CoreIPCData;
+class CoreIPCDate;
+class CoreIPCCFDictionary;
+class CoreIPCNull;
+class CoreIPCNumber;
+class CoreIPCString;
+class CoreIPCCFURL;
 
 class CoreIPCCFDictionary {
 public:
-    using KeyValueVector = Vector<KeyValuePair<CoreIPCCFType, CoreIPCCFType>>;
+    using KeyType = Variant<CoreIPCCFArray, CoreIPCBoolean, CoreIPCCFCharacterSet, CoreIPCData, CoreIPCDate, CoreIPCCFDictionary, CoreIPCNull, CoreIPCNumber, CoreIPCString, CoreIPCCFURL>;
+    using KeyValueVector = Vector<KeyValuePair<KeyType, CoreIPCCFType>>;
 
     CoreIPCCFDictionary(CFDictionaryRef);
     CoreIPCCFDictionary(CoreIPCCFDictionary&&);

--- a/Source/WebKit/Shared/cf/CoreIPCCFDictionary.serialization.in
+++ b/Source/WebKit/Shared/cf/CoreIPCCFDictionary.serialization.in
@@ -25,7 +25,9 @@
 webkit_platform_headers: "CoreIPCCFDictionary.h"
 
 [WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WebKit::CoreIPCCFDictionary {
-    std::unique_ptr<Vector<KeyValuePair<WebKit::CoreIPCCFType, WebKit::CoreIPCCFType>>> vector();
+    std::unique_ptr<Vector<KeyValuePair<WebKit::CoreIPCCFDictionary::KeyType, WebKit::CoreIPCCFType>>> vector();
 }
 
 #endif
+
+using WebKit::CoreIPCCFDictionary::KeyType = Variant<WebKit::CoreIPCCFArray, WebKit::CoreIPCBoolean, WebKit::CoreIPCCFCharacterSet, WebKit::CoreIPCData, WebKit::CoreIPCDate, WebKit::CoreIPCCFDictionary, WebKit::CoreIPCNull, WebKit::CoreIPCNumber, WebKit::CoreIPCString, WebKit::CoreIPCCFURL>;


### PR DESCRIPTION
#### e4ba40c3c46f9c60dafec7edb23940dce736e9df
<pre>
CoreIPCCFDictionary::createCFDictionary() doesn&apos;t validate key/value type
<a href="https://bugs.webkit.org/show_bug.cgi?id=289280">https://bugs.webkit.org/show_bug.cgi?id=289280</a>
<a href="https://rdar.apple.com/146384453">rdar://146384453</a>

Reviewed by Alex Christensen.

Restrict the types that can be used as keys for CoreIPCCFDictionary.

* Source/WebKit/Shared/cf/CoreIPCCFDictionary.h:
* Source/WebKit/Shared/cf/CoreIPCCFDictionary.mm:
(WebKit::keyVariantFromCFType):
(WebKit::keyToCFType):
(WebKit::CoreIPCCFDictionary::CoreIPCCFDictionary):
(WebKit::CoreIPCCFDictionary::createCFDictionary const):
* Source/WebKit/Shared/cf/CoreIPCCFDictionary.serialization.in:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST(CoreIPCCFDictionary, InsertDifferentValueTypes)):
(TEST(CoreIPCCFDictionary, InsertDifferentKeyTypes)):

Canonical link: <a href="https://commits.webkit.org/294544@main">https://commits.webkit.org/294544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73130bda291d683076f4401bfa8cc8025f711903

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21885 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12200 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107376 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52853 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104256 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30392 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77783 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34773 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105223 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17173 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92266 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58119 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17003 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10294 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52211 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86838 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109752 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29349 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21635 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86765 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29712 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88469 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86349 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21968 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31156 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8869 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23591 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29277 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34572 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29088 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32411 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30647 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->