### PR TITLE
Adopt C++'s [[likely]] / [[unlikely]] in WebKit/ & WebKitLegacy

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTBuilder.h
+++ b/Source/WebGPU/WGSL/AST/ASTBuilder.h
@@ -68,7 +68,7 @@ public:
         constexpr size_t size = sizeof(T);
         constexpr size_t alignedSize = alignSize(size);
         static_assert(alignedSize <= arenaSize);
-        if (UNLIKELY(m_arena.size() < alignedSize))
+        if (m_arena.size() < alignedSize) [[unlikely]]
             allocateArena();
 
 #if ASAN_ENABLED

--- a/Source/WebGPU/WGSL/AttributeValidator.cpp
+++ b/Source/WebGPU/WGSL/AttributeValidator.cpp
@@ -353,7 +353,7 @@ void AttributeValidator::visit(AST::Structure& structure)
 
         unsigned currentSize = UNLIKELY(size.hasOverflowed()) ? std::numeric_limits<unsigned>::max() : size.value();
         unsigned offset;
-        if (UNLIKELY(size.hasOverflowed()))
+        if (size.hasOverflowed()) [[unlikely]]
             offset = currentSize;
         else {
             CheckedUint32 checkedOffset = WTF::roundUpToMultipleOf(*fieldAlignment, static_cast<uint64_t>(currentSize));
@@ -365,7 +365,7 @@ void AttributeValidator::visit(AST::Structure& structure)
         alignment = std::max(alignment, *fieldAlignment);
         size = offset;
         size += *fieldSize;
-        if (UNLIKELY(size.hasOverflowed()))
+        if (size.hasOverflowed()) [[unlikely]]
             size = std::numeric_limits<unsigned>::max();
 
         if (previousMember)
@@ -375,11 +375,11 @@ void AttributeValidator::visit(AST::Structure& structure)
 
         previousSize = offset;
         previousSize += typeSize;
-        if (UNLIKELY(previousSize.hasOverflowed()))
+        if (previousSize.hasOverflowed()) [[unlikely]]
             previousSize = currentSize;
     }
     unsigned finalSize;
-    if (UNLIKELY(size.hasOverflowed()))
+    if (size.hasOverflowed()) [[unlikely]]
         finalSize = std::numeric_limits<unsigned>::max();
     else {
         CheckedUint32 checkedFinalSize = WTF::roundUpToMultipleOf(alignment, static_cast<uint64_t>(size.value()));
@@ -447,7 +447,7 @@ void AttributeValidator::visit(AST::StructureMember& member)
             else if (!isPowerOf2)
                 error(attribute.span(), "@align value must be a power of two"_s);
 
-            if (UNLIKELY(!m_errors.isEmpty())) {
+            if (!m_errors.isEmpty()) [[unlikely]] {
                 // It's not safe to access Type::alignment below if errors have
                 // already occurred
                 continue;

--- a/Source/WebGPU/WGSL/ConstantValue.h
+++ b/Source/WebGPU/WGSL/ConstantValue.h
@@ -185,7 +185,7 @@ template<typename To, typename From>
 std::optional<To> convertInteger(From value)
 {
     auto result = Checked<To, RecordOverflow>(value);
-    if (UNLIKELY(result.hasOverflowed()))
+    if (result.hasOverflowed()) [[unlikely]]
         return std::nullopt;
     return { result.value() };
 }

--- a/Source/WebGPU/WGSL/ContextProviderInlines.h
+++ b/Source/WebGPU/WGSL/ContextProviderInlines.h
@@ -51,7 +51,7 @@ template<typename Value>
 const Value* ContextProvider<Value>::Context::add(const String& name, const Value& value)
 {
     auto result = m_map.add(name, value);
-    if (UNLIKELY(!result.isNewEntry))
+    if (!result.isNewEntry) [[unlikely]]
         return nullptr;
     return &result.iterator->value;
 }

--- a/Source/WebGPU/WGSL/GlobalSorting.cpp
+++ b/Source/WebGPU/WGSL/GlobalSorting.cpp
@@ -229,7 +229,7 @@ void GraphBuilder::visit(AST::VariableStatement& variable)
 void GraphBuilder::visit(AST::Expression& expression)
 {
     SetForScope expressionDepthScope(m_expressionDepth, m_expressionDepth + 1);
-    if (UNLIKELY(m_expressionDepth > s_maxExpressionDepth)) {
+    if (m_expressionDepth > s_maxExpressionDepth) [[unlikely]] {
         setError({ makeString("reached maximum expression depth of "_s, String::number(s_maxExpressionDepth)), expression.span() });
         return;
     }

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -354,7 +354,7 @@ void RewriteGlobalVariables::visit(AST::Function& function)
 
     // https://www.w3.org/TR/WGSL/#limits
     constexpr unsigned maximumCombinedFunctionVariablesSize = 8192;
-    if (UNLIKELY(m_combinedFunctionVariablesSize.hasOverflowed() || m_combinedFunctionVariablesSize.value() > maximumCombinedFunctionVariablesSize))
+    if (m_combinedFunctionVariablesSize.hasOverflowed() || m_combinedFunctionVariablesSize.value() > maximumCombinedFunctionVariablesSize) [[unlikely]]
         setError(Error(makeString("The combined byte size of all variables in this function exceeds "_s, String::number(maximumCombinedFunctionVariablesSize), " bytes"_s), function.span()));
 }
 
@@ -1337,7 +1337,7 @@ auto RewriteGlobalVariables::determineUsedGlobals(const AST::Function& function)
         CheckedUint32 combinedWorkgroupVariablesSize = 0;
         for (const Type* type : variables)
             combinedWorkgroupVariablesSize += type->size();
-        if (UNLIKELY(combinedWorkgroupVariablesSize.hasOverflowed() || combinedWorkgroupVariablesSize.value() > maximumCombinedWorkgroupVariablesSize))
+        if (combinedWorkgroupVariablesSize.hasOverflowed() || combinedWorkgroupVariablesSize.value() > maximumCombinedWorkgroupVariablesSize) [[unlikely]]
             return { Error(makeString("The combined byte size of all variables in the workgroup address space exceeds "_s, String::number(maximumCombinedWorkgroupVariablesSize), " bytes"_s), span) };
         return std::nullopt;
     });
@@ -1345,7 +1345,7 @@ auto RewriteGlobalVariables::determineUsedGlobals(const AST::Function& function)
         CheckedUint32 combinedPrivateVariablesSize = 0;
         for (const Type* type : variables)
             combinedPrivateVariablesSize += type->size();
-        if (UNLIKELY(combinedPrivateVariablesSize.hasOverflowed() || combinedPrivateVariablesSize.value() > maximumCombinedPrivateVariablesSize))
+        if (combinedPrivateVariablesSize.hasOverflowed() || combinedPrivateVariablesSize.value() > maximumCombinedPrivateVariablesSize) [[unlikely]]
             return { Error(makeString("The combined byte size of all variables in the private address space exceeds "_s, String::number(maximumCombinedPrivateVariablesSize), " bytes"_s), span) };
         return std::nullopt;
     });

--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -465,11 +465,11 @@ FOREACH_KEYWORD(MAPPING_ENTRY)
             if (tokenType != TokenType::Invalid)
                 return makeToken(tokenType);
 
-            if (UNLIKELY(reservedWordSet.contains(view)))
+            if (reservedWordSet.contains(view)) [[unlikely]]
                 return makeToken(TokenType::ReservedWord);
 
 
-            if (UNLIKELY(length >= 2 && startOfToken[0] == '_' && startOfToken[1] == '_'))
+            if (length >= 2 && startOfToken[0] == '_' && startOfToken[1] == '_') [[unlikely]]
                 return makeToken(TokenType::Invalid);
 
 
@@ -491,7 +491,7 @@ T Lexer<T>::shift(unsigned i)
     m_code.advanceBy(i);
     m_currentPosition.offset += i;
     m_currentPosition.lineOffset += i;
-    if (LIKELY(m_code.hasCharactersRemaining()))
+    if (m_code.hasCharactersRemaining()) [[likely]]
         m_current = m_code[0];
     return last;
 }
@@ -499,7 +499,7 @@ T Lexer<T>::shift(unsigned i)
 template <typename T>
 T Lexer<T>::peek(unsigned i)
 {
-    if (UNLIKELY(i >= m_code.lengthRemaining()))
+    if (i >= m_code.lengthRemaining()) [[unlikely]]
         return 0;
     return m_code[i];
 }

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -2381,7 +2381,7 @@ void FunctionDefinitionWriter::visit(AST::IndexAccessExpression& access)
 void FunctionDefinitionWriter::visit(AST::IdentifierExpression& identifier)
 {
     auto it = m_constantValues.find(identifier.identifier());
-    if (UNLIKELY(it != m_constantValues.end())) {
+    if (it != m_constantValues.end()) [[unlikely]] {
         m_body.append('(');
         serializeConstant(identifier.inferredType(), it->value);
         m_body.append(')');

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -850,7 +850,7 @@ Result<AST::Structure::Ref> Parser<Lexer>::parseStructure(AST::Attribute::List&&
 
         // https://www.w3.org/TR/WGSL/#limits
         static constexpr unsigned maximumNumberOfStructMembers = 1023;
-        if (UNLIKELY(members.size() > maximumNumberOfStructMembers))
+        if (members.size() > maximumNumberOfStructMembers) [[unlikely]]
             FAIL(makeString("struct cannot have more than "_s, String::number(maximumNumberOfStructMembers), " members"_s));
 
         if (current().type == TokenType::Comma)
@@ -889,7 +889,7 @@ Result<AST::Expression::Ref> Parser<Lexer>::parseTypeName()
 
     // https://www.w3.org/TR/WGSL/#limits
     static constexpr unsigned maximumCompositeTypeNestingDepth = 15;
-    if (UNLIKELY(m_compositeTypeDepth > maximumCompositeTypeNestingDepth))
+    if (m_compositeTypeDepth > maximumCompositeTypeNestingDepth) [[unlikely]]
         FAIL(makeString("composite type may not be nested more than "_s, String::number(maximumCompositeTypeNestingDepth), " levels"_s));
 
     if (current().type == TokenType::Identifier) {
@@ -1107,7 +1107,7 @@ Result<AST::Function::Ref> Parser<Lexer>::parseFunction(AST::Attribute::List&& a
 
         // https://www.w3.org/TR/WGSL/#limits
         static constexpr unsigned maximumNumberOfFunctionParameters = 255;
-        if (UNLIKELY(parameters.size() > maximumNumberOfFunctionParameters))
+        if (parameters.size() > maximumNumberOfFunctionParameters) [[unlikely]]
             FAIL(makeString("function cannot have more than "_s, String::number(maximumNumberOfFunctionParameters), " parameters"_s));
 
         if (current().type == TokenType::Comma)
@@ -1469,7 +1469,7 @@ Result<AST::Statement::Ref> Parser<Lexer>::parseSwitchStatement()
 
         // https://www.w3.org/TR/WGSL/#limits
         static constexpr unsigned maximumNumberOfCaseSelectors = 1023;
-        if (UNLIKELY(selectorCount > maximumNumberOfCaseSelectors))
+        if (selectorCount > maximumNumberOfCaseSelectors) [[unlikely]]
             FAIL(makeString("switch statement cannot have more than "_s, String::number(maximumNumberOfCaseSelectors), " case selector values"_s));
     }
     CONSUME_TYPE(BraceRight);

--- a/Source/WebGPU/WGSL/PhaseTimer.h
+++ b/Source/WebGPU/WGSL/PhaseTimer.h
@@ -45,7 +45,7 @@ static constexpr bool dumpPhaseTimes = false;
 
 static inline bool dumpASTIfNeeded(bool shouldDump, ShaderModule& program, const char* message)
 {
-    if (UNLIKELY(shouldDump)) {
+    if (shouldDump) [[unlikely]] {
         dataLogLn(message);
         AST::dumpAST(program);
         return true;
@@ -73,7 +73,7 @@ using PhaseTimes = Vector<std::pair<const char*, Seconds>>;
 
 static inline void logPhaseTimes(PhaseTimes& phaseTimes)
 {
-    if (LIKELY(!dumpPhaseTimes))
+    if (!dumpPhaseTimes) [[likely]]
         return;
 
     for (auto& entry : phaseTimes)

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -304,7 +304,7 @@ template<typename T>
 static std::span<T> makeSpanFromBuffer(id<MTLBuffer> buffer, size_t byteOffset = 0)
 {
     auto bufferLength = buffer.length;
-    if (UNLIKELY(bufferLength < byteOffset || (bufferLength - byteOffset < sizeof(T))))
+    if (bufferLength < byteOffset || (bufferLength - byteOffset < sizeof(T))) [[unlikely]]
         return { };
 
     return unsafeMakeSpan(static_cast<T*>(buffer.contents), (bufferLength - byteOffset) / sizeof(T));

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -70,7 +70,7 @@ static std::pair<uint64_t, uint32_t> makeKey(uint64_t bufferIdentifier, uint32_t
 
 void RenderPassEncoder::setVertexBuffer(id<MTLRenderCommandEncoder> commandEncoder, id<MTLBuffer> buffer, uint32_t offset, uint32_t bufferIndex)
 {
-    if (UNLIKELY(m_ignoreBufferCache)) {
+    if (m_ignoreBufferCache) [[unlikely]] {
         [commandEncoder setVertexBuffer:buffer offset:offset atIndex:bufferIndex];
         return;
     }
@@ -85,7 +85,7 @@ void RenderPassEncoder::setVertexBuffer(id<MTLRenderCommandEncoder> commandEncod
 
 void RenderPassEncoder::setFragmentBuffer(id<MTLRenderCommandEncoder> commandEncoder, id<MTLBuffer> buffer, uint32_t offset, uint32_t bufferIndex)
 {
-    if (UNLIKELY(m_ignoreBufferCache)) {
+    if (m_ignoreBufferCache) [[unlikely]] {
         [commandEncoder setFragmentBuffer:buffer offset:offset atIndex:bufferIndex];
         return;
     }

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -33,13 +33,13 @@
     void attachShader(uint32_t program, uint32_t shader)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+        if (!m_objectNames.isValidKey(program)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
         if (program)
             program = m_objectNames.get(program);
-        if (UNLIKELY(!m_objectNames.isValidKey(shader))) {
+        if (!m_objectNames.isValidKey(shader)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -50,7 +50,7 @@
     void bindAttribLocation(uint32_t arg0, uint32_t index, String&& name)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -61,7 +61,7 @@
     void bindBuffer(uint32_t target, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg1))) {
+        if (!m_objectNames.isValidKey(arg1)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -72,7 +72,7 @@
     void bindFramebuffer(uint32_t target, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg1))) {
+        if (!m_objectNames.isValidKey(arg1)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -83,7 +83,7 @@
     void bindRenderbuffer(uint32_t target, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg1))) {
+        if (!m_objectNames.isValidKey(arg1)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -94,7 +94,7 @@
     void bindTexture(uint32_t target, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg1))) {
+        if (!m_objectNames.isValidKey(arg1)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -162,7 +162,7 @@
     void compileShader(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -183,7 +183,7 @@
     void createBuffer(uint32_t name)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+        if (!m_objectNames.isValidKey(name)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -194,7 +194,7 @@
     void createFramebuffer(uint32_t name)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+        if (!m_objectNames.isValidKey(name)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -205,7 +205,7 @@
     void createProgram(uint32_t name)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+        if (!m_objectNames.isValidKey(name)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -216,7 +216,7 @@
     void createRenderbuffer(uint32_t name)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+        if (!m_objectNames.isValidKey(name)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -227,7 +227,7 @@
     void createShader(uint32_t name, uint32_t arg0)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+        if (!m_objectNames.isValidKey(name)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -238,7 +238,7 @@
     void createTexture(uint32_t name)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+        if (!m_objectNames.isValidKey(name)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -254,11 +254,11 @@
     void deleteBuffer(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
-        if (UNLIKELY(!arg0))
+        if (!arg0) [[unlikely]]
             return;
         arg0 = m_objectNames.take(arg0);
         protectedContext()->deleteBuffer(arg0);
@@ -266,11 +266,11 @@
     void deleteFramebuffer(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
-        if (UNLIKELY(!arg0))
+        if (!arg0) [[unlikely]]
             return;
         arg0 = m_objectNames.take(arg0);
         protectedContext()->deleteFramebuffer(arg0);
@@ -278,11 +278,11 @@
     void deleteProgram(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
-        if (UNLIKELY(!arg0))
+        if (!arg0) [[unlikely]]
             return;
         arg0 = m_objectNames.take(arg0);
         protectedContext()->deleteProgram(arg0);
@@ -290,11 +290,11 @@
     void deleteRenderbuffer(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
-        if (UNLIKELY(!arg0))
+        if (!arg0) [[unlikely]]
             return;
         arg0 = m_objectNames.take(arg0);
         protectedContext()->deleteRenderbuffer(arg0);
@@ -302,11 +302,11 @@
     void deleteShader(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
-        if (UNLIKELY(!arg0))
+        if (!arg0) [[unlikely]]
             return;
         arg0 = m_objectNames.take(arg0);
         protectedContext()->deleteShader(arg0);
@@ -314,11 +314,11 @@
     void deleteTexture(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
-        if (UNLIKELY(!arg0))
+        if (!arg0) [[unlikely]]
             return;
         arg0 = m_objectNames.take(arg0);
         protectedContext()->deleteTexture(arg0);
@@ -341,13 +341,13 @@
     void detachShader(uint32_t arg0, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
-        if (UNLIKELY(!m_objectNames.isValidKey(arg1))) {
+        if (!m_objectNames.isValidKey(arg1)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -398,7 +398,7 @@
     void framebufferRenderbuffer(uint32_t target, uint32_t attachment, uint32_t renderbuffertarget, uint32_t arg3)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg3))) {
+        if (!m_objectNames.isValidKey(arg3)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -409,7 +409,7 @@
     void framebufferTexture2D(uint32_t target, uint32_t attachment, uint32_t textarget, uint32_t arg3, int32_t level)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg3))) {
+        if (!m_objectNames.isValidKey(arg3)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -431,7 +431,7 @@
     {
         assertIsCurrent(workQueue());
         bool returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+        if (!m_objectNames.isValidKey(program)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -445,7 +445,7 @@
     {
         assertIsCurrent(workQueue());
         bool returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+        if (!m_objectNames.isValidKey(program)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -459,7 +459,7 @@
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -525,7 +525,7 @@
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+        if (!m_objectNames.isValidKey(program)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -554,7 +554,7 @@
     {
         assertIsCurrent(workQueue());
         String returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -574,7 +574,7 @@
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -587,7 +587,7 @@
     {
         assertIsCurrent(workQueue());
         String returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -608,7 +608,7 @@
     {
         assertIsCurrent(workQueue());
         String returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -634,7 +634,7 @@
     void getUniformfv(uint32_t program, int32_t location, size_t valueSize, CompletionHandler<void(std::span<const float>)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+        if (!m_objectNames.isValidKey(program)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -649,7 +649,7 @@
     void getUniformiv(uint32_t program, int32_t location, size_t valueSize, CompletionHandler<void(std::span<const int32_t>)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+        if (!m_objectNames.isValidKey(program)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -664,7 +664,7 @@
     void getUniformuiv(uint32_t program, int32_t location, size_t valueSize, CompletionHandler<void(std::span<const uint32_t>)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+        if (!m_objectNames.isValidKey(program)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -680,7 +680,7 @@
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -705,7 +705,7 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -725,7 +725,7 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -738,7 +738,7 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -751,7 +751,7 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -764,7 +764,7 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -777,7 +777,7 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -794,7 +794,7 @@
     void linkProgram(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -830,7 +830,7 @@
     void shaderSource(uint32_t arg0, String&& arg1)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -976,7 +976,7 @@
     void useProgram(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -987,7 +987,7 @@
     void validateProgram(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1123,7 +1123,7 @@
     void createVertexArray(uint32_t name)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+        if (!m_objectNames.isValidKey(name)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1134,11 +1134,11 @@
     void deleteVertexArray(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
-        if (UNLIKELY(!arg0))
+        if (!arg0) [[unlikely]]
             return;
         arg0 = m_objectNames.take(arg0);
         protectedContext()->deleteVertexArray(arg0);
@@ -1147,7 +1147,7 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1159,7 +1159,7 @@
     void bindVertexArray(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1180,7 +1180,7 @@
     void framebufferTextureLayer(uint32_t target, uint32_t attachment, uint32_t texture, int32_t level, int32_t layer)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(texture))) {
+        if (!m_objectNames.isValidKey(texture)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1267,7 +1267,7 @@
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+        if (!m_objectNames.isValidKey(program)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1404,7 +1404,7 @@
     void createQuery(uint32_t name)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+        if (!m_objectNames.isValidKey(name)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1415,11 +1415,11 @@
     void deleteQuery(uint32_t query)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(query))) {
+        if (!m_objectNames.isValidKey(query)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
-        if (UNLIKELY(!query))
+        if (!query) [[unlikely]]
             return;
         query = m_objectNames.take(query);
         protectedContext()->deleteQuery(query);
@@ -1428,7 +1428,7 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(query))) {
+        if (!m_objectNames.isValidKey(query)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1440,7 +1440,7 @@
     void beginQuery(uint32_t target, uint32_t query)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(query))) {
+        if (!m_objectNames.isValidKey(query)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1464,7 +1464,7 @@
     {
         assertIsCurrent(workQueue());
         GCGLuint returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(query))) {
+        if (!m_objectNames.isValidKey(query)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1476,7 +1476,7 @@
     void createSampler(uint32_t name)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+        if (!m_objectNames.isValidKey(name)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1487,11 +1487,11 @@
     void deleteSampler(uint32_t sampler)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(sampler))) {
+        if (!m_objectNames.isValidKey(sampler)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
-        if (UNLIKELY(!sampler))
+        if (!sampler) [[unlikely]]
             return;
         sampler = m_objectNames.take(sampler);
         protectedContext()->deleteSampler(sampler);
@@ -1500,7 +1500,7 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(sampler))) {
+        if (!m_objectNames.isValidKey(sampler)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1512,7 +1512,7 @@
     void bindSampler(uint32_t unit, uint32_t sampler)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(sampler))) {
+        if (!m_objectNames.isValidKey(sampler)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1523,7 +1523,7 @@
     void samplerParameteri(uint32_t sampler, uint32_t pname, int32_t param)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(sampler))) {
+        if (!m_objectNames.isValidKey(sampler)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1534,7 +1534,7 @@
     void samplerParameterf(uint32_t sampler, uint32_t pname, float param)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(sampler))) {
+        if (!m_objectNames.isValidKey(sampler)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1546,7 +1546,7 @@
     {
         assertIsCurrent(workQueue());
         GCGLfloat returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(sampler))) {
+        if (!m_objectNames.isValidKey(sampler)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1559,7 +1559,7 @@
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(sampler))) {
+        if (!m_objectNames.isValidKey(sampler)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1609,7 +1609,7 @@
     void createTransformFeedback(uint32_t name)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+        if (!m_objectNames.isValidKey(name)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1620,11 +1620,11 @@
     void deleteTransformFeedback(uint32_t id)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(id))) {
+        if (!m_objectNames.isValidKey(id)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
-        if (UNLIKELY(!id))
+        if (!id) [[unlikely]]
             return;
         id = m_objectNames.take(id);
         protectedContext()->deleteTransformFeedback(id);
@@ -1633,7 +1633,7 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(id))) {
+        if (!m_objectNames.isValidKey(id)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1645,7 +1645,7 @@
     void bindTransformFeedback(uint32_t target, uint32_t id)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(id))) {
+        if (!m_objectNames.isValidKey(id)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1666,7 +1666,7 @@
     void transformFeedbackVaryings(uint32_t program, Vector<String>&& varyings, uint32_t bufferMode)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+        if (!m_objectNames.isValidKey(program)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1677,7 +1677,7 @@
     void getTransformFeedbackVarying(uint32_t program, uint32_t index, CompletionHandler<void(struct WebCore::GraphicsContextGLActiveInfo&&)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+        if (!m_objectNames.isValidKey(program)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1700,7 +1700,7 @@
     void bindBufferBase(uint32_t target, uint32_t index, uint32_t buffer)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(buffer))) {
+        if (!m_objectNames.isValidKey(buffer)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1711,7 +1711,7 @@
     void bindBufferRange(uint32_t target, uint32_t index, uint32_t buffer, uint64_t offset, uint64_t arg4)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(buffer))) {
+        if (!m_objectNames.isValidKey(buffer)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1723,7 +1723,7 @@
     {
         assertIsCurrent(workQueue());
         Vector<GCGLuint> returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+        if (!m_objectNames.isValidKey(program)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1736,7 +1736,7 @@
     {
         assertIsCurrent(workQueue());
         Vector<GCGLint> returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+        if (!m_objectNames.isValidKey(program)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1749,7 +1749,7 @@
     {
         assertIsCurrent(workQueue());
         GCGLuint returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+        if (!m_objectNames.isValidKey(program)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1762,7 +1762,7 @@
     {
         assertIsCurrent(workQueue());
         String returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+        if (!m_objectNames.isValidKey(program)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1774,7 +1774,7 @@
     void uniformBlockBinding(uint32_t program, uint32_t uniformBlockIndex, uint32_t uniformBlockBinding)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+        if (!m_objectNames.isValidKey(program)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1785,7 +1785,7 @@
     void getActiveUniformBlockiv(uint32_t program, uint32_t uniformBlockIndex, uint32_t pname, size_t paramsSize, CompletionHandler<void(std::span<const int32_t>)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+        if (!m_objectNames.isValidKey(program)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1801,7 +1801,7 @@
     {
         assertIsCurrent(workQueue());
         String returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1818,7 +1818,7 @@
     void createQueryEXT(uint32_t name)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+        if (!m_objectNames.isValidKey(name)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1829,11 +1829,11 @@
     void deleteQueryEXT(uint32_t query)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(query))) {
+        if (!m_objectNames.isValidKey(query)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
-        if (UNLIKELY(!query))
+        if (!query) [[unlikely]]
             return;
         query = m_objectNames.take(query);
         protectedContext()->deleteQueryEXT(query);
@@ -1842,7 +1842,7 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(query))) {
+        if (!m_objectNames.isValidKey(query)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1854,7 +1854,7 @@
     void beginQueryEXT(uint32_t target, uint32_t query)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(query))) {
+        if (!m_objectNames.isValidKey(query)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1870,7 +1870,7 @@
     void queryCounterEXT(uint32_t query, uint32_t target)
     {
         assertIsCurrent(workQueue());
-        if (UNLIKELY(!m_objectNames.isValidKey(query))) {
+        if (!m_objectNames.isValidKey(query)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1889,7 +1889,7 @@
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(query))) {
+        if (!m_objectNames.isValidKey(query)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -1902,7 +1902,7 @@
     {
         assertIsCurrent(workQueue());
         GCGLuint64 returnValue = { };
-        if (UNLIKELY(!m_objectNames.isValidKey(query))) {
+        if (!m_objectNames.isValidKey(query)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -2007,7 +2007,7 @@
     {
         assertIsCurrent(workQueue());
         messageCheck(webXRPromptAccepted());
-        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+        if (!m_objectNames.isValidKey(name)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -2019,11 +2019,11 @@
     {
         assertIsCurrent(workQueue());
         messageCheck(webXRPromptAccepted());
-        if (UNLIKELY(!m_objectNames.isValidKey(handle))) {
+        if (!m_objectNames.isValidKey(handle)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
-        if (UNLIKELY(!handle))
+        if (!handle) [[unlikely]]
             return;
         handle = m_objectNames.take(handle);
         protectedContext()->deleteExternalImage(handle);
@@ -2032,7 +2032,7 @@
     {
         assertIsCurrent(workQueue());
         messageCheck(webXRPromptAccepted());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg1))) {
+        if (!m_objectNames.isValidKey(arg1)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -2044,7 +2044,7 @@
     {
         assertIsCurrent(workQueue());
         messageCheck(webXRPromptAccepted());
-        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+        if (!m_objectNames.isValidKey(name)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -2057,11 +2057,11 @@
     {
         assertIsCurrent(workQueue());
         messageCheck(webXRPromptAccepted());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
-        if (UNLIKELY(!arg0))
+        if (!arg0) [[unlikely]]
             return;
         arg0 = m_objectNames.take(arg0);
         protectedContext()->deleteExternalSync(arg0);
@@ -2087,7 +2087,7 @@
     {
         assertIsCurrent(workQueue());
         messageCheck(webXRPromptAccepted());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+        if (!m_objectNames.isValidKey(arg0)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }
@@ -2111,7 +2111,7 @@
     {
         assertIsCurrent(workQueue());
         messageCheck(webXRPromptAccepted());
-        if (UNLIKELY(!m_objectNames.isValidKey(arg3))) {
+        if (!m_objectNames.isValidKey(arg3)) [[unlikely]] {
             ASSERT_IS_TESTING_IPC();
             return;
         }

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
@@ -407,7 +407,7 @@ void ResourceLoadStatisticsStore::removeDataRecords(CompletionHandler<void()>&& 
         return;
     }
 
-    if (UNLIKELY(m_debugLoggingEnabled)) {
+    if (m_debugLoggingEnabled) [[unlikely]] {
         ITP_DEBUG_MODE_RELEASE_LOG("About to remove data records for %" PUBLIC_LOG_STRING ".", domainsToString(domainsToDeleteOrRestrictWebsiteDataFor).utf8().data());
         debugBroadcastConsoleMessage(MessageSource::ITPDebug, MessageLevel::Info, makeString("[ITP] About to remove data records for: ["_s, domainsToString(domainsToDeleteOrRestrictWebsiteDataFor), "]."_s));
     }
@@ -431,7 +431,7 @@ void ResourceLoadStatisticsStore::removeDataRecords(CompletionHandler<void()>&& 
                 for (auto& dataRecordRemovalCompletionHandler : dataRecordRemovalCompletionHandlers)
                     dataRecordRemovalCompletionHandler();
 
-                if (UNLIKELY(weakThis->m_debugLoggingEnabled)) {
+                if (weakThis->m_debugLoggingEnabled) [[unlikely]] {
                     ITP_DEBUG_MODE_RELEASE_LOG("Done removing data records.");
                     weakThis->debugBroadcastConsoleMessage(MessageSource::ITPDebug, MessageLevel::Info, "[ITP] Done removing data records"_s);
                 }
@@ -1695,14 +1695,14 @@ void ResourceLoadStatisticsStore::requestStorageAccess(SubFrameDomain&& subFrame
 
     switch (cookieAccess(subFrameDomain, topFrameDomain, canRequestStorageAccessWithoutUserInteraction)) {
     case CookieAccess::CannotRequest:
-        if (UNLIKELY(debugLoggingEnabled())) {
+        if (debugLoggingEnabled()) [[unlikely]] {
             ITP_DEBUG_MODE_RELEASE_LOG("Cannot grant storage access to %" PRIVATE_LOG_STRING " since its cookies are blocked in third-party contexts and it has not received user interaction as first-party.", subFrameDomain.string().utf8().data());
             debugBroadcastConsoleMessage(MessageSource::ITPDebug, MessageLevel::Error, makeString("[ITP] Cannot grant storage access to '"_s, subFrameDomain.string(), "' since its cookies are blocked in third-party contexts and it has not received user interaction as first-party."_s));
         }
         completionHandler(StorageAccessStatus::CannotRequestAccess);
         return;
     case CookieAccess::BasedOnCookiePolicy:
-        if (UNLIKELY(debugLoggingEnabled())) {
+        if (debugLoggingEnabled()) [[unlikely]] {
             ITP_DEBUG_MODE_RELEASE_LOG("No need to grant storage access to %" PRIVATE_LOG_STRING " since its cookies are not blocked in third-party contexts. Note that the underlying cookie policy may still block this third-party from setting cookies.", subFrameDomain.string().utf8().data());
             debugBroadcastConsoleMessage(MessageSource::ITPDebug, MessageLevel::Info, makeString("[ITP] No need to grant storage access to '"_s, subFrameDomain.string(), "' since its cookies are not blocked in third-party contexts. Note that the underlying cookie policy may still block this third-party from setting cookies."_s));
         }
@@ -1715,7 +1715,7 @@ void ResourceLoadStatisticsStore::requestStorageAccess(SubFrameDomain&& subFrame
 
     auto userWasPromptedEarlier = hasUserGrantedStorageAccessThroughPrompt(*subFrameStatus.second, topFrameDomain);
     if (userWasPromptedEarlier == StorageAccessPromptWasShown::No) {
-        if (UNLIKELY(debugLoggingEnabled())) {
+        if (debugLoggingEnabled()) [[unlikely]] {
             ITP_DEBUG_MODE_RELEASE_LOG("About to ask the user whether they want to grant storage access to %" PRIVATE_LOG_STRING " under %" PRIVATE_LOG_STRING " or not.", subFrameDomain.string().utf8().data(), topFrameDomain.string().utf8().data());
             debugBroadcastConsoleMessage(MessageSource::ITPDebug, MessageLevel::Info, makeString("[ITP] About to ask the user whether they want to grant storage access to '"_s, subFrameDomain.string(), "' under '"_s, topFrameDomain.string(), "' or not."_s));
         }
@@ -1724,7 +1724,7 @@ void ResourceLoadStatisticsStore::requestStorageAccess(SubFrameDomain&& subFrame
     }
 
     if (userWasPromptedEarlier == StorageAccessPromptWasShown::Yes) {
-        if (UNLIKELY(debugLoggingEnabled())) {
+        if (debugLoggingEnabled()) [[unlikely]] {
             ITP_DEBUG_MODE_RELEASE_LOG("Storage access was granted to %" PRIVATE_LOG_STRING " under %" PRIVATE_LOG_STRING ".", subFrameDomain.string().utf8().data(), topFrameDomain.string().utf8().data());
             debugBroadcastConsoleMessage(MessageSource::ITPDebug, MessageLevel::Info, makeString("[ITP] Storage access was granted to '"_s, subFrameDomain.string(), "' under '"_s, topFrameDomain.string(), "'."_s));
         }
@@ -1753,7 +1753,7 @@ void ResourceLoadStatisticsStore::requestStorageAccessUnderOpener(DomainInNeedOf
     if (domainInNeedOfStorageAccess == openerDomain)
         return;
 
-    if (UNLIKELY(debugLoggingEnabled())) {
+    if (debugLoggingEnabled()) [[unlikely]] {
         ITP_DEBUG_MODE_RELEASE_LOG("[Temporary combatibility fix] Storage access was granted for %" PRIVATE_LOG_STRING " under opener page from %" PRIVATE_LOG_STRING ", with user interaction in the opened window.", domainInNeedOfStorageAccess.string().utf8().data(), openerDomain.string().utf8().data());
         debugBroadcastConsoleMessage(MessageSource::ITPDebug, MessageLevel::Info, makeString("[ITP] Storage access was granted for '"_s, domainInNeedOfStorageAccess.string(), "' under opener page from '"_s, openerDomain.string(), "', with user interaction in the opened window."_s));
     }
@@ -1939,7 +1939,7 @@ void ResourceLoadStatisticsStore::logFrameNavigation(const RegistrableDomain& ta
                 if (isRedirect) {
                     insertDomainRelationshipList(topFrameUniqueRedirectsToSinceSameSiteStrictEnforcementQuery, HashSet<RegistrableDomain>({ targetDomain }), *redirectingDomainResult.second);
 
-                    if (UNLIKELY(debugLoggingEnabled())) {
+                    if (debugLoggingEnabled()) [[unlikely]] {
                         ITP_DEBUG_MODE_RELEASE_LOG("Did set %" PUBLIC_LOG_STRING " as making a top frame redirect to %" PUBLIC_LOG_STRING ".", sourceDomain.string().utf8().data(), targetDomain.string().utf8().data());
                         debugBroadcastConsoleMessage(MessageSource::ITPDebug, MessageLevel::Info, makeString("Did set '"_s, sourceDomain.string(), "' as making a top frame redirect to '"_s, targetDomain.string(), "'."_s));
                     }
@@ -2688,7 +2688,7 @@ void ResourceLoadStatisticsStore::updateCookieBlocking(CompletionHandler<void()>
                 if (!weakThis)
                     return;
 
-                if (UNLIKELY(weakThis->debugLoggingEnabled())) {
+                if (weakThis->debugLoggingEnabled()) [[unlikely]] {
                     ITP_DEBUG_MODE_RELEASE_LOG("Done applying cross-site tracking restrictions.");
                     weakThis->debugBroadcastConsoleMessage(MessageSource::ITPDebug, MessageLevel::Info, "[ITP] Done applying cross-site tracking restrictions."_s);
                 }
@@ -2847,7 +2847,7 @@ RegistrableDomainsToDeleteOrRestrictWebsiteDataFor ResourceLoadStatisticsStore::
             if (shouldEnforceSameSiteStrictFor(statistic, shouldCheckForGrandfathering)) {
                 toDeleteOrRestrictFor.domainsToEnforceSameSiteStrictFor.append(statistic.registrableDomain);
 
-                if (UNLIKELY(debugLoggingEnabled())) {
+                if (debugLoggingEnabled()) [[unlikely]] {
                     ITP_DEBUG_MODE_RELEASE_LOG("Scheduled %" PUBLIC_LOG_STRING " to have its cookies set to SameSite=strict.", statistic.registrableDomain.string().utf8().data());
                     debugBroadcastConsoleMessage(MessageSource::ITPDebug, MessageLevel::Info, makeString("Scheduled '"_s, statistic.registrableDomain.string(), "' to have its cookies set to SameSite=strict'."_s));
                 }

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -548,7 +548,7 @@ RefPtr<ServiceWorkerFetchTask> NetworkConnectionToWebProcess::createFetchTask(Ne
 void NetworkConnectionToWebProcess::scheduleResourceLoad(NetworkResourceLoadParameters&& loadParameters, std::optional<NetworkResourceLoadIdentifier> existingLoaderToResume)
 {
     auto allowCookieAccess = protectedNetworkProcess()->allowsFirstPartyForCookies(m_webProcessIdentifier, loadParameters.request.firstPartyForCookies());
-    if (UNLIKELY(allowCookieAccess != NetworkProcess::AllowCookieAccess::Allow))
+    if (allowCookieAccess != NetworkProcess::AllowCookieAccess::Allow) [[unlikely]]
         RELEASE_LOG_ERROR(Loading, "scheduleResourceLoad: Web process does not have cookie access to url %" SENSITIVE_LOG_STRING " for request %" SENSITIVE_LOG_STRING, loadParameters.request.firstPartyForCookies().string().utf8().data(), loadParameters.request.url().string().utf8().data());
 
     MESSAGE_CHECK(allowCookieAccess != NetworkProcess::AllowCookieAccess::Terminate);

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp
@@ -465,7 +465,7 @@ void PrivateClickMeasurementManager::attribute(SourceSite&& sourceSite, Attribut
         if (!attributionSecondsUntilSendData)
             return;
 
-        if (UNLIKELY(protectedThis->debugModeEnabled())) {
+        if (protectedThis->debugModeEnabled()) [[unlikely]] {
             for (auto& message : debugInfo.messages)
                 protectedThis->m_client->broadcastConsoleMessage(message.messageLevel, message.message);
         }
@@ -480,7 +480,7 @@ void PrivateClickMeasurementManager::attribute(SourceSite&& sourceSite, Attribut
             if (protectedThis->m_firePendingAttributionRequestsTimer.isActive() && protectedThis->m_firePendingAttributionRequestsTimer.secondsUntilFire() < *minSecondsUntilSend)
                 return;
 
-            if (UNLIKELY(protectedThis->debugModeEnabled())) {
+            if (protectedThis->debugModeEnabled()) [[unlikely]] {
                 protectedThis->m_client->broadcastConsoleMessage(MessageLevel::Log, makeString("[Private Click Measurement] Setting timer for firing attribution request to the debug mode timeout of "_s, debugModeSecondsUntilSend.seconds(), " seconds where the regular timeout would have been "_s, minSecondsUntilSend.value().seconds(), " seconds."_s));
                 minSecondsUntilSend = debugModeSecondsUntilSend;
             } else

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.cpp
@@ -200,7 +200,7 @@ void handlePCMMessage(std::span<const uint8_t> encodedMessage)
 
     std::optional<typename Info::ArgsTuple> arguments;
     decoder >> arguments;
-    if (UNLIKELY(!arguments))
+    if (!arguments) [[unlikely]]
         return;
 
     IPC::callMemberFunction(&daemonManagerSingleton(), Info::MemberFunction, WTFMove(*arguments));
@@ -212,7 +212,7 @@ static void handlePCMMessageSetDebugModeIsEnabled(const Daemon::Connection& conn
     Daemon::Decoder decoder(encodedMessage);
     std::optional<bool> enabled;
     decoder >> enabled;
-    if (UNLIKELY(!enabled))
+    if (!enabled) [[unlikely]]
         return;
 
     auto& connectionSet = DaemonConnectionSet::singleton();
@@ -233,7 +233,7 @@ void handlePCMMessageWithReply(std::span<const uint8_t> encodedMessage, Completi
 
     std::optional<typename Info::ArgsTuple> arguments;
     decoder >> arguments;
-    if (UNLIKELY(!arguments))
+    if (!arguments) [[unlikely]]
         return;
 
     typename Info::Reply completionHandler { [replySender = WTFMove(replySender)] (auto&&... args) mutable {

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -106,7 +106,7 @@ struct ArgumentCoder<ArrayReferenceTuple<Types...>> {
     {
         size_t size = arrayReference.size();
         encoder << size;
-        if (UNLIKELY(!size))
+        if (!size) [[unlikely]]
             return;
 
         (..., encoder.encodeSpan(arrayReference.template span<Indices>()));
@@ -116,14 +116,14 @@ struct ArgumentCoder<ArrayReferenceTuple<Types...>> {
     static std::optional<ArrayReferenceTuple<Types...>> decode(Decoder& decoder)
     {
         auto decodedSize = decoder.template decode<size_t>();
-        if (UNLIKELY(!decodedSize))
+        if (!decodedSize) [[unlikely]]
             return std::nullopt;
-        if (UNLIKELY(!*decodedSize))
+        if (!*decodedSize) [[unlikely]]
             return ArrayReferenceTuple<Types...> { };
 
         CheckedSize size { *decodedSize };
         bool anyOverflow = (... || (size * sizeof(Types)).hasOverflowed());
-        if (UNLIKELY(anyOverflow))
+        if (anyOverflow) [[unlikely]]
             return std::nullopt;
 
         return decode(decoder, size);
@@ -469,7 +469,7 @@ template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t min
 
         // Calls to reserveInitialCapacity with untrusted large sizes can cause allocator crashes.
         // Limit allocations from untrusted sources to 1MB.
-        if (LIKELY(*size < 1024 * 1024 / sizeof(T))) {
+        if (*size < 1024 * 1024 / sizeof(T)) [[likely]] {
             vector.reserveInitialCapacity(*size);
             for (size_t i = 0; i < *size; ++i) {
                 auto element = decoder.template decode<T>();
@@ -533,17 +533,17 @@ template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTrai
         HashMapType hashMap;
         for (unsigned i = 0; i < *hashMapSize; ++i) {
             auto key = decoder.template decode<KeyArg>();
-            if (UNLIKELY(!key))
+            if (!key) [[unlikely]]
                 return std::nullopt;
 
             auto value = decoder.template decode<MappedArg>();
-            if (UNLIKELY(!value))
+            if (!value) [[unlikely]]
                 return std::nullopt;
 
-            if (UNLIKELY(!HashMapType::isValidKey(*key)))
+            if (!HashMapType::isValidKey(*key)) [[unlikely]]
                 return std::nullopt;
 
-            if (UNLIKELY(!hashMap.add(WTFMove(*key), WTFMove(*value)).isNewEntry)) {
+            if (!hashMap.add(WTFMove(*key), WTFMove(*value)).isNewEntry) [[unlikely]] {
                 // The hash map already has the specified key, bail.
                 return std::nullopt;
             }
@@ -576,17 +576,17 @@ template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTrai
         HashMapType hashMap;
         for (unsigned i = 0; i < *hashMapSize; ++i) {
             auto key = decoder.template decode<KeyArg>();
-            if (UNLIKELY(!key))
+            if (!key) [[unlikely]]
                 return std::nullopt;
 
             auto value = decoder.template decode<MappedArg>();
-            if (UNLIKELY(!value))
+            if (!value) [[unlikely]]
                 return std::nullopt;
 
-            if (UNLIKELY(!HashMapType::isValidKey(*key)))
+            if (!HashMapType::isValidKey(*key)) [[unlikely]]
                 return std::nullopt;
 
-            if (UNLIKELY(!hashMap.add(WTFMove(*key), WTFMove(*value)).isNewEntry)) {
+            if (!hashMap.add(WTFMove(*key), WTFMove(*value)).isNewEntry) [[unlikely]] {
                 // The hash map already has the specified key, bail.
                 return std::nullopt;
             }
@@ -620,10 +620,10 @@ template<typename KeyArg, typename HashArg, typename KeyTraitsArg, typename Hash
             if (!key)
                 return std::nullopt;
 
-            if (UNLIKELY(!HashSetType::isValidValue(*key)))
+            if (!HashSetType::isValidValue(*key)) [[unlikely]]
                 return std::nullopt;
 
-            if (UNLIKELY(!hashSet.add(WTFMove(*key)).isNewEntry)) {
+            if (!hashSet.add(WTFMove(*key)).isNewEntry) [[unlikely]] {
                 // The hash set already has the specified key, bail.
                 return std::nullopt;
             }
@@ -663,10 +663,10 @@ template<typename KeyArg, typename HashArg, typename KeyTraitsArg> struct Argume
             if (!count)
                 return std::nullopt;
 
-            if (UNLIKELY(!HashCountedSetType::isValidValue(*key)))
+            if (!HashCountedSetType::isValidValue(*key)) [[unlikely]]
                 return std::nullopt;
 
-            if (UNLIKELY(!tempHashCountedSet.add(*key, *count).isNewEntry)) {
+            if (!tempHashCountedSet.add(*key, *count).isNewEntry) [[unlikely]] {
                 // The hash counted set already has the specified key, bail.
                 return std::nullopt;
             }
@@ -836,14 +836,14 @@ template<typename T, typename Traits> struct ArgumentCoder<WTF::Markable<T, Trai
     static std::optional<WTF::Markable<T>> decode(Decoder& decoder)
     {
         auto isEmpty = decoder.template decode<bool>();
-        if (UNLIKELY(!isEmpty))
+        if (!isEmpty) [[unlikely]]
             return std::nullopt;
 
         if (*isEmpty)
             return WTF::Markable<T, Traits> { };
 
         auto value = decoder.template decode<T>();
-        if (UNLIKELY(!value))
+        if (!value) [[unlikely]]
             return std::nullopt;
 
         return WTF::Markable<T, Traits>(WTFMove(*value));

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -828,7 +828,7 @@ auto Connection::waitForMessage(MessageName messageName, uint64_t destinationID,
             return makeUnexpected(Error::WaitingOnAlreadyDispatchedMessage);
         }
 
-        if (UNLIKELY(m_inDispatchSyncMessageCount && !timeout.isInfinity())) {
+        if (m_inDispatchSyncMessageCount && !timeout.isInfinity()) [[unlikely]] {
             RELEASE_LOG_ERROR(IPC, "Connection::waitForMessage(%" PUBLIC_LOG_STRING "): Exiting immediately, since we're handling a sync message already", description(messageName).characters());
             m_waitingForMessage = nullptr;
             return makeUnexpected(Error::AttemptingToWaitInsideSyncMessageHandling);

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -130,7 +130,7 @@ extern ASCIILiteral errorAsString(Error);
 #endif
 
 #define MESSAGE_CHECK_WITH_MESSAGE_BASE(assertion, connection, message) do { \
-    if (UNLIKELY(!(assertion))) { \
+    if (!(assertion)) [[unlikely]] { \
         RELEASE_LOG_FAULT(IPC, __FILE__ " " CONNECTION_STRINGIFY_MACRO(__LINE__) ": Invalid message dispatched %" PUBLIC_LOG_STRING ": " message, WTF_PRETTY_FUNCTION); \
         IPC::Connection::markCurrentlyDispatchedMessageAsInvalid(connection); \
         CRASH_IF_TESTING \
@@ -142,7 +142,7 @@ extern ASCIILiteral errorAsString(Error);
 #define MESSAGE_CHECK_BASE_COROUTINE(assertion, connection) MESSAGE_CHECK_COMPLETION_BASE_COROUTINE(assertion, connection, (void)0)
 
 #define MESSAGE_CHECK_OPTIONAL_CONNECTION_BASE(assertion, connection) do { \
-    if (UNLIKELY(!(assertion))) { \
+    if (!(assertion)) [[unlikely]] { \
         RELEASE_LOG_FAULT(IPC, __FILE__ " " CONNECTION_STRINGIFY_MACRO(__LINE__) ": Invalid message dispatched %" PUBLIC_LOG_STRING, WTF_PRETTY_FUNCTION); \
         IPC::Connection::markCurrentlyDispatchedMessageAsInvalid(connection); \
         CRASH_IF_TESTING \
@@ -151,7 +151,7 @@ extern ASCIILiteral errorAsString(Error);
 } while (0)
 
 #define MESSAGE_CHECK_COMPLETION_BASE(assertion, connection, completion) do { \
-    if (UNLIKELY(!(assertion))) { \
+    if (!(assertion)) [[unlikely]] { \
         RELEASE_LOG_FAULT(IPC, __FILE__ " " CONNECTION_STRINGIFY_MACRO(__LINE__) ": Invalid message dispatched %" PUBLIC_LOG_STRING, WTF_PRETTY_FUNCTION); \
         IPC::Connection::markCurrentlyDispatchedMessageAsInvalid(connection); \
         CRASH_IF_TESTING \
@@ -161,7 +161,7 @@ extern ASCIILiteral errorAsString(Error);
 } while (0)
 
 #define MESSAGE_CHECK_COMPLETION_BASE_COROUTINE(assertion, connection, completion) do { \
-    if (UNLIKELY(!(assertion))) { \
+    if (!(assertion)) [[unlikely]] { \
         RELEASE_LOG_FAULT(IPC, __FILE__ " " CONNECTION_STRINGIFY_MACRO(__LINE__) ": Invalid message dispatched %" PUBLIC_LOG_STRING, WTF_PRETTY_FUNCTION); \
         IPC::Connection::markCurrentlyDispatchedMessageAsInvalid(connection); \
         CRASH_IF_TESTING \
@@ -171,7 +171,7 @@ extern ASCIILiteral errorAsString(Error);
 } while (0)
 
 #define MESSAGE_CHECK_WITH_RETURN_VALUE_BASE(assertion, connection, returnValue) do { \
-    if (UNLIKELY(!(assertion))) { \
+    if (!(assertion)) [[unlikely]] { \
         RELEASE_LOG_FAULT(IPC, __FILE__ " " CONNECTION_STRINGIFY_MACRO(__LINE__) ": Invalid message dispatched %" PUBLIC_LOG_STRING, WTF_PRETTY_FUNCTION); \
         IPC::Connection::markCurrentlyDispatchedMessageAsInvalid(connection); \
         CRASH_IF_TESTING \

--- a/Source/WebKit/Platform/IPC/Decoder.cpp
+++ b/Source/WebKit/Platform/IPC/Decoder.cpp
@@ -61,7 +61,7 @@ std::unique_ptr<Decoder> Decoder::create(std::span<const uint8_t> buffer, Buffer
 {
     ASSERT(bufferDeallocator);
     ASSERT(!!buffer.data());
-    if (UNLIKELY(!buffer.data())) {
+    if (!buffer.data()) [[unlikely]] {
         RELEASE_LOG_FAULT(IPC, "Decoder::create() called with a null buffer (buffer size: %lu)", buffer.size_bytes());
         return nullptr;
     }
@@ -77,23 +77,23 @@ Decoder::Decoder(std::span<const uint8_t> buffer, BufferDeallocator&& bufferDeal
     , m_bufferDeallocator { WTFMove(bufferDeallocator) }
     , m_attachments { WTFMove(attachments) }
 {
-    if (UNLIKELY(reinterpret_cast<uintptr_t>(m_buffer.data()) % alignof(uint64_t))) {
+    if (reinterpret_cast<uintptr_t>(m_buffer.data()) % alignof(uint64_t)) [[unlikely]] {
         markInvalid();
         return;
     }
 
     auto messageFlags = decode<OptionSet<MessageFlags>>();
-    if (UNLIKELY(!messageFlags))
+    if (!messageFlags) [[unlikely]]
         return;
     m_messageFlags = WTFMove(*messageFlags);
 
     auto messageName = decode<MessageName>();
-    if (UNLIKELY(!messageName))
+    if (!messageName) [[unlikely]]
         return;
     m_messageName = WTFMove(*messageName);
 
     auto destinationID = decode<uint64_t>();
-    if (UNLIKELY(!destinationID))
+    if (!destinationID) [[unlikely]]
         return;
     // 0 is a valid destinationID but we can at least reject -1 which is the HashTable deleted value.
     if (*destinationID && !WTF::ObjectIdentifierGenericBase<uint64_t>::isValidIdentifier(*destinationID)) {
@@ -103,7 +103,7 @@ Decoder::Decoder(std::span<const uint8_t> buffer, BufferDeallocator&& bufferDeal
     m_destinationID = WTFMove(*destinationID);
     if (messageIsSync(m_messageName)) {
         auto syncRequestID = decode<SyncRequestID>();
-        if (UNLIKELY(!syncRequestID))
+        if (!syncRequestID) [[unlikely]]
             return;
         m_syncRequestID = syncRequestID;
     }
@@ -122,12 +122,12 @@ Decoder::Decoder(std::span<const uint8_t> stream, uint64_t destinationID)
     }
 
     auto messageName = decode<MessageName>();
-    if (UNLIKELY(!messageName))
+    if (!messageName) [[unlikely]]
         return;
     m_messageName = WTFMove(*messageName);
     if (messageIsSync(m_messageName)) {
         auto syncRequestID = decode<SyncRequestID>();
-        if (UNLIKELY(!syncRequestID))
+        if (!syncRequestID) [[unlikely]]
             return;
         m_syncRequestID = syncRequestID;
     }

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -134,7 +134,7 @@ public:
     std::optional<T> decode()
     {
         std::optional<T> t { ArgumentCoder<std::remove_cvref_t<T>, void>::decode(*this) };
-        if (UNLIKELY(!t))
+        if (!t) [[unlikely]]
             markInvalid();
         return t;
     }
@@ -225,7 +225,7 @@ inline std::span<const T> Decoder::decodeSpan(size_t size)
 
     const size_t alignedBufferPosition = static_cast<size_t>(std::distance(m_buffer.data(), roundUpToMultipleOf<alignof(T)>(std::to_address(m_bufferPosition))));
     const size_t bytesNeeded = size * sizeof(T);
-    if (UNLIKELY(!alignedBufferIsLargeEnoughToContain(m_buffer.size_bytes(), alignedBufferPosition, bytesNeeded))) {
+    if (!alignedBufferIsLargeEnoughToContain(m_buffer.size_bytes(), alignedBufferPosition, bytesNeeded)) [[unlikely]] {
         markInvalid();
         return { };
     }

--- a/Source/WebKit/Platform/IPC/HandleMessage.h
+++ b/Source/WebKit/Platform/IPC/HandleMessage.h
@@ -321,7 +321,7 @@ void handleMessage(C& connection, Decoder& decoder, T* object, MF U::* function)
     static_assert(std::is_same_v<typename ValidationType::MessageArguments, typename MessageType::Arguments>);
 
     auto arguments = decoder.decode<typename MessageType::Arguments>();
-    if (UNLIKELY(!arguments))
+    if (!arguments) [[unlikely]]
         return;
 
     logMessage(connection, MessageType::name(), object, *arguments);
@@ -345,7 +345,7 @@ void handleMessageWithoutUsingIPCConnection(Decoder& decoder, T* object, MF U::*
     static_assert(std::is_same_v<typename ValidationType::MessageArguments, typename MessageType::Arguments>);
 
     auto arguments = decoder.decode<typename MessageType::Arguments>();
-    if (UNLIKELY(!arguments))
+    if (!arguments) [[unlikely]]
         return;
 
     callMemberFunction(object, function, WTFMove(*arguments));
@@ -358,7 +358,7 @@ bool handleMessageSynchronous(Connection& connection, Decoder& decoder, UniqueRe
     static_assert(std::is_same_v<typename ValidationType::MessageArguments, typename MessageType::Arguments>);
 
     auto arguments = decoder.decode<typename MessageType::Arguments>();
-    if (UNLIKELY(!arguments))
+    if (!arguments) [[unlikely]]
         return true; // Message handler found, but decode failed.
 
     static_assert(std::is_same_v<typename ValidationType::CompletionHandlerArguments, typename MessageType::ReplyArguments>);
@@ -386,7 +386,7 @@ void handleMessageSynchronous(StreamServerConnection& connection, Decoder& decod
     static_assert(std::is_same_v<typename ValidationType::MessageArguments, typename MessageType::Arguments>);
 
     auto arguments = decoder.decode<typename MessageType::Arguments>();
-    if (UNLIKELY(!arguments))
+    if (!arguments) [[unlikely]]
         return;
 
     static_assert(std::is_same_v<typename ValidationType::CompletionHandlerArguments, typename MessageType::ReplyArguments>);
@@ -407,10 +407,10 @@ void handleMessageAsync(C& connection, Decoder& decoder, T* object, MF U::* func
     static_assert(std::is_same_v<typename ValidationType::MessageArguments, typename MessageType::Arguments>);
 
     auto arguments = decoder.decode<typename MessageType::Arguments>();
-    if (UNLIKELY(!arguments))
+    if (!arguments) [[unlikely]]
         return;
     auto replyID = decoder.decode<IPC::AsyncReplyID>();
-    if (UNLIKELY(!replyID))
+    if (!replyID) [[unlikely]]
         return;
 
     if constexpr (ValidationType::returnsVoid)
@@ -452,7 +452,7 @@ void handleMessageAsyncWithoutUsingIPCConnection(Decoder& decoder, Function<void
     static_assert(std::is_same_v<typename ValidationType::MessageArguments, typename MessageType::Arguments>);
 
     auto arguments = decoder.decode<typename MessageType::Arguments>();
-    if (UNLIKELY(!arguments))
+    if (!arguments) [[unlikely]]
         return;
 
     static_assert(std::is_same_v<typename ValidationType::CompletionHandlerArguments, typename MessageType::ReplyArguments>);
@@ -475,7 +475,7 @@ void handleMessageAsyncWithReplyID(Connection& connection, Decoder& decoder, T* 
     static_assert(std::is_same_v<typename ValidationType::MessageArguments, std::tuple<IPC::AsyncReplyID>>);
 
     auto replyID = decoder.decode<Connection::AsyncReplyID>();
-    if (UNLIKELY(!replyID))
+    if (!replyID) [[unlikely]]
         return;
 
     logMessage(connection, MessageType::name(), object, std::tuple<>());

--- a/Source/WebKit/Platform/IPC/StreamServerConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnectionBuffer.h
@@ -60,7 +60,7 @@ private:
 inline std::optional<StreamServerConnectionBuffer> StreamServerConnectionBuffer::map(Handle&& handle)
 {
     auto sharedMemory = WebCore::SharedMemory::map(WTFMove(handle), WebCore::SharedMemory::Protection::ReadWrite);
-    if (UNLIKELY(!sharedMemory))
+    if (!sharedMemory) [[unlikely]]
         return std::nullopt;
     return StreamServerConnectionBuffer { sharedMemory.releaseNonNull() };
 }

--- a/Source/WebKit/Platform/IPC/glib/ArgumentCodersGlib.h
+++ b/Source/WebKit/Platform/IPC/glib/ArgumentCodersGlib.h
@@ -48,7 +48,7 @@ template<> struct ArgumentCoder<GUniquePtr<char*>> {
     {
         auto length = decoder.decode<unsigned>();
 
-        if (UNLIKELY(!length))
+        if (!length) [[unlikely]]
             return std::nullopt;
 
         GUniquePtr<char*>strv(g_new0(char*, *length + 1));
@@ -56,7 +56,7 @@ template<> struct ArgumentCoder<GUniquePtr<char*>> {
 
         for (auto& str : strvSpan) {
             auto strOptional = decoder.decode<CString>();
-            if (UNLIKELY(!strOptional))
+            if (!strOptional) [[unlikely]]
                 return std::nullopt;
             str = g_strdup(strOptional->data());
         }

--- a/Source/WebKit/Platform/IPC/unix/IPCSemaphoreUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/IPCSemaphoreUnix.cpp
@@ -65,7 +65,7 @@ void Semaphore::signal()
     uint64_t value = 1;
     while (true) {
         int ret = write(m_fd.value(), &value, sizeof(uint64_t));
-        if (LIKELY(ret != -1 || errno != EINTR))
+        if (ret != -1 || errno != EINTR) [[likely]]
             break;
     }
 #endif
@@ -80,7 +80,7 @@ static bool waitImpl(int fd, int timeout)
     // Iterate on polling while interrupts are thrown, otherwise bail out of the loop immediately.
     while (true) {
         ret = poll(&pollfdValue, 1, timeout);
-        if (LIKELY(ret != -1 || errno != EINTR))
+        if (ret != -1 || errno != EINTR) [[likely]]
             break;
     }
 

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -45,7 +45,7 @@ OBJC_CLASS NSString;
 OBJC_CLASS NSUUID;
 
 #define THROW_UNLESS(condition, message) \
-    if (UNLIKELY(!(condition))) \
+    if (!(condition)) [[unlikely]] \
         [NSException raise:NSInternalInconsistencyException format:message]
 
 namespace API {

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1680,10 +1680,10 @@ def generate_message_handler(receiver):
                 continue
             result.append('    case IPC::MessageName::%s_%s: {\n' % (receiver.name, message.name))
             result.append('        auto arguments = decoder.decode<typename Messages::%s::%s::Arguments>();\n' % (receiver.name, message.name))
-            result.append('        if (UNLIKELY(!arguments))\n')
+            result.append('        if (!arguments) [[unlikely]]\n')
             result.append('            return;\n')
             result.append('        auto replyID = decoder.decode<IPC::AsyncReplyID>();\n')
-            result.append('        if (UNLIKELY(!replyID))\n')
+            result.append('        if (!replyID) [[unlikely]]\n')
             result.append('            return;\n')
             result.append('        connection.sendAsyncReply<Messages::%s::%s>(*replyID\n' % (receiver.name, message.name))
             for parameter in message.reply_parameters:

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -184,17 +184,17 @@ void ArgumentCoder<Namespace::Subnamespace::StructName>::encode(OtherEncoder& en
 std::optional<Namespace::Subnamespace::StructName> ArgumentCoder<Namespace::Subnamespace::StructName>::decode(Decoder& decoder)
 {
     auto firstMemberName = decoder.decode<FirstMemberType>();
-    if (UNLIKELY(!firstMemberName))
+    if (!firstMemberName) [[unlikely]]
         decoder.setIndexOfDecodingFailure(0);
 #if ENABLE(SECOND_MEMBER)
     auto secondMemberName = decoder.decode<SecondMemberType>();
-    if (UNLIKELY(!secondMemberName))
+    if (!secondMemberName) [[unlikely]]
         decoder.setIndexOfDecodingFailure(1);
 #endif
     auto nullableTestMember = decoder.decode<RetainPtr<CFTypeRef>>();
-    if (UNLIKELY(!nullableTestMember))
+    if (!nullableTestMember) [[unlikely]]
         decoder.setIndexOfDecodingFailure(2);
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         Namespace::Subnamespace::StructName {
@@ -235,7 +235,7 @@ std::optional<Namespace::OtherClass> ArgumentCoder<Namespace::OtherClass>::decod
     auto a = decoder.decode<int>();
     auto b = decoder.decode<bool>();
     auto dataDetectorResults = decoder.decodeWithAllowedClasses<NSArray>({ NSArray.class, PAL::getDDScannerResultClass() });
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         Namespace::OtherClass {
@@ -265,7 +265,7 @@ std::optional<Namespace::ClassWithMemberPrecondition> ArgumentCoder<Namespace::C
     if (!(PAL::isPassKitCoreFrameworkAvailable()))
         return std::nullopt;
     auto m_pkPaymentMethod = decoder.decodeWithAllowedClasses<PKPaymentMethod>({ PAL::getPKPaymentMethodClass() });
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         Namespace::ClassWithMemberPrecondition {
@@ -290,7 +290,7 @@ std::optional<Ref<Namespace::ReturnRefClass>> ArgumentCoder<Namespace::ReturnRef
     auto functionCallmember1 = decoder.decode<double>();
     auto functionCallmember2 = decoder.decode<double>();
     auto uniqueMember = decoder.decode<std::unique_ptr<int>>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         Namespace::ReturnRefClass::create(
@@ -323,7 +323,7 @@ std::optional<Namespace::EmptyConstructorStruct> ArgumentCoder<Namespace::EmptyC
 {
     auto m_int = decoder.decode<int>();
     auto m_double = decoder.decode<double>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     Namespace::EmptyConstructorStruct result;
     result.m_int = WTFMove(*m_int);
@@ -373,7 +373,7 @@ std::optional<Namespace::EmptyConstructorWithIf> ArgumentCoder<Namespace::EmptyC
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
     auto m_value = decoder.decode<OtherMemberType>();
 #endif
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     Namespace::EmptyConstructorWithIf result;
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
@@ -402,7 +402,7 @@ void ArgumentCoder<WithoutNamespace>::encode(Encoder& encoder, const WithoutName
 std::optional<WithoutNamespace> ArgumentCoder<WithoutNamespace>::decode(Decoder& decoder)
 {
     auto a = decoder.decode<int>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WithoutNamespace {
@@ -442,7 +442,7 @@ void ArgumentCoder<WithoutNamespaceWithAttributes>::encode(OtherEncoder& encoder
 std::optional<WithoutNamespaceWithAttributes> ArgumentCoder<WithoutNamespaceWithAttributes>::decode(Decoder& decoder)
 {
     auto a = decoder.decode<int>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WithoutNamespaceWithAttributes {
@@ -471,7 +471,7 @@ std::optional<WebCore::InheritsFrom> ArgumentCoder<WebCore::InheritsFrom>::decod
 {
     auto a = decoder.decode<int>();
     auto b = decoder.decode<float>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WebCore::InheritsFrom {
@@ -510,7 +510,7 @@ std::optional<WebCore::InheritanceGrandchild> ArgumentCoder<WebCore::Inheritance
     auto a = decoder.decode<int>();
     auto b = decoder.decode<float>();
     auto c = decoder.decode<double>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WebCore::InheritanceGrandchild {
@@ -535,7 +535,7 @@ void ArgumentCoder<WTF::Seconds>::encode(Encoder& encoder, const WTF::Seconds& i
 std::optional<WTF::Seconds> ArgumentCoder<WTF::Seconds>::decode(Decoder& decoder)
 {
     auto value = decoder.decode<double>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WTF::Seconds {
@@ -561,7 +561,7 @@ void ArgumentCoder<WTF::CreateUsingClass>::encode(Encoder& encoder, const WTF::C
 std::optional<WTF::CreateUsingClass> ArgumentCoder<WTF::CreateUsingClass>::decode(Decoder& decoder)
 {
     auto value = decoder.decode<double>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WTF::CreateUsingClass::fromDouble(
@@ -589,7 +589,7 @@ std::optional<WebCore::FloatBoxExtent> ArgumentCoder<WebCore::FloatBoxExtent>::d
     auto right = decoder.decode<float>();
     auto bottom = decoder.decode<float>();
     auto left = decoder.decode<float>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WebCore::FloatBoxExtent {
@@ -623,7 +623,7 @@ std::optional<SoftLinkedMember> ArgumentCoder<SoftLinkedMember>::decode(Decoder&
 {
     auto firstMember = decoder.decodeWithAllowedClasses<DDActionContext>({ PAL::getDDActionContextClass() });
     auto secondMember = decoder.decodeWithAllowedClasses<DDActionContext>({ PAL::getDDActionContextClass() });
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         SoftLinkedMember {
@@ -675,32 +675,32 @@ std::optional<Ref<WebCore::TimingFunction>> ArgumentCoder<WebCore::TimingFunctio
 {
     auto type = decoder.decode<WebCore_TimingFunction_Subclass>();
     UNUSED_PARAM(type);
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
 
     if (type == WebCore_TimingFunction_Subclass::LinearTimingFunction) {
         auto result = decoder.decode<Ref<WebCore::LinearTimingFunction>>();
-        if (UNLIKELY(!decoder.isValid()))
+        if (!decoder.isValid()) [[unlikely]]
             return std::nullopt;
         return WTFMove(*result);
     }
     if (type == WebCore_TimingFunction_Subclass::CubicBezierTimingFunction) {
         auto result = decoder.decode<Ref<WebCore::CubicBezierTimingFunction>>();
-        if (UNLIKELY(!decoder.isValid()))
+        if (!decoder.isValid()) [[unlikely]]
             return std::nullopt;
         return WTFMove(*result);
     }
 #if CONDITION
     if (type == WebCore_TimingFunction_Subclass::StepsTimingFunction) {
         auto result = decoder.decode<Ref<WebCore::StepsTimingFunction>>();
-        if (UNLIKELY(!decoder.isValid()))
+        if (!decoder.isValid()) [[unlikely]]
             return std::nullopt;
         return WTFMove(*result);
     }
 #endif
     if (type == WebCore_TimingFunction_Subclass::SpringTimingFunction) {
         auto result = decoder.decode<Ref<WebCore::SpringTimingFunction>>();
-        if (UNLIKELY(!decoder.isValid()))
+        if (!decoder.isValid()) [[unlikely]]
             return std::nullopt;
         return WTFMove(*result);
     }
@@ -726,7 +726,7 @@ void ArgumentCoder<Namespace::ConditionalCommonClass>::encode(Encoder& encoder, 
 std::optional<Namespace::ConditionalCommonClass> ArgumentCoder<Namespace::ConditionalCommonClass>::decode(Decoder& decoder)
 {
     auto value = decoder.decode<int>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         Namespace::ConditionalCommonClass {
@@ -754,7 +754,7 @@ void ArgumentCoder<Namespace::CommonClass>::encode(Encoder& encoder, const Names
 std::optional<Namespace::CommonClass> ArgumentCoder<Namespace::CommonClass>::decode(Decoder& decoder)
 {
     auto value = decoder.decode<int>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         Namespace::CommonClass {
@@ -783,7 +783,7 @@ void ArgumentCoder<Namespace::AnotherCommonClass>::encode(Encoder& encoder, cons
 std::optional<Ref<Namespace::AnotherCommonClass>> ArgumentCoder<Namespace::AnotherCommonClass>::decode(Decoder& decoder)
 {
     auto value = decoder.decode<int>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         Namespace::AnotherCommonClass::create(
@@ -812,12 +812,12 @@ std::optional<WebCore::MoveOnlyBaseClass> ArgumentCoder<WebCore::MoveOnlyBaseCla
 {
     auto type = decoder.decode<WebCore_MoveOnlyBaseClass_Subclass>();
     UNUSED_PARAM(type);
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
 
     if (type == WebCore_MoveOnlyBaseClass_Subclass::MoveOnlyDerivedClass) {
         auto result = decoder.decode<Ref<WebCore::MoveOnlyDerivedClass>>();
-        if (UNLIKELY(!decoder.isValid()))
+        if (!decoder.isValid()) [[unlikely]]
             return std::nullopt;
         return WTFMove(*result);
     }
@@ -847,7 +847,7 @@ std::optional<WebCore::MoveOnlyDerivedClass> ArgumentCoder<WebCore::MoveOnlyDeri
 {
     auto firstMember = decoder.decode<int>();
     auto secondMember = decoder.decode<int>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WebCore::MoveOnlyDerivedClass {
@@ -860,7 +860,7 @@ std::optional<WebCore::MoveOnlyDerivedClass> ArgumentCoder<WebCore::MoveOnlyDeri
 std::optional<WebKit::CustomEncoded> ArgumentCoder<WebKit::CustomEncoded>::decode(Decoder& decoder)
 {
     auto value = decoder.decode<int>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WebKit::CustomEncoded {
@@ -943,7 +943,7 @@ std::optional<WebKit::LayerProperties> ArgumentCoder<WebKit::LayerProperties>::d
         else
             return std::nullopt;
     }
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return { WTFMove(result) };
 }
@@ -965,7 +965,7 @@ void ArgumentCoder<WebKit::TemplateTest<WebKit::Fabulous>>::encode(Encoder& enco
 std::optional<WebKit::TemplateTest<WebKit::Fabulous>> ArgumentCoder<WebKit::TemplateTest<WebKit::Fabulous>>::decode(Decoder& decoder)
 {
     auto value = decoder.decode<bool>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WebKit::TemplateTest<WebKit::Fabulous> {
@@ -991,7 +991,7 @@ void ArgumentCoder<WebKit::TemplateTest<WebCore::Amazing>>::encode(Encoder& enco
 std::optional<WebKit::TemplateTest<WebCore::Amazing>> ArgumentCoder<WebKit::TemplateTest<WebCore::Amazing>>::decode(Decoder& decoder)
 {
     auto value = decoder.decode<bool>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WebKit::TemplateTest<WebCore::Amazing> {
@@ -1017,7 +1017,7 @@ void ArgumentCoder<WebKit::TemplateTest<JSC::Incredible>>::encode(Encoder& encod
 std::optional<WebKit::TemplateTest<JSC::Incredible>> ArgumentCoder<WebKit::TemplateTest<JSC::Incredible>>::decode(Decoder& decoder)
 {
     auto value = decoder.decode<bool>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WebKit::TemplateTest<JSC::Incredible> {
@@ -1043,7 +1043,7 @@ void ArgumentCoder<WebKit::TemplateTest<Testing::StorageSize>>::encode(Encoder& 
 std::optional<WebKit::TemplateTest<Testing::StorageSize>> ArgumentCoder<WebKit::TemplateTest<Testing::StorageSize>>::decode(Decoder& decoder)
 {
     auto value = decoder.decode<bool>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WebKit::TemplateTest<Testing::StorageSize> {
@@ -1085,7 +1085,7 @@ std::optional<Ref<WebCore::ScrollingStateFrameHostingNode>> ArgumentCoder<WebCor
         else
             return std::nullopt;
     }
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WebCore::ScrollingStateFrameHostingNode::create(
@@ -1145,7 +1145,7 @@ std::optional<Ref<WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple>> A
             return std::nullopt;
     }
     auto memberAfterTuple = decoder.decode<int>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple::create(
@@ -1181,7 +1181,7 @@ std::optional<RequestEncodedWithBody> ArgumentCoder<RequestEncodedWithBody>::dec
         if (auto requestBody = decoder.decode<IPC::FormDataReference>())
             request->setHTTPBody(requestBody->takeData());
     }
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         RequestEncodedWithBody {
@@ -1213,7 +1213,7 @@ std::optional<RequestEncodedWithBodyRValue> ArgumentCoder<RequestEncodedWithBody
         if (auto requestBody = decoder.decode<IPC::FormDataReference>())
             request->setHTTPBody(requestBody->takeData());
     }
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         RequestEncodedWithBodyRValue {
@@ -1230,7 +1230,7 @@ void ArgumentCoder<CFFooRef>::encode(Encoder& encoder, CFFooRef instance)
 std::optional<RetainPtr<CFFooRef>> ArgumentCoder<RetainPtr<CFFooRef>>::decode(Decoder& decoder)
 {
     auto result = decoder.decode<WebKit::FooWrapper>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return result->toCF();
 }
@@ -1249,7 +1249,7 @@ void ArgumentCoder<CFBarRef>::encode(StreamConnectionEncoder& encoder, CFBarRef 
 std::optional<RetainPtr<CFBarRef>> ArgumentCoder<RetainPtr<CFBarRef>>::decode(Decoder& decoder)
 {
     auto result = decoder.decode<WebKit::BarWrapper>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return createCFBar(*result);
 }
@@ -1281,7 +1281,7 @@ std::optional<SkFooBar> ArgumentCoder<SkFooBar>::decode(Decoder& decoder)
 {
     auto foo = decoder.decode<int>();
     auto bar = decoder.decode<double>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         CoreIPCSkFooBar {
@@ -1303,7 +1303,7 @@ void ArgumentCoder<WebKit::RValueWithFunctionCalls>::encode(Encoder& encoder, We
 std::optional<WebKit::RValueWithFunctionCalls> ArgumentCoder<WebKit::RValueWithFunctionCalls>::decode(Decoder& decoder)
 {
     auto callFunction = decoder.decode<SandboxExtensionHandle>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WebKit::RValueWithFunctionCalls {
@@ -1334,7 +1334,7 @@ std::optional<WebKit::RemoteVideoFrameReference> ArgumentCoder<WebKit::RemoteVid
 {
     auto identifier = decoder.decode<WebKit::RemoteVideoFrameIdentifier>();
     auto version = decoder.decode<uint64_t>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WebKit::RemoteVideoFrameReference {
@@ -1366,7 +1366,7 @@ std::optional<WebKit::RemoteVideoFrameWriteReference> ArgumentCoder<WebKit::Remo
 {
     auto reference = decoder.decode<IPC::ObjectIdentifierReference<WebKit::RemoteVideoFrameIdentifier>>();
     auto pendingReads = decoder.decode<uint64_t>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WebKit::RemoteVideoFrameWriteReference {
@@ -1394,7 +1394,7 @@ void ArgumentCoder<Namespace::OuterClass>::encode(Encoder& encoder, const Namesp
 std::optional<Namespace::OuterClass> ArgumentCoder<Namespace::OuterClass>::decode(Decoder& decoder)
 {
     auto outerValue = decoder.decode<int>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         Namespace::OuterClass {
@@ -1423,7 +1423,7 @@ void ArgumentCoder<Namespace::OtherOuterClass>::encode(Encoder& encoder, const N
 std::optional<Namespace::OtherOuterClass> ArgumentCoder<Namespace::OtherOuterClass>::decode(Decoder& decoder)
 {
     auto outerValue = decoder.decode<int>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         Namespace::OtherOuterClass {
@@ -1481,7 +1481,7 @@ std::optional<Ref<WebCore::AppKitControlSystemImage>> ArgumentCoder<WebCore::App
 {
     auto m_tintColor = decoder.decode<WebCore::Color>();
     auto m_useDarkAppearance = decoder.decode<bool>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WebCore::ScrollbarTrackCornerSystemImageMac::create(
@@ -1512,7 +1512,7 @@ std::optional<WebCore::RectEdges<bool>> ArgumentCoder<WebCore::RectEdges<bool>>:
     auto right = decoder.decode<bool>();
     auto bottom = decoder.decode<bool>();
     auto left = decoder.decode<bool>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WebCore::RectEdges<bool> {

--- a/Source/WebKit/Scripts/webkit/tests/TestWithValidatorMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithValidatorMessageReceiver.cpp
@@ -81,10 +81,10 @@ void TestWithValidator::sendCancelReply(IPC::Connection& connection, IPC::Decode
     switch (decoder.messageName()) {
     case IPC::MessageName::TestWithValidator_MessageWithReply: {
         auto arguments = decoder.decode<typename Messages::TestWithValidator::MessageWithReply::Arguments>();
-        if (UNLIKELY(!arguments))
+        if (!arguments) [[unlikely]]
             return;
         auto replyID = decoder.decode<IPC::AsyncReplyID>();
-        if (UNLIKELY(!replyID))
+        if (!replyID) [[unlikely]]
             return;
         connection.sendAsyncReply<Messages::TestWithValidator::MessageWithReply>(*replyID
             , IPC::AsyncReplyError<String>::create()

--- a/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
@@ -103,7 +103,7 @@ void ArgumentCoder<WebKit::PlatformClass>::encode(Encoder& encoder, const WebKit
 std::optional<WebKit::PlatformClass> ArgumentCoder<WebKit::PlatformClass>::decode(Decoder& decoder)
 {
     auto value = decoder.decode<int>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WebKit::PlatformClass {
@@ -141,7 +141,7 @@ std::optional<WebKit::CoreIPCAVOutputContext> ArgumentCoder<WebKit::CoreIPCAVOut
     if (!AVOutputContextSerializationKeyContextType)
         return std::nullopt;
 
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WebKit::CoreIPCAVOutputContext {
@@ -221,7 +221,7 @@ std::optional<WebKit::CoreIPCNSSomeFoundationType> ArgumentCoder<WebKit::CoreIPC
     if (!OptionalDictionaryKey)
         return std::nullopt;
 
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WebKit::CoreIPCNSSomeFoundationType {
@@ -256,7 +256,7 @@ std::optional<WebKit::CoreIPCclass NSSomeOtherFoundationType> ArgumentCoder<WebK
     if (!DictionaryKey)
         return std::nullopt;
 
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WebKit::CoreIPCclass NSSomeOtherFoundationType {
@@ -350,7 +350,7 @@ std::optional<WebKit::CoreIPCDDScannerResult> ArgumentCoder<WebKit::CoreIPCDDSca
     if (!SecTrustArrayKey)
         return std::nullopt;
 
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         WebKit::CoreIPCDDScannerResult {
@@ -383,7 +383,7 @@ void ArgumentCoder<CFStringRef>::encode(StreamConnectionEncoder& encoder, CFStri
 std::optional<RetainPtr<CFStringRef>> ArgumentCoder<RetainPtr<CFStringRef>>::decode(Decoder& decoder)
 {
     auto result = decoder.decode<WTF::String>();
-    if (UNLIKELY(!decoder.isValid()))
+    if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return result->createCFString();
 }

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp
@@ -189,7 +189,7 @@ ALLOW_NONLITERAL_FORMAT_END
 
     String source = sourceKey;
 
-    if (UNLIKELY(!callingAPIName.isEmpty() && !sourceKey.isEmpty() && formattedUnderlyingErrorString.contains("value is invalid"_s))) {
+    if (!callingAPIName.isEmpty() && !sourceKey.isEmpty() && formattedUnderlyingErrorString.contains("value is invalid"_s)) [[unlikely]] {
         ASSERT_NOT_REACHED_WITH_MESSAGE("Overly nested error string, use a `nullString()` sourceKey for this call instead.");
         source = nullString();
     }

--- a/Source/WebKit/Shared/ScriptTelemetry.cpp
+++ b/Source/WebKit/Shared/ScriptTelemetry.cpp
@@ -66,10 +66,10 @@ bool ScriptTelemetryFilter::matches(const URL& url, const WebCore::SecurityOrigi
             return true;
     }
 
-    if (UNLIKELY(m_firstPartyHosts.contains(hostName)))
+    if (m_firstPartyHosts.contains(hostName)) [[unlikely]]
         return true;
 
-    if (UNLIKELY(m_firstPartyTopDomains.contains(scriptTopDomainName)))
+    if (m_firstPartyTopDomains.contains(scriptTopDomainName)) [[unlikely]]
         return true;
 
     return false;

--- a/Source/WebKit/Shared/cf/CoreIPCCGColorSpace.h
+++ b/Source/WebKit/Shared/cf/CoreIPCCGColorSpace.h
@@ -69,7 +69,7 @@ public:
                 return adoptCF(CGColorSpaceCreateWithPropertyList(propertyList.get()));
             }
         );
-        if (UNLIKELY(!colorSpace))
+        if (!colorSpace) [[unlikely]]
             return nullptr;
         return colorSpace;
     }

--- a/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
+++ b/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
@@ -49,14 +49,14 @@ void ArgumentCoder<GRefPtr<GByteArray>>::encode(Encoder& encoder, const GRefPtr<
 std::optional<GRefPtr<GByteArray>> ArgumentCoder<GRefPtr<GByteArray>>::decode(Decoder& decoder)
 {
     auto isEngaged = decoder.decode<bool>();
-    if (!UNLIKELY(isEngaged))
+    if (!isEngaged) [[unlikely]]
         return std::nullopt;
 
     if (!(*isEngaged))
         return GRefPtr<GByteArray>();
 
     auto data = decoder.decode<std::span<const uint8_t>>();
-    if (UNLIKELY(!data))
+    if (!data) [[unlikely]]
         return std::nullopt;
 
     GRefPtr<GByteArray> array = adoptGRef(g_byte_array_sized_new(data->size()));
@@ -79,7 +79,7 @@ void ArgumentCoder<GRefPtr<GVariant>>::encode(Encoder& encoder, const GRefPtr<GV
 std::optional<GRefPtr<GVariant>> ArgumentCoder<GRefPtr<GVariant>>::decode(Decoder& decoder)
 {
     auto variantTypeString = decoder.decode<CString>();
-    if (UNLIKELY(!variantTypeString))
+    if (!variantTypeString) [[unlikely]]
         return std::nullopt;
 
     if (variantTypeString->isNull())
@@ -89,7 +89,7 @@ std::optional<GRefPtr<GVariant>> ArgumentCoder<GRefPtr<GVariant>>::decode(Decode
         return std::nullopt;
 
     auto data = decoder.decode<std::span<const uint8_t>>();
-    if (UNLIKELY(!data))
+    if (!data) [[unlikely]]
         return std::nullopt;
 
     GUniquePtr<GVariantType> variantType(g_variant_type_new(variantTypeString->data()));
@@ -132,7 +132,7 @@ std::optional<GRefPtr<GTlsCertificate>> ArgumentCoder<GRefPtr<GTlsCertificate>>:
 {
     auto certificatesData = decoder.decode<WTF::Vector<GRefPtr<GByteArray>>>();
 
-    if (UNLIKELY(!certificatesData))
+    if (!certificatesData) [[unlikely]]
         return std::nullopt;
 
     if (!certificatesData->size())
@@ -140,12 +140,12 @@ std::optional<GRefPtr<GTlsCertificate>> ArgumentCoder<GRefPtr<GTlsCertificate>>:
 
     std::optional<GRefPtr<GByteArray>> privateKey;
     decoder >> privateKey;
-    if (UNLIKELY(!privateKey))
+    if (!privateKey) [[unlikely]]
         return std::nullopt;
 
     std::optional<CString> privateKeyPKCS11Uri;
     decoder >> privateKeyPKCS11Uri;
-    if (UNLIKELY(!privateKeyPKCS11Uri))
+    if (!privateKeyPKCS11Uri) [[unlikely]]
         return std::nullopt;
 
     GType certificateType = g_tls_backend_get_certificate_type(g_tls_backend_get_default());
@@ -173,7 +173,7 @@ void ArgumentCoder<GTlsCertificateFlags>::encode(Encoder& encoder, GTlsCertifica
 std::optional<GTlsCertificateFlags> ArgumentCoder<GTlsCertificateFlags>::decode(Decoder& decoder)
 {
     auto flags = decoder.decode<uint32_t>();
-    if (UNLIKELY(!flags))
+    if (!flags) [[unlikely]]
         return std::nullopt;
     return static_cast<GTlsCertificateFlags>(*flags);
 }
@@ -198,19 +198,19 @@ void ArgumentCoder<GRefPtr<GUnixFDList>>::encode(Encoder& encoder, const GRefPtr
 std::optional<GRefPtr<GUnixFDList>> ArgumentCoder<GRefPtr<GUnixFDList>>::decode(Decoder& decoder)
 {
     auto hasObject = decoder.decode<bool>();
-    if (UNLIKELY(!hasObject))
+    if (!hasObject) [[unlikely]]
         return std::nullopt;
     if (!*hasObject)
         return GRefPtr<GUnixFDList> { };
 
     auto attachments = decoder.decode<Vector<UnixFileDescriptor>>();
-    if (UNLIKELY(!attachments))
+    if (!attachments) [[unlikely]]
         return std::nullopt;
 
     GRefPtr<GUnixFDList> fdList = adoptGRef(g_unix_fd_list_new());
     for (auto& attachment : *attachments) {
         int ret = g_unix_fd_list_append(fdList.get(), attachment.value(), nullptr);
-        if (UNLIKELY(ret == -1))
+        if (ret == -1) [[unlikely]]
             return std::nullopt;
     }
     return fdList;

--- a/Source/WebKit/Shared/gtk/ArgumentCodersGtk.cpp
+++ b/Source/WebKit/Shared/gtk/ArgumentCodersGtk.cpp
@@ -48,7 +48,7 @@ void ArgumentCoder<GRefPtr<GtkPrintSettings>>::encode(Encoder& encoder, const GR
 std::optional<GRefPtr<GtkPrintSettings>> ArgumentCoder<GRefPtr<GtkPrintSettings>>::decode(Decoder& decoder)
 {
     auto variant = decoder.decode<GRefPtr<GVariant>>();
-    if (UNLIKELY(!variant))
+    if (!variant) [[unlikely]]
         return std::nullopt;
 
     return gtk_print_settings_new_from_gvariant(variant->get());
@@ -64,7 +64,7 @@ void ArgumentCoder<GRefPtr<GtkPageSetup>>::encode(Encoder& encoder, const GRefPt
 std::optional<GRefPtr<GtkPageSetup>> ArgumentCoder<GRefPtr<GtkPageSetup>>::decode(Decoder& decoder)
 {
     auto variant = decoder.decode<GRefPtr<GVariant>>();
-    if (UNLIKELY(!variant))
+    if (!variant) [[unlikely]]
         return std::nullopt;
 
     return gtk_page_setup_new_from_gvariant(variant->get());

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -186,7 +186,7 @@ NO_RETURN_DUE_TO_CRASH NEVER_INLINE static void crashBecausePageIsSuspended()
     CRASH();
 }
 
-#define CRASH_IF_SUSPENDED if (UNLIKELY(pageRef && toImpl(pageRef)->isSuspended())) \
+#define CRASH_IF_SUSPENDED if (pageRef && toImpl(pageRef)->isSuspended()) [[unlikely]] \
     crashBecausePageIsSuspended()
 
 WKTypeID WKPageGetTypeID()

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -275,7 +275,7 @@ SOFT_LINK_OPTIONAL(libAccessibility, _AXSReduceMotionAutoplayAnimatedImagesEnabl
 #import <WebCore/GameControllerSoftLink.h>
 #endif
 
-#define THROW_IF_SUSPENDED if (UNLIKELY(_page && _page->isSuspended())) \
+#define THROW_IF_SUSPENDED if (_page && _page->isSuspended()) [[unlikely]] \
     [NSException raise:NSInternalInconsistencyException format:@"The WKWebView is suspended"]
 
 RetainPtr<NSError> nsErrorFromExceptionDetails(const std::optional<WebCore::ExceptionDetails>& details)

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -4374,7 +4374,7 @@ gboolean webkit_settings_apply_from_key_file(WebKitSettings* settings, GKeyFile*
 
     GUniqueOutPtr<GError> getKeysError;
     auto allKeys = gKeyFileGetKeys(keyFile, groupName, getKeysError);
-    if (UNLIKELY(getKeysError)) {
+    if (getKeysError) [[unlikely]] {
         g_propagate_error(error, getKeysError.release());
         return FALSE;
     }

--- a/Source/WebKit/UIProcess/API/gtk/InputMethodFilterGtk.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/InputMethodFilterGtk.cpp
@@ -43,7 +43,7 @@ IntRect InputMethodFilter::platformTransformCursorRectToViewCoordinates(const In
 bool InputMethodFilter::platformEventKeyIsKeyPress(PlatformEventKey* event) const
 {
 #if USE(GTK4)
-    if (UNLIKELY(m_filteringContext.isFakeKeyEventForTesting))
+    if (m_filteringContext.isFakeKeyEventForTesting) [[unlikely]]
         return reinterpret_cast<KeyEvent*>(event)->type == GDK_KEY_PRESS;
 #endif
     return gdk_event_get_event_type(event) == GDK_KEY_PRESS;

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -1670,7 +1670,7 @@ static gboolean webkitWebViewBaseCrossingNotifyEvent(GtkWidget* widget, GdkEvent
     // Do not send mouse move events to the WebProcess for crossing events during testing.
     // WTR never generates crossing events and they can confuse tests.
     // https://bugs.webkit.org/show_bug.cgi?id=185072.
-    if (UNLIKELY(priv->pageProxy->configuration().processPool().configuration().fullySynchronousModeIsAllowedForTesting()))
+    if (priv->pageProxy->configuration().processPool().configuration().fullySynchronousModeIsAllowedForTesting()) [[unlikely]]
         return GDK_EVENT_PROPAGATE;
 #endif
 
@@ -1721,7 +1721,7 @@ static void webkitWebViewBaseEnter(WebKitWebViewBase* webViewBase, double x, dou
     // Do not send mouse move events to the WebProcess for crossing events during testing.
     // WTR never generates crossing events and they can confuse tests.
     // https://bugs.webkit.org/show_bug.cgi?id=185072.
-    if (UNLIKELY(priv->pageProxy->configuration().processPool().configuration().fullySynchronousModeIsAllowedForTesting()))
+    if (priv->pageProxy->configuration().processPool().configuration().fullySynchronousModeIsAllowedForTesting()) [[unlikely]]
         return;
 #endif
 
@@ -1761,7 +1761,7 @@ static void webkitWebViewBaseLeave(WebKitWebViewBase* webViewBase, GdkCrossingMo
     // Do not send mouse move events to the WebProcess for crossing events during testing.
     // WTR never generates crossing events and they can confuse tests.
     // https://bugs.webkit.org/show_bug.cgi?id=185072.
-    if (UNLIKELY(priv->pageProxy->configuration().processPool().configuration().fullySynchronousModeIsAllowedForTesting()))
+    if (priv->pageProxy->configuration().processPool().configuration().fullySynchronousModeIsAllowedForTesting()) [[unlikely]]
         return;
 #endif
 

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp
@@ -172,7 +172,7 @@ QSGTexture* wpe_view_qtquick_render_buffer_to_texture(WPEViewQtQuick* view, QSiz
         RELEASE_ASSERT(priv->wpeQtView->window());
 
         auto texture = QNativeInterface::QSGOpenGLTexture::fromNative(priv->textureId, priv->wpeQtView->window(), size, QQuickWindow::TextureHasAlphaChannel);
-        if (UNLIKELY(!texture)) {
+        if (!texture) [[unlikely]] {
             g_set_error_literal(error, WPE_VIEW_ERROR, WPE_VIEW_ERROR_RENDER_FAILED, "Failed to import QSOpenGLTexture from native OpenGL texture");
             return nullptr;
         }
@@ -180,7 +180,7 @@ QSGTexture* wpe_view_qtquick_render_buffer_to_texture(WPEViewQtQuick* view, QSiz
         return texture;
     };
 
-    if (UNLIKELY(!priv->pendingBuffer)) {
+    if (!priv->pendingBuffer) [[unlikely]] {
         if (!priv->committedBuffer) {
             g_set_error_literal(error, WPE_VIEW_ERROR, WPE_VIEW_ERROR_RENDER_FAILED, "Failed to render, no pending buffer available to render into, and no commitedBuffer.");
             return nullptr;
@@ -192,13 +192,13 @@ QSGTexture* wpe_view_qtquick_render_buffer_to_texture(WPEViewQtQuick* view, QSiz
 
     GUniqueOutPtr<GError> bufferError;
     auto eglImage = wpe_buffer_import_to_egl_image(priv->pendingBuffer.get(), &bufferError.outPtr());
-    if (UNLIKELY(!eglImage)) {
+    if (!eglImage) [[unlikely]] {
         g_set_error(error, WPE_VIEW_ERROR, WPE_VIEW_ERROR_RENDER_FAILED, "Failed to render: %s", bufferError->message);
         return nullptr;
     }
 
     auto* glFunctions = priv->context->functions();
-    if (UNLIKELY(!priv->textureId)) {
+    if (!priv->textureId) [[unlikely]] {
         glFunctions->glGenTextures(1, &priv->textureId);
         glFunctions->glBindTexture(GL_TEXTURE_2D, priv->textureId);
         glFunctions->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -340,7 +340,7 @@ bool AuxiliaryProcessProxy::send(T&& message, uint64_t destinationID, OptionSet<
     static_assert(!T::isSync, "Async message expected");
 
     if constexpr (T::deferSendingIfSuspended) {
-        if (UNLIKELY(m_isSuspended)) {
+        if (m_isSuspended) [[unlikely]] {
             auto coalescingKeyEncoder = makeUniqueRef<IPC::Encoder>(T::name(), destinationID);
             message.encodeCoalescingKey(coalescingKeyEncoder.get());
             Vector<uint8_t> coalescingKey { coalescingKeyEncoder->mutableSpan() };

--- a/Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.mm
@@ -79,13 +79,13 @@ inline static RetainPtr<WKTextExtractionTextItem> createWKTextItem(const TextExt
 
     auto selectedRange = NSMakeRange(NSNotFound, 0);
     if (auto range = data.selectedRange) {
-        if (LIKELY(range->location + range->length <= data.content.length()))
+        if (range->location + range->length <= data.content.length()) [[likely]]
             selectedRange = NSMakeRange(range->location, range->length);
     }
 
     auto links = createNSArray(data.links, [&](auto& linkAndRange) -> RetainPtr<WKTextExtractionLink> {
         auto& [url, range] = linkAndRange;
-        if (UNLIKELY(range.location + range.length > data.content.length()))
+        if (range.location + range.length > data.content.length()) [[unlikely]]
             return { };
 
         RetainPtr nsURL = url.createNSURL();

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -1946,7 +1946,7 @@ Ref<WebExtensionWindow> WebExtensionContext::getOrCreateWindow(WKWebExtensionWin
 
 RefPtr<WebExtensionWindow> WebExtensionContext::getWindow(WebExtensionWindowIdentifier identifier, std::optional<WebPageProxyIdentifier> webPageProxyIdentifier, IgnoreExtensionAccess ignoreExtensionAccess) const
 {
-    if (UNLIKELY(!isValid(identifier)))
+    if (!isValid(identifier)) [[unlikely]]
         return nullptr;
 
     RefPtr<WebExtensionWindow> result;
@@ -1962,7 +1962,7 @@ RefPtr<WebExtensionWindow> WebExtensionContext::getWindow(WebExtensionWindowIden
     } else
         result = m_windowMap.get(identifier);
 
-    if (UNLIKELY(!result)) {
+    if (!result) [[unlikely]] {
         if (isCurrent(identifier)) {
             if (webPageProxyIdentifier)
                 RELEASE_LOG_ERROR(Extensions, "Current window for page %{public}llu was not found", webPageProxyIdentifier.value().toUInt64());
@@ -1974,7 +1974,7 @@ RefPtr<WebExtensionWindow> WebExtensionContext::getWindow(WebExtensionWindowIden
         return nullptr;
     }
 
-    if (UNLIKELY(!result->isValid())) {
+    if (!result->isValid()) [[unlikely]] {
         RELEASE_LOG_ERROR(Extensions, "Window %{public}llu has nil delegate; reference not removed via didCloseWindow: before release", result->identifier().toUInt64());
         forgetWindow(result->identifier());
         return nullptr;
@@ -2024,16 +2024,16 @@ Ref<WebExtensionTab> WebExtensionContext::getOrCreateTab(WKWebExtensionTab *dele
 
 RefPtr<WebExtensionTab> WebExtensionContext::getTab(WebExtensionTabIdentifier identifier, IgnoreExtensionAccess ignoreExtensionAccess) const
 {
-    if (UNLIKELY(!isValid(identifier)))
+    if (!isValid(identifier)) [[unlikely]]
         return nullptr;
 
     RefPtr result = m_tabMap.get(identifier);
-    if (UNLIKELY(!result)) {
+    if (!result) [[unlikely]] {
         RELEASE_LOG_ERROR(Extensions, "Tab %{public}llu was not found", identifier.toUInt64());
         return nullptr;
     }
 
-    if (UNLIKELY(!result->isValid())) {
+    if (!result->isValid()) [[unlikely]] {
         RELEASE_LOG_ERROR(Extensions, "Tab %{public}llu has nil delegate; reference not removed via didCloseTab: before release", identifier.toUInt64());
         forgetTab(identifier);
         return nullptr;
@@ -2131,12 +2131,12 @@ RefPtr<WebExtensionTab> WebExtensionContext::getCurrentTab(WebPageProxyIdentifie
 #endif // ENABLE(INSPECTOR_EXTENSIONS)
 
 finish:
-    if (UNLIKELY(!result)) {
+    if (!result) [[unlikely]] {
         RELEASE_LOG_DEBUG(Extensions, "Tab for page %{public}llu was not found", webPageProxyIdentifier.toUInt64());
         return nullptr;
     }
 
-    if (UNLIKELY(!result->isValid())) {
+    if (!result->isValid()) [[unlikely]] {
         RELEASE_LOG_ERROR(Extensions, "Tab %{public}llu has nil delegate; reference not removed via didCloseTab: before release", result->identifier().toUInt64());
         forgetTab(result->identifier());
         return nullptr;

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -499,7 +499,7 @@ void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name)
 
     xpc_connection_resume(m_xpcConnection.get());
 
-    if (UNLIKELY(m_launchOptions.shouldMakeProcessLaunchFailForTesting)) {
+    if (m_launchOptions.shouldMakeProcessLaunchFailForTesting) [[unlikely]] {
         eventHandlerBlock(nullptr);
         return;
     }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -74,7 +74,7 @@
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
     CheckedPtr scrollingTreeNodeDelegate = _scrollingTreeNodeDelegate.get();
-    if (UNLIKELY(!scrollingTreeNodeDelegate))
+    if (!scrollingTreeNodeDelegate) [[unlikely]]
         return;
 
     if (RetainPtr baseScrollView = dynamic_objc_cast<WKBaseScrollView>(scrollView))
@@ -86,7 +86,7 @@
 - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView
 {
     CheckedPtr scrollingTreeNodeDelegate = _scrollingTreeNodeDelegate.get();
-    if (UNLIKELY(!scrollingTreeNodeDelegate))
+    if (!scrollingTreeNodeDelegate) [[unlikely]]
         return;
 
     _inUserInteraction = YES;
@@ -99,7 +99,7 @@
 - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset
 {
     CheckedPtr scrollingTreeNodeDelegate = _scrollingTreeNodeDelegate.get();
-    if (UNLIKELY(!scrollingTreeNodeDelegate))
+    if (!scrollingTreeNodeDelegate) [[unlikely]]
         return;
 
     if (![scrollView isZooming]) {
@@ -143,7 +143,7 @@
 - (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)willDecelerate
 {
     CheckedPtr scrollingTreeNodeDelegate = _scrollingTreeNodeDelegate.get();
-    if (UNLIKELY(!scrollingTreeNodeDelegate))
+    if (!scrollingTreeNodeDelegate) [[unlikely]]
         return;
 
     if (_inUserInteraction && !willDecelerate) {
@@ -156,7 +156,7 @@
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView
 {
     CheckedPtr scrollingTreeNodeDelegate = _scrollingTreeNodeDelegate.get();
-    if (UNLIKELY(!scrollingTreeNodeDelegate))
+    if (!scrollingTreeNodeDelegate) [[unlikely]]
         return;
 
     if (_inUserInteraction) {
@@ -169,7 +169,7 @@
 - (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView
 {
     CheckedPtr scrollingTreeNodeDelegate = _scrollingTreeNodeDelegate.get();
-    if (UNLIKELY(!scrollingTreeNodeDelegate))
+    if (!scrollingTreeNodeDelegate) [[unlikely]]
         return;
 
     scrollingTreeNodeDelegate->scrollDidEnd();
@@ -183,7 +183,7 @@
 - (void)cancelPointersForGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
 {
     CheckedPtr scrollingTreeNodeDelegate = _scrollingTreeNodeDelegate.get();
-    if (UNLIKELY(!scrollingTreeNodeDelegate))
+    if (!scrollingTreeNodeDelegate) [[unlikely]]
         return;
 
     scrollingTreeNodeDelegate->cancelPointersForGestureRecognizer(gestureRecognizer);
@@ -194,7 +194,7 @@
 - (BOOL)shouldAllowPanGestureRecognizerToReceiveTouchesInScrollView:(WKBaseScrollView *)scrollView
 {
     CheckedPtr scrollingTreeNodeDelegate = _scrollingTreeNodeDelegate.get();
-    if (UNLIKELY(!scrollingTreeNodeDelegate))
+    if (!scrollingTreeNodeDelegate) [[unlikely]]
         return YES;
 
     return scrollingTreeNodeDelegate->shouldAllowPanGestureRecognizerToReceiveTouches();
@@ -203,7 +203,7 @@
 - (UIAxis)axesToPreventScrollingForPanGestureInScrollView:(WKBaseScrollView *)scrollView
 {
     CheckedPtr scrollingTreeNodeDelegate = _scrollingTreeNodeDelegate.get();
-    if (UNLIKELY(!scrollingTreeNodeDelegate))
+    if (!scrollingTreeNodeDelegate) [[unlikely]]
         return UIAxisNeither;
 
     auto panGestureRecognizer = scrollView.panGestureRecognizer;
@@ -237,7 +237,7 @@
 - (WKBEScrollView *)parentScrollViewForScrollView:(WKBEScrollView *)scrollView
 {
     CheckedPtr scrollingTreeNodeDelegate = _scrollingTreeNodeDelegate.get();
-    if (UNLIKELY(!scrollingTreeNodeDelegate))
+    if (!scrollingTreeNodeDelegate) [[unlikely]]
         return nil;
 
     // An "acting parent" is a non-ancestor scrolling parent. We tell this to UIKit so it can propagate scrolls correctly.
@@ -258,7 +258,7 @@
 - (void)scrollView:(WKBaseScrollView *)scrollView handleScrollUpdate:(WKBEScrollViewScrollUpdate *)update completion:(void (^)(BOOL handled))completion
 {
     CheckedPtr scrollingTreeNodeDelegate = _scrollingTreeNodeDelegate.get();
-    if (UNLIKELY(!scrollingTreeNodeDelegate))
+    if (!scrollingTreeNodeDelegate) [[unlikely]]
         return;
 
     scrollingTreeNodeDelegate->handleAsynchronousCancelableScrollEvent(scrollView, update, completion);

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -1799,7 +1799,7 @@ void WebsiteDataStore::getNetworkProcessConnection(WebProcessProxy& webProcessPr
 {
     Ref networkProcessProxy = networkProcess();
     networkProcessProxy->getNetworkProcessConnection(webProcessProxy, [weakThis = WeakPtr { *this }, networkProcessProxy = WeakPtr { networkProcessProxy }, webProcessProxy = WeakPtr { webProcessProxy }, reply = WTFMove(reply), shouldRetryOnFailure] (NetworkProcessConnectionInfo&& connectionInfo) mutable {
-        if (UNLIKELY(!connectionInfo.connection)) {
+        if (!connectionInfo.connection) [[unlikely]] {
             if (shouldRetryOnFailure == ShouldRetryOnFailure::No || !webProcessProxy) {
                 RELEASE_LOG_ERROR(Process, "getNetworkProcessConnection: Failed to get connection to network process, will reply invalid identifier ...");
                 reply({ });
@@ -2872,7 +2872,7 @@ void WebsiteDataStore::processPushMessage(WebPushMessage&& pushMessage, Completi
 
 RestrictedOpenerType WebsiteDataStore::openerTypeForDomain(const WebCore::RegistrableDomain& domain) const
 {
-    if (UNLIKELY(!m_restrictedOpenerTypesForTesting.isEmpty())) {
+    if (!m_restrictedOpenerTypesForTesting.isEmpty()) [[unlikely]] {
         auto it = m_restrictedOpenerTypesForTesting.find(domain);
         return it == m_restrictedOpenerTypesForTesting.end() ? RestrictedOpenerType::Unrestricted : it->value;
     }

--- a/Source/WebKit/UIProcess/glib/FenceMonitor.cpp
+++ b/Source/WebKit/UIProcess/glib/FenceMonitor.cpp
@@ -73,7 +73,7 @@ GSourceFuncs FenceSource::sourceFuncs = {
 
 void FenceMonitor::ensureSource()
 {
-    if (LIKELY(m_source))
+    if (m_source) [[likely]]
         return;
 
     m_source = adoptGRef(g_source_new(&FenceSource::sourceFuncs, sizeof(FenceSource)));

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -1153,7 +1153,7 @@ static WKDragSessionContext *ensureLocalDragSessionContext(id <UIDragSession> se
 @end
 
 #define RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED() do { \
-    if (UNLIKELY(self.shouldUseAsyncInteractions)) { \
+    if (self.shouldUseAsyncInteractions) [[unlikely]] { \
         RELEASE_LOG_ERROR(TextInteraction, "Received unexpected call to %s", __PRETTY_FUNCTION__); \
         RELEASE_ASSERT_NOT_REACHED(); \
     } \

--- a/Source/WebKit/WPEPlatform/wpe/drm/RefPtrUdev.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/RefPtrUdev.cpp
@@ -32,40 +32,40 @@ namespace WTF {
 
 struct udev* DefaultRefDerefTraits<struct udev>::refIfNotNull(struct udev* ptr)
 {
-    if (LIKELY(ptr))
+    if (ptr) [[likely]]
         udev_ref(ptr);
     return ptr;
 }
 
 void DefaultRefDerefTraits<struct udev>::derefIfNotNull(struct udev* ptr)
 {
-    if (LIKELY(ptr))
+    if (ptr) [[likely]]
         udev_unref(ptr);
 }
 
 struct udev_device* DefaultRefDerefTraits<struct udev_device>::refIfNotNull(struct udev_device* ptr)
 {
-    if (LIKELY(ptr))
+    if (ptr) [[likely]]
         udev_device_ref(ptr);
     return ptr;
 }
 
 void DefaultRefDerefTraits<struct udev_device>::derefIfNotNull(struct udev_device* ptr)
 {
-    if (LIKELY(ptr))
+    if (ptr) [[likely]]
         udev_device_unref(ptr);
 }
 
 struct udev_enumerate* DefaultRefDerefTraits<struct udev_enumerate>::refIfNotNull(struct udev_enumerate* ptr)
 {
-    if (LIKELY(ptr))
+    if (ptr) [[likely]]
         udev_enumerate_ref(ptr);
     return ptr;
 }
 
 void DefaultRefDerefTraits<struct udev_enumerate>::derefIfNotNull(struct udev_enumerate* ptr)
 {
-    if (LIKELY(ptr))
+    if (ptr) [[likely]]
         udev_enumerate_unref(ptr);
 }
 

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp
@@ -201,7 +201,7 @@ struct DMABufFeedback {
     std::pair<uint32_t, uint64_t> format(uint16_t index)
     {
         ASSERT(index < formatTable.size);
-        if (UNLIKELY(index >= formatTable.size))
+        if (index >= formatTable.size) [[unlikely]]
             return { 0, 0 };
 
         return { formatTable.data[index].format, formatTable.data[index].modifier };
@@ -672,7 +672,7 @@ static WPEBufferDMABufFormats* wpeToplevelWaylandGetPreferredDMABufFormats(WPETo
 
         for (const auto& format : tranche.formats) {
             auto [fourcc, modifier] = priv->committedDMABufFeedback->format(format);
-            if (LIKELY(fourcc))
+            if (fourcc) [[likely]]
                 wpe_buffer_dma_buf_formats_builder_append_format(builder, fourcc, modifier);
         }
     }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
@@ -88,7 +88,7 @@ bool WebExtensionAPIExtension::parseViewFilters(NSDictionary *filter, std::optio
 
 bool WebExtensionAPIExtension::isPropertyAllowed(const ASCIILiteral& name, WebPage*)
 {
-    if (UNLIKELY(extensionContext().isUnsupportedAPI(propertyPath(), name)))
+    if (extensionContext().isUnsupportedAPI(propertyPath(), name)) [[unlikely]]
         return false;
 
     // This method was removed in manifest version 3.

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
@@ -44,7 +44,7 @@ namespace WebKit {
 
 bool WebExtensionAPINamespace::isPropertyAllowed(const ASCIILiteral& name, WebPage* page)
 {
-    if (UNLIKELY(extensionContext().isUnsupportedAPI(propertyPath(), name)))
+    if (extensionContext().isUnsupportedAPI(propertyPath(), name)) [[unlikely]]
         return false;
 
     if (name == "action"_s)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
@@ -157,7 +157,7 @@ bool WebExtensionAPIRuntime::parseConnectOptions(NSDictionary *options, std::opt
 
 bool WebExtensionAPIRuntime::isPropertyAllowed(const ASCIILiteral& name, WebPage*)
 {
-    if (UNLIKELY(extensionContext().isUnsupportedAPI(propertyPath(), name)))
+    if (extensionContext().isUnsupportedAPI(propertyPath(), name)) [[unlikely]]
         return false;
 
     if (name == "connectNative"_s || name == "sendNativeMessage"_s)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
@@ -52,7 +52,7 @@ namespace WebKit {
 
 bool WebExtensionAPIStorageArea::isPropertyAllowed(const ASCIILiteral& propertyName, WebPage*)
 {
-    if (UNLIKELY(extensionContext().isUnsupportedAPI(propertyPath(), propertyName)))
+    if (extensionContext().isUnsupportedAPI(propertyPath(), propertyName)) [[unlikely]]
         return false;
 
     static NeverDestroyed<HashSet<AtomString>> syncStorageProperties { HashSet { AtomString("QUOTA_BYTES_PER_ITEM"_s), AtomString("MAX_ITEMS"_s), AtomString("MAX_WRITE_OPERATIONS_PER_HOUR"_s), AtomString("MAX_WRITE_OPERATIONS_PER_MINUTE"_s) } };

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm
@@ -42,7 +42,7 @@ namespace WebKit {
 
 bool WebExtensionAPIStorage::isPropertyAllowed(const ASCIILiteral& propertyName, WebPage*)
 {
-    if (UNLIKELY(extensionContext().isUnsupportedAPI(propertyPath(), propertyName)))
+    if (extensionContext().isUnsupportedAPI(propertyPath(), propertyName)) [[unlikely]]
         return false;
 
     if (propertyName == "session"_s)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -586,7 +586,7 @@ bool WebExtensionAPITabs::parseScriptOptions(NSDictionary *options, WebExtension
 
 bool isValid(std::optional<WebExtensionTabIdentifier> identifier, NSString **outExceptionString)
 {
-    if (UNLIKELY(!isValid(identifier))) {
+    if (!isValid(identifier)) [[unlikely]] {
         if (isNone(identifier))
             *outExceptionString = toErrorString(nullString(), @"tabId", @"'tabs.TAB_ID_NONE' is not allowed").createNSString().autorelease();
         else if (identifier)
@@ -601,7 +601,7 @@ bool isValid(std::optional<WebExtensionTabIdentifier> identifier, NSString **out
 
 bool WebExtensionAPITabs::isPropertyAllowed(const ASCIILiteral& name, WebPage*)
 {
-    if (UNLIKELY(extensionContext().isUnsupportedAPI(propertyPath(), name)))
+    if (extensionContext().isUnsupportedAPI(propertyPath(), name)) [[unlikely]]
         return false;
 
     static NeverDestroyed<HashSet<AtomString>> removedInManifestVersion3 { HashSet { AtomString("executeScript"_s), AtomString("getSelected"_s), AtomString("insertCSS"_s), AtomString("removeCSS"_s) } };

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
@@ -363,7 +363,7 @@ bool WebExtensionAPIWindows::parseWindowUpdateOptions(NSDictionary *options, Web
 
 bool isValid(std::optional<WebExtensionWindowIdentifier> identifier, NSString **outExceptionString)
 {
-    if (UNLIKELY(!isValid(identifier))) {
+    if (!isValid(identifier)) [[unlikely]] {
         if (isNone(identifier))
             *outExceptionString = toErrorString(nullString(), @"windowId", @"'windows.WINDOW_ID_NONE' is not allowed").createNSString().autorelease();
         else if (identifier)
@@ -378,7 +378,7 @@ bool isValid(std::optional<WebExtensionWindowIdentifier> identifier, NSString **
 
 bool WebExtensionAPIWindows::isPropertyAllowed(const ASCIILiteral& name, WebPage*)
 {
-    if (UNLIKELY(extensionContext().isUnsupportedAPI(propertyPath(), name)))
+    if (extensionContext().isUnsupportedAPI(propertyPath(), name)) [[unlikely]]
         return false;
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -80,7 +80,7 @@ template<typename T>
 ALWAYS_INLINE void RemoteDisplayListRecorderProxy::send(T&& message)
 {
     RefPtr connection = m_connection;
-    if (UNLIKELY(!connection)) {
+    if (!connection) [[unlikely]] {
         if (RefPtr backend = m_renderingBackend.get())
             connection = backend->connection();
         if (!connection)
@@ -94,7 +94,7 @@ ALWAYS_INLINE void RemoteDisplayListRecorderProxy::send(T&& message)
         m_hasDrawn = true;
     }
     auto result = connection->send(std::forward<T>(message), m_identifier);
-    if (UNLIKELY(result != IPC::Error::NoError)) {
+    if (result != IPC::Error::NoError) [[unlikely]] {
         RELEASE_LOG(RemoteLayerBuffers, "RemoteDisplayListRecorderProxy::send - failed, name:%" PUBLIC_LOG_STRING ", error:%" PUBLIC_LOG_STRING,
             IPC::description(T::name()).characters(), IPC::errorAsString(result).characters());
         didBecomeUnresponsive();
@@ -104,7 +104,7 @@ ALWAYS_INLINE void RemoteDisplayListRecorderProxy::send(T&& message)
 void RemoteDisplayListRecorderProxy::didBecomeUnresponsive() const
 {
     RefPtr backend = m_renderingBackend.get();
-    if (UNLIKELY(!backend))
+    if (!backend) [[unlikely]]
         return;
     backend->didBecomeUnresponsive();
 }
@@ -610,7 +610,7 @@ void RemoteDisplayListRecorderProxy::setURLForRect(const URL& link, const FloatR
 bool RemoteDisplayListRecorderProxy::recordResourceUse(NativeImage& image)
 {
     RefPtr renderingBackend = m_renderingBackend.get();
-    if (UNLIKELY(!renderingBackend)) {
+    if (!renderingBackend) [[unlikely]] {
         ASSERT_NOT_REACHED();
         return false;
     }
@@ -641,7 +641,7 @@ bool RemoteDisplayListRecorderProxy::recordResourceUse(NativeImage& image)
 bool RemoteDisplayListRecorderProxy::recordResourceUse(ImageBuffer& imageBuffer)
 {
     RefPtr renderingBackend = m_renderingBackend.get();
-    if (UNLIKELY(!renderingBackend)) {
+    if (!renderingBackend) [[unlikely]] {
         ASSERT_NOT_REACHED();
         return false;
     }
@@ -662,7 +662,7 @@ bool RemoteDisplayListRecorderProxy::recordResourceUse(const SourceImage& image)
 bool RemoteDisplayListRecorderProxy::recordResourceUse(Font& font)
 {
     RefPtr renderingBackend = m_renderingBackend.get();
-    if (UNLIKELY(!renderingBackend)) {
+    if (!renderingBackend) [[unlikely]] {
         ASSERT_NOT_REACHED();
         return false;
     }
@@ -674,7 +674,7 @@ bool RemoteDisplayListRecorderProxy::recordResourceUse(Font& font)
 bool RemoteDisplayListRecorderProxy::recordResourceUse(DecomposedGlyphs& decomposedGlyphs)
 {
     RefPtr renderingBackend = m_renderingBackend.get();
-    if (UNLIKELY(!renderingBackend)) {
+    if (!renderingBackend) [[unlikely]] {
         ASSERT_NOT_REACHED();
         return false;
     }
@@ -686,7 +686,7 @@ bool RemoteDisplayListRecorderProxy::recordResourceUse(DecomposedGlyphs& decompo
 bool RemoteDisplayListRecorderProxy::recordResourceUse(Gradient& gradient)
 {
     RefPtr renderingBackend = m_renderingBackend.get();
-    if (UNLIKELY(!renderingBackend)) {
+    if (!renderingBackend) [[unlikely]] {
         ASSERT_NOT_REACHED();
         return false;
     }
@@ -698,7 +698,7 @@ bool RemoteDisplayListRecorderProxy::recordResourceUse(Gradient& gradient)
 bool RemoteDisplayListRecorderProxy::recordResourceUse(Filter& filter)
 {
     RefPtr renderingBackend = m_renderingBackend.get();
-    if (UNLIKELY(!renderingBackend)) {
+    if (!renderingBackend) [[unlikely]] {
         ASSERT_NOT_REACHED();
         return false;
     }
@@ -710,7 +710,7 @@ bool RemoteDisplayListRecorderProxy::recordResourceUse(Filter& filter)
 RefPtr<ImageBuffer> RemoteDisplayListRecorderProxy::createImageBuffer(const FloatSize& size, float resolutionScale, const DestinationColorSpace& colorSpace, std::optional<RenderingMode> renderingMode, std::optional<RenderingMethod> renderingMethod) const
 {
     RefPtr renderingBackend = m_renderingBackend.get();
-    if (UNLIKELY(!renderingBackend)) {
+    if (!renderingBackend) [[unlikely]] {
         ASSERT_NOT_REACHED();
         return nullptr;
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
@@ -118,11 +118,11 @@ template<typename T>
 ALWAYS_INLINE auto RemoteImageBufferSetProxy::send(T&& message)
 {
     RefPtr connection = this->connection();
-    if (UNLIKELY(!connection))
+    if (!connection) [[unlikely]]
         return IPC::Error::InvalidConnection;
 
     auto result = connection->send(std::forward<T>(message), identifier());
-    if (UNLIKELY(result != IPC::Error::NoError)) {
+    if (result != IPC::Error::NoError) [[unlikely]] {
         RELEASE_LOG(RemoteLayerBuffers, "RemoteImageBufferSetProxy::send - failed, name:%" PUBLIC_LOG_STRING ", error:%" PUBLIC_LOG_STRING,
             IPC::description(T::name()).characters(), IPC::errorAsString(result).characters());
         didBecomeUnresponsive();
@@ -134,15 +134,15 @@ template<typename T>
 ALWAYS_INLINE auto RemoteImageBufferSetProxy::sendSync(T&& message)
 {
     RefPtr connection = this->connection();
-    if (UNLIKELY(!connection))
+    if (!connection) [[unlikely]]
         return IPC::StreamClientConnection::SendSyncResult<T> { IPC::Error::InvalidConnection };
 
     auto result = connection->sendSync(std::forward<T>(message), identifier());
-    if (LIKELY(result.succeeded()))
+    if (result.succeeded()) [[likely]]
         return result;
 
     RefPtr remoteRenderingBackendProxy = m_remoteRenderingBackendProxy.get();
-    if (UNLIKELY(!remoteRenderingBackendProxy)) {
+    if (!remoteRenderingBackendProxy) [[unlikely]] {
         RELEASE_LOG(RemoteLayerBuffers, "[renderingBackend was deleted] Proxy::sendSync - failed, name:%" PUBLIC_LOG_STRING ", error:%" PUBLIC_LOG_STRING,
             IPC::description(T::name()).characters(), IPC::errorAsString(result.error()).characters());
         return result;
@@ -158,7 +158,7 @@ ALWAYS_INLINE auto RemoteImageBufferSetProxy::sendSync(T&& message)
 ALWAYS_INLINE RefPtr<IPC::StreamClientConnection> RemoteImageBufferSetProxy::connection() const
 {
     RefPtr backend = m_remoteRenderingBackendProxy.get();
-    if (UNLIKELY(!backend))
+    if (!backend) [[unlikely]]
         return nullptr;
     return backend->connection();
 }
@@ -166,7 +166,7 @@ ALWAYS_INLINE RefPtr<IPC::StreamClientConnection> RemoteImageBufferSetProxy::con
 void RemoteImageBufferSetProxy::didBecomeUnresponsive() const
 {
     RefPtr backend = m_remoteRenderingBackendProxy.get();
-    if (UNLIKELY(!backend))
+    if (!backend) [[unlikely]]
         return;
     backend->didBecomeUnresponsive();
 }
@@ -325,7 +325,7 @@ GraphicsContext& RemoteImageBufferSetProxy::context()
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
 std::optional<WebCore::DynamicContentScalingDisplayList> RemoteImageBufferSetProxy::dynamicContentScalingDisplayList()
 {
-    if (UNLIKELY(!m_remoteRenderingBackendProxy))
+    if (!m_remoteRenderingBackendProxy) [[unlikely]]
         return std::nullopt;
     auto sendResult = sendSync(Messages::RemoteImageBufferSet::DynamicContentScalingDisplayList());
     if (!sendResult.succeeded())

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -125,10 +125,10 @@ template<typename T, typename U, typename V, typename W>
 auto RemoteRenderingBackendProxy::send(T&& message, ObjectIdentifierGeneric<U, V, W> destination)
 {
     RefPtr connection = this->connection();
-    if (UNLIKELY(!connection))
+    if (!connection) [[unlikely]]
         return IPC::Error::InvalidConnection;
     auto result = connection->send(std::forward<T>(message), destination);
-    if (UNLIKELY(result != IPC::Error::NoError)) {
+    if (result != IPC::Error::NoError) [[unlikely]] {
         RELEASE_LOG(RemoteLayerBuffers, "[renderingBackend=%" PRIu64 "] RemoteRenderingBackendProxy::send - failed, name:%" PUBLIC_LOG_STRING ", error:%" PUBLIC_LOG_STRING, m_identifier.toUInt64(), IPC::description(T::name()).characters(), IPC::errorAsString(result).characters());
         didBecomeUnresponsive();
     }
@@ -142,7 +142,7 @@ auto RemoteRenderingBackendProxy::sendSync(T&& message, ObjectIdentifierGeneric<
     if (!connection)
         return IPC::StreamClientConnection::SendSyncResult<T> { IPC::Error::InvalidConnection };
     auto result = connection->sendSync(std::forward<T>(message), destination);
-    if (UNLIKELY(!result.succeeded())) {
+    if (!result.succeeded()) [[unlikely]] {
         RELEASE_LOG(RemoteLayerBuffers, "[renderingBackend=%" PRIu64 "] RemoteRenderingBackendProxy::sendSync - failed, name:%" PUBLIC_LOG_STRING ", error:%" PUBLIC_LOG_STRING,  m_identifier.toUInt64(), IPC::description(T::name()).characters(), IPC::errorAsString(result.error()).characters());
         didBecomeUnresponsive();
     }
@@ -153,10 +153,10 @@ template<typename T, typename C, typename U, typename V, typename W>
 auto RemoteRenderingBackendProxy::sendWithAsyncReply(T&& message, C&& callback, ObjectIdentifierGeneric<U, V, W> destination)
 {
     RefPtr connection = this->connection();
-    if (UNLIKELY(!connection))
+    if (!connection) [[unlikely]]
         return IPC::Error::InvalidConnection;
     auto replyID = connection->sendWithAsyncReply(std::forward<T>(message), std::forward<C>(callback), destination);
-    if (UNLIKELY(!replyID)) {
+    if (!replyID) [[unlikely]] {
         RELEASE_LOG(RemoteLayerBuffers, "[renderingBackend=%" PRIu64 "] RemoteRenderingBackendProxy::sendWithAsyncReply - failed, name:%" PUBLIC_LOG_STRING, m_identifier.toUInt64(), IPC::description(T::name()).characters());
         didBecomeUnresponsive();
         return IPC::Error::Unspecified;
@@ -621,7 +621,7 @@ RefPtr<IPC::StreamClientConnection> RemoteRenderingBackendProxy::connection()
         return nullptr;
 
     RefPtr connection = m_connection;
-    if (UNLIKELY(!connection->hasSemaphores())) {
+    if (!connection->hasSemaphores()) [[unlikely]] {
         auto error = connection->waitForAndDispatchImmediately<Messages::RemoteRenderingBackendProxy::DidInitialize>(renderingBackendIdentifier());
         if (error != IPC::Error::NoError) {
             RELEASE_LOG(RemoteLayerBuffers, "[renderingBackend=%" PRIu64 "] RemoteRenderingBackendProxy::connection() - waitForAndDispatchImmediately returned error: %" PUBLIC_LOG_STRING, renderingBackendIdentifier().toUInt64(), IPC::errorAsString(error).characters());

--- a/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp
+++ b/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp
@@ -41,7 +41,7 @@ namespace WebKit {
 using namespace WebCore;
 
 #define WP_MESSAGE_CHECK(assertion, ...) { \
-    if (UNLIKELY(!(assertion))) { \
+    if (!(assertion)) [[unlikely]] { \
         RELEASE_LOG_FAULT(IPC, "Exiting: %" PUBLIC_LOG_STRING " is false", #assertion); \
         CRASH_WITH_INFO(__VA_ARGS__); \
     } \

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
@@ -233,7 +233,7 @@ void WebResourceLoader::didReceiveData(IPC::SharedBufferReference&& data, uint64
     LOG(Network, "(WebProcess) WebResourceLoader::didReceiveData of size %zu for '%s'", data.size(), coreLoader->url().string().latin1().data());
     ASSERT_WITH_MESSAGE(!m_isProcessingNetworkResponse, "Network process should not send data until we've validated the response");
 
-    if (UNLIKELY(m_interceptController.isIntercepting(*coreLoader->identifier()))) {
+    if (m_interceptController.isIntercepting(*coreLoader->identifier())) [[unlikely]] {
         m_interceptController.defer(*coreLoader->identifier(), [this, protectedThis = Ref { *this }, buffer = WTFMove(data), bytesTransferredOverNetwork]() mutable {
             if (m_coreLoader)
                 didReceiveData(WTFMove(buffer), bytesTransferredOverNetwork);
@@ -263,7 +263,7 @@ void WebResourceLoader::didFinishResourceLoad(NetworkLoadMetrics&& networkLoadMe
     LOG(Network, "(WebProcess) WebResourceLoader::didFinishResourceLoad for '%s'", coreLoader->url().string().latin1().data());
     WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_DIDFINISHRESOURCELOAD, m_numBytesReceived);
 
-    if (UNLIKELY(m_interceptController.isIntercepting(*coreLoader->identifier()))) {
+    if (m_interceptController.isIntercepting(*coreLoader->identifier())) [[unlikely]] {
         m_interceptController.defer(*coreLoader->identifier(), [this, protectedThis = Ref { *this }, networkLoadMetrics = WTFMove(networkLoadMetrics)]() mutable {
             if (m_coreLoader)
                 didFinishResourceLoad(WTFMove(networkLoadMetrics));
@@ -323,7 +323,7 @@ void WebResourceLoader::didFailResourceLoad(const ResourceError& error)
     LOG(Network, "(WebProcess) WebResourceLoader::didFailResourceLoad for '%s'", coreLoader->url().string().latin1().data());
     WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_DIDFAILRESOURCELOAD);
 
-    if (UNLIKELY(m_interceptController.isIntercepting(*coreLoader->identifier()))) {
+    if (m_interceptController.isIntercepting(*coreLoader->identifier())) [[unlikely]] {
         m_interceptController.defer(*coreLoader->identifier(), [this, protectedThis = Ref { *this }, error]() mutable {
             if (m_coreLoader)
                 didFailResourceLoad(error);

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
@@ -180,7 +180,7 @@ bool WebSocketChannel::increaseBufferedAmount(size_t byteLength)
 
     CheckedSize checkedNewBufferedAmount = m_bufferedAmount;
     checkedNewBufferedAmount += byteLength;
-    if (UNLIKELY(checkedNewBufferedAmount.hasOverflowed())) {
+    if (checkedNewBufferedAmount.hasOverflowed()) [[unlikely]] {
         fail("Failed to send WebSocket frame: buffer has no more space"_s);
         return false;
     }

--- a/Source/WebKit/WebProcess/Network/WebTransportSendStreamSink.cpp
+++ b/Source/WebKit/WebProcess/Network/WebTransportSendStreamSink.cpp
@@ -62,7 +62,7 @@ void WebTransportSendStreamSink::write(WebCore::ScriptExecutionContext& context,
     auto scope = DECLARE_THROW_SCOPE(globalObject.vm());
 
     auto bufferSource = convert<WebCore::IDLUnion<WebCore::IDLArrayBuffer, WebCore::IDLArrayBufferView>>(globalObject, value);
-    if (UNLIKELY(bufferSource.hasException(scope)))
+    if (bufferSource.hasException(scope)) [[unlikely]]
         return promise.settle(WebCore::Exception { WebCore::ExceptionCode::ExistingExceptionError });
 
     WTF::switchOn(bufferSource.releaseReturnValue(), [&](auto&& arrayBufferOrView) {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7282,7 +7282,7 @@ void WebPage::didChangeSelection(LocalFrame& frame)
         return;
 
     callOnMainRunLoop([protectedThis = Ref { *this }, frame = Ref { frame }] {
-        if (UNLIKELY(!frame->document() || !frame->document()->hasLivingRenderTree() || frame->selection().isNone()))
+        if (!frame->document() || !frame->document()->hasLivingRenderTree() || frame->selection().isNone()) [[unlikely]]
             return;
 
         protectedThis->preemptivelySendAutocorrectionContext();
@@ -8243,7 +8243,7 @@ void WebPage::updateCachedDocumentLoader(DocumentLoader& documentLoader, LocalFr
 
 void WebPage::getBytecodeProfile(CompletionHandler<void(const String&)>&& callback)
 {
-    if (LIKELY(!commonVM().m_perBytecodeProfiler))
+    if (!commonVM().m_perBytecodeProfiler) [[likely]]
         return callback({ });
 
     String result = commonVM().m_perBytecodeProfiler->toJSON()->toJSONString();

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
@@ -357,7 +357,7 @@ void TiledCoreAnimationDrawingArea::updateRendering(UpdateRenderingType flushTyp
         return;
 
     Ref webPage = m_webPage.get();
-    if (UNLIKELY(!webPage->hasRootFrames()))
+    if (!webPage->hasRootFrames()) [[unlikely]]
         return;
 
     @autoreleasepool {

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
@@ -162,7 +162,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     static std::atomic<bool> didInitialize { false };
     static std::atomic<unsigned> screenHeight { 0 };
-    if (UNLIKELY(!didInitialize)) {
+    if (!didInitialize) [[unlikely]] {
         didInitialize = true;
         callOnMainRunLoopAndWait([protectedSelf = retainPtr(self)] {
             if (!WebCore::AXObjectCache::accessibilityEnabled())

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -468,7 +468,7 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
             if (m_pagesInWindows.isEmpty() && critical == Critical::No)
                 critical = Critical::Yes;
 
-            if (UNLIKELY(Options::dumpHeapOnLowMemory()))
+            if (Options::dumpHeapOnLowMemory()) [[unlikely]]
                 GCController::singleton().dumpHeap();
 
 #if PLATFORM(COCOA)

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
@@ -262,7 +262,7 @@ void WebSocketChannel::didOpenSocketStream(SocketStreamHandle& handle)
     ASSERT(&handle == m_handle);
     if (!m_document)
         return;
-    if (UNLIKELY(LegacyWebSocketInspectorInstrumentation::hasFrontends())) {
+    if (LegacyWebSocketInspectorInstrumentation::hasFrontends()) [[unlikely]] {
         auto cookieRequestHeaderFieldValue = [document = m_document] (const URL& url) -> String {
             if (!document || !document->page())
                 return { };

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -7481,7 +7481,7 @@ static NSAppleEventDescriptor* aeDescFromJSValue(JSC::JSGlobalObject* lexicalGlo
             }
         }
         JSC::JSValue primitive = object->toPrimitive(lexicalGlobalObject);
-        if (UNLIKELY(scope.exception())) {
+        if (scope.exception()) [[unlikely]] {
             scope.clearException();
             return [NSAppleEventDescriptor nullDescriptor];
         }


### PR DESCRIPTION
#### 678107547a9ba8f5bc3c236f4c78ab2be1591ff1
<pre>
Adopt C++&apos;s [[likely]] / [[unlikely]] in WebKit/ &amp; WebKitLegacy
<a href="https://bugs.webkit.org/show_bug.cgi?id=292417">https://bugs.webkit.org/show_bug.cgi?id=292417</a>

Reviewed by Timothy Hatcher.

Adopt C++&apos;s [[likely]] / [[unlikely]] in WebKit/ &amp; WebKitLegacy.

It is now part of the C++ language and has several benefits over
our macros. In particular, those annotations can be used for
`switch` cases and `else` statements.

* Source/WebGPU/WGSL/AST/ASTBuilder.h:
(WGSL::AST::Builder::construct):
* Source/WebGPU/WGSL/AttributeValidator.cpp:
(WGSL::AttributeValidator::visit):
* Source/WebGPU/WGSL/ConstantValue.h:
(WGSL::convertInteger):
* Source/WebGPU/WGSL/ContextProviderInlines.h:
(WGSL::ContextProvider&lt;Value&gt;::Context::add):
* Source/WebGPU/WGSL/GlobalSorting.cpp:
(WGSL::GraphBuilder::visit):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::visit):
(WGSL::RewriteGlobalVariables::determineUsedGlobals):
* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::nextToken):
(WGSL::Lexer&lt;T&gt;::shift):
(WGSL::Lexer&lt;T&gt;::peek):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseStructure):
(WGSL::Parser&lt;Lexer&gt;::parseTypeName):
(WGSL::Parser&lt;Lexer&gt;::parseFunction):
(WGSL::Parser&lt;Lexer&gt;::parseSwitchStatement):
* Source/WebGPU/WGSL/PhaseTimer.h:
(WGSL::dumpASTIfNeeded):
(WGSL::logPhaseTimes):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::TypeChecker):
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::bitcast):
(WGSL::TypeChecker::convertValue):
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::makeSpanFromBuffer):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::setVertexBuffer):
(WebGPU::RenderPassEncoder::setFragmentBuffer):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(attachShader):
(bindAttribLocation):
(bindBuffer):
(bindFramebuffer):
(bindRenderbuffer):
(bindTexture):
(compileShader):
(createBuffer):
(createFramebuffer):
(createProgram):
(createRenderbuffer):
(createShader):
(createTexture):
(deleteBuffer):
(deleteFramebuffer):
(deleteProgram):
(deleteRenderbuffer):
(deleteShader):
(deleteTexture):
(detachShader):
(framebufferRenderbuffer):
(framebufferTexture2D):
(getActiveAttrib):
(getActiveUniform):
(getAttribLocation):
(getProgrami):
(getProgramInfoLog):
(getShaderi):
(getShaderInfoLog):
(getShaderSource):
(getUniformfv):
(getUniformiv):
(getUniformuiv):
(getUniformLocation):
(isBuffer):
(isFramebuffer):
(isProgram):
(isRenderbuffer):
(isShader):
(isTexture):
(linkProgram):
(shaderSource):
(useProgram):
(validateProgram):
(createVertexArray):
(deleteVertexArray):
(isVertexArray):
(bindVertexArray):
(framebufferTextureLayer):
(getFragDataLocation):
(createQuery):
(deleteQuery):
(isQuery):
(beginQuery):
(getQueryObjectui):
(createSampler):
(deleteSampler):
(isSampler):
(bindSampler):
(samplerParameteri):
(samplerParameterf):
(getSamplerParameterf):
(getSamplerParameteri):
(createTransformFeedback):
(deleteTransformFeedback):
(isTransformFeedback):
(bindTransformFeedback):
(transformFeedbackVaryings):
(getTransformFeedbackVarying):
(bindBufferBase):
(bindBufferRange):
(getUniformIndices):
(getActiveUniforms):
(getUniformBlockIndex):
(getActiveUniformBlockName):
(uniformBlockBinding):
(getActiveUniformBlockiv):
(getTranslatedShaderSourceANGLE):
(createQueryEXT):
(deleteQueryEXT):
(isQueryEXT):
(beginQueryEXT):
(queryCounterEXT):
(getQueryObjectiEXT):
(getQueryObjectui64EXT):
(createExternalImage):
(deleteExternalImage):
(bindExternalImage):
(createExternalSync):
(deleteExternalSync):
(enableFoveation):
(framebufferResolveRenderbuffer):
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::ResourceLoadStatisticsStore::removeDataRecords):
(WebKit::ResourceLoadStatisticsStore::requestStorageAccess):
(WebKit::ResourceLoadStatisticsStore::requestStorageAccessUnderOpener):
(WebKit::ResourceLoadStatisticsStore::logFrameNavigation):
(WebKit::ResourceLoadStatisticsStore::updateCookieBlocking):
(WebKit::ResourceLoadStatisticsStore::registrableDomainsToDeleteOrRestrictWebsiteDataFor):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::scheduleResourceLoad):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp:
(WebKit::PrivateClickMeasurementManager::attribute):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.cpp:
(WebKit::PCM::handlePCMMessage):
(WebKit::PCM::handlePCMMessageSetDebugModeIsEnabled):
(WebKit::PCM::handlePCMMessageWithReply):
* Source/WebKit/Platform/IPC/ArgumentCoders.h:
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::waitForMessage):
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/Platform/IPC/Decoder.cpp:
(IPC::Decoder::create):
* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::Decoder::decode):
(IPC::Decoder::decodeSpan):
* Source/WebKit/Platform/IPC/HandleMessage.h:
(IPC::handleMessage):
(IPC::handleMessageWithoutUsingIPCConnection):
(IPC::handleMessageSynchronous):
(IPC::handleMessageAsync):
(IPC::handleMessageAsyncWithoutUsingIPCConnection):
(IPC::handleMessageAsyncWithReplyID):
* Source/WebKit/Platform/IPC/StreamServerConnectionBuffer.h:
(IPC::StreamServerConnectionBuffer::map):
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
(IPC::Connection::sendOutgoingMessage):
(IPC::createMessageDecoder):
(IPC::Connection::receiveSourceEventHandler):
* Source/WebKit/Platform/IPC/glib/ArgumentCodersGlib.h:
* Source/WebKit/Platform/IPC/unix/IPCSemaphoreUnix.cpp:
(IPC::Semaphore::signal):
(IPC::waitImpl):
* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
* Source/WebKit/Scripts/generate-serializers.py:
(decode_cf_type):
(decode_type):
(generate_one_impl):
* Source/WebKit/Scripts/webkit/messages.py:
(generate_message_handler):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;Namespace::Subnamespace::StructName&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::OtherClass&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::ClassWithMemberPrecondition&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::ReturnRefClass&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::EmptyConstructorStruct&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::EmptyConstructorWithIf&gt;::decode):
(IPC::ArgumentCoder&lt;WithoutNamespace&gt;::decode):
(IPC::ArgumentCoder&lt;WithoutNamespaceWithAttributes&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::InheritsFrom&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::InheritanceGrandchild&gt;::decode):
(IPC::ArgumentCoder&lt;WTF::Seconds&gt;::decode):
(IPC::ArgumentCoder&lt;WTF::CreateUsingClass&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::FloatBoxExtent&gt;::decode):
(IPC::ArgumentCoder&lt;SoftLinkedMember&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::TimingFunction&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::ConditionalCommonClass&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::CommonClass&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::AnotherCommonClass&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::MoveOnlyBaseClass&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::MoveOnlyDerivedClass&gt;::decode):
(IPC::ArgumentCoder&lt;WebKit::CustomEncoded&gt;::decode):
(IPC::ArgumentCoder&lt;WebKit::LayerProperties&gt;::decode):
(IPC::ArgumentCoder&lt;WebKit::TemplateTest&lt;WebKit::Fabulous&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;WebKit::TemplateTest&lt;WebCore::Amazing&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;WebKit::TemplateTest&lt;JSC::Incredible&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;WebKit::TemplateTest&lt;Testing::StorageSize&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::ScrollingStateFrameHostingNode&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple&gt;::decode):
(IPC::ArgumentCoder&lt;RequestEncodedWithBody&gt;::decode):
(IPC::ArgumentCoder&lt;RequestEncodedWithBodyRValue&gt;::decode):
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFFooRef&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFBarRef&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;SkFooBar&gt;::decode):
(IPC::ArgumentCoder&lt;WebKit::RValueWithFunctionCalls&gt;::decode):
(IPC::ArgumentCoder&lt;WebKit::RemoteVideoFrameReference&gt;::decode):
(IPC::ArgumentCoder&lt;WebKit::RemoteVideoFrameWriteReference&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::OuterClass&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::OtherOuterClass&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::AppKitControlSystemImage&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::RectEdges&lt;bool&gt;&gt;::decode):
* Source/WebKit/Scripts/webkit/tests/TestWithValidatorMessageReceiver.cpp:
(WebKit::TestWithValidator::sendCancelReply):
* Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;WebKit::PlatformClass&gt;::decode):
(IPC::ArgumentCoder&lt;WebKit::CoreIPCAVOutputContext&gt;::decode):
(IPC::ArgumentCoder&lt;WebKit::CoreIPCNSSomeFoundationType&gt;::decode):
(IPC::NSSomeOtherFoundationType&gt;::decode):
(IPC::ArgumentCoder&lt;WebKit::CoreIPCDDScannerResult&gt;::decode):
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFStringRef&gt;&gt;::decode):
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp:
(WebKit::toErrorString):
* Source/WebKit/Shared/ScriptTelemetry.cpp:
(WebKit::ScriptTelemetryFilter::matches):
* Source/WebKit/Shared/cf/CoreIPCCGColorSpace.h:
(WebKit::CoreIPCCGColorSpace::toCF const):
* Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp:
(IPC::ArgumentCoder&lt;GRefPtr&lt;GByteArray&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GVariant&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GTlsCertificate&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;GTlsCertificateFlags&gt;::decode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GUnixFDList&gt;&gt;::decode):
* Source/WebKit/Shared/gtk/ArgumentCodersGtk.cpp:
(IPC::ArgumentCoder&lt;GRefPtr&lt;GtkPrintSettings&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GtkPageSetup&gt;&gt;::decode):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
(webkit_settings_apply_from_key_file):
* Source/WebKit/UIProcess/API/gtk/InputMethodFilterGtk.cpp:
(WebKit::InputMethodFilter::platformEventKeyIsKeyPress const):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseCrossingNotifyEvent):
(webkitWebViewBaseEnter):
(webkitWebViewBaseLeave):
* Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp:
(wpe_view_qtquick_render_buffer_to_texture):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::send):
* Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.mm:
(WebKit::createWKTextItem):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::getWindow const):
(WebKit::WebExtensionContext::getTab const):
(WebKit::WebExtensionContext::getCurrentTab const):
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::ProcessLauncher::finishLaunchingProcess):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(-[WKScrollingNodeScrollViewDelegate scrollViewDidScroll:]):
(-[WKScrollingNodeScrollViewDelegate scrollViewWillBeginDragging:]):
(-[WKScrollingNodeScrollViewDelegate scrollViewWillEndDragging:withVelocity:targetContentOffset:]):
(-[WKScrollingNodeScrollViewDelegate scrollViewDidEndDragging:willDecelerate:]):
(-[WKScrollingNodeScrollViewDelegate scrollViewDidEndDecelerating:]):
(-[WKScrollingNodeScrollViewDelegate scrollViewDidEndScrollingAnimation:]):
(-[WKScrollingNodeScrollViewDelegate cancelPointersForGestureRecognizer:]):
(-[WKScrollingNodeScrollViewDelegate shouldAllowPanGestureRecognizerToReceiveTouchesInScrollView:]):
(-[WKScrollingNodeScrollViewDelegate axesToPreventScrollingForPanGestureInScrollView:]):
(-[WKScrollingNodeScrollViewDelegate parentScrollViewForScrollView:]):
(-[WKScrollingNodeScrollViewDelegate scrollView:handleScrollUpdate:completion:]):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::isMainThreadOrCheckDisabled):
(WebKit::WebProcessProxy::didChangeThrottleState):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::getNetworkProcessConnection):
(WebKit::WebsiteDataStore::openerTypeForDomain const):
* Source/WebKit/UIProcess/glib/FenceMonitor.cpp:
(WebKit::FenceMonitor::ensureSource):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
* Source/WebKit/WPEPlatform/wpe/drm/RefPtrUdev.cpp:
(WTF::udev&gt;::refIfNotNull):
(WTF::udev&gt;::derefIfNotNull):
(WTF::udev_device&gt;::refIfNotNull):
(WTF::udev_device&gt;::derefIfNotNull):
(WTF::udev_enumerate&gt;::refIfNotNull):
(WTF::udev_enumerate&gt;::derefIfNotNull):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp:
(DMABufFeedback::format):
(wpeToplevelWaylandGetPreferredDMABufFormats):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm:
(WebKit::WebExtensionAPIExtension::isPropertyAllowed):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm:
(WebKit::WebExtensionAPINamespace::isPropertyAllowed):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntime::isPropertyAllowed):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm:
(WebKit::WebExtensionAPIStorageArea::isPropertyAllowed):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm:
(WebKit::WebExtensionAPIStorage::isPropertyAllowed):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::isValid):
(WebKit::WebExtensionAPITabs::isPropertyAllowed):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm:
(WebKit::isValid):
(WebKit::WebExtensionAPIWindows::isPropertyAllowed):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::send):
(WebKit::RemoteDisplayListRecorderProxy::didBecomeUnresponsive const):
(WebKit::RemoteDisplayListRecorderProxy::recordResourceUse):
(WebKit::RemoteDisplayListRecorderProxy::createImageBuffer const):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::send):
(WebKit::RemoteImageBufferProxy::sendSync):
(WebKit::RemoteImageBufferProxy::connection const):
(WebKit::RemoteImageBufferProxy::didBecomeUnresponsive const):
(WebKit::RemoteImageBufferProxy::ensureBackend const):
(WebKit::RemoteImageBufferProxy::copyNativeImage const):
(WebKit::RemoteImageBufferProxy::filteredNativeImage):
(WebKit::RemoteImageBufferProxy::getPixelBuffer const):
(WebKit::RemoteImageBufferProxy::putPixelBuffer):
(WebKit::RemoteImageBufferProxy::flushDrawingContext):
(WebKit::RemoteImageBufferProxy::flushDrawingContextAsync):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp:
(WebKit::RemoteImageBufferSetProxy::send):
(WebKit::RemoteImageBufferSetProxy::sendSync):
(WebKit::RemoteImageBufferSetProxy::connection const):
(WebKit::RemoteImageBufferSetProxy::didBecomeUnresponsive const):
(WebKit::RemoteImageBufferSetProxy::dynamicContentScalingDisplayList):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::send):
(WebKit::RemoteRenderingBackendProxy::sendSync):
(WebKit::RemoteRenderingBackendProxy::sendWithAsyncReply):
(WebKit::RemoteRenderingBackendProxy::connection):
* Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp:
* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:
(WebKit::WebResourceLoader::didReceiveData):
(WebKit::WebResourceLoader::didFinishResourceLoad):
(WebKit::WebResourceLoader::didFailResourceLoad):
* Source/WebKit/WebProcess/Network/WebSocketChannel.cpp:
(WebKit::WebSocketChannel::increaseBufferedAmount):
* Source/WebKit/WebProcess/Network/WebTransportSendStreamSink.cpp:
(WebKit::WebTransportSendStreamSink::write):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didChangeSelection):
(WebKit::WebPage::getBytecodeProfile):
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm:
(WebKit::TiledCoreAnimationDrawingArea::updateRendering):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm:
(-[WKAccessibilityWebPageObject accessibilityAttributeValue:]):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::initializeWebProcess):
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp:
(WebCore::WebSocketChannel::didOpenSocketStream):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(aeDescFromJSValue):

Canonical link: <a href="https://commits.webkit.org/294410@main">https://commits.webkit.org/294410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8f04f7ccdfc1b4e4ce3196c490ccaec0ef75a88

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101744 "394 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106902 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/52378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21720 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29914 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/77466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/52378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91878 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/57804 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/101216 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/16609 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9896 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51729 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/86467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9973 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109258 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28877 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/21266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29238 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86013 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21885 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30768 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8491 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/23040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28805 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34095 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28616 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31939 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30175 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->