### PR TITLE
AX: content-visibility change from hidden to visible ignored by VoiceOver

### DIFF
--- a/LayoutTests/accessibility/dynamic-content-visibility-expected.txt
+++ b/LayoutTests/accessibility/dynamic-content-visibility-expected.txt
@@ -1,0 +1,21 @@
+This test ensures we update the accessibility tree when content-visibility changes.
+
+
+{#button-one AXRole: AXButton}
+
+{#button-two AXRole: AXButton}
+
+
+Tree traversal after adding content-visibility: hidden:
+
+
+Tree traversal after adding content-visibility: hidden:
+
+{#button-one AXRole: AXButton}
+
+{#button-two AXRole: AXButton}
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Press Press

--- a/LayoutTests/accessibility/dynamic-content-visibility.html
+++ b/LayoutTests/accessibility/dynamic-content-visibility.html
@@ -1,0 +1,62 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="wrapper" role="presentation">
+    <button id="button-one">Press</button>
+    <button id="button-two" style="display:contents">Press</button>
+</div>
+
+<script>
+var output = "This test ensures we update the accessibility tree when content-visibility changes.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var webarea = accessibilityController.rootElement.childAtIndex(0);
+    output += dumpAXSearchTraversal(webarea);
+
+    var button;
+    document.getElementById("wrapper").setAttribute("style", "content-visibility: hidden");
+    setTimeout(async function() {
+        await waitFor(() => {
+            button = accessibilityController.accessibleElementById("button-one");
+            if (button && !button.isIgnored)
+                return false;
+
+            button = accessibilityController.accessibleElementById("button-two");
+            if (button && !button.isIgnored)
+                return false;
+
+            return true;
+        });
+        output += "\n\nTree traversal after adding content-visibility: hidden:\n"
+        output += dumpAXSearchTraversal(webarea);
+
+        document.getElementById("wrapper").removeAttribute("style");
+        await waitFor(() => {
+            button = accessibilityController.accessibleElementById("button-one");
+            if (!button || button.isIgnored)
+                return false;
+
+            button = accessibilityController.accessibleElementById("button-two");
+            if (!button || button.isIgnored)
+                return false;
+
+            return true;
+        });
+        output += "\n\nTree traversal after adding content-visibility: hidden:\n"
+        output += dumpAXSearchTraversal(webarea);
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -679,6 +679,8 @@ imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-b
 accessibility/opacity-0-bounding-box.html [ Skip ]
 accessibility/clip-path-bounding-box.html [ Skip ]
 
+accessibility/dynamic-content-visibility.html [ Skip ]
+
 # AXObjectCache::announce not implemented.
 accessibility/announcement-notification.html [ Skip ]
 


### PR DESCRIPTION
#### ff17b1c5fada186205359a855696ff0dabfd9f66
<pre>
AX: content-visibility change from hidden to visible ignored by VoiceOver
<a href="https://bugs.webkit.org/show_bug.cgi?id=292380">https://bugs.webkit.org/show_bug.cgi?id=292380</a>
<a href="https://rdar.apple.com/150453039">rdar://150453039</a>

Reviewed by Chris Fleizach.

While changes to the `visibility` property result in children-changed notifications from the render tree, changes to
`content-visibility` do not. We can hook into `AXObjectCache::onStyleChange` to listen for these, and then create
a children-changed event.

* LayoutTests/accessibility/dynamic-content-visibility-expected.txt: Added.
* LayoutTests/accessibility/dynamic-content-visibility.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::isContentVisibilityHidden):
(WebCore::AXObjectCache::onStyleChange):
(WebCore::isVisibilityHidden):

Canonical link: <a href="https://commits.webkit.org/294420@main">https://commits.webkit.org/294420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/108e28b8e41d87c7a165ef576ee3559bf9369425

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101747 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106905 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52381 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103787 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29917 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77465 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34493 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104754 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16781 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91887 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57803 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16608 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9905 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51732 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86466 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9982 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109261 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28880 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21268 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86448 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29241 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88088 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86016 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21892 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30774 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8499 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23043 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28808 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34098 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28619 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31942 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30178 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->