### PR TITLE
Make sure all classes used in PackedRefPtr and CompactUniquePtrTuple tests are compact-allocated

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/CompactUniquePtrTuple.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CompactUniquePtrTuple.cpp
@@ -156,7 +156,7 @@ TEST(WTF_CompactUniquePtrTuple, Basic)
 }
 
 class B : public A {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_COMPACT_ALLOCATED;
 
 public:
     B() { ++s_constructorCallCount; }

--- a/Tools/TestWebKitAPI/Tests/WTF/PackedRefPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/PackedRefPtr.cpp
@@ -407,7 +407,7 @@ TEST(WTF_PackedRefPtr, ReturnValue)
 }
 
 struct ConstRefCounted : RefCounted<ConstRefCounted> {
-    WTF_ALLOW_STRUCT_COMPACT_POINTERS;
+    WTF_MAKE_STRUCT_FAST_COMPACT_ALLOCATED;
     static Ref<ConstRefCounted> create() { return adoptRef(*new ConstRefCounted); }
 };
 


### PR DESCRIPTION
#### d314f14388217833b27c792ff54e33cd98dd1495
<pre>
Make sure all classes used in PackedRefPtr and CompactUniquePtrTuple tests are compact-allocated
<a href="https://bugs.webkit.org/show_bug.cgi?id=292400">https://bugs.webkit.org/show_bug.cgi?id=292400</a>
<a href="https://rdar.apple.com/149629257">rdar://149629257</a>

Reviewed by Yijia Huang.

Makes some classes used in TestWebKitAPI to test compact/packed pointer
behavior compact-allocated when they weren&apos;t before.

* Tools/TestWebKitAPI/Tests/WTF/CompactUniquePtrTuple.cpp:
* Tools/TestWebKitAPI/Tests/WTF/PackedRefPtr.cpp:

Canonical link: <a href="https://commits.webkit.org/294461@main">https://commits.webkit.org/294461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59e600d3b6379893c731d29d9528911ef39a30f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21376 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11692 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106866 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52342 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103748 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21684 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77444 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34470 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104715 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16755 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91851 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57781 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16584 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9868 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51692 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86444 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9946 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109220 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28841 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21290 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86420 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29202 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88052 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85985 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21916 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30741 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8467 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23004 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28769 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28580 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31903 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30139 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->