### PR TITLE
[results.webkit.org] Track whether a test run completed

### DIFF
--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -1147,6 +1147,7 @@ sub uploadResults
             'builder-name' => $builderName,
             'build-number' => $buildNumber,
             'buildbot-worker' => $buildbotWorker,
+            'finished' => JSON::true,
         };
     } else {
         print "    No buildbot details provided, test run will not be linked to CI system\n";

--- a/Tools/Scripts/webkitpy/api_tests/manager.py
+++ b/Tools/Scripts/webkitpy/api_tests/manager.py
@@ -289,6 +289,7 @@ class Manager(object):
                     start_time=start_time,
                     end_time=end_time,
                     tests_skipped=len(result_dictionary['Skipped']),
+                    details={'finished': True},
                 ), results={
                     test: Upload.create_test_result(
                         actual=status_to_test_result[result[0]],

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
@@ -470,6 +470,7 @@ class Manager(object):
                         start_time=start_time_for_device,
                         end_time=time.time(),
                         tests_skipped=temp_initial_results.remaining + temp_initial_results.expected_skips,
+                        details={'finished': True},
                     ),
                     results=self._results_to_upload_json_trie(self._expectations[device_type], temp_initial_results),
                 )

--- a/Tools/Scripts/webkitpy/test/main.py
+++ b/Tools/Scripts/webkitpy/test/main.py
@@ -284,6 +284,7 @@ class Tester(object):
                     start_time=start_time,
                     end_time=end_time,
                     tests_skipped=len(test_runner.tests_run) - len(parallel_tests) - len(serial_tests),
+                    details={'finished': True},
                 ),
                 results=results,
             )


### PR DESCRIPTION
#### 4dfd2e3c5aeea8fbff51cfa1cf6f43bdf7899c8e
<pre>
[results.webkit.org] Track whether a test run completed
<a href="https://bugs.webkit.org/show_bug.cgi?id=292399">https://bugs.webkit.org/show_bug.cgi?id=292399</a>
<a href="https://rdar.apple.com/149323521">rdar://149323521</a>

Reviewed by NOBODY (OOPS!).

Add &quot;finished&quot; when test suites are completed successfully.

* Tools/Scripts/run-javascriptcore-tests:
(uploadResults):
* Tools/Scripts/webkitpy/api_tests/manager.py:
(Manager.run):
* Tools/Scripts/webkitpy/layout_tests/controllers/manager.py:
(Manager.run):
* Tools/Scripts/webkitpy/test/main.py:
(Tester._run_tests):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dfd2e3c5aeea8fbff51cfa1cf6f43bdf7899c8e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21899 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107390 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52867 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22207 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30406 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77791 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34784 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105237 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92285 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58127 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/101703 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17012 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10313 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52225 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94902 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86847 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10383 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109766 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100840 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29363 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21644 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86772 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29726 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86356 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31162 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8884 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23605 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29291 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124466 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29102 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34560 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32425 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30661 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->