### PR TITLE
AX: [AX Thread Text APIs] RightWord/LeftWorld shouldn't return a range that ends/starts with the current marker

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/editable-word-navigation-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/editable-word-navigation-expected.txt
@@ -16,7 +16,7 @@ Pre word start to next word end: Edit me
 
 Current character is: e
 Left word is: me
-Right word is: me
+Right word is:
 Pre word start to next word end: me
 
 

--- a/LayoutTests/accessibility/isolated-tree/simple-word-navigation-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/simple-word-navigation-expected.txt
@@ -36,7 +36,7 @@ Pre word start to next word end: some text
 
 Current character is: t
 Left word is: text
-Right word is: text
+Right word is:
 Pre word start to next word end: text
 
 Current character is: I

--- a/LayoutTests/accessibility/mac/right-word-range-at-boundary-expected.txt
+++ b/LayoutTests/accessibility/mac/right-word-range-at-boundary-expected.txt
@@ -1,0 +1,10 @@
+This test verifies that we get the correct right word range when we are at the border of containing blocks.
+
+PASS: textChild.stringForTextMarkerRange(range) === ''
+PASS: textChild.stringForTextMarkerRange(range) === ''
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello
+World

--- a/LayoutTests/accessibility/mac/right-word-range-at-boundary.html
+++ b/LayoutTests/accessibility/mac/right-word-range-at-boundary.html
@@ -1,0 +1,42 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div>
+    <div id="text1">Hello</div>
+    <div id="text2">World</div>
+</div>
+    
+<script>
+var textMarker, textRange, textChild, range, rangeStart, rangeEnd;
+
+if (window.accessibilityController) {
+    var output = "This test verifies that we get the correct right word range when we are at the border of containing blocks.\n\n";
+    textChild = accessibilityController.accessibleElementById("text1").childAtIndex(0);
+    textRange = textChild.textMarkerRangeForElement(textChild);
+    textMarker = textChild.endTextMarkerForTextMarkerRange(textRange);
+
+    // Right Word
+    range = textChild.rightWordTextMarkerRangeForTextMarker(textMarker);
+    rangeEnd = textChild.endTextMarkerForTextMarkerRange(range);
+    output += expect("textChild.stringForTextMarkerRange(range)", "''");
+
+    // Left Word
+    textChild = accessibilityController.accessibleElementById("text2").childAtIndex(0);
+    textRange = textChild.textMarkerRangeForElement(textChild);
+    textMarker = textChild.startTextMarkerForTextMarkerRange(textRange);
+    range = textChild.leftWordTextMarkerRangeForTextMarker(textMarker);
+    rangeStart = textChild.startTextMarkerForTextMarkerRange(range);
+    output += expect("textChild.stringForTextMarkerRange(range)", "''");
+
+    debug(output);
+}
+</script>
+</body>
+</html>
+
+

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -1502,6 +1502,10 @@ AXTextMarkerRange AXTextMarker::wordRange(WordRangeType type) const
 
     if (type == WordRangeType::Right) {
         endMarker = nextWordEnd();
+        // To match the live tree, if we end up in the same spot, return a length 0 text marker.
+        if (hasSameObjectAndOffset(endMarker))
+            return { *this, *this };
+
         startMarker = endMarker.previousWordStart();
         // Don't return a right word if the word start is more than a position away from current text marker (e.g., there's a space between the word and current marker).
         auto order = startMarker <=> *this;
@@ -1511,6 +1515,10 @@ AXTextMarkerRange AXTextMarker::wordRange(WordRangeType type) const
             return { *this, *this };
     } else {
         startMarker = previousWordStart();
+        // To match the live tree, if we end up in the same spot, return a length 0 text marker.
+        if (hasSameObjectAndOffset(startMarker))
+            return { *this, *this };
+
         endMarker = startMarker.nextWordEnd();
         // Don't return a left word if the word end is more than a position away from current text marker.
         auto order = endMarker <=> *this;


### PR DESCRIPTION
#### f397ef43f70ca67710a1920ac97c1a5e289d0e65
<pre>
AX: [AX Thread Text APIs] RightWord/LeftWorld shouldn&apos;t return a range that ends/starts with the current marker
<a href="https://bugs.webkit.org/show_bug.cgi?id=292413">https://bugs.webkit.org/show_bug.cgi?id=292413</a>
<a href="https://rdar.apple.com/150488243">rdar://150488243</a>

Reviewed by Tyler Wilcock.

On the live tree, if we are at the boundary of a containing block (and at the end of a word), we will return
a length-zero text marker range at that position. But, with the accessibiltiy thread text markers, we would
return the word range that ended on that marker.

We should match the live tree, and instead, if the result of the word range from a marker is a range that ends
with that marker, just return a length-zero range at that position. This behavior is also matched for left word
too.

I updated isolated tree -only text marker expectations for this new behavior, and added a new test to
verify.

* LayoutTests/accessibility/isolated-tree/editable-word-navigation-expected.txt:
* LayoutTests/accessibility/isolated-tree/simple-word-navigation-expected.txt:
* LayoutTests/accessibility/mac/right-word-range-at-boundary-expected.txt: Added.
* LayoutTests/accessibility/mac/right-word-range-at-boundary.html: Added.
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::wordRange const):

Canonical link: <a href="https://commits.webkit.org/294427@main">https://commits.webkit.org/294427@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f865cf784a22ceccd91a88b9d38432464435514e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106890 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52366 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21708 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29902 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77459 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34487 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91869 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57797 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16599 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9887 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51717 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86457 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109244 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28865 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21259 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86442 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29226 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88070 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86007 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21898 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30762 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8485 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23028 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28793 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34083 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28604 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31927 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30163 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->