### PR TITLE
[WPE][GTK][WebDriver][BiDi] Implement the browser.close command

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -136,6 +136,7 @@ set(WebKitGTK_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitAutomationSession.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitBackForwardList.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitBackForwardListItem.h.in
+    ${WEBKIT_DIR}/UIProcess/API/glib/WebKitBrowserAutomation.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitClipboardPermissionRequest.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitCredential.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitContextMenu.h.in

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -164,6 +164,7 @@ set(WPE_API_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitAutomationSession.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitBackForwardList.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitBackForwardListItem.h.in
+    ${WEBKIT_DIR}/UIProcess/API/glib/WebKitBrowserAutomation.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitCredential.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitContextMenu.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitContextMenuActions.h.in

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -121,6 +121,7 @@ UIProcess/API/glib/WebKitAuthenticationRequest.cpp @no-unify
 UIProcess/API/glib/WebKitAutomationSession.cpp @no-unify
 UIProcess/API/glib/WebKitBackForwardList.cpp @no-unify
 UIProcess/API/glib/WebKitBackForwardListItem.cpp @no-unify
+UIProcess/API/glib/WebKitBrowserAutomation.cpp @no-unify
 UIProcess/API/glib/WebKitClipboardPermissionRequest.cpp @no-unify
 UIProcess/API/glib/WebKitContextMenuClient.cpp @no-unify
 UIProcess/API/glib/WebKitCookieManager.cpp @no-unify

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -124,6 +124,7 @@ UIProcess/API/glib/WebKitAuthenticationRequest.cpp @no-unify
 UIProcess/API/glib/WebKitAutomationSession.cpp @no-unify
 UIProcess/API/glib/WebKitBackForwardList.cpp @no-unify
 UIProcess/API/glib/WebKitBackForwardListItem.cpp @no-unify
+UIProcess/API/glib/WebKitBrowserAutomation.cpp @no-unify
 UIProcess/API/glib/WebKitContextMenuClient.cpp @no-unify
 UIProcess/API/glib/WebKitCookieManager.cpp @no-unify
 UIProcess/API/glib/WebKitCredential.cpp @no-unify

--- a/Source/WebKit/UIProcess/API/APIAutomationClient.h
+++ b/Source/WebKit/UIProcess/API/APIAutomationClient.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Microsoft Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,8 +24,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef APIAutomationClient_h
-#define APIAutomationClient_h
+#pragma once
 
 #include <wtf/Forward.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -35,8 +35,8 @@ class AutomationClient {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(AutomationClient);
 public:
     virtual ~AutomationClient() { }
+
+    virtual void closeBrowser() { }
 };
 
 } // namespace API
-
-#endif // APIAutomationClient_h

--- a/Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp
@@ -51,6 +51,11 @@ using namespace WebKit;
  * #WebKitWebView to interact with it. When this happens the signal #WebKitAutomationSession::create-web-view
  * is emitted.
  *
+ * This class is used for implementation of the old WebDriver protocol and is different from
+ * the WebKitBrowserAutomation. The latter is used to implement features of the WebDriver Bidi
+ * protocol (https://w3c.github.io/webdriver-bidi/) that span beyond the scope of a single
+ * WebKitWebContext.
+ *
  * Since: 2.18
  */
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitBrowserAutomation.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitBrowserAutomation.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2025 Microsoft Corporation.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "WebKitBrowserAutomation.h"
+
+#include "APIAutomationClient.h"
+#include "WebKitBrowserAutomationPrivate.h"
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/WTFGType.h>
+
+/**
+ * WebKitBrowserAutomation:
+ *
+ * WebKitBrowserAutomation represents an automation session of a WebKit application.
+ * It is used to implement the WebDriver Bidi protocol (https://w3c.github.io/webdriver-bidi/).
+ * It is different from WebKitAutomationSession, which is used to implement the old WebDriver
+ * protocol and is bound to a single WebKitWebContext.
+ *
+ * Since: 2.50
+ */
+
+enum {
+    CLOSE_BROWSER,
+
+    LAST_SIGNAL
+};
+
+struct _WebKitBrowserAutomationPrivate {
+    int unused { 0 };
+};
+
+static std::array<unsigned, LAST_SIGNAL> signals;
+
+WEBKIT_DEFINE_FINAL_TYPE(WebKitBrowserAutomation, webkit_browser_automation, G_TYPE_OBJECT, GObject)
+
+namespace {
+
+class WebKitAutomationClient final : public API::AutomationClient {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WebKitAutomationClient);
+public:
+    explicit WebKitAutomationClient(WebKitBrowserAutomation* webkitBrowserAutomation)
+        : m_webkitBrowserAutomation(webkitBrowserAutomation)
+    {
+    }
+
+private:
+    void closeBrowser() override
+    {
+        g_signal_emit(m_webkitBrowserAutomation.get(), signals[CLOSE_BROWSER], 0);
+    }
+
+    GRefPtr<WebKitBrowserAutomation> m_webkitBrowserAutomation;
+};
+
+} // namespace
+
+static void webkit_browser_automation_class_init(WebKitBrowserAutomationClass* automationClass)
+{
+    GObjectClass* gObjectClass = G_OBJECT_CLASS(automationClass);
+
+    /**
+     * WebKitBrowserAutomation::close-browser:
+     * @browser_automation: the #WebKitBrowserAutomation on which the signal is emitted
+     *
+     * Emitted when the browser_automation is requested to close the browser application.
+     *
+     * This signal is emitted when browser_automation receives 'browser.close' WebDriver Bidi command
+     * from its remote client. If the signal is not handled the command will fail.
+     */
+    signals[CLOSE_BROWSER] = g_signal_new(
+        "close-browser",
+        G_TYPE_FROM_CLASS(gObjectClass),
+        G_SIGNAL_RUN_LAST,
+        0,
+        nullptr, nullptr,
+        g_cclosure_marshal_VOID__VOID,
+        G_TYPE_NONE, 0);
+}
+
+static WebKitBrowserAutomation* existingBrowserAutomation;
+
+static gpointer createDefaultBrowserAutomation(gpointer)
+{
+    static GRefPtr<WebKitBrowserAutomation> browserAutomation = adoptGRef(WEBKIT_BROWSER_AUTOMATION(g_object_new(WEBKIT_TYPE_BROWSER_AUTOMATION, nullptr)));
+    existingBrowserAutomation = browserAutomation.get();
+    return browserAutomation.get();
+}
+
+void webkitBrowserAutomationMaybeSetClient(WebKit::WebProcessPool& processPool)
+{
+    if (!existingBrowserAutomation)
+        return;
+    processPool.setAutomationClient(makeUnique<WebKitAutomationClient>(existingBrowserAutomation));
+}
+
+/**
+ * webkit_browser_automation_get_default:
+ *
+ * Get global #WebKitBrowserAutomation
+ *
+ * Returns: (transfer none): a #WebKitBrowserAutomation
+ *
+ * Since: 2.50
+ */
+WebKitBrowserAutomation* webkit_browser_automation_get_default()
+{
+    static GOnce onceInit = G_ONCE_INIT;
+    return WEBKIT_BROWSER_AUTOMATION(g_once(&onceInit, createDefaultBrowserAutomation, 0));
+}

--- a/Source/WebKit/UIProcess/API/glib/WebKitBrowserAutomation.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitBrowserAutomation.h.in
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2025 Microsoft Corporation.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+@API_SINGLE_HEADER_CHECK@
+
+#ifndef WebKitBrowserAutomation_h
+#define WebKitBrowserAutomation_h
+
+#include <glib-object.h>
+#include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
+
+G_BEGIN_DECLS
+
+#define WEBKIT_TYPE_BROWSER_AUTOMATION                    (webkit_browser_automation_get_type())
+WEBKIT_DECLARE_FINAL_TYPE (WebKitBrowserAutomation, webkit_browser_automation, WEBKIT, BROWSER_AUTOMATION, GObject)
+
+WEBKIT_API WebKitBrowserAutomation *
+webkit_browser_automation_get_default          (void);
+
+G_END_DECLS
+
+#endif /* WebKitBrowserAutomation_h */

--- a/Source/WebKit/UIProcess/API/glib/WebKitBrowserAutomationPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitBrowserAutomationPrivate.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2025 Microsoft Corporation.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include "WebKitBrowserAutomation.h"
+#include "WebProcessPool.h"
+
+void webkitBrowserAutomationMaybeSetClient(WebKit::WebProcessPool&);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
@@ -31,6 +31,7 @@
 #include "TextCheckerState.h"
 #include "WebAutomationSession.h"
 #include "WebKitAutomationSessionPrivate.h"
+#include "WebKitBrowserAutomationPrivate.h"
 #include "WebKitDownloadPrivate.h"
 #include "WebKitGeolocationManagerPrivate.h"
 #include "WebKitInitialize.h"
@@ -918,8 +919,11 @@ void webkit_web_context_set_automation_allowed(WebKitWebContext* context, gboole
             return;
         }
         context->priv->automationClient = makeUnique<WebKitAutomationClient>(context);
-    } else
+        webkitBrowserAutomationMaybeSetClient(webkitWebContextGetProcessPool(context));
+    } else {
         context->priv->automationClient = nullptr;
+        webkitWebContextGetProcessPool(context).setAutomationClient(nullptr);
+    }
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/glib/webkit.h.in
+++ b/Source/WebKit/UIProcess/API/glib/webkit.h.in
@@ -45,6 +45,7 @@
 #include <@API_INCLUDE_PREFIX@/WebKitAutomationSession.h>
 #include <@API_INCLUDE_PREFIX@/WebKitBackForwardList.h>
 #include <@API_INCLUDE_PREFIX@/WebKitBackForwardListItem.h>
+#include <@API_INCLUDE_PREFIX@/WebKitBrowserAutomation.h>
 #if PLATFORM(GTK)
 #include <@API_INCLUDE_PREFIX@/WebKitClipboardPermissionRequest.h>
 #include <@API_INCLUDE_PREFIX@/WebKitColorChooserRequest.h>

--- a/Source/WebKit/UIProcess/Automation/BidiBrowserAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowserAgent.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBDRIVER_BIDI)
 
+#include "APIAutomationClient.h"
 #include "AutomationProtocolObjects.h"
 #include "BidiUserContext.h"
 #include "WebAutomationSession.h"
@@ -79,6 +80,12 @@ Inspector::CommandResult<void> BidiBrowserAgent::close()
     SYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
 
     session->terminate();
+
+    // FIXME: this should not depend on a particular process pool.
+    if (auto* client = session->protectedProcessPool()->automationClient())
+        client->closeBrowser();
+    else
+        SYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS(InternalError, "unable to close browser"_s); // Fixme: this should be a Bidi error code.
 
     return { };
 }

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -223,6 +223,7 @@ public:
     void setHistoryClient(std::unique_ptr<API::LegacyContextHistoryClient>&&);
     void setLegacyDownloadClient(RefPtr<API::DownloadClient>&&);
     void setAutomationClient(std::unique_ptr<API::AutomationClient>&&);
+    API::AutomationClient* automationClient() const { return m_automationClient.get(); }
 
     const Vector<Ref<WebProcessProxy>>& processes() const { return m_processes; }
 

--- a/Tools/MiniBrowser/gtk/main.c
+++ b/Tools/MiniBrowser/gtk/main.c
@@ -2,6 +2,7 @@
  * Copyright (C) 2006, 2007 Apple Inc.
  * Copyright (C) 2007 Alp Toker <alp@atoker.com>
  * Copyright (C) 2011 Igalia S.L.
+ * Copyright (C) 2025 Microsoft Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -795,6 +796,11 @@ static void setupDarkMode(GtkSettings *settings)
     g_signal_connect_swapped(interfaceSettings, "changed::color-scheme", G_CALLBACK(colorSchemeChanged), settings);
 }
 
+static void quitApplicationForAutomation(WebKitBrowserAutomation* browserAutomation, GApplication *application)
+{
+    g_application_quit(application);
+}
+
 static void activate(GApplication *application, WebKitSettings *webkitSettings)
 {
 #if GTK_CHECK_VERSION(3, 98, 0)
@@ -1071,6 +1077,10 @@ int main(int argc, char *argv[])
     GtkApplication *application = gtk_application_new("org.webkitgtk.MiniBrowser", G_APPLICATION_NON_UNIQUE);
     g_signal_connect(application, "startup", G_CALLBACK(startup), NULL);
     g_signal_connect(application, "activate", G_CALLBACK(activate), webkitSettings);
+    if (automationMode) {
+        WebKitBrowserAutomation *browserAutomation = webkit_browser_automation_get_default();
+        g_signal_connect(browserAutomation, "quit-application", G_CALLBACK(quitApplicationForAutomation), application);
+    }
     g_application_run(G_APPLICATION(application), 0, NULL);
     g_object_unref(application);
 

--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018, 2024 Igalia S.L.
+ * Copyright (C) 2025 Microsoft Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -418,6 +419,11 @@ void loadConfigFile(WPESettings* settings)
 }
 #endif
 
+static void quitApplicationForAutomation(WebKitBrowserAutomation*, GApplication *application)
+{
+    g_application_quit(application);
+}
+
 static void activate(GApplication* application, WPEToolingBackends::ViewBackend* backend)
 {
     g_application_hold(application);
@@ -730,6 +736,10 @@ int main(int argc, char *argv[])
 
     GApplication* application = g_application_new("org.wpewebkit.MiniBrowser", G_APPLICATION_NON_UNIQUE);
     g_signal_connect(application, "activate", G_CALLBACK(activate), backend.release());
+    if (automationMode) {
+        WebKitBrowserAutomation* browserAutomation = webkit_browser_automation_get_default();
+        g_signal_connect(browserAutomation, "quit-application", G_CALLBACK(quitApplicationForAutomation), application);
+    }
     g_application_run(application, 0, nullptr);
     g_object_unref(application);
 


### PR DESCRIPTION
#### b455e41fb59d4599c6af7c5ec0326c672d358706
<pre>
[WPE][GTK][WebDriver][BiDi] Implement the browser.close command
<a href="https://bugs.webkit.org/show_bug.cgi?id=288103">https://bugs.webkit.org/show_bug.cgi?id=288103</a>

Reviewed by NOBODY (OOPS!).

Added basic implementation of browser.close() command that closes
the application process.

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/API/APIAutomationClient.h:
(API::AutomationClient::closeBrowser):
* Source/WebKit/UIProcess/API/glib/WebKitBrowserAutomation.cpp: Added.
A new browser wide automation interface. It can be used with WebDriver Bidi
where Automation spans across WebKitWebContext&apos;s rather than being bound
to a single context as glib/WebKitAutomationSession today. The same interface
can be extended later with signals for creating pages in particular user
contexts and creating contexts for automation.

(WEBKIT_DEFINE_FINAL_TYPE):
(webkit_browser_automation_class_init):
(createDefaultBrowserAutomation):
(webkitBrowserAutomationMaybeSetClient):
(webkit_browser_automation_get_default):
* Source/WebKit/UIProcess/API/glib/WebKitBrowserAutomation.h.in: Added.
* Source/WebKit/UIProcess/API/glib/WebKitBrowserAutomationPrivate.h: Added.
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp:
AutomationClient is currently owned by WebProcessPool. This will need to be
changed to support WebDriver Bidi browser module that operates on multiple
user contexts.

* Source/WebKit/UIProcess/API/glib/webkit.h.in:
* Source/WebKit/UIProcess/Automation/BidiBrowserAgent.cpp:
(WebKit::BidiBrowserAgent::close):
The agent calls into the automation client, eventually the client will need
to be global per browser rather than bound to a process pool.

* Source/WebKit/UIProcess/WebProcessPool.h:
* Tools/MiniBrowser/gtk/main.c:
(quitApplicationForAutomation):
(main):
* Tools/MiniBrowser/wpe/main.cpp:
(quitApplicationForAutomation):
(main):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b455e41fb59d4599c6af7c5ec0326c672d358706

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104201 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109399 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54869 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32449 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79142 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107207 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94012 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59469 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18713 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12048 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54229 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88415 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111783 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31357 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23119 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88165 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31721 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90199 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87826 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32716 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10470 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25821 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31286 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36599 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31080 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34416 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32640 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->