### PR TITLE
[JSC] Uint8Array.prototype.setFromBase64 doesn't work correctly in Ubuntu build

### DIFF
--- a/JSTests/stress/uint8array-base64-bad-char-decode.js
+++ b/JSTests/stress/uint8array-base64-bad-char-decode.js
@@ -1,0 +1,22 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (var i = 0; i < expected.length; ++i) {
+        try {
+            shouldBe(actual[i], expected[i]);
+        } catch(e) {
+            print(JSON.stringify(actual));
+            throw e;
+        }
+    }
+}
+
+let target = new Uint8Array([255, 255, 255, 255, 255]);
+try {
+    target.setFromBase64('MjYyZg===');
+} catch { }
+shouldBeArray(target, [50, 54, 50, 255, 255]);

--- a/Source/WTF/wtf/simdutf/simdutf_impl.cpp.h
+++ b/Source/WTF/wtf/simdutf/simdutf_impl.cpp.h
@@ -1,4 +1,4 @@
-/* auto-generated on 2025-04-01 17:18:52 -0400. Do not edit! */
+/* auto-generated on 2025-05-01 00:20:41 -0400. Do not edit! */
 /* begin file src/simdutf.cpp */
 // #include "simdutf.h"
 
@@ -496,6 +496,185 @@ const uint32_t d3[256] = {
     0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
     0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff};
 } // namespace base64_url
+
+namespace base64_default_or_url {
+const uint32_t d0[256] = {
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x000000f8, 0x01ffffff, 0x000000f8, 0x01ffffff, 0x000000fc,
+    0x000000d0, 0x000000d4, 0x000000d8, 0x000000dc, 0x000000e0, 0x000000e4,
+    0x000000e8, 0x000000ec, 0x000000f0, 0x000000f4, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x00000000,
+    0x00000004, 0x00000008, 0x0000000c, 0x00000010, 0x00000014, 0x00000018,
+    0x0000001c, 0x00000020, 0x00000024, 0x00000028, 0x0000002c, 0x00000030,
+    0x00000034, 0x00000038, 0x0000003c, 0x00000040, 0x00000044, 0x00000048,
+    0x0000004c, 0x00000050, 0x00000054, 0x00000058, 0x0000005c, 0x00000060,
+    0x00000064, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x000000fc,
+    0x01ffffff, 0x00000068, 0x0000006c, 0x00000070, 0x00000074, 0x00000078,
+    0x0000007c, 0x00000080, 0x00000084, 0x00000088, 0x0000008c, 0x00000090,
+    0x00000094, 0x00000098, 0x0000009c, 0x000000a0, 0x000000a4, 0x000000a8,
+    0x000000ac, 0x000000b0, 0x000000b4, 0x000000b8, 0x000000bc, 0x000000c0,
+    0x000000c4, 0x000000c8, 0x000000cc, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff};
+const uint32_t d1[256] = {
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x0000e003, 0x01ffffff, 0x0000e003, 0x01ffffff, 0x0000f003,
+    0x00004003, 0x00005003, 0x00006003, 0x00007003, 0x00008003, 0x00009003,
+    0x0000a003, 0x0000b003, 0x0000c003, 0x0000d003, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x00000000,
+    0x00001000, 0x00002000, 0x00003000, 0x00004000, 0x00005000, 0x00006000,
+    0x00007000, 0x00008000, 0x00009000, 0x0000a000, 0x0000b000, 0x0000c000,
+    0x0000d000, 0x0000e000, 0x0000f000, 0x00000001, 0x00001001, 0x00002001,
+    0x00003001, 0x00004001, 0x00005001, 0x00006001, 0x00007001, 0x00008001,
+    0x00009001, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x0000f003,
+    0x01ffffff, 0x0000a001, 0x0000b001, 0x0000c001, 0x0000d001, 0x0000e001,
+    0x0000f001, 0x00000002, 0x00001002, 0x00002002, 0x00003002, 0x00004002,
+    0x00005002, 0x00006002, 0x00007002, 0x00008002, 0x00009002, 0x0000a002,
+    0x0000b002, 0x0000c002, 0x0000d002, 0x0000e002, 0x0000f002, 0x00000003,
+    0x00001003, 0x00002003, 0x00003003, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff};
+const uint32_t d2[256] = {
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x00800f00, 0x01ffffff, 0x00800f00, 0x01ffffff, 0x00c00f00,
+    0x00000d00, 0x00400d00, 0x00800d00, 0x00c00d00, 0x00000e00, 0x00400e00,
+    0x00800e00, 0x00c00e00, 0x00000f00, 0x00400f00, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x00000000,
+    0x00400000, 0x00800000, 0x00c00000, 0x00000100, 0x00400100, 0x00800100,
+    0x00c00100, 0x00000200, 0x00400200, 0x00800200, 0x00c00200, 0x00000300,
+    0x00400300, 0x00800300, 0x00c00300, 0x00000400, 0x00400400, 0x00800400,
+    0x00c00400, 0x00000500, 0x00400500, 0x00800500, 0x00c00500, 0x00000600,
+    0x00400600, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x00c00f00,
+    0x01ffffff, 0x00800600, 0x00c00600, 0x00000700, 0x00400700, 0x00800700,
+    0x00c00700, 0x00000800, 0x00400800, 0x00800800, 0x00c00800, 0x00000900,
+    0x00400900, 0x00800900, 0x00c00900, 0x00000a00, 0x00400a00, 0x00800a00,
+    0x00c00a00, 0x00000b00, 0x00400b00, 0x00800b00, 0x00c00b00, 0x00000c00,
+    0x00400c00, 0x00800c00, 0x00c00c00, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff};
+const uint32_t d3[256] = {
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x003e0000, 0x01ffffff, 0x003e0000, 0x01ffffff, 0x003f0000,
+    0x00340000, 0x00350000, 0x00360000, 0x00370000, 0x00380000, 0x00390000,
+    0x003a0000, 0x003b0000, 0x003c0000, 0x003d0000, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x00000000,
+    0x00010000, 0x00020000, 0x00030000, 0x00040000, 0x00050000, 0x00060000,
+    0x00070000, 0x00080000, 0x00090000, 0x000a0000, 0x000b0000, 0x000c0000,
+    0x000d0000, 0x000e0000, 0x000f0000, 0x00100000, 0x00110000, 0x00120000,
+    0x00130000, 0x00140000, 0x00150000, 0x00160000, 0x00170000, 0x00180000,
+    0x00190000, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x003f0000,
+    0x01ffffff, 0x001a0000, 0x001b0000, 0x001c0000, 0x001d0000, 0x001e0000,
+    0x001f0000, 0x00200000, 0x00210000, 0x00220000, 0x00230000, 0x00240000,
+    0x00250000, 0x00260000, 0x00270000, 0x00280000, 0x00290000, 0x002a0000,
+    0x002b0000, 0x002c0000, 0x002d0000, 0x002e0000, 0x002f0000, 0x00300000,
+    0x00310000, 0x00320000, 0x00330000, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff,
+    0x01ffffff, 0x01ffffff, 0x01ffffff, 0x01ffffff};
+} // namespace base64_default_or_url
 const uint64_t thintable_epi8[256] = {
     0x0706050403020100, 0x0007060504030201, 0x0007060504030200,
     0x0000070605040302, 0x0007060504030100, 0x0000070605040301,
@@ -655,6 +834,27 @@ constexpr uint8_t to_base64_url_value[] = {
     255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
     255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
     255};
+
+constexpr uint8_t to_base64_default_or_url_value[] = {
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 64,  64,  255, 64,  64,  255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 64,  255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 62,  255,
+    62,  255, 63,  52,  53,  54,  55,  56,  57,  58,  59,  60,  61,  255, 255,
+    255, 255, 255, 255, 255, 0,   1,   2,   3,   4,   5,   6,   7,   8,   9,
+    10,  11,  12,  13,  14,  15,  16,  17,  18,  19,  20,  21,  22,  23,  24,
+    25,  255, 255, 255, 255, 63,  255, 26,  27,  28,  29,  30,  31,  32,  33,
+    34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,  45,  46,  47,  48,
+    49,  50,  51,  255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255};
+
 static_assert(sizeof(to_base64_value) == 256,
               "to_base64_value must have 256 elements");
 static_assert(sizeof(to_base64_url_value) == 256,
@@ -2440,6 +2640,9 @@ const uint8_t pack_utf32_to_utf16be[16][16] = {
 // only for peculiar build targets.
 
 // The best choice should always come first!
+#ifndef SIMDUTF_REGULAR_VISUAL_STUDIO
+SIMDUTF_DISABLE_UNUSED_WARNING
+#endif
 /* begin file src/simdutf/arm64.h */
 #ifndef SIMDUTF_ARM64_H
 #define SIMDUTF_ARM64_H
@@ -2515,6 +2718,10 @@ public:
       const char16_t *buf, size_t len) const noexcept final;
   simdutf_warn_unused result validate_utf16be_with_errors(
       const char16_t *buf, size_t len) const noexcept final;
+  void to_well_formed_utf16be(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
+  void to_well_formed_utf16le(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
 #endif // SIMDUTF_FEATURE_UTF16
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING
   simdutf_warn_unused bool validate_utf32(const char32_t *buf,
@@ -2781,6 +2988,9 @@ simdutf_really_inline int trailing_zeroes(uint64_t input_num) {
   #endif // SIMDUTF_REGULAR_VISUAL_STUDIO
 }
 #endif
+template <typename T> T clear_least_significant_bit(T x) {
+  return (x & (x - 1));
+}
 
 } // unnamed namespace
 } // namespace arm64
@@ -2878,9 +3088,6 @@ template <typename T, typename Mask = simd8<bool>> struct base_u8 {
   simdutf_really_inline operator const uint8x16_t &() const {
     return this->value;
   }
-  simdutf_really_inline operator uint8x16_t &() { return this->value; }
-  simdutf_really_inline T first() const { return vgetq_lane_u8(*this, 0); }
-  simdutf_really_inline T last() const { return vgetq_lane_u8(*this, 15); }
 
   // Bit operations
   simdutf_really_inline simd8<T> operator|(const simd8<T> other) const {
@@ -2892,23 +3099,9 @@ template <typename T, typename Mask = simd8<bool>> struct base_u8 {
   simdutf_really_inline simd8<T> operator^(const simd8<T> other) const {
     return veorq_u8(*this, other);
   }
-  simdutf_really_inline simd8<T> bit_andnot(const simd8<T> other) const {
-    return vbicq_u8(*this, other);
-  }
-  simdutf_really_inline simd8<T> operator~() const { return *this ^ 0xFFu; }
   simdutf_really_inline simd8<T> &operator|=(const simd8<T> other) {
     auto this_cast = static_cast<simd8<T> *>(this);
     *this_cast = *this_cast | other;
-    return *this_cast;
-  }
-  simdutf_really_inline simd8<T> &operator&=(const simd8<T> other) {
-    auto this_cast = static_cast<simd8<T> *>(this);
-    *this_cast = *this_cast & other;
-    return *this_cast;
-  }
-  simdutf_really_inline simd8<T> &operator^=(const simd8<T> other) {
-    auto this_cast = static_cast<simd8<T> *>(this);
-    *this_cast = *this_cast ^ other;
     return *this_cast;
   }
 
@@ -2925,9 +3118,6 @@ template <typename T, typename Mask = simd8<bool>> struct base_u8 {
 
 // SIMD byte mask type (returned by things like eq and gt)
 template <> struct simd8<bool> : base_u8<bool> {
-  typedef uint16_t bitmask_t;
-  typedef uint32_t bitmask2_t;
-
   static simdutf_really_inline simd8<bool> splat(bool _value) {
     return vmovq_n_u8(uint8_t(-(!!_value)));
   }
@@ -2968,16 +3158,6 @@ template <> struct simd8<bool> : base_u8<bool> {
   simdutf_really_inline uint64_t to_bitmask64() const {
     return vget_lane_u64(
         vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(*this), 4)), 0);
-  }
-
-  simdutf_really_inline bool any() const {
-    return vmaxvq_u32(vreinterpretq_u32_u8(*this)) != 0;
-  }
-  simdutf_really_inline bool none() const {
-    return vmaxvq_u32(vreinterpretq_u32_u8(*this)) == 0;
-  }
-  simdutf_really_inline bool all() const {
-    return vminvq_u32(vreinterpretq_u32_u8(*this)) == 0xFFFFF;
   }
 };
 
@@ -3030,28 +3210,10 @@ template <> struct simd8<uint8_t> : base_u8<uint8_t> {
     return vst1q_u8(dst, *this);
   }
 
-  // Saturated math
-  simdutf_really_inline simd8<uint8_t>
-  saturating_add(const simd8<uint8_t> other) const {
-    return vqaddq_u8(*this, other);
-  }
-  simdutf_really_inline simd8<uint8_t>
-  saturating_sub(const simd8<uint8_t> other) const {
-    return vqsubq_u8(*this, other);
-  }
-
   // Addition/subtraction are the same for signed and unsigned
-  simdutf_really_inline simd8<uint8_t>
-  operator+(const simd8<uint8_t> other) const {
-    return vaddq_u8(*this, other);
-  }
   simdutf_really_inline simd8<uint8_t>
   operator-(const simd8<uint8_t> other) const {
     return vsubq_u8(*this, other);
-  }
-  simdutf_really_inline simd8<uint8_t> &operator+=(const simd8<uint8_t> other) {
-    *this = *this + other;
-    return *this;
   }
   simdutf_really_inline simd8<uint8_t> &operator-=(const simd8<uint8_t> other) {
     *this = *this - other;
@@ -3060,26 +3222,9 @@ template <> struct simd8<uint8_t> : base_u8<uint8_t> {
 
   // Order-specific operations
   simdutf_really_inline uint8_t max_val() const { return vmaxvq_u8(*this); }
-  simdutf_really_inline uint8_t min_val() const { return vminvq_u8(*this); }
-  simdutf_really_inline simd8<uint8_t>
-  max_val(const simd8<uint8_t> other) const {
-    return vmaxq_u8(*this, other);
-  }
-  simdutf_really_inline simd8<uint8_t>
-  min_val(const simd8<uint8_t> other) const {
-    return vminq_u8(*this, other);
-  }
-  simdutf_really_inline simd8<bool>
-  operator<=(const simd8<uint8_t> other) const {
-    return vcleq_u8(*this, other);
-  }
   simdutf_really_inline simd8<bool>
   operator>=(const simd8<uint8_t> other) const {
     return vcgeq_u8(*this, other);
-  }
-  simdutf_really_inline simd8<bool>
-  operator<(const simd8<uint8_t> other) const {
-    return vcltq_u8(*this, other);
   }
   simdutf_really_inline simd8<bool>
   operator>(const simd8<uint8_t> other) const {
@@ -3091,17 +3236,12 @@ template <> struct simd8<uint8_t> : base_u8<uint8_t> {
   gt_bits(const simd8<uint8_t> other) const {
     return simd8<uint8_t>(*this > other);
   }
-  // Same as <, but instead of guaranteeing all 1's == true, false = 0 and true
-  // = nonzero. For ARM, returns all 1's.
-  simdutf_really_inline simd8<uint8_t>
-  lt_bits(const simd8<uint8_t> other) const {
-    return simd8<uint8_t>(*this < other);
-  }
 
   // Bit-specific operations
   simdutf_really_inline simd8<bool> any_bits_set(simd8<uint8_t> bits) const {
     return vtstq_u8(*this, bits);
   }
+
   simdutf_really_inline bool is_ascii() const {
     return this->max_val() < 0b10000000u;
   }
@@ -3109,14 +3249,8 @@ template <> struct simd8<uint8_t> : base_u8<uint8_t> {
   simdutf_really_inline bool any_bits_set_anywhere() const {
     return this->max_val() != 0;
   }
-  simdutf_really_inline bool any_bits_set_anywhere(simd8<uint8_t> bits) const {
-    return (*this & bits).any_bits_set_anywhere();
-  }
   template <int N> simdutf_really_inline simd8<uint8_t> shr() const {
     return vshrq_n_u8(*this, N);
-  }
-  template <int N> simdutf_really_inline simd8<uint8_t> shl() const {
-    return vshlq_n_u8(*this, N);
   }
   simdutf_really_inline uint16_t sum_bytes() const { return vaddvq_u8(*this); }
 
@@ -3179,26 +3313,6 @@ template <> struct simd8<int8_t> {
     vst2q_s8(reinterpret_cast<int8_t *>(p), pair);
   }
 
-  // currently unused
-  // Technically this could be done with ST4 like in store_ascii_as_utf16, but
-  // it is very much not worth it, as explicitly mentioned in the ARM Cortex-X1
-  // Core Software Optimization Guide:
-  //   4.18 Complex ASIMD instructions
-  //     The bandwidth of [ST4 with element size less than 64b] is limited by
-  //     decode constraints and it is advisable to avoid them when high
-  //     performing code is desired.
-  // Instead, it is better to use ZIP1+ZIP2 and two ST2.
-  simdutf_really_inline void store_ascii_as_utf32(char32_t *p) const {
-    const uint16x8_t low =
-        vreinterpretq_u16_s8(vzip1q_s8(this->value, vmovq_n_s8(0)));
-    const uint16x8_t high =
-        vreinterpretq_u16_s8(vzip2q_s8(this->value, vmovq_n_s8(0)));
-    const uint16x8x2_t low_pair{{low, vmovq_n_u16(0)}};
-    vst2q_u16(reinterpret_cast<uint16_t *>(p), low_pair);
-    const uint16x8x2_t high_pair{{high, vmovq_n_u16(0)}};
-    vst2q_u16(reinterpret_cast<uint16_t *>(p + 8), high_pair);
-  }
-
   // In places where the table can be reused, which is most uses in simdutf, it
   // is worth it to do 4 table lookups, as there is no direct zero extension
   // from u8 to u32.
@@ -3257,14 +3371,6 @@ template <> struct simd8<int8_t> {
       : simd8(int8x16_t{v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12,
                         v13, v14, v15}) {}
 #endif
-  // Repeat 16 values as many times as necessary (usually for lookup tables)
-  simdutf_really_inline static simd8<int8_t>
-  repeat_16(int8_t v0, int8_t v1, int8_t v2, int8_t v3, int8_t v4, int8_t v5,
-            int8_t v6, int8_t v7, int8_t v8, int8_t v9, int8_t v10, int8_t v11,
-            int8_t v12, int8_t v13, int8_t v14, int8_t v15) {
-    return simd8<int8_t>(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12,
-                         v13, v14, v15);
-  }
 
   // Store to array
   simdutf_really_inline void store(int8_t dst[16]) const {
@@ -3287,80 +3393,17 @@ template <> struct simd8<int8_t> {
   operator|(const simd8<int8_t> other) const {
     return vorrq_s8(value, other.value);
   }
-  simdutf_really_inline simd8<int8_t>
-  operator&(const simd8<int8_t> other) const {
-    return vandq_s8(value, other.value);
-  }
-  simdutf_really_inline simd8<int8_t>
-  operator^(const simd8<int8_t> other) const {
-    return veorq_s8(value, other.value);
-  }
-  simdutf_really_inline simd8<int8_t>
-  bit_andnot(const simd8<int8_t> other) const {
-    return vbicq_s8(value, other.value);
-  }
-
-  // Math
-  simdutf_really_inline simd8<int8_t>
-  operator+(const simd8<int8_t> other) const {
-    return vaddq_s8(value, other.value);
-  }
-  simdutf_really_inline simd8<int8_t>
-  operator-(const simd8<int8_t> other) const {
-    return vsubq_s8(value, other.value);
-  }
-  simdutf_really_inline simd8<int8_t> &operator+=(const simd8<int8_t> other) {
-    *this = *this + other;
-    return *this;
-  }
-  simdutf_really_inline simd8<int8_t> &operator-=(const simd8<int8_t> other) {
-    *this = *this - other;
-    return *this;
-  }
 
   simdutf_really_inline int8_t max_val() const { return vmaxvq_s8(value); }
   simdutf_really_inline int8_t min_val() const { return vminvq_s8(value); }
   simdutf_really_inline bool is_ascii() const { return this->min_val() >= 0; }
 
   // Order-sensitive comparisons
-  simdutf_really_inline simd8<int8_t> max_val(const simd8<int8_t> other) const {
-    return vmaxq_s8(value, other.value);
-  }
-  simdutf_really_inline simd8<int8_t> min_val(const simd8<int8_t> other) const {
-    return vminq_s8(value, other.value);
-  }
   simdutf_really_inline simd8<bool> operator>(const simd8<int8_t> other) const {
     return vcgtq_s8(value, other.value);
   }
   simdutf_really_inline simd8<bool> operator<(const simd8<int8_t> other) const {
     return vcltq_s8(value, other.value);
-  }
-  simdutf_really_inline simd8<bool>
-  operator==(const simd8<int8_t> other) const {
-    return vceqq_s8(value, other.value);
-  }
-
-  template <int N = 1>
-  simdutf_really_inline simd8<int8_t>
-  prev(const simd8<int8_t> prev_chunk) const {
-    return vextq_s8(prev_chunk, *this, 16 - N);
-  }
-
-  // Perform a lookup assuming no value is larger than 16
-  template <typename L>
-  simdutf_really_inline simd8<L> lookup_16(simd8<L> lookup_table) const {
-    return lookup_table.apply_lookup_16_to(*this);
-  }
-  template <typename L>
-  simdutf_really_inline simd8<L>
-  lookup_16(L replace0, L replace1, L replace2, L replace3, L replace4,
-            L replace5, L replace6, L replace7, L replace8, L replace9,
-            L replace10, L replace11, L replace12, L replace13, L replace14,
-            L replace15) const {
-    return lookup_16(simd8<L>::repeat_16(
-        replace0, replace1, replace2, replace3, replace4, replace5, replace6,
-        replace7, replace8, replace9, replace10, replace11, replace12,
-        replace13, replace14, replace15));
   }
 
   template <typename T>
@@ -3453,41 +3496,6 @@ template <typename T> struct simd8x64 {
     return vgetq_lane_u64(vreinterpretq_u64_u8(sum0), 0);
   }
 
-  simdutf_really_inline uint64_t eq(const T m) const {
-    const simd8<T> mask = simd8<T>::splat(m);
-    return simd8x64<bool>(this->chunks[0] == mask, this->chunks[1] == mask,
-                          this->chunks[2] == mask, this->chunks[3] == mask)
-        .to_bitmask();
-  }
-
-  simdutf_really_inline uint64_t lteq(const T m) const {
-    const simd8<T> mask = simd8<T>::splat(m);
-    return simd8x64<bool>(this->chunks[0] <= mask, this->chunks[1] <= mask,
-                          this->chunks[2] <= mask, this->chunks[3] <= mask)
-        .to_bitmask();
-  }
-
-  simdutf_really_inline uint64_t in_range(const T low, const T high) const {
-    const simd8<T> mask_low = simd8<T>::splat(low);
-    const simd8<T> mask_high = simd8<T>::splat(high);
-
-    return simd8x64<bool>(
-               (this->chunks[0] <= mask_high) & (this->chunks[0] >= mask_low),
-               (this->chunks[1] <= mask_high) & (this->chunks[1] >= mask_low),
-               (this->chunks[2] <= mask_high) & (this->chunks[2] >= mask_low),
-               (this->chunks[3] <= mask_high) & (this->chunks[3] >= mask_low))
-        .to_bitmask();
-  }
-  simdutf_really_inline uint64_t not_in_range(const T low, const T high) const {
-    const simd8<T> mask_low = simd8<T>::splat(low);
-    const simd8<T> mask_high = simd8<T>::splat(high);
-    return simd8x64<bool>(
-               (this->chunks[0] > mask_high) | (this->chunks[0] < mask_low),
-               (this->chunks[1] > mask_high) | (this->chunks[1] < mask_low),
-               (this->chunks[2] > mask_high) | (this->chunks[2] < mask_low),
-               (this->chunks[3] > mask_high) | (this->chunks[3] < mask_low))
-        .to_bitmask();
-  }
   simdutf_really_inline uint64_t lt(const T m) const {
     const simd8<T> mask = simd8<T>::splat(m);
     return simd8x64<bool>(this->chunks[0] < mask, this->chunks[1] < mask,
@@ -3498,12 +3506,6 @@ template <typename T> struct simd8x64 {
     const simd8<T> mask = simd8<T>::splat(m);
     return simd8x64<bool>(this->chunks[0] > mask, this->chunks[1] > mask,
                           this->chunks[2] > mask, this->chunks[3] > mask)
-        .to_bitmask();
-  }
-  simdutf_really_inline uint64_t gteq(const T m) const {
-    const simd8<T> mask = simd8<T>::splat(m);
-    return simd8x64<bool>(this->chunks[0] >= mask, this->chunks[1] >= mask,
-                          this->chunks[2] >= mask, this->chunks[3] >= mask)
         .to_bitmask();
   }
   simdutf_really_inline uint64_t gteq_unsigned(const uint8_t m) const {
@@ -3771,20 +3773,6 @@ template <> struct simd16<uint16_t> : base16_numeric<uint16_t> {
     return simd16<uint16_t>(vshlq_n_u16(*this, N));
   }
 
-  // logical operations
-  simdutf_really_inline simd16<uint16_t>
-  operator|(const simd16<uint16_t> other) const {
-    return vorrq_u16(*this, other);
-  }
-  simdutf_really_inline simd16<uint16_t>
-  operator&(const simd16<uint16_t> other) const {
-    return vandq_u16(*this, other);
-  }
-  simdutf_really_inline simd16<uint16_t>
-  operator^(const simd16<uint16_t> other) const {
-    return veorq_u16(*this, other);
-  }
-
   // Pack with the unsigned saturation of two uint16_t code units into single
   // uint8_t vector
   static simdutf_really_inline simd8<uint8_t> pack(const simd16<uint16_t> &v0,
@@ -3796,6 +3784,7 @@ template <> struct simd16<uint16_t> : base16_numeric<uint16_t> {
   simdutf_really_inline simd16<uint16_t> swap_bytes() const {
     return vreinterpretq_u16_u8(vrev16q_u8(vreinterpretq_u8_u16(*this)));
   }
+
   void dump() const {
     uint16_t temp[8];
     vst1q_u16(temp, *this);
@@ -3805,6 +3794,7 @@ template <> struct simd16<uint16_t> : base16_numeric<uint16_t> {
 
   simdutf_really_inline uint32_t sum() const { return vaddlvq_u16(value); }
 };
+
 simdutf_really_inline simd16<int16_t>::operator simd16<uint16_t>() const {
   return this->value;
 }
@@ -3880,13 +3870,6 @@ template <typename T> struct simd16x32 {
     this->chunks[3] = this->chunks[3].swap_bytes();
   }
 
-  simdutf_really_inline uint64_t eq(const T m) const {
-    const simd16<T> mask = simd16<T>::splat(m);
-    return simd16x32<bool>(this->chunks[0] == mask, this->chunks[1] == mask,
-                           this->chunks[2] == mask, this->chunks[3] == mask)
-        .to_bitmask();
-  }
-
   simdutf_really_inline uint64_t lteq(const T m) const {
     const simd16<T> mask = simd16<T>::splat(m);
     return simd16x32<bool>(this->chunks[0] <= mask, this->chunks[1] <= mask,
@@ -3894,17 +3877,6 @@ template <typename T> struct simd16x32 {
         .to_bitmask();
   }
 
-  simdutf_really_inline uint64_t in_range(const T low, const T high) const {
-    const simd16<T> mask_low = simd16<T>::splat(low);
-    const simd16<T> mask_high = simd16<T>::splat(high);
-
-    return simd16x32<bool>(
-               (this->chunks[0] <= mask_high) & (this->chunks[0] >= mask_low),
-               (this->chunks[1] <= mask_high) & (this->chunks[1] >= mask_low),
-               (this->chunks[2] <= mask_high) & (this->chunks[2] >= mask_low),
-               (this->chunks[3] <= mask_high) & (this->chunks[3] >= mask_low))
-        .to_bitmask();
-  }
   simdutf_really_inline uint64_t not_in_range(const T low, const T high) const {
     const simd16<T> mask_low = simd16<T>::splat(low);
     const simd16<T> mask_high = simd16<T>::splat(high);
@@ -3915,13 +3887,6 @@ template <typename T> struct simd16x32 {
                (this->chunks[3] > mask_high) | (this->chunks[3] < mask_low))
         .to_bitmask();
   }
-  simdutf_really_inline uint64_t lt(const T m) const {
-    const simd16<T> mask = simd16<T>::splat(m);
-    return simd16x32<bool>(this->chunks[0] < mask, this->chunks[1] < mask,
-                           this->chunks[2] < mask, this->chunks[3] < mask)
-        .to_bitmask();
-  }
-
 }; // struct simd16x32<T>
 template <>
 simdutf_really_inline uint64_t simd16x32<uint16_t>::not_in_range(
@@ -4121,6 +4086,7 @@ simdutf_really_inline simd64<uint64_t> sum_8bytes(const simd8<uint8_t> v) {
 /* end file src/simdutf/arm64/simd.h */
 
 /* begin file src/simdutf/arm64/end.h */
+#undef SIMDUTF_SIMD_HAS_BYTEMASK
 /* end file src/simdutf/arm64/end.h */
 
 #endif // SIMDUTF_IMPLEMENTATION_ARM64
@@ -4385,6 +4351,10 @@ public:
       const char16_t *buf, size_t len) const noexcept final;
   simdutf_warn_unused result validate_utf16be_with_errors(
       const char16_t *buf, size_t len) const noexcept final;
+  void to_well_formed_utf16be(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
+  void to_well_formed_utf16le(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING
@@ -5130,6 +5100,10 @@ public:
                                            size_t length) const noexcept;
   simdutf_warn_unused size_t count_utf16be(const char16_t *buf,
                                            size_t length) const noexcept;
+  void to_well_formed_utf16be(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
+  void to_well_formed_utf16le(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8
@@ -5356,9 +5330,9 @@ template <typename Child> struct base {
 
   // Conversion from SIMD register
   simdutf_really_inline base(const __m256i _value) : value(_value) {}
-  // Conversion to SIMD register
+
   simdutf_really_inline operator const __m256i &() const { return this->value; }
-  simdutf_really_inline operator __m256i &() { return this->value; }
+
   template <endianness big_endian>
   simdutf_really_inline void store_ascii_as_utf16(char16_t *ptr) const {
     __m256i first = _mm256_cvtepu8_epi16(_mm256_castsi256_si128(*this));
@@ -5373,6 +5347,7 @@ template <typename Child> struct base {
     _mm256_storeu_si256(reinterpret_cast<__m256i *>(ptr), first);
     _mm256_storeu_si256(reinterpret_cast<__m256i *>(ptr + 16), second);
   }
+
   simdutf_really_inline void store_ascii_as_utf32(char32_t *ptr) const {
     _mm256_storeu_si256(reinterpret_cast<__m256i *>(ptr),
                         _mm256_cvtepu8_epi32(_mm256_castsi256_si128(*this)));
@@ -5396,22 +5371,9 @@ template <typename Child> struct base {
   simdutf_really_inline Child operator^(const Child other) const {
     return _mm256_xor_si256(*this, other);
   }
-  simdutf_really_inline Child bit_andnot(const Child other) const {
-    return _mm256_andnot_si256(other, *this);
-  }
   simdutf_really_inline Child &operator|=(const Child other) {
     auto this_cast = static_cast<Child *>(this);
     *this_cast = *this_cast | other;
-    return *this_cast;
-  }
-  simdutf_really_inline Child &operator&=(const Child other) {
-    auto this_cast = static_cast<Child *>(this);
-    *this_cast = *this_cast & other;
-    return *this_cast;
-  }
-  simdutf_really_inline Child &operator^=(const Child other) {
-    auto this_cast = static_cast<Child *>(this);
-    *this_cast = *this_cast ^ other;
     return *this_cast;
   }
 };
@@ -5421,17 +5383,10 @@ template <typename T> struct simd8;
 
 template <typename T, typename Mask = simd8<bool>>
 struct base8 : base<simd8<T>> {
-  typedef uint32_t bitmask_t;
-  typedef uint64_t bitmask2_t;
-
   simdutf_really_inline base8() : base<simd8<T>>() {}
+
   simdutf_really_inline base8(const __m256i _value) : base<simd8<T>>(_value) {}
-  simdutf_really_inline T first() const {
-    return _mm256_extract_epi8(*this, 0);
-  }
-  simdutf_really_inline T last() const {
-    return _mm256_extract_epi8(*this, 31);
-  }
+
   friend simdutf_always_inline Mask operator==(const simd8<T> lhs,
                                                const simd8<T> rhs) {
     return _mm256_cmpeq_epi8(lhs, rhs);
@@ -5452,24 +5407,13 @@ template <> struct simd8<bool> : base8<bool> {
     return _mm256_set1_epi8(uint8_t(-(!!_value)));
   }
 
-  simdutf_really_inline simd8() : base8() {}
   simdutf_really_inline simd8(const __m256i _value) : base8<bool>(_value) {}
-  // Splat constructor
+
   simdutf_really_inline simd8(bool _value) : base8<bool>(splat(_value)) {}
 
   simdutf_really_inline uint32_t to_bitmask() const {
-    return uint32_t(_mm256_movemask_epi8(*this));
+    return uint32_t(_mm256_movemask_epi8(value));
   }
-  simdutf_really_inline bool any() const {
-    return !_mm256_testz_si256(*this, *this);
-  }
-  simdutf_really_inline bool none() const {
-    return _mm256_testz_si256(*this, *this);
-  }
-  simdutf_really_inline bool all() const {
-    return static_cast<uint32_t>(_mm256_movemask_epi8(*this)) == 0xFFFFFFFF;
-  }
-  simdutf_really_inline simd8<bool> operator~() const { return *this ^ true; }
 };
 
 template <typename T> struct base8_numeric : base8<T> {
@@ -5502,15 +5446,8 @@ template <typename T> struct base8_numeric : base8<T> {
   }
 
   // Addition/subtraction are the same for signed and unsigned
-  simdutf_really_inline simd8<T> operator+(const simd8<T> other) const {
-    return _mm256_add_epi8(*this, other);
-  }
   simdutf_really_inline simd8<T> operator-(const simd8<T> other) const {
     return _mm256_sub_epi8(*this, other);
-  }
-  simdutf_really_inline simd8<T> &operator+=(const simd8<T> other) {
-    *this = *this + other;
-    return *static_cast<simd8<T> *>(this);
   }
   simdutf_really_inline simd8<T> &operator-=(const simd8<T> other) {
     *this = *this - other;
@@ -5551,37 +5488,11 @@ template <> struct simd8<int8_t> : base8_numeric<int8_t> {
   // Array constructor
   simdutf_really_inline simd8(const int8_t values[32]) : simd8(load(values)) {}
   simdutf_really_inline operator simd8<uint8_t>() const;
-  // Member-by-member initialization
-  simdutf_really_inline
-  simd8(int8_t v0, int8_t v1, int8_t v2, int8_t v3, int8_t v4, int8_t v5,
-        int8_t v6, int8_t v7, int8_t v8, int8_t v9, int8_t v10, int8_t v11,
-        int8_t v12, int8_t v13, int8_t v14, int8_t v15, int8_t v16, int8_t v17,
-        int8_t v18, int8_t v19, int8_t v20, int8_t v21, int8_t v22, int8_t v23,
-        int8_t v24, int8_t v25, int8_t v26, int8_t v27, int8_t v28, int8_t v29,
-        int8_t v30, int8_t v31)
-      : simd8(_mm256_setr_epi8(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11,
-                               v12, v13, v14, v15, v16, v17, v18, v19, v20, v21,
-                               v22, v23, v24, v25, v26, v27, v28, v29, v30,
-                               v31)) {}
-  // Repeat 16 values as many times as necessary (usually for lookup tables)
-  simdutf_really_inline static simd8<int8_t>
-  repeat_16(int8_t v0, int8_t v1, int8_t v2, int8_t v3, int8_t v4, int8_t v5,
-            int8_t v6, int8_t v7, int8_t v8, int8_t v9, int8_t v10, int8_t v11,
-            int8_t v12, int8_t v13, int8_t v14, int8_t v15) {
-    return simd8<int8_t>(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12,
-                         v13, v14, v15, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9,
-                         v10, v11, v12, v13, v14, v15);
-  }
+
   simdutf_really_inline bool is_ascii() const {
     return _mm256_movemask_epi8(*this) == 0;
   }
   // Order-sensitive comparisons
-  simdutf_really_inline simd8<int8_t> max_val(const simd8<int8_t> other) const {
-    return _mm256_max_epi8(*this, other);
-  }
-  simdutf_really_inline simd8<int8_t> min_val(const simd8<int8_t> other) const {
-    return _mm256_min_epi8(*this, other);
-  }
   simdutf_really_inline simd8<bool> operator>(const simd8<int8_t> other) const {
     return _mm256_cmpgt_epi8(*this, other);
   }
@@ -5612,32 +5523,14 @@ template <> struct simd8<uint8_t> : base8_numeric<uint8_t> {
                                v12, v13, v14, v15, v16, v17, v18, v19, v20, v21,
                                v22, v23, v24, v25, v26, v27, v28, v29, v30,
                                v31)) {}
-  // Repeat 16 values as many times as necessary (usually for lookup tables)
-  simdutf_really_inline static simd8<uint8_t>
-  repeat_16(uint8_t v0, uint8_t v1, uint8_t v2, uint8_t v3, uint8_t v4,
-            uint8_t v5, uint8_t v6, uint8_t v7, uint8_t v8, uint8_t v9,
-            uint8_t v10, uint8_t v11, uint8_t v12, uint8_t v13, uint8_t v14,
-            uint8_t v15) {
-    return simd8<uint8_t>(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12,
-                          v13, v14, v15, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9,
-                          v10, v11, v12, v13, v14, v15);
-  }
 
   // Saturated math
-  simdutf_really_inline simd8<uint8_t>
-  saturating_add(const simd8<uint8_t> other) const {
-    return _mm256_adds_epu8(*this, other);
-  }
   simdutf_really_inline simd8<uint8_t>
   saturating_sub(const simd8<uint8_t> other) const {
     return _mm256_subs_epu8(*this, other);
   }
 
   // Order-specific operations
-  simdutf_really_inline simd8<uint8_t>
-  max_val(const simd8<uint8_t> other) const {
-    return _mm256_max_epu8(*this, other);
-  }
   simdutf_really_inline simd8<uint8_t>
   min_val(const simd8<uint8_t> other) const {
     return _mm256_min_epu8(other, *this);
@@ -5647,66 +5540,25 @@ template <> struct simd8<uint8_t> : base8_numeric<uint8_t> {
   gt_bits(const simd8<uint8_t> other) const {
     return this->saturating_sub(other);
   }
-  // Same as <, but only guarantees true is nonzero (< guarantees true = -1)
-  simdutf_really_inline simd8<uint8_t>
-  lt_bits(const simd8<uint8_t> other) const {
-    return other.saturating_sub(*this);
-  }
-  simdutf_really_inline simd8<bool>
-  operator<=(const simd8<uint8_t> other) const {
-    return other.max_val(*this) == other;
-  }
   simdutf_really_inline simd8<bool>
   operator>=(const simd8<uint8_t> other) const {
     return other.min_val(*this) == other;
   }
-  simdutf_really_inline simd8<bool>
-  operator>(const simd8<uint8_t> other) const {
-    return this->gt_bits(other).any_bits_set();
-  }
-  simdutf_really_inline simd8<bool>
-  operator<(const simd8<uint8_t> other) const {
-    return this->lt_bits(other).any_bits_set();
-  }
 
   // Bit-specific operations
-  simdutf_really_inline simd8<bool> bits_not_set() const {
-    return *this == uint8_t(0);
-  }
-  simdutf_really_inline simd8<bool> bits_not_set(simd8<uint8_t> bits) const {
-    return (*this & bits).bits_not_set();
-  }
-  simdutf_really_inline simd8<bool> any_bits_set() const {
-    return ~this->bits_not_set();
-  }
-  simdutf_really_inline simd8<bool> any_bits_set(simd8<uint8_t> bits) const {
-    return ~this->bits_not_set(bits);
-  }
   simdutf_really_inline bool is_ascii() const {
     return _mm256_movemask_epi8(*this) == 0;
   }
   simdutf_really_inline bool bits_not_set_anywhere() const {
     return _mm256_testz_si256(*this, *this);
   }
+
   simdutf_really_inline bool any_bits_set_anywhere() const {
     return !bits_not_set_anywhere();
   }
-  simdutf_really_inline bool bits_not_set_anywhere(simd8<uint8_t> bits) const {
-    return _mm256_testz_si256(*this, bits);
-  }
-  simdutf_really_inline bool any_bits_set_anywhere(simd8<uint8_t> bits) const {
-    return !bits_not_set_anywhere(bits);
-  }
+
   template <int N> simdutf_really_inline simd8<uint8_t> shr() const {
     return simd8<uint8_t>(_mm256_srli_epi16(*this, N)) & uint8_t(0xFFu >> N);
-  }
-  template <int N> simdutf_really_inline simd8<uint8_t> shl() const {
-    return simd8<uint8_t>(_mm256_slli_epi16(*this, N)) & uint8_t(0xFFu << N);
-  }
-  // Get one of the bits and make a bitmask out of it.
-  // e.g. value.get_bit<7>() gets the high bit
-  template <int N> simdutf_really_inline int get_bit() const {
-    return _mm256_movemask_epi8(_mm256_slli_epi16(*this, 7 - N));
   }
 
   simdutf_really_inline uint64_t sum_bytes() const {
@@ -5775,29 +5627,6 @@ template <typename T> struct simd8x64 {
     this->chunks[1].store_ascii_as_utf32(ptr + sizeof(simd8<T>) * 1);
   }
 
-  simdutf_really_inline simd8x64<T> bit_or(const T m) const {
-    const simd8<T> mask = simd8<T>::splat(m);
-    return simd8x64<T>(this->chunks[0] | mask, this->chunks[1] | mask);
-  }
-
-  simdutf_really_inline uint64_t eq(const T m) const {
-    const simd8<T> mask = simd8<T>::splat(m);
-    return simd8x64<bool>(this->chunks[0] == mask, this->chunks[1] == mask)
-        .to_bitmask();
-  }
-
-  simdutf_really_inline uint64_t eq(const simd8x64<uint8_t> &other) const {
-    return simd8x64<bool>(this->chunks[0] == other.chunks[0],
-                          this->chunks[1] == other.chunks[1])
-        .to_bitmask();
-  }
-
-  simdutf_really_inline uint64_t lteq(const T m) const {
-    const simd8<T> mask = simd8<T>::splat(m);
-    return simd8x64<bool>(this->chunks[0] <= mask, this->chunks[1] <= mask)
-        .to_bitmask();
-  }
-
   simdutf_really_inline uint64_t in_range(const T low, const T high) const {
     const simd8<T> mask_low = simd8<T>::splat(low);
     const simd8<T> mask_high = simd8<T>::splat(high);
@@ -5807,14 +5636,7 @@ template <typename T> struct simd8x64 {
                (this->chunks[1] <= mask_high) & (this->chunks[1] >= mask_low))
         .to_bitmask();
   }
-  simdutf_really_inline uint64_t not_in_range(const T low, const T high) const {
-    const simd8<T> mask_low = simd8<T>::splat(low);
-    const simd8<T> mask_high = simd8<T>::splat(high);
-    return simd8x64<bool>(
-               (this->chunks[0] > mask_high) | (this->chunks[0] < mask_low),
-               (this->chunks[1] > mask_high) | (this->chunks[1] < mask_low))
-        .to_bitmask();
-  }
+
   simdutf_really_inline uint64_t lt(const T m) const {
     const simd8<T> mask = simd8<T>::splat(m);
     return simd8x64<bool>(this->chunks[0] < mask, this->chunks[1] < mask)
@@ -5826,11 +5648,7 @@ template <typename T> struct simd8x64 {
     return simd8x64<bool>(this->chunks[0] > mask, this->chunks[1] > mask)
         .to_bitmask();
   }
-  simdutf_really_inline uint64_t gteq(const T m) const {
-    const simd8<T> mask = simd8<T>::splat(m);
-    return simd8x64<bool>(this->chunks[0] >= mask, this->chunks[1] >= mask)
-        .to_bitmask();
-  }
+
   simdutf_really_inline uint64_t gteq_unsigned(const uint8_t m) const {
     const simd8<uint8_t> mask = simd8<uint8_t>::splat(m);
     return simd8x64<bool>((simd8<uint8_t>(__m256i(this->chunks[0])) >= mask),
@@ -5863,6 +5681,7 @@ struct base16 : base<simd16<T>> {
   template <typename Pointer>
   simdutf_really_inline base16(const Pointer *ptr)
       : base16(_mm256_loadu_si256(reinterpret_cast<const __m256i *>(ptr))) {}
+
   friend simdutf_always_inline Mask operator==(const simd16<T> lhs,
                                                const simd16<T> rhs) {
     return _mm256_cmpeq_epi16(lhs, rhs);
@@ -5873,11 +5692,6 @@ struct base16 : base<simd16<T>> {
 
   /// the number of elements of type T a vector can hold
   static const int ELEMENTS = SIZE / sizeof(T);
-
-  template <int N = 1>
-  simdutf_really_inline simd16<T> prev(const simd16<T> prev_chunk) const {
-    return _mm256_alignr_epi8(*this, prev_chunk, 16 - N);
-  }
 };
 
 // SIMD byte mask type (returned by things like eq and gt)
@@ -5887,16 +5701,16 @@ template <> struct simd16<bool> : base16<bool> {
   }
 
   simdutf_really_inline simd16() : base16() {}
+
   simdutf_really_inline simd16(const __m256i _value) : base16<bool>(_value) {}
+
   // Splat constructor
   simdutf_really_inline simd16(bool _value) : base16<bool>(splat(_value)) {}
 
   simdutf_really_inline bitmask_type to_bitmask() const {
     return _mm256_movemask_epi8(*this);
   }
-  simdutf_really_inline bool any() const {
-    return !_mm256_testz_si256(*this, *this);
-  }
+
   simdutf_really_inline simd16<bool> operator~() const { return *this ^ true; }
 };
 
@@ -5904,14 +5718,17 @@ template <typename T> struct base16_numeric : base16<T> {
   static simdutf_really_inline simd16<T> splat(T _value) {
     return _mm256_set1_epi16(_value);
   }
+
   static simdutf_really_inline simd16<T> zero() {
     return _mm256_setzero_si256();
   }
+
   static simdutf_really_inline simd16<T> load(const T values[8]) {
     return _mm256_loadu_si256(reinterpret_cast<const __m256i *>(values));
   }
 
   simdutf_really_inline base16_numeric() : base16<T>() {}
+
   simdutf_really_inline base16_numeric(const __m256i _value)
       : base16<T>(_value) {}
 
@@ -5927,46 +5744,9 @@ template <typename T> struct base16_numeric : base16<T> {
   simdutf_really_inline simd16<T> operator+(const simd16<T> other) const {
     return _mm256_add_epi16(*this, other);
   }
-  simdutf_really_inline simd16<T> operator-(const simd16<T> other) const {
-    return _mm256_sub_epi16(*this, other);
-  }
   simdutf_really_inline simd16<T> &operator+=(const simd16<T> other) {
     *this = *this + other;
     return *static_cast<simd16<T> *>(this);
-  }
-  simdutf_really_inline simd16<T> &operator-=(const simd16<T> other) {
-    *this = *this - other;
-    return *static_cast<simd16<T> *>(this);
-  }
-};
-
-// Signed code units
-template <> struct simd16<int16_t> : base16_numeric<int16_t> {
-  simdutf_really_inline simd16() : base16_numeric<int16_t>() {}
-  simdutf_really_inline simd16(const __m256i _value)
-      : base16_numeric<int16_t>(_value) {}
-  // Splat constructor
-  simdutf_really_inline simd16(int16_t _value) : simd16(splat(_value)) {}
-  // Array constructor
-  simdutf_really_inline simd16(const int16_t *values) : simd16(load(values)) {}
-  simdutf_really_inline simd16(const char16_t *values)
-      : simd16(load(reinterpret_cast<const int16_t *>(values))) {}
-  // Order-sensitive comparisons
-  simdutf_really_inline simd16<int16_t>
-  max_val(const simd16<int16_t> other) const {
-    return _mm256_max_epi16(*this, other);
-  }
-  simdutf_really_inline simd16<int16_t>
-  min_val(const simd16<int16_t> other) const {
-    return _mm256_min_epi16(*this, other);
-  }
-  simdutf_really_inline simd16<bool>
-  operator>(const simd16<int16_t> other) const {
-    return _mm256_cmpgt_epi16(*this, other);
-  }
-  simdutf_really_inline simd16<bool>
-  operator<(const simd16<int16_t> other) const {
-    return _mm256_cmpgt_epi16(other, *this);
   }
 };
 
@@ -5982,17 +5762,6 @@ template <> struct simd16<uint16_t> : base16_numeric<uint16_t> {
   simdutf_really_inline simd16(const uint16_t *values) : simd16(load(values)) {}
   simdutf_really_inline simd16(const char16_t *values)
       : simd16(load(reinterpret_cast<const uint16_t *>(values))) {}
-  simdutf_really_inline simd16(const simd16<bool> bm) : simd16(bm.value) {}
-
-  // Saturated math
-  simdutf_really_inline simd16<uint16_t>
-  saturating_add(const simd16<uint16_t> other) const {
-    return _mm256_adds_epu16(*this, other);
-  }
-  simdutf_really_inline simd16<uint16_t>
-  saturating_sub(const simd16<uint16_t> other) const {
-    return _mm256_subs_epu16(*this, other);
-  }
 
   // Order-specific operations
   simdutf_really_inline simd16<uint16_t>
@@ -6003,16 +5772,7 @@ template <> struct simd16<uint16_t> : base16_numeric<uint16_t> {
   min_val(const simd16<uint16_t> other) const {
     return _mm256_min_epu16(*this, other);
   }
-  // Same as >, but only guarantees true is nonzero (< guarantees true = -1)
-  simdutf_really_inline simd16<uint16_t>
-  gt_bits(const simd16<uint16_t> other) const {
-    return this->saturating_sub(other);
-  }
   // Same as <, but only guarantees true is nonzero (< guarantees true = -1)
-  simdutf_really_inline simd16<uint16_t>
-  lt_bits(const simd16<uint16_t> other) const {
-    return other.saturating_sub(*this);
-  }
   simdutf_really_inline simd16<bool>
   operator<=(const simd16<uint16_t> other) const {
     return other.max_val(*this) == other;
@@ -6021,53 +5781,18 @@ template <> struct simd16<uint16_t> : base16_numeric<uint16_t> {
   operator>=(const simd16<uint16_t> other) const {
     return other.min_val(*this) == other;
   }
-  simdutf_really_inline simd16<bool>
-  operator>(const simd16<uint16_t> other) const {
-    return this->gt_bits(other).any_bits_set();
-  }
-  simdutf_really_inline simd16<bool>
-  operator<(const simd16<uint16_t> other) const {
-    return this->gt_bits(other).any_bits_set();
-  }
 
   // Bit-specific operations
   simdutf_really_inline simd16<bool> bits_not_set() const {
     return *this == uint16_t(0);
   }
-  simdutf_really_inline simd16<bool> bits_not_set(simd16<uint16_t> bits) const {
-    return (*this & bits).bits_not_set();
-  }
+
   simdutf_really_inline simd16<bool> any_bits_set() const {
     return ~this->bits_not_set();
   }
-  simdutf_really_inline simd16<bool> any_bits_set(simd16<uint16_t> bits) const {
-    return ~this->bits_not_set(bits);
-  }
 
-  simdutf_really_inline bool bits_not_set_anywhere() const {
-    return _mm256_testz_si256(*this, *this);
-  }
-  simdutf_really_inline bool any_bits_set_anywhere() const {
-    return !bits_not_set_anywhere();
-  }
-  simdutf_really_inline bool
-  bits_not_set_anywhere(simd16<uint16_t> bits) const {
-    return _mm256_testz_si256(*this, bits);
-  }
-  simdutf_really_inline bool
-  any_bits_set_anywhere(simd16<uint16_t> bits) const {
-    return !bits_not_set_anywhere(bits);
-  }
   template <int N> simdutf_really_inline simd16<uint16_t> shr() const {
     return simd16<uint16_t>(_mm256_srli_epi16(*this, N));
-  }
-  template <int N> simdutf_really_inline simd16<uint16_t> shl() const {
-    return simd16<uint16_t>(_mm256_slli_epi16(*this, N));
-  }
-  // Get one of the bits and make a bitmask out of it.
-  // e.g. value.get_bit<7>() gets the high bit
-  template <int N> simdutf_really_inline int get_bit() const {
-    return _mm256_movemask_epi8(_mm256_slli_epi16(*this, 15 - N));
   }
 
   // Change the endianness
@@ -6161,26 +5886,9 @@ template <typename T> struct simd16x32 {
     this->chunks[1].store_ascii_as_utf16(ptr + sizeof(simd16<T>));
   }
 
-  simdutf_really_inline simd16x32<T> bit_or(const T m) const {
-    const simd16<T> mask = simd16<T>::splat(m);
-    return simd16x32<T>(this->chunks[0] | mask, this->chunks[1] | mask);
-  }
-
   simdutf_really_inline void swap_bytes() {
     this->chunks[0] = this->chunks[0].swap_bytes();
     this->chunks[1] = this->chunks[1].swap_bytes();
-  }
-
-  simdutf_really_inline uint64_t eq(const T m) const {
-    const simd16<T> mask = simd16<T>::splat(m);
-    return simd16x32<bool>(this->chunks[0] == mask, this->chunks[1] == mask)
-        .to_bitmask();
-  }
-
-  simdutf_really_inline uint64_t eq(const simd16x32<uint16_t> &other) const {
-    return simd16x32<bool>(this->chunks[0] == other.chunks[0],
-                           this->chunks[1] == other.chunks[1])
-        .to_bitmask();
   }
 
   simdutf_really_inline uint64_t lteq(const T m) const {
@@ -6189,26 +5897,12 @@ template <typename T> struct simd16x32 {
         .to_bitmask();
   }
 
-  simdutf_really_inline uint64_t in_range(const T low, const T high) const {
-    const simd16<T> mask_low = simd16<T>::splat(low);
-    const simd16<T> mask_high = simd16<T>::splat(high);
-
-    return simd16x32<bool>(
-               (this->chunks[0] <= mask_high) & (this->chunks[0] >= mask_low),
-               (this->chunks[1] <= mask_high) & (this->chunks[1] >= mask_low))
-        .to_bitmask();
-  }
   simdutf_really_inline uint64_t not_in_range(const T low, const T high) const {
     const simd16<T> mask_low = simd16<T>::splat(static_cast<T>(low - 1));
     const simd16<T> mask_high = simd16<T>::splat(static_cast<T>(high + 1));
     return simd16x32<bool>(
                (this->chunks[0] >= mask_high) | (this->chunks[0] <= mask_low),
                (this->chunks[1] >= mask_high) | (this->chunks[1] <= mask_low))
-        .to_bitmask();
-  }
-  simdutf_really_inline uint64_t lt(const T m) const {
-    const simd16<T> mask = simd16<T>::splat(m);
-    return simd16x32<bool>(this->chunks[0] < mask, this->chunks[1] < mask)
         .to_bitmask();
   }
 }; // struct simd16x32<T>
@@ -6309,6 +6003,11 @@ simdutf_really_inline simd32<uint32_t> operator&(const simd32<uint32_t> b,
 simdutf_really_inline simd32<uint32_t> operator+(const simd32<uint32_t> a,
                                                  const simd32<uint32_t> b) {
   return _mm256_add_epi32(a.value, b.value);
+}
+
+simdutf_really_inline simd32<bool> operator==(const simd32<uint32_t> a,
+                                              const simd32<uint32_t> b) {
+  return _mm256_cmpeq_epi32(a.value, b.value);
 }
 
 simdutf_really_inline simd32<bool> operator>=(const simd32<uint32_t> a,
@@ -6655,6 +6354,10 @@ public:
                                            size_t length) const noexcept;
   simdutf_warn_unused size_t count_utf16be(const char16_t *buf,
                                            size_t length) const noexcept;
+  void to_well_formed_utf16be(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
+  void to_well_formed_utf16le(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8
@@ -6850,7 +6553,6 @@ template <typename Child> struct base {
   simdutf_really_inline base(const __m128i _value) : value(_value) {}
   // Conversion to SIMD register
   simdutf_really_inline operator const __m128i &() const { return this->value; }
-  simdutf_really_inline operator __m128i &() { return this->value; }
   template <endianness big_endian>
   simdutf_really_inline void store_ascii_as_utf16(char16_t *p) const {
     __m128i first = _mm_cvtepu8_epi16(*this);
@@ -6883,22 +6585,9 @@ template <typename Child> struct base {
   simdutf_really_inline Child operator^(const Child other) const {
     return _mm_xor_si128(*this, other);
   }
-  simdutf_really_inline Child bit_andnot(const Child other) const {
-    return _mm_andnot_si128(other, *this);
-  }
   simdutf_really_inline Child &operator|=(const Child other) {
     auto this_cast = static_cast<Child *>(this);
     *this_cast = *this_cast | other;
-    return *this_cast;
-  }
-  simdutf_really_inline Child &operator&=(const Child other) {
-    auto this_cast = static_cast<Child *>(this);
-    *this_cast = *this_cast & other;
-    return *this_cast;
-  }
-  simdutf_really_inline Child &operator^=(const Child other) {
-    auto this_cast = static_cast<Child *>(this);
-    *this_cast = *this_cast ^ other;
     return *this_cast;
   }
 };
@@ -6943,15 +6632,6 @@ template <> struct simd8<bool> : base8<bool> {
   simdutf_really_inline int to_bitmask() const {
     return _mm_movemask_epi8(*this);
   }
-  simdutf_really_inline bool any() const {
-    return !_mm_testz_si128(*this, *this);
-  }
-  simdutf_really_inline bool none() const {
-    return _mm_testz_si128(*this, *this);
-  }
-  simdutf_really_inline bool all() const {
-    return _mm_movemask_epi8(*this) == 0xFFFF;
-  }
   simdutf_really_inline simd8<bool> operator~() const { return *this ^ true; }
 };
 
@@ -6985,15 +6665,8 @@ template <typename T> struct base8_numeric : base8<T> {
   simdutf_really_inline simd8<T> operator~() const { return *this ^ 0xFFu; }
 
   // Addition/subtraction are the same for signed and unsigned
-  simdutf_really_inline simd8<T> operator+(const simd8<T> other) const {
-    return _mm_add_epi8(*this, other);
-  }
   simdutf_really_inline simd8<T> operator-(const simd8<T> other) const {
     return _mm_sub_epi8(*this, other);
-  }
-  simdutf_really_inline simd8<T> &operator+=(const simd8<T> other) {
-    *this = *this + other;
-    return *static_cast<simd8<T> *>(this);
   }
   simdutf_really_inline simd8<T> &operator-=(const simd8<T> other) {
     *this = *this - other;
@@ -7027,35 +6700,13 @@ template <> struct simd8<int8_t> : base8_numeric<int8_t> {
       : base8_numeric<int8_t>(_value) {}
   // Splat constructor
   simdutf_really_inline simd8(int8_t _value) : simd8(splat(_value)) {}
-  // Array constructor
-  simdutf_really_inline simd8(const int8_t *values) : simd8(load(values)) {}
   // Member-by-member initialization
-  simdutf_really_inline simd8(int8_t v0, int8_t v1, int8_t v2, int8_t v3,
-                              int8_t v4, int8_t v5, int8_t v6, int8_t v7,
-                              int8_t v8, int8_t v9, int8_t v10, int8_t v11,
-                              int8_t v12, int8_t v13, int8_t v14, int8_t v15)
-      : simd8(_mm_setr_epi8(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11,
-                            v12, v13, v14, v15)) {}
-  // Repeat 16 values as many times as necessary (usually for lookup tables)
-  simdutf_really_inline static simd8<int8_t>
-  repeat_16(int8_t v0, int8_t v1, int8_t v2, int8_t v3, int8_t v4, int8_t v5,
-            int8_t v6, int8_t v7, int8_t v8, int8_t v9, int8_t v10, int8_t v11,
-            int8_t v12, int8_t v13, int8_t v14, int8_t v15) {
-    return simd8<int8_t>(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12,
-                         v13, v14, v15);
-  }
   simdutf_really_inline operator simd8<uint8_t>() const;
   simdutf_really_inline bool is_ascii() const {
     return _mm_movemask_epi8(*this) == 0;
   }
 
   // Order-sensitive comparisons
-  simdutf_really_inline simd8<int8_t> max_val(const simd8<int8_t> other) const {
-    return _mm_max_epi8(*this, other);
-  }
-  simdutf_really_inline simd8<int8_t> min_val(const simd8<int8_t> other) const {
-    return _mm_min_epi8(*this, other);
-  }
   simdutf_really_inline simd8<bool> operator>(const simd8<int8_t> other) const {
     return _mm_cmpgt_epi8(*this, other);
   }
@@ -7081,31 +6732,14 @@ template <> struct simd8<uint8_t> : base8_numeric<uint8_t> {
         uint8_t v11, uint8_t v12, uint8_t v13, uint8_t v14, uint8_t v15)
       : simd8(_mm_setr_epi8(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11,
                             v12, v13, v14, v15)) {}
-  // Repeat 16 values as many times as necessary (usually for lookup tables)
-  simdutf_really_inline static simd8<uint8_t>
-  repeat_16(uint8_t v0, uint8_t v1, uint8_t v2, uint8_t v3, uint8_t v4,
-            uint8_t v5, uint8_t v6, uint8_t v7, uint8_t v8, uint8_t v9,
-            uint8_t v10, uint8_t v11, uint8_t v12, uint8_t v13, uint8_t v14,
-            uint8_t v15) {
-    return simd8<uint8_t>(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12,
-                          v13, v14, v15);
-  }
 
   // Saturated math
-  simdutf_really_inline simd8<uint8_t>
-  saturating_add(const simd8<uint8_t> other) const {
-    return _mm_adds_epu8(*this, other);
-  }
   simdutf_really_inline simd8<uint8_t>
   saturating_sub(const simd8<uint8_t> other) const {
     return _mm_subs_epu8(*this, other);
   }
 
   // Order-specific operations
-  simdutf_really_inline simd8<uint8_t>
-  max_val(const simd8<uint8_t> other) const {
-    return _mm_max_epu8(*this, other);
-  }
   simdutf_really_inline simd8<uint8_t>
   min_val(const simd8<uint8_t> other) const {
     return _mm_min_epu8(*this, other);
@@ -7116,39 +6750,17 @@ template <> struct simd8<uint8_t> : base8_numeric<uint8_t> {
     return this->saturating_sub(other);
   }
   // Same as <, but only guarantees true is nonzero (< guarantees true = -1)
-  simdutf_really_inline simd8<uint8_t>
-  lt_bits(const simd8<uint8_t> other) const {
-    return other.saturating_sub(*this);
-  }
-  simdutf_really_inline simd8<bool>
-  operator<=(const simd8<uint8_t> other) const {
-    return other.max_val(*this) == other;
-  }
   simdutf_really_inline simd8<bool>
   operator>=(const simd8<uint8_t> other) const {
     return other.min_val(*this) == other;
-  }
-  simdutf_really_inline simd8<bool>
-  operator>(const simd8<uint8_t> other) const {
-    return this->gt_bits(other).any_bits_set();
-  }
-  simdutf_really_inline simd8<bool>
-  operator<(const simd8<uint8_t> other) const {
-    return this->gt_bits(other).any_bits_set();
   }
 
   // Bit-specific operations
   simdutf_really_inline simd8<bool> bits_not_set() const {
     return *this == uint8_t(0);
   }
-  simdutf_really_inline simd8<bool> bits_not_set(simd8<uint8_t> bits) const {
-    return (*this & bits).bits_not_set();
-  }
   simdutf_really_inline simd8<bool> any_bits_set() const {
     return ~this->bits_not_set();
-  }
-  simdutf_really_inline simd8<bool> any_bits_set(simd8<uint8_t> bits) const {
-    return ~this->bits_not_set(bits);
   }
   simdutf_really_inline bool is_ascii() const {
     return _mm_movemask_epi8(*this) == 0;
@@ -7160,22 +6772,11 @@ template <> struct simd8<uint8_t> : base8_numeric<uint8_t> {
   simdutf_really_inline bool any_bits_set_anywhere() const {
     return !bits_not_set_anywhere();
   }
-  simdutf_really_inline bool bits_not_set_anywhere(simd8<uint8_t> bits) const {
-    return _mm_testz_si128(*this, bits);
-  }
-  simdutf_really_inline bool any_bits_set_anywhere(simd8<uint8_t> bits) const {
-    return !bits_not_set_anywhere(bits);
-  }
   template <int N> simdutf_really_inline simd8<uint8_t> shr() const {
     return simd8<uint8_t>(_mm_srli_epi16(*this, N)) & uint8_t(0xFFu >> N);
   }
   template <int N> simdutf_really_inline simd8<uint8_t> shl() const {
     return simd8<uint8_t>(_mm_slli_epi16(*this, N)) & uint8_t(0xFFu << N);
-  }
-  // Get one of the bits and make a bitmask out of it.
-  // e.g. value.get_bit<7>() gets the high bit
-  template <int N> simdutf_really_inline int get_bit() const {
-    return _mm_movemask_epi8(_mm_slli_epi16(*this, 7 - N));
   }
 
   simdutf_really_inline uint64_t sum_bytes() const {
@@ -7259,49 +6860,6 @@ template <typename T> struct simd8x64 {
     return r0 | (r1 << 16) | (r2 << 32) | (r3 << 48);
   }
 
-  simdutf_really_inline uint64_t eq(const T m) const {
-    const simd8<T> mask = simd8<T>::splat(m);
-    return simd8x64<bool>(this->chunks[0] == mask, this->chunks[1] == mask,
-                          this->chunks[2] == mask, this->chunks[3] == mask)
-        .to_bitmask();
-  }
-
-  simdutf_really_inline uint64_t eq(const simd8x64<uint8_t> &other) const {
-    return simd8x64<bool>(this->chunks[0] == other.chunks[0],
-                          this->chunks[1] == other.chunks[1],
-                          this->chunks[2] == other.chunks[2],
-                          this->chunks[3] == other.chunks[3])
-        .to_bitmask();
-  }
-
-  simdutf_really_inline uint64_t lteq(const T m) const {
-    const simd8<T> mask = simd8<T>::splat(m);
-    return simd8x64<bool>(this->chunks[0] <= mask, this->chunks[1] <= mask,
-                          this->chunks[2] <= mask, this->chunks[3] <= mask)
-        .to_bitmask();
-  }
-
-  simdutf_really_inline uint64_t in_range(const T low, const T high) const {
-    const simd8<T> mask_low = simd8<T>::splat(low);
-    const simd8<T> mask_high = simd8<T>::splat(high);
-
-    return simd8x64<bool>(
-               (this->chunks[0] <= mask_high) & (this->chunks[0] >= mask_low),
-               (this->chunks[1] <= mask_high) & (this->chunks[1] >= mask_low),
-               (this->chunks[2] <= mask_high) & (this->chunks[2] >= mask_low),
-               (this->chunks[3] <= mask_high) & (this->chunks[3] >= mask_low))
-        .to_bitmask();
-  }
-  simdutf_really_inline uint64_t not_in_range(const T low, const T high) const {
-    const simd8<T> mask_low = simd8<T>::splat(low - 1);
-    const simd8<T> mask_high = simd8<T>::splat(high + 1);
-    return simd8x64<bool>(
-               (this->chunks[0] >= mask_high) | (this->chunks[0] <= mask_low),
-               (this->chunks[1] >= mask_high) | (this->chunks[1] <= mask_low),
-               (this->chunks[2] >= mask_high) | (this->chunks[2] <= mask_low),
-               (this->chunks[3] >= mask_high) | (this->chunks[3] <= mask_low))
-        .to_bitmask();
-  }
   simdutf_really_inline uint64_t lt(const T m) const {
     const simd8<T> mask = simd8<T>::splat(m);
     return simd8x64<bool>(this->chunks[0] < mask, this->chunks[1] < mask,
@@ -7313,12 +6871,6 @@ template <typename T> struct simd8x64 {
     const simd8<T> mask = simd8<T>::splat(m);
     return simd8x64<bool>(this->chunks[0] > mask, this->chunks[1] > mask,
                           this->chunks[2] > mask, this->chunks[3] > mask)
-        .to_bitmask();
-  }
-  simdutf_really_inline uint64_t gteq(const T m) const {
-    const simd8<T> mask = simd8<T>::splat(m);
-    return simd8x64<bool>(this->chunks[0] >= mask, this->chunks[1] >= mask,
-                          this->chunks[2] >= mask, this->chunks[3] >= mask)
         .to_bitmask();
   }
   simdutf_really_inline uint64_t gteq_unsigned(const uint8_t m) const {
@@ -7336,15 +6888,10 @@ template <typename T> struct simd16;
 
 template <typename T, typename Mask = simd16<bool>>
 struct base16 : base<simd16<T>> {
-  typedef uint16_t bitmask_t;
-  typedef uint32_t bitmask2_t;
-
   simdutf_really_inline base16() : base<simd16<T>>() {}
+
   simdutf_really_inline base16(const __m128i _value)
       : base<simd16<T>>(_value) {}
-  template <typename Pointer>
-  simdutf_really_inline base16(const Pointer *ptr)
-      : base16(_mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr))) {}
 
   friend simdutf_really_inline Mask operator==(const simd16<T> lhs,
                                                const simd16<T> rhs) {
@@ -7356,11 +6903,6 @@ struct base16 : base<simd16<T>> {
 
   /// the number of elements of type T a vector can hold
   static const int ELEMENTS = SIZE / sizeof(T);
-
-  template <int N = 1>
-  simdutf_really_inline simd16<T> prev(const simd16<T> prev_chunk) const {
-    return _mm_alignr_epi8(*this, prev_chunk, 16 - N);
-  }
 };
 
 // SIMD byte mask type (returned by things like eq and gt)
@@ -7369,17 +6911,15 @@ template <> struct simd16<bool> : base16<bool> {
     return _mm_set1_epi16(uint16_t(-(!!_value)));
   }
 
-  simdutf_really_inline simd16() : base16() {}
   simdutf_really_inline simd16(const __m128i _value) : base16<bool>(_value) {}
+
   // Splat constructor
   simdutf_really_inline simd16(bool _value) : base16<bool>(splat(_value)) {}
 
   simdutf_really_inline int to_bitmask() const {
     return _mm_movemask_epi8(*this);
   }
-  simdutf_really_inline bool any() const {
-    return !_mm_testz_si128(*this, *this);
-  }
+
   simdutf_really_inline simd16<bool> operator~() const { return *this ^ true; }
 };
 
@@ -7387,12 +6927,15 @@ template <typename T> struct base16_numeric : base16<T> {
   static simdutf_really_inline simd16<T> splat(T _value) {
     return _mm_set1_epi16(_value);
   }
+
   static simdutf_really_inline simd16<T> zero() { return _mm_setzero_si128(); }
+
   static simdutf_really_inline simd16<T> load(const T values[8]) {
     return _mm_loadu_si128(reinterpret_cast<const __m128i *>(values));
   }
 
   simdutf_really_inline base16_numeric() : base16<T>() {}
+
   simdutf_really_inline base16_numeric(const __m128i _value)
       : base16<T>(_value) {}
 
@@ -7408,109 +6951,37 @@ template <typename T> struct base16_numeric : base16<T> {
   simdutf_really_inline simd16<T> operator+(const simd16<T> other) const {
     return _mm_add_epi16(*this, other);
   }
-  simdutf_really_inline simd16<T> operator-(const simd16<T> other) const {
-    return _mm_sub_epi16(*this, other);
-  }
   simdutf_really_inline simd16<T> &operator+=(const simd16<T> other) {
     *this = *this + other;
     return *static_cast<simd16<T> *>(this);
-  }
-  simdutf_really_inline simd16<T> &operator-=(const simd16<T> other) {
-    *this = *this - other;
-    return *static_cast<simd16<T> *>(this);
-  }
-};
-
-// Signed code units
-template <> struct simd16<int16_t> : base16_numeric<int16_t> {
-  simdutf_really_inline simd16() : base16_numeric<int16_t>() {}
-  simdutf_really_inline simd16(const __m128i _value)
-      : base16_numeric<int16_t>(_value) {}
-  // Splat constructor
-  simdutf_really_inline simd16(int16_t _value) : simd16(splat(_value)) {}
-  // Array constructor
-  simdutf_really_inline simd16(const int16_t *values) : simd16(load(values)) {}
-  simdutf_really_inline simd16(const char16_t *values)
-      : simd16(load(reinterpret_cast<const int16_t *>(values))) {}
-  // Member-by-member initialization
-  simdutf_really_inline simd16(int16_t v0, int16_t v1, int16_t v2, int16_t v3,
-                               int16_t v4, int16_t v5, int16_t v6, int16_t v7)
-      : simd16(_mm_setr_epi16(v0, v1, v2, v3, v4, v5, v6, v7)) {}
-  simdutf_really_inline operator simd16<uint16_t>() const;
-
-  // Order-sensitive comparisons
-  simdutf_really_inline simd16<int16_t>
-  max_val(const simd16<int16_t> other) const {
-    return _mm_max_epi16(*this, other);
-  }
-  simdutf_really_inline simd16<int16_t>
-  min_val(const simd16<int16_t> other) const {
-    return _mm_min_epi16(*this, other);
-  }
-  simdutf_really_inline simd16<bool>
-  operator>(const simd16<int16_t> other) const {
-    return _mm_cmpgt_epi16(*this, other);
-  }
-  simdutf_really_inline simd16<bool>
-  operator<(const simd16<int16_t> other) const {
-    return _mm_cmpgt_epi16(other, *this);
   }
 };
 
 // Unsigned code units
 template <> struct simd16<uint16_t> : base16_numeric<uint16_t> {
   simdutf_really_inline simd16() : base16_numeric<uint16_t>() {}
+
   simdutf_really_inline simd16(const __m128i _value)
       : base16_numeric<uint16_t>(_value) {}
 
   // Splat constructor
   simdutf_really_inline simd16(uint16_t _value) : simd16(splat(_value)) {}
+
   // Array constructor
-  simdutf_really_inline simd16(const uint16_t *values) : simd16(load(values)) {}
   simdutf_really_inline simd16(const char16_t *values)
       : simd16(load(reinterpret_cast<const uint16_t *>(values))) {}
-  simdutf_really_inline simd16(const simd16<bool> bm) : simd16(bm.value) {}
-  // Member-by-member initialization
-  simdutf_really_inline simd16(uint16_t v0, uint16_t v1, uint16_t v2,
-                               uint16_t v3, uint16_t v4, uint16_t v5,
-                               uint16_t v6, uint16_t v7)
-      : simd16(_mm_setr_epi16(v0, v1, v2, v3, v4, v5, v6, v7)) {}
-  // Repeat 16 values as many times as necessary (usually for lookup tables)
-  simdutf_really_inline static simd16<uint16_t>
-  repeat_16(uint16_t v0, uint16_t v1, uint16_t v2, uint16_t v3, uint16_t v4,
-            uint16_t v5, uint16_t v6, uint16_t v7) {
-    return simd16<uint16_t>(v0, v1, v2, v3, v4, v5, v6, v7);
-  }
-
-  // Saturated math
-  simdutf_really_inline simd16<uint16_t>
-  saturating_add(const simd16<uint16_t> other) const {
-    return _mm_adds_epu16(*this, other);
-  }
-  simdutf_really_inline simd16<uint16_t>
-  saturating_sub(const simd16<uint16_t> other) const {
-    return _mm_subs_epu16(*this, other);
-  }
 
   // Order-specific operations
   simdutf_really_inline simd16<uint16_t>
   max_val(const simd16<uint16_t> other) const {
     return _mm_max_epu16(*this, other);
   }
+
   simdutf_really_inline simd16<uint16_t>
   min_val(const simd16<uint16_t> other) const {
     return _mm_min_epu16(*this, other);
   }
-  // Same as >, but only guarantees true is nonzero (< guarantees true = -1)
-  simdutf_really_inline simd16<uint16_t>
-  gt_bits(const simd16<uint16_t> other) const {
-    return this->saturating_sub(other);
-  }
-  // Same as <, but only guarantees true is nonzero (< guarantees true = -1)
-  simdutf_really_inline simd16<uint16_t>
-  lt_bits(const simd16<uint16_t> other) const {
-    return other.saturating_sub(*this);
-  }
+
   simdutf_really_inline simd16<bool>
   operator<=(const simd16<uint16_t> other) const {
     return other.max_val(*this) == other;
@@ -7519,53 +6990,18 @@ template <> struct simd16<uint16_t> : base16_numeric<uint16_t> {
   operator>=(const simd16<uint16_t> other) const {
     return other.min_val(*this) == other;
   }
-  simdutf_really_inline simd16<bool>
-  operator>(const simd16<uint16_t> other) const {
-    return this->gt_bits(other).any_bits_set();
-  }
-  simdutf_really_inline simd16<bool>
-  operator<(const simd16<uint16_t> other) const {
-    return this->gt_bits(other).any_bits_set();
-  }
 
   // Bit-specific operations
   simdutf_really_inline simd16<bool> bits_not_set() const {
     return *this == uint16_t(0);
   }
-  simdutf_really_inline simd16<bool> bits_not_set(simd16<uint16_t> bits) const {
-    return (*this & bits).bits_not_set();
-  }
+
   simdutf_really_inline simd16<bool> any_bits_set() const {
     return ~this->bits_not_set();
   }
-  simdutf_really_inline simd16<bool> any_bits_set(simd16<uint16_t> bits) const {
-    return ~this->bits_not_set(bits);
-  }
 
-  simdutf_really_inline bool bits_not_set_anywhere() const {
-    return _mm_testz_si128(*this, *this);
-  }
-  simdutf_really_inline bool any_bits_set_anywhere() const {
-    return !bits_not_set_anywhere();
-  }
-  simdutf_really_inline bool
-  bits_not_set_anywhere(simd16<uint16_t> bits) const {
-    return _mm_testz_si128(*this, bits);
-  }
-  simdutf_really_inline bool
-  any_bits_set_anywhere(simd16<uint16_t> bits) const {
-    return !bits_not_set_anywhere(bits);
-  }
   template <int N> simdutf_really_inline simd16<uint16_t> shr() const {
     return simd16<uint16_t>(_mm_srli_epi16(*this, N));
-  }
-  template <int N> simdutf_really_inline simd16<uint16_t> shl() const {
-    return simd16<uint16_t>(_mm_slli_epi16(*this, N));
-  }
-  // Get one of the bits and make a bitmask out of it.
-  // e.g. value.get_bit<7>() gets the high bit
-  template <int N> simdutf_really_inline int get_bit() const {
-    return _mm_movemask_epi8(_mm_slli_epi16(*this, 7 - N));
   }
 
   // Change the endianness
@@ -7595,10 +7031,6 @@ template <> struct simd16<uint16_t> : base16_numeric<uint16_t> {
            uint64_t(_mm_extract_epi64(sum_u64, 1));
   }
 };
-
-simdutf_really_inline simd16<int16_t>::operator simd16<uint16_t>() const {
-  return this->value;
-}
 
 template <typename T> struct simd16x32 {
   static constexpr int NUM_CHUNKS = 64 / sizeof(simd16<T>);
@@ -7659,21 +7091,6 @@ template <typename T> struct simd16x32 {
     this->chunks[3] = this->chunks[3].swap_bytes();
   }
 
-  simdutf_really_inline uint64_t eq(const T m) const {
-    const simd16<T> mask = simd16<T>::splat(m);
-    return simd16x32<bool>(this->chunks[0] == mask, this->chunks[1] == mask,
-                           this->chunks[2] == mask, this->chunks[3] == mask)
-        .to_bitmask();
-  }
-
-  simdutf_really_inline uint64_t eq(const simd16x32<uint16_t> &other) const {
-    return simd16x32<bool>(this->chunks[0] == other.chunks[0],
-                           this->chunks[1] == other.chunks[1],
-                           this->chunks[2] == other.chunks[2],
-                           this->chunks[3] == other.chunks[3])
-        .to_bitmask();
-  }
-
   simdutf_really_inline uint64_t lteq(const T m) const {
     const simd16<T> mask = simd16<T>::splat(m);
     return simd16x32<bool>(this->chunks[0] <= mask, this->chunks[1] <= mask,
@@ -7681,17 +7098,6 @@ template <typename T> struct simd16x32 {
         .to_bitmask();
   }
 
-  simdutf_really_inline uint64_t in_range(const T low, const T high) const {
-    const simd16<T> mask_low = simd16<T>::splat(low);
-    const simd16<T> mask_high = simd16<T>::splat(high);
-
-    return simd16x32<bool>(
-               (this->chunks[0] <= mask_high) & (this->chunks[0] >= mask_low),
-               (this->chunks[1] <= mask_high) & (this->chunks[1] >= mask_low),
-               (this->chunks[2] <= mask_high) & (this->chunks[2] >= mask_low),
-               (this->chunks[3] <= mask_high) & (this->chunks[3] >= mask_low))
-        .to_bitmask();
-  }
   simdutf_really_inline uint64_t not_in_range(const T low, const T high) const {
     const simd16<T> mask_low = simd16<T>::splat(static_cast<T>(low - 1));
     const simd16<T> mask_high = simd16<T>::splat(static_cast<T>(high + 1));
@@ -7700,12 +7106,6 @@ template <typename T> struct simd16x32 {
                (this->chunks[1] >= mask_high) | (this->chunks[1] <= mask_low),
                (this->chunks[2] >= mask_high) | (this->chunks[2] <= mask_low),
                (this->chunks[3] >= mask_high) | (this->chunks[3] <= mask_low))
-        .to_bitmask();
-  }
-  simdutf_really_inline uint64_t lt(const T m) const {
-    const simd16<T> mask = simd16<T>::splat(m);
-    return simd16x32<bool>(this->chunks[0] < mask, this->chunks[1] < mask,
-                           this->chunks[2] < mask, this->chunks[3] < mask)
         .to_bitmask();
   }
 }; // struct simd16x32<T>
@@ -7839,6 +7239,11 @@ simdutf_really_inline simd32<uint32_t> operator+(const simd32<uint32_t> a,
 simdutf_really_inline simd32<uint32_t> operator-(const simd32<uint32_t> a,
                                                  uint32_t b) {
   return _mm_sub_epi32(a.value, _mm_set1_epi32(b));
+}
+
+simdutf_really_inline simd32<bool> operator==(const simd32<uint32_t> a,
+                                              const simd32<uint32_t> b) {
+  return _mm_cmpeq_epi32(a.value, b.value);
 }
 
 simdutf_really_inline simd32<bool> operator>=(const simd32<uint32_t> a,
@@ -8251,6 +7656,10 @@ public:
 #ifdef SIMDUTF_INTERNAL_TESTS
   virtual std::vector<TestProcedure> internal_tests() const override;
 #endif
+  void to_well_formed_utf16be(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
+  void to_well_formed_utf16le(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
 };
 
 } // namespace ppc64
@@ -9531,6 +8940,11 @@ simd32<bool> operator>(const simd32<T> a, const simd32<T> b) {
 }
 
 template <typename T>
+simd32<bool> operator>=(const simd32<T> a, const simd32<T> b) {
+  return vec_cmpge(a.value, b.value);
+}
+
+template <typename T>
 simd32<T> operator&(const simd32<T> a, const simd32<T> b) {
   return vec_and(a.value, b.value);
 }
@@ -9745,6 +9159,10 @@ public:
 #if SIMDUTF_FEATURE_UTF16
   simdutf_warn_unused bool validate_utf16be(const char16_t *buf,
                                             size_t len) const noexcept final;
+  void to_well_formed_utf16be(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
+  void to_well_formed_utf16le(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
 #endif // SIMDUTF_FEATURE_UTF16
 #if SIMDUTF_FEATURE_UTF16
   simdutf_warn_unused result validate_utf16le_with_errors(
@@ -10215,6 +9633,10 @@ public:
       const char16_t *buf, size_t len) const noexcept final;
   simdutf_warn_unused result validate_utf16be_with_errors(
       const char16_t *buf, size_t len) const noexcept final;
+  void to_well_formed_utf16be(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
+  void to_well_formed_utf16le(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
 #endif // SIMDUTF_FEATURE_UTF16
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING
   simdutf_warn_unused bool validate_utf32(const char32_t *buf,
@@ -10669,7 +10091,6 @@ simdutf_really_inline int count_ones(uint64_t input_num) {
 #ifndef SIMDUTF_LSX_SIMD_H
 #define SIMDUTF_LSX_SIMD_H
 
-#include <type_traits>
 
 namespace simdutf {
 namespace lsx {
@@ -10690,12 +10111,6 @@ template <typename T, typename Mask = simd8<bool>> struct base_u8 {
   simdutf_really_inline base_u8(const __m128i _value) : value(_value) {}
   simdutf_really_inline operator const __m128i &() const { return this->value; }
   simdutf_really_inline operator __m128i &() { return this->value; }
-  simdutf_really_inline T first() const {
-    return __lsx_vpickve2gr_bu(this->value, 0);
-  }
-  simdutf_really_inline T last() const {
-    return __lsx_vpickve2gr_bu(this->value, 15);
-  }
 
   // Bit operations
   simdutf_really_inline simd8<T> operator|(const simd8<T> other) const {
@@ -10707,23 +10122,10 @@ template <typename T, typename Mask = simd8<bool>> struct base_u8 {
   simdutf_really_inline simd8<T> operator^(const simd8<T> other) const {
     return __lsx_vxor_v(this->value, other);
   }
-  simdutf_really_inline simd8<T> bit_andnot(const simd8<T> other) const {
-    return __lsx_vandn_v(this->value, other);
-  }
   simdutf_really_inline simd8<T> operator~() const { return *this ^ 0xFFu; }
   simdutf_really_inline simd8<T> &operator|=(const simd8<T> other) {
     auto this_cast = static_cast<simd8<T> *>(this);
     *this_cast = *this_cast | other;
-    return *this_cast;
-  }
-  simdutf_really_inline simd8<T> &operator&=(const simd8<T> other) {
-    auto this_cast = static_cast<simd8<T> *>(this);
-    *this_cast = *this_cast & other;
-    return *this_cast;
-  }
-  simdutf_really_inline simd8<T> &operator^=(const simd8<T> other) {
-    auto this_cast = static_cast<simd8<T> *>(this);
-    *this_cast = *this_cast ^ other;
     return *this_cast;
   }
 
@@ -10760,16 +10162,6 @@ template <> struct simd8<bool> : base_u8<bool> {
   simdutf_really_inline uint32_t to_bitmask() const {
     return __lsx_vpickve2gr_wu(__lsx_vmsknz_b(*this), 0);
   }
-
-  simdutf_really_inline bool any() const {
-    return __lsx_vpickve2gr_hu(__lsx_vmsknz_b(*this), 0) != 0;
-  }
-  simdutf_really_inline bool none() const {
-    return __lsx_vpickve2gr_hu(__lsx_vmsknz_b(*this), 0) == 0;
-  }
-  simdutf_really_inline bool all() const {
-    return __lsx_vpickve2gr_hu(__lsx_vmsknz_b(*this), 0) == 0xFFFF;
-  }
 };
 
 // Unsigned bytes
@@ -10790,7 +10182,6 @@ template <> struct simd8<uint8_t> : base_u8<uint8_t> {
   // Splat constructor
   simdutf_really_inline simd8(uint8_t _value) : simd8(splat(_value)) {}
   // Member-by-member initialization
-
   simdutf_really_inline
   simd8(uint8_t v0, uint8_t v1, uint8_t v2, uint8_t v3, uint8_t v4, uint8_t v5,
         uint8_t v6, uint8_t v7, uint8_t v8, uint8_t v9, uint8_t v10,
@@ -10813,70 +10204,24 @@ template <> struct simd8<uint8_t> : base_u8<uint8_t> {
     return __lsx_vst(this->value, dst, 0);
   }
 
-  // Saturated math
-  simdutf_really_inline simd8<uint8_t>
-  saturating_add(const simd8<uint8_t> other) const {
-    return __lsx_vsadd_bu(this->value, other);
-  }
-  simdutf_really_inline simd8<uint8_t>
-  saturating_sub(const simd8<uint8_t> other) const {
-    return __lsx_vssub_bu(this->value, other);
-  }
-
-  // Addition/subtraction are the same for signed and unsigned
-  simdutf_really_inline simd8<uint8_t>
-  operator+(const simd8<uint8_t> other) const {
-    return __lsx_vadd_b(this->value, other);
-  }
-  simdutf_really_inline simd8<uint8_t>
-  operator-(const simd8<uint8_t> other) const {
-    return __lsx_vsub_b(this->value, other);
-  }
-  simdutf_really_inline simd8<uint8_t> &operator+=(const simd8<uint8_t> other) {
-    *this = *this + other;
-    return *this;
-  }
-  simdutf_really_inline simd8<uint8_t> &operator-=(const simd8<uint8_t> other) {
-    *this = *this - other;
-    return *this;
-  }
-
   // Order-specific operations
-  simdutf_really_inline simd8<uint8_t>
-  max_val(const simd8<uint8_t> other) const {
-    return __lsx_vmax_bu(*this, other);
-  }
-  simdutf_really_inline simd8<uint8_t>
-  min_val(const simd8<uint8_t> other) const {
-    return __lsx_vmin_bu(*this, other);
-  }
-  simdutf_really_inline simd8<bool>
-  operator<=(const simd8<uint8_t> other) const {
-    return __lsx_vsle_bu(*this, other);
-  }
   simdutf_really_inline simd8<bool>
   operator>=(const simd8<uint8_t> other) const {
     return __lsx_vsle_bu(other, *this);
   }
   simdutf_really_inline simd8<bool>
-  operator<(const simd8<uint8_t> other) const {
-    return __lsx_vslt_bu(*this, other);
-  }
-  simdutf_really_inline simd8<bool>
   operator>(const simd8<uint8_t> other) const {
     return __lsx_vslt_bu(other, *this);
+  }
+  simdutf_really_inline simd8 &operator-=(const simd8<uint8_t> other) {
+    value = __lsx_vsub_b(value, other.value);
+    return *this;
   }
   // Same as >, but instead of guaranteeing all 1's == true, false = 0 and true
   // = nonzero. For ARM, returns all 1's.
   simdutf_really_inline simd8<uint8_t>
   gt_bits(const simd8<uint8_t> other) const {
     return simd8<uint8_t>(*this > other);
-  }
-  // Same as <, but instead of guaranteeing all 1's == true, false = 0 and true
-  // = nonzero. For ARM, returns all 1's.
-  simdutf_really_inline simd8<uint8_t>
-  lt_bits(const simd8<uint8_t> other) const {
-    return simd8<uint8_t>(*this < other);
   }
 
   // Bit-specific operations
@@ -10889,9 +10234,6 @@ template <> struct simd8<uint8_t> : base_u8<uint8_t> {
 
   simdutf_really_inline bool any_bits_set_anywhere() const {
     return __lsx_vpickve2gr_hu(__lsx_vmsknz_b(this->value), 0) > 0;
-  }
-  simdutf_really_inline bool any_bits_set_anywhere(simd8<uint8_t> bits) const {
-    return (*this & bits).any_bits_set_anywhere();
   }
   template <int N> simdutf_really_inline simd8<uint8_t> shr() const {
     return __lsx_vsrli_b(this->value, N);
@@ -10925,11 +10267,22 @@ template <> struct simd8<uint8_t> : base_u8<uint8_t> {
     __m128i original_tmp = __lsx_vand_v(original, __lsx_vldi(0x1f));
     return __lsx_vshuf_b(__lsx_vldi(0), *this, simd8<uint8_t>(original_tmp));
   }
+
+  simdutf_really_inline uint64_t sum_bytes() const {
+    const auto sum_u16 = __lsx_vhaddw_hu_bu(value, value);
+    const auto sum_u32 = __lsx_vhaddw_wu_hu(sum_u16, sum_u16);
+    const auto sum_u64 = __lsx_vhaddw_du_wu(sum_u32, sum_u32);
+
+    return uint64_t(__lsx_vpickve2gr_du(sum_u64, 0)) +
+           uint64_t(__lsx_vpickve2gr_du(sum_u64, 1));
+  }
 };
 
 // Signed bytes
 template <> struct simd8<int8_t> {
   __m128i value;
+
+  static const int SIZE = sizeof(value);
 
   static simdutf_really_inline simd8<int8_t> splat(int8_t _value) {
     return __lsx_vreplgr2vr_b(_value);
@@ -10995,11 +10348,6 @@ template <> struct simd8<int8_t> {
   }
   // Conversion from/to SIMD register
   simdutf_really_inline simd8(const __m128i _value) : value(_value) {}
-  simdutf_really_inline operator const __m128i &() const { return this->value; }
-
-  simdutf_really_inline operator const __m128i() const { return this->value; }
-
-  simdutf_really_inline operator __m128i &() { return this->value; }
 
   // Zero constructor
   simdutf_really_inline simd8() : simd8(zero()) {}
@@ -11007,23 +10355,6 @@ template <> struct simd8<int8_t> {
   simdutf_really_inline simd8(int8_t _value) : simd8(splat(_value)) {}
   // Array constructor
   simdutf_really_inline simd8(const int8_t *values) : simd8(load(values)) {}
-  // Member-by-member initialization
-
-  simdutf_really_inline simd8(int8_t v0, int8_t v1, int8_t v2, int8_t v3,
-                              int8_t v4, int8_t v5, int8_t v6, int8_t v7,
-                              int8_t v8, int8_t v9, int8_t v10, int8_t v11,
-                              int8_t v12, int8_t v13, int8_t v14, int8_t v15)
-      : simd8((__m128i)v16i8{v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11,
-                             v12, v13, v14, v15}) {}
-
-  // Repeat 16 values as many times as necessary (usually for lookup tables)
-  simdutf_really_inline static simd8<int8_t>
-  repeat_16(int8_t v0, int8_t v1, int8_t v2, int8_t v3, int8_t v4, int8_t v5,
-            int8_t v6, int8_t v7, int8_t v8, int8_t v9, int8_t v10, int8_t v11,
-            int8_t v12, int8_t v13, int8_t v14, int8_t v15) {
-    return simd8<int8_t>(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12,
-                         v13, v14, v15);
-  }
 
   // Store to array
   simdutf_really_inline void store(int8_t dst[16]) const {
@@ -11038,36 +10369,6 @@ template <> struct simd8<int8_t> {
   operator|(const simd8<int8_t> other) const {
     return __lsx_vor_v((__m128i)value, (__m128i)other.value);
   }
-  simdutf_really_inline simd8<int8_t>
-  operator&(const simd8<int8_t> other) const {
-    return __lsx_vand_v((__m128i)value, (__m128i)other.value);
-  }
-  simdutf_really_inline simd8<int8_t>
-  operator^(const simd8<int8_t> other) const {
-    return __lsx_vxor_v((__m128i)value, (__m128i)other.value);
-  }
-  simdutf_really_inline simd8<int8_t>
-  bit_andnot(const simd8<int8_t> other) const {
-    return __lsx_vandn_v((__m128i)other.value, (__m128i)value);
-  }
-
-  // Math
-  simdutf_really_inline simd8<int8_t>
-  operator+(const simd8<int8_t> other) const {
-    return __lsx_vadd_b((__m128i)value, (__m128i)other.value);
-  }
-  simdutf_really_inline simd8<int8_t>
-  operator-(const simd8<int8_t> other) const {
-    return __lsx_vsub_b((__m128i)value, (__m128i)other.value);
-  }
-  simdutf_really_inline simd8<int8_t> &operator+=(const simd8<int8_t> other) {
-    *this = *this + other;
-    return *this;
-  }
-  simdutf_really_inline simd8<int8_t> &operator-=(const simd8<int8_t> other) {
-    *this = *this - other;
-    return *this;
-  }
 
   simdutf_really_inline bool is_ascii() const {
     return (__lsx_vpickve2gr_hu(__lsx_vmskgez_b((__m128i)this->value), 0) ==
@@ -11075,21 +10376,11 @@ template <> struct simd8<int8_t> {
   }
 
   // Order-sensitive comparisons
-  simdutf_really_inline simd8<int8_t> max_val(const simd8<int8_t> other) const {
-    return __lsx_vmax_b((__m128i)value, (__m128i)other.value);
-  }
-  simdutf_really_inline simd8<int8_t> min_val(const simd8<int8_t> other) const {
-    return __lsx_vmin_b((__m128i)value, (__m128i)other.value);
-  }
   simdutf_really_inline simd8<bool> operator>(const simd8<int8_t> other) const {
     return __lsx_vslt_b((__m128i)other.value, (__m128i)value);
   }
   simdutf_really_inline simd8<bool> operator<(const simd8<int8_t> other) const {
     return __lsx_vslt_b((__m128i)value, (__m128i)other.value);
-  }
-  simdutf_really_inline simd8<bool>
-  operator==(const simd8<int8_t> other) const {
-    return __lsx_vseq_b((__m128i)value, (__m128i)other.value);
   }
 
   template <int N = 1>
@@ -11097,23 +10388,6 @@ template <> struct simd8<int8_t> {
   prev(const simd8<int8_t> prev_chunk) const {
     return __lsx_vor_v(__lsx_vbsll_v(this->value, N),
                        __lsx_vbsrl_v(prev_chunk.value, 16 - N));
-  }
-
-  // Perform a lookup assuming no value is larger than 16
-  template <typename L>
-  simdutf_really_inline simd8<L> lookup_16(simd8<L> lookup_table) const {
-    return lookup_table.apply_lookup_16_to(*this);
-  }
-  template <typename L>
-  simdutf_really_inline simd8<L>
-  lookup_16(L replace0, L replace1, L replace2, L replace3, L replace4,
-            L replace5, L replace6, L replace7, L replace8, L replace9,
-            L replace10, L replace11, L replace12, L replace13, L replace14,
-            L replace15) const {
-    return lookup_16(simd8<L>::repeat_16(
-        replace0, replace1, replace2, replace3, replace4, replace5, replace6,
-        replace7, replace8, replace9, replace10, replace11, replace12,
-        replace13, replace14, replace15));
   }
 
   template <typename T>
@@ -11195,41 +10469,6 @@ template <typename T> struct simd8x64 {
     return __lsx_vpickve2gr_du(mask, 0);
   }
 
-  simdutf_really_inline uint64_t eq(const T m) const {
-    const simd8<T> mask = simd8<T>::splat(m);
-    return simd8x64<bool>(this->chunks[0] == mask, this->chunks[1] == mask,
-                          this->chunks[2] == mask, this->chunks[3] == mask)
-        .to_bitmask();
-  }
-
-  simdutf_really_inline uint64_t lteq(const T m) const {
-    const simd8<T> mask = simd8<T>::splat(m);
-    return simd8x64<bool>(this->chunks[0] <= mask, this->chunks[1] <= mask,
-                          this->chunks[2] <= mask, this->chunks[3] <= mask)
-        .to_bitmask();
-  }
-
-  simdutf_really_inline uint64_t in_range(const T low, const T high) const {
-    const simd8<T> mask_low = simd8<T>::splat(low);
-    const simd8<T> mask_high = simd8<T>::splat(high);
-
-    return simd8x64<bool>(
-               (this->chunks[0] <= mask_high) & (this->chunks[0] >= mask_low),
-               (this->chunks[1] <= mask_high) & (this->chunks[1] >= mask_low),
-               (this->chunks[2] <= mask_high) & (this->chunks[2] >= mask_low),
-               (this->chunks[3] <= mask_high) & (this->chunks[3] >= mask_low))
-        .to_bitmask();
-  }
-  simdutf_really_inline uint64_t not_in_range(const T low, const T high) const {
-    const simd8<T> mask_low = simd8<T>::splat(low);
-    const simd8<T> mask_high = simd8<T>::splat(high);
-    return simd8x64<bool>(
-               (this->chunks[0] > mask_high) | (this->chunks[0] < mask_low),
-               (this->chunks[1] > mask_high) | (this->chunks[1] < mask_low),
-               (this->chunks[2] > mask_high) | (this->chunks[2] < mask_low),
-               (this->chunks[3] > mask_high) | (this->chunks[3] < mask_low))
-        .to_bitmask();
-  }
   simdutf_really_inline uint64_t lt(const T m) const {
     const simd8<T> mask = simd8<T>::splat(m);
     return simd8x64<bool>(this->chunks[0] < mask, this->chunks[1] < mask,
@@ -11240,12 +10479,6 @@ template <typename T> struct simd8x64 {
     const simd8<T> mask = simd8<T>::splat(m);
     return simd8x64<bool>(this->chunks[0] > mask, this->chunks[1] > mask,
                           this->chunks[2] > mask, this->chunks[3] > mask)
-        .to_bitmask();
-  }
-  simdutf_really_inline uint64_t gteq(const T m) const {
-    const simd8<T> mask = simd8<T>::splat(m);
-    return simd8x64<bool>(this->chunks[0] >= mask, this->chunks[1] >= mask,
-                          this->chunks[2] >= mask, this->chunks[3] >= mask)
         .to_bitmask();
   }
   simdutf_really_inline uint64_t gteq_unsigned(const uint8_t m) const {
@@ -11263,7 +10496,8 @@ template <typename T> struct simd16;
 
 template <typename T, typename Mask = simd16<bool>> struct base_u16 {
   __m128i value;
-  static const int SIZE = sizeof(value);
+  static const size_t SIZE = sizeof(value);
+  static const size_t ELEMENTS = sizeof(value) / sizeof(T);
 
   // Conversion from/to SIMD register
   simdutf_really_inline base_u16() = default;
@@ -11275,27 +10509,8 @@ template <typename T, typename Mask = simd16<bool>> struct base_u16 {
   simdutf_really_inline simd16<T> operator&(const simd16<T> other) const {
     return __lsx_vand_v(this->value, other.value);
   }
-  simdutf_really_inline simd16<T> operator^(const simd16<T> other) const {
-    return __lsx_vxor_v(this->value, other.value);
-  }
-  simdutf_really_inline simd16<T> bit_andnot(const simd16<T> other) const {
-    return __lsx_vandn_v(this->value, other.value);
-  }
-  simdutf_really_inline simd16<T> operator~() const { return *this ^ 0xFFu; }
-  simdutf_really_inline simd16<T> &operator|=(const simd16<T> other) {
-    auto this_cast = static_cast<simd16<T> *>(this);
-    *this_cast = *this_cast | other;
-    return *this_cast;
-  }
-  simdutf_really_inline simd16<T> &operator&=(const simd16<T> other) {
-    auto this_cast = static_cast<simd16<T> *>(this);
-    *this_cast = *this_cast & other;
-    return *this_cast;
-  }
-  simdutf_really_inline simd16<T> &operator^=(const simd16<T> other) {
-    auto this_cast = static_cast<simd16<T> *>(this);
-    *this_cast = *this_cast ^ other;
-    return *this_cast;
+  simdutf_really_inline simd16<T> operator~() const {
+    return __lsx_vxori_b(this->value, 0xFF);
   }
 
   friend simdutf_really_inline Mask operator==(const simd16<T> lhs,
@@ -11303,18 +10518,18 @@ template <typename T, typename Mask = simd16<bool>> struct base_u16 {
     return __lsx_vseq_h(lhs.value, rhs.value);
   }
 
-  template <int N = 1>
-  simdutf_really_inline simd16<T> prev(const simd16<T> prev_chunk) const {
-    return __lsx_vor_v(__lsx_vbsll_v(*this, N * 2),
-                       __lsx_vbsrl_v(prev_chunk, 16 - N * 2));
+  template <unsigned N>
+  simdutf_really_inline simd16<T> byte_right_shift() const {
+    return __lsx_vbsrl_v(this->value, N);
+  }
+
+  simdutf_really_inline uint16_t first() const {
+    return uint16_t(__lsx_vpickve2gr_w(value, 0));
   }
 };
 
 template <typename T, typename Mask = simd16<bool>>
 struct base16 : base_u16<T> {
-  typedef uint16_t bitmask_t;
-  typedef uint32_t bitmask2_t;
-
   simdutf_really_inline base16() : base_u16<T>() {}
   simdutf_really_inline base16(const __m128i _value) : base_u16<T>(_value) {}
   template <typename Pointer>
@@ -11323,7 +10538,7 @@ struct base16 : base_u16<T> {
 
   static const int SIZE = sizeof(base_u16<T>::value);
 
-  template <int N = 1>
+  template <unsigned N = 1>
   simdutf_really_inline simd16<T> prev(const simd16<T> prev_chunk) const {
     return __lsx_vor_v(__lsx_vbsll_v(*this, N * 2),
                        __lsx_vbsrl_v(prev_chunk, 16 - N * 2));
@@ -11338,8 +10553,8 @@ template <> struct simd16<bool> : base16<bool> {
 
   simdutf_really_inline simd16() : base16() {}
   simdutf_really_inline simd16(const __m128i _value) : base16<bool>(_value) {}
-  // Splat constructor
-  simdutf_really_inline simd16(bool _value) : base16<bool>(splat(_value)) {}
+
+  simdutf_really_inline bool is_zero() const { return __lsx_bz_v(this->value); }
 };
 
 template <typename T> struct base16_numeric : base16<T> {
@@ -11347,11 +10562,12 @@ template <typename T> struct base16_numeric : base16<T> {
     return __lsx_vreplgr2vr_h(_value);
   }
   static simdutf_really_inline simd16<T> zero() { return __lsx_vldi(0); }
-  static simdutf_really_inline simd16<T> load(const T values[8]) {
-    return __lsx_vld(reinterpret_cast<const uint16_t *>(values), 0);
+
+  template <typename Pointer>
+  static simdutf_really_inline simd16<T> load(const Pointer values) {
+    return __lsx_vld(values, 0);
   }
 
-  simdutf_really_inline base16_numeric() : base16<T>() {}
   simdutf_really_inline base16_numeric(const __m128i _value)
       : base16<T>(_value) {}
 
@@ -11361,162 +10577,59 @@ template <typename T> struct base16_numeric : base16<T> {
   }
 
   // Override to distinguish from bool version
-  simdutf_really_inline simd16<T> operator~() const { return *this ^ 0xFFu; }
-
-  // Addition/subtraction are the same for signed and unsigned
-  simdutf_really_inline simd16<T> operator+(const simd16<T> other) const {
-    return __lsx_vadd_b(*this, other);
-  }
-  simdutf_really_inline simd16<T> operator-(const simd16<T> other) const {
-    return __lsx_vsub_b(*this, other);
-  }
-  simdutf_really_inline simd16<T> &operator+=(const simd16<T> other) {
-    *this = *this + other;
-    return *static_cast<simd16<T> *>(this);
-  }
-  simdutf_really_inline simd16<T> &operator-=(const simd16<T> other) {
-    *this = *this - other;
-    return *static_cast<simd16<T> *>(this);
-  }
-};
-
-// Signed code unitstemplate<>
-template <> struct simd16<int16_t> : base16_numeric<int16_t> {
-  simdutf_really_inline simd16() : base16_numeric<int16_t>() {}
-  simdutf_really_inline simd16(const __m128i _value)
-      : base16_numeric<int16_t>(_value) {}
-  simdutf_really_inline simd16(simd16<bool> other)
-      : base16_numeric<int16_t>(other.value) {}
-
-  // Splat constructor
-  simdutf_really_inline simd16(int16_t _value) : simd16(splat(_value)) {}
-  // Array constructor
-  simdutf_really_inline simd16(const int16_t *values) : simd16(load(values)) {}
-  simdutf_really_inline simd16(const char16_t *values)
-      : simd16(load(reinterpret_cast<const int16_t *>(values))) {}
-  simdutf_really_inline operator simd16<uint16_t>() const;
-
-  // Order-sensitive comparisons
-  simdutf_really_inline simd16<int16_t>
-  max_val(const simd16<int16_t> other) const {
-    return __lsx_vmax_h(this->value, other.value);
-  }
-  simdutf_really_inline simd16<int16_t>
-  min_val(const simd16<int16_t> other) const {
-    return __lsx_vmin_h(this->value, other.value);
-  }
-  simdutf_really_inline simd16<bool>
-  operator>(const simd16<int16_t> other) const {
-    return __lsx_vsle_h(other.value, this->value);
-  }
-  simdutf_really_inline simd16<bool>
-  operator<(const simd16<int16_t> other) const {
-    return __lsx_vslt_h(this->value, other.value);
+  simdutf_really_inline simd16<T> operator~() const {
+    return __lsx_vxori_b(this->value, 0xFF);
   }
 };
 
 // Unsigned code unitstemplate<>
 template <> struct simd16<uint16_t> : base16_numeric<uint16_t> {
-  simdutf_really_inline simd16() : base16_numeric<uint16_t>() {}
   simdutf_really_inline simd16(const __m128i _value)
       : base16_numeric<uint16_t>((__m128i)_value) {}
-  simdutf_really_inline simd16(simd16<bool> other)
-      : base16_numeric<uint16_t>(other.value) {}
 
   // Splat constructor
   simdutf_really_inline simd16(uint16_t _value) : simd16(splat(_value)) {}
+
   // Array constructor
   simdutf_really_inline simd16(const uint16_t *values) : simd16(load(values)) {}
   simdutf_really_inline simd16(const char16_t *values)
       : simd16(load(reinterpret_cast<const uint16_t *>(values))) {}
 
-  // Saturated math
-  simdutf_really_inline simd16<uint16_t>
-  saturating_add(const simd16<uint16_t> other) const {
-    return __lsx_vsadd_hu(this->value, other.value);
-  }
-  simdutf_really_inline simd16<uint16_t>
-  saturating_sub(const simd16<uint16_t> other) const {
-    return __lsx_vssub_hu(this->value, other.value);
-  }
+  // Copy constructor
+  simdutf_really_inline simd16(const simd16<bool> mask) : simd16(mask.value) {}
 
   // Order-specific operations
-  simdutf_really_inline simd16<uint16_t>
-  max_val(const simd16<uint16_t> other) const {
-    return __lsx_vmax_hu(this->value, other.value);
-  }
-  simdutf_really_inline simd16<uint16_t>
-  min_val(const simd16<uint16_t> other) const {
-    return __lsx_vmin_hu(this->value, other.value);
-  }
-  // Same as >, but only guarantees true is nonzero (< guarantees true = -1)
-  simdutf_really_inline simd16<uint16_t>
-  gt_bits(const simd16<uint16_t> other) const {
-    return this->saturating_sub(other);
-  }
-  // Same as <, but only guarantees true is nonzero (< guarantees true = -1)
-  simdutf_really_inline simd16<uint16_t>
-  lt_bits(const simd16<uint16_t> other) const {
-    return other.saturating_sub(*this);
-  }
-  simdutf_really_inline simd16<bool>
-  operator<=(const simd16<uint16_t> other) const {
-    return __lsx_vsle_hu(this->value, other.value);
-  }
-  simdutf_really_inline simd16<bool>
-  operator>=(const simd16<uint16_t> other) const {
-    return __lsx_vsle_hu(other.value, this->value);
-  }
-  simdutf_really_inline simd16<bool>
-  operator>(const simd16<uint16_t> other) const {
-    return __lsx_vslt_hu(other.value, this->value);
-  }
-  simdutf_really_inline simd16<bool>
-  operator<(const simd16<uint16_t> other) const {
-    return __lsx_vslt_hu(this->value, other.value);
+  simdutf_really_inline simd16 &operator+=(const simd16 other) {
+    value = __lsx_vadd_h(value, other.value);
+    return *this;
   }
 
-  // Bit-specific operations
-  simdutf_really_inline simd16<bool> bits_not_set() const {
-    return *this == uint16_t(0);
-  }
-  template <int N> simdutf_really_inline simd16<uint16_t> shr() const {
-    return simd16<uint16_t>(__lsx_vsrli_h(this->value, N));
-  }
-  template <int N> simdutf_really_inline simd16<uint16_t> shl() const {
-    return simd16<uint16_t>(__lsx_vslli_h(this->value, N));
-  }
-
-  // logical operations
-  simdutf_really_inline simd16<uint16_t>
-  operator|(const simd16<uint16_t> other) const {
-    return __lsx_vor_v(this->value, other.value);
-  }
-  simdutf_really_inline simd16<uint16_t>
-  operator&(const simd16<uint16_t> other) const {
-    return __lsx_vand_v(this->value, other.value);
-  }
-  simdutf_really_inline simd16<uint16_t>
-  operator^(const simd16<uint16_t> other) const {
-    return __lsx_vxor_v(this->value, other.value);
+  template <unsigned N>
+  static simdutf_really_inline simd8<uint8_t>
+  pack_shifted_right(const simd16<uint16_t> &v0, const simd16<uint16_t> &v1) {
+    return __lsx_vssrlni_bu_h(v1.value, v0.value, N);
   }
 
   // Pack with the unsigned saturation of two uint16_t code units into single
   // uint8_t vector
   static simdutf_really_inline simd8<uint8_t> pack(const simd16<uint16_t> &v0,
                                                    const simd16<uint16_t> &v1) {
-    return __lsx_vssrlni_bu_h(v1.value, v0.value, 0);
+    return pack_shifted_right<0>(v0, v1);
   }
 
   // Change the endianness
   simdutf_really_inline simd16<uint16_t> swap_bytes() const {
     return __lsx_vshuf4i_b(this->value, 0b10110001);
   }
-};
 
-simdutf_really_inline simd16<int16_t>::operator simd16<uint16_t>() const {
-  return this->value;
-}
+  simdutf_really_inline uint64_t sum() const {
+    const auto sum_u32 = __lsx_vhaddw_wu_hu(value, value);
+    const auto sum_u64 = __lsx_vhaddw_du_wu(sum_u32, sum_u32);
+
+    return uint64_t(__lsx_vpickve2gr_du(sum_u64, 0)) +
+           uint64_t(__lsx_vpickve2gr_du(sum_u64, 1));
+  }
+};
 
 template <typename T> struct simd16x32 {
   static constexpr int NUM_CHUNKS = 64 / sizeof(simd16<T>);
@@ -11547,95 +10660,32 @@ template <typename T> struct simd16x32 {
     this->chunks[3].store(ptr + sizeof(simd16<T>) * 3 / sizeof(T));
   }
 
-  simdutf_really_inline simd16<T> reduce_or() const {
-    return (this->chunks[0] | this->chunks[1]) |
-           (this->chunks[2] | this->chunks[3]);
-  }
-
-  simdutf_really_inline bool is_ascii() const { return reduce_or().is_ascii(); }
-
-  simdutf_really_inline void store_ascii_as_utf16(char16_t *ptr) const {
-    this->chunks[0].store_ascii_as_utf16(ptr + sizeof(simd16<T>) * 0);
-    this->chunks[1].store_ascii_as_utf16(ptr + sizeof(simd16<T>) * 1);
-    this->chunks[2].store_ascii_as_utf16(ptr + sizeof(simd16<T>) * 2);
-    this->chunks[3].store_ascii_as_utf16(ptr + sizeof(simd16<T>) * 3);
-  }
-
-  simdutf_really_inline uint64_t to_bitmask() const {
-    __m128i mask = __lsx_vbsll_v(__lsx_vmsknz_b((this->chunks[3]).value), 6);
-    mask = __lsx_vor_v(
-        mask, __lsx_vbsll_v(__lsx_vmsknz_b((this->chunks[2]).value), 4));
-    mask = __lsx_vor_v(
-        mask, __lsx_vbsll_v(__lsx_vmsknz_b((this->chunks[1]).value), 2));
-    mask = __lsx_vor_v(mask, __lsx_vmsknz_b((this->chunks[0]).value));
-    return __lsx_vpickve2gr_du(mask, 0);
-  }
-
   simdutf_really_inline void swap_bytes() {
     this->chunks[0] = this->chunks[0].swap_bytes();
     this->chunks[1] = this->chunks[1].swap_bytes();
     this->chunks[2] = this->chunks[2].swap_bytes();
     this->chunks[3] = this->chunks[3].swap_bytes();
   }
-
-  simdutf_really_inline uint64_t eq(const T m) const {
-    const simd16<T> mask = simd16<T>::splat(m);
-    return simd16x32<bool>(this->chunks[0] == mask, this->chunks[1] == mask,
-                           this->chunks[2] == mask, this->chunks[3] == mask)
-        .to_bitmask();
-  }
-
-  simdutf_really_inline uint64_t lteq(const T m) const {
-    const simd16<T> mask = simd16<T>::splat(m);
-    return simd16x32<bool>(this->chunks[0] <= mask, this->chunks[1] <= mask,
-                           this->chunks[2] <= mask, this->chunks[3] <= mask)
-        .to_bitmask();
-  }
-
-  simdutf_really_inline uint64_t in_range(const T low, const T high) const {
-    const simd16<T> mask_low = simd16<T>::splat(low);
-    const simd16<T> mask_high = simd16<T>::splat(high);
-
-    return simd16x32<bool>(
-               (this->chunks[0] <= mask_high) & (this->chunks[0] >= mask_low),
-               (this->chunks[1] <= mask_high) & (this->chunks[1] >= mask_low),
-               (this->chunks[2] <= mask_high) & (this->chunks[2] >= mask_low),
-               (this->chunks[3] <= mask_high) & (this->chunks[3] >= mask_low))
-        .to_bitmask();
-  }
-  simdutf_really_inline uint64_t not_in_range(const T low, const T high) const {
-    const simd16<T> mask_low = simd16<T>::splat(low);
-    const simd16<T> mask_high = simd16<T>::splat(high);
-    return simd16x32<bool>(
-               (this->chunks[0] > mask_high) | (this->chunks[0] < mask_low),
-               (this->chunks[1] > mask_high) | (this->chunks[1] < mask_low),
-               (this->chunks[2] > mask_high) | (this->chunks[2] < mask_low),
-               (this->chunks[3] > mask_high) | (this->chunks[3] < mask_low))
-        .to_bitmask();
-  }
-  simdutf_really_inline uint64_t lt(const T m) const {
-    const simd16<T> mask = simd16<T>::splat(m);
-    return simd16x32<bool>(this->chunks[0] < mask, this->chunks[1] < mask,
-                           this->chunks[2] < mask, this->chunks[3] < mask)
-        .to_bitmask();
-  }
-
 }; // struct simd16x32<T>
 
-template <>
-simdutf_really_inline uint64_t simd16x32<uint16_t>::not_in_range(
-    const uint16_t low, const uint16_t high) const {
-  const simd16<uint16_t> mask_low = simd16<uint16_t>::splat(low);
-  const simd16<uint16_t> mask_high = simd16<uint16_t>::splat(high);
-  simd16x32<uint16_t> x(simd16<uint16_t>((this->chunks[0] > mask_high) |
-                                         (this->chunks[0] < mask_low)),
-                        simd16<uint16_t>((this->chunks[1] > mask_high) |
-                                         (this->chunks[1] < mask_low)),
-                        simd16<uint16_t>((this->chunks[2] > mask_high) |
-                                         (this->chunks[2] < mask_low)),
-                        simd16<uint16_t>((this->chunks[3] > mask_high) |
-                                         (this->chunks[3] < mask_low)));
-  return x.to_bitmask();
+simdutf_really_inline simd16<uint16_t> operator^(const simd16<uint16_t> a,
+                                                 uint16_t b) {
+  const auto bv = __lsx_vreplgr2vr_h(b);
+  return __lsx_vxor_v(a.value, bv);
+}
+
+simdutf_really_inline simd16<bool> operator^(const simd16<bool> a,
+                                             const simd16<bool> b) {
+  return __lsx_vxor_v(a.value, b.value);
+}
+
+simdutf_really_inline simd16<uint16_t> min(const simd16<uint16_t> a,
+                                           const simd16<uint16_t> b) {
+  return __lsx_vmin_hu(a.value, b.value);
+}
+
+simdutf_really_inline simd16<uint16_t> as_vector_u16(const simd16<bool> x) {
+  return x.value;
 }
 /* end file src/simdutf/lsx/simd16-inl.h */
 /* begin file src/simdutf/lsx/simd32-inl.h */
@@ -11709,6 +10759,58 @@ simdutf_really_inline simd32<uint32_t> as_vector_u32(const simd32<bool> v) {
   return v.value;
 }
 /* end file src/simdutf/lsx/simd32-inl.h */
+/* begin file src/simdutf/lsx/simd64-inl.h */
+template <typename T> struct simd64;
+
+template <> struct simd64<uint64_t> {
+  __m128i value;
+  static const int SIZE = sizeof(value);
+  static const int ELEMENTS = SIZE / sizeof(uint64_t);
+
+  // constructors
+  simdutf_really_inline simd64(__m128i v) : value(v) {}
+
+  template <typename Ptr>
+  simdutf_really_inline simd64(Ptr *ptr) : value(__lsx_vld(ptr, 0)) {}
+
+  // in-place operators
+  simdutf_really_inline simd64 &operator+=(const simd64 other) {
+    value = __lsx_vadd_d(value, other.value);
+    return *this;
+  }
+
+  // members
+  simdutf_really_inline uint64_t sum() const {
+    return uint64_t(__lsx_vpickve2gr_du(value, 0)) +
+           uint64_t(__lsx_vpickve2gr_du(value, 1));
+  }
+
+  // static members
+  static simdutf_really_inline simd64<uint64_t> zero() {
+    return __lsx_vrepli_d(0);
+  }
+};
+
+// ------------------------------------------------------------
+
+template <> struct simd64<bool> {
+  __m128i value;
+  static const int SIZE = sizeof(value);
+
+  // constructors
+  simdutf_really_inline simd64(__m128i v) : value(v) {}
+};
+
+// ------------------------------------------------------------
+
+simd64<uint64_t> sum_8bytes(const simd8<uint8_t> v) {
+  const auto sum_u16 = __lsx_vhaddw_hu_bu(v, v);
+  const auto sum_u32 = __lsx_vhaddw_wu_hu(sum_u16, sum_u16);
+  const auto sum_u64 = __lsx_vhaddw_du_wu(sum_u32, sum_u32);
+
+  return simd64<uint64_t>(sum_u64);
+}
+/* end file src/simdutf/lsx/simd64-inl.h */
 
 } // namespace simd
 } // unnamed namespace
@@ -11803,6 +10905,10 @@ public:
       const char16_t *buf, size_t len) const noexcept final;
   simdutf_warn_unused result validate_utf16be_with_errors(
       const char16_t *buf, size_t len) const noexcept final;
+  void to_well_formed_utf16be(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
+  void to_well_formed_utf16le(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
 #endif // SIMDUTF_FEATURE_UTF16
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING
   simdutf_warn_unused bool validate_utf32(const char32_t *buf,
@@ -12349,7 +11455,6 @@ simdutf_really_inline int count_ones(uint64_t input_num) {
 #ifndef SIMDUTF_LASX_SIMD_H
 #define SIMDUTF_LASX_SIMD_H
 
-#include <type_traits>
 
 namespace simdutf {
 namespace lasx {
@@ -12576,22 +11681,9 @@ template <typename Child> struct base {
   simdutf_really_inline Child operator^(const Child other) const {
     return __lasx_xvxor_v(this->value, other);
   }
-  simdutf_really_inline Child bit_andnot(const Child other) const {
-    return __lasx_xvandn_v(this->value, other);
-  }
   simdutf_really_inline Child &operator|=(const Child other) {
     auto this_cast = static_cast<Child *>(this);
     *this_cast = *this_cast | other;
-    return *this_cast;
-  }
-  simdutf_really_inline Child &operator&=(const Child other) {
-    auto this_cast = static_cast<Child *>(this);
-    *this_cast = *this_cast & other;
-    return *this_cast;
-  }
-  simdutf_really_inline Child &operator^=(const Child other) {
-    auto this_cast = static_cast<Child *>(this);
-    *this_cast = *this_cast ^ other;
     return *this_cast;
   }
 };
@@ -12600,17 +11692,8 @@ template <typename T> struct simd8;
 
 template <typename T, typename Mask = simd8<bool>>
 struct base8 : base<simd8<T>> {
-  typedef uint32_t bitmask_t;
-  typedef uint64_t bitmask2_t;
-
   simdutf_really_inline base8() : base<simd8<T>>() {}
   simdutf_really_inline base8(const __m256i _value) : base<simd8<T>>(_value) {}
-  simdutf_really_inline T first() const {
-    return __lasx_xvpickve2gr_wu(this->value, 0);
-  }
-  simdutf_really_inline T last() const {
-    return __lasx_xvpickve2gr_wu(this->value, 7);
-  }
   friend simdutf_really_inline Mask operator==(const simd8<T> lhs,
                                                const simd8<T> rhs) {
     return __lasx_xvseq_b(lhs, rhs);
@@ -12618,8 +11701,10 @@ struct base8 : base<simd8<T>> {
 
   static const int SIZE = sizeof(base<T>::value);
 
-  template <int N = 1>
+  template <unsigned N = 1>
   simdutf_really_inline simd8<T> prev(const simd8<T> prev_chunk) const {
+    static_assert(N <= 16, "unsupported shift value");
+
     if (!N)
       return this->value;
 
@@ -12639,17 +11724,7 @@ struct base8 : base<simd8<T>> {
       return result;
     } else if (N == 16) {
       return __lasx_xvpermi_q(this->value, prev_chunk.value, 0b00100001);
-    } /*else {
-      __m256i sll_value = __lasx_xvbsll_v(
-          __lasx_xvpermi_q(zero, this->value, 0b00000011), (N - 16) % 32);
-      __m256i mask = __lasx_xvld(bitsel_mask_table[N], 0);
-      shuf = __lasx_xvld(prev_shuf_table[N], 0);
-      result = __lasx_xvshuf_b(
-          __lasx_xvpermi_q(prev_chunk.value, prev_chunk.value, 0b00000001),
-          prev_chunk.value, shuf);
-      result = __lasx_xvbitsel_v(sll_value, result, mask);
-      return result;
-    }*/
+    }
   }
 };
 
@@ -12674,16 +11749,6 @@ template <> struct simd8<bool> : base8<bool> {
     if (__lasx_xbz_b(this->value))
       return false;
     return true;
-  }
-  simdutf_really_inline bool none() const {
-    if (__lasx_xbz_b(this->value))
-      return true;
-    return false;
-  }
-  simdutf_really_inline bool all() const {
-    if (__lasx_xbnz_b(this->value))
-      return true;
-    return false;
   }
   simdutf_really_inline simd8<bool> operator~() const { return *this ^ true; }
 };
@@ -12713,22 +11778,6 @@ template <typename T> struct base8_numeric : base8<T> {
   // Store to array
   simdutf_really_inline void store(T dst[32]) const {
     return __lasx_xvst(this->value, reinterpret_cast<__m256i *>(dst), 0);
-  }
-
-  // Addition/subtraction are the same for signed and unsigned
-  simdutf_really_inline simd8<T> operator+(const simd8<T> other) const {
-    return __lasx_xvadd_b(this->value, other);
-  }
-  simdutf_really_inline simd8<T> operator-(const simd8<T> other) const {
-    return __lasx_xvsub_b(this->value, other);
-  }
-  simdutf_really_inline simd8<T> &operator+=(const simd8<T> other) {
-    *this = *this + other;
-    return *static_cast<simd8<T> *>(this);
-  }
-  simdutf_really_inline simd8<T> &operator-=(const simd8<T> other) {
-    *this = *this - other;
-    return *static_cast<simd8<T> *>(this);
   }
 
   // Override to distinguish from bool version
@@ -12766,27 +11815,6 @@ template <> struct simd8<int8_t> : base8_numeric<int8_t> {
   // Array constructor
   simdutf_really_inline simd8(const int8_t values[32]) : simd8(load(values)) {}
   simdutf_really_inline operator simd8<uint8_t>() const;
-  // Member-by-member initialization
-  simdutf_really_inline
-  simd8(int8_t v0, int8_t v1, int8_t v2, int8_t v3, int8_t v4, int8_t v5,
-        int8_t v6, int8_t v7, int8_t v8, int8_t v9, int8_t v10, int8_t v11,
-        int8_t v12, int8_t v13, int8_t v14, int8_t v15, int8_t v16, int8_t v17,
-        int8_t v18, int8_t v19, int8_t v20, int8_t v21, int8_t v22, int8_t v23,
-        int8_t v24, int8_t v25, int8_t v26, int8_t v27, int8_t v28, int8_t v29,
-        int8_t v30, int8_t v31)
-      : simd8((__m256i)v32i8{v0,  v1,  v2,  v3,  v4,  v5,  v6,  v7,
-                             v8,  v9,  v10, v11, v12, v13, v14, v15,
-                             v16, v17, v18, v19, v20, v21, v22, v23,
-                             v24, v25, v26, v27, v28, v29, v30, v31}) {}
-  // Repeat 16 values as many times as necessary (usually for lookup tables)
-  simdutf_really_inline static simd8<int8_t>
-  repeat_16(int8_t v0, int8_t v1, int8_t v2, int8_t v3, int8_t v4, int8_t v5,
-            int8_t v6, int8_t v7, int8_t v8, int8_t v9, int8_t v10, int8_t v11,
-            int8_t v12, int8_t v13, int8_t v14, int8_t v15) {
-    return simd8<int8_t>(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12,
-                         v13, v14, v15, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9,
-                         v10, v11, v12, v13, v14, v15);
-  }
   simdutf_really_inline bool is_ascii() const {
     __m256i ascii_mask = __lasx_xvslti_b(this->value, 0);
     if (__lasx_xbnz_v(ascii_mask))
@@ -12794,12 +11822,6 @@ template <> struct simd8<int8_t> : base8_numeric<int8_t> {
     return true;
   }
   // Order-sensitive comparisons
-  simdutf_really_inline simd8<int8_t> max_val(const simd8<int8_t> other) const {
-    return __lasx_xvmax_b(this->value, other);
-  }
-  simdutf_really_inline simd8<int8_t> min_val(const simd8<int8_t> other) const {
-    return __lasx_xvmin_b(this->value, other);
-  }
   simdutf_really_inline simd8<bool> operator>(const simd8<int8_t> other) const {
     return __lasx_xvslt_b(other, this->value);
   }
@@ -12830,76 +11852,28 @@ template <> struct simd8<uint8_t> : base8_numeric<uint8_t> {
                              v8,  v9,  v10, v11, v12, v13, v14, v15,
                              v16, v17, v18, v19, v20, v21, v22, v23,
                              v24, v25, v26, v27, v28, v29, v30, v31}) {}
-  // Repeat 16 values as many times as necessary (usually for lookup tables)
-  simdutf_really_inline static simd8<uint8_t>
-  repeat_16(uint8_t v0, uint8_t v1, uint8_t v2, uint8_t v3, uint8_t v4,
-            uint8_t v5, uint8_t v6, uint8_t v7, uint8_t v8, uint8_t v9,
-            uint8_t v10, uint8_t v11, uint8_t v12, uint8_t v13, uint8_t v14,
-            uint8_t v15) {
-    return simd8<uint8_t>(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12,
-                          v13, v14, v15, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9,
-                          v10, v11, v12, v13, v14, v15);
-  }
 
   // Saturated math
-  simdutf_really_inline simd8<uint8_t>
-  saturating_add(const simd8<uint8_t> other) const {
-    return __lasx_xvsadd_bu(this->value, other);
-  }
   simdutf_really_inline simd8<uint8_t>
   saturating_sub(const simd8<uint8_t> other) const {
     return __lasx_xvssub_bu(this->value, other);
   }
 
-  // Order-specific operations
-  simdutf_really_inline simd8<uint8_t>
-  max_val(const simd8<uint8_t> other) const {
-    return __lasx_xvmax_bu(*this, other);
-  }
-  simdutf_really_inline simd8<uint8_t>
-  min_val(const simd8<uint8_t> other) const {
-    return __lasx_xvmin_bu(*this, other);
-  }
   // Same as >, but only guarantees true is nonzero (< guarantees true = -1)
   simdutf_really_inline simd8<uint8_t>
   gt_bits(const simd8<uint8_t> other) const {
     return this->saturating_sub(other);
   }
-  // Same as <, but only guarantees true is nonzero (< guarantees true = -1)
-  simdutf_really_inline simd8<uint8_t>
-  lt_bits(const simd8<uint8_t> other) const {
-    return other.saturating_sub(*this);
-  }
-  simdutf_really_inline simd8<bool>
-  operator<=(const simd8<uint8_t> other) const {
-    return __lasx_xvsle_bu(*this, other);
-  }
   simdutf_really_inline simd8<bool>
   operator>=(const simd8<uint8_t> other) const {
     return __lasx_xvsle_bu(other, *this);
   }
-  simdutf_really_inline simd8<bool>
-  operator>(const simd8<uint8_t> other) const {
-    return __lasx_xvslt_bu(*this, other);
-  }
-  simdutf_really_inline simd8<bool>
-  operator<(const simd8<uint8_t> other) const {
-    return __lasx_xvslt_bu(other, *this);
+  simdutf_really_inline simd8 &operator-=(const simd8<uint8_t> other) {
+    value = __lasx_xvsub_b(value, other.value);
+    return *this;
   }
 
   // Bit-specific operations
-  simdutf_really_inline simd8<bool> bits_not_set() const {
-    return *this == uint8_t(0);
-  }
-  simdutf_really_inline simd8<bool> bits_not_set(simd8<uint8_t> bits) const {
-    return (*this & bits).bits_not_set();
-  }
-  simdutf_really_inline simd8<bool> any_bits_set() const {
-    return ~this->bits_not_set();
-  }
-  simdutf_really_inline simd8<bool> any_bits_set(simd8<uint8_t> bits) const {
-    return ~this->bits_not_set(bits);
-  }
   simdutf_really_inline bool is_ascii() const {
     __m256i ascii_mask = __lasx_xvslti_b(this->value, 0);
     if (__lasx_xbnz_v(ascii_mask))
@@ -12911,14 +11885,22 @@ template <> struct simd8<uint8_t> : base8_numeric<uint8_t> {
       return true;
     return false;
   }
-  simdutf_really_inline bool any_bits_set_anywhere(simd8<uint8_t> bits) const {
-    return (*this & bits).any_bits_set_anywhere();
-  }
   template <int N> simdutf_really_inline simd8<uint8_t> shr() const {
     return __lasx_xvsrli_b(this->value, N);
   }
   template <int N> simdutf_really_inline simd8<uint8_t> shl() const {
     return __lasx_xvslli_b(this->value, N);
+  }
+
+  simdutf_really_inline uint64_t sum_bytes() const {
+    const auto sum_u16 = __lasx_xvhaddw_hu_bu(value, value);
+    const auto sum_u32 = __lasx_xvhaddw_wu_hu(sum_u16, sum_u16);
+    const auto sum_u64 = __lasx_xvhaddw_du_wu(sum_u32, sum_u32);
+
+    return uint64_t(__lasx_xvpickve2gr_du(sum_u64, 0)) +
+           uint64_t(__lasx_xvpickve2gr_du(sum_u64, 1)) +
+           uint64_t(__lasx_xvpickve2gr_du(sum_u64, 2)) +
+           uint64_t(__lasx_xvpickve2gr_du(sum_u64, 3));
   }
 };
 simdutf_really_inline simd8<int8_t>::operator simd8<uint8_t>() const {
@@ -12980,46 +11962,6 @@ template <typename T> struct simd8x64 {
     this->chunks[1].store_ascii_as_utf32(ptr + sizeof(simd8<T>) * 1);
   }
 
-  simdutf_really_inline simd8x64<T> bit_or(const T m) const {
-    const simd8<T> mask = simd8<T>::splat(m);
-    return simd8x64<T>(this->chunks[0] | mask, this->chunks[1] | mask);
-  }
-
-  simdutf_really_inline uint64_t eq(const T m) const {
-    const simd8<T> mask = simd8<T>::splat(m);
-    return simd8x64<bool>(this->chunks[0] == mask, this->chunks[1] == mask)
-        .to_bitmask();
-  }
-
-  simdutf_really_inline uint64_t eq(const simd8x64<uint8_t> &other) const {
-    return simd8x64<bool>(this->chunks[0] == other.chunks[0],
-                          this->chunks[1] == other.chunks[1])
-        .to_bitmask();
-  }
-
-  simdutf_really_inline uint64_t lteq(const T m) const {
-    const simd8<T> mask = simd8<T>::splat(m);
-    return simd8x64<bool>(this->chunks[0] <= mask, this->chunks[1] <= mask)
-        .to_bitmask();
-  }
-
-  simdutf_really_inline uint64_t in_range(const T low, const T high) const {
-    const simd8<T> mask_low = simd8<T>::splat(low);
-    const simd8<T> mask_high = simd8<T>::splat(high);
-
-    return simd8x64<bool>(
-               (this->chunks[0] <= mask_high) & (this->chunks[0] >= mask_low),
-               (this->chunks[1] <= mask_high) & (this->chunks[1] >= mask_low))
-        .to_bitmask();
-  }
-  simdutf_really_inline uint64_t not_in_range(const T low, const T high) const {
-    const simd8<T> mask_low = simd8<T>::splat(low);
-    const simd8<T> mask_high = simd8<T>::splat(high);
-    return simd8x64<bool>(
-               (this->chunks[0] > mask_high) | (this->chunks[0] < mask_low),
-               (this->chunks[1] > mask_high) | (this->chunks[1] < mask_low))
-        .to_bitmask();
-  }
   simdutf_really_inline uint64_t lt(const T m) const {
     const simd8<T> mask = simd8<T>::splat(m);
     return simd8x64<bool>(this->chunks[0] < mask, this->chunks[1] < mask)
@@ -13029,11 +11971,6 @@ template <typename T> struct simd8x64 {
   simdutf_really_inline uint64_t gt(const T m) const {
     const simd8<T> mask = simd8<T>::splat(m);
     return simd8x64<bool>(this->chunks[0] > mask, this->chunks[1] > mask)
-        .to_bitmask();
-  }
-  simdutf_really_inline uint64_t gteq(const T m) const {
-    const simd8<T> mask = simd8<T>::splat(m);
-    return simd8x64<bool>(this->chunks[0] >= mask, this->chunks[1] >= mask)
         .to_bitmask();
   }
   simdutf_really_inline uint64_t gteq_unsigned(const uint8_t m) const {
@@ -13057,56 +11994,18 @@ struct base16 : base<simd16<T>> {
   template <typename Pointer>
   simdutf_really_inline base16(const Pointer *ptr)
       : base16(__lasx_xvld(reinterpret_cast<const __m256i *>(ptr), 0)) {}
-  friend simdutf_really_inline Mask operator==(const simd16<T> lhs,
-                                               const simd16<T> rhs) {
-    return __lasx_xvseq_h(lhs.value, rhs.value);
-  }
 
   /// the size of vector in bytes
   static const int SIZE = sizeof(base<simd16<T>>::value);
 
   /// the number of elements of type T a vector can hold
   static const int ELEMENTS = SIZE / sizeof(T);
-
-  template <int N = 1>
-  simdutf_really_inline simd16<T> prev(const simd16<T> prev_chunk) const {
-    if (!N)
-      return this->value;
-
-    __m256i zero = __lasx_xvldi(0);
-    __m256i result, shuf;
-    if (N < 8) {
-      shuf = __lasx_xvld(prev_shuf_table[N * 2], 0);
-
-      result = __lasx_xvshuf_b(
-          __lasx_xvpermi_q(this->value, this->value, 0b00000001), this->value,
-          shuf);
-      __m256i srl_prev = __lasx_xvbsrl_v(
-          __lasx_xvpermi_q(zero, prev_chunk, 0b00110001), (16 - N * 2));
-      __m256i mask = __lasx_xvld(bitsel_mask_table[N], 0);
-      result = __lasx_xvbitsel_v(result, srl_prev, mask);
-
-      return result;
-    } else if (N == 8) {
-      return __lasx_xvpermi_q(this->value, prev_chunk, 0b00100001);
-    } else {
-      __m256i sll_value = __lasx_xvbsll_v(
-          __lasx_xvpermi_q(zero, this->value, 0b00000011), (N * 2 - 16));
-      __m256i mask = __lasx_xvld(bitsel_mask_table[N * 2], 0);
-      shuf = __lasx_xvld(prev_shuf_table[N * 2], 0);
-      result =
-          __lasx_xvshuf_b(__lasx_xvpermi_q(prev_chunk, prev_chunk, 0b00000001),
-                          prev_chunk, shuf);
-      result = __lasx_xvbitsel_v(sll_value, result, mask);
-      return result;
-    }
-  }
 };
 
 // SIMD byte mask type (returned by things like eq and gt)
 template <> struct simd16<bool> : base16<bool> {
   static simdutf_really_inline simd16<bool> splat(bool _value) {
-    return __lasx_xvreplgr2vr_h(uint8_t(-(!!_value)));
+    return __lasx_xvreplgr2vr_h(uint16_t(-(!!_value)));
   }
 
   simdutf_really_inline simd16() : base16() {}
@@ -13120,12 +12019,23 @@ template <> struct simd16<bool> : base16<bool> {
     bitmask_type mask1 = __lasx_xvpickve2gr_wu(mask, 4);
     return (mask0 | (mask1 << 16));
   }
-  simdutf_really_inline bool any() const {
-    if (__lasx_xbz_v(this->value))
-      return false;
-    return true;
-  }
   simdutf_really_inline simd16<bool> operator~() const { return *this ^ true; }
+
+  simdutf_really_inline bool is_zero() const {
+    return __lasx_xbz_v(this->value);
+  }
+
+  template <unsigned N> simdutf_really_inline simd16 byte_right_shift() const {
+    const auto t0 = __lasx_xvbsrl_v(this->value, N);
+    const auto t1 = __lasx_xvpermi_q(this->value, __lasx_xvldi(0), 0b00000011);
+    const auto t2 = __lasx_xvbsll_v(t1, 16 - N);
+    const auto t3 = __lasx_xvor_v(t0, t2);
+    return t3;
+  }
+
+  simdutf_really_inline uint16_t first() const {
+    return uint16_t(__lasx_xvpickve2gr_w(value, 0));
+  }
 };
 
 template <typename T> struct base16_numeric : base16<T> {
@@ -13133,8 +12043,9 @@ template <typename T> struct base16_numeric : base16<T> {
     return __lasx_xvreplgr2vr_h((uint16_t)_value);
   }
   static simdutf_really_inline simd16<T> zero() { return __lasx_xvldi(0); }
-  static simdutf_really_inline simd16<T> load(const T values[8]) {
-    return __lasx_xvld(reinterpret_cast<const __m256i *>(values), 0);
+  template <typename Pointer>
+  static simdutf_really_inline simd16<T> load(const Pointer values) {
+    return __lasx_xvld(values, 0);
   }
 
   simdutf_really_inline base16_numeric() : base16<T>() {}
@@ -13148,52 +12059,6 @@ template <typename T> struct base16_numeric : base16<T> {
 
   // Override to distinguish from bool version
   simdutf_really_inline simd16<T> operator~() const { return *this ^ 0xFFFFu; }
-
-  // Addition/subtraction are the same for signed and unsigned
-  simdutf_really_inline simd16<T> operator+(const simd16<T> other) const {
-    return __lasx_xvadd_h(*this, other);
-  }
-  simdutf_really_inline simd16<T> operator-(const simd16<T> other) const {
-    return __lasx_xvsub_h(*this, other);
-  }
-  simdutf_really_inline simd16<T> &operator+=(const simd16<T> other) {
-    *this = *this + other;
-    return *static_cast<simd16<T> *>(this);
-  }
-  simdutf_really_inline simd16<T> &operator-=(const simd16<T> other) {
-    *this = *this - other;
-    return *static_cast<simd16<T> *>(this);
-  }
-};
-
-// Signed code units
-template <> struct simd16<int16_t> : base16_numeric<int16_t> {
-  simdutf_really_inline simd16() : base16_numeric<int16_t>() {}
-  simdutf_really_inline simd16(const __m256i _value)
-      : base16_numeric<int16_t>(_value) {}
-  // Splat constructor
-  simdutf_really_inline simd16(int16_t _value) : simd16(splat(_value)) {}
-  // Array constructor
-  simdutf_really_inline simd16(const int16_t *values) : simd16(load(values)) {}
-  simdutf_really_inline simd16(const char16_t *values)
-      : simd16(load(reinterpret_cast<const int16_t *>(values))) {}
-  // Order-sensitive comparisons
-  simdutf_really_inline simd16<int16_t>
-  max_val(const simd16<int16_t> other) const {
-    return __lasx_xvmax_h(*this, other);
-  }
-  simdutf_really_inline simd16<int16_t>
-  min_val(const simd16<int16_t> other) const {
-    return __lasx_xvmin_h(*this, other);
-  }
-  simdutf_really_inline simd16<bool>
-  operator>(const simd16<int16_t> other) const {
-    return __lasx_xvsle_h(other.value, this->value);
-  }
-  simdutf_really_inline simd16<bool>
-  operator<(const simd16<int16_t> other) const {
-    return __lasx_xvslt_h(this->value, other.value);
-  }
 };
 
 // Unsigned code units
@@ -13204,86 +12069,16 @@ template <> struct simd16<uint16_t> : base16_numeric<uint16_t> {
 
   // Splat constructor
   simdutf_really_inline simd16(uint16_t _value) : simd16(splat(_value)) {}
+
   // Array constructor
   simdutf_really_inline simd16(const uint16_t *values) : simd16(load(values)) {}
   simdutf_really_inline simd16(const char16_t *values)
       : simd16(load(reinterpret_cast<const uint16_t *>(values))) {}
 
-  // Saturated math
-  simdutf_really_inline simd16<uint16_t>
-  saturating_add(const simd16<uint16_t> other) const {
-    return __lasx_xvsadd_hu(this->value, other.value);
-  }
-  simdutf_really_inline simd16<uint16_t>
-  saturating_sub(const simd16<uint16_t> other) const {
-    return __lasx_xvssub_hu(this->value, other.value);
-  }
-
   // Order-specific operations
-  simdutf_really_inline simd16<uint16_t>
-  max_val(const simd16<uint16_t> other) const {
-    return __lasx_xvmax_hu(this->value, other.value);
-  }
-  simdutf_really_inline simd16<uint16_t>
-  min_val(const simd16<uint16_t> other) const {
-    return __lasx_xvmin_hu(this->value, other.value);
-  }
-  // Same as >, but only guarantees true is nonzero (< guarantees true = -1)
-  simdutf_really_inline simd16<uint16_t>
-  gt_bits(const simd16<uint16_t> other) const {
-    return this->saturating_sub(other);
-  }
-  // Same as <, but only guarantees true is nonzero (< guarantees true = -1)
-  simdutf_really_inline simd16<uint16_t>
-  lt_bits(const simd16<uint16_t> other) const {
-    return other.saturating_sub(*this);
-  }
-  simdutf_really_inline simd16<bool>
-  operator<=(const simd16<uint16_t> other) const {
-    return __lasx_xvsle_hu(this->value, other.value);
-  }
-  simdutf_really_inline simd16<bool>
-  operator>=(const simd16<uint16_t> other) const {
-    return __lasx_xvsle_hu(other.value, this->value);
-  }
-  simdutf_really_inline simd16<bool>
-  operator>(const simd16<uint16_t> other) const {
-    return __lasx_xvslt_hu(other.value, this->value);
-  }
-  simdutf_really_inline simd16<bool>
-  operator<(const simd16<uint16_t> other) const {
-    return __lasx_xvslt_hu(this->value, other.value);
-  }
-
-  // Bit-specific operations
-  simdutf_really_inline simd16<bool> bits_not_set() const {
-    return *this == uint16_t(0);
-  }
-  simdutf_really_inline simd16<bool> bits_not_set(simd16<uint16_t> bits) const {
-    return (*this & bits).bits_not_set();
-  }
-  simdutf_really_inline simd16<bool> any_bits_set() const {
-    return ~this->bits_not_set();
-  }
-  simdutf_really_inline simd16<bool> any_bits_set(simd16<uint16_t> bits) const {
-    return ~this->bits_not_set(bits);
-  }
-
-  simdutf_really_inline bool any_bits_set_anywhere() const {
-    if (__lasx_xbnz_v(this->value))
-      return true;
-    return false;
-  }
-  simdutf_really_inline bool
-  any_bits_set_anywhere(simd16<uint16_t> bits) const {
-    return (*this & bits).any_bits_set_anywhere();
-  }
-
-  template <int N> simdutf_really_inline simd16<uint16_t> shr() const {
-    return simd16<uint16_t>(__lasx_xvsrli_h(this->value, N));
-  }
-  template <int N> simdutf_really_inline simd16<uint16_t> shl() const {
-    return simd16<uint16_t>(__lasx_xvslli_h(this->value, N));
+  simdutf_really_inline simd16 &operator+=(const simd16 other) {
+    value = __lasx_xvadd_h(value, other.value);
+    return *this;
   }
 
   // Change the endianness
@@ -13304,6 +12099,20 @@ template <> struct simd16<uint16_t> : base16_numeric<uint16_t> {
                                                    const simd16<uint16_t> &v1) {
 
     return pack_shifted_right<0>(v0, v1);
+  }
+
+  simdutf_really_inline uint64_t sum() const {
+    const auto sum_u32 = __lasx_xvhaddw_wu_hu(value, value);
+    const auto sum_u64 = __lasx_xvhaddw_du_wu(sum_u32, sum_u32);
+
+    return uint64_t(__lasx_xvpickve2gr_du(sum_u64, 0)) +
+           uint64_t(__lasx_xvpickve2gr_du(sum_u64, 1)) +
+           uint64_t(__lasx_xvpickve2gr_du(sum_u64, 2)) +
+           uint64_t(__lasx_xvpickve2gr_du(sum_u64, 3));
+  }
+
+  template <unsigned N> simdutf_really_inline simd16 byte_right_shift() const {
+    return __lasx_xvbsrl_v(this->value, N);
   }
 };
 
@@ -13330,76 +12139,48 @@ template <typename T> struct simd16x32 {
     this->chunks[1].store(ptr + sizeof(simd16<T>) * 1 / sizeof(T));
   }
 
-  simdutf_really_inline uint64_t to_bitmask() const {
-    uint64_t r_lo = uint32_t(this->chunks[0].to_bitmask());
-    uint64_t r_hi = this->chunks[1].to_bitmask();
-    return r_lo | (r_hi << 32);
-  }
-
-  simdutf_really_inline simd16<T> reduce_or() const {
-    return this->chunks[0] | this->chunks[1];
-  }
-
-  simdutf_really_inline bool is_ascii() const {
-    return this->reduce_or().is_ascii();
-  }
-
-  simdutf_really_inline void store_ascii_as_utf16(char16_t *ptr) const {
-    this->chunks[0].store_ascii_as_utf16(ptr + sizeof(simd16<T>) * 0);
-    this->chunks[1].store_ascii_as_utf16(ptr + sizeof(simd16<T>));
-  }
-
-  simdutf_really_inline simd16x32<T> bit_or(const T m) const {
-    const simd16<T> mask = simd16<T>::splat(m);
-    return simd16x32<T>(this->chunks[0] | mask, this->chunks[1] | mask);
-  }
-
   simdutf_really_inline void swap_bytes() {
     this->chunks[0] = this->chunks[0].swap_bytes();
     this->chunks[1] = this->chunks[1].swap_bytes();
   }
-
-  simdutf_really_inline uint64_t eq(const T m) const {
-    const simd16<T> mask = simd16<T>::splat(m);
-    return simd16x32<bool>(this->chunks[0] == mask, this->chunks[1] == mask)
-        .to_bitmask();
-  }
-
-  simdutf_really_inline uint64_t eq(const simd16x32<uint16_t> &other) const {
-    return simd16x32<bool>(this->chunks[0] == other.chunks[0],
-                           this->chunks[1] == other.chunks[1])
-        .to_bitmask();
-  }
-
-  simdutf_really_inline uint64_t lteq(const T m) const {
-    const simd16<T> mask = simd16<T>::splat(m);
-    return simd16x32<bool>(this->chunks[0] <= mask, this->chunks[1] <= mask)
-        .to_bitmask();
-  }
-
-  simdutf_really_inline uint64_t in_range(const T low, const T high) const {
-    const simd16<T> mask_low = simd16<T>::splat(low);
-    const simd16<T> mask_high = simd16<T>::splat(high);
-
-    return simd16x32<bool>(
-               (this->chunks[0] <= mask_high) & (this->chunks[0] >= mask_low),
-               (this->chunks[1] <= mask_high) & (this->chunks[1] >= mask_low))
-        .to_bitmask();
-  }
-  simdutf_really_inline uint64_t not_in_range(const T low, const T high) const {
-    const simd16<T> mask_low = simd16<T>::splat(static_cast<T>(low - 1));
-    const simd16<T> mask_high = simd16<T>::splat(static_cast<T>(high + 1));
-    return simd16x32<bool>(
-               (this->chunks[0] >= mask_high) | (this->chunks[0] <= mask_low),
-               (this->chunks[1] >= mask_high) | (this->chunks[1] <= mask_low))
-        .to_bitmask();
-  }
-  simdutf_really_inline uint64_t lt(const T m) const {
-    const simd16<T> mask = simd16<T>::splat(m);
-    return simd16x32<bool>(this->chunks[0] < mask, this->chunks[1] < mask)
-        .to_bitmask();
-  }
 }; // struct simd16x32<T>
+
+simdutf_really_inline simd16<uint16_t> min(const simd16<uint16_t> a,
+                                           const simd16<uint16_t> b) {
+  return __lasx_xvmin_hu(a.value, b.value);
+}
+
+simdutf_really_inline simd16<bool> operator==(const simd16<uint16_t> a,
+                                              uint16_t b) {
+  const auto bv = __lasx_xvreplgr2vr_h(b);
+  return __lasx_xvseq_h(a.value, bv);
+}
+
+simdutf_really_inline simd16<uint16_t> as_vector_u16(const simd16<bool> x) {
+  return x.value;
+}
+
+simdutf_really_inline simd16<uint16_t> operator&(const simd16<uint16_t> a,
+                                                 uint16_t b) {
+  const auto bv = __lasx_xvreplgr2vr_h(b);
+  return __lasx_xvand_v(a.value, bv);
+}
+
+simdutf_really_inline simd16<uint16_t> operator&(const simd16<uint16_t> a,
+                                                 const simd16<uint16_t> b) {
+  return __lasx_xvand_v(a.value, b.value);
+}
+
+simdutf_really_inline simd16<uint16_t> operator^(const simd16<uint16_t> a,
+                                                 uint16_t b) {
+  const auto bv = __lasx_xvreplgr2vr_h(b);
+  return __lasx_xvxor_v(a.value, bv);
+}
+
+simdutf_really_inline simd16<bool> operator^(const simd16<bool> a,
+                                             const simd16<bool> b) {
+  return __lasx_xvxor_v(a.value, b.value);
+}
 /* end file src/simdutf/lasx/simd16-inl.h */
 /* begin file src/simdutf/lasx/simd32-inl.h */
 template <typename T> struct simd32;
@@ -13477,6 +12258,60 @@ simdutf_really_inline simd32<uint32_t> as_vector_u32(const simd32<bool> v) {
   return v.value;
 }
 /* end file src/simdutf/lasx/simd32-inl.h */
+/* begin file src/simdutf/lasx/simd64-inl.h */
+template <typename T> struct simd64;
+
+template <> struct simd64<uint64_t> {
+  __m256i value;
+  static const int SIZE = sizeof(value);
+  static const int ELEMENTS = SIZE / sizeof(uint64_t);
+
+  // constructors
+  simdutf_really_inline simd64(__m256i v) : value(v) {}
+
+  template <typename Ptr>
+  simdutf_really_inline simd64(Ptr *ptr) : value(__lasx_xvld(ptr, 0)) {}
+
+  // in-place operators
+  simdutf_really_inline simd64 &operator+=(const simd64 other) {
+    value = __lasx_xvadd_d(value, other.value);
+    return *this;
+  }
+
+  // members
+  simdutf_really_inline uint64_t sum() const {
+    return uint64_t(__lasx_xvpickve2gr_du(value, 0)) +
+           uint64_t(__lasx_xvpickve2gr_du(value, 1)) +
+           uint64_t(__lasx_xvpickve2gr_du(value, 2)) +
+           uint64_t(__lasx_xvpickve2gr_du(value, 3));
+  }
+
+  // static members
+  static simdutf_really_inline simd64<uint64_t> zero() {
+    return __lasx_xvrepli_d(0);
+  }
+};
+
+// ------------------------------------------------------------
+
+template <> struct simd64<bool> {
+  __m256i value;
+  static const int SIZE = sizeof(value);
+
+  // constructors
+  simdutf_really_inline simd64(__m256i v) : value(v) {}
+};
+
+// ------------------------------------------------------------
+
+simd64<uint64_t> sum_8bytes(const simd8<uint8_t> v) {
+  const auto sum_u16 = __lasx_xvhaddw_hu_bu(v, v);
+  const auto sum_u32 = __lasx_xvhaddw_wu_hu(sum_u16, sum_u16);
+  const auto sum_u64 = __lasx_xvhaddw_du_wu(sum_u32, sum_u32);
+
+  return simd64<uint64_t>(sum_u64);
+}
+/* end file src/simdutf/lasx/simd64-inl.h */
 
 } // namespace simd
 } // unnamed namespace
@@ -13577,6 +12412,10 @@ public:
       const char16_t *buf, size_t len) const noexcept final;
   simdutf_warn_unused result validate_utf16be_with_errors(
       const char16_t *buf, size_t len) const noexcept final;
+  void to_well_formed_utf16be(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
+  void to_well_formed_utf16le(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING
@@ -13848,6 +12687,9 @@ namespace {} // unnamed namespace
 #endif // SIMDUTF_IMPLEMENTATION_FALLBACK
 #endif // SIMDUTF_FALLBACK_H
 /* end file src/simdutf/fallback.h */
+#ifndef SIMDUTF_REGULAR_VISUAL_STUDIO
+SIMDUTF_POP_DISABLE_WARNINGS
+#endif
 
 // The scalar routines should be included once.
 /* begin file src/scalar/swap_bytes.h */
@@ -14371,6 +13213,48 @@ simdutf_warn_unused inline size_t trim_partial_utf16(const char16_t *input,
   return length;
 }
 
+template <endianness big_endian> bool is_high_surrogate(char16_t c) {
+  c = !match_system(big_endian) ? u16_swap_bytes(c) : c;
+  return (0xd800 <= c && c <= 0xdbff);
+}
+
+template <endianness big_endian> bool is_low_surrogate(char16_t c) {
+  c = !match_system(big_endian) ? u16_swap_bytes(c) : c;
+  return (0xdc00 <= c && c <= 0xdfff);
+}
+
+// variable templates are a C++14 extension
+template <endianness big_endian> char16_t replacement() {
+  return !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
+}
+
+template <endianness big_endian>
+void to_well_formed_utf16(const char16_t *input, size_t len, char16_t *output) {
+  const char16_t replacement = utf16::replacement<big_endian>();
+  bool high_surrogate_prev = false, high_surrogate, low_surrogate;
+  size_t i = 0;
+  for (; i < len; i++) {
+    char16_t c = input[i];
+    high_surrogate = is_high_surrogate<big_endian>(c);
+    low_surrogate = is_low_surrogate<big_endian>(c);
+    if (high_surrogate_prev && !low_surrogate) {
+      output[i - 1] = replacement;
+    }
+
+    if (!high_surrogate_prev && low_surrogate) {
+      output[i] = replacement;
+    } else {
+      output[i] = input[i];
+    }
+    high_surrogate_prev = high_surrogate;
+  }
+
+  /* string may not end with high surrogate */
+  if (high_surrogate_prev) {
+    output[i - 1] = replacement;
+  }
+}
+
 } // namespace utf16
 } // unnamed namespace
 } // namespace scalar
@@ -14523,30 +13407,42 @@ base64_tail_decode(char *dst, const char_type *src, size_t length,
                                              // '=', typically 0, 1, 2.
                    base64_options options,
                    last_chunk_handling_options last_chunk_options) {
-  // This looks like 5 branches, but we expect the compiler to resolve this to a
-  // single branch:
-  const uint8_t *to_base64 = (options & base64_url)
-                                 ? tables::base64::to_base64_url_value
-                                 : tables::base64::to_base64_value;
-  const uint32_t *d0 = (options & base64_url)
-                           ? tables::base64::base64_url::d0
-                           : tables::base64::base64_default::d0;
-  const uint32_t *d1 = (options & base64_url)
-                           ? tables::base64::base64_url::d1
-                           : tables::base64::base64_default::d1;
-  const uint32_t *d2 = (options & base64_url)
-                           ? tables::base64::base64_url::d2
-                           : tables::base64::base64_default::d2;
-  const uint32_t *d3 = (options & base64_url)
-                           ? tables::base64::base64_url::d3
-                           : tables::base64::base64_default::d3;
+
+  // This looks like 10 branches, but we expect the compiler to resolve this to
+  // two branches (easily predicted):
+  const uint8_t *to_base64 =
+      (options & base64_default_or_url)
+          ? tables::base64::to_base64_default_or_url_value
+          : ((options & base64_url) ? tables::base64::to_base64_url_value
+                                    : tables::base64::to_base64_value);
+  const uint32_t *d0 =
+      (options & base64_default_or_url)
+          ? tables::base64::base64_default_or_url::d0
+          : ((options & base64_url) ? tables::base64::base64_url::d0
+                                    : tables::base64::base64_default::d0);
+  const uint32_t *d1 =
+      (options & base64_default_or_url)
+          ? tables::base64::base64_default_or_url::d1
+          : ((options & base64_url) ? tables::base64::base64_url::d1
+                                    : tables::base64::base64_default::d1);
+  const uint32_t *d2 =
+      (options & base64_default_or_url)
+          ? tables::base64::base64_default_or_url::d2
+          : ((options & base64_url) ? tables::base64::base64_url::d2
+                                    : tables::base64::base64_default::d2);
+  const uint32_t *d3 =
+      (options & base64_default_or_url)
+          ? tables::base64::base64_default_or_url::d3
+          : ((options & base64_url) ? tables::base64::base64_url::d3
+                                    : tables::base64::base64_default::d3);
+  const bool ignore_garbage =
+      (options == base64_options::base64_url_accept_garbage) ||
+      (options == base64_options::base64_default_accept_garbage) ||
+      (options == base64_options::base64_default_or_url_accept_garbage);
 
   const char_type *srcend = src + length;
   const char_type *srcinit = src;
   const char *dstinit = dst;
-  const bool ignore_garbage =
-      (options == base64_options::base64_url_accept_garbage) ||
-      (options == base64_options::base64_default_accept_garbage);
 
   uint32_t x;
   size_t idx;
@@ -14679,7 +13575,7 @@ base64_tail_decode(char *dst, const char_type *src, size_t length,
 }
 
 // like base64_tail_decode, but it will not write past the end of the output
-// buffer. The outlen paramter is modified to reflect the number of bytes
+// buffer. The outlen parameter is modified to reflect the number of bytes
 // written. This functions assumes that the padding (=) has been removed.
 template <class char_type>
 result base64_tail_decode_safe(
@@ -14692,26 +13588,37 @@ result base64_tail_decode_safe(
     outlen = 0;
     return {SUCCESS, 0};
   }
-  // This looks like 5 branches, but we expect the compiler to resolve this to a
-  // single branch:
-  const uint8_t *to_base64 = (options & base64_url)
-                                 ? tables::base64::to_base64_url_value
-                                 : tables::base64::to_base64_value;
-  const uint32_t *d0 = (options & base64_url)
-                           ? tables::base64::base64_url::d0
-                           : tables::base64::base64_default::d0;
-  const uint32_t *d1 = (options & base64_url)
-                           ? tables::base64::base64_url::d1
-                           : tables::base64::base64_default::d1;
-  const uint32_t *d2 = (options & base64_url)
-                           ? tables::base64::base64_url::d2
-                           : tables::base64::base64_default::d2;
-  const uint32_t *d3 = (options & base64_url)
-                           ? tables::base64::base64_url::d3
-                           : tables::base64::base64_default::d3;
+  // This looks like 10 branches, but we expect the compiler to resolve this to
+  // two branches (easily predicted):
+  const uint8_t *to_base64 =
+      (options & base64_default_or_url)
+          ? tables::base64::to_base64_default_or_url_value
+          : ((options & base64_url) ? tables::base64::to_base64_url_value
+                                    : tables::base64::to_base64_value);
+  const uint32_t *d0 =
+      (options & base64_default_or_url)
+          ? tables::base64::base64_default_or_url::d0
+          : ((options & base64_url) ? tables::base64::base64_url::d0
+                                    : tables::base64::base64_default::d0);
+  const uint32_t *d1 =
+      (options & base64_default_or_url)
+          ? tables::base64::base64_default_or_url::d1
+          : ((options & base64_url) ? tables::base64::base64_url::d1
+                                    : tables::base64::base64_default::d1);
+  const uint32_t *d2 =
+      (options & base64_default_or_url)
+          ? tables::base64::base64_default_or_url::d2
+          : ((options & base64_url) ? tables::base64::base64_url::d2
+                                    : tables::base64::base64_default::d2);
+  const uint32_t *d3 =
+      (options & base64_default_or_url)
+          ? tables::base64::base64_default_or_url::d3
+          : ((options & base64_url) ? tables::base64::base64_url::d3
+                                    : tables::base64::base64_default::d3);
   const bool ignore_garbage =
       (options == base64_options::base64_url_accept_garbage) ||
-      (options == base64_options::base64_default_accept_garbage);
+      (options == base64_options::base64_default_accept_garbage) ||
+      (options == base64_options::base64_default_or_url_accept_garbage);
 
   const char_type *srcend = src + length;
   const char_type *srcinit = src;
@@ -17241,6 +16148,115 @@ inline size_t convert_valid(const char32_t *buf, size_t len,
 #include <initializer_list>
 #include <climits>
 #include <type_traits>
+#if SIMDUTF_ATOMIC_REF
+/* begin file src/scalar/atomic_util.h */
+#ifndef SIMDUTF_ATOMIC_UTIL_H
+#define SIMDUTF_ATOMIC_UTIL_H
+#if SIMDUTF_ATOMIC_REF
+  #include <atomic>
+namespace simdutf {
+namespace scalar {
+
+// This function is a memcpy that uses atomic operations to read from the
+// source.
+inline void memcpy_atomic_read(char *dst, const char *src, size_t len) {
+  static_assert(std::atomic_ref<char>::required_alignment == sizeof(char),
+                "std::atomic_ref requires the same alignment as char_type");
+  // We expect all 64-bit systems to be able to read 64-bit words from an
+  // aligned memory region atomically. You might be able to do better on
+  // specific systems, e.g., x64 systems can read 128-bit words atomically.
+  constexpr size_t alignment = sizeof(uint64_t);
+
+  // Lambda for atomic byte-by-byte copy
+  auto bbb_memcpy_atomic_read = [](char *bytedst, const char *bytesrc,
+                                   size_t bytelen) noexcept {
+    char *mutable_src = const_cast<char *>(bytesrc);
+    for (size_t j = 0; j < bytelen; ++j) {
+      bytedst[j] =
+          std::atomic_ref<char>(mutable_src[j]).load(std::memory_order_relaxed);
+    }
+  };
+
+  // Handle unaligned start
+  size_t offset = reinterpret_cast<std::uintptr_t>(src) % alignment;
+  if (offset) {
+    size_t to_align = std::min(len, alignment - offset);
+    bbb_memcpy_atomic_read(dst, src, to_align);
+    src += to_align;
+    dst += to_align;
+    len -= to_align;
+  }
+
+  // Process aligned 64-bit chunks
+  while (len >= alignment) {
+    auto *src_aligned = reinterpret_cast<uint64_t *>(const_cast<char *>(src));
+    const auto dst_value =
+        std::atomic_ref<uint64_t>(*src_aligned).load(std::memory_order_relaxed);
+    std::memcpy(dst, &dst_value, sizeof(uint64_t));
+    src += alignment;
+    dst += alignment;
+    len -= alignment;
+  }
+
+  // Handle remaining bytes
+  if (len) {
+    bbb_memcpy_atomic_read(dst, src, len);
+  }
+}
+
+// This function is a memcpy that uses atomic operations to write to the
+// destination.
+inline void memcpy_atomic_write(char *dst, const char *src, size_t len) {
+  static_assert(std::atomic_ref<char>::required_alignment == sizeof(char),
+                "std::atomic_ref requires the same alignment as char");
+  // We expect all 64-bit systems to be able to write 64-bit words to an aligned
+  // memory region atomically.
+  // You might be able to do better on specific systems, e.g., x64 systems can
+  // write 128-bit words atomically.
+  constexpr size_t alignment = sizeof(uint64_t);
+
+  // Lambda for atomic byte-by-byte write
+  auto bbb_memcpy_atomic_write = [](char *bytedst, const char *bytesrc,
+                                    size_t bytelen) noexcept {
+    for (size_t j = 0; j < bytelen; ++j) {
+      std::atomic_ref<char>(bytedst[j])
+          .store(bytesrc[j], std::memory_order_relaxed);
+    }
+  };
+
+  // Handle unaligned start
+  size_t offset = reinterpret_cast<std::uintptr_t>(dst) % alignment;
+  if (offset) {
+    size_t to_align = std::min(len, alignment - offset);
+    bbb_memcpy_atomic_write(dst, src, to_align);
+    dst += to_align;
+    src += to_align;
+    len -= to_align;
+  }
+
+  // Process aligned 64-bit chunks
+  while (len >= alignment) {
+    auto *dst_aligned = reinterpret_cast<uint64_t *>(dst);
+    uint64_t src_val;
+    std::memcpy(&src_val, src, sizeof(uint64_t)); // Non-atomic read from src
+    std::atomic_ref<uint64_t>(*dst_aligned)
+        .store(src_val, std::memory_order_relaxed);
+    dst += alignment;
+    src += alignment;
+    len -= alignment;
+  }
+
+  // Handle remaining bytes
+  if (len) {
+    bbb_memcpy_atomic_write(dst, src, len);
+  }
+}
+} // namespace scalar
+} // namespace simdutf
+#endif // SIMDUTF_ATOMIC_REF
+#endif // SIMDUTF_ATOMIC_UTIL_H
+/* end file src/scalar/atomic_util.h */
+#endif
 
 static_assert(sizeof(uint8_t) == sizeof(char),
               "simdutf requires that uint8_t be a char");
@@ -17505,6 +16521,14 @@ public:
   simdutf_warn_unused result validate_utf16be_with_errors(
       const char16_t *buf, size_t len) const noexcept final override {
     return set_best()->validate_utf16be_with_errors(buf, len);
+  }
+  void to_well_formed_utf16be(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final override {
+    return set_best()->to_well_formed_utf16be(input, len, output);
+  }
+  void to_well_formed_utf16le(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final override {
+    return set_best()->to_well_formed_utf16le(input, len, output);
   }
 #endif // SIMDUTF_FEATURE_UTF16
 
@@ -18084,6 +17108,10 @@ public:
       const char16_t *, size_t) const noexcept final override {
     return result(error_code::OTHER, 0);
   }
+  void to_well_formed_utf16be(const char16_t *, size_t,
+                              char16_t *) const noexcept final override {}
+  void to_well_formed_utf16le(const char16_t *, size_t,
+                              char16_t *) const noexcept final override {}
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING
@@ -18711,6 +17739,24 @@ simdutf_warn_unused bool validate_utf16(const char16_t *buf,
   return validate_utf16le(buf, len);
   #endif
 }
+void to_well_formed_utf16be(const char16_t *input, size_t len,
+                            char16_t *output) noexcept {
+  return get_default_implementation()->to_well_formed_utf16be(input, len,
+                                                              output);
+}
+void to_well_formed_utf16le(const char16_t *input, size_t len,
+                            char16_t *output) noexcept {
+  return get_default_implementation()->to_well_formed_utf16le(input, len,
+                                                              output);
+}
+void to_well_formed_utf16(const char16_t *input, size_t len,
+                          char16_t *output) noexcept {
+  #if SIMDUTF_IS_BIG_ENDIAN
+  to_well_formed_utf16be(input, len, output);
+  #else
+  to_well_formed_utf16le(input, len, output);
+  #endif
+}
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
@@ -18718,6 +17764,69 @@ simdutf_warn_unused bool validate_utf16le(const char16_t *buf,
                                           size_t len) noexcept {
   return get_default_implementation()->validate_utf16le(buf, len);
 }
+
+  #if SIMDUTF_ATOMIC_REF
+template <typename char_type>
+simdutf_warn_unused result atomic_base64_to_binary_safe_impl(
+    const char_type *input, size_t length, char *output, size_t &outlen,
+    base64_options options,
+    last_chunk_handling_options last_chunk_handling_options,
+    bool decode_up_to_bad_char) noexcept {
+    #if defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
+  // We use a smaller buffer during fuzzing to more easily detect bugs.
+  constexpr size_t buffer_size = 128;
+    #else
+  // Arbitrary block sizes: 4KB for input.
+  constexpr size_t buffer_size = 4096;
+    #endif
+  std::array<char, buffer_size> temp_buffer;
+  const char_type *input_init = input;
+  size_t actual_out = 0;
+  while (true) {
+    const bool last_chunk = (temp_buffer.size() >= outlen - actual_out);
+    size_t temp_outlen = (std::min)(temp_buffer.size(), outlen - actual_out);
+    result r = base64_to_binary_safe(
+        input, length, temp_buffer.data(), temp_outlen, options,
+        last_chunk_handling_options, decode_up_to_bad_char);
+    // We wrote temp_outlen bytes to temp_buffer.
+    // We need to copy them to output.
+    // Copy with relaxed atomic operations to the output
+    simdutf::scalar::memcpy_atomic_write(output + actual_out,
+                                         temp_buffer.data(), temp_outlen);
+    actual_out += temp_outlen;
+    length -= r.count;
+    input += r.count;
+
+    // If we are done, return the result, the only case where
+    // we are not done is when we ran out of space in output.
+    if (last_chunk || r.error != error_code::OUTPUT_BUFFER_TOO_SMALL) {
+      outlen = actual_out;
+      r.count = size_t(input - input_init);
+      return r;
+    }
+  }
+}
+
+simdutf_warn_unused result atomic_base64_to_binary_safe(
+    const char *input, size_t length, char *output, size_t &outlen,
+    base64_options options,
+    last_chunk_handling_options last_chunk_handling_options,
+    bool decode_up_to_bad_char) noexcept {
+  return atomic_base64_to_binary_safe_impl<char>(
+      input, length, output, outlen, options, last_chunk_handling_options,
+      decode_up_to_bad_char);
+}
+simdutf_warn_unused result atomic_base64_to_binary_safe(
+    const char16_t *input, size_t length, char *output, size_t &outlen,
+    base64_options options,
+    last_chunk_handling_options last_chunk_handling_options,
+    bool decode_up_to_bad_char) noexcept {
+  return atomic_base64_to_binary_safe_impl<char16_t>(
+      input, length, output, outlen, options, last_chunk_handling_options,
+      decode_up_to_bad_char);
+}
+  #endif // SIMDUTF_ATOMIC_REF
+
 #endif // SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
 
 #if SIMDUTF_FEATURE_UTF16
@@ -18965,6 +18074,16 @@ simdutf_warn_unused size_t convert_utf32_to_latin1(
   return get_default_implementation()->convert_utf32_to_latin1(input, length,
                                                                latin1_output);
 }
+simdutf_warn_unused result convert_utf32_to_latin1_with_errors(
+    const char32_t *input, size_t length, char *latin1_buffer) noexcept {
+  return get_default_implementation()->convert_utf32_to_latin1_with_errors(
+      input, length, latin1_buffer);
+}
+simdutf_warn_unused size_t convert_valid_utf32_to_latin1(
+    const char32_t *input, size_t length, char *latin1_buffer) noexcept {
+  return get_default_implementation()->convert_valid_utf32_to_latin1(
+      input, length, latin1_buffer);
+}
 #endif // SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
@@ -19208,10 +18327,77 @@ simdutf_warn_unused result base64_to_binary(
 }
 
 template <typename chartype>
+simdutf_warn_unused result slow_base64_to_binary_safe_impl(
+    const chartype *input, size_t length, char *output, size_t &outlen,
+    base64_options options,
+    last_chunk_handling_options last_chunk_options) noexcept {
+  const bool ignore_garbage = (options & base64_default_accept_garbage) != 0;
+  while (length > 0 &&
+         scalar::base64::is_ascii_white_space(input[length - 1])) {
+    length--;
+  }
+  size_t equallocation =
+      length; // location of the first padding character if any
+  size_t equalsigns = 0;
+  if (length > 0 && input[length - 1] == '=') {
+    equallocation = length - 1;
+    length -= 1;
+    equalsigns++;
+    while (length > 0 &&
+           scalar::base64::is_ascii_white_space(input[length - 1])) {
+      length--;
+    }
+    if (length > 0 && input[length - 1] == '=') {
+      equallocation = length - 1;
+      equalsigns++;
+      length -= 1;
+    }
+  }
+  if (length == 0) {
+    outlen = 0;
+    if (!ignore_garbage && equalsigns > 0) {
+      if (last_chunk_options == last_chunk_handling_options::strict) {
+        return {BASE64_INPUT_REMAINDER, 0};
+      } else if (last_chunk_options ==
+                 last_chunk_handling_options::stop_before_partial) {
+        return {SUCCESS, 0};
+      }
+      return {INVALID_BASE64_CHARACTER, equallocation};
+    }
+    return {SUCCESS, 0};
+  }
+
+  // The parameters of base64_tail_decode_safe are:
+  // - dst: the output buffer
+  // - outlen: the size of the output buffer, modified to the number of
+  //   bytes written to the output buffer
+  // - srcr: the input buffer
+  // - length: the size of the input buffer
+  // - padded_characters: the number of padding characters
+  // - options: the options for the base64 decoder
+  // - last_chunk_options: the options for the last chunk
+  // The function will return the number of bytes written to the output buffer
+  // and the number of bytes read from the input buffer.
+  // The function will also return an error code if the input buffer is not
+  // valid base64.
+  result r = scalar::base64::base64_tail_decode_safe(
+      output, outlen, input, length, equalsigns, options, last_chunk_options);
+  if (last_chunk_options != stop_before_partial &&
+      r.error == error_code::SUCCESS && equalsigns > 0) {
+    // additional checks
+    if ((outlen % 3 == 0) || ((outlen % 3) + 1 + equalsigns != 4)) {
+      r.error = error_code::INVALID_BASE64_CHARACTER;
+    }
+  }
+  return r;
+}
+
+template <typename chartype>
 simdutf_warn_unused result base64_to_binary_safe_impl(
     const chartype *input, size_t length, char *output, size_t &outlen,
     base64_options options,
-    last_chunk_handling_options last_chunk_handling_options) noexcept {
+    last_chunk_handling_options last_chunk_handling_options,
+    bool decode_up_to_bad_char) noexcept {
   static_assert(std::is_same<chartype, char>::value ||
                     std::is_same<chartype, char16_t>::value,
                 "Only char and char16_t are supported.");
@@ -19222,6 +18408,14 @@ simdutf_warn_unused result base64_to_binary_safe_impl(
     // fast path
     full_result r = get_default_implementation()->base64_to_binary_details(
         input, length, output, options, last_chunk_handling_options);
+    if (decode_up_to_bad_char &&
+        r.error == error_code::INVALID_BASE64_CHARACTER) {
+      // We need to use the slow path because we want to make sure that
+      // we write as much data as possible to the output buffer to meet
+      // the requirements of the JavaScript standard.
+      return slow_base64_to_binary_safe_impl(
+          input, length, output, outlen, options, last_chunk_handling_options);
+    }
     if (r.error != error_code::INVALID_BASE64_CHARACTER &&
         r.error != error_code::BASE64_EXTRA_BITS) {
       outlen = r.output_count;
@@ -19249,8 +18443,15 @@ simdutf_warn_unused result base64_to_binary_safe_impl(
   size_t outlen3 = outlen / 3 * 3; // round down to multiple of 3
   size_t safe_input = base64_length_from_binary(outlen3, options);
   full_result r = get_default_implementation()->base64_to_binary_details(
-      input, safe_input, output, options, loose);
+      input, safe_input, output, options, last_chunk_handling_options);
   if (r.error == error_code::INVALID_BASE64_CHARACTER) {
+    if (decode_up_to_bad_char) { // We need to use the slow path because we want
+                                 // to make sure that
+      // we write as much data as possible to the output buffer to meet
+      // the requirements of the JavaScript standard.
+      return slow_base64_to_binary_safe_impl(
+          input, length, output, outlen, options, last_chunk_handling_options);
+    }
     return r;
   }
   size_t offset =
@@ -19304,53 +18505,40 @@ simdutf_warn_unused result base64_to_binary_safe_impl(
       rr.error = error_code::INVALID_BASE64_CHARACTER;
     }
   }
-  if (rr.error == error_code::SUCCESS &&
-      last_chunk_handling_options == stop_before_partial) {
-    if (tail_input > input + input_index) {
-      rr.count = tail_input - input;
-    } else if (r.input_count > 0) {
-      rr.count = r.input_count + rr.count;
+  if (rr.error == error_code::SUCCESS) {
+    if (last_chunk_handling_options == stop_before_partial) {
+      if (tail_input > input + input_index) {
+        rr.count = tail_input - input;
+      } else if (r.input_count > 0) {
+        rr.count = r.input_count + rr.count;
+      }
+      return rr;
     }
-    return rr;
+    rr.count = length;
+  } else {
+    rr.count += input_index;
   }
-  rr.count += input_index;
   return rr;
 }
 
   #if SIMDUTF_ATOMIC_REF
 size_t atomic_binary_to_base64(const char *input, size_t length, char *output,
                                base64_options options) noexcept {
-  static_assert(std::atomic_ref<char>::required_alignment == 1);
   size_t retval = 0;
-  // Arbitrary block sizes: 3KB for input, 4KB for output. Total is 7KB.
+    #if defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
+  // We use a smaller buffer during fuzzing to more easily detect bugs.
+  constexpr size_t input_block_size = 128 * 3;
+    #else
+  // Arbitrary block sizes: 3KB for input which produces 4KB in output.
   constexpr size_t input_block_size = 1024 * 3;
-  constexpr size_t output_block_size = input_block_size * 4 / 3;
+    #endif
   std::array<char, input_block_size> inbuf;
-  std::array<char, output_block_size> outbuf;
-
-  // std::atomic_ref<T> must not have a const T, see
-  // https://cplusplus.github.io/LWG/issue3508
-  // we instead provide a mutable input, which is ok since we are only reading
-  // from it.
-  char *mutable_input = const_cast<char *>(input);
-
   for (size_t i = 0; i < length; i += input_block_size) {
     const size_t current_block_size = std::min(input_block_size, length - i);
-    // This copy is inefficient.
-    // Under x64, we could use 16-byte aligned loads.
-    // Note that we warn users that the performance might be poor.
-    for (size_t j = 0; j < current_block_size; ++j) {
-      inbuf[j] = std::atomic_ref<char>(mutable_input[i + j])
-                     .load(std::memory_order_relaxed);
-    }
+    simdutf::scalar::memcpy_atomic_read(inbuf.data(), input + i,
+                                        current_block_size);
     const size_t written = binary_to_base64(inbuf.data(), current_block_size,
-                                            outbuf.data(), options);
-    // This copy is inefficient.
-    // Under x64, we could use 16-byte aligned stores.
-    for (size_t j = 0; j < written; ++j) {
-      std::atomic_ref<char>(output[retval + j])
-          .store(outbuf[j], std::memory_order_relaxed);
-    }
+                                            output + retval, options);
     retval += written;
   }
   return retval;
@@ -19388,19 +18576,23 @@ simdutf_warn_unused size_t convert_latin1_to_utf8_safe(
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_BASE64
-simdutf_warn_unused result base64_to_binary_safe(
-    const char *input, size_t length, char *output, size_t &outlen,
-    base64_options options,
-    last_chunk_handling_options last_chunk_handling_options) noexcept {
+simdutf_warn_unused result
+base64_to_binary_safe(const char *input, size_t length, char *output,
+                      size_t &outlen, base64_options options,
+                      last_chunk_handling_options last_chunk_handling_options,
+                      bool decode_up_to_bad_char) noexcept {
   return base64_to_binary_safe_impl<char>(input, length, output, outlen,
-                                          options, last_chunk_handling_options);
+                                          options, last_chunk_handling_options,
+                                          decode_up_to_bad_char);
 }
-simdutf_warn_unused result base64_to_binary_safe(
-    const char16_t *input, size_t length, char *output, size_t &outlen,
-    base64_options options,
-    last_chunk_handling_options last_chunk_handling_options) noexcept {
+simdutf_warn_unused result
+base64_to_binary_safe(const char16_t *input, size_t length, char *output,
+                      size_t &outlen, base64_options options,
+                      last_chunk_handling_options last_chunk_handling_options,
+                      bool decode_up_to_bad_char) noexcept {
   return base64_to_binary_safe_impl<char16_t>(
-      input, length, output, outlen, options, last_chunk_handling_options);
+      input, length, output, outlen, options, last_chunk_handling_options,
+      decode_up_to_bad_char);
 }
 
 simdutf_warn_unused size_t
@@ -19582,6 +18774,195 @@ convert_utf8_1_to_2_byte_to_utf16(uint8x16_t in, size_t shufutf8_idx) {
 #endif // SIMDUTF_FEATURE_UTF8 && (SIMDUTF_FEATURE_UTF16 ||
        // SIMDUTF_FEATURE_UTF32)
 
+#if SIMDUTF_FEATURE_UTF16
+/* begin file src/arm64/arm_utf16fix.cpp */
+
+/*
+ * Returns if a vector of type uint8x16_t is all zero.
+ */
+simdutf_really_inline int veq_non_zero(uint8x16_t v) {
+  // might compile to two instructions:
+  //	umaxv   s0, v0.4s
+  //	fmov	w0, s0
+  // On Apple hardware, they both have a latency of 3 cycles, with a throughput
+  // of four instructions per cycle. So that's 6 cycles of latency (!!!) for the
+  // two instructions. A narrowing shift has the same latency and throughput.
+  return vmaxvq_u32(vreinterpretq_u32_u8(v));
+}
+
+/*
+ * Process one block of 16 characters.  If in_place is false,
+ * copy the block from in to out.  If there is a sequencing
+ * error in the block, overwrite the illsequenced characters
+ * with the replacement character.  This function reads one
+ * character before the beginning of the buffer as a lookback.
+ * If that character is illsequenced, it too is overwritten.
+ */
+template <endianness big_endian, bool inplace>
+void utf16fix_block(char16_t *out, const char16_t *in) {
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
+  uint8x16x2_t lb, block;
+  uint8x16_t lb_masked, block_masked, lb_is_high, block_is_low;
+  uint8x16_t illseq;
+
+  const int idx = !match_system(big_endian) ? 0 : 1;
+
+  /* TODO: compute lookback using shifts */
+  lb = vld2q_u8((const uint8_t *)(in - 1));
+  block = vld2q_u8((const uint8_t *)in);
+  lb_masked = vandq_u8(lb.val[idx], vdupq_n_u8(0xfc));
+  block_masked = vandq_u8(block.val[idx], vdupq_n_u8(0xfc));
+  lb_is_high = vceqq_u8(lb_masked, vdupq_n_u8(0xd8));
+  block_is_low = vceqq_u8(block_masked, vdupq_n_u8(0xdc));
+
+  illseq = veorq_u8(lb_is_high, block_is_low);
+  if (veq_non_zero(illseq)) {
+    uint8x16_t lb_illseq, block_illseq;
+    char16_t lbc;
+    int ill;
+
+    /* compute the cause of the illegal sequencing */
+    lb_illseq = vbicq_u8(lb_is_high, block_is_low);
+    block_illseq = vorrq_u8(vbicq_u8(block_is_low, lb_is_high),
+                            vextq_u8(lb_illseq, vdupq_n_u8(0), 1));
+
+    /* fix illegal sequencing in the lookback */
+    ill = vgetq_lane_u8(lb_illseq, 0);
+    lbc = out[-1];
+    out[-1] = ill ? replacement : lbc;
+
+    /* fix illegal sequencing in the main block */
+    if (!match_system(big_endian)) {
+      block.val[1] = vbslq_u8(block_illseq, vdupq_n_u8(0xfd), block.val[1]);
+      block.val[0] = vorrq_u8(block_illseq, block.val[0]);
+    } else {
+      block.val[0] = vbslq_u8(block_illseq, vdupq_n_u8(0xfd), block.val[0]);
+      block.val[1] = vorrq_u8(block_illseq, block.val[1]);
+    }
+
+    vst2q_u8((uint8_t *)out, block);
+  } else if (!inplace) {
+    vst2q_u8((uint8_t *)out, block);
+  }
+}
+
+template <endianness big_endian, bool inplace>
+uint8x16_t get_mismatch_copy(const char16_t *in, char16_t *out) {
+  const int idx = !match_system(big_endian) ? 0 : 1;
+  uint8x16x2_t lb = vld2q_u8((const uint8_t *)(in - 1));
+  uint8x16x2_t block = vld2q_u8((const uint8_t *)in);
+  uint8x16_t lb_masked = vandq_u8(lb.val[idx], vdupq_n_u8(0xfc));
+  uint8x16_t block_masked = vandq_u8(block.val[idx], vdupq_n_u8(0xfc));
+  uint8x16_t lb_is_high = vceqq_u8(lb_masked, vdupq_n_u8(0xd8));
+  uint8x16_t block_is_low = vceqq_u8(block_masked, vdupq_n_u8(0xdc));
+  uint8x16_t illseq = veorq_u8(lb_is_high, block_is_low);
+  if (!inplace) {
+    vst2q_u8((uint8_t *)out, block);
+  }
+  return illseq;
+}
+
+simdutf_really_inline uint64_t get_mask(uint8x16_t illse0, uint8x16_t illse1,
+                                        uint8x16_t illse2, uint8x16_t illse3) {
+#ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
+  uint8x16_t bit_mask =
+      simdutf_make_uint8x16_t(0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80,
+                              0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80);
+#else
+  uint8x16_t bit_mask = {0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80,
+                         0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80};
+#endif
+  uint8x16_t sum0 =
+      vpaddq_u8(vandq_u8(illse0, bit_mask), vandq_u8(illse1, bit_mask));
+  uint8x16_t sum1 =
+      vpaddq_u8(vandq_u8(illse2, bit_mask), vandq_u8(illse3, bit_mask));
+  sum0 = vpaddq_u8(sum0, sum1);
+  sum0 = vpaddq_u8(sum0, sum0);
+  return vgetq_lane_u64(vreinterpretq_u64_u8(sum0), 0);
+}
+
+// The idea is to process 64 characters at a time, and if there is a mismatch
+// we can fix it with a bit of scalar code. When the input is correct, this
+// function might be faster than alternative implementations working on small
+// blocks of input.
+template <endianness big_endian, bool inplace>
+bool utf16fix_block64(char16_t *out, const char16_t *in) {
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
+
+  uint8x16_t illse0 = inplace ? get_mismatch_copy<big_endian, true>(in, out)
+                              : get_mismatch_copy<big_endian, false>(in, out);
+  uint8x16_t illse1 =
+      inplace ? get_mismatch_copy<big_endian, true>(in + 16, out + 16)
+              : get_mismatch_copy<big_endian, false>(in + 16, out + 16);
+  uint8x16_t illse2 =
+      inplace ? get_mismatch_copy<big_endian, true>(in + 32, out + 32)
+              : get_mismatch_copy<big_endian, false>(in + 32, out + 32);
+  uint8x16_t illse3 =
+      inplace ? get_mismatch_copy<big_endian, true>(in + 48, out + 48)
+              : get_mismatch_copy<big_endian, false>(in + 48, out + 48);
+  // this branch could be marked as unlikely:
+  if (veq_non_zero(
+          vorrq_u8(vorrq_u8(illse0, illse1), vorrq_u8(illse2, illse3)))) {
+    uint64_t matches = get_mask(illse0, illse1, illse2, illse3);
+    // Given that ARM has a fast bitreverse instruction, we can
+    // reverse once and then use clz to find the first bit set.
+    // It is how it is done in simdjson and *might* be beneficial.
+    //
+    // We might also proceed in reverse to reduce the RAW hazard,
+    // but it might require more instructions.
+
+    while (matches != 0) {
+      int r = trailing_zeroes(matches); // generates rbit + clz
+      // Either we have a high surrogate followed by a non-low surrogate
+      // or we have a low surrogate not preceded by a high surrogate.
+      bool is_high = scalar::utf16::is_high_surrogate<big_endian>(in[r - 1]);
+      out[r - is_high] = replacement;
+      matches = clear_least_significant_bit(matches);
+    }
+    return false;
+  }
+  return true;
+}
+
+template <endianness big_endian>
+void utf16fix_neon_64bits(const char16_t *in, size_t n, char16_t *out) {
+  size_t i;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
+  if (n < 17) {
+    return scalar::utf16::to_well_formed_utf16<big_endian>(in, n, out);
+  }
+  out[0] =
+      scalar::utf16::is_low_surrogate<big_endian>(in[0]) ? replacement : in[0];
+  i = 1;
+
+  /* duplicate code to have the compiler specialise utf16fix_block() */
+  if (in == out) {
+    for (i = 1; i + 64 < n; i += 64) {
+      utf16fix_block64<big_endian, true>(out + i, in + i);
+    }
+
+    for (; i + 16 < n; i += 16) {
+      utf16fix_block<big_endian, true>(out + i, in + i);
+    }
+
+    /* tbd: find carry */
+    utf16fix_block<big_endian, true>(out + n - 16, in + n - 16);
+  } else {
+    for (i = 1; i + 64 < n; i += 64) {
+      utf16fix_block64<big_endian, false>(out + i, in + i);
+    }
+    for (; i + 16 < n; i += 16) {
+      utf16fix_block<big_endian, false>(out + i, in + i);
+    }
+
+    utf16fix_block<big_endian, false>(out + n - 16, in + n - 16);
+  }
+  out[n - 1] = scalar::utf16::is_high_surrogate<big_endian>(out[n - 1])
+                   ? replacement
+                   : out[n - 1];
+}
+/* end file src/arm64/arm_utf16fix.cpp */
+#endif // SIMDUTF_FEATURE_UTF16
 #if SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
 /* begin file src/arm64/arm_validate_utf16.cpp */
 template <endianness big_endian>
@@ -21488,6 +20869,26 @@ size_t encode_base64(char *dst, const char *src, size_t srclen,
     vst4q_u8(out, result);
     out += 64;
   }
+
+  if (i + 24 <= srclen) {
+    const uint8x8_t v3f_d = vdup_n_u8(0x3f);
+    const uint8x8x3_t in = vld3_u8((const uint8_t *)src + i);
+    uint8x8x4_t result;
+    result.val[0] = vshr_n_u8(in.val[0], 2);
+    result.val[1] =
+        vand_u8(vsli_n_u8(vshr_n_u8(in.val[1], 4), in.val[0], 4), v3f_d);
+    result.val[2] =
+        vand_u8(vsli_n_u8(vshr_n_u8(in.val[2], 6), in.val[1], 2), v3f_d);
+    result.val[3] = vand_u8(in.val[2], v3f_d);
+    result.val[0] = vqtbl4_u8(table, result.val[0]);
+    result.val[1] = vqtbl4_u8(table, result.val[1]);
+    result.val[2] = vqtbl4_u8(table, result.val[2]);
+    result.val[3] = vqtbl4_u8(table, result.val[3]);
+    vst4_u8(out, result);
+    out += 32;
+    i += 24;
+  }
+
   out += scalar::base64::tail_encode_base64((char *)out, src + i, srclen - i,
                                             options);
 
@@ -21529,21 +20930,10 @@ struct block64 {
 };
 
 static_assert(sizeof(block64) == 64, "block64 is not 64 bytes");
-template <bool base64_url> uint64_t to_base64_mask(block64 *b, bool *error) {
+template <bool base64_url, bool default_or_url>
+uint64_t to_base64_mask(block64 *b, bool *error) {
   uint8x16_t v0f = vdupq_n_u8(0xf);
-
-  uint8x16_t underscore0, underscore1, underscore2, underscore3;
-  if (base64_url) {
-    underscore0 = vceqq_u8(b->chunks[0], vdupq_n_u8(0x5f));
-    underscore1 = vceqq_u8(b->chunks[1], vdupq_n_u8(0x5f));
-    underscore2 = vceqq_u8(b->chunks[2], vdupq_n_u8(0x5f));
-    underscore3 = vceqq_u8(b->chunks[3], vdupq_n_u8(0x5f));
-  } else {
-    (void)underscore0;
-    (void)underscore1;
-    (void)underscore2;
-    (void)underscore3;
-  }
+  uint8x16_t v01 = vdupq_n_u8(0x1);
 
   uint8x16_t lo_nibbles0 = vandq_u8(b->chunks[0], v0f);
   uint8x16_t lo_nibbles1 = vandq_u8(b->chunks[1], v0f);
@@ -21551,28 +20941,35 @@ template <bool base64_url> uint64_t to_base64_mask(block64 *b, bool *error) {
   uint8x16_t lo_nibbles3 = vandq_u8(b->chunks[3], v0f);
 
   // Needed by the decoding step.
-  uint8x16_t hi_nibbles0 = vshrq_n_u8(b->chunks[0], 4);
-  uint8x16_t hi_nibbles1 = vshrq_n_u8(b->chunks[1], 4);
-  uint8x16_t hi_nibbles2 = vshrq_n_u8(b->chunks[2], 4);
-  uint8x16_t hi_nibbles3 = vshrq_n_u8(b->chunks[3], 4);
+  uint8x16_t hi_bits0 = vshrq_n_u8(b->chunks[0], 3);
+  uint8x16_t hi_bits1 = vshrq_n_u8(b->chunks[1], 3);
+  uint8x16_t hi_bits2 = vshrq_n_u8(b->chunks[2], 3);
+  uint8x16_t hi_bits3 = vshrq_n_u8(b->chunks[3], 3);
   uint8x16_t lut_lo;
 #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
-  if (base64_url) {
+  if (default_or_url) {
     lut_lo =
-        simdutf_make_uint8x16_t(0x3a, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70,
-                                0x70, 0x61, 0xe1, 0xf4, 0xe5, 0xa5, 0xf4, 0xf4);
+        simdutf_make_uint8x16_t(0x15, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c,
+                                0x1c, 0x1d, 0x19, 0x12, 0x11, 0x13, 0x10, 0x32);
+  } else if (base64_url) {
+    lut_lo =
+        simdutf_make_uint8x16_t(0x15, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c,
+                                0x1c, 0x1d, 0x19, 0x10, 0x11, 0x13, 0x10, 0x30);
   } else {
     lut_lo =
-        simdutf_make_uint8x16_t(0x3a, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70,
-                                0x70, 0x61, 0xe1, 0xb4, 0xe5, 0xe5, 0xf4, 0xb4);
+        simdutf_make_uint8x16_t(0x15, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c,
+                                0x1c, 0x1d, 0x19, 0x12, 0x11, 0x11, 0x10, 0x12);
   }
 #else
-  if (base64_url) {
-    lut_lo = uint8x16_t{0x3a, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70,
-                        0x70, 0x61, 0xe1, 0xf4, 0xe5, 0xa5, 0xf4, 0xf4};
+  if (default_or_url) {
+    lut_lo = uint8x16_t{0x15, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c,
+                        0x1c, 0x1d, 0x19, 0x12, 0x11, 0x13, 0x10, 0x32};
+  } else if (base64_url) {
+    lut_lo = uint8x16_t{0x15, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c,
+                        0x1c, 0x1d, 0x19, 0x10, 0x11, 0x13, 0x10, 0x30};
   } else {
-    lut_lo = uint8x16_t{0x3a, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70,
-                        0x70, 0x61, 0xe1, 0xb4, 0xe5, 0xe5, 0xf4, 0xb4};
+    lut_lo = uint8x16_t{0x15, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c, 0x1c,
+                        0x1c, 0x1d, 0x19, 0x12, 0x11, 0x11, 0x10, 0x12};
   }
 #endif
   uint8x16_t lo0 = vqtbl1q_u8(lut_lo, lo_nibbles0);
@@ -21581,39 +20978,44 @@ template <bool base64_url> uint64_t to_base64_mask(block64 *b, bool *error) {
   uint8x16_t lo3 = vqtbl1q_u8(lut_lo, lo_nibbles3);
   uint8x16_t lut_hi;
 #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
-  if (base64_url) {
+  if (default_or_url) {
     lut_hi =
-        simdutf_make_uint8x16_t(0x11, 0x20, 0x42, 0x80, 0x8, 0x4, 0x8, 0x4,
-                                0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20);
+        simdutf_make_uint8x16_t(0x0, 0x1, 0x0, 0x0, 0x1, 0x2, 0x4, 0x4, 0x8,
+                                0x10, 0x10, 0x28, 0x8, 0x10, 0x10, 0x8);
+  } else if (base64_url) {
+    lut_hi =
+        simdutf_make_uint8x16_t(0x0, 0x1, 0x0, 0x0, 0x1, 0x2, 0x4, 0x4, 0x8,
+                                0x10, 0x10, 0x28, 0x8, 0x10, 0x10, 0x8);
   } else {
     lut_hi =
-        simdutf_make_uint8x16_t(0x11, 0x20, 0x42, 0x80, 0x8, 0x4, 0x8, 0x4,
-                                0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20);
+        simdutf_make_uint8x16_t(0x0, 0x1, 0x0, 0x0, 0x1, 0x2, 0x4, 0x4, 0x8,
+                                0x10, 0x10, 0x8, 0x8, 0x10, 0x10, 0x8);
   }
 #else
-  if (base64_url) {
-    lut_hi = uint8x16_t{0x11, 0x20, 0x42, 0x80, 0x8,  0x4,  0x8,  0x4,
-                        0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20};
+  if (default_or_url) {
+    lut_hi = uint8x16_t{0x0, 0x1,  0x0,  0x0,  0x1, 0x2,  0x4,  0x4,
+                        0x8, 0x10, 0x10, 0x28, 0x8, 0x10, 0x10, 0x8};
+  } else if (base64_url) {
+    lut_hi = uint8x16_t{0x0, 0x1,  0x0,  0x0,  0x1, 0x2,  0x4,  0x4,
+                        0x8, 0x10, 0x10, 0x28, 0x8, 0x10, 0x10, 0x8};
   } else {
-    lut_hi = uint8x16_t{0x11, 0x20, 0x42, 0x80, 0x8,  0x4,  0x8,  0x4,
-                        0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20};
+    lut_hi = uint8x16_t{0x0, 0x1,  0x0,  0x0, 0x1, 0x2,  0x4,  0x4,
+                        0x8, 0x10, 0x10, 0x8, 0x8, 0x10, 0x10, 0x8};
   }
 #endif
-  uint8x16_t hi0 = vqtbl1q_u8(lut_hi, hi_nibbles0);
-  uint8x16_t hi1 = vqtbl1q_u8(lut_hi, hi_nibbles1);
-  uint8x16_t hi2 = vqtbl1q_u8(lut_hi, hi_nibbles2);
-  uint8x16_t hi3 = vqtbl1q_u8(lut_hi, hi_nibbles3);
+  uint8x16_t hi0 = vqtbl1q_u8(lut_hi, hi_bits0);
+  uint8x16_t hi1 = vqtbl1q_u8(lut_hi, hi_bits1);
+  uint8x16_t hi2 = vqtbl1q_u8(lut_hi, hi_bits2);
+  uint8x16_t hi3 = vqtbl1q_u8(lut_hi, hi_bits3);
 
-  if (base64_url) {
-    hi0 = vbicq_u8(hi0, underscore0);
-    hi1 = vbicq_u8(hi1, underscore1);
-    hi2 = vbicq_u8(hi2, underscore2);
-    hi3 = vbicq_u8(hi3, underscore3);
-  }
+  // maps error byte to 0 and space byte to 1, valid bytes are >1
+  uint8x16_t res0 = vandq_u8(lo0, hi0);
+  uint8x16_t res1 = vandq_u8(lo1, hi1);
+  uint8x16_t res2 = vandq_u8(lo2, hi2);
+  uint8x16_t res3 = vandq_u8(lo3, hi3);
 
   uint8_t checks =
-      vmaxvq_u8(vorrq_u8(vorrq_u8(vandq_u8(lo0, hi0), vandq_u8(lo1, hi1)),
-                         vorrq_u8(vandq_u8(lo2, hi2), vandq_u8(lo3, hi3))));
+      vminvq_u8(vminq_u8(vminq_u8(res0, res1), vminq_u8(res2, res3)));
 #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
   const uint8x16_t bit_mask =
       simdutf_make_uint8x16_t(0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80,
@@ -21623,14 +21025,14 @@ template <bool base64_url> uint64_t to_base64_mask(block64 *b, bool *error) {
                                0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80};
 #endif
   uint64_t badcharmask = 0;
-  *error = checks > 0x3;
-  if (checks) {
+  *error = checks == 0;
+  if (checks <= 1) {
     // Add each of the elements next to each other, successively, to stuff each
     // 8 byte mask into one.
-    uint8x16_t test0 = vtstq_u8(lo0, hi0);
-    uint8x16_t test1 = vtstq_u8(lo1, hi1);
-    uint8x16_t test2 = vtstq_u8(lo2, hi2);
-    uint8x16_t test3 = vtstq_u8(lo3, hi3);
+    uint8x16_t test0 = vcleq_u8(res0, v01);
+    uint8x16_t test1 = vcleq_u8(res1, v01);
+    uint8x16_t test2 = vcleq_u8(res2, v01);
+    uint8x16_t test3 = vcleq_u8(res3, v01);
     uint8x16_t sum0 =
         vpaddq_u8(vandq_u8(test0, bit_mask), vandq_u8(test1, bit_mask));
     uint8x16_t sum1 =
@@ -21642,40 +21044,73 @@ template <bool base64_url> uint64_t to_base64_mask(block64 *b, bool *error) {
   // This is the transformation step that can be done while we are waiting for
   // sum0
   uint8x16_t roll_lut;
+  uint8x16_t delta_asso;
 #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
-  if (base64_url) {
+  if (default_or_url) {
     roll_lut =
-        simdutf_make_uint8x16_t(0xe0, 0x11, 0x13, 0x4, 0xbf, 0xbf, 0xb9, 0xb9,
-                                0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0);
+        simdutf_make_uint8x16_t(0xBF, 0xE0, 0xB9, 0x13, 0x04, 0xBF, 0xBF, 0xB9,
+                                0xB9, 0x00, 0xFF, 0x11, 0xFF, 0xBF, 0x10, 0xB9);
+  } else if (base64_url) {
+    roll_lut =
+        simdutf_make_uint8x16_t(0x00, 0x00, 0x00, 0x13, 0x04, 0xBF, 0xBF, 0xB9,
+                                0xB9, 0x00, 0x11, 0xC3, 0xBF, 0xE0, 0xB9, 0xB9);
   } else {
     roll_lut =
-        simdutf_make_uint8x16_t(0x0, 0x10, 0x13, 0x4, 0xbf, 0xbf, 0xb9, 0xb9,
-                                0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0);
+        simdutf_make_uint8x16_t(0x00, 0x00, 0x00, 0x13, 0x04, 0xBF, 0xBF, 0xB9,
+                                0xB9, 0x00, 0x10, 0xC3, 0xBF, 0xBF, 0xB9, 0xB9);
+  }
+  if (default_or_url) {
+    delta_asso =
+        simdutf_make_uint8x16_t(0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x00, 0x16);
+  } else {
+    delta_asso =
+        simdutf_make_uint8x16_t(0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x0F, 0x00, 0x0F);
   }
 #else
-  if (base64_url) {
-    roll_lut = uint8x16_t{0xe0, 0x11, 0x13, 0x4, 0xbf, 0xbf, 0xb9, 0xb9,
-                          0x0,  0x0,  0x0,  0x0, 0x0,  0x0,  0x0,  0x0};
+  if (default_or_url) {
+    roll_lut = uint8x16_t{0xBF, 0xE0, 0xB9, 0x13, 0x04, 0xBF, 0xBF, 0xB9,
+                          0xB9, 0x00, 0xFF, 0x11, 0xFF, 0xBF, 0x10, 0xB9};
+  } else if (base64_url) {
+    roll_lut = uint8x16_t{0x00, 0x00, 0x00, 0x13, 0x04, 0xBF, 0xBF, 0xB9,
+                          0xB9, 0x00, 0x11, 0xC3, 0xBF, 0xE0, 0xB9, 0xB9};
   } else {
-    roll_lut = uint8x16_t{0x0, 0x10, 0x13, 0x4, 0xbf, 0xbf, 0xb9, 0xb9,
-                          0x0, 0x0,  0x0,  0x0, 0x0,  0x0,  0x0,  0x0};
+    roll_lut = uint8x16_t{0x00, 0x00, 0x00, 0x13, 0x04, 0xBF, 0xBF, 0xB9,
+                          0xB9, 0x00, 0x10, 0xC3, 0xBF, 0xBF, 0xB9, 0xB9};
+  }
+  if (default_or_url) {
+    delta_asso = uint8x16_t{0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+                            0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x00, 0x16};
+  } else {
+    delta_asso = uint8x16_t{0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+                            0x00, 0x00, 0x00, 0x00, 0x00, 0x0F, 0x00, 0x0F};
   }
 #endif
-  uint8x16_t vsecond_last = base64_url ? vdupq_n_u8(0x2d) : vdupq_n_u8(0x2f);
-  if (base64_url) {
-    hi_nibbles0 = vbicq_u8(hi_nibbles0, underscore0);
-    hi_nibbles1 = vbicq_u8(hi_nibbles1, underscore1);
-    hi_nibbles2 = vbicq_u8(hi_nibbles2, underscore2);
-    hi_nibbles3 = vbicq_u8(hi_nibbles3, underscore3);
+  // the logic of translating is based on westmere
+  uint8x16_t delta_hash0 =
+      vrhaddq_u8(vqtbl1q_u8(delta_asso, lo_nibbles0), hi_bits0);
+  uint8x16_t delta_hash1 =
+      vrhaddq_u8(vqtbl1q_u8(delta_asso, lo_nibbles1), hi_bits1);
+  uint8x16_t delta_hash2 =
+      vrhaddq_u8(vqtbl1q_u8(delta_asso, lo_nibbles2), hi_bits2);
+  uint8x16_t delta_hash3 =
+      vrhaddq_u8(vqtbl1q_u8(delta_asso, lo_nibbles3), hi_bits3);
+
+  uint8x16_t roll0, roll1, roll2, roll3;
+  if (default_or_url) {
+    const uint8x16x2_t roll_lut_2 = {roll_lut, roll_lut};
+    roll0 = vqtbl2q_u8(roll_lut_2, delta_hash0);
+    roll1 = vqtbl2q_u8(roll_lut_2, delta_hash1);
+    roll2 = vqtbl2q_u8(roll_lut_2, delta_hash2);
+    roll3 = vqtbl2q_u8(roll_lut_2, delta_hash3);
+  } else {
+    roll0 = vqtbl1q_u8(roll_lut, delta_hash0);
+    roll1 = vqtbl1q_u8(roll_lut, delta_hash1);
+    roll2 = vqtbl1q_u8(roll_lut, delta_hash2);
+    roll3 = vqtbl1q_u8(roll_lut, delta_hash3);
   }
-  uint8x16_t roll0 = vqtbl1q_u8(
-      roll_lut, vaddq_u8(vceqq_u8(b->chunks[0], vsecond_last), hi_nibbles0));
-  uint8x16_t roll1 = vqtbl1q_u8(
-      roll_lut, vaddq_u8(vceqq_u8(b->chunks[1], vsecond_last), hi_nibbles1));
-  uint8x16_t roll2 = vqtbl1q_u8(
-      roll_lut, vaddq_u8(vceqq_u8(b->chunks[2], vsecond_last), hi_nibbles2));
-  uint8x16_t roll3 = vqtbl1q_u8(
-      roll_lut, vaddq_u8(vceqq_u8(b->chunks[3], vsecond_last), hi_nibbles3));
+
   b->chunks[0] = vaddq_u8(b->chunks[0], roll0);
   b->chunks[1] = vaddq_u8(b->chunks[1], roll1);
   b->chunks[2] = vaddq_u8(b->chunks[2], roll2);
@@ -21813,13 +21248,16 @@ static size_t compress_block_single(block64 *b, uint64_t mask, char *output) {
 
 template <typename T> bool is_power_of_two(T x) { return (x & (x - 1)) == 0; }
 
-template <bool base64_url, bool ignore_garbage, typename char_type>
+template <bool base64_url, bool ignore_garbage, bool default_or_url,
+          typename char_type>
 full_result
 compress_decode_base64(char *dst, const char_type *src, size_t srclen,
                        base64_options options,
                        last_chunk_handling_options last_chunk_options) {
-  const uint8_t *to_base64 = base64_url ? tables::base64::to_base64_url_value
-                                        : tables::base64::to_base64_value;
+  const uint8_t *to_base64 =
+      default_or_url ? tables::base64::to_base64_default_or_url_value
+                     : (base64_url ? tables::base64::to_base64_url_value
+                                   : tables::base64::to_base64_value);
   size_t equallocation =
       srclen; // location of the first padding character if any
   // skip trailing spaces
@@ -21869,7 +21307,8 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
       load_block(&b, src);
       src += 64;
       bool error = false;
-      uint64_t badcharmask = to_base64_mask<base64_url>(&b, &error);
+      uint64_t badcharmask =
+          to_base64_mask<base64_url, default_or_url>(&b, &error);
       if (badcharmask) {
         if (error && !ignore_garbage) {
           src -= 64;
@@ -22072,6 +21511,72 @@ arm_convert_utf32_to_latin1_with_errors(const char32_t *buf, size_t len,
 #endif // SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
 #if SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_UTF16
 /* begin file src/arm64/arm_convert_utf32_to_utf16.cpp */
+struct expansion_result_t {
+  size_t u16count;
+  uint8x16_t compressed_v;
+};
+
+// This function is used to check for invalid UTF-32 characters
+// and surrogate pairs in the input
+simdutf_really_inline uint64_t invalid_utf32(const uint32x4x2_t in) {
+  const auto standardmax = vdupq_n_u32(0x10ffff);
+  const auto v_d800 = vdupq_n_u32(0xd800);
+  const auto v_fffff800 = vdupq_n_u32(0xfffff800);
+  const auto too_large1 = vcgtq_u32(in.val[0], standardmax);
+  const auto too_large2 = vcgtq_u32(in.val[1], standardmax);
+  const auto surrogate1 = vceqq_u32(vandq_u32(in.val[0], v_fffff800), v_d800);
+  const auto surrogate2 = vceqq_u32(vandq_u32(in.val[1], v_fffff800), v_d800);
+  const auto err1 = vorrq_u32(too_large1, surrogate1);
+  const auto err2 = vorrq_u32(too_large2, surrogate2);
+  const auto err =
+      vuzp2q_u16(vreinterpretq_u16_u32(err1), vreinterpretq_u16_u32(err2));
+
+  return vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u16(err, 8)), 0);
+}
+
+// This function is used to check for surrogate pairs in the input
+simdutf_really_inline uint64_t fast_invalid_utf32(const uint32x4x2_t in) {
+  const auto v_d800 = vdupq_n_u32(0xd800);
+  const auto v_fffff800 = vdupq_n_u32(0xfffff800);
+  const auto surrogate1 = vceqq_u32(vandq_u32(in.val[0], v_fffff800), v_d800);
+  const auto surrogate2 = vceqq_u32(vandq_u32(in.val[1], v_fffff800), v_d800);
+  const auto err = vuzp2q_u16(vreinterpretq_u16_u32(surrogate1),
+                              vreinterpretq_u16_u32(surrogate2));
+  return vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u16(err, 8)), 0);
+}
+
+template <endianness byte_order>
+simdutf_really_inline expansion_result_t
+neon_expand_surrogate(const uint32x4_t in) {
+  const uint32x4_t v_ffff0000 = vdupq_n_u32(0xffff0000);
+  const uint32x4_t non_surrogate_mask = vceqzq_u32(vandq_u32(in, v_ffff0000));
+  const uint64_t cmp_bits =
+      vget_lane_u64(vreinterpret_u64_u32(vshrn_n_u64(
+                        vreinterpretq_u64_u32(non_surrogate_mask), 31)),
+                    0);
+  const uint8_t mask =
+      uint8_t(~((cmp_bits & 0x3) | ((cmp_bits >> 30) & 0xc)) & 0xf);
+  const uint32x4_t v_10000 = vdupq_n_u32(0x00010000);
+  const uint32x4_t t0 = vsubq_u32(in, v_10000);
+  const uint32x4_t t1 = vandq_u32(t0, vdupq_n_u32(0xfffff));
+  const uint32x4_t t2 = vshrq_n_u32(t1, 10);
+  const uint32x4_t t3 = vsliq_n_u32(t2, t1, 16);
+  const uint32x4_t surrogates = vorrq_u32(
+      vandq_u32(t3, vdupq_n_u32(0x03ff03ff)), vdupq_n_u32(0xdc00d800));
+  const uint8x16_t merged =
+      vreinterpretq_u8_u32(vbslq_u32(non_surrogate_mask, in, surrogates));
+
+  const uint8x16_t shuffle_v = vld1q_u8(reinterpret_cast<const uint8_t *>(
+      (byte_order == endianness::LITTLE)
+          ? tables::utf32_to_utf16::pack_utf32_to_utf16le[mask]
+          : tables::utf32_to_utf16::pack_utf32_to_utf16be[mask]));
+
+  const size_t u16count = 4 + vget_lane_u8(vcnt_u8(vcreate_u8(mask)), 0);
+  const uint8x16_t compressed_v = vqtbl1q_u8(merged, shuffle_v);
+
+  return {u16count, compressed_v};
+}
+
 template <endianness big_endian>
 std::pair<const char32_t *, char16_t *>
 arm_convert_utf32_to_utf16(const char32_t *buf, size_t len,
@@ -22079,69 +21584,48 @@ arm_convert_utf32_to_utf16(const char32_t *buf, size_t len,
   uint16_t *utf16_output = reinterpret_cast<uint16_t *>(utf16_out);
   const char32_t *end = buf + len;
 
-  uint16x4_t forbidden_bytemask = vmov_n_u16(0x0);
-
-  while (end - buf >= 4) {
-    uint32x4_t in = vld1q_u32(reinterpret_cast<const uint32_t *>(buf));
+  uint16x8_t forbidden_bytemask = vmovq_n_u16(0x0);
+  // To avoid buffer overflow while writing compressed_v
+  const size_t safety_margin = 4;
+  while (end - buf >= std::ptrdiff_t(8 + safety_margin)) {
+    uint32x4x2_t in = vld1q_u32_x2(reinterpret_cast<const uint32_t *>(buf));
 
     // Check if no bits set above 16th
-    if (vmaxvq_u32(in) <= 0xFFFF) {
-      uint16x4_t utf16_packed = vmovn_u32(in);
+    uint32_t max_val = vmaxvq_u32(vmaxq_u32(in.val[0], in.val[1]));
+    if (simdutf_likely(max_val <= 0xFFFF)) {
+      uint16x8_t utf16_packed = vuzp1q_u16(vreinterpretq_u16_u32(in.val[0]),
+                                           vreinterpretq_u16_u32(in.val[1]));
 
-      const uint16x4_t v_d800 = vmov_n_u16((uint16_t)0xd800);
-      const uint16x4_t v_dfff = vmov_n_u16((uint16_t)0xdfff);
-      forbidden_bytemask = vorr_u16(vand_u16(vcle_u16(utf16_packed, v_dfff),
-                                             vcge_u16(utf16_packed, v_d800)),
-                                    forbidden_bytemask);
+      const uint16x8_t v_d800 = vmovq_n_u16((uint16_t)0xd800);
+      const uint16x8_t v_f800 = vmovq_n_u16((uint16_t)0xf800);
+      forbidden_bytemask =
+          vorrq_u16(vceqq_u16(vandq_u16(utf16_packed, v_f800), v_d800),
+                    forbidden_bytemask);
 
       if (!match_system(big_endian)) {
-        utf16_packed =
-            vreinterpret_u16_u8(vrev16_u8(vreinterpret_u8_u16(utf16_packed)));
+        utf16_packed = vreinterpretq_u16_u8(
+            vrev16q_u8(vreinterpretq_u8_u16(utf16_packed)));
       }
-      vst1_u16(utf16_output, utf16_packed);
-      utf16_output += 4;
-      buf += 4;
+      vst1q_u16(utf16_output, utf16_packed);
+      utf16_output += 8;
+      buf += 8;
     } else {
-      size_t forward = 3;
-      size_t k = 0;
-      if (size_t(end - buf) < forward + 1) {
-        forward = size_t(end - buf - 1);
+      if (simdutf_unlikely(fast_invalid_utf32(in) || max_val > 0x10ffff)) {
+        return std::make_pair(nullptr,
+                              reinterpret_cast<char16_t *>(utf16_output));
       }
-      for (; k < forward; k++) {
-        uint32_t word = buf[k];
-        if ((word & 0xFFFF0000) == 0) {
-          // will not generate a surrogate pair
-          if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(nullptr,
-                                  reinterpret_cast<char16_t *>(utf16_output));
-          }
-          *utf16_output++ = !match_system(big_endian)
-                                ? char16_t(word >> 8 | word << 8)
-                                : char16_t(word);
-        } else {
-          // will generate a surrogate pair
-          if (word > 0x10FFFF) {
-            return std::make_pair(nullptr,
-                                  reinterpret_cast<char16_t *>(utf16_output));
-          }
-          word -= 0x10000;
-          uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
-          uint16_t low_surrogate = uint16_t(0xDC00 + (word & 0x3FF));
-          if (!match_system(big_endian)) {
-            high_surrogate =
-                uint16_t(high_surrogate >> 8 | high_surrogate << 8);
-            low_surrogate = uint16_t(low_surrogate << 8 | low_surrogate >> 8);
-          }
-          *utf16_output++ = char16_t(high_surrogate);
-          *utf16_output++ = char16_t(low_surrogate);
-        }
-      }
-      buf += k;
+      expansion_result_t res = neon_expand_surrogate<big_endian>(in.val[0]);
+      vst1q_u8(reinterpret_cast<uint8_t *>(utf16_output), res.compressed_v);
+      utf16_output += res.u16count;
+      res = neon_expand_surrogate<big_endian>(in.val[1]);
+      vst1q_u8(reinterpret_cast<uint8_t *>(utf16_output), res.compressed_v);
+      utf16_output += res.u16count;
+      buf += 8;
     }
   }
 
   // check for invalid input
-  if (vmaxv_u16(forbidden_bytemask) != 0) {
+  if (vmaxvq_u32(vreinterpretq_u32_u16(forbidden_bytemask)) != 0) {
     return std::make_pair(nullptr, reinterpret_cast<char16_t *>(utf16_output));
   }
 
@@ -22156,67 +21640,79 @@ arm_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
   const char32_t *start = buf;
   const char32_t *end = buf + len;
 
-  while (end - buf >= 4) {
-    uint32x4_t in = vld1q_u32(reinterpret_cast<const uint32_t *>(buf));
+  // To avoid buffer overflow while writing compressed_v
+  const size_t safety_margin = 4;
+  while (end - buf >= std::ptrdiff_t(8 + safety_margin)) {
+    uint32x4x2_t in = vld1q_u32_x2(reinterpret_cast<const uint32_t *>(buf));
 
     // Check if no bits set above 16th
-    if (vmaxvq_u32(in) <= 0xFFFF) {
-      uint16x4_t utf16_packed = vmovn_u32(in);
+    uint32_t max_val = vmaxvq_u32(vmaxq_u32(in.val[0], in.val[1]));
+    if (simdutf_likely(max_val <= 0xFFFF)) {
+      uint16x8_t utf16_packed = vuzp1q_u16(vreinterpretq_u16_u32(in.val[0]),
+                                           vreinterpretq_u16_u32(in.val[1]));
 
-      const uint16x4_t v_d800 = vmov_n_u16((uint16_t)0xd800);
-      const uint16x4_t v_dfff = vmov_n_u16((uint16_t)0xdfff);
-      const uint16x4_t forbidden_bytemask = vand_u16(
-          vcle_u16(utf16_packed, v_dfff), vcge_u16(utf16_packed, v_d800));
-      if (vmaxv_u16(forbidden_bytemask) != 0) {
+      const uint16x8_t v_d800 = vmovq_n_u16((uint16_t)0xd800);
+      const uint16x8_t v_f800 = vmovq_n_u16((uint16_t)0xf800);
+      const uint16x8_t forbidden_bytemask =
+          vceqq_u16(vandq_u16(utf16_packed, v_f800), v_d800);
+      if (vmaxvq_u16(forbidden_bytemask) != 0) {
         return std::make_pair(result(error_code::SURROGATE, buf - start),
                               reinterpret_cast<char16_t *>(utf16_output));
       }
 
       if (!match_system(big_endian)) {
-        utf16_packed =
-            vreinterpret_u16_u8(vrev16_u8(vreinterpret_u8_u16(utf16_packed)));
+        utf16_packed = vreinterpretq_u16_u8(
+            vrev16q_u8(vreinterpretq_u8_u16(utf16_packed)));
       }
-      vst1_u16(utf16_output, utf16_packed);
-      utf16_output += 4;
-      buf += 4;
+      vst1q_u16(utf16_output, utf16_packed);
+      utf16_output += 8;
+      buf += 8;
     } else {
-      size_t forward = 3;
-      size_t k = 0;
-      if (size_t(end - buf) < forward + 1) {
-        forward = size_t(end - buf - 1);
-      }
-      for (; k < forward; k++) {
-        uint32_t word = buf[k];
-        if ((word & 0xFFFF0000) == 0) {
-          // will not generate a surrogate pair
-          if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(
-                result(error_code::SURROGATE, buf - start + k),
-                reinterpret_cast<char16_t *>(utf16_output));
+      const uint64_t err =
+          max_val <= 0x10ffff ? fast_invalid_utf32(in) : invalid_utf32(in);
+      if (simdutf_unlikely(err)) {
+        const size_t pos = trailing_zeroes(err) / 8;
+        for (size_t k = 0; k < pos; k++) {
+          uint32_t word = buf[k];
+          if ((word & 0xFFFF0000) == 0) {
+            // will not generate a surrogate pair
+            *utf16_output++ = !match_system(big_endian)
+                                  ? char16_t(word >> 8 | word << 8)
+                                  : char16_t(word);
+          } else {
+            // will generate a surrogate pair
+            word -= 0x10000;
+            uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
+            uint16_t low_surrogate = uint16_t(0xDC00 + (word & 0x3FF));
+            if (!match_system(big_endian)) {
+              high_surrogate =
+                  uint16_t(high_surrogate >> 8 | high_surrogate << 8);
+              low_surrogate = uint16_t(low_surrogate << 8 | low_surrogate >> 8);
+            }
+            *utf16_output++ = char16_t(high_surrogate);
+            *utf16_output++ = char16_t(low_surrogate);
           }
-          *utf16_output++ = !match_system(big_endian)
-                                ? char16_t(word >> 8 | word << 8)
-                                : char16_t(word);
-        } else {
-          // will generate a surrogate pair
-          if (word > 0x10FFFF) {
-            return std::make_pair(
-                result(error_code::TOO_LARGE, buf - start + k),
-                reinterpret_cast<char16_t *>(utf16_output));
-          }
-          word -= 0x10000;
-          uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
-          uint16_t low_surrogate = uint16_t(0xDC00 + (word & 0x3FF));
-          if (!match_system(big_endian)) {
-            high_surrogate =
-                uint16_t(high_surrogate >> 8 | high_surrogate << 8);
-            low_surrogate = uint16_t(low_surrogate << 8 | low_surrogate >> 8);
-          }
-          *utf16_output++ = char16_t(high_surrogate);
-          *utf16_output++ = char16_t(low_surrogate);
         }
+        const uint32_t word = buf[pos];
+        const size_t error_pos = buf - start + pos;
+        if (word > 0x10FFFF) {
+          return {result(error_code::TOO_LARGE, error_pos),
+                  reinterpret_cast<char16_t *>(utf16_output)};
+        }
+        if (word >= 0xD800 && word <= 0xDFFF) {
+          return {result(error_code::SURROGATE, error_pos),
+                  reinterpret_cast<char16_t *>(utf16_output)};
+        }
+        return {result(error_code::OTHER, error_pos),
+                reinterpret_cast<char16_t *>(utf16_output)};
       }
-      buf += k;
+      expansion_result_t res = neon_expand_surrogate<big_endian>(in.val[0]);
+      vst1q_u8(reinterpret_cast<uint8_t *>(utf16_output), res.compressed_v);
+      utf16_output += res.u16count;
+      res = neon_expand_surrogate<big_endian>(in.val[1]);
+      vst1q_u8(reinterpret_cast<uint8_t *>(utf16_output), res.compressed_v);
+      utf16_output += res.u16count;
+      buf += 8;
     }
   }
 
@@ -24050,87 +23546,6 @@ simdutf_really_inline size_t utf8_length_from_utf16(const char16_t *in,
                                                                    size - pos);
 }
 
-#ifdef SIMDUTF_SIMD_HAS_BYTEMASK
-template <endianness big_endian>
-simdutf_really_inline size_t utf8_length_from_utf16_bytemask(const char16_t *in,
-                                                             size_t size) {
-  size_t pos = 0;
-
-  using vector_u16 = simd16<uint16_t>;
-  constexpr size_t N = vector_u16::ELEMENTS;
-
-  const auto one = vector_u16::splat(1);
-
-  auto v_count = vector_u16::zero();
-
-  // each char16 yields at least one byte
-  size_t count = size / N * N;
-
-  // in a single iteration the increment is 0, 1 or 2, despite we have
-  // three additions
-  constexpr size_t max_iterations = 65535 / 2;
-  size_t iteration = max_iterations;
-
-  for (; pos < size / N * N; pos += N) {
-    auto input = vector_u16::load(reinterpret_cast<const uint16_t *>(in + pos));
-    if (!match_system(big_endian)) {
-      input = input.swap_bytes();
-    }
-    // 0xd800 .. 0xdbff - low surrogate
-    // 0xdc00 .. 0xdfff - high surrogate
-    const auto is_surrogate = ((input & uint16_t(0xf800)) == uint16_t(0xd800));
-
-    // c0 - chars that yield 2- or 3-byte UTF-8 codes
-    const auto c0 = min(input & uint16_t(0xff80), one);
-
-    // c1 - chars that yield 3-byte UTF-8 codes (including surrogates)
-    const auto c1 = min(input & uint16_t(0xf800), one);
-
-    /*
-        Explanation how the counting works.
-
-        In the case of a non-surrogate character we count:
-        * always 1 -- see how `count` is initialized above;
-        * c0 = 1 if the current char yields 2 or 3 bytes;
-        * c1 = 1 if the current char yields 3 bytes.
-
-        Thus, we always have correct count for the current char:
-        from 1, 2 or 3 bytes.
-
-        A trickier part is how we count surrogate pairs. Whether
-        we encounter a surrogate (low or high), we count it as
-        3 chars and then minus 1 (`is_surrogate` is -1 or 0).
-        Each surrogate char yields 2. A surrogate pair, that
-        is a low surrogate followed by a high one, yields
-        the expected 4 bytes.
-
-        It also correctly handles cases when low surrogate is
-        processed by the this loop, but high surrogate is counted
-        by the scalar procedure. The scalar procedure uses exactly
-        the described approach, thanks to that for valid UTF-16
-        strings it always count correctly.
-    */
-    v_count += c0;
-    v_count += c1;
-    v_count += vector_u16(is_surrogate);
-
-    iteration -= 1;
-    if (iteration == 0) {
-      count += v_count.sum();
-      v_count = vector_u16::zero();
-      iteration = max_iterations;
-    }
-  }
-
-  if (iteration > 0) {
-    count += v_count.sum();
-  }
-
-  return count + scalar::utf16::utf8_length_from_utf16<big_endian>(in + pos,
-                                                                   size - pos);
-}
-#endif // SIMDUTF_SIMD_HAS_BYTEMASK
-
 template <endianness big_endian>
 simdutf_really_inline size_t utf32_length_from_utf16(const char16_t *in,
                                                      size_t size) {
@@ -24229,7 +23644,7 @@ simdutf_really_inline size_t count_code_points_bytemask(const char *in,
 
   return count + scalar::utf8::count_code_points(in + pos, size - pos);
 }
-#endif
+#endif // SIMDUTF_SIMD_HAS_BYTEMASK
 
 simdutf_really_inline size_t utf16_length_from_utf8(const char *in,
                                                     size_t size) {
@@ -24247,6 +23662,7 @@ simdutf_really_inline size_t utf16_length_from_utf8(const char *in,
   }
   return count + scalar::utf8::utf16_length_from_utf8(in + pos, size - pos);
 }
+
 } // namespace utf8
 } // unnamed namespace
 } // namespace arm64
@@ -24778,6 +24194,16 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
   } else {
     return res;
   }
+}
+
+void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return utf16fix_neon_64bits<endianness::LITTLE>(input, len, output);
+}
+
+void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return utf16fix_neon_64bits<endianness::BIG>(input, len, output);
 }
 #endif // SIMDUTF_FEATURE_UTF16
 
@@ -25669,21 +25095,29 @@ simdutf_warn_unused size_t implementation::utf32_length_from_utf8(
 simdutf_warn_unused result implementation::base64_to_binary(
     const char *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return compress_decode_base64<true, true>(output, input, length, options,
-                                                last_chunk_options);
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return compress_decode_base64<false, true, true>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<true, false>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return compress_decode_base64<true, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return compress_decode_base64<false, true>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, true, false>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<false, false>(output, input, length,
-                                                  options, last_chunk_options);
+      return compress_decode_base64<false, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   }
 }
@@ -25691,21 +25125,29 @@ simdutf_warn_unused result implementation::base64_to_binary(
 simdutf_warn_unused full_result implementation::base64_to_binary_details(
     const char *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return compress_decode_base64<true, true>(output, input, length, options,
-                                                last_chunk_options);
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return compress_decode_base64<false, true, true>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<true, false>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return compress_decode_base64<true, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return compress_decode_base64<false, true>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, true, false>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<false, false>(output, input, length,
-                                                  options, last_chunk_options);
+      return compress_decode_base64<false, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   }
 }
@@ -25713,21 +25155,29 @@ simdutf_warn_unused full_result implementation::base64_to_binary_details(
 simdutf_warn_unused result implementation::base64_to_binary(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return compress_decode_base64<true, true>(output, input, length, options,
-                                                last_chunk_options);
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return compress_decode_base64<false, true, true>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<true, false>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return compress_decode_base64<true, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return compress_decode_base64<false, true>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, true, false>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<false, false>(output, input, length,
-                                                  options, last_chunk_options);
+      return compress_decode_base64<false, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   }
 }
@@ -25735,21 +25185,29 @@ simdutf_warn_unused result implementation::base64_to_binary(
 simdutf_warn_unused full_result implementation::base64_to_binary_details(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return compress_decode_base64<true, true>(output, input, length, options,
-                                                last_chunk_options);
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return compress_decode_base64<false, true, true>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<true, false>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return compress_decode_base64<true, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return compress_decode_base64<false, true>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, true, false>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<false, false>(output, input, length,
-                                                  options, last_chunk_options);
+      return compress_decode_base64<false, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   }
 }
@@ -25765,6 +25223,7 @@ size_t implementation::binary_to_base64(const char *input, size_t length,
 } // namespace simdutf
 
 /* begin file src/simdutf/arm64/end.h */
+#undef SIMDUTF_SIMD_HAS_BYTEMASK
 /* end file src/simdutf/arm64/end.h */
 /* end file src/arm64/implementation.cpp */
 #endif
@@ -25856,6 +25315,18 @@ simdutf_warn_unused result implementation::validate_utf16le_with_errors(
 simdutf_warn_unused result implementation::validate_utf16be_with_errors(
     const char16_t *buf, size_t len) const noexcept {
   return scalar::utf16::validate_with_errors<endianness::BIG>(buf, len);
+}
+
+void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::LITTLE>(input, len,
+                                                                 output);
+}
+
+void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::BIG>(input, len,
+                                                              output);
 }
 #endif // SIMDUTF_FEATURE_UTF16
 
@@ -26283,7 +25754,8 @@ simdutf_warn_unused result implementation::base64_to_binary(
     last_chunk_handling_options last_chunk_options) const noexcept {
   const bool ignore_garbage =
       (options == base64_options::base64_url_accept_garbage) ||
-      (options == base64_options::base64_default_accept_garbage);
+      (options == base64_options::base64_default_accept_garbage) ||
+      (options == base64_options::base64_default_or_url_accept_garbage);
   while (length > 0 &&
          scalar::base64::is_ascii_white_space(input[length - 1])) {
     length--;
@@ -26334,7 +25806,8 @@ simdutf_warn_unused full_result implementation::base64_to_binary_details(
     last_chunk_handling_options last_chunk_options) const noexcept {
   const bool ignore_garbage =
       (options == base64_options::base64_url_accept_garbage) ||
-      (options == base64_options::base64_default_accept_garbage);
+      (options == base64_options::base64_default_accept_garbage) ||
+      (options == base64_options::base64_default_or_url_accept_garbage);
   while (length > 0 &&
          scalar::base64::is_ascii_white_space(input[length - 1])) {
     length--;
@@ -26386,7 +25859,8 @@ simdutf_warn_unused result implementation::base64_to_binary(
     last_chunk_handling_options last_chunk_options) const noexcept {
   const bool ignore_garbage =
       (options == base64_options::base64_url_accept_garbage) ||
-      (options == base64_options::base64_default_accept_garbage);
+      (options == base64_options::base64_default_accept_garbage) ||
+      (options == base64_options::base64_default_or_url_accept_garbage);
   while (length > 0 &&
          scalar::base64::is_ascii_white_space(input[length - 1])) {
     length--;
@@ -26704,6 +26178,12 @@ __m512i shuffle_epi128(__m512i v) {
 
 template <unsigned idx> constexpr __m512i broadcast_epi128(__m512i v) {
   return shuffle_epi128<idx, idx, idx, idx>(v);
+}
+
+simdutf_really_inline __m512i broadcast_128bit_lane(__m128i lane) {
+  const __m512i tmp = _mm512_castsi128_si512(lane);
+
+  return broadcast_epi128<0>(tmp);
 }
 /* end file src/icelake/icelake_common.inl.cpp */
 #if SIMDUTF_FEATURE_UTF8
@@ -27996,6 +27476,147 @@ validating_utf8_to_fixed_length_with_constant_checks(const char *str,
 #endif // SIMDUTF_FEATURE_UTF8 && (SIMDUTF_FEATURE_UTF16 ||
        // SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_LATIN1)
 
+#if SIMDUTF_FEATURE_UTF16
+/* begin file src/icelake/icelake_utf16fix.cpp */
+/*
+ * Process one block of 32 characters.  If in_place is false,
+ * copy the block from in to out.  If there is a sequencing
+ * error in the block, overwrite the illsequenced characters
+ * with the replacement character.  This function reads one
+ * character before the beginning of the buffer as a lookback.
+ * If that character is illsequenced, it too is overwritten.
+ */
+template <endianness big_endian, bool in_place>
+simdutf_really_inline void utf16fix_block(char16_t *out, const char16_t *in) {
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
+  auto swap_if_needed = [](uint16_t c) -> uint16_t {
+    return !simdutf::match_system(big_endian) ? scalar::u16_swap_bytes(c) : c;
+  };
+
+  __m512i lookback, block, lb_masked, block_masked;
+  __mmask32 lb_is_high, block_is_low, illseq;
+
+  lookback = _mm512_loadu_si512((const __m512i *)(in - 1));
+  block = _mm512_loadu_si512((const __m512i *)in);
+  lb_masked =
+      _mm512_and_epi32(lookback, _mm512_set1_epi16(swap_if_needed(0xfc00U)));
+  block_masked =
+      _mm512_and_epi32(block, _mm512_set1_epi16(swap_if_needed(0xfc00U)));
+
+  lb_is_high = _mm512_cmpeq_epi16_mask(
+      lb_masked, _mm512_set1_epi16(swap_if_needed(0xd800U)));
+  block_is_low = _mm512_cmpeq_epi16_mask(
+      block_masked, _mm512_set1_epi16(swap_if_needed(0xdc00U)));
+  illseq = _kxor_mask32(lb_is_high, block_is_low);
+  if (!_ktestz_mask32_u8(illseq, illseq)) {
+    __mmask32 lb_illseq, block_illseq;
+
+    /* compute the cause of the illegal sequencing */
+    lb_illseq = _kandn_mask32(block_is_low, lb_is_high);
+    block_illseq = _kor_mask32(_kandn_mask32(lb_is_high, block_is_low),
+                               _kshiftri_mask32(lb_illseq, 1));
+
+    /* fix illegal sequencing in the lookback */
+    lb_illseq = _kand_mask32(lb_illseq, _cvtu32_mask32(1));
+    _mm512_mask_storeu_epi16(out - 1, lb_illseq,
+                             _mm512_set1_epi16(replacement));
+
+    /* fix illegal sequencing in the main block */
+    if (in_place) {
+      _mm512_mask_storeu_epi16(out, block_illseq,
+                               _mm512_set1_epi16(replacement));
+    } else {
+      _mm512_storeu_epi32(
+          out, _mm512_mask_blend_epi16(block_illseq, block,
+                                       _mm512_set1_epi16(replacement)));
+    }
+  } else if (!in_place) {
+    _mm512_storeu_si512((__m512i *)out, block);
+  }
+}
+
+/*
+ * Special case for inputs of 0--32 bytes.  Works for both in-place and
+ * out-of-place operation.
+ */
+template <endianness big_endian>
+void utf16fix_runt(const char16_t *in, size_t n, char16_t *out) {
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
+  auto swap_if_needed = [](uint16_t c) -> uint16_t {
+    return !simdutf::match_system(big_endian) ? scalar::u16_swap_bytes(c) : c;
+  };
+  __m512i lookback, block, lb_masked, block_masked;
+  __mmask32 lb_is_high, block_is_low, illseq;
+  uint32_t mask = 0xFFFFFFFF >> (32 - n);
+  lookback = _mm512_maskz_loadu_epi16(_cvtmask32_u32(mask << 1),
+                                      (const uint16_t *)(in - 1));
+  block = _mm512_maskz_loadu_epi16(_cvtmask32_u32(mask), (const uint16_t *)in);
+  lb_masked =
+      _mm512_and_epi32(lookback, _mm512_set1_epi16(swap_if_needed(0xfc00u)));
+  block_masked =
+      _mm512_and_epi32(block, _mm512_set1_epi16(swap_if_needed(0xfc00u)));
+
+  lb_is_high = _mm512_cmpeq_epi16_mask(
+      lb_masked, _mm512_set1_epi16(swap_if_needed(0xd800u)));
+  block_is_low = _mm512_cmpeq_epi16_mask(
+      block_masked, _mm512_set1_epi16(swap_if_needed(0xdc00u)));
+  illseq = _kxor_mask32(lb_is_high, block_is_low);
+  if (!_ktestz_mask32_u8(illseq, illseq)) {
+    __mmask32 lb_illseq, block_illseq;
+
+    /* compute the cause of the illegal sequencing */
+    lb_illseq = _kandn_mask32(block_is_low, lb_is_high);
+    block_illseq = _kor_mask32(_kandn_mask32(lb_is_high, block_is_low),
+                               _kshiftri_mask32(lb_illseq, 1));
+
+    /* fix illegal sequencing in the main block */
+    _mm512_mask_storeu_epi16(
+        (uint16_t *)out, _cvtmask32_u32(mask),
+        _mm512_mask_blend_epi16(block_illseq, block,
+                                _mm512_set1_epi16(replacement)));
+  } else {
+    _mm512_mask_storeu_epi16((uint16_t *)out, _cvtmask32_u32(mask), block);
+  }
+  out[n - 1] = scalar::utf16::is_high_surrogate<big_endian>(out[n - 1])
+                   ? replacement
+                   : out[n - 1];
+}
+
+template <endianness big_endian>
+void utf16fix_avx512(const char16_t *in, size_t n, char16_t *out) {
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
+  size_t i;
+
+  if (n == 0)
+    return;
+  else if (n < 33) {
+    utf16fix_runt<big_endian>(in, n, out);
+    return;
+  }
+  out[0] =
+      scalar::utf16::is_low_surrogate<big_endian>(in[0]) ? replacement : in[0];
+
+  /* duplicate code to have the compiler specialise utf16fix_block() */
+  if (in == out) {
+    for (i = 1; i + 32 < n; i += 32) {
+      utf16fix_block<big_endian, true>(out + i, in + i);
+    }
+
+    utf16fix_block<big_endian, true>(out + n - 32, in + n - 32);
+  } else {
+    for (i = 1; i + 32 < n; i += 32) {
+      utf16fix_block<big_endian, false>(out + i, in + i);
+    }
+
+    utf16fix_block<big_endian, false>(out + n - 32, in + n - 32);
+  }
+
+  out[n - 1] = scalar::utf16::is_high_surrogate<big_endian>(out[n - 1])
+                   ? replacement
+                   : out[n - 1];
+}
+/* end file src/icelake/icelake_utf16fix.cpp */
+#endif // SIMDUTF_FEATURE_UTF16
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 /* begin file src/icelake/icelake_convert_utf8_to_latin1.inl.cpp */
 // file included directly
@@ -30137,7 +29758,7 @@ size_t encode_base64(char *dst, const char *src, size_t srclen,
   return (size_t)(out - (uint8_t *)dst) + output_len;
 }
 
-template <bool base64_url, bool ignore_garbage>
+template <bool base64_url, bool ignore_garbage, bool default_or_url>
 static inline uint64_t to_base64_mask(block64 *b, uint64_t *error,
                                       uint64_t input_mask = UINT64_MAX) {
   __m512i input = b->chunks[0];
@@ -30146,7 +29767,14 @@ static inline uint64_t to_base64_mask(block64 *b, uint64_t *error,
       9, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 13, 12, 0, 10, 9, 0, 0, 0, 0, 0, 0,
       0, 0, 32, 0, 0, 13, 12, 0, 10, 9, 0, 0, 0, 0, 0, 0, 0, 0, 32);
   __m512i lookup0;
-  if (base64_url) {
+  if (default_or_url) {
+    lookup0 = _mm512_set_epi8(
+        -128, -128, -128, -128, -128, -128, 61, 60, 59, 58, 57, 56, 55, 54, 53,
+        52, 63, -128, 62, -128, 62, -128, -128, -128, -128, -128, -128, -128,
+        -128, -128, -128, -1, -128, -128, -128, -128, -128, -128, -128, -128,
+        -128, -128, -128, -128, -128, -128, -128, -128, -128, -128, -1, -128,
+        -128, -1, -1, -128, -128, -128, -128, -128, -128, -128, -128, -1);
+  } else if (base64_url) {
     lookup0 = _mm512_set_epi8(
         -128, -128, -128, -128, -128, -128, 61, 60, 59, 58, 57, 56, 55, 54, 53,
         52, -128, -128, 62, -128, -128, -128, -128, -128, -128, -128, -128,
@@ -30162,7 +29790,13 @@ static inline uint64_t to_base64_mask(block64 *b, uint64_t *error,
         -128, -1, -1, -128, -128, -128, -128, -128, -128, -128, -128, -128);
   }
   __m512i lookup1;
-  if (base64_url) {
+  if (default_or_url) {
+    lookup1 = _mm512_set_epi8(
+        -128, -128, -128, -128, -128, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42,
+        41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, -128,
+        63, -128, -128, -128, -128, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15,
+        14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -128);
+  } else if (base64_url) {
     lookup1 = _mm512_set_epi8(
         -128, -128, -128, -128, -128, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42,
         41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, -128,
@@ -30260,14 +29894,17 @@ static inline void base64_decode_block(char *out, block64 *b) {
   base64_decode(out, b->chunks[0]);
 }
 
-template <bool base64_url, bool ignore_garbage, typename chartype>
+template <bool base64_url, bool ignore_garbage, bool default_or_url,
+          typename chartype>
 full_result
 compress_decode_base64(char *dst, const chartype *src, size_t srclen,
                        base64_options options,
                        last_chunk_handling_options last_chunk_options) {
   (void)options;
-  const uint8_t *to_base64 = base64_url ? tables::base64::to_base64_url_value
-                                        : tables::base64::to_base64_value;
+  const uint8_t *to_base64 =
+      default_or_url ? tables::base64::to_base64_default_or_url_value
+                     : (base64_url ? tables::base64::to_base64_url_value
+                                   : tables::base64::to_base64_value);
   size_t equallocation =
       srclen; // location of the first padding character if any
   size_t equalsigns = 0;
@@ -30320,7 +29957,8 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
       src += 64;
       uint64_t error = 0;
       uint64_t badcharmask =
-          to_base64_mask<base64_url, ignore_garbage>(&b, &error);
+          to_base64_mask<base64_url, ignore_garbage, default_or_url>(&b,
+                                                                     &error);
       if (!ignore_garbage && error) {
         src -= 64;
         size_t error_offset = _tzcnt_u64(error);
@@ -30358,7 +29996,8 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
     load_block_partial(&b, src, input_mask);
     uint64_t error = 0;
     uint64_t badcharmask =
-        to_base64_mask<base64_url, ignore_garbage>(&b, &error, input_mask);
+        to_base64_mask<base64_url, ignore_garbage, default_or_url>(&b, &error,
+                                                                   input_mask);
     if (!ignore_garbage && error) {
       size_t error_offset = _tzcnt_u64(error);
       return {error_code::INVALID_BASE64_CHARACTER,
@@ -31037,6 +30676,16 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
     }
   }
   return result(error_code::SUCCESS, len);
+}
+
+void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return utf16fix_avx512<endianness::LITTLE>(input, len, output);
+}
+
+void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return utf16fix_avx512<endianness::BIG>(input, len, output);
 }
 #endif // SIMDUTF_FEATURE_UTF16
 
@@ -32025,19 +31674,75 @@ simdutf_warn_unused size_t implementation::utf8_length_from_latin1(
 simdutf_warn_unused size_t implementation::utf16_length_from_utf8(
     const char *input, size_t length) const noexcept {
   size_t pos = 0;
-  size_t count = 0;
-  // This algorithm could no doubt be improved!
+
+  // UTF-16 char length based on the four most significant bits of UTF-8 bytes
+  const __m128i utf8_length_128 = _mm_setr_epi8(
+      // ASCII chars
+      /* 0000 */ 1,
+      /* 0001 */ 1,
+      /* 0010 */ 1,
+      /* 0011 */ 1,
+      /* 0100 */ 1,
+      /* 0101 */ 1,
+      /* 0110 */ 1,
+      /* 0111 */ 1,
+
+      // continutation bytes
+      /* 1000 */ 0,
+      /* 1001 */ 0,
+      /* 1010 */ 0,
+      /* 1011 */ 0,
+
+      // leading bytes
+      /* 1100 */ 1, // 2-byte UTF-8 char => 1 UTF-16 word
+      /* 1101 */ 1, // 2-byte UTF-8 char => 1 UTF-16 word
+      /* 1110 */ 1, // 3-byte UTF-8 char => 1 UTF-16 word
+      /* 1111 */ 2  // 4-byte UTF-8 char => 2 UTF-16 words (surrogate pair)
+  );
+
+  const __m512i char_length = broadcast_128bit_lane(utf8_length_128);
+
+  constexpr size_t max_iterations = 255 / 2;
+
+  size_t iterations = 0;
+  const auto zero = _mm512_setzero_si512();
+  __m512i local = _mm512_setzero_si512();    // byte-wise counters
+  __m512i counters = _mm512_setzero_si512(); // 64-bit counters
   for (; pos + 64 <= length; pos += 64) {
     __m512i utf8 = _mm512_loadu_si512((const __m512i *)(input + pos));
-    uint64_t utf8_continuation_mask =
-        _mm512_cmplt_epi8_mask(utf8, _mm512_set1_epi8(-65 + 1));
-    // We count one word for anything that is not a continuation (so
-    // leading bytes).
-    count += 64 - count_ones(utf8_continuation_mask);
-    uint64_t utf8_4byte =
-        _mm512_cmpge_epu8_mask(utf8, _mm512_set1_epi8(int8_t(240)));
-    count += count_ones(utf8_4byte);
+    const auto t0 = _mm512_srli_epi32(utf8, 4);
+    const auto t1 = _mm512_and_si512(t0, _mm512_set1_epi8(0xf));
+    const auto t2 = _mm512_shuffle_epi8(char_length, t1);
+    local = _mm512_add_epi8(local, t2);
+
+    iterations += 1;
+    if (iterations == max_iterations) {
+      counters = _mm512_add_epi64(counters, _mm512_sad_epu8(local, zero));
+      local = zero;
+      iterations = 0;
+    }
   }
+
+  size_t count = 0;
+
+  if (pos > 0) {
+    // don't waste time for short strings
+    if (iterations > 0) {
+      counters = _mm512_add_epi64(counters, _mm512_sad_epu8(local, zero));
+    }
+
+    const auto l0 = _mm512_extracti32x4_epi32(counters, 0);
+    const auto l1 = _mm512_extracti32x4_epi32(counters, 1);
+    const auto l2 = _mm512_extracti32x4_epi32(counters, 2);
+    const auto l3 = _mm512_extracti32x4_epi32(counters, 3);
+
+    const auto sum =
+        _mm_add_epi64(_mm_add_epi64(l0, l1), _mm_add_epi64(l2, l3));
+
+    count = uint64_t(_mm_extract_epi64(sum, 0)) +
+            uint64_t(_mm_extract_epi64(sum, 1));
+  }
+
   return count +
          scalar::utf8::utf16_length_from_utf8(input + pos, length - pos);
 }
@@ -32087,21 +31792,29 @@ simdutf_warn_unused size_t implementation::utf32_length_from_utf8(
 simdutf_warn_unused result implementation::base64_to_binary(
     const char *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return compress_decode_base64<true, true>(output, input, length, options,
-                                                last_chunk_options);
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return compress_decode_base64<false, true, true>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<true, false>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return compress_decode_base64<true, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return compress_decode_base64<false, true>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, true, false>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<false, false>(output, input, length,
-                                                  options, last_chunk_options);
+      return compress_decode_base64<false, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   }
 }
@@ -32109,21 +31822,29 @@ simdutf_warn_unused result implementation::base64_to_binary(
 simdutf_warn_unused full_result implementation::base64_to_binary_details(
     const char *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return compress_decode_base64<true, true>(output, input, length, options,
-                                                last_chunk_options);
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return compress_decode_base64<false, true, true>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<true, false>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return compress_decode_base64<true, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return compress_decode_base64<false, true>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, true, false>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<false, false>(output, input, length,
-                                                  options, last_chunk_options);
+      return compress_decode_base64<false, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   }
 }
@@ -32131,21 +31852,29 @@ simdutf_warn_unused full_result implementation::base64_to_binary_details(
 simdutf_warn_unused result implementation::base64_to_binary(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return compress_decode_base64<true, true>(output, input, length, options,
-                                                last_chunk_options);
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return compress_decode_base64<false, true, true>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<true, false>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return compress_decode_base64<true, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return compress_decode_base64<false, true>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, true, false>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<false, false>(output, input, length,
-                                                  options, last_chunk_options);
+      return compress_decode_base64<false, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   }
 }
@@ -32153,21 +31882,29 @@ simdutf_warn_unused result implementation::base64_to_binary(
 simdutf_warn_unused full_result implementation::base64_to_binary_details(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return compress_decode_base64<true, true>(output, input, length, options,
-                                                last_chunk_options);
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return compress_decode_base64<false, true, true>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<true, false>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return compress_decode_base64<true, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return compress_decode_base64<false, true>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, true, false>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<false, false>(output, input, length,
-                                                  options, last_chunk_options);
+      return compress_decode_base64<false, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   }
 }
@@ -32274,6 +32011,169 @@ simd8<uint8_t> utf16_gather_high_bytes(const simd16<uint16_t> &in0,
 }
 #endif // SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
 
+#if SIMDUTF_FEATURE_UTF16
+/* begin file src/haswell/avx2_utf16fix.cpp */
+/*
+ * Process one block of 16 characters.  If in_place is false,
+ * copy the block from in to out.  If there is a sequencing
+ * error in the block, overwrite the illsequenced characters
+ * with the replacement character.  This function reads one
+ * character before the beginning of the buffer as a lookback.
+ * If that character is illsequenced, it too is overwritten.
+ */
+template <endianness big_endian, bool in_place>
+void utf16fix_block(char16_t *out, const char16_t *in) {
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
+  auto swap_if_needed = [](uint16_t c) -> uint16_t {
+    return !simdutf::match_system(big_endian) ? scalar::u16_swap_bytes(c) : c;
+  };
+  __m256i lookback, block, lb_masked, block_masked, lb_is_high, block_is_low;
+  __m256i illseq, lb_illseq, block_illseq, lb_illseq_shifted;
+
+  lookback = _mm256_loadu_si256((const __m256i *)(in - 1));
+  block = _mm256_loadu_si256((const __m256i *)in);
+  lb_masked =
+      _mm256_and_si256(lookback, _mm256_set1_epi16(swap_if_needed(0xfc00u)));
+  block_masked =
+      _mm256_and_si256(block, _mm256_set1_epi16(swap_if_needed(0xfc00u)));
+  lb_is_high =
+      _mm256_cmpeq_epi16(lb_masked, _mm256_set1_epi16(swap_if_needed(0xd800u)));
+  block_is_low = _mm256_cmpeq_epi16(block_masked,
+                                    _mm256_set1_epi16(swap_if_needed(0xdc00u)));
+
+  illseq = _mm256_xor_si256(lb_is_high, block_is_low);
+  if (!_mm256_testz_si256(illseq, illseq)) {
+    int lb;
+
+    /* compute the cause of the illegal sequencing */
+    lb_illseq = _mm256_andnot_si256(block_is_low, lb_is_high);
+    lb_illseq_shifted =
+        _mm256_or_si256(_mm256_bsrli_epi128(lb_illseq, 2),
+                        _mm256_zextsi128_si256(_mm_bslli_si128(
+                            _mm256_extracti128_si256(lb_illseq, 1), 14)));
+    block_illseq = _mm256_or_si256(
+        _mm256_andnot_si256(lb_is_high, block_is_low), lb_illseq_shifted);
+
+    /* fix illegal sequencing in the lookback */
+    lb = _mm256_cvtsi256_si32(lb_illseq);
+    lb = (lb & replacement) | (~lb & out[-1]);
+    out[-1] = char16_t(lb);
+
+    /* fix illegal sequencing in the main block */
+    block =
+        _mm256_blendv_epi8(block, _mm256_set1_epi16(replacement), block_illseq);
+    _mm256_storeu_si256((__m256i *)out, block);
+  } else if (!in_place) {
+    _mm256_storeu_si256((__m256i *)out, block);
+  }
+}
+
+template <endianness big_endian, bool in_place>
+void utf16fix_block_sse(char16_t *out, const char16_t *in) {
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
+  auto swap_if_needed = [](uint16_t c) -> uint16_t {
+    return !simdutf::match_system(big_endian) ? scalar::u16_swap_bytes(c) : c;
+  };
+
+  __m128i lookback, block, lb_masked, block_masked, lb_is_high, block_is_low;
+  __m128i illseq, lb_illseq, block_illseq;
+
+  lookback = _mm_loadu_si128((const __m128i *)(in - 1));
+  block = _mm_loadu_si128((const __m128i *)in);
+  lb_masked = _mm_and_si128(lookback, _mm_set1_epi16(swap_if_needed(0xfc00U)));
+  block_masked = _mm_and_si128(block, _mm_set1_epi16(swap_if_needed(0xfc00U)));
+  lb_is_high =
+      _mm_cmpeq_epi16(lb_masked, _mm_set1_epi16(swap_if_needed(0xd800U)));
+  block_is_low =
+      _mm_cmpeq_epi16(block_masked, _mm_set1_epi16(swap_if_needed(0xdc00U)));
+
+  illseq = _mm_xor_si128(lb_is_high, block_is_low);
+  if (_mm_movemask_epi8(illseq) != 0) {
+    /* compute the cause of the illegal sequencing */
+    lb_illseq = _mm_andnot_si128(block_is_low, lb_is_high);
+    block_illseq = _mm_or_si128(_mm_andnot_si128(lb_is_high, block_is_low),
+                                _mm_bsrli_si128(lb_illseq, 2));
+    /* fix illegal sequencing in the lookback */
+    int lb = _mm_cvtsi128_si32(lb_illseq);
+    lb = (lb & replacement) | (~lb & out[-1]);
+    out[-1] = char16_t(lb);
+    /* fix illegal sequencing in the main block */
+    block =
+        _mm_or_si128(_mm_andnot_si128(block_illseq, block),
+                     _mm_and_si128(block_illseq, _mm_set1_epi16(replacement)));
+    _mm_storeu_si128((__m128i *)out, block);
+  } else if (!in_place) {
+    _mm_storeu_si128((__m128i *)out, block);
+  }
+}
+
+template <endianness big_endian>
+void utf16fix_sse(const char16_t *in, size_t n, char16_t *out) {
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
+  size_t i;
+
+  if (n < 9) {
+    scalar::utf16::to_well_formed_utf16<big_endian>(in, n, out);
+    return;
+  }
+
+  out[0] =
+      scalar::utf16::is_low_surrogate<big_endian>(in[0]) ? replacement : in[0];
+
+  /* duplicate code to have the compiler specialise utf16fix_block() */
+  if (in == out) {
+    for (i = 1; i + 8 < n; i += 8) {
+      utf16fix_block_sse<big_endian, true>(out + i, in + i);
+    }
+
+    utf16fix_block_sse<big_endian, true>(out + n - 8, in + n - 8);
+  } else {
+    for (i = 1; i + 8 < n; i += 8) {
+      utf16fix_block_sse<big_endian, false>(out + i, in + i);
+    }
+
+    utf16fix_block_sse<big_endian, false>(out + n - 8, in + n - 8);
+  }
+
+  out[n - 1] = scalar::utf16::is_high_surrogate<big_endian>(out[n - 1])
+                   ? replacement
+                   : out[n - 1];
+}
+
+template <endianness big_endian>
+void utf16fix_avx(const char16_t *in, size_t n, char16_t *out) {
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
+  size_t i;
+
+  if (n < 17) {
+    utf16fix_sse<big_endian>(in, n, out);
+    return;
+  }
+
+  out[0] =
+      scalar::utf16::is_low_surrogate<big_endian>(in[0]) ? replacement : in[0];
+
+  /* duplicate code to have the compiler specialise utf16fix_block() */
+  if (in == out) {
+    for (i = 1; i + 16 < n; i += 16) {
+      utf16fix_block<big_endian, true>(out + i, in + i);
+    }
+
+    utf16fix_block<big_endian, true>(out + n - 16, in + n - 16);
+  } else {
+    for (i = 1; i + 16 < n; i += 16) {
+      utf16fix_block<big_endian, false>(out + i, in + i);
+    }
+
+    utf16fix_block<big_endian, false>(out + n - 16, in + n - 16);
+  }
+
+  out[n - 1] = scalar::utf16::is_high_surrogate<big_endian>(out[n - 1])
+                   ? replacement
+                   : out[n - 1];
+}
+/* end file src/haswell/avx2_utf16fix.cpp */
+#endif // SIMDUTF_FEATURE_UTF16
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 /* begin file src/haswell/avx2_convert_latin1_to_utf8.cpp */
 std::pair<const char *, char *>
@@ -34901,19 +34801,21 @@ public:
     std::memcpy(out + 24, buffer, 24);
   }
 
-  template <bool base64_url, bool ignore_garbage>
+  template <bool base64_url, bool ignore_garbage, bool default_or_url>
   simdutf_really_inline uint64_t to_base64_mask(uint64_t *error) {
     uint32_t err0 = 0;
     uint32_t err1 = 0;
-    uint64_t m0 = to_base64_mask<base64_url, ignore_garbage>(&chunks[0], &err0);
-    uint64_t m1 = to_base64_mask<base64_url, ignore_garbage>(&chunks[1], &err1);
+    uint64_t m0 = to_base64_mask<base64_url, ignore_garbage, default_or_url>(
+        &chunks[0], &err0);
+    uint64_t m1 = to_base64_mask<base64_url, ignore_garbage, default_or_url>(
+        &chunks[1], &err1);
     if (!ignore_garbage) {
       *error = err0 | ((uint64_t)err1 << 32);
     }
     return m0 | (m1 << 32);
   }
 
-  template <bool base64_url, bool ignore_garbage>
+  template <bool base64_url, bool ignore_garbage, bool default_or_url>
   simdutf_really_inline uint32_t to_base64_mask(__m256i *src, uint32_t *error) {
     const __m256i ascii_space_tbl =
         _mm256_setr_epi8(0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x9, 0xa,
@@ -34921,7 +34823,12 @@ public:
                          0x0, 0x0, 0x0, 0x9, 0xa, 0x0, 0xc, 0xd, 0x0, 0x0);
     // credit: aqrit
     __m256i delta_asso;
-    if (base64_url) {
+    if (default_or_url) {
+      delta_asso = _mm256_setr_epi8(
+          0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x11, 0x00, 0x16, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+          0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x00, 0x16);
+    } else if (base64_url) {
       delta_asso = _mm256_setr_epi8(0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x0,
                                     0x0, 0x0, 0x0, 0x0, 0xF, 0x0, 0xF, 0x1, 0x1,
                                     0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x0, 0x0, 0x0,
@@ -34934,7 +34841,17 @@ public:
     }
 
     __m256i delta_values;
-    if (base64_url) {
+    if (default_or_url) {
+      delta_values = _mm256_setr_epi8(
+          uint8_t(0xBF), uint8_t(0xE0), uint8_t(0xB9), uint8_t(0x13),
+          uint8_t(0x04), uint8_t(0xBF), uint8_t(0xBF), uint8_t(0xB9),
+          uint8_t(0xB9), uint8_t(0x00), uint8_t(0xFF), uint8_t(0x11),
+          uint8_t(0xFF), uint8_t(0xBF), uint8_t(0x10), uint8_t(0xB9),
+          uint8_t(0xBF), uint8_t(0xE0), uint8_t(0xB9), uint8_t(0x13),
+          uint8_t(0x04), uint8_t(0xBF), uint8_t(0xBF), uint8_t(0xB9),
+          uint8_t(0xB9), uint8_t(0x00), uint8_t(0xFF), uint8_t(0x11),
+          uint8_t(0xFF), uint8_t(0xBF), uint8_t(0x10), uint8_t(0xB9));
+    } else if (base64_url) {
       delta_values = _mm256_setr_epi8(
           0x0, 0x0, 0x0, 0x13, 0x4, uint8_t(0xBF), uint8_t(0xBF), uint8_t(0xB9),
           uint8_t(0xB9), 0x0, 0x11, uint8_t(0xC3), uint8_t(0xBF), uint8_t(0xE0),
@@ -34953,7 +34870,12 @@ public:
     }
 
     __m256i check_asso;
-    if (base64_url) {
+    if (default_or_url) {
+      check_asso = _mm256_setr_epi8(
+          0x0D, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x03,
+          0x07, 0x0B, 0x0E, 0x0B, 0x06, 0x0D, 0x01, 0x01, 0x01, 0x01, 0x01,
+          0x01, 0x01, 0x01, 0x01, 0x03, 0x07, 0x0B, 0x0E, 0x0B, 0x06);
+    } else if (base64_url) {
       check_asso = _mm256_setr_epi8(0xD, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1,
                                     0x1, 0x3, 0x7, 0xB, 0xE, 0xB, 0x6, 0xD, 0x1,
                                     0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x3,
@@ -34965,7 +34887,17 @@ public:
           0x01, 0x01, 0x01, 0x01, 0x03, 0x07, 0x0B, 0x0B, 0x0B, 0x0F);
     }
     __m256i check_values;
-    if (base64_url) {
+    if (default_or_url) {
+      check_values = _mm256_setr_epi8(
+          uint8_t(0x80), uint8_t(0x80), uint8_t(0x80), uint8_t(0x80),
+          uint8_t(0xCF), uint8_t(0xBF), uint8_t(0xD5), uint8_t(0xA6),
+          uint8_t(0xB5), uint8_t(0xA1), uint8_t(0x00), uint8_t(0x80),
+          uint8_t(0x00), uint8_t(0x80), uint8_t(0x00), uint8_t(0x80),
+          uint8_t(0x80), uint8_t(0x80), uint8_t(0x80), uint8_t(0x80),
+          uint8_t(0xCF), uint8_t(0xBF), uint8_t(0xD5), uint8_t(0xA6),
+          uint8_t(0xB5), uint8_t(0xA1), uint8_t(0x00), uint8_t(0x80),
+          uint8_t(0x00), uint8_t(0x80), uint8_t(0x00), uint8_t(0x80));
+    } else if (base64_url) {
       check_values = _mm256_setr_epi8(
           uint8_t(0x80), uint8_t(0x80), uint8_t(0x80), uint8_t(0x80),
           uint8_t(0xCF), uint8_t(0xBF), uint8_t(0xB6), uint8_t(0xA6),
@@ -34985,8 +34917,11 @@ public:
           int8_t(0x91), int8_t(0x80));
     }
     const __m256i shifted = _mm256_srli_epi32(*src, 3);
-    const __m256i delta_hash =
+    __m256i delta_hash =
         _mm256_avg_epu8(_mm256_shuffle_epi8(delta_asso, *src), shifted);
+    if (default_or_url) {
+      delta_hash = _mm256_and_si256(delta_hash, _mm256_set1_epi8(0xf));
+    }
     const __m256i check_hash =
         _mm256_avg_epu8(_mm256_shuffle_epi8(check_asso, *src), shifted);
     const __m256i out =
@@ -35987,6 +35922,61 @@ struct validating_transcoder {
 } // namespace haswell
 } // namespace simdutf
 /* end file src/generic/utf8_to_utf16/utf8_to_utf16.h */
+/* begin file src/generic/utf8/utf16_length_from_utf8_bytemask.h */
+namespace simdutf {
+namespace haswell {
+namespace {
+namespace utf8 {
+
+using namespace simd;
+
+simdutf_really_inline size_t utf16_length_from_utf8_bytemask(const char *in,
+                                                             size_t size) {
+  using vector_i8 = simd8<int8_t>;
+  using vector_u8 = simd8<uint8_t>;
+  using vector_u64 = simd64<uint64_t>;
+
+  constexpr size_t N = vector_i8::SIZE;
+  constexpr size_t max_iterations = 255 / 2;
+
+  auto counters = vector_u64::zero();
+  auto local = vector_u8::zero();
+
+  size_t iterations = 0;
+  size_t pos = 0;
+  size_t count = 0;
+  for (; pos + N <= size; pos += N) {
+    const auto input =
+        vector_i8::load(reinterpret_cast<const int8_t *>(in + pos));
+
+    const auto continuation = input > int8_t(-65);
+    const auto utf_4bytes = vector_u8(input.value) >= uint8_t(240);
+
+    local -= vector_u8(continuation);
+    local -= vector_u8(utf_4bytes);
+
+    iterations += 1;
+    if (iterations == max_iterations) {
+      counters += sum_8bytes(local);
+      local = vector_u8::zero();
+      iterations = 0;
+    }
+  }
+
+  if (iterations > 0) {
+    count += local.sum_bytes();
+  }
+
+  count += counters.sum();
+
+  return count + scalar::utf8::utf16_length_from_utf8(in + pos, size - pos);
+}
+
+} // namespace utf8
+} // unnamed namespace
+} // namespace haswell
+} // namespace simdutf
+/* end file src/generic/utf8/utf16_length_from_utf8_bytemask.h */
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
@@ -36567,7 +36557,7 @@ simdutf_really_inline size_t count_code_points_bytemask(const char *in,
 
   return count + scalar::utf8::count_code_points(in + pos, size - pos);
 }
-#endif
+#endif // SIMDUTF_SIMD_HAS_BYTEMASK
 
 simdutf_really_inline size_t utf16_length_from_utf8(const char *in,
                                                     size_t size) {
@@ -36585,6 +36575,7 @@ simdutf_really_inline size_t utf16_length_from_utf8(const char *in,
   }
   return count + scalar::utf8::utf16_length_from_utf8(in + pos, size - pos);
 }
+
 } // namespace utf8
 } // unnamed namespace
 } // namespace haswell
@@ -36642,7 +36633,40 @@ simdutf_really_inline size_t utf8_length_from_utf16(const char16_t *in,
                                                                    size - pos);
 }
 
-#ifdef SIMDUTF_SIMD_HAS_BYTEMASK
+template <endianness big_endian>
+simdutf_really_inline size_t utf32_length_from_utf16(const char16_t *in,
+                                                     size_t size) {
+  return count_code_points<big_endian>(in, size);
+}
+
+simdutf_really_inline void
+change_endianness_utf16(const char16_t *in, size_t size, char16_t *output) {
+  size_t pos = 0;
+
+  while (pos < size / 32 * 32) {
+    simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(in + pos));
+    input.swap_bytes();
+    input.store(reinterpret_cast<uint16_t *>(output));
+    pos += 32;
+    output += 32;
+  }
+
+  scalar::utf16::change_endianness_utf16(in + pos, size - pos, output);
+}
+
+} // namespace utf16
+} // unnamed namespace
+} // namespace haswell
+} // namespace simdutf
+/* end file src/generic/utf16.h */
+/* begin file src/generic/utf16/utf8_length_from_utf16_bytemask.h */
+namespace simdutf {
+namespace haswell {
+namespace {
+namespace utf16 {
+
+using namespace simd;
+
 template <endianness big_endian>
 simdutf_really_inline size_t utf8_length_from_utf16_bytemask(const char16_t *in,
                                                              size_t size) {
@@ -36721,34 +36745,12 @@ simdutf_really_inline size_t utf8_length_from_utf16_bytemask(const char16_t *in,
   return count + scalar::utf16::utf8_length_from_utf16<big_endian>(in + pos,
                                                                    size - pos);
 }
-#endif // SIMDUTF_SIMD_HAS_BYTEMASK
-
-template <endianness big_endian>
-simdutf_really_inline size_t utf32_length_from_utf16(const char16_t *in,
-                                                     size_t size) {
-  return count_code_points<big_endian>(in, size);
-}
-
-simdutf_really_inline void
-change_endianness_utf16(const char16_t *in, size_t size, char16_t *output) {
-  size_t pos = 0;
-
-  while (pos < size / 32 * 32) {
-    simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(in + pos));
-    input.swap_bytes();
-    input.store(reinterpret_cast<uint16_t *>(output));
-    pos += 32;
-    output += 32;
-  }
-
-  scalar::utf16::change_endianness_utf16(in + pos, size - pos, output);
-}
 
 } // namespace utf16
 } // unnamed namespace
 } // namespace haswell
 } // namespace simdutf
-/* end file src/generic/utf16.h */
+/* end file src/generic/utf16/utf8_length_from_utf16_bytemask.h */
 #endif // SIMDUTF_FEATURE_UTF16
 #if SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
 /* begin file src/generic/validate_utf16.h */
@@ -37351,9 +37353,9 @@ simdutf_really_inline result validate_with_errors(const char32_t *input,
 
   using vector_u32 = simd32<uint32_t>;
 
-  const auto standardmax = vector_u32::splat(0x10ffff);
-  const auto offset = vector_u32::splat(0xffff2000);
-  const auto standardoffsetmax = vector_u32::splat(0xfffff7ff);
+  const auto standardmax = vector_u32::splat(0x10ffff + 1);
+  const auto surrogate_mask = vector_u32::splat(0xfffff800);
+  const auto surrogate_byte = vector_u32::splat(0x0000d800);
 
   constexpr size_t N = vector_u32::ELEMENTS;
 
@@ -37363,8 +37365,8 @@ simdutf_really_inline result validate_with_errors(const char32_t *input,
       in.swap_bytes();
     }
 
-    const auto too_large = in > standardmax;
-    const auto surrogate = (in + offset) > standardoffsetmax;
+    const auto too_large = in >= standardmax;
+    const auto surrogate = (in & surrogate_mask) == surrogate_byte;
 
     const auto combined = too_large | surrogate;
     if (simdutf_unlikely(combined.any())) {
@@ -37433,13 +37435,16 @@ namespace base64 {
     associated methods that perform actual conversion. Please refer
     to any vectorized implementation to learn the API of these procedures.
 */
-template <bool base64_url, bool ignore_garbage, typename chartype>
+template <bool base64_url, bool ignore_garbage, bool default_or_url,
+          typename chartype>
 full_result
 compress_decode_base64(char *dst, const chartype *src, size_t srclen,
                        base64_options options,
                        last_chunk_handling_options last_chunk_options) {
-  const uint8_t *to_base64 = base64_url ? tables::base64::to_base64_url_value
-                                        : tables::base64::to_base64_value;
+  const uint8_t *to_base64 =
+      default_or_url ? tables::base64::to_base64_default_or_url_value
+                     : (base64_url ? tables::base64::to_base64_url_value
+                                   : tables::base64::to_base64_value);
   size_t equallocation =
       srclen; // location of the first padding character if any
   // skip trailing spaces
@@ -37494,7 +37499,7 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
       src += 64;
       uint64_t error = 0;
       const uint64_t badcharmask =
-          b.to_base64_mask<base64_url, ignore_garbage>(&error);
+          b.to_base64_mask<base64_url, ignore_garbage, default_or_url>(&error);
       if (!ignore_garbage && error) {
         src -= 64;
         const size_t error_offset = trailing_zeroes(error);
@@ -37857,6 +37862,16 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
   } else {
     return res;
   }
+}
+
+void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return utf16fix_avx<endianness::LITTLE>(input, len, output);
+}
+
+void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return utf16fix_avx<endianness::BIG>(input, len, output);
 }
 #endif // SIMDUTF_FEATURE_UTF16
 
@@ -38621,7 +38636,7 @@ simdutf_warn_unused size_t implementation::utf32_length_from_utf16be(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 simdutf_warn_unused size_t implementation::utf16_length_from_utf8(
     const char *input, size_t length) const noexcept {
-  return utf8::utf16_length_from_utf8(input, length);
+  return utf8::utf16_length_from_utf8_bytemask(input, length);
 }
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
@@ -38722,20 +38737,28 @@ simdutf_warn_unused size_t implementation::utf32_length_from_utf8(
 simdutf_warn_unused result implementation::base64_to_binary(
     const char *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return base64::compress_decode_base64<true, true>(
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return base64::compress_decode_base64<false, true, true>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<true, false>(
+      return base64::compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return base64::compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return base64::compress_decode_base64<true, false, false>(
           output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return base64::compress_decode_base64<false, true>(
+      return base64::compress_decode_base64<false, true, false>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<false, false>(
+      return base64::compress_decode_base64<false, false, false>(
           output, input, length, options, last_chunk_options);
     }
   }
@@ -38744,20 +38767,28 @@ simdutf_warn_unused result implementation::base64_to_binary(
 simdutf_warn_unused full_result implementation::base64_to_binary_details(
     const char *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return base64::compress_decode_base64<true, true>(
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return base64::compress_decode_base64<false, true, true>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<true, false>(
+      return base64::compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return base64::compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return base64::compress_decode_base64<true, false, false>(
           output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return base64::compress_decode_base64<false, true>(
+      return base64::compress_decode_base64<false, true, false>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<false, false>(
+      return base64::compress_decode_base64<false, false, false>(
           output, input, length, options, last_chunk_options);
     }
   }
@@ -38766,20 +38797,28 @@ simdutf_warn_unused full_result implementation::base64_to_binary_details(
 simdutf_warn_unused result implementation::base64_to_binary(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return base64::compress_decode_base64<true, true>(
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return base64::compress_decode_base64<false, true, true>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<true, false>(
+      return base64::compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return base64::compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return base64::compress_decode_base64<true, false, false>(
           output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return base64::compress_decode_base64<false, true>(
+      return base64::compress_decode_base64<false, true, false>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<false, false>(
+      return base64::compress_decode_base64<false, false, false>(
           output, input, length, options, last_chunk_options);
     }
   }
@@ -38788,20 +38827,28 @@ simdutf_warn_unused result implementation::base64_to_binary(
 simdutf_warn_unused full_result implementation::base64_to_binary_details(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return base64::compress_decode_base64<true, true>(
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return base64::compress_decode_base64<false, true, true>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<true, false>(
+      return base64::compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return base64::compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return base64::compress_decode_base64<true, false, false>(
           output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return base64::compress_decode_base64<false, true>(
+      return base64::compress_decode_base64<false, true, false>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<false, false>(
+      return base64::compress_decode_base64<false, false, false>(
           output, input, length, options, last_chunk_options);
     }
   }
@@ -41789,7 +41836,7 @@ private:
   }
 
 public:
-  template <bool base64_url, bool ignore_garbage>
+  template <bool base64_url, bool ignore_garbage, bool default_or_url>
   static inline uint16_t to_base64_mask(vector_u8 &src, uint16_t &error) {
     const auto ascii_space_tbl =
         vector_u8(0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x9, 0xa, 0x0,
@@ -41797,28 +41844,41 @@ public:
 
     // credit: aqrit
     const auto delta_asso =
-        base64_url ? vector_u8(0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x0, 0x0,
-                               0x0, 0x0, 0x0, 0xF, 0x0, 0xF)
-                   : vector_u8(0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
-                               0x00, 0x00, 0x00, 0x00, 0x00, 0x0F, 0x00, 0x0F);
+        default_or_url
+            ? vector_u8(0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00,
+                        0x00, 0x00, 0x00, 0x00, 0x11, 0x00, 0x16)
+            : vector_u8(0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00,
+                        0x00, 0x00, 0x00, 0x00, 0x0F, 0x00, 0x0F);
 
     const auto delta_values =
-        base64_url ? vector_u8(0x0, 0x0, 0x0, 0x13, 0x4, 0xBF, 0xBF, 0xB9, 0xB9,
+        default_or_url
+            ? vector_u8(0xBF, 0xE0, 0xB9, 0x13, 0x04, 0xBF, 0xBF, 0xB9, 0xB9,
+                        0x00, 0xFF, 0x11, 0xFF, 0xBF, 0x10, 0xB9)
+            : (base64_url
+                   ? vector_u8(0x0, 0x0, 0x0, 0x13, 0x4, 0xBF, 0xBF, 0xB9, 0xB9,
                                0x0, 0x11, 0xC3, 0xBF, 0xE0, 0xB9, 0xB9)
                    : vector_u8(0x00, 0x00, 0x00, 0x13, 0x04, 0xBF, 0xBF, 0xB9,
-                               0xB9, 0x00, 0x10, 0xC3, 0xBF, 0xBF, 0xB9, 0xB9);
+                               0xB9, 0x00, 0x10, 0xC3, 0xBF, 0xBF, 0xB9, 0xB9));
 
     const auto check_asso =
-        base64_url ? vector_u8(0xD, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1,
+        default_or_url
+            ? vector_u8(0x0D, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+                        0x01, 0x03, 0x07, 0x0B, 0x0E, 0x0B, 0x06)
+            : (base64_url
+                   ? vector_u8(0xD, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1,
                                0x3, 0x7, 0xB, 0xE, 0xB, 0x6)
                    : vector_u8(0x0D, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
-                               0x01, 0x01, 0x03, 0x07, 0x0B, 0x0B, 0x0B, 0x0F);
+                               0x01, 0x01, 0x03, 0x07, 0x0B, 0x0B, 0x0B, 0x0F));
 
     const auto check_values =
-        base64_url ? vector_u8(0x80, 0x80, 0x80, 0x80, 0xCF, 0xBF, 0xB6, 0xA6,
+        default_or_url
+            ? vector_u8(0x80, 0x80, 0x80, 0x80, 0xCF, 0xBF, 0xD5, 0xA6, 0xB5,
+                        0xA1, 0x00, 0x80, 0x00, 0x80, 0x00, 0x80)
+            : (base64_url
+                   ? vector_u8(0x80, 0x80, 0x80, 0x80, 0xCF, 0xBF, 0xB6, 0xA6,
                                0xB5, 0xA1, 0x0, 0x80, 0x0, 0x80, 0x0, 0x80)
                    : vector_u8(0x80, 0x80, 0x80, 0x80, 0xCF, 0xBF, 0xD5, 0xA6,
-                               0xB5, 0x86, 0xD1, 0x80, 0xB1, 0x80, 0x91, 0x80);
+                               0xB5, 0x86, 0xD1, 0x80, 0xB1, 0x80, 0x91, 0x80));
 
     const auto shifted = src.shr<3>();
 
@@ -41841,16 +41901,20 @@ public:
     return mask;
   }
 
-  template <bool base64_url, bool ignore_garbage>
+  template <bool base64_url, bool ignore_garbage, bool default_or_url>
   simdutf_really_inline uint64_t to_base64_mask(uint64_t *error) {
     uint16_t err0 = 0;
     uint16_t err1 = 0;
     uint16_t err2 = 0;
     uint16_t err3 = 0;
-    uint64_t m0 = to_base64_mask<base64_url, ignore_garbage>(b.chunks[0], err0);
-    uint64_t m1 = to_base64_mask<base64_url, ignore_garbage>(b.chunks[1], err1);
-    uint64_t m2 = to_base64_mask<base64_url, ignore_garbage>(b.chunks[2], err2);
-    uint64_t m3 = to_base64_mask<base64_url, ignore_garbage>(b.chunks[3], err3);
+    uint64_t m0 = to_base64_mask<base64_url, ignore_garbage, default_or_url>(
+        b.chunks[0], err0);
+    uint64_t m1 = to_base64_mask<base64_url, ignore_garbage, default_or_url>(
+        b.chunks[1], err1);
+    uint64_t m2 = to_base64_mask<base64_url, ignore_garbage, default_or_url>(
+        b.chunks[2], err2);
+    uint64_t m3 = to_base64_mask<base64_url, ignore_garbage, default_or_url>(
+        b.chunks[3], err3);
 
     if (!ignore_garbage) {
       *error = (err0) | ((uint64_t)err1 << 16) | ((uint64_t)err2 << 32) |
@@ -43174,7 +43238,7 @@ simdutf_really_inline size_t count_code_points_bytemask(const char *in,
 
   return count + scalar::utf8::count_code_points(in + pos, size - pos);
 }
-#endif
+#endif // SIMDUTF_SIMD_HAS_BYTEMASK
 
 simdutf_really_inline size_t utf16_length_from_utf8(const char *in,
                                                     size_t size) {
@@ -43192,6 +43256,7 @@ simdutf_really_inline size_t utf16_length_from_utf8(const char *in,
   }
   return count + scalar::utf8::utf16_length_from_utf8(in + pos, size - pos);
 }
+
 } // namespace utf8
 } // unnamed namespace
 } // namespace ppc64
@@ -43248,87 +43313,6 @@ simdutf_really_inline size_t utf8_length_from_utf16(const char16_t *in,
   return count + scalar::utf16::utf8_length_from_utf16<big_endian>(in + pos,
                                                                    size - pos);
 }
-
-#ifdef SIMDUTF_SIMD_HAS_BYTEMASK
-template <endianness big_endian>
-simdutf_really_inline size_t utf8_length_from_utf16_bytemask(const char16_t *in,
-                                                             size_t size) {
-  size_t pos = 0;
-
-  using vector_u16 = simd16<uint16_t>;
-  constexpr size_t N = vector_u16::ELEMENTS;
-
-  const auto one = vector_u16::splat(1);
-
-  auto v_count = vector_u16::zero();
-
-  // each char16 yields at least one byte
-  size_t count = size / N * N;
-
-  // in a single iteration the increment is 0, 1 or 2, despite we have
-  // three additions
-  constexpr size_t max_iterations = 65535 / 2;
-  size_t iteration = max_iterations;
-
-  for (; pos < size / N * N; pos += N) {
-    auto input = vector_u16::load(reinterpret_cast<const uint16_t *>(in + pos));
-    if (!match_system(big_endian)) {
-      input = input.swap_bytes();
-    }
-    // 0xd800 .. 0xdbff - low surrogate
-    // 0xdc00 .. 0xdfff - high surrogate
-    const auto is_surrogate = ((input & uint16_t(0xf800)) == uint16_t(0xd800));
-
-    // c0 - chars that yield 2- or 3-byte UTF-8 codes
-    const auto c0 = min(input & uint16_t(0xff80), one);
-
-    // c1 - chars that yield 3-byte UTF-8 codes (including surrogates)
-    const auto c1 = min(input & uint16_t(0xf800), one);
-
-    /*
-        Explanation how the counting works.
-
-        In the case of a non-surrogate character we count:
-        * always 1 -- see how `count` is initialized above;
-        * c0 = 1 if the current char yields 2 or 3 bytes;
-        * c1 = 1 if the current char yields 3 bytes.
-
-        Thus, we always have correct count for the current char:
-        from 1, 2 or 3 bytes.
-
-        A trickier part is how we count surrogate pairs. Whether
-        we encounter a surrogate (low or high), we count it as
-        3 chars and then minus 1 (`is_surrogate` is -1 or 0).
-        Each surrogate char yields 2. A surrogate pair, that
-        is a low surrogate followed by a high one, yields
-        the expected 4 bytes.
-
-        It also correctly handles cases when low surrogate is
-        processed by the this loop, but high surrogate is counted
-        by the scalar procedure. The scalar procedure uses exactly
-        the described approach, thanks to that for valid UTF-16
-        strings it always count correctly.
-    */
-    v_count += c0;
-    v_count += c1;
-    v_count += vector_u16(is_surrogate);
-
-    iteration -= 1;
-    if (iteration == 0) {
-      count += v_count.sum();
-      v_count = vector_u16::zero();
-      iteration = max_iterations;
-    }
-  }
-
-  if (iteration > 0) {
-    count += v_count.sum();
-  }
-
-  return count + scalar::utf16::utf8_length_from_utf16<big_endian>(in + pos,
-                                                                   size - pos);
-}
-#endif // SIMDUTF_SIMD_HAS_BYTEMASK
 
 template <endianness big_endian>
 simdutf_really_inline size_t utf32_length_from_utf16(const char16_t *in,
@@ -43692,9 +43676,9 @@ simdutf_really_inline result validate_with_errors(const char32_t *input,
 
   using vector_u32 = simd32<uint32_t>;
 
-  const auto standardmax = vector_u32::splat(0x10ffff);
-  const auto offset = vector_u32::splat(0xffff2000);
-  const auto standardoffsetmax = vector_u32::splat(0xfffff7ff);
+  const auto standardmax = vector_u32::splat(0x10ffff + 1);
+  const auto surrogate_mask = vector_u32::splat(0xfffff800);
+  const auto surrogate_byte = vector_u32::splat(0x0000d800);
 
   constexpr size_t N = vector_u32::ELEMENTS;
 
@@ -43704,8 +43688,8 @@ simdutf_really_inline result validate_with_errors(const char32_t *input,
       in.swap_bytes();
     }
 
-    const auto too_large = in > standardmax;
-    const auto surrogate = (in + offset) > standardoffsetmax;
+    const auto too_large = in >= standardmax;
+    const auto surrogate = (in & surrogate_mask) == surrogate_byte;
 
     const auto combined = too_large | surrogate;
     if (simdutf_unlikely(combined.any())) {
@@ -44231,13 +44215,16 @@ namespace base64 {
     associated methods that perform actual conversion. Please refer
     to any vectorized implementation to learn the API of these procedures.
 */
-template <bool base64_url, bool ignore_garbage, typename chartype>
+template <bool base64_url, bool ignore_garbage, bool default_or_url,
+          typename chartype>
 full_result
 compress_decode_base64(char *dst, const chartype *src, size_t srclen,
                        base64_options options,
                        last_chunk_handling_options last_chunk_options) {
-  const uint8_t *to_base64 = base64_url ? tables::base64::to_base64_url_value
-                                        : tables::base64::to_base64_value;
+  const uint8_t *to_base64 =
+      default_or_url ? tables::base64::to_base64_default_or_url_value
+                     : (base64_url ? tables::base64::to_base64_url_value
+                                   : tables::base64::to_base64_value);
   size_t equallocation =
       srclen; // location of the first padding character if any
   // skip trailing spaces
@@ -44292,7 +44279,7 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
       src += 64;
       uint64_t error = 0;
       const uint64_t badcharmask =
-          b.to_base64_mask<base64_url, ignore_garbage>(&error);
+          b.to_base64_mask<base64_url, ignore_garbage, default_or_url>(&error);
       if (!ignore_garbage && error) {
         src -= 64;
         const size_t error_offset = trailing_zeroes(error);
@@ -44624,6 +44611,18 @@ simdutf_warn_unused bool
 implementation::validate_utf16be(const char16_t *buf,
                                  size_t len) const noexcept {
   return validate_utf16be_with_errors(buf, len).is_ok();
+}
+
+void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::LITTLE>(input, len,
+                                                                 output);
+}
+
+void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::BIG>(input, len,
+                                                              output);
 }
 
 simdutf_warn_unused result implementation::validate_utf16le_with_errors(
@@ -45143,20 +45142,28 @@ simdutf_warn_unused size_t implementation::maximal_binary_length_from_base64(
 simdutf_warn_unused result implementation::base64_to_binary(
     const char *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return base64::compress_decode_base64<true, true>(
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return base64::compress_decode_base64<false, true, true>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<true, false>(
+      return base64::compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return base64::compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return base64::compress_decode_base64<true, false, false>(
           output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return base64::compress_decode_base64<false, true>(
+      return base64::compress_decode_base64<false, true, false>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<false, false>(
+      return base64::compress_decode_base64<false, false, false>(
           output, input, length, options, last_chunk_options);
     }
   }
@@ -45165,20 +45172,28 @@ simdutf_warn_unused result implementation::base64_to_binary(
 simdutf_warn_unused full_result implementation::base64_to_binary_details(
     const char *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return base64::compress_decode_base64<true, true>(
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return base64::compress_decode_base64<false, true, true>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<true, false>(
+      return base64::compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return base64::compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return base64::compress_decode_base64<true, false, false>(
           output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return base64::compress_decode_base64<false, true>(
+      return base64::compress_decode_base64<false, true, false>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<false, false>(
+      return base64::compress_decode_base64<false, false, false>(
           output, input, length, options, last_chunk_options);
     }
   }
@@ -45187,20 +45202,28 @@ simdutf_warn_unused full_result implementation::base64_to_binary_details(
 simdutf_warn_unused result implementation::base64_to_binary(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return base64::compress_decode_base64<true, true>(
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return base64::compress_decode_base64<false, true, true>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<true, false>(
+      return base64::compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return base64::compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return base64::compress_decode_base64<true, false, false>(
           output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return base64::compress_decode_base64<false, true>(
+      return base64::compress_decode_base64<false, true, false>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<false, false>(
+      return base64::compress_decode_base64<false, false, false>(
           output, input, length, options, last_chunk_options);
     }
   }
@@ -45209,20 +45232,28 @@ simdutf_warn_unused result implementation::base64_to_binary(
 simdutf_warn_unused full_result implementation::base64_to_binary_details(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return base64::compress_decode_base64<true, true>(
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return base64::compress_decode_base64<false, true, true>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<true, false>(
+      return base64::compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return base64::compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return base64::compress_decode_base64<true, false, false>(
           output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return base64::compress_decode_base64<false, true>(
+      return base64::compress_decode_base64<false, true, false>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<false, false>(
+      return base64::compress_decode_base64<false, false, false>(
           output, input, length, options, last_chunk_options);
     }
   }
@@ -45565,14 +45596,9 @@ simdutf_really_inline static size_t rvv_count_valid_utf8(const char *src,
     vuint8m4_t v2 = __riscv_vslide1down_vx_u8m4(v1, next1, vl);
     vuint8m4_t v3 = __riscv_vslide1down_vx_u8m4(v2, next2, vl);
 
-    vuint8m4_t s1 = __riscv_vreinterpret_v_u16m4_u8m4(__riscv_vsrl_vx_u16m4(
-        __riscv_vreinterpret_v_u8m4_u16m4(v2), 4, __riscv_vsetvlmax_e16m4()));
-    vuint8m4_t s3 = __riscv_vreinterpret_v_u16m4_u8m4(__riscv_vsrl_vx_u16m4(
-        __riscv_vreinterpret_v_u8m4_u16m4(v3), 4, __riscv_vsetvlmax_e16m4()));
-
     vuint8m4_t idx2 = __riscv_vand_vx_u8m4(v2, 0xF, vl);
-    vuint8m4_t idx1 = __riscv_vand_vx_u8m4(s1, 0xF, vl);
-    vuint8m4_t idx3 = __riscv_vand_vx_u8m4(s3, 0xF, vl);
+    vuint8m4_t idx1 = __riscv_vsrl_vx_u8m4(v2, 4, vl);
+    vuint8m4_t idx3 = __riscv_vsrl_vx_u8m4(v3, 4, vl);
 
     vuint8m4_t err1 = simdutf_vrgather_u8m1x4(err1tbl, idx1);
     vuint8m4_t err2 = simdutf_vrgather_u8m1x4(err2tbl, idx2);
@@ -46241,8 +46267,10 @@ simdutf_warn_unused size_t implementation::convert_valid_utf32_to_latin1(
 #endif // SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
-simdutf_warn_unused result implementation::convert_utf32_to_utf8_with_errors(
-    const char32_t *src, size_t len, char *dst) const noexcept {
+template <bool with_validation>
+simdutf_warn_unused result convert_utf32_to_utf8_aux(const char32_t *src,
+                                                     size_t len,
+                                                     char *dst) noexcept {
   size_t n = len;
   const char32_t *srcBeg = src;
   const char *dstBeg = dst;
@@ -46298,23 +46326,21 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf8_with_errors(
       n -= vl, src += vl, dst += vlOut;
       continue;
     }
-    long idx1 =
-        __riscv_vfirst_m_b8(__riscv_vmsgtu_vx_u32m4_b8(v, 0x10FFFF, vl), vl);
-    vbool8_t sur = __riscv_vmseq_vx_u32m4_b8(
-        __riscv_vand_vx_u32m4(v, 0xFFFFF800, vl), 0xD800, vl);
-    long idx2 = __riscv_vfirst_m_b8(sur, vl);
-    if (idx1 >= 0 && idx2 >= 0) {
-      if (idx1 <= idx2) {
-        return result(error_code::TOO_LARGE, src - srcBeg + idx1);
-      } else {
-        return result(error_code::SURROGATE, src - srcBeg + idx2);
+
+    if (with_validation) {
+      const long idx1 =
+          __riscv_vfirst_m_b8(__riscv_vmsgtu_vx_u32m4_b8(v, 0x10FFFF, vl), vl);
+      vbool8_t sur = __riscv_vmseq_vx_u32m4_b8(
+          __riscv_vand_vx_u32m4(v, 0xFFFFF800, vl), 0xD800, vl);
+      const long idx2 = __riscv_vfirst_m_b8(sur, vl);
+      if (idx1 >= 0 || idx2 >= 0) {
+        if (static_cast<unsigned long>(idx1) <=
+            static_cast<unsigned long>(idx2)) {
+          return result(error_code::TOO_LARGE, src - srcBeg + idx1);
+        } else {
+          return result(error_code::SURROGATE, src - srcBeg + idx2);
+        }
       }
-    }
-    if (idx1 >= 0) {
-      return result(error_code::TOO_LARGE, src - srcBeg + idx1);
-    }
-    if (idx2 >= 0) {
-      return result(error_code::SURROGATE, src - srcBeg + idx2);
     }
 
     vbool8_t m4 = __riscv_vmsgtu_vx_u32m4_b8(v, 0x10000 - 1, vl);
@@ -46382,6 +46408,12 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf8_with_errors(
   return result(error_code::SUCCESS, dst - dstBeg);
 }
 
+simdutf_warn_unused result implementation::convert_utf32_to_utf8_with_errors(
+    const char32_t *src, size_t len, char *dst) const noexcept {
+  constexpr bool with_validation = true;
+  return convert_utf32_to_utf8_aux<with_validation>(src, len, dst);
+}
+
 simdutf_warn_unused size_t implementation::convert_utf32_to_utf8(
     const char32_t *src, size_t len, char *dst) const noexcept {
   result res = convert_utf32_to_utf8_with_errors(src, len, dst);
@@ -46390,7 +46422,9 @@ simdutf_warn_unused size_t implementation::convert_utf32_to_utf8(
 
 simdutf_warn_unused size_t implementation::convert_valid_utf32_to_utf8(
     const char32_t *src, size_t len, char *dst) const noexcept {
-  return convert_utf32_to_utf8(src, len, dst);
+  constexpr bool with_validation = false;
+  const auto res = convert_utf32_to_utf8_aux<with_validation>(src, len, dst);
+  return res.count;
 }
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 
@@ -46408,20 +46442,19 @@ rvv_convert_utf32_to_utf16_with_errors(const char32_t *src, size_t len,
     vl = __riscv_vsetvl_e32m4(len);
     vuint32m4_t v = __riscv_vle32_v_u32m4((uint32_t *)src, vl);
     vuint32m4_t off = __riscv_vadd_vx_u32m4(v, 0xFFFF2000, vl);
-    long idx1 =
+    const long idx1 =
         __riscv_vfirst_m_b8(__riscv_vmsgtu_vx_u32m4_b8(v, 0x10FFFF, vl), vl);
-    long idx2 = __riscv_vfirst_m_b8(
+    const long idx2 = __riscv_vfirst_m_b8(
         __riscv_vmsgtu_vx_u32m4_b8(off, 0xFFFFF7FF, vl), vl);
-    if (idx1 >= 0 && idx2 >= 0) {
-      if (idx1 <= idx2)
+    if (idx1 >= 0 || idx2 >= 0) {
+      if (static_cast<unsigned long>(idx1) <=
+          static_cast<unsigned long>(idx2)) {
         return result(error_code::TOO_LARGE, src - srcBeg + idx1);
-      return result(error_code::SURROGATE, src - srcBeg + idx2);
+      } else {
+        return result(error_code::SURROGATE, src - srcBeg + idx2);
+      }
     }
-    if (idx1 >= 0)
-      return result(error_code::TOO_LARGE, src - srcBeg + idx1);
-    if (idx2 >= 0)
-      return result(error_code::SURROGATE, src - srcBeg + idx2);
-    long idx =
+    const long idx =
         __riscv_vfirst_m_b8(__riscv_vmsgtu_vx_u32m4_b8(v, 0xFFFF, vl), vl);
     if (idx < 0) {
       vlOut = vl;
@@ -46584,14 +46617,9 @@ simdutf_really_inline static size_t rvv_utf8_to_common(char const *src,
     vuint8m2_t v3 = __riscv_vslide1down_vx_u8m2(v2, next2, vl);
 
     if (validate) {
-      vuint8m2_t s1 = __riscv_vreinterpret_v_u16m2_u8m2(__riscv_vsrl_vx_u16m2(
-          __riscv_vreinterpret_v_u8m2_u16m2(v2), 4, __riscv_vsetvlmax_e16m2()));
-      vuint8m2_t s3 = __riscv_vreinterpret_v_u16m2_u8m2(__riscv_vsrl_vx_u16m2(
-          __riscv_vreinterpret_v_u8m2_u16m2(v3), 4, __riscv_vsetvlmax_e16m2()));
-
       vuint8m2_t idx2 = __riscv_vand_vx_u8m2(v2, 0xF, vl);
-      vuint8m2_t idx1 = __riscv_vand_vx_u8m2(s1, 0xF, vl);
-      vuint8m2_t idx3 = __riscv_vand_vx_u8m2(s3, 0xF, vl);
+      vuint8m2_t idx1 = __riscv_vsrl_vx_u8m2(v2, 4, vl);
+      vuint8m2_t idx3 = __riscv_vsrl_vx_u8m2(v3, 4, vl);
 
       vuint8m2_t err1 = simdutf_vrgather_u8m1x2(err1tbl, idx1);
       vuint8m2_t err2 = simdutf_vrgather_u8m1x2(err2tbl, idx2);
@@ -46972,6 +47000,19 @@ implementation::detect_encodings(const char *input,
 #endif // SIMDUTF_FEATURE_DETECT_ENCODING
 
 #if SIMDUTF_FEATURE_UTF16
+
+void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::LITTLE>(input, len,
+                                                                 output);
+}
+
+void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::BIG>(input, len,
+                                                              output);
+}
+
 template <simdutf_ByteFlip bflip>
 simdutf_really_inline static void
 rvv_change_endianness_utf16(const char16_t *src, size_t len, char16_t *dst) {
@@ -47339,6 +47380,92 @@ inline void write_v_u16_11bits_to_utf8(const __m128i v_u16, char *&utf8_output,
 /* end file src/westmere/internal/loader.cpp */
 #endif // SIMDUTF_FEATURE_UTF8
 
+#if SIMDUTF_FEATURE_UTF16
+/* begin file src/westmere/sse_utf16fix.cpp */
+/*
+ * Process one block of 8 characters.  If in_place is false,
+ * copy the block from in to out.  If there is a sequencing
+ * error in the block, overwrite the illsequenced characters
+ * with the replacement character.  This function reads one
+ * character before the beginning of the buffer as a lookback.
+ * If that character is illsequenced, it too is overwritten.
+ */
+template <endianness big_endian, bool in_place>
+simdutf_really_inline void utf16fix_block_sse(char16_t *out,
+                                              const char16_t *in) {
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
+  auto swap_if_needed = [](uint16_t c) -> uint16_t {
+    return !simdutf::match_system(big_endian) ? scalar::u16_swap_bytes(c) : c;
+  };
+
+  __m128i lookback, block, lb_masked, block_masked, lb_is_high, block_is_low;
+  __m128i illseq, lb_illseq, block_illseq;
+
+  lookback = _mm_loadu_si128((const __m128i *)(in - 1));
+  block = _mm_loadu_si128((const __m128i *)in);
+  lb_masked = _mm_and_si128(lookback, _mm_set1_epi16(swap_if_needed(0xfc00U)));
+  block_masked = _mm_and_si128(block, _mm_set1_epi16(swap_if_needed(0xfc00U)));
+  lb_is_high =
+      _mm_cmpeq_epi16(lb_masked, _mm_set1_epi16(swap_if_needed(0xd800U)));
+  block_is_low =
+      _mm_cmpeq_epi16(block_masked, _mm_set1_epi16(swap_if_needed(0xdc00U)));
+
+  illseq = _mm_xor_si128(lb_is_high, block_is_low);
+  if (_mm_movemask_epi8(illseq) != 0) {
+    int lb;
+
+    /* compute the cause of the illegal sequencing */
+    lb_illseq = _mm_andnot_si128(block_is_low, lb_is_high);
+    block_illseq = _mm_or_si128(_mm_andnot_si128(lb_is_high, block_is_low),
+                                _mm_bsrli_si128(lb_illseq, 2));
+
+    /* fix illegal sequencing in the lookback */
+    lb = _mm_cvtsi128_si32(lb_illseq);
+    lb = (lb & replacement) | (~lb & out[-1]);
+    out[-1] = char16_t(lb);
+    /* fix illegal sequencing in the main block */
+    block =
+        _mm_or_si128(_mm_andnot_si128(block_illseq, block),
+                     _mm_and_si128(block_illseq, _mm_set1_epi16(replacement)));
+    _mm_storeu_si128((__m128i *)out, block);
+  } else if (!in_place) {
+    _mm_storeu_si128((__m128i *)out, block);
+  }
+}
+
+template <endianness big_endian>
+void utf16fix_sse(const char16_t *in, size_t n, char16_t *out) {
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
+  size_t i;
+  if (n < 9) {
+    scalar::utf16::to_well_formed_utf16<big_endian>(in, n, out);
+    return;
+  }
+
+  out[0] =
+      scalar::utf16::is_low_surrogate<big_endian>(in[0]) ? replacement : in[0];
+
+  /* duplicate code to have the compiler specialise utf16fix_block() */
+  if (in == out) {
+    for (i = 1; i + 8 < n; i += 8) {
+      utf16fix_block_sse<big_endian, true>(out + i, in + i);
+    }
+
+    utf16fix_block_sse<big_endian, true>(out + n - 8, in + n - 8);
+  } else {
+    for (i = 1; i + 8 < n; i += 8) {
+      utf16fix_block_sse<big_endian, false>(out + i, in + i);
+    }
+
+    utf16fix_block_sse<big_endian, false>(out + n - 8, in + n - 8);
+  }
+
+  out[n - 1] = scalar::utf16::is_high_surrogate<big_endian>(out[n - 1])
+                   ? replacement
+                   : out[n - 1];
+}
+/* end file src/westmere/sse_utf16fix.cpp */
+#endif // SIMDUTF_FEATURE_UTF16
 #if SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
 /* begin file src/westmere/sse_validate_utf16.cpp */
 template <endianness big_endian>
@@ -49984,16 +50111,20 @@ private:
   }
 
 public:
-  template <bool base64_url, bool ignore_garbage>
+  template <bool base64_url, bool ignore_garbage, bool default_or_url>
   simdutf_really_inline uint64_t to_base64_mask(uint64_t *error) {
     uint32_t err0 = 0;
     uint32_t err1 = 0;
     uint32_t err2 = 0;
     uint32_t err3 = 0;
-    uint64_t m0 = to_base64_mask<base64_url, ignore_garbage>(&chunks[0], &err0);
-    uint64_t m1 = to_base64_mask<base64_url, ignore_garbage>(&chunks[1], &err1);
-    uint64_t m2 = to_base64_mask<base64_url, ignore_garbage>(&chunks[2], &err2);
-    uint64_t m3 = to_base64_mask<base64_url, ignore_garbage>(&chunks[3], &err3);
+    uint64_t m0 = to_base64_mask<base64_url, ignore_garbage, default_or_url>(
+        &chunks[0], &err0);
+    uint64_t m1 = to_base64_mask<base64_url, ignore_garbage, default_or_url>(
+        &chunks[1], &err1);
+    uint64_t m2 = to_base64_mask<base64_url, ignore_garbage, default_or_url>(
+        &chunks[2], &err2);
+    uint64_t m3 = to_base64_mask<base64_url, ignore_garbage, default_or_url>(
+        &chunks[3], &err3);
     if (!ignore_garbage) {
       *error = (err0) | ((uint64_t)err1 << 16) | ((uint64_t)err2 << 32) |
                ((uint64_t)err3 << 48);
@@ -50002,24 +50133,34 @@ public:
   }
 
 private:
-  template <bool base64_url, bool ignore_garbage>
+  template <bool base64_url, bool ignore_garbage, bool default_or_url>
   simdutf_really_inline uint16_t to_base64_mask(__m128i *src, uint32_t *error) {
     const __m128i ascii_space_tbl =
         _mm_setr_epi8(0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x9, 0xa,
                       0x0, 0xc, 0xd, 0x0, 0x0);
     // credit: aqrit
     __m128i delta_asso;
-    if (base64_url) {
+    if (default_or_url) {
+      delta_asso =
+          _mm_setr_epi8(0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00,
+                        0x00, 0x00, 0x00, 0x00, 0x11, 0x00, 0x16);
+    } else if (base64_url) {
       delta_asso = _mm_setr_epi8(0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x0,
                                  0x0, 0x0, 0x0, 0x0, 0xF, 0x0, 0xF);
     } else {
-
       delta_asso =
           _mm_setr_epi8(0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00,
                         0x00, 0x00, 0x00, 0x00, 0x0F, 0x00, 0x0F);
     }
     __m128i delta_values;
-    if (base64_url) {
+    if (default_or_url) {
+      delta_values = _mm_setr_epi8(
+          uint8_t(0xBF), uint8_t(0xE0), uint8_t(0xB9), uint8_t(0x13),
+          uint8_t(0x04), uint8_t(0xBF), uint8_t(0xBF), uint8_t(0xB9),
+          uint8_t(0xB9), uint8_t(0x00), uint8_t(0xFF), uint8_t(0x11),
+          uint8_t(0xFF), uint8_t(0xBF), uint8_t(0x10), uint8_t(0xB9));
+
+    } else if (base64_url) {
       delta_values = _mm_setr_epi8(0x0, 0x0, 0x0, 0x13, 0x4, uint8_t(0xBF),
                                    uint8_t(0xBF), uint8_t(0xB9), uint8_t(0xB9),
                                    0x0, 0x11, uint8_t(0xC3), uint8_t(0xBF),
@@ -50032,7 +50173,11 @@ private:
                         int8_t(0xBF), int8_t(0xBF), int8_t(0xB9), int8_t(0xB9));
     }
     __m128i check_asso;
-    if (base64_url) {
+    if (default_or_url) {
+      check_asso =
+          _mm_setr_epi8(0x0D, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+                        0x01, 0x03, 0x07, 0x0B, 0x0E, 0x0B, 0x06);
+    } else if (base64_url) {
       check_asso = _mm_setr_epi8(0xD, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1,
                                  0x1, 0x3, 0x7, 0xB, 0xE, 0xB, 0x6);
     } else {
@@ -50041,7 +50186,13 @@ private:
                         0x01, 0x03, 0x07, 0x0B, 0x0B, 0x0B, 0x0F);
     }
     __m128i check_values;
-    if (base64_url) {
+    if (default_or_url) {
+      check_values = _mm_setr_epi8(
+          uint8_t(0x80), uint8_t(0x80), uint8_t(0x80), uint8_t(0x80),
+          uint8_t(0xCF), uint8_t(0xBF), uint8_t(0xD5), uint8_t(0xA6),
+          uint8_t(0xB5), uint8_t(0xA1), uint8_t(0x00), uint8_t(0x80),
+          uint8_t(0x00), uint8_t(0x80), uint8_t(0x00), uint8_t(0x80));
+    } else if (base64_url) {
       check_values = _mm_setr_epi8(uint8_t(0x80), uint8_t(0x80), uint8_t(0x80),
                                    uint8_t(0x80), uint8_t(0xCF), uint8_t(0xBF),
                                    uint8_t(0xB6), uint8_t(0xA6), uint8_t(0xB5),
@@ -50056,8 +50207,11 @@ private:
     }
     const __m128i shifted = _mm_srli_epi32(*src, 3);
 
-    const __m128i delta_hash =
+    __m128i delta_hash =
         _mm_avg_epu8(_mm_shuffle_epi8(delta_asso, *src), shifted);
+    if (default_or_url) {
+      delta_hash = _mm_and_si128(delta_hash, _mm_set1_epi8(0xf));
+    }
     const __m128i check_hash =
         _mm_avg_epu8(_mm_shuffle_epi8(check_asso, *src), shifted);
 
@@ -50992,6 +51146,61 @@ struct validating_transcoder {
 } // namespace westmere
 } // namespace simdutf
 /* end file src/generic/utf8_to_utf16/utf8_to_utf16.h */
+/* begin file src/generic/utf8/utf16_length_from_utf8_bytemask.h */
+namespace simdutf {
+namespace westmere {
+namespace {
+namespace utf8 {
+
+using namespace simd;
+
+simdutf_really_inline size_t utf16_length_from_utf8_bytemask(const char *in,
+                                                             size_t size) {
+  using vector_i8 = simd8<int8_t>;
+  using vector_u8 = simd8<uint8_t>;
+  using vector_u64 = simd64<uint64_t>;
+
+  constexpr size_t N = vector_i8::SIZE;
+  constexpr size_t max_iterations = 255 / 2;
+
+  auto counters = vector_u64::zero();
+  auto local = vector_u8::zero();
+
+  size_t iterations = 0;
+  size_t pos = 0;
+  size_t count = 0;
+  for (; pos + N <= size; pos += N) {
+    const auto input =
+        vector_i8::load(reinterpret_cast<const int8_t *>(in + pos));
+
+    const auto continuation = input > int8_t(-65);
+    const auto utf_4bytes = vector_u8(input.value) >= uint8_t(240);
+
+    local -= vector_u8(continuation);
+    local -= vector_u8(utf_4bytes);
+
+    iterations += 1;
+    if (iterations == max_iterations) {
+      counters += sum_8bytes(local);
+      local = vector_u8::zero();
+      iterations = 0;
+    }
+  }
+
+  if (iterations > 0) {
+    count += local.sum_bytes();
+  }
+
+  count += counters.sum();
+
+  return count + scalar::utf8::utf16_length_from_utf8(in + pos, size - pos);
+}
+
+} // namespace utf8
+} // unnamed namespace
+} // namespace westmere
+} // namespace simdutf
+/* end file src/generic/utf8/utf16_length_from_utf8_bytemask.h */
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
@@ -51570,7 +51779,7 @@ simdutf_really_inline size_t count_code_points_bytemask(const char *in,
 
   return count + scalar::utf8::count_code_points(in + pos, size - pos);
 }
-#endif
+#endif // SIMDUTF_SIMD_HAS_BYTEMASK
 
 simdutf_really_inline size_t utf16_length_from_utf8(const char *in,
                                                     size_t size) {
@@ -51588,6 +51797,7 @@ simdutf_really_inline size_t utf16_length_from_utf8(const char *in,
   }
   return count + scalar::utf8::utf16_length_from_utf8(in + pos, size - pos);
 }
+
 } // namespace utf8
 } // unnamed namespace
 } // namespace westmere
@@ -51644,7 +51854,40 @@ simdutf_really_inline size_t utf8_length_from_utf16(const char16_t *in,
                                                                    size - pos);
 }
 
-#ifdef SIMDUTF_SIMD_HAS_BYTEMASK
+template <endianness big_endian>
+simdutf_really_inline size_t utf32_length_from_utf16(const char16_t *in,
+                                                     size_t size) {
+  return count_code_points<big_endian>(in, size);
+}
+
+simdutf_really_inline void
+change_endianness_utf16(const char16_t *in, size_t size, char16_t *output) {
+  size_t pos = 0;
+
+  while (pos < size / 32 * 32) {
+    simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(in + pos));
+    input.swap_bytes();
+    input.store(reinterpret_cast<uint16_t *>(output));
+    pos += 32;
+    output += 32;
+  }
+
+  scalar::utf16::change_endianness_utf16(in + pos, size - pos, output);
+}
+
+} // namespace utf16
+} // unnamed namespace
+} // namespace westmere
+} // namespace simdutf
+/* end file src/generic/utf16.h */
+/* begin file src/generic/utf16/utf8_length_from_utf16_bytemask.h */
+namespace simdutf {
+namespace westmere {
+namespace {
+namespace utf16 {
+
+using namespace simd;
+
 template <endianness big_endian>
 simdutf_really_inline size_t utf8_length_from_utf16_bytemask(const char16_t *in,
                                                              size_t size) {
@@ -51723,34 +51966,12 @@ simdutf_really_inline size_t utf8_length_from_utf16_bytemask(const char16_t *in,
   return count + scalar::utf16::utf8_length_from_utf16<big_endian>(in + pos,
                                                                    size - pos);
 }
-#endif // SIMDUTF_SIMD_HAS_BYTEMASK
-
-template <endianness big_endian>
-simdutf_really_inline size_t utf32_length_from_utf16(const char16_t *in,
-                                                     size_t size) {
-  return count_code_points<big_endian>(in, size);
-}
-
-simdutf_really_inline void
-change_endianness_utf16(const char16_t *in, size_t size, char16_t *output) {
-  size_t pos = 0;
-
-  while (pos < size / 32 * 32) {
-    simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(in + pos));
-    input.swap_bytes();
-    input.store(reinterpret_cast<uint16_t *>(output));
-    pos += 32;
-    output += 32;
-  }
-
-  scalar::utf16::change_endianness_utf16(in + pos, size - pos, output);
-}
 
 } // namespace utf16
 } // unnamed namespace
 } // namespace westmere
 } // namespace simdutf
-/* end file src/generic/utf16.h */
+/* end file src/generic/utf16/utf8_length_from_utf16_bytemask.h */
 #endif // SIMDUTF_FEATURE_UTF16
 #if SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
 /* begin file src/generic/validate_utf16.h */
@@ -52351,9 +52572,9 @@ simdutf_really_inline result validate_with_errors(const char32_t *input,
 
   using vector_u32 = simd32<uint32_t>;
 
-  const auto standardmax = vector_u32::splat(0x10ffff);
-  const auto offset = vector_u32::splat(0xffff2000);
-  const auto standardoffsetmax = vector_u32::splat(0xfffff7ff);
+  const auto standardmax = vector_u32::splat(0x10ffff + 1);
+  const auto surrogate_mask = vector_u32::splat(0xfffff800);
+  const auto surrogate_byte = vector_u32::splat(0x0000d800);
 
   constexpr size_t N = vector_u32::ELEMENTS;
 
@@ -52363,8 +52584,8 @@ simdutf_really_inline result validate_with_errors(const char32_t *input,
       in.swap_bytes();
     }
 
-    const auto too_large = in > standardmax;
-    const auto surrogate = (in + offset) > standardoffsetmax;
+    const auto too_large = in >= standardmax;
+    const auto surrogate = (in & surrogate_mask) == surrogate_byte;
 
     const auto combined = too_large | surrogate;
     if (simdutf_unlikely(combined.any())) {
@@ -52433,13 +52654,16 @@ namespace base64 {
     associated methods that perform actual conversion. Please refer
     to any vectorized implementation to learn the API of these procedures.
 */
-template <bool base64_url, bool ignore_garbage, typename chartype>
+template <bool base64_url, bool ignore_garbage, bool default_or_url,
+          typename chartype>
 full_result
 compress_decode_base64(char *dst, const chartype *src, size_t srclen,
                        base64_options options,
                        last_chunk_handling_options last_chunk_options) {
-  const uint8_t *to_base64 = base64_url ? tables::base64::to_base64_url_value
-                                        : tables::base64::to_base64_value;
+  const uint8_t *to_base64 =
+      default_or_url ? tables::base64::to_base64_default_or_url_value
+                     : (base64_url ? tables::base64::to_base64_url_value
+                                   : tables::base64::to_base64_value);
   size_t equallocation =
       srclen; // location of the first padding character if any
   // skip trailing spaces
@@ -52494,7 +52718,7 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
       src += 64;
       uint64_t error = 0;
       const uint64_t badcharmask =
-          b.to_base64_mask<base64_url, ignore_garbage>(&error);
+          b.to_base64_mask<base64_url, ignore_garbage, default_or_url>(&error);
       if (!ignore_garbage && error) {
         src -= 64;
         const size_t error_offset = trailing_zeroes(error);
@@ -52891,6 +53115,16 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
   } else {
     return res;
   }
+}
+
+void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return utf16fix_sse<endianness::LITTLE>(input, len, output);
+}
+
+void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return utf16fix_sse<endianness::BIG>(input, len, output);
 }
 #endif // SIMDUTF_FEATURE_UTF16
 
@@ -53715,7 +53949,7 @@ simdutf_warn_unused size_t implementation::utf32_length_from_utf16be(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 simdutf_warn_unused size_t implementation::utf16_length_from_utf8(
     const char *input, size_t length) const noexcept {
-  return utf8::utf16_length_from_utf8(input, length);
+  return utf8::utf16_length_from_utf8_bytemask(input, length);
 }
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
@@ -53758,20 +53992,28 @@ simdutf_warn_unused size_t implementation::utf32_length_from_utf8(
 simdutf_warn_unused result implementation::base64_to_binary(
     const char *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return base64::compress_decode_base64<true, true>(
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return base64::compress_decode_base64<false, true, true>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<true, false>(
+      return base64::compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return base64::compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return base64::compress_decode_base64<true, false, false>(
           output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return base64::compress_decode_base64<false, true>(
+      return base64::compress_decode_base64<false, true, false>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<false, false>(
+      return base64::compress_decode_base64<false, false, false>(
           output, input, length, options, last_chunk_options);
     }
   }
@@ -53780,20 +54022,28 @@ simdutf_warn_unused result implementation::base64_to_binary(
 simdutf_warn_unused full_result implementation::base64_to_binary_details(
     const char *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return base64::compress_decode_base64<true, true>(
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return base64::compress_decode_base64<false, true, true>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<true, false>(
+      return base64::compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return base64::compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return base64::compress_decode_base64<true, false, false>(
           output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return base64::compress_decode_base64<false, true>(
+      return base64::compress_decode_base64<false, true, false>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<false, false>(
+      return base64::compress_decode_base64<false, false, false>(
           output, input, length, options, last_chunk_options);
     }
   }
@@ -53802,20 +54052,28 @@ simdutf_warn_unused full_result implementation::base64_to_binary_details(
 simdutf_warn_unused result implementation::base64_to_binary(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return base64::compress_decode_base64<true, true>(
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return base64::compress_decode_base64<false, true, true>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<true, false>(
+      return base64::compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return base64::compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return base64::compress_decode_base64<true, false, false>(
           output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return base64::compress_decode_base64<false, true>(
+      return base64::compress_decode_base64<false, true, false>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<false, false>(
+      return base64::compress_decode_base64<false, false, false>(
           output, input, length, options, last_chunk_options);
     }
   }
@@ -53824,20 +54082,28 @@ simdutf_warn_unused result implementation::base64_to_binary(
 simdutf_warn_unused full_result implementation::base64_to_binary_details(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return base64::compress_decode_base64<true, true>(
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return base64::compress_decode_base64<false, true, true>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<true, false>(
+      return base64::compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return base64::compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return base64::compress_decode_base64<true, false, false>(
           output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return base64::compress_decode_base64<false, true>(
+      return base64::compress_decode_base64<false, true, false>(
           output, input, length, options, last_chunk_options);
     } else {
-      return base64::compress_decode_base64<false, false>(
+      return base64::compress_decode_base64<false, false, false>(
           output, input, length, options, last_chunk_options);
     }
   }
@@ -54004,7 +54270,7 @@ simd8<uint8_t> utf16_gather_high_bytes(const simd16<uint16_t> in0,
 
     return simd16<uint16_t>::pack(t0, t1);
   } else {
-    return simd8<uint8_t>(__lsx_vssrlni_bu_h(in1.value, in0.value, 8));
+    return simd16<uint16_t>::pack_shifted_right<8>(in0, in1);
   }
 }
 /* end file src/lsx/lsx_validate_utf16.cpp */
@@ -56428,7 +56694,7 @@ struct block64 {
   __m128i chunks[4];
 };
 
-template <bool base64_url>
+template <bool base64_url, bool default_or_url>
 static inline uint16_t to_base64_mask(__m128i *src, bool *error) {
   const v16u8 ascii_space_tbl = {0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
                                  0x0,  0x9, 0xa, 0x0, 0xc, 0xd, 0x0, 0x0};
@@ -56442,10 +56708,22 @@ static inline uint16_t to_base64_mask(__m128i *src, bool *error) {
   '-'(0x2d)           => delta_values_index = 2+8 = 10
   '_'(0x5f)           => delta_values_index = 5+8 = 13
   */
-  v16u8 delta_asso = {0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1,
-                      0x0, 0x0, 0x0, 0x0, 0x0, 0xF, 0x0, 0xF};
+  v16u8 delta_asso;
+  if (default_or_url) {
+    delta_asso = v16u8{0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+                       0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x00, 0x16};
+  } else {
+    delta_asso = v16u8{0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1,
+                       0x0, 0x0, 0x0, 0x0, 0x0, 0xF, 0x0, 0xF};
+  }
   v16i8 delta_values;
-  if (base64_url) {
+  if (default_or_url) {
+    delta_values =
+        v16i8{int8_t(0xBF), int8_t(0xE0), int8_t(0xB9), int8_t(0x13),
+              int8_t(0x04), int8_t(0xBF), int8_t(0xBF), int8_t(0xB9),
+              int8_t(0xB9), int8_t(0x00), int8_t(0xFF), int8_t(0x11),
+              int8_t(0xFF), int8_t(0xBF), int8_t(0x10), int8_t(0xB9)};
+  } else if (base64_url) {
     delta_values =
         v16i8{int8_t(0x00), int8_t(0x00), int8_t(0x00), int8_t(0x13),
               int8_t(0x04), int8_t(0xBF), int8_t(0xBF), int8_t(0xB9),
@@ -56460,7 +56738,10 @@ static inline uint16_t to_base64_mask(__m128i *src, bool *error) {
   }
 
   v16u8 check_asso;
-  if (base64_url) {
+  if (default_or_url) {
+    check_asso = v16u8{0x0D, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+                       0x01, 0x01, 0x03, 0x07, 0x0B, 0x0E, 0x0B, 0x06};
+  } else if (base64_url) {
     check_asso = v16u8{0x0D, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
                        0x01, 0x01, 0x03, 0x07, 0x0B, 0x06, 0x0B, 0x12};
   } else {
@@ -56469,7 +56750,13 @@ static inline uint16_t to_base64_mask(__m128i *src, bool *error) {
   }
 
   v16i8 check_values;
-  if (base64_url) {
+  if (default_or_url) {
+    check_values =
+        v16i8{int8_t(0x80), int8_t(0x80), int8_t(0x80), int8_t(0x80),
+              int8_t(0xCF), int8_t(0xBF), int8_t(0xD5), int8_t(0xA6),
+              int8_t(0xB5), int8_t(0xA1), int8_t(0x00), int8_t(0x80),
+              int8_t(0x00), int8_t(0x80), int8_t(0x00), int8_t(0x80)};
+  } else if (base64_url) {
     check_values = v16i8{int8_t(0x0),  int8_t(0x80), int8_t(0x80), int8_t(0x80),
                          int8_t(0xCF), int8_t(0xBF), int8_t(0xD3), int8_t(0xA6),
                          int8_t(0xB5), int8_t(0x86), int8_t(0xD0), int8_t(0x80),
@@ -56515,13 +56802,17 @@ static inline uint16_t to_base64_mask(__m128i *src, bool *error) {
   return (uint16_t)mask;
 }
 
-template <bool base64_url>
+template <bool base64_url, bool default_or_url>
 static inline uint64_t to_base64_mask(block64 *b, bool *error) {
   *error = 0;
-  uint64_t m0 = to_base64_mask<base64_url>(&b->chunks[0], error);
-  uint64_t m1 = to_base64_mask<base64_url>(&b->chunks[1], error);
-  uint64_t m2 = to_base64_mask<base64_url>(&b->chunks[2], error);
-  uint64_t m3 = to_base64_mask<base64_url>(&b->chunks[3], error);
+  uint64_t m0 =
+      to_base64_mask<base64_url, default_or_url>(&b->chunks[0], error);
+  uint64_t m1 =
+      to_base64_mask<base64_url, default_or_url>(&b->chunks[1], error);
+  uint64_t m2 =
+      to_base64_mask<base64_url, default_or_url>(&b->chunks[2], error);
+  uint64_t m3 =
+      to_base64_mask<base64_url, default_or_url>(&b->chunks[3], error);
   return m0 | (m1 << 16) | (m2 << 32) | (m3 << 48);
 }
 
@@ -56611,13 +56902,16 @@ static inline void base64_decode_block_safe(char *out, block64 *b) {
   base64_decode_block(out, b);
 }
 
-template <bool base64_url, bool ignore_garbage, typename char_type>
+template <bool base64_url, bool ignore_garbage, bool default_or_url,
+          typename char_type>
 full_result
 compress_decode_base64(char *dst, const char_type *src, size_t srclen,
                        base64_options options,
                        last_chunk_handling_options last_chunk_options) {
-  const uint8_t *to_base64 = base64_url ? tables::base64::to_base64_url_value
-                                        : tables::base64::to_base64_value;
+  const uint8_t *to_base64 =
+      default_or_url ? tables::base64::to_base64_default_or_url_value
+                     : (base64_url ? tables::base64::to_base64_url_value
+                                   : tables::base64::to_base64_value);
   size_t equallocation =
       srclen; // location of the first padding character if any
   // skip trailing spaces
@@ -56667,7 +56961,8 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
       load_block(&b, src);
       src += 64;
       bool error = false;
-      uint64_t badcharmask = to_base64_mask<base64_url>(&b, &error);
+      uint64_t badcharmask =
+          to_base64_mask<base64_url, default_or_url>(&b, &error);
       if (badcharmask) {
         if (error && !ignore_garbage) {
           src -= 64;
@@ -58099,6 +58394,61 @@ struct validating_transcoder {
 } // namespace lsx
 } // namespace simdutf
 /* end file src/generic/utf8_to_utf16/utf8_to_utf16.h */
+/* begin file src/generic/utf8/utf16_length_from_utf8_bytemask.h */
+namespace simdutf {
+namespace lsx {
+namespace {
+namespace utf8 {
+
+using namespace simd;
+
+simdutf_really_inline size_t utf16_length_from_utf8_bytemask(const char *in,
+                                                             size_t size) {
+  using vector_i8 = simd8<int8_t>;
+  using vector_u8 = simd8<uint8_t>;
+  using vector_u64 = simd64<uint64_t>;
+
+  constexpr size_t N = vector_i8::SIZE;
+  constexpr size_t max_iterations = 255 / 2;
+
+  auto counters = vector_u64::zero();
+  auto local = vector_u8::zero();
+
+  size_t iterations = 0;
+  size_t pos = 0;
+  size_t count = 0;
+  for (; pos + N <= size; pos += N) {
+    const auto input =
+        vector_i8::load(reinterpret_cast<const int8_t *>(in + pos));
+
+    const auto continuation = input > int8_t(-65);
+    const auto utf_4bytes = vector_u8(input.value) >= uint8_t(240);
+
+    local -= vector_u8(continuation);
+    local -= vector_u8(utf_4bytes);
+
+    iterations += 1;
+    if (iterations == max_iterations) {
+      counters += sum_8bytes(local);
+      local = vector_u8::zero();
+      iterations = 0;
+    }
+  }
+
+  if (iterations > 0) {
+    count += local.sum_bytes();
+  }
+
+  count += counters.sum();
+
+  return count + scalar::utf8::utf16_length_from_utf8(in + pos, size - pos);
+}
+
+} // namespace utf8
+} // unnamed namespace
+} // namespace lsx
+} // namespace simdutf
+/* end file src/generic/utf8/utf16_length_from_utf8_bytemask.h */
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
@@ -58540,7 +58890,7 @@ simdutf_really_inline size_t count_code_points_bytemask(const char *in,
 
   return count + scalar::utf8::count_code_points(in + pos, size - pos);
 }
-#endif
+#endif // SIMDUTF_SIMD_HAS_BYTEMASK
 
 simdutf_really_inline size_t utf16_length_from_utf8(const char *in,
                                                     size_t size) {
@@ -58558,6 +58908,7 @@ simdutf_really_inline size_t utf16_length_from_utf8(const char *in,
   }
   return count + scalar::utf8::utf16_length_from_utf8(in + pos, size - pos);
 }
+
 } // namespace utf8
 } // unnamed namespace
 } // namespace lsx
@@ -58566,56 +58917,100 @@ simdutf_really_inline size_t utf16_length_from_utf8(const char *in,
 #endif // SIMDUTF_FEATURE_UTF8
 
 #if SIMDUTF_FEATURE_UTF16
-/* begin file src/generic/utf16.h */
+/* begin file src/generic/utf16/count_code_points_bytemask.h */
 namespace simdutf {
 namespace lsx {
 namespace {
 namespace utf16 {
 
+using namespace simd;
+
 template <endianness big_endian>
 simdutf_really_inline size_t count_code_points(const char16_t *in,
                                                size_t size) {
+  using vector_u16 = simd16<uint16_t>;
+  constexpr size_t N = vector_u16::ELEMENTS;
+
   size_t pos = 0;
   size_t count = 0;
-  for (; pos < size / 32 * 32; pos += 32) {
-    simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(in + pos));
+
+  constexpr size_t max_itertions = 65535;
+  const auto one = vector_u16::splat(1);
+  const auto zero = vector_u16::zero();
+
+  size_t itertion = 0;
+
+  auto counters = zero;
+  for (; pos < size / N * N; pos += N) {
+    auto input = vector_u16::load(in + pos);
     if (!match_system(big_endian)) {
-      input.swap_bytes();
+      input = input.swap_bytes();
     }
-    uint64_t not_pair = input.not_in_range(0xDC00, 0xDFFF);
-    count += count_ones(not_pair) / 2;
+
+    const auto t0 = input & uint16_t(0xfc00);
+    const auto t1 = t0 ^ uint16_t(0xdc00);
+
+    // t2[0] == 1 iff input[0] outside range 0xdc00..dfff (the word is not a
+    // high surrogate)
+    const auto t2 = min(t1, one);
+
+    counters += t2;
+
+    itertion += 1;
+    if (itertion == max_itertions) {
+      count += counters.sum();
+      counters = zero;
+      itertion = 0;
+    }
   }
+
+  if (itertion > 0) {
+    count += counters.sum();
+  }
+
   return count +
          scalar::utf16::count_code_points<big_endian>(in + pos, size - pos);
 }
 
-template <endianness big_endian>
-simdutf_really_inline size_t utf8_length_from_utf16(const char16_t *in,
-                                                    size_t size) {
-  size_t pos = 0;
-  size_t count = 0;
-  // This algorithm could no doubt be improved!
-  for (; pos < size / 32 * 32; pos += 32) {
-    simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(in + pos));
-    if (!match_system(big_endian)) {
-      input.swap_bytes();
-    }
-    uint64_t ascii_mask = input.lteq(0x7F);
-    uint64_t twobyte_mask = input.lteq(0x7FF);
-    uint64_t not_pair_mask = input.not_in_range(0xD800, 0xDFFF);
+} // namespace utf16
+} // unnamed namespace
+} // namespace lsx
+} // namespace simdutf
+/* end file src/generic/utf16/count_code_points_bytemask.h */
+/* begin file src/generic/utf16/change_endianness.h */
+namespace simdutf {
+namespace lsx {
+namespace {
+namespace utf16 {
 
-    size_t ascii_count = count_ones(ascii_mask) / 2;
-    size_t twobyte_count = count_ones(twobyte_mask & ~ascii_mask) / 2;
-    size_t threebyte_count = count_ones(not_pair_mask & ~twobyte_mask) / 2;
-    size_t fourbyte_count = 32 - count_ones(not_pair_mask) / 2;
-    count += 2 * fourbyte_count + 3 * threebyte_count + 2 * twobyte_count +
-             ascii_count;
+simdutf_really_inline void
+change_endianness_utf16(const char16_t *in, size_t size, char16_t *output) {
+  size_t pos = 0;
+
+  while (pos < size / 32 * 32) {
+    simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(in + pos));
+    input.swap_bytes();
+    input.store(reinterpret_cast<uint16_t *>(output));
+    pos += 32;
+    output += 32;
   }
-  return count + scalar::utf16::utf8_length_from_utf16<big_endian>(in + pos,
-                                                                   size - pos);
+
+  scalar::utf16::change_endianness_utf16(in + pos, size - pos, output);
 }
 
-#ifdef SIMDUTF_SIMD_HAS_BYTEMASK
+} // namespace utf16
+} // unnamed namespace
+} // namespace lsx
+} // namespace simdutf
+/* end file src/generic/utf16/change_endianness.h */
+/* begin file src/generic/utf16/utf8_length_from_utf16_bytemask.h */
+namespace simdutf {
+namespace lsx {
+namespace {
+namespace utf16 {
+
+using namespace simd;
+
 template <endianness big_endian>
 simdutf_really_inline size_t utf8_length_from_utf16_bytemask(const char16_t *in,
                                                              size_t size) {
@@ -58694,7 +59089,17 @@ simdutf_really_inline size_t utf8_length_from_utf16_bytemask(const char16_t *in,
   return count + scalar::utf16::utf8_length_from_utf16<big_endian>(in + pos,
                                                                    size - pos);
 }
-#endif // SIMDUTF_SIMD_HAS_BYTEMASK
+
+} // namespace utf16
+} // unnamed namespace
+} // namespace lsx
+} // namespace simdutf
+/* end file src/generic/utf16/utf8_length_from_utf16_bytemask.h */
+/* begin file src/generic/utf16/utf32_length_from_utf16.h */
+namespace simdutf {
+namespace lsx {
+namespace {
+namespace utf16 {
 
 template <endianness big_endian>
 simdutf_really_inline size_t utf32_length_from_utf16(const char16_t *in,
@@ -58702,26 +59107,107 @@ simdutf_really_inline size_t utf32_length_from_utf16(const char16_t *in,
   return count_code_points<big_endian>(in, size);
 }
 
-simdutf_really_inline void
-change_endianness_utf16(const char16_t *in, size_t size, char16_t *output) {
-  size_t pos = 0;
+} // namespace utf16
+} // unnamed namespace
+} // namespace lsx
+} // namespace simdutf
+/* end file src/generic/utf16/utf32_length_from_utf16.h */
+/* begin file src/generic/utf16/to_well_formed.h */
+namespace simdutf {
+namespace lsx {
+namespace {
+namespace utf16 {
 
-  while (pos < size / 32 * 32) {
-    simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(in + pos));
-    input.swap_bytes();
-    input.store(reinterpret_cast<uint16_t *>(output));
-    pos += 32;
-    output += 32;
+// Note: this is direct translation of westmere implementation.
+
+/*
+ * Process one block of 8 characters.  If in_place is false,
+ * copy the block from in to out.  If there is a sequencing
+ * error in the block, overwrite the illsequenced characters
+ * with the replacement character.  This function reads one
+ * character before the beginning of the buffer as a lookback.
+ * If that character is illsequenced, it too is overwritten.
+ */
+template <endianness big_endian, bool in_place>
+simdutf_really_inline void utf16fix_block(char16_t *out, const char16_t *in) {
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
+  auto swap_if_needed = [](uint16_t c) -> uint16_t {
+    return !simdutf::match_system(big_endian) ? scalar::u16_swap_bytes(c) : c;
+  };
+
+  using vector_u16 = simd16<uint16_t>;
+
+  const auto lookback = vector_u16::load(in - 1);
+  const auto block = vector_u16::load(in);
+
+  const auto lb_masked = lookback & swap_if_needed(0xfc00);
+  const auto block_masked = block & swap_if_needed(0xfc00);
+
+  const auto lb_is_high = lb_masked == swap_if_needed(0xd800);
+  const auto block_is_low = block_masked == swap_if_needed(0xdc00);
+
+  const auto illseq = lb_is_high ^ block_is_low;
+  if (!illseq.is_zero()) {
+    /* compute the cause of the illegal sequencing */
+    const auto lb_illseq = ~block_is_low & lb_is_high;
+    const auto block_illseq =
+        (~lb_is_high & block_is_low) | lb_illseq.template byte_right_shift<2>();
+
+    /* fix illegal sequencing in the lookback */
+    const auto lb = lb_illseq.first();
+    out[-1] = char16_t((lb & replacement) | (~lb & out[-1]));
+    /* fix illegal sequencing in the main block */
+    const auto mask = as_vector_u16(block_illseq);
+    const auto fixed = (~mask & block) | (mask & replacement);
+
+    fixed.store(reinterpret_cast<uint16_t *>(out));
+  } else if (!in_place) {
+    block.store(reinterpret_cast<uint16_t *>(out));
+  }
+}
+
+template <endianness big_endian>
+void to_well_formed(const char16_t *in, size_t n, char16_t *out) {
+  using vector_u16 = simd16<uint16_t>;
+  constexpr size_t N = vector_u16::ELEMENTS;
+
+  if (n < N + 1) {
+    scalar::utf16::to_well_formed_utf16<big_endian>(in, n, out);
+    return;
   }
 
-  scalar::utf16::change_endianness_utf16(in + pos, size - pos, output);
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
+
+  out[0] =
+      scalar::utf16::is_low_surrogate<big_endian>(in[0]) ? replacement : in[0];
+
+  /* duplicate code to have the compiler specialise utf16fix_block() */
+  if (in == out) {
+    constexpr bool inplace = true;
+    for (size_t i = 1; i + N < n; i += N) {
+      utf16fix_block<big_endian, inplace>(out + i, in + i);
+    }
+
+    utf16fix_block<big_endian, inplace>(out + n - N, in + n - N);
+  } else {
+    constexpr bool copy_data = false;
+    for (size_t i = 1; i + N < n; i += N) {
+      utf16fix_block<big_endian, copy_data>(out + i, in + i);
+    }
+
+    utf16fix_block<big_endian, copy_data>(out + n - N, in + n - N);
+  }
+
+  out[n - 1] = scalar::utf16::is_high_surrogate<big_endian>(out[n - 1])
+                   ? replacement
+                   : out[n - 1];
 }
 
 } // namespace utf16
 } // unnamed namespace
 } // namespace lsx
 } // namespace simdutf
-/* end file src/generic/utf16.h */
+/* end file src/generic/utf16/to_well_formed.h */
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
@@ -59141,6 +59627,16 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
   } else {
     return res;
   }
+}
+
+void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  utf16::to_well_formed<endianness::LITTLE>(input, len, output);
+}
+
+void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  utf16::to_well_formed<endianness::BIG>(input, len, output);
 }
 #endif // SIMDUTF_FEATURE_UTF16
 
@@ -59916,12 +60412,13 @@ simdutf_warn_unused size_t implementation::utf8_length_from_latin1(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 simdutf_warn_unused size_t implementation::utf8_length_from_utf16le(
     const char16_t *input, size_t length) const noexcept {
-  return utf16::utf8_length_from_utf16<endianness::LITTLE>(input, length);
+  return utf16::utf8_length_from_utf16_bytemask<endianness::LITTLE>(input,
+                                                                    length);
 }
 
 simdutf_warn_unused size_t implementation::utf8_length_from_utf16be(
     const char16_t *input, size_t length) const noexcept {
-  return utf16::utf8_length_from_utf16<endianness::BIG>(input, length);
+  return utf16::utf8_length_from_utf16_bytemask<endianness::BIG>(input, length);
 }
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
@@ -59940,7 +60437,7 @@ simdutf_warn_unused size_t implementation::utf32_length_from_utf16be(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 simdutf_warn_unused size_t implementation::utf16_length_from_utf8(
     const char *input, size_t length) const noexcept {
-  return utf8::utf16_length_from_utf8(input, length);
+  return utf8::utf16_length_from_utf8_bytemask(input, length);
 }
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
@@ -59980,21 +60477,29 @@ simdutf_warn_unused size_t implementation::utf32_length_from_utf8(
 simdutf_warn_unused result implementation::base64_to_binary(
     const char *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return compress_decode_base64<true, true>(output, input, length, options,
-                                                last_chunk_options);
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return compress_decode_base64<false, true, true>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<true, false>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return compress_decode_base64<true, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return compress_decode_base64<false, true>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, true, false>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<false, false>(output, input, length,
-                                                  options, last_chunk_options);
+      return compress_decode_base64<false, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   }
 }
@@ -60002,21 +60507,29 @@ simdutf_warn_unused result implementation::base64_to_binary(
 simdutf_warn_unused full_result implementation::base64_to_binary_details(
     const char *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return compress_decode_base64<true, true>(output, input, length, options,
-                                                last_chunk_options);
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return compress_decode_base64<false, true, true>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<true, false>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return compress_decode_base64<true, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return compress_decode_base64<false, true>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, true, false>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<false, false>(output, input, length,
-                                                  options, last_chunk_options);
+      return compress_decode_base64<false, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   }
 }
@@ -60024,21 +60537,29 @@ simdutf_warn_unused full_result implementation::base64_to_binary_details(
 simdutf_warn_unused result implementation::base64_to_binary(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return compress_decode_base64<true, true>(output, input, length, options,
-                                                last_chunk_options);
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return compress_decode_base64<false, true, true>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<true, false>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return compress_decode_base64<true, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return compress_decode_base64<false, true>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, true, false>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<false, false>(output, input, length,
-                                                  options, last_chunk_options);
+      return compress_decode_base64<false, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   }
 }
@@ -60046,21 +60567,29 @@ simdutf_warn_unused result implementation::base64_to_binary(
 simdutf_warn_unused full_result implementation::base64_to_binary_details(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return compress_decode_base64<true, true>(output, input, length, options,
-                                                last_chunk_options);
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return compress_decode_base64<false, true, true>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<true, false>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return compress_decode_base64<true, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return compress_decode_base64<false, true>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, true, false>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<false, false>(output, input, length,
-                                                  options, last_chunk_options);
+      return compress_decode_base64<false, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   }
 }
@@ -63052,17 +63581,30 @@ struct block64 {
   __m256i chunks[2];
 };
 
-template <bool base64_url>
+template <bool base64_url, bool default_or_url>
 static inline uint32_t to_base64_mask(__m256i *src, bool *error) {
   __m256i ascii_space_tbl =
       ____m256i((__m128i)v16u8{0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
                                0x9, 0xa, 0x0, 0xc, 0xd, 0x0, 0x0});
   // credit: aqrit
-  __m256i delta_asso =
-      ____m256i((__m128i)v16u8{0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x0, 0x0,
-                               0x0, 0x0, 0x0, 0xF, 0x0, 0xF});
+  __m256i delta_asso;
+  if (default_or_url) {
+    delta_asso =
+        ____m256i((__m128i)v16u8{0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x0,
+                                 0x0, 0x0, 0x0, 0x0, 0x11, 0x0, 0x16});
+  } else {
+    delta_asso =
+        ____m256i((__m128i)v16u8{0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x0,
+                                 0x0, 0x0, 0x0, 0x0, 0xF, 0x0, 0xF});
+  }
   __m256i delta_values;
-  if (base64_url) {
+  if (default_or_url) {
+    delta_values = ____m256i(
+        (__m128i)v16i8{int8_t(0xBF), int8_t(0xE0), int8_t(0xB9), int8_t(0x13),
+                       int8_t(0x04), int8_t(0xBF), int8_t(0xBF), int8_t(0xB9),
+                       int8_t(0xB9), int8_t(0x00), int8_t(0xFF), int8_t(0x11),
+                       int8_t(0xFF), int8_t(0xBF), int8_t(0x10), int8_t(0xB9)});
+  } else if (base64_url) {
     delta_values = ____m256i(
         (__m128i)v16i8{int8_t(0x00), int8_t(0x00), int8_t(0x00), int8_t(0x13),
                        int8_t(0x04), int8_t(0xBF), int8_t(0xBF), int8_t(0xB9),
@@ -63077,7 +63619,12 @@ static inline uint32_t to_base64_mask(__m256i *src, bool *error) {
   }
 
   __m256i check_asso;
-  if (base64_url) {
+  if (default_or_url) {
+    check_asso = ____m256i((__m128i)v16u8{0x0D, 0x01, 0x01, 0x01, 0x01, 0x01,
+                                          0x01, 0x01, 0x01, 0x01, 0x03, 0x07,
+                                          0x0B, 0x0E, 0x0B, 0x06});
+
+  } else if (base64_url) {
     check_asso = ____m256i((__m128i)v16u8{0x0D, 0x01, 0x01, 0x01, 0x01, 0x01,
                                           0x01, 0x01, 0x01, 0x01, 0x03, 0x07,
                                           0x0B, 0x06, 0x0B, 0x12});
@@ -63088,7 +63635,14 @@ static inline uint32_t to_base64_mask(__m256i *src, bool *error) {
   }
 
   __m256i check_values;
-  if (base64_url) {
+  if (default_or_url) {
+
+    check_values = ____m256i(
+        (__m128i)v16i8{int8_t(0x80), int8_t(0x80), int8_t(0x80), int8_t(0x80),
+                       int8_t(0xCF), int8_t(0xBF), int8_t(0xD5), int8_t(0xA6),
+                       int8_t(0xB5), int8_t(0xA1), int8_t(0x00), int8_t(0x80),
+                       int8_t(0x00), int8_t(0x80), int8_t(0x00), int8_t(0x80)});
+  } else if (base64_url) {
     check_values = ____m256i(
         (__m128i)v16i8{int8_t(0x0), int8_t(0x80), int8_t(0x80), int8_t(0x80),
                        int8_t(0xCF), int8_t(0xBF), int8_t(0xD3), int8_t(0xA6),
@@ -63131,11 +63685,13 @@ static inline uint32_t to_base64_mask(__m256i *src, bool *error) {
   return (uint32_t)mask;
 }
 
-template <bool base64_url>
+template <bool base64_url, bool default_or_url>
 static inline uint64_t to_base64_mask(block64 *b, bool *error) {
   *error = 0;
-  uint64_t m0 = to_base64_mask<base64_url>(&b->chunks[0], error);
-  uint64_t m1 = to_base64_mask<base64_url>(&b->chunks[1], error);
+  uint64_t m0 =
+      to_base64_mask<base64_url, default_or_url>(&b->chunks[0], error);
+  uint64_t m1 =
+      to_base64_mask<base64_url, default_or_url>(&b->chunks[1], error);
   return m0 | (m1 << 32);
 }
 
@@ -63219,13 +63775,16 @@ static inline void base64_decode_block_safe(char *out, block64 *b) {
   std::memcpy(out + 24, buffer, 24);
 }
 
-template <bool base64_url, bool ignore_garbage, typename chartype>
+template <bool base64_url, bool ignore_garbage, bool default_or_url,
+          typename chartype>
 full_result
 compress_decode_base64(char *dst, const chartype *src, size_t srclen,
                        base64_options options,
                        last_chunk_handling_options last_chunk_options) {
-  const uint8_t *to_base64 = base64_url ? tables::base64::to_base64_url_value
-                                        : tables::base64::to_base64_value;
+  const uint8_t *to_base64 =
+      default_or_url ? tables::base64::to_base64_default_or_url_value
+                     : (base64_url ? tables::base64::to_base64_url_value
+                                   : tables::base64::to_base64_value);
   size_t equallocation =
       srclen; // location of the first padding character if any
   // skip trailing spaces
@@ -63279,7 +63838,8 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
       load_block(&b, src);
       src += 64;
       bool error = false;
-      uint64_t badcharmask = to_base64_mask<base64_url>(&b, &error);
+      uint64_t badcharmask =
+          to_base64_mask<base64_url, default_or_url>(&b, &error);
       if (error && !ignore_garbage) {
         src -= 64;
         while (src < srcend && scalar::base64::is_eight_byte(*src) &&
@@ -64721,6 +65281,61 @@ struct validating_transcoder {
 } // namespace lasx
 } // namespace simdutf
 /* end file src/generic/utf8_to_utf16/utf8_to_utf16.h */
+/* begin file src/generic/utf8/utf16_length_from_utf8_bytemask.h */
+namespace simdutf {
+namespace lasx {
+namespace {
+namespace utf8 {
+
+using namespace simd;
+
+simdutf_really_inline size_t utf16_length_from_utf8_bytemask(const char *in,
+                                                             size_t size) {
+  using vector_i8 = simd8<int8_t>;
+  using vector_u8 = simd8<uint8_t>;
+  using vector_u64 = simd64<uint64_t>;
+
+  constexpr size_t N = vector_i8::SIZE;
+  constexpr size_t max_iterations = 255 / 2;
+
+  auto counters = vector_u64::zero();
+  auto local = vector_u8::zero();
+
+  size_t iterations = 0;
+  size_t pos = 0;
+  size_t count = 0;
+  for (; pos + N <= size; pos += N) {
+    const auto input =
+        vector_i8::load(reinterpret_cast<const int8_t *>(in + pos));
+
+    const auto continuation = input > int8_t(-65);
+    const auto utf_4bytes = vector_u8(input.value) >= uint8_t(240);
+
+    local -= vector_u8(continuation);
+    local -= vector_u8(utf_4bytes);
+
+    iterations += 1;
+    if (iterations == max_iterations) {
+      counters += sum_8bytes(local);
+      local = vector_u8::zero();
+      iterations = 0;
+    }
+  }
+
+  if (iterations > 0) {
+    count += local.sum_bytes();
+  }
+
+  count += counters.sum();
+
+  return count + scalar::utf8::utf16_length_from_utf8(in + pos, size - pos);
+}
+
+} // namespace utf8
+} // unnamed namespace
+} // namespace lasx
+} // namespace simdutf
+/* end file src/generic/utf8/utf16_length_from_utf8_bytemask.h */
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
   // transcoding from UTF-8 to UTF-32
@@ -65161,7 +65776,7 @@ simdutf_really_inline size_t count_code_points_bytemask(const char *in,
 
   return count + scalar::utf8::count_code_points(in + pos, size - pos);
 }
-#endif
+#endif // SIMDUTF_SIMD_HAS_BYTEMASK
 
 simdutf_really_inline size_t utf16_length_from_utf8(const char *in,
                                                     size_t size) {
@@ -65179,6 +65794,7 @@ simdutf_really_inline size_t utf16_length_from_utf8(const char *in,
   }
   return count + scalar::utf8::utf16_length_from_utf8(in + pos, size - pos);
 }
+
 } // namespace utf8
 } // unnamed namespace
 } // namespace lasx
@@ -65187,56 +65803,100 @@ simdutf_really_inline size_t utf16_length_from_utf8(const char *in,
 #endif // SIMDUTF_FEATURE_UTF8
 
 #if SIMDUTF_FEATURE_UTF16
-/* begin file src/generic/utf16.h */
+/* begin file src/generic/utf16/count_code_points_bytemask.h */
 namespace simdutf {
 namespace lasx {
 namespace {
 namespace utf16 {
 
+using namespace simd;
+
 template <endianness big_endian>
 simdutf_really_inline size_t count_code_points(const char16_t *in,
                                                size_t size) {
+  using vector_u16 = simd16<uint16_t>;
+  constexpr size_t N = vector_u16::ELEMENTS;
+
   size_t pos = 0;
   size_t count = 0;
-  for (; pos < size / 32 * 32; pos += 32) {
-    simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(in + pos));
+
+  constexpr size_t max_itertions = 65535;
+  const auto one = vector_u16::splat(1);
+  const auto zero = vector_u16::zero();
+
+  size_t itertion = 0;
+
+  auto counters = zero;
+  for (; pos < size / N * N; pos += N) {
+    auto input = vector_u16::load(in + pos);
     if (!match_system(big_endian)) {
-      input.swap_bytes();
+      input = input.swap_bytes();
     }
-    uint64_t not_pair = input.not_in_range(0xDC00, 0xDFFF);
-    count += count_ones(not_pair) / 2;
+
+    const auto t0 = input & uint16_t(0xfc00);
+    const auto t1 = t0 ^ uint16_t(0xdc00);
+
+    // t2[0] == 1 iff input[0] outside range 0xdc00..dfff (the word is not a
+    // high surrogate)
+    const auto t2 = min(t1, one);
+
+    counters += t2;
+
+    itertion += 1;
+    if (itertion == max_itertions) {
+      count += counters.sum();
+      counters = zero;
+      itertion = 0;
+    }
   }
+
+  if (itertion > 0) {
+    count += counters.sum();
+  }
+
   return count +
          scalar::utf16::count_code_points<big_endian>(in + pos, size - pos);
 }
 
-template <endianness big_endian>
-simdutf_really_inline size_t utf8_length_from_utf16(const char16_t *in,
-                                                    size_t size) {
-  size_t pos = 0;
-  size_t count = 0;
-  // This algorithm could no doubt be improved!
-  for (; pos < size / 32 * 32; pos += 32) {
-    simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(in + pos));
-    if (!match_system(big_endian)) {
-      input.swap_bytes();
-    }
-    uint64_t ascii_mask = input.lteq(0x7F);
-    uint64_t twobyte_mask = input.lteq(0x7FF);
-    uint64_t not_pair_mask = input.not_in_range(0xD800, 0xDFFF);
+} // namespace utf16
+} // unnamed namespace
+} // namespace lasx
+} // namespace simdutf
+/* end file src/generic/utf16/count_code_points_bytemask.h */
+/* begin file src/generic/utf16/change_endianness.h */
+namespace simdutf {
+namespace lasx {
+namespace {
+namespace utf16 {
 
-    size_t ascii_count = count_ones(ascii_mask) / 2;
-    size_t twobyte_count = count_ones(twobyte_mask & ~ascii_mask) / 2;
-    size_t threebyte_count = count_ones(not_pair_mask & ~twobyte_mask) / 2;
-    size_t fourbyte_count = 32 - count_ones(not_pair_mask) / 2;
-    count += 2 * fourbyte_count + 3 * threebyte_count + 2 * twobyte_count +
-             ascii_count;
+simdutf_really_inline void
+change_endianness_utf16(const char16_t *in, size_t size, char16_t *output) {
+  size_t pos = 0;
+
+  while (pos < size / 32 * 32) {
+    simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(in + pos));
+    input.swap_bytes();
+    input.store(reinterpret_cast<uint16_t *>(output));
+    pos += 32;
+    output += 32;
   }
-  return count + scalar::utf16::utf8_length_from_utf16<big_endian>(in + pos,
-                                                                   size - pos);
+
+  scalar::utf16::change_endianness_utf16(in + pos, size - pos, output);
 }
 
-#ifdef SIMDUTF_SIMD_HAS_BYTEMASK
+} // namespace utf16
+} // unnamed namespace
+} // namespace lasx
+} // namespace simdutf
+/* end file src/generic/utf16/change_endianness.h */
+/* begin file src/generic/utf16/utf8_length_from_utf16_bytemask.h */
+namespace simdutf {
+namespace lasx {
+namespace {
+namespace utf16 {
+
+using namespace simd;
+
 template <endianness big_endian>
 simdutf_really_inline size_t utf8_length_from_utf16_bytemask(const char16_t *in,
                                                              size_t size) {
@@ -65315,7 +65975,17 @@ simdutf_really_inline size_t utf8_length_from_utf16_bytemask(const char16_t *in,
   return count + scalar::utf16::utf8_length_from_utf16<big_endian>(in + pos,
                                                                    size - pos);
 }
-#endif // SIMDUTF_SIMD_HAS_BYTEMASK
+
+} // namespace utf16
+} // unnamed namespace
+} // namespace lasx
+} // namespace simdutf
+/* end file src/generic/utf16/utf8_length_from_utf16_bytemask.h */
+/* begin file src/generic/utf16/utf32_length_from_utf16.h */
+namespace simdutf {
+namespace lasx {
+namespace {
+namespace utf16 {
 
 template <endianness big_endian>
 simdutf_really_inline size_t utf32_length_from_utf16(const char16_t *in,
@@ -65323,26 +65993,107 @@ simdutf_really_inline size_t utf32_length_from_utf16(const char16_t *in,
   return count_code_points<big_endian>(in, size);
 }
 
-simdutf_really_inline void
-change_endianness_utf16(const char16_t *in, size_t size, char16_t *output) {
-  size_t pos = 0;
+} // namespace utf16
+} // unnamed namespace
+} // namespace lasx
+} // namespace simdutf
+/* end file src/generic/utf16/utf32_length_from_utf16.h */
+/* begin file src/generic/utf16/to_well_formed.h */
+namespace simdutf {
+namespace lasx {
+namespace {
+namespace utf16 {
 
-  while (pos < size / 32 * 32) {
-    simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(in + pos));
-    input.swap_bytes();
-    input.store(reinterpret_cast<uint16_t *>(output));
-    pos += 32;
-    output += 32;
+// Note: this is direct translation of westmere implementation.
+
+/*
+ * Process one block of 8 characters.  If in_place is false,
+ * copy the block from in to out.  If there is a sequencing
+ * error in the block, overwrite the illsequenced characters
+ * with the replacement character.  This function reads one
+ * character before the beginning of the buffer as a lookback.
+ * If that character is illsequenced, it too is overwritten.
+ */
+template <endianness big_endian, bool in_place>
+simdutf_really_inline void utf16fix_block(char16_t *out, const char16_t *in) {
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
+  auto swap_if_needed = [](uint16_t c) -> uint16_t {
+    return !simdutf::match_system(big_endian) ? scalar::u16_swap_bytes(c) : c;
+  };
+
+  using vector_u16 = simd16<uint16_t>;
+
+  const auto lookback = vector_u16::load(in - 1);
+  const auto block = vector_u16::load(in);
+
+  const auto lb_masked = lookback & swap_if_needed(0xfc00);
+  const auto block_masked = block & swap_if_needed(0xfc00);
+
+  const auto lb_is_high = lb_masked == swap_if_needed(0xd800);
+  const auto block_is_low = block_masked == swap_if_needed(0xdc00);
+
+  const auto illseq = lb_is_high ^ block_is_low;
+  if (!illseq.is_zero()) {
+    /* compute the cause of the illegal sequencing */
+    const auto lb_illseq = ~block_is_low & lb_is_high;
+    const auto block_illseq =
+        (~lb_is_high & block_is_low) | lb_illseq.template byte_right_shift<2>();
+
+    /* fix illegal sequencing in the lookback */
+    const auto lb = lb_illseq.first();
+    out[-1] = char16_t((lb & replacement) | (~lb & out[-1]));
+    /* fix illegal sequencing in the main block */
+    const auto mask = as_vector_u16(block_illseq);
+    const auto fixed = (~mask & block) | (mask & replacement);
+
+    fixed.store(reinterpret_cast<uint16_t *>(out));
+  } else if (!in_place) {
+    block.store(reinterpret_cast<uint16_t *>(out));
+  }
+}
+
+template <endianness big_endian>
+void to_well_formed(const char16_t *in, size_t n, char16_t *out) {
+  using vector_u16 = simd16<uint16_t>;
+  constexpr size_t N = vector_u16::ELEMENTS;
+
+  if (n < N + 1) {
+    scalar::utf16::to_well_formed_utf16<big_endian>(in, n, out);
+    return;
   }
 
-  scalar::utf16::change_endianness_utf16(in + pos, size - pos, output);
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
+
+  out[0] =
+      scalar::utf16::is_low_surrogate<big_endian>(in[0]) ? replacement : in[0];
+
+  /* duplicate code to have the compiler specialise utf16fix_block() */
+  if (in == out) {
+    constexpr bool inplace = true;
+    for (size_t i = 1; i + N < n; i += N) {
+      utf16fix_block<big_endian, inplace>(out + i, in + i);
+    }
+
+    utf16fix_block<big_endian, inplace>(out + n - N, in + n - N);
+  } else {
+    constexpr bool copy_data = false;
+    for (size_t i = 1; i + N < n; i += N) {
+      utf16fix_block<big_endian, copy_data>(out + i, in + i);
+    }
+
+    utf16fix_block<big_endian, copy_data>(out + n - N, in + n - N);
+  }
+
+  out[n - 1] = scalar::utf16::is_high_surrogate<big_endian>(out[n - 1])
+                   ? replacement
+                   : out[n - 1];
 }
 
 } // namespace utf16
 } // unnamed namespace
 } // namespace lasx
 } // namespace simdutf
-/* end file src/generic/utf16.h */
+/* end file src/generic/utf16/to_well_formed.h */
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
@@ -65761,6 +66512,16 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
   } else {
     return res;
   }
+}
+
+void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return utf16::to_well_formed<endianness::LITTLE>(input, len, output);
+}
+
+void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return utf16::to_well_formed<endianness::BIG>(input, len, output);
 }
 #endif // SIMDUTF_FEATURE_UTF16
 
@@ -66650,12 +67411,13 @@ simdutf_warn_unused size_t implementation::utf8_length_from_latin1(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 simdutf_warn_unused size_t implementation::utf8_length_from_utf16le(
     const char16_t *input, size_t length) const noexcept {
-  return utf16::utf8_length_from_utf16<endianness::LITTLE>(input, length);
+  return utf16::utf8_length_from_utf16_bytemask<endianness::LITTLE>(input,
+                                                                    length);
 }
 
 simdutf_warn_unused size_t implementation::utf8_length_from_utf16be(
     const char16_t *input, size_t length) const noexcept {
-  return utf16::utf8_length_from_utf16<endianness::BIG>(input, length);
+  return utf16::utf8_length_from_utf16_bytemask<endianness::BIG>(input, length);
 }
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
@@ -66674,7 +67436,7 @@ simdutf_warn_unused size_t implementation::utf32_length_from_utf16be(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 simdutf_warn_unused size_t implementation::utf16_length_from_utf8(
     const char *input, size_t length) const noexcept {
-  return utf8::utf16_length_from_utf8(input, length);
+  return utf8::utf16_length_from_utf8_bytemask(input, length);
 }
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
@@ -66714,21 +67476,29 @@ simdutf_warn_unused size_t implementation::utf32_length_from_utf8(
 simdutf_warn_unused result implementation::base64_to_binary(
     const char *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return compress_decode_base64<true, true>(output, input, length, options,
-                                                last_chunk_options);
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return compress_decode_base64<false, true, true>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<true, false>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return compress_decode_base64<true, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return compress_decode_base64<false, true>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, true, false>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<false, false>(output, input, length,
-                                                  options, last_chunk_options);
+      return compress_decode_base64<false, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   }
 }
@@ -66736,21 +67506,29 @@ simdutf_warn_unused result implementation::base64_to_binary(
 simdutf_warn_unused full_result implementation::base64_to_binary_details(
     const char *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return compress_decode_base64<true, true>(output, input, length, options,
-                                                last_chunk_options);
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return compress_decode_base64<false, true, true>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<true, false>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return compress_decode_base64<true, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return compress_decode_base64<false, true>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, true, false>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<false, false>(output, input, length,
-                                                  options, last_chunk_options);
+      return compress_decode_base64<false, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   }
 }
@@ -66758,21 +67536,29 @@ simdutf_warn_unused full_result implementation::base64_to_binary_details(
 simdutf_warn_unused result implementation::base64_to_binary(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return compress_decode_base64<true, true>(output, input, length, options,
-                                                last_chunk_options);
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return compress_decode_base64<false, true, true>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<true, false>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return compress_decode_base64<true, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return compress_decode_base64<false, true>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, true, false>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<false, false>(output, input, length,
-                                                  options, last_chunk_options);
+      return compress_decode_base64<false, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   }
 }
@@ -66780,21 +67566,29 @@ simdutf_warn_unused result implementation::base64_to_binary(
 simdutf_warn_unused full_result implementation::base64_to_binary_details(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
-  if (options & base64_url) {
-    if (options == base64_options::base64_url_accept_garbage) {
-      return compress_decode_base64<true, true>(output, input, length, options,
-                                                last_chunk_options);
+  if (options & base64_default_or_url) {
+    if (options == base64_options::base64_default_or_url_accept_garbage) {
+      return compress_decode_base64<false, true, true>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<true, false>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, false, true>(
+          output, input, length, options, last_chunk_options);
+    }
+  } else if (options & base64_url) {
+    if (options == base64_options::base64_url_accept_garbage) {
+      return compress_decode_base64<true, true, false>(
+          output, input, length, options, last_chunk_options);
+    } else {
+      return compress_decode_base64<true, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   } else {
     if (options == base64_options::base64_default_accept_garbage) {
-      return compress_decode_base64<false, true>(output, input, length, options,
-                                                 last_chunk_options);
+      return compress_decode_base64<false, true, false>(
+          output, input, length, options, last_chunk_options);
     } else {
-      return compress_decode_base64<false, false>(output, input, length,
-                                                  options, last_chunk_options);
+      return compress_decode_base64<false, false, false>(
+          output, input, length, options, last_chunk_options);
     }
   }
 }

--- a/Source/WTF/wtf/simdutf/simdutf_impl.h
+++ b/Source/WTF/wtf/simdutf/simdutf_impl.h
@@ -1,4 +1,4 @@
-/* auto-generated on 2025-04-01 17:18:52 -0400. Do not edit! */
+/* auto-generated on 2025-05-01 00:20:41 -0400. Do not edit! */
 /* begin file include/simdutf.h */
 #ifndef SIMDUTF_H
 #define SIMDUTF_H
@@ -85,6 +85,9 @@
   #if __cpp_lib_atomic_ref >= 201806L
     #define SIMDUTF_ATOMIC_REF 1
   #endif // __cpp_lib_atomic_ref
+  #if __has_cpp_attribute(maybe_unused) >= 201603L
+    #define SIMDUTF_MAYBE_UNUSED_AVAILABLE 1
+  #endif // __has_cpp_attribute(maybe_unused) >= 201603L
 #endif
 
 /**
@@ -437,7 +440,7 @@
   #define SIMDUTF_DISABLE_DEPRECATED_WARNING SIMDUTF_DISABLE_VS_WARNING(4996)
   #define SIMDUTF_DISABLE_STRICT_OVERFLOW_WARNING
   #define SIMDUTF_POP_DISABLE_WARNINGS __pragma(warning(pop))
-
+  #define SIMDUTF_DISABLE_UNUSED_WARNING
 #else // SIMDUTF_REGULAR_VISUAL_STUDIO
   #if defined(__OPTIMIZE__) || defined(NDEBUG)
     #define simdutf_really_inline inline __attribute__((always_inline))
@@ -458,7 +461,6 @@
   #ifndef simdutf_unlikely
     #define simdutf_unlikely(x) __builtin_expect(!!(x), 0)
   #endif
-
   // clang-format off
   #define SIMDUTF_PUSH_DISABLE_WARNINGS _Pragma("GCC diagnostic push")
   // gcc doesn't seem to disable all warnings with all and extra, add warnings
@@ -490,6 +492,10 @@
   #define SIMDUTF_DISABLE_STRICT_OVERFLOW_WARNING                              \
     SIMDUTF_DISABLE_GCC_WARNING(-Wstrict-overflow)
   #define SIMDUTF_POP_DISABLE_WARNINGS _Pragma("GCC diagnostic pop")
+  #define SIMDUTF_DISABLE_UNUSED_WARNING                                       \
+    SIMDUTF_PUSH_DISABLE_WARNINGS                                              \
+    SIMDUTF_DISABLE_GCC_WARNING(-Wunused-function)                             \
+    SIMDUTF_DISABLE_GCC_WARNING(-Wunused-const-variable)
   // clang-format on
 
 #endif // MSC_VER
@@ -509,6 +515,12 @@
   #else
     #define SIMDUTF_DLLIMPORTEXPORT
   #endif
+#endif
+
+#if SIMDUTF_MAYBE_UNUSED_AVAILABLE
+  #define simdutf_maybe_unused [[maybe_unused]]
+#else
+  #define simdutf_maybe_unused
 #endif
 
 #endif // SIMDUTF_COMMON_DEFS_H
@@ -652,22 +664,22 @@ SIMDUTF_DISABLE_UNDESIRED_WARNINGS
 #define SIMDUTF_SIMDUTF_VERSION_H
 
 /** The version of simdutf being used (major.minor.revision) */
-#define SIMDUTF_VERSION "6.4.1"
+#define SIMDUTF_VERSION "7.0.0"
 
 namespace simdutf {
 enum {
   /**
    * The major version (MAJOR.minor.revision) of simdutf being used.
    */
-  SIMDUTF_VERSION_MAJOR = 6,
+  SIMDUTF_VERSION_MAJOR = 7,
   /**
    * The minor version (major.MINOR.revision) of simdutf being used.
    */
-  SIMDUTF_VERSION_MINOR = 4,
+  SIMDUTF_VERSION_MINOR = 0,
   /**
    * The revision (major.minor.REVISION) of simdutf being used.
    */
-  SIMDUTF_VERSION_REVISION = 1
+  SIMDUTF_VERSION_REVISION = 0
 };
 } // namespace simdutf
 
@@ -680,7 +692,9 @@ enum {
   #include <atomic>
 #endif
 #include <string>
-#include <vector>
+#ifdef SIMDUTF_INTERNAL_TESTS
+  #include <vector>
+#endif
 /* begin file include/simdutf/internal/isadetection.h */
 /* From
 https://github.com/endorno/pytorch/blob/master/torch/lib/TH/generic/simd/simd.h
@@ -1012,6 +1026,7 @@ static inline uint32_t detect_supported_architectures() {
   #include <concepts>
   #include <type_traits>
   #include <span>
+  #include <tuple>
 #endif
 
 // The following defines are conditionally enabled/disabled during amalgamation.
@@ -1381,7 +1396,74 @@ validate_utf16be_with_errors(std::span<const char16_t> input) noexcept {
   return validate_utf16be_with_errors(input.data(), input.size());
 }
   #endif // SIMDUTF_SPAN
-#endif   // SIMDUTF_FEATURE_UTF16
+
+/**
+ * Fixes an ill-formed UTF-16LE string by replacing mismatched surrogates with
+ * the Unicode replacement character U+FFFD. If input and output points to
+ * different memory areas, the procedure copies string, and it's expected that
+ * output memory is at least as big as the input. It's also possible to set
+ * input equal output, that makes replacements an in-place operation.
+ *
+ * @param input the UTF-16LE string to correct.
+ * @param len the length of the string in number of 2-byte code units
+ * (char16_t).
+ * @param output the output buffer.
+ */
+void to_well_formed_utf16le(const char16_t *input, size_t len,
+                            char16_t *output) noexcept;
+  #if SIMDUTF_SPAN
+simdutf_really_inline void
+to_well_formed_utf16le(std::span<const char16_t> input,
+                       std::span<char16_t> output) noexcept {
+  to_well_formed_utf16le(input.data(), input.size(), output.data());
+}
+  #endif // SIMDUTF_SPAN
+
+/**
+ * Fixes an ill-formed UTF-16BE string by replacing mismatched surrogates with
+ * the Unicode replacement character U+FFFD. If input and output points to
+ * different memory areas, the procedure copies string, and it's expected that
+ * output memory is at least as big as the input. It's also possible to set
+ * input equal output, that makes replacements an in-place operation.
+ *
+ * @param input the UTF-16BE string to correct.
+ * @param len the length of the string in number of 2-byte code units
+ * (char16_t).
+ * @param output the output buffer.
+ */
+void to_well_formed_utf16be(const char16_t *input, size_t len,
+                            char16_t *output) noexcept;
+  #if SIMDUTF_SPAN
+simdutf_really_inline void
+to_well_formed_utf16be(std::span<const char16_t> input,
+                       std::span<char16_t> output) noexcept {
+  to_well_formed_utf16be(input.data(), input.size(), output.data());
+}
+  #endif // SIMDUTF_SPAN
+
+/**
+ * Fixes an ill-formed UTF-16 string by replacing mismatched surrogates with the
+ * Unicode replacement character U+FFFD. If input and output points to different
+ * memory areas, the procedure copies string, and it's expected that output
+ * memory is at least as big as the input. It's also possible to set input equal
+ * output, that makes replacements an in-place operation.
+ *
+ * @param input the UTF-16 string to correct.
+ * @param len the length of the string in number of 2-byte code units
+ * (char16_t).
+ * @param output the output buffer.
+ */
+void to_well_formed_utf16(const char16_t *input, size_t len,
+                          char16_t *output) noexcept;
+  #if SIMDUTF_SPAN
+simdutf_really_inline void
+to_well_formed_utf16(std::span<const char16_t> input,
+                     std::span<char16_t> output) noexcept {
+  to_well_formed_utf16(input.data(), input.size(), output.data());
+}
+  #endif // SIMDUTF_SPAN
+
+#endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING
 /**
@@ -2116,7 +2198,7 @@ simdutf_warn_unused size_t convert_utf16_to_utf8(const char16_t *input,
                                                  char *utf8_buffer) noexcept;
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused size_t convert_utf16_to_utf8(
-    std::span<char16_t> utf16_input,
+    std::span<const char16_t> utf16_input,
     detail::output_span_of_byte_like auto &&utf8_output) noexcept {
   return convert_utf16_to_utf8(utf16_input.data(), utf16_input.size(),
                                reinterpret_cast<char *>(utf8_output.data()));
@@ -2144,7 +2226,7 @@ simdutf_warn_unused size_t convert_utf16_to_latin1(
     const char16_t *input, size_t length, char *latin1_buffer) noexcept;
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused size_t convert_utf16_to_latin1(
-    std::span<char16_t> utf16_input,
+    std::span<const char16_t> utf16_input,
     detail::output_span_of_byte_like auto &&latin1_output) noexcept {
   return convert_utf16_to_latin1(
       utf16_input.data(), utf16_input.size(),
@@ -2172,7 +2254,7 @@ simdutf_warn_unused size_t convert_utf16le_to_latin1(
     const char16_t *input, size_t length, char *latin1_buffer) noexcept;
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused size_t convert_utf16le_to_latin1(
-    std::span<char16_t> utf16_input,
+    std::span<const char16_t> utf16_input,
     detail::output_span_of_byte_like auto &&latin1_output) noexcept {
   return convert_utf16le_to_latin1(
       utf16_input.data(), utf16_input.size(),
@@ -2198,7 +2280,7 @@ simdutf_warn_unused size_t convert_utf16be_to_latin1(
     const char16_t *input, size_t length, char *latin1_buffer) noexcept;
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused size_t convert_utf16be_to_latin1(
-    std::span<char16_t> utf16_input,
+    std::span<const char16_t> utf16_input,
     detail::output_span_of_byte_like auto &&latin1_output) noexcept {
   return convert_utf16be_to_latin1(
       utf16_input.data(), utf16_input.size(),
@@ -2227,7 +2309,7 @@ simdutf_warn_unused size_t convert_utf16le_to_utf8(const char16_t *input,
                                                    char *utf8_buffer) noexcept;
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused size_t convert_utf16le_to_utf8(
-    std::span<char16_t> utf16_input,
+    std::span<const char16_t> utf16_input,
     detail::output_span_of_byte_like auto &&utf8_output) noexcept {
   return convert_utf16le_to_utf8(utf16_input.data(), utf16_input.size(),
                                  reinterpret_cast<char *>(utf8_output.data()));
@@ -2253,7 +2335,7 @@ simdutf_warn_unused size_t convert_utf16be_to_utf8(const char16_t *input,
                                                    char *utf8_buffer) noexcept;
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused size_t convert_utf16be_to_utf8(
-    std::span<char16_t> utf16_input,
+    std::span<const char16_t> utf16_input,
     detail::output_span_of_byte_like auto &&utf8_output) noexcept {
   return convert_utf16be_to_utf8(utf16_input.data(), utf16_input.size(),
                                  reinterpret_cast<char *>(utf8_output.data()));
@@ -2283,7 +2365,7 @@ simdutf_warn_unused result convert_utf16_to_latin1_with_errors(
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused result
 convert_utf16_to_latin1_with_errors(
-    std::span<char16_t> utf16_input,
+    std::span<const char16_t> utf16_input,
     detail::output_span_of_byte_like auto &&latin1_output) noexcept {
   return convert_utf16_to_latin1_with_errors(
       utf16_input.data(), utf16_input.size(),
@@ -2311,7 +2393,7 @@ simdutf_warn_unused result convert_utf16le_to_latin1_with_errors(
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused result
 convert_utf16le_to_latin1_with_errors(
-    std::span<char16_t> utf16_input,
+    std::span<const char16_t> utf16_input,
     detail::output_span_of_byte_like auto &&latin1_output) noexcept {
   return convert_utf16le_to_latin1_with_errors(
       utf16_input.data(), utf16_input.size(),
@@ -2341,7 +2423,7 @@ simdutf_warn_unused result convert_utf16be_to_latin1_with_errors(
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused result
 convert_utf16be_to_latin1_with_errors(
-    std::span<char16_t> utf16_input,
+    std::span<const char16_t> utf16_input,
     detail::output_span_of_byte_like auto &&latin1_output) noexcept {
   return convert_utf16be_to_latin1_with_errors(
       utf16_input.data(), utf16_input.size(),
@@ -2373,7 +2455,7 @@ simdutf_warn_unused result convert_utf16_to_utf8_with_errors(
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused result
 convert_utf16_to_utf8_with_errors(
-    std::span<char16_t> utf16_input,
+    std::span<const char16_t> utf16_input,
     detail::output_span_of_byte_like auto &&utf8_output) noexcept {
   return convert_utf16_to_utf8_with_errors(
       utf16_input.data(), utf16_input.size(),
@@ -2402,7 +2484,7 @@ simdutf_warn_unused result convert_utf16le_to_utf8_with_errors(
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused result
 convert_utf16le_to_utf8_with_errors(
-    std::span<char16_t> utf16_input,
+    std::span<const char16_t> utf16_input,
     detail::output_span_of_byte_like auto &&utf8_output) noexcept {
   return convert_utf16le_to_utf8_with_errors(
       utf16_input.data(), utf16_input.size(),
@@ -2431,7 +2513,7 @@ simdutf_warn_unused result convert_utf16be_to_utf8_with_errors(
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused result
 convert_utf16be_to_utf8_with_errors(
-    std::span<char16_t> utf16_input,
+    std::span<const char16_t> utf16_input,
     detail::output_span_of_byte_like auto &&utf8_output) noexcept {
   return convert_utf16be_to_utf8_with_errors(
       utf16_input.data(), utf16_input.size(),
@@ -2456,7 +2538,7 @@ simdutf_warn_unused size_t convert_valid_utf16_to_utf8(
     const char16_t *input, size_t length, char *utf8_buffer) noexcept;
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf16_to_utf8(
-    std::span<char16_t> valid_utf16_input,
+    std::span<const char16_t> valid_utf16_input,
     detail::output_span_of_byte_like auto &&utf8_output) noexcept {
   return convert_valid_utf16_to_utf8(
       valid_utf16_input.data(), valid_utf16_input.size(),
@@ -2489,7 +2571,7 @@ simdutf_warn_unused size_t convert_valid_utf16_to_latin1(
     const char16_t *input, size_t length, char *latin1_buffer) noexcept;
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf16_to_latin1(
-    std::span<char16_t> valid_utf16_input,
+    std::span<const char16_t> valid_utf16_input,
     detail::output_span_of_byte_like auto &&latin1_output) noexcept {
   return convert_valid_utf16_to_latin1(
       valid_utf16_input.data(), valid_utf16_input.size(),
@@ -2521,7 +2603,7 @@ simdutf_warn_unused size_t convert_valid_utf16le_to_latin1(
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused size_t
 convert_valid_utf16le_to_latin1(
-    std::span<char16_t> valid_utf16_input,
+    std::span<const char16_t> valid_utf16_input,
     detail::output_span_of_byte_like auto &&latin1_output) noexcept {
   return convert_valid_utf16le_to_latin1(
       valid_utf16_input.data(), valid_utf16_input.size(),
@@ -2553,7 +2635,7 @@ simdutf_warn_unused size_t convert_valid_utf16be_to_latin1(
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused size_t
 convert_valid_utf16be_to_latin1(
-    std::span<char16_t> valid_utf16_input,
+    std::span<const char16_t> valid_utf16_input,
     detail::output_span_of_byte_like auto &&latin1_output) noexcept {
   return convert_valid_utf16be_to_latin1(
       valid_utf16_input.data(), valid_utf16_input.size(),
@@ -2581,7 +2663,7 @@ simdutf_warn_unused size_t convert_valid_utf16le_to_utf8(
     const char16_t *input, size_t length, char *utf8_buffer) noexcept;
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf16le_to_utf8(
-    std::span<char16_t> valid_utf16_input,
+    std::span<const char16_t> valid_utf16_input,
     detail::output_span_of_byte_like auto &&utf8_output) noexcept {
   return convert_valid_utf16le_to_utf8(
       valid_utf16_input.data(), valid_utf16_input.size(),
@@ -2606,7 +2688,7 @@ simdutf_warn_unused size_t convert_valid_utf16be_to_utf8(
     const char16_t *input, size_t length, char *utf8_buffer) noexcept;
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf16be_to_utf8(
-    std::span<char16_t> valid_utf16_input,
+    std::span<const char16_t> valid_utf16_input,
     detail::output_span_of_byte_like auto &&utf8_output) noexcept {
   return convert_valid_utf16be_to_utf8(
       valid_utf16_input.data(), valid_utf16_input.size(),
@@ -3082,7 +3164,7 @@ simdutf_warn_unused size_t convert_utf32_to_latin1(
     const char32_t *input, size_t length, char *latin1_buffer) noexcept;
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused size_t convert_utf32_to_latin1(
-    std::span<char32_t> utf32_input,
+    std::span<const char32_t> utf32_input,
     detail::output_span_of_byte_like auto &&latin1_output) noexcept {
   return convert_utf32_to_latin1(
       utf32_input.data(), utf32_input.size(),
@@ -3112,7 +3194,7 @@ simdutf_warn_unused result convert_utf32_to_latin1_with_errors(
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused result
 convert_utf32_to_latin1_with_errors(
-    std::span<char32_t> utf32_input,
+    std::span<const char32_t> utf32_input,
     detail::output_span_of_byte_like auto &&latin1_output) noexcept {
   return convert_utf32_to_latin1_with_errors(
       utf32_input.data(), utf32_input.size(),
@@ -3144,7 +3226,7 @@ simdutf_warn_unused size_t convert_valid_utf32_to_latin1(
     const char32_t *input, size_t length, char *latin1_buffer) noexcept;
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf32_to_latin1(
-    std::span<char32_t> valid_utf32_input,
+    std::span<const char32_t> valid_utf32_input,
     detail::output_span_of_byte_like auto &&latin1_output) noexcept {
   return convert_valid_utf32_to_latin1(
       valid_utf32_input.data(), valid_utf32_input.size(),
@@ -3719,6 +3801,11 @@ enum base64_options : uint64_t {
       4, /* standard base64 format accepting garbage characters */
   base64_url_accept_garbage =
       5, /* base64url format accepting garbage characters */
+  base64_default_or_url =
+      8, /* standard/base64url hybrid format (only meaningful for decoding!) */
+  base64_default_or_url_accept_garbage =
+      12, /* standard/base64url hybrid format accepting garbage characters
+             (only meaningful for decoding!) */
 };
 
 // last_chunk_handling_options are used to specify the handling of the last
@@ -3889,8 +3976,8 @@ binary_to_base64(const detail::input_span_of_byte_like auto &input,
 /**
  * Convert a binary input to a base64 output, using atomic accesses.
  * This function comes with a potentially significant performance
- * penalty, but it may be useful in some cases where the input and
- * output buffers are shared between threads, to avoid undefined
+ * penalty, but it may be useful in some cases where the input
+ * buffers are shared between threads, to avoid undefined
  * behavior in case of data races.
  *
  * The function is for advanced users. Its main use case is when
@@ -3966,7 +4053,7 @@ atomic_binary_to_base64(const detail::input_span_of_byte_like auto &input,
  * characters) must be divisible by four.
  *
  * You should call this function with a buffer that is at least
- * maximal_binary_length_from_utf6_base64(input, length) bytes long. If you fail
+ * maximal_binary_length_from_base64(input, length) bytes long. If you fail
  * to provide that much space, the function may cause a buffer overflow.
  *
  * Advanced users may want to taylor how the last chunk is handled. By default,
@@ -4044,7 +4131,9 @@ simdutf_really_inline simdutf_warn_unused result base64_to_binary(
  * characters) must be divisible by four.
  *
  * The INVALID_BASE64_CHARACTER cases are considered fatal and you are expected
- * to discard the output.
+ * to discard the output unless the parameter decode_up_to_bad_char is set to
+ * true. In that case, the function will decode up to the first invalid
+ * character. Extra padding characters ('=') are considered invalid characters.
  *
  * Advanced users may want to taylor how the last chunk is handled. By default,
  * we use a loose (forgiving) approach but we also support a strict approach
@@ -4065,6 +4154,9 @@ simdutf_really_inline simdutf_warn_unused result base64_to_binary(
  * last_chunk_handling_options::loose by default
  * but can also be last_chunk_handling_options::strict or
  * last_chunk_handling_options::stop_before_partial.
+ * @param decode_up_to_bad_char if true, the function will decode up to the
+ * first invalid character. By default (false), it is assumed that the output
+ * buffer is to be discarded.
  * @return a result pair struct (of type simdutf::result containing the two
  * fields error and count) with an error code and position of the
  * INVALID_BASE64_CHARACTER error (in the input in units) if any, or the number
@@ -4074,21 +4166,25 @@ simdutf_warn_unused result
 base64_to_binary_safe(const char *input, size_t length, char *output,
                       size_t &outlen, base64_options options = base64_default,
                       last_chunk_handling_options last_chunk_options =
-                          last_chunk_handling_options::loose) noexcept;
+                          last_chunk_handling_options::loose,
+                      bool decode_up_to_bad_char = false) noexcept;
   #if SIMDUTF_SPAN
-simdutf_really_inline simdutf_warn_unused result base64_to_binary_safe(
-    const detail::input_span_of_byte_like auto &input,
-    detail::output_span_of_byte_like auto &&binary_output,
-    base64_options options = base64_default,
-    last_chunk_handling_options last_chunk_options = loose) noexcept {
-  // we can't write the outlen to the provided output span, the user will have
-  // to pick it up from the returned value instead (assuming success). we still
-  // get the benefit of providing info of how long the output buffer is.
+/**
+ * @brief span overload
+ * @return a tuple of result and outlen
+ */
+simdutf_really_inline simdutf_warn_unused std::tuple<result, std::size_t>
+base64_to_binary_safe(const detail::input_span_of_byte_like auto &input,
+                      detail::output_span_of_byte_like auto &&binary_output,
+                      base64_options options = base64_default,
+                      last_chunk_handling_options last_chunk_options = loose,
+                      bool decode_up_to_bad_char = false) noexcept {
   size_t outlen = binary_output.size();
-  return base64_to_binary_safe(reinterpret_cast<const char *>(input.data()),
-                               input.size(),
-                               reinterpret_cast<char *>(binary_output.data()),
-                               outlen, options, last_chunk_options);
+  auto r = base64_to_binary_safe(
+      reinterpret_cast<const char *>(input.data()), input.size(),
+      reinterpret_cast<char *>(binary_output.data()), outlen, options,
+      last_chunk_options, decode_up_to_bad_char);
+  return {r, outlen};
 }
   #endif // SIMDUTF_SPAN
 
@@ -4096,23 +4192,114 @@ simdutf_warn_unused result
 base64_to_binary_safe(const char16_t *input, size_t length, char *output,
                       size_t &outlen, base64_options options = base64_default,
                       last_chunk_handling_options last_chunk_options =
-                          last_chunk_handling_options::loose) noexcept;
+                          last_chunk_handling_options::loose,
+                      bool decode_up_to_bad_char = false) noexcept;
   #if SIMDUTF_SPAN
-simdutf_really_inline simdutf_warn_unused result base64_to_binary_safe(
-    std::span<const char16_t> input,
-    detail::output_span_of_byte_like auto &&binary_output,
-    base64_options options = base64_default,
-    last_chunk_handling_options last_chunk_options = loose) noexcept {
-  // we can't write the outlen to the provided output span, the user will have
-  // to pick it up from the returned value instead (assuming success). we still
-  // get the benefit of providing info of how long the output buffer is.
+/**
+ * @brief span overload
+ * @return a tuple of result and outlen
+ */
+simdutf_really_inline simdutf_warn_unused std::tuple<result, std::size_t>
+base64_to_binary_safe(std::span<const char16_t> input,
+                      detail::output_span_of_byte_like auto &&binary_output,
+                      base64_options options = base64_default,
+                      last_chunk_handling_options last_chunk_options = loose,
+                      bool decode_up_to_bad_char = false) noexcept {
   size_t outlen = binary_output.size();
-  return base64_to_binary_safe(input.data(), input.size(),
-                               reinterpret_cast<char *>(binary_output.data()),
-                               outlen, options, last_chunk_options);
+  auto r = base64_to_binary_safe(input.data(), input.size(),
+                                 reinterpret_cast<char *>(binary_output.data()),
+                                 outlen, options, last_chunk_options,
+                                 decode_up_to_bad_char);
+  return {r, outlen};
 }
   #endif // SIMDUTF_SPAN
-#endif   // SIMDUTF_FEATURE_BASE64
+
+  #if SIMDUTF_ATOMIC_REF
+/**
+ * Convert a base64 input to a binary output with a size limit and using atomic
+ * operations.
+ *
+ * Like `base64_to_binary_safe` but using atomic operations, this function is
+ * thread-safe for concurrent memory access, allowing the output
+ * buffers to be shared between threads without undefined behavior in case of
+ * data races.
+ *
+ * This function comes with a potentially significant performance penalty, but
+ * is useful when thread safety is needed during base64 decoding.
+ *
+ * This function is only available when simdutf is compiled with
+ * C++20 support and __cpp_lib_atomic_ref >= 201806L. You may check
+ * the availability of this function by checking the macro
+ * SIMDUTF_ATOMIC_REF.
+ *
+ * @param input         the base64 input to decode
+ * @param length        the length of the input in bytes
+ * @param output        the pointer to buffer that can hold the conversion
+ * result
+ * @param outlen        the number of bytes that can be written in the output
+ * buffer. Upon return, it is modified to reflect how many bytes were written.
+ * @param options       the base64 options to use (default, url, etc.)
+ * @param last_chunk_options the last chunk handling options (loose, strict,
+ * stop_before_partial)
+ * @param decode_up_to_bad_char if true, the function will decode up to the
+ * first invalid character. By default (false), it is assumed that the output
+ * buffer is to be discarded.
+ * @return a result struct with an error code and count indicating error
+ * position or success
+ */
+simdutf_warn_unused result atomic_base64_to_binary_safe(
+    const char *input, size_t length, char *output, size_t &outlen,
+    base64_options options = base64_default,
+    last_chunk_handling_options last_chunk_options =
+        last_chunk_handling_options::loose,
+    bool decode_up_to_bad_char = false) noexcept;
+simdutf_warn_unused result atomic_base64_to_binary_safe(
+    const char16_t *input, size_t length, char *output, size_t &outlen,
+    base64_options options = base64_default,
+    last_chunk_handling_options last_chunk_options = loose,
+    bool decode_up_to_bad_char = false) noexcept;
+    #if SIMDUTF_SPAN
+/**
+ * @brief span overload
+ * @return a tuple of result and outlen
+ */
+simdutf_really_inline simdutf_warn_unused std::tuple<result, std::size_t>
+atomic_base64_to_binary_safe(
+    const detail::input_span_of_byte_like auto &binary_input,
+    detail::output_span_of_byte_like auto &&output,
+    base64_options options = base64_default,
+    last_chunk_handling_options last_chunk_options =
+        last_chunk_handling_options::loose,
+    bool decode_up_to_bad_char = false) noexcept {
+  size_t outlen = output.size();
+  auto ret = atomic_base64_to_binary_safe(
+      reinterpret_cast<const char *>(binary_input.data()), binary_input.size(),
+      reinterpret_cast<char *>(output.data()), outlen, options,
+      last_chunk_options, decode_up_to_bad_char);
+  return {ret, outlen};
+}
+/**
+ * @brief span overload
+ * @return a tuple of result and outlen
+ */
+simdutf_warn_unused std::tuple<result, std::size_t>
+atomic_base64_to_binary_safe(
+    std::span<const char16_t> base64_input,
+    detail::output_span_of_byte_like auto &&binary_output,
+    base64_options options = base64_default,
+    last_chunk_handling_options last_chunk_options = loose,
+    bool decode_up_to_bad_char = false) noexcept {
+  size_t outlen = binary_output.size();
+  auto ret = atomic_base64_to_binary_safe(
+      base64_input.data(), base64_input.size(),
+      reinterpret_cast<char *>(binary_output.data()), outlen, options,
+      last_chunk_options, decode_up_to_bad_char);
+  return {ret, outlen};
+}
+    #endif // SIMDUTF_SPAN
+  #endif   // SIMDUTF_ATOMIC_REF
+
+#endif // SIMDUTF_FEATURE_BASE64
 
 /**
  * An implementation of simdutf for a particular CPU architecture.
@@ -4323,6 +4510,34 @@ public:
   simdutf_warn_unused virtual result
   validate_utf16be_with_errors(const char16_t *buf,
                                size_t len) const noexcept = 0;
+  /**
+   * Copies the UTF-16LE string while replacing mismatched surrogates with the
+   * Unicode replacement character U+FFFD. We allow the input and output to be
+   * the same buffer so that the correction is done in-place.
+   *
+   * Overridden by each implementation.
+   *
+   * @param input the UTF-16LE string to correct.
+   * @param len the length of the string in number of 2-byte code units
+   * (char16_t).
+   * @param output the output buffer.
+   */
+  virtual void to_well_formed_utf16le(const char16_t *input, size_t len,
+                                      char16_t *output) const noexcept = 0;
+  /**
+   * Copies the UTF-16BE string while replacing mismatched surrogates with the
+   * Unicode replacement character U+FFFD. We allow the input and output to be
+   * the same buffer so that the correction is done in-place.
+   *
+   * Overridden by each implementation.
+   *
+   * @param input the UTF-16BE string to correct.
+   * @param len the length of the string in number of 2-byte code units
+   * (char16_t).
+   * @param output the output buffer.
+   */
+  virtual void to_well_formed_utf16be(const char16_t *input, size_t len,
+                                      char16_t *output) const noexcept = 0;
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING
@@ -5715,7 +5930,7 @@ public:
    * character that is not a valid base64 character (INVALID_BASE64_CHARACTER).
    *
    * You should call this function with a buffer that is at least
-   * maximal_binary_length_from_utf6_base64(input, length) bytes long. If you
+   * maximal_binary_length_from_base64(input, length) bytes long. If you
    * fail to provide that much space, the function may cause a buffer overflow.
    *
    * @param input         the base64 string to process, in ASCII stored as

--- a/Source/WTF/wtf/text/Base64.cpp
+++ b/Source/WTF/wtf/text/Base64.cpp
@@ -455,7 +455,8 @@ static std::tuple<FromBase64ShouldThrowError, size_t, size_t> fromBase64Impl(std
         return { FromBase64ShouldThrowError::No, 0, 0 };
 
     size_t outputLength = output.size();
-    auto result = simdutf::base64_to_binary_safe(std::bit_cast<const UTFType*>(span.data()), span.size(), std::bit_cast<char*>(output.data()), outputLength, options);
+    constexpr bool decodeUpToBadChar = true;
+    auto result = simdutf::base64_to_binary_safe(std::bit_cast<const UTFType*>(span.data()), span.size(), std::bit_cast<char*>(output.data()), outputLength, options, simdutf::last_chunk_handling_options::loose, decodeUpToBadChar);
     switch (result.error) {
     case simdutf::error_code::INVALID_BASE64_CHARACTER:
         return { FromBase64ShouldThrowError::Yes, result.count, outputLength };


### PR DESCRIPTION
#### fd8940ddb7da8cfa3ec29501fe092eeb40a4ed6a
<pre>
[JSC] Uint8Array.prototype.setFromBase64 doesn&apos;t work correctly in Ubuntu build
<a href="https://bugs.webkit.org/show_bug.cgi?id=290829">https://bugs.webkit.org/show_bug.cgi?id=290829</a>
<a href="https://rdar.apple.com/148546882">rdar://148546882</a>

Reviewed by Yijia Huang.

Compared to the ECMAScript spec&apos;s behavior SIMDUTF library had a difference
that it does not fill the decoded buffer with some results when the input has
bad characters. New option is added to the library, thus this patch
upgrades SIMDUTF and use this new option to fix the issue.

* JSTests/stress/uint8array-base64-bad-char-decode.js: Added.
(shouldBe):
(shouldBeArray):
* Source/WTF/wtf/simdutf/simdutf_impl.cpp.h:
(simdutf::scalar::memcpy_atomic_read):
(simdutf::scalar::memcpy_atomic_write):
(simdutf::rvv::rvv_count_valid_utf8):
(simdutf::rvv::rvv_convert_utf32_to_utf16_with_errors):
(simdutf::rvv::rvv_utf8_to_common):
* Source/WTF/wtf/simdutf/simdutf_impl.h:
* Source/WTF/wtf/text/Base64.cpp:
(WTF::fromBase64Impl):

Canonical link: <a href="https://commits.webkit.org/294827@main">https://commits.webkit.org/294827@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6da30ee4350a722e1bbcd9e8cc39b765ca11eefb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101740 "2343 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11724 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106898 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52374 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29910 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77461 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34489 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104747 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91877 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57799 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16605 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9895 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51725 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94412 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86463 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9972 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109252 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100350 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28873 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86443 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29234 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88078 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86009 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30767 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8490 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23036 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16749 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28801 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34091 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/123974 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28612 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34443 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31935 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30171 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->