### PR TITLE
[webkitpy] Change VisionOSSimulatorPort's method of determining the default device type.

### DIFF
--- a/Tools/Scripts/webkitpy/port/visionos_simulator.py
+++ b/Tools/Scripts/webkitpy/port/visionos_simulator.py
@@ -41,7 +41,9 @@ class VisionOSSimulatorPort(VisionOSPort):
 
     DEVICE_MANAGER = SimulatedDeviceManager
 
-    DEFAULT_DEVICE_TYPES = [DeviceType(software_variant='visionOS', hardware_family='Vision', hardware_type='Pro')]
+    DEFAULT_DEVICE_TYPES = apple_additions().get_default_visionos_device_types() if apple_additions() else [
+        DeviceType(software_variant='visionOS', hardware_family='Vision', hardware_type='Pro')
+    ]
     SDK = apple_additions().get_sdk('xrsimulator') if apple_additions() else 'xrsimulator'
 
     def architecture(self):


### PR DESCRIPTION
#### e449abd917042ee5b0ba133c43a4e6c0e655218a
<pre>
[webkitpy] Change VisionOSSimulatorPort&apos;s method of determining the default device type.
<a href="https://bugs.webkit.org/show_bug.cgi?id=292409">https://bugs.webkit.org/show_bug.cgi?id=292409</a>
<a href="https://rdar.apple.com/150004024">rdar://150004024</a>

Reviewed by Jonathan Bedard.

We should determine default device types for visionOS simulator depending on
the presence of apple_additions().

* Tools/Scripts/webkitpy/port/visionos_simulator.py:
    (VisionOSSimulatorPort):
        -&gt; (DEFAULT_DEVICE_TYPES): Use different default device types for visionOS simulator if apple_additions() is present.

Canonical link: <a href="https://commits.webkit.org/294519@main">https://commits.webkit.org/294519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c081ce470abd0f30cde5dd06cdc58fdc7c12854

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106882 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52358 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103764 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29893 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77454 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34480 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91858 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57792 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/101196 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16593 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9875 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51708 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86452 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9953 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109236 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28857 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21255 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86432 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29218 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88059 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85998 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30758 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8474 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23020 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16601 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28785 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28596 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31919 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30155 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->