### PR TITLE
[selectors] `:host(:not(.a .b))` should be an invalid selector

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-is-where-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-is-where-expected.txt
@@ -11,8 +11,8 @@ PASS ":host(:is(div))" should be a valid selector
 PASS ":host(:where(div))" should be a valid selector
 PASS ":host(:is(div ))" should be a valid selector
 PASS ":host(:where(div ))" should be a valid selector
-FAIL ":host(:is(div .foo))" should be a valid selector assert_equals: CSS.supports() reports the expected value expected false but got true
-FAIL ":host(:where(div .foo))" should be a valid selector assert_equals: CSS.supports() reports the expected value expected false but got true
+FAIL ":host(:is(div .foo))" should be a valid selector ':host(:is(div .foo))' is not a valid selector.
+FAIL ":host(:where(div .foo))" should be a valid selector ':host(:where(div .foo))' is not a valid selector.
 PASS ":is(:hover, :active)" should be a valid selector
 PASS ":where(:hover, :active)" should be a valid selector
 PASS ":is(div):hover" should be a valid selector

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-not-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-not-expected.txt
@@ -24,5 +24,5 @@ PASS ":not(::before)" should be an invalid selector
 PASS ":not(:unknownpseudo)" should be an invalid selector
 PASS ":not(.a, :unknownpseudo)" should be an invalid selector
 PASS ":not(:unknownpseudo, .a)" should be an invalid selector
-FAIL ":host(:not(.a .b))" should be an invalid selector assert_throws_dom: ":host(:not(.a .b))" should throw in querySelector function "() => document.querySelector(selector)" did not throw
+PASS ":host(:not(.a .b))" should be an invalid selector
 

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -884,6 +884,19 @@ std::unique_ptr<MutableCSSSelector> CSSSelectorParser::consumePseudo(CSSParserTo
             block.consumeWhitespace();
             if (!innerSelector || !block.atEnd())
                 return nullptr;
+            if (innerSelector->selector() && innerSelector->selector()->selectorList()) {
+                for (const auto& subSelector : *innerSelector->selector()->selectorList()) {
+                    // Skip :has() verification for now, as it is not well-defined whether it should be valid inside :host()
+                    if (subSelector.match() == CSSSelector::Match::Tag)
+                        continue;
+                    if (subSelector.tagHistory()
+                    && (subSelector.relation() == CSSSelector::Relation::DescendantSpace
+                    || subSelector.relation() == CSSSelector::Relation::DirectAdjacent
+                    || subSelector.relation() == CSSSelector::Relation::IndirectAdjacent
+                    || subSelector.relation() == CSSSelector::Relation::Child))
+                        return nullptr;
+                }
+            }
             selector->adoptSelectorVector(MutableCSSSelectorList::from(WTFMove(innerSelector)));
             return selector;
         }


### PR DESCRIPTION
#### 3135bfcc10d03dfb229c50b99be1afa1f9a11cf9
<pre>
[selectors] `:host(:not(.a .b))` should be an invalid selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=220532">https://bugs.webkit.org/show_bug.cgi?id=220532</a>

Reviewed by NOBODY (OOPS!).

as per spec <a href="https://drafts.csswg.org/css-scoping/#host-selector">https://drafts.csswg.org/css-scoping/#host-selector</a>,
:host() selector receives a compound selector that should not allow combinators inside it.
constructions like `:host(:not(.a .b))` should be considered invalid, as combinators are not allowed within `:host`.
The parser should check if any selector in the selector list has `tagHistory` reference.
If so, it means it has a combinator construct inside `:host()`.

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-not-expected.txt:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumePseudo):
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-is-where-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3135bfcc10d03dfb229c50b99be1afa1f9a11cf9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12660 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107834 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53310 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104708 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30844 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78090 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35063 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105675 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92660 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58422 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17401 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10692 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52667 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87210 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10762 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110210 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29806 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21979 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87070 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30170 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88852 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86675 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31504 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9238 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24059 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29733 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35053 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29541 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32867 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31103 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->