### PR TITLE
Start adopting C++20's [[likely]] / [[unlikely]] in WebCore/

### DIFF
--- a/Source/WebCore/dom/NodeInlines.h
+++ b/Source/WebCore/dom/NodeInlines.h
@@ -94,7 +94,7 @@ inline void Node::setRenderer(RenderObject* renderer)
 {
     m_renderer = renderer;
 
-    if (UNLIKELY(InspectorInstrumentationPublic::hasFrontends()))
+    if (InspectorInstrumentationPublic::hasFrontends()) [[unlikely]]
         notifyInspectorOfRendererChange();
 }
 

--- a/Source/WebCore/html/parser/AtomHTMLToken.h
+++ b/Source/WebCore/html/parser/AtomHTMLToken.h
@@ -236,7 +236,7 @@ inline void AtomHTMLToken::initializeAttributes(const HTMLToken::AttributeList& 
             return std::nullopt;
 
         auto qualifiedName = HTMLNameCache::makeAttributeQualifiedName(attribute.name);
-        if (UNLIKELY(!insertInUniquedSortedVector(addedAttributes, qualifiedName.localName().impl()))) {
+        if (!insertInUniquedSortedVector(addedAttributes, qualifiedName.localName().impl())) [[unlikely]] {
             m_hasDuplicateAttribute = true;
             return std::nullopt;
         }
@@ -253,7 +253,7 @@ inline AtomHTMLToken::AtomHTMLToken(HTMLToken& token)
         ASSERT_NOT_REACHED();
         return;
     case Type::DOCTYPE:
-        if (LIKELY(token.name().size() == 4 && equal(HTMLNames::htmlTag->localName().impl(), token.name().span())))
+        if (token.name().size() == 4 && equal(HTMLNames::htmlTag->localName().impl(), token.name().span())) [[likely]]
             m_name = HTMLNames::htmlTag->localName();
         else
             m_name = AtomString(token.name().span());
@@ -265,7 +265,7 @@ inline AtomHTMLToken::AtomHTMLToken(HTMLToken& token)
     case Type::EndTag:
         m_selfClosing = token.selfClosing();
         m_tagName = findTagName(token.name());
-        if (UNLIKELY(m_tagName == TagName::Unknown))
+        if (m_tagName == TagName::Unknown) [[unlikely]]
             m_name = AtomString(token.name().span());
         initializeAttributes(token.attributes());
         return;

--- a/Source/WebCore/html/parser/HTMLDocumentParser.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.cpp
@@ -268,7 +268,7 @@ bool HTMLDocumentParser::pumpTokenizerLoop(SynchronousMode mode, bool parsingFra
 {
     RefPtr parserScheduler = m_parserScheduler;
     do {
-        if (UNLIKELY(isWaitingForScripts())) {
+        if (isWaitingForScripts()) [[unlikely]] {
             if (mode == SynchronousMode::AllowYield && parserScheduler->shouldYieldBeforeExecutingScript(m_treeBuilder->protectedScriptToProcess().get(), session))
                 return true;
             
@@ -282,10 +282,10 @@ bool HTMLDocumentParser::pumpTokenizerLoop(SynchronousMode mode, bool parsingFra
         // how the parser has always handled stopping when the page assigns window.location. What should
         // happen instead is that assigning window.location causes the parser to stop parsing cleanly.
         // The problem is we're not prepared to do that at every point where we run JavaScript.
-        if (UNLIKELY(!parsingFragment && document()->frame() && document()->protectedFrame()->protectedNavigationScheduler()->locationChangePending()))
+        if (!parsingFragment && document()->frame() && document()->protectedFrame()->protectedNavigationScheduler()->locationChangePending()) [[unlikely]]
             return false;
 
-        if (UNLIKELY(mode == SynchronousMode::AllowYield && parserScheduler->shouldYieldBeforeToken(session)))
+        if (mode == SynchronousMode::AllowYield && parserScheduler->shouldYieldBeforeToken(session)) [[unlikely]]
             return true;
 
         auto token = m_tokenizer.nextToken(m_input.current());

--- a/Source/WebCore/html/parser/HTMLElementStack.cpp
+++ b/Source/WebCore/html/parser/HTMLElementStack.cpp
@@ -519,7 +519,7 @@ void HTMLElementStack::pushCommon(HTMLStackItem&& item)
 {
     ASSERT(m_rootNode);
 
-    if (UNLIKELY(is<HTMLTemplateElement>(item.node())))
+    if (is<HTMLTemplateElement>(item.node())) [[unlikely]]
         ++m_templateElementCount;
 
     ++m_stackDepth;
@@ -535,7 +535,7 @@ void HTMLElementStack::popCommon()
     Ref oldTop = top();
     m_top = m_top->releaseNext();
 
-    if (UNLIKELY(is<HTMLTemplateElement>(oldTop))) {
+    if (is<HTMLTemplateElement>(oldTop)) [[unlikely]] {
         ASSERT(m_templateElementCount);
         --m_templateElementCount;
     }
@@ -555,7 +555,7 @@ void HTMLElementStack::removeNonTopCommon(Element& element)
             record->setNext(record->next()->releaseNext());
             --m_stackDepth;
 
-            if (UNLIKELY(is<HTMLTemplateElement>(element))) {
+            if (is<HTMLTemplateElement>(element)) [[unlikely]] {
                 ASSERT(m_templateElementCount);
                 --m_templateElementCount;
             }

--- a/Source/WebCore/html/parser/HTMLParserIdioms.cpp
+++ b/Source/WebCore/html/parser/HTMLParserIdioms.cpp
@@ -167,7 +167,7 @@ Expected<int, HTMLIntegerParsingError> parseHTMLInteger(StringView input)
     if (input.isEmpty())
         return makeUnexpected(HTMLIntegerParsingError::Other);
 
-    if (LIKELY(input.is8Bit()))
+    if (input.is8Bit()) [[likely]]
         return parseHTMLIntegerInternal(input.span8());
 
     return parseHTMLIntegerInternal(input.span16());
@@ -208,7 +208,7 @@ std::optional<int> parseValidHTMLNonNegativeInteger(StringView input)
     if (input.isEmpty())
         return std::nullopt;
 
-    if (LIKELY(input.is8Bit()))
+    if (input.is8Bit()) [[likely]]
         return parseValidHTMLNonNegativeIntegerInternal(input.span8());
     return parseValidHTMLNonNegativeIntegerInternal(input.span16());
 }
@@ -233,7 +233,7 @@ std::optional<double> parseValidHTMLFloatingPointNumber(StringView input)
 {
     if (input.isEmpty())
         return std::nullopt;
-    if (LIKELY(input.is8Bit()))
+    if (input.is8Bit()) [[likely]]
         return parseValidHTMLFloatingPointNumberInternal(input.span8());
     return parseValidHTMLFloatingPointNumberInternal(input.span16());
 }
@@ -260,7 +260,7 @@ static double parseHTMLFloatingPointNumberValueInternal(std::span<const Characte
 // https://html.spec.whatwg.org/#rules-for-parsing-floating-point-number-values
 double parseHTMLFloatingPointNumberValue(StringView input, double fallbackValue)
 {
-    if (LIKELY(input.is8Bit()))
+    if (input.is8Bit()) [[likely]]
         return parseHTMLFloatingPointNumberValueInternal(input.span8(), input.length(), fallbackValue);
 
     return parseHTMLFloatingPointNumberValueInternal(input.span16(), input.length(), fallbackValue);
@@ -312,7 +312,7 @@ static Vector<double> parseHTMLListOfOfFloatingPointNumberValuesInternal(std::sp
 
 Vector<double> parseHTMLListOfOfFloatingPointNumberValues(StringView input)
 {
-    if (LIKELY(input.is8Bit()))
+    if (input.is8Bit()) [[likely]]
         return parseHTMLListOfOfFloatingPointNumberValuesInternal(input.span8());
     return parseHTMLListOfOfFloatingPointNumberValuesInternal(input.span16());
 }
@@ -440,7 +440,7 @@ static bool parseHTTPRefreshInternal(std::span<const CharacterType> data, double
 
 bool parseMetaHTTPEquivRefresh(StringView input, double& delay, String& url)
 {
-    if (LIKELY(input.is8Bit()))
+    if (input.is8Bit()) [[likely]]
         return parseHTTPRefreshInternal(input.span8(), delay, url);
     return parseHTTPRefreshInternal(input.span16(), delay, url);
 }

--- a/Source/WebCore/html/parser/HTMLParserScheduler.cpp
+++ b/Source/WebCore/html/parser/HTMLParserScheduler.cpp
@@ -140,7 +140,7 @@ bool HTMLParserScheduler::shouldYieldBeforeExecutingScript(const ScriptElement* 
     if (!document->haveStylesheetsLoaded())
         return false;
 
-    if (UNLIKELY(m_documentHasActiveParserYieldTokens))
+    if (m_documentHasActiveParserYieldTokens) [[unlikely]]
         return true;
 
     // Yield if we have never painted and there is meaningful content

--- a/Source/WebCore/html/parser/HTMLParserScheduler.h
+++ b/Source/WebCore/html/parser/HTMLParserScheduler.h
@@ -78,10 +78,10 @@ public:
         if (WebThreadShouldYield())
             return true;
 #endif
-        if (UNLIKELY(m_documentHasActiveParserYieldTokens))
+        if (m_documentHasActiveParserYieldTokens) [[unlikely]]
             return true;
 
-        if (UNLIKELY(session.processedTokens > session.processedTokensOnLastCheck + numberOfTokensBeforeCheckingForYield || session.didSeeScript))
+        if (session.processedTokens > session.processedTokensOnLastCheck + numberOfTokensBeforeCheckingForYield || session.didSeeScript) [[unlikely]]
             return checkForYield(session);
 
         ++session.processedTokens;

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -1561,7 +1561,7 @@ void HTMLTreeBuilder::processAnyOtherEndTagForInBody(AtomHTMLToken&& token)
         }
     };
 
-    if (auto elementName = elementNameForTag(Namespace::HTML, token.tagName()); LIKELY(elementName != ElementName::Unknown))
+    if (auto elementName = elementNameForTag(Namespace::HTML, token.tagName()); elementName != ElementName::Unknown) [[likely]]
         popOpenElements(elementName);
     else
         popOpenElements(token.name());

--- a/Source/WebCore/html/parser/InputStreamPreprocessor.h
+++ b/Source/WebCore/html/parser/InputStreamPreprocessor.h
@@ -48,7 +48,7 @@ public:
     // characters in |source| (after collapsing \r\n, etc).
     ALWAYS_INLINE bool peek(SegmentedString& source, bool skipNullCharacters = false)
     {
-        if (UNLIKELY(source.isEmpty()))
+        if (source.isEmpty()) [[unlikely]]
             return false;
 
         m_nextInputCharacter = source.currentCharacter();
@@ -58,7 +58,7 @@ public:
         // handling. Please run the parser benchmark whenever you touch
         // this function. It's very hot.
         constexpr UChar specialCharacterMask = '\n' | '\r' | '\0';
-        if (LIKELY(m_nextInputCharacter & ~specialCharacterMask)) {
+        if (m_nextInputCharacter & ~specialCharacterMask) [[likely]] {
             m_skipNextNewLine = false;
             return true;
         }

--- a/Source/WebCore/inspector/InspectorFrontendHost.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendHost.cpp
@@ -189,7 +189,7 @@ void InspectorFrontendHost::addSelfToGlobalObjectInWorld(DOMWrapperWorld& world)
     JSC::JSLockHolder lock(vm);
     auto scope = DECLARE_CATCH_SCOPE(vm);
     globalObject.putDirect(vm, JSC::Identifier::fromString(vm, "InspectorFrontendHost"_s), toJS<IDLInterface<InspectorFrontendHost>>(globalObject, globalObject, *this));
-    if (UNLIKELY(scope.exception()))
+    if (scope.exception()) [[unlikely]]
         reportException(&globalObject, scope.exception());
 }
 

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -232,7 +232,7 @@ void InspectorInstrumentation::documentDetachedImpl(InstrumentingAgents& instrum
 
 void InspectorInstrumentation::frameWindowDiscardedImpl(InstrumentingAgents& instrumentingAgents, LocalDOMWindow* window)
 {
-    if (LIKELY(!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()))
+    if (!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()) [[likely]]
         return;
 
     if (!window)
@@ -640,7 +640,7 @@ void InspectorInstrumentation::didLoadResourceFromMemoryCacheImpl(InstrumentingA
 
 void InspectorInstrumentation::didReceiveResourceResponseImpl(InstrumentingAgents& instrumentingAgents, ResourceLoaderIdentifier identifier, DocumentLoader* loader, const ResourceResponse& response, ResourceLoader* resourceLoader)
 {
-    if (LIKELY(!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()))
+    if (!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()) [[likely]]
         return;
 
     if (auto* networkAgent = instrumentingAgents.enabledNetworkAgent())
@@ -669,7 +669,7 @@ void InspectorInstrumentation::didFinishLoadingImpl(InstrumentingAgents& instrum
 
 void InspectorInstrumentation::didFailLoadingImpl(InstrumentingAgents& instrumentingAgents, ResourceLoaderIdentifier identifier, DocumentLoader* loader, const ResourceError& error)
 {
-    if (LIKELY(!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()))
+    if (!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()) [[likely]]
         return;
 
     if (auto* networkAgent = instrumentingAgents.enabledNetworkAgent())
@@ -734,7 +734,7 @@ void InspectorInstrumentation::frameDetachedFromParentImpl(InstrumentingAgents& 
 
 void InspectorInstrumentation::didCommitLoadImpl(InstrumentingAgents& instrumentingAgents, LocalFrame& frame, DocumentLoader* loader)
 {
-    if (LIKELY(!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()))
+    if (!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()) [[likely]]
         return;
 
     if (!frame.page())
@@ -917,7 +917,7 @@ static bool isConsoleAssertMessage(MessageSource source, MessageType type)
 
 void InspectorInstrumentation::addMessageToConsoleImpl(InstrumentingAgents& instrumentingAgents, std::unique_ptr<ConsoleMessage> message)
 {
-    if (LIKELY(!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()))
+    if (!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()) [[likely]]
         return;
 
     MessageSource source = message->source();
@@ -935,7 +935,7 @@ void InspectorInstrumentation::addMessageToConsoleImpl(InstrumentingAgents& inst
 
 void InspectorInstrumentation::consoleCountImpl(InstrumentingAgents& instrumentingAgents, JSC::JSGlobalObject* state, const String& label)
 {
-    if (LIKELY(!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()))
+    if (!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()) [[likely]]
         return;
 
     if (auto* consoleAgent = instrumentingAgents.webConsoleAgent())
@@ -944,7 +944,7 @@ void InspectorInstrumentation::consoleCountImpl(InstrumentingAgents& instrumenti
 
 void InspectorInstrumentation::consoleCountResetImpl(InstrumentingAgents& instrumentingAgents, JSC::JSGlobalObject* state, const String& label)
 {
-    if (LIKELY(!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()))
+    if (!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()) [[likely]]
         return;
 
     if (auto* consoleAgent = instrumentingAgents.webConsoleAgent())
@@ -959,7 +959,7 @@ void InspectorInstrumentation::takeHeapSnapshotImpl(InstrumentingAgents& instrum
 
 void InspectorInstrumentation::startConsoleTimingImpl(InstrumentingAgents& instrumentingAgents, JSC::JSGlobalObject* exec, const String& label)
 {
-    if (LIKELY(!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()))
+    if (!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()) [[likely]]
         return;
 
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
@@ -970,7 +970,7 @@ void InspectorInstrumentation::startConsoleTimingImpl(InstrumentingAgents& instr
 
 void InspectorInstrumentation::logConsoleTimingImpl(InstrumentingAgents& instrumentingAgents, JSC::JSGlobalObject* exec, const String& label, Ref<Inspector::ScriptArguments>&& arguments)
 {
-    if (LIKELY(!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()))
+    if (!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()) [[likely]]
         return;
 
     if (auto* consoleAgent = instrumentingAgents.webConsoleAgent())
@@ -979,7 +979,7 @@ void InspectorInstrumentation::logConsoleTimingImpl(InstrumentingAgents& instrum
 
 void InspectorInstrumentation::stopConsoleTimingImpl(InstrumentingAgents& instrumentingAgents, JSC::JSGlobalObject* exec, const String& label)
 {
-    if (LIKELY(!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()))
+    if (!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()) [[likely]]
         return;
 
     if (auto* consoleAgent = instrumentingAgents.webConsoleAgent())

--- a/Source/WebCore/inspector/InspectorInstrumentationPublic.h
+++ b/Source/WebCore/inspector/InspectorInstrumentationPublic.h
@@ -28,8 +28,8 @@
 #include <atomic>
 namespace WebCore {
 
-#define FAST_RETURN_IF_NO_FRONTENDS(value)                       \
-    if (LIKELY(!InspectorInstrumentationPublic::hasFrontends())) \
+#define FAST_RETURN_IF_NO_FRONTENDS(value)                          \
+    if (!InspectorInstrumentationPublic::hasFrontends()) [[likely]] \
         return value;
 
 class WEBCORE_EXPORT InspectorInstrumentationPublic {

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -2162,7 +2162,7 @@ Ref<Inspector::Protocol::DOM::EventListener> InspectorDOMAgent::buildObjectForEv
                 // If the handler is not actually a function, see if it implements the EventListener interface and use that.
                 auto handleEventValue = handlerObject->get(globalObject, JSC::Identifier::fromString(vm, "handleEvent"_s));
 
-                if (UNLIKELY(scope.exception()))
+                if (scope.exception()) [[unlikely]]
                     scope.clearException();
 
                 if (handleEventValue)

--- a/Source/WebCore/layout/LayoutState.cpp
+++ b/Source/WebCore/layout/LayoutState.cpp
@@ -77,7 +77,7 @@ BoxGeometry& LayoutState::geometryForRootBox()
 
 BoxGeometry& LayoutState::ensureGeometryForBoxSlow(const Box& layoutBox)
 {
-    if (LIKELY(m_type == Type::Primary)) {
+    if (m_type == Type::Primary) [[likely]] {
 #if ASSERT_ENABLED
         ASSERT(!layoutBox.m_cachedGeometryForPrimaryLayoutState);
         ASSERT(!layoutBox.m_primaryLayoutState);

--- a/Source/WebCore/layout/LayoutState.h
+++ b/Source/WebCore/layout/LayoutState.h
@@ -143,7 +143,7 @@ private:
 
 inline bool LayoutState::hasBoxGeometry(const Box& layoutBox) const
 {
-    if (LIKELY(m_type == Type::Primary))
+    if (m_type == Type::Primary) [[likely]]
         return !!layoutBox.m_cachedGeometryForPrimaryLayoutState;
 
     return m_layoutBoxToBoxGeometry.contains(&layoutBox);
@@ -151,7 +151,7 @@ inline bool LayoutState::hasBoxGeometry(const Box& layoutBox) const
 
 inline BoxGeometry& LayoutState::ensureGeometryForBox(const Box& layoutBox)
 {
-    if (LIKELY(m_type == Type::Primary)) {
+    if (m_type == Type::Primary) [[likely]] {
         if (auto* boxGeometry = layoutBox.m_cachedGeometryForPrimaryLayoutState.get()) {
             ASSERT(layoutBox.m_primaryLayoutState == this);
             return *boxGeometry;
@@ -162,7 +162,7 @@ inline BoxGeometry& LayoutState::ensureGeometryForBox(const Box& layoutBox)
 
 inline const BoxGeometry& LayoutState::geometryForBox(const Box& layoutBox) const
 {
-    if (LIKELY(m_type == Type::Primary)) {
+    if (m_type == Type::Primary) [[likely]] {
         ASSERT(layoutBox.m_primaryLayoutState == this);
         return *layoutBox.m_cachedGeometryForPrimaryLayoutState;
     }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -60,7 +60,7 @@ static std::optional<WhitespaceContent> moveToNextNonWhitespacePosition(std::spa
     };
     auto nextNonWhiteSpacePosition = startPosition;
     while (nextNonWhiteSpacePosition < characters.size() && isWhitespaceCharacter(characters[nextNonWhiteSpacePosition])) {
-        if (UNLIKELY(stopAtWordSeparatorBoundary && hasWordSeparatorCharacter && !isWordSeparatorCharacter))
+        if (stopAtWordSeparatorBoundary && hasWordSeparatorCharacter && !isWordSeparatorCharacter) [[unlikely]]
             break;
         ++nextNonWhiteSpacePosition;
     }

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -94,7 +94,7 @@ InlineLayoutUnit TextUtil::width(const InlineTextBox& inlineTextBox, const FontC
     if (extendedMeasuring)
         width -= (spaceWidth(fontCascade, useSimplifiedContentMeasuring) + fontCascade.wordSpacing());
 
-    if (UNLIKELY(std::isnan(width) || std::isinf(width)))
+    if (std::isnan(width) || std::isinf(width)) [[unlikely]]
         return std::isnan(width) ? 0.0f : maxInlineLayoutUnit();
     return std::max(0.f, width);
 }
@@ -117,7 +117,7 @@ InlineLayoutUnit TextUtil::width(const InlineTextItem& inlineTextItem, const Fon
 
         if (singleWhiteSpace) {
             auto width = spaceWidth(fontCascade, useSimplifiedContentMeasuring);
-            if (UNLIKELY(std::isnan(width) || std::isinf(width)))
+            if (std::isnan(width) || std::isinf(width)) [[unlikely]]
                 return std::isnan(width) ? 0.0f : maxInlineLayoutUnit();
             return std::max(0.f, width);
         }
@@ -249,7 +249,7 @@ TextUtil::WordBreakLeft TextUtil::breakWord(const InlineTextBox& inlineTextBox, 
     ASSERT(length);
     auto& text = inlineTextBox.content();
 
-    if (UNLIKELY(!textWidth)) {
+    if (!textWidth) [[unlikely]] {
         ASSERT_NOT_REACHED();
         return { };
     }

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -57,7 +57,7 @@ Box::Box(ElementAttributes&& elementAttributes, RenderStyle&& style, std::unique
 
 Box::~Box()
 {
-    if (UNLIKELY(m_hasRareData))
+    if (m_hasRareData) [[unlikely]]
         removeRareData();
     if (m_renderer)
         m_renderer->clearLayoutBox();

--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -154,7 +154,7 @@ bool MixedContentChecker::frameAndAncestorsCanRunInsecureContent(LocalFrame& fra
         return false;
 
     bool allowed = !document->isStrictMixedContentMode() && frame.settings().allowRunningOfInsecureContent() && !frame.document()->geolocationAccessed() && !frame.document()->secureCookiesAccessed();
-    if (LIKELY(shouldLogWarning == ShouldLogWarning::Yes))
+    if (shouldLogWarning == ShouldLogWarning::Yes) [[likely]]
         logConsoleWarning(frame, allowed, "run"_s, url);
 
     if (allowed) {

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -890,7 +890,7 @@ bool ResourceLoader::shouldIncludeCertificateInfo() const
 {
     if (m_options.certificateInfoPolicy == CertificateInfoPolicy::IncludeCertificateInfo)
         return true;
-    if (UNLIKELY(InspectorInstrumentation::hasFrontends()))
+    if (InspectorInstrumentation::hasFrontends()) [[unlikely]]
         return true;
     return false;
 }

--- a/Source/WebCore/loader/SubresourceIntegrity.h
+++ b/Source/WebCore/loader/SubresourceIntegrity.h
@@ -41,7 +41,7 @@ std::optional<Vector<EncodedResourceCryptographicDigest>> parseIntegrityMetadata
 
 inline bool matchIntegrityMetadata(const CachedResource& resource, const String& integrityMetadata)
 {
-    if (LIKELY(integrityMetadata.isEmpty() && !resource.isHashReportingNeeded()))
+    if (integrityMetadata.isEmpty() && !resource.isHashReportingNeeded()) [[likely]]
         return true;
     bool result = matchIntegrityMetadataSlow(resource, integrityMetadata);
     if (result)

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -775,7 +775,7 @@ bool CachedImage::isOriginClean(SecurityOrigin* origin)
 
 CachedResource::RevalidationDecision CachedImage::makeRevalidationDecision(CachePolicy cachePolicy) const
 {
-    if (UNLIKELY(isManuallyCached())) {
+    if (isManuallyCached()) [[unlikely]] {
         // Do not revalidate manually cached images. This mechanism is used as a
         // way to efficiently share an image from the client to content and
         // the URL for that image may not represent a resource that can be

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -121,11 +121,11 @@ static inline ResourceErrorOr<CachedResourceHandle<T>> castCachedResourceTo(Reso
 
 static ScriptRequiresTelemetry scriptRequiresTelemetry(const Document* document, const ResourceRequest& request)
 {
-    if (UNLIKELY(!document))
+    if (!document) [[unlikely]]
         return ScriptRequiresTelemetry::No;
 
     RefPtr page = document->page();
-    if (UNLIKELY(!page))
+    if (!page) [[unlikely]]
         return ScriptRequiresTelemetry::No;
 
     return page->requiresScriptTelemetryForURL(request.url()) ? ScriptRequiresTelemetry::Yes : ScriptRequiresTelemetry::No;

--- a/Source/WebCore/page/DOMTimer.cpp
+++ b/Source/WebCore/page/DOMTimer.cpp
@@ -267,7 +267,7 @@ void DOMTimer::updateThrottlingStateIfNecessary(const DOMTimerFireState& fireSta
     if (!contextDocument)
         return;
 
-    if (UNLIKELY(!isDOMTimersThrottlingEnabled(*contextDocument))) {
+    if (!isDOMTimersThrottlingEnabled(*contextDocument)) [[unlikely]] {
         if (m_throttleState == ShouldThrottle) {
             // Unthrottle the timer in case it was throttled before the setting was updated.
             LOG(DOMTimers, "%p - Unthrottling DOM timer because throttling was disabled via settings.", this);

--- a/Source/WebCore/page/DebugPageOverlays.h
+++ b/Source/WebCore/page/DebugPageOverlays.h
@@ -81,7 +81,7 @@ private:
     static DebugPageOverlays* sharedDebugOverlays;
 };
 
-#define FAST_RETURN_IF_NO_OVERLAYS(page) if (LIKELY(!page || !hasOverlays(*page))) return;
+#define FAST_RETURN_IF_NO_OVERLAYS(page) if (!page || !hasOverlays(*page)) [[likely]] return;
 
 inline bool DebugPageOverlays::hasOverlays(Page& page)
 {
@@ -113,7 +113,7 @@ inline void DebugPageOverlays::didChangeEventHandlers(LocalFrame& frame)
 
 inline void DebugPageOverlays::doAfterUpdateRendering(Page& page)
 {
-    if (LIKELY(!hasOverlays(page)))
+    if (!hasOverlays(page)) [[likely]]
         return;
 
     sharedDebugOverlays->updateRegionIfNecessary(page, RegionType::WheelEventHandlers);
@@ -124,7 +124,7 @@ inline void DebugPageOverlays::doAfterUpdateRendering(Page& page)
 
 inline bool DebugPageOverlays::shouldPaintOverlayIntoLayerForRegionType(Page& page, RegionType regionType)
 {
-    if (LIKELY(!hasOverlays(page)))
+    if (!hasOverlays(page)) [[likely]]
         return false;
     return sharedDebugOverlays->shouldPaintOverlayIntoLayer(page, regionType);
 }

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -210,7 +210,7 @@ Node* FocusNavigationScope::parentInScope(const Node& node) const
     if (m_treeScopeRootNode == &node)
         return nullptr;
 
-    if (UNLIKELY(m_slotElement)) {
+    if (m_slotElement) [[unlikely]] {
         if (m_slotKind == SlotKind::Assigned) {
             if (m_slotElement == node.assignedSlot())
                 return nullptr;
@@ -227,7 +227,7 @@ Node* FocusNavigationScope::parentInScope(const Node& node) const
 
 Node* FocusNavigationScope::nextSiblingInScope(const Node& node) const
 {
-    if (UNLIKELY(m_slotElement && m_slotElement == node.assignedSlot())) {
+    if (m_slotElement && m_slotElement == node.assignedSlot()) [[unlikely]] {
         for (Node* current = node.nextSibling(); current; current = current->nextSibling()) {
             if (current->assignedSlot() == m_slotElement)
                 return current;
@@ -244,7 +244,7 @@ Node* FocusNavigationScope::nextSiblingInScope(const Node& node) const
 
 Node* FocusNavigationScope::previousSiblingInScope(const Node& node) const
 {
-    if (UNLIKELY(m_slotElement && m_slotElement == node.assignedSlot())) {
+    if (m_slotElement && m_slotElement == node.assignedSlot()) [[unlikely]] {
         for (Node* current = node.previousSibling(); current; current = current->previousSibling()) {
             if (current->assignedSlot() == m_slotElement)
                 return current;
@@ -261,7 +261,7 @@ Node* FocusNavigationScope::previousSiblingInScope(const Node& node) const
 
 Node* FocusNavigationScope::firstNodeInScope() const
 {
-    if (UNLIKELY(m_slotElement)) {
+    if (m_slotElement) [[unlikely]] {
         auto* assignedNodes = m_slotElement->assignedNodes();
         if (m_slotKind == SlotKind::Assigned) {
             ASSERT(assignedNodes);
@@ -279,7 +279,7 @@ Node* FocusNavigationScope::firstNodeInScope() const
 
 Node* FocusNavigationScope::lastNodeInScope() const
 {
-    if (UNLIKELY(m_slotElement)) {
+    if (m_slotElement) [[unlikely]] {
         auto* assignedNodes = m_slotElement->assignedNodes();
         if (m_slotKind == SlotKind::Assigned) {
             ASSERT(assignedNodes);

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -971,7 +971,7 @@ void LocalDOMWindow::processPostMessage(JSC::JSGlobalObject& lexicalGlobalObject
 
         auto ports = MessagePort::entanglePorts(*document, WTFMove(message.transferredPorts));
         auto event = MessageEvent::create(*globalObject, message.message.releaseNonNull(), sourceOrigin, { }, incumbentWindowProxy ? std::make_optional(MessageEventSource(WTFMove(incumbentWindowProxy))) : std::nullopt, WTFMove(ports));
-        if (UNLIKELY(scope.exception())) {
+        if (scope.exception()) [[unlikely]] {
             // Currently, we assume that the only way we can get here is if we have a termination.
             RELEASE_ASSERT(vm.hasPendingTerminationException());
             return;
@@ -2382,7 +2382,7 @@ void LocalDOMWindow::dispatchEvent(Event& event, EventTarget* target)
     // FIXME: It doesn't seem right to have the inspector instrumentation here since not all
     // events dispatched to the window object are guaranteed to flow through this function.
     // But the instrumentation prevents us from calling EventDispatcher::dispatchEvent here.
-    if (UNLIKELY(InspectorInstrumentation::hasFrontends())) {
+    if (InspectorInstrumentation::hasFrontends()) [[unlikely]] {
         protectedFrame = frame();
         hasListenersForEvent = hasEventListeners(event.type());
         if (hasListenersForEvent)
@@ -2463,7 +2463,7 @@ void LocalDOMWindow::setLocation(LocalDOMWindow& activeWindow, const URL& comple
         return;
 
     RefPtr frame = this->frame();
-    if (UNLIKELY(navigationState != CanNavigateState::Able))
+    if (navigationState != CanNavigateState::Able) [[unlikely]]
         navigationState = activeDocument->canNavigate(frame.get(), completedURL);
     if (navigationState == CanNavigateState::Unable)
         return;

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -1112,7 +1112,7 @@ inline void LocalFrameView::incrementVisuallyNonEmptyPixelCount(const IntSize& s
         return;
 
     auto area = size.area<RecordOverflow>() + m_visuallyNonEmptyPixelCount;
-    if (UNLIKELY(area.hasOverflowed()))
+    if (area.hasOverflowed()) [[unlikely]]
         m_visuallyNonEmptyPixelCount = std::numeric_limits<decltype(m_visuallyNonEmptyPixelCount)>::max();
     else
         m_visuallyNonEmptyPixelCount = area;

--- a/Source/WebCore/page/OpportunisticTaskScheduler.cpp
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.cpp
@@ -84,7 +84,7 @@ void OpportunisticTaskScheduler::runLoopObserverFired()
         return;
 #endif
 
-    if (UNLIKELY(!m_page))
+    if (!m_page) [[unlikely]]
         return;
 
     RefPtr page = m_page.get();

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2236,7 +2236,7 @@ void Page::updateRendering()
 
     m_renderingUpdateRemainingSteps.last().remove(RenderingUpdateStep::WheelEventMonitorCallbacks);
 
-    if (UNLIKELY(isMonitoringWheelEvents()))
+    if (isMonitoringWheelEvents()) [[unlikely]]
         wheelEventTestMonitor()->checkShouldFireCallbacks();
 
     if (m_isTrackingRenderingUpdates)

--- a/Source/WebCore/page/PageConsoleClient.cpp
+++ b/Source/WebCore/page/PageConsoleClient.cpp
@@ -156,7 +156,7 @@ void PageConsoleClient::addMessage(std::unique_ptr<Inspector::ConsoleMessage>&& 
         page->chrome().client().addMessageToConsole(consoleMessage->source(), consoleMessage->level(), message, consoleMessage->line(), consoleMessage->column(), consoleMessage->url());
         page->chrome().client().addMessageWithArgumentsToConsole(consoleMessage->source(), consoleMessage->level(), message, additionalArguments, consoleMessage->line(), consoleMessage->column(), consoleMessage->url());
 
-        if (UNLIKELY(page->settings().logsPageMessagesToSystemConsoleEnabled() || shouldPrintExceptions()))
+        if (page->settings().logsPageMessagesToSystemConsoleEnabled() || shouldPrintExceptions()) [[unlikely]]
             logMessageToSystemConsole(*consoleMessage);
     }
 
@@ -308,7 +308,7 @@ static CanvasRenderingContext* canvasRenderingContext(JSC::VM& vm, JSC::JSValue 
 
 void PageConsoleClient::record(JSC::JSGlobalObject* lexicalGlobalObject, Ref<ScriptArguments>&& arguments)
 {
-    if (LIKELY(!InspectorInstrumentation::hasFrontends()))
+    if (!InspectorInstrumentation::hasFrontends()) [[likely]]
         return;
 
     if (auto* target = objectArgumentAt(arguments, 0)) {
@@ -319,7 +319,7 @@ void PageConsoleClient::record(JSC::JSGlobalObject* lexicalGlobalObject, Ref<Scr
 
 void PageConsoleClient::recordEnd(JSC::JSGlobalObject* lexicalGlobalObject, Ref<ScriptArguments>&& arguments)
 {
-    if (LIKELY(!InspectorInstrumentation::hasFrontends()))
+    if (!InspectorInstrumentation::hasFrontends()) [[likely]]
         return;
 
     if (auto* target = objectArgumentAt(arguments, 0)) {
@@ -341,7 +341,7 @@ void PageConsoleClient::screenshot(JSC::JSGlobalObject* lexicalGlobalObject, Ref
 
         if (auto* node = JSNode::toWrapped(vm, possibleTarget)) {
             target = possibleTarget;
-            if (UNLIKELY(InspectorInstrumentation::hasFrontends())) {
+            if (InspectorInstrumentation::hasFrontends()) [[unlikely]] {
                 RefPtr<ImageBuffer> snapshot;
 
                 // Only try to do something special for subclasses of Node if they're detached from the DOM tree.
@@ -390,7 +390,7 @@ void PageConsoleClient::screenshot(JSC::JSGlobalObject* lexicalGlobalObject, Ref
             }
         } else if (auto* imageData = JSImageData::toWrapped(vm, possibleTarget)) {
             target = possibleTarget;
-            if (UNLIKELY(InspectorInstrumentation::hasFrontends())) {
+            if (InspectorInstrumentation::hasFrontends()) [[unlikely]] {
                 auto sourceSize = imageData->size();
                 if (auto imageBuffer = ImageBuffer::create(sourceSize, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), ImageBufferPixelFormat::BGRA8)) {
                     IntRect sourceRect(IntPoint(), sourceSize);
@@ -400,19 +400,19 @@ void PageConsoleClient::screenshot(JSC::JSGlobalObject* lexicalGlobalObject, Ref
             }
         } else if (auto* imageBitmap = JSImageBitmap::toWrapped(vm, possibleTarget)) {
             target = possibleTarget;
-            if (UNLIKELY(InspectorInstrumentation::hasFrontends())) {
+            if (InspectorInstrumentation::hasFrontends()) [[unlikely]] {
                 if (auto* imageBuffer = imageBitmap->buffer())
                     dataURL = imageBuffer->toDataURL("image/png"_s, std::nullopt, PreserveResolution::Yes);
             }
         } else if (auto* context = canvasRenderingContext(vm, possibleTarget)) {
             target = possibleTarget;
-            if (UNLIKELY(InspectorInstrumentation::hasFrontends())) {
+            if (InspectorInstrumentation::hasFrontends()) [[unlikely]] {
                 if (auto result = InspectorCanvas::getContentAsDataURL(*context))
                     dataURL = result.value();
             }
         } else if (auto* rect = JSDOMRectReadOnly::toWrapped(vm, possibleTarget)) {
             target = possibleTarget;
-            if (UNLIKELY(InspectorInstrumentation::hasFrontends())) {
+            if (InspectorInstrumentation::hasFrontends()) [[unlikely]] {
                 if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame())) {
                     if (auto snapshot = WebCore::snapshotFrameRect(*localMainFrame, enclosingIntRect(rect->toFloatRect()), { { }, ImageBufferPixelFormat::BGRA8, DestinationColorSpace::SRGB() }))
                         dataURL = snapshot->toDataURL("image/png"_s, std::nullopt, PreserveResolution::Yes);
@@ -427,7 +427,7 @@ void PageConsoleClient::screenshot(JSC::JSGlobalObject* lexicalGlobalObject, Ref
         }
     }
 
-    if (UNLIKELY(InspectorInstrumentation::hasFrontends())) {
+    if (InspectorInstrumentation::hasFrontends()) [[unlikely]] {
         if (!target) {
             if (RefPtr localMainFrame = m_page->localMainFrame()) {
                 // If no target is provided, capture an image of the viewport.

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1553,11 +1553,13 @@ String Quirks::scriptToEvaluateBeforeRunningScriptFromURL(const URL& scriptURL)
         return { };
 
     // player.anyclip.com rdar://138789765
-    if (UNLIKELY(m_quirksData.isThesaurus && scriptURL.lastPathComponent().endsWith("lre.js"_s)) && scriptURL.host() == "player.anyclip.com"_s)
-        return "(function() { let userAgent = navigator.userAgent; Object.defineProperty(navigator, 'userAgent', { get: () => { return userAgent + ' Chrome/130.0.0.0 Android/15.0'; }, configurable: true }); })();"_s;
+    if (m_quirksData.isThesaurus && scriptURL.lastPathComponent().endsWith("lre.js"_s)) [[unlikely]] {
+        if (scriptURL.host() == "player.anyclip.com"_s)
+            return "(function() { let userAgent = navigator.userAgent; Object.defineProperty(navigator, 'userAgent', { get: () => { return userAgent + ' Chrome/130.0.0.0 Android/15.0'; }, configurable: true }); })();"_s;
+    }
 
 #if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
-    if (UNLIKELY(m_quirksData.isWebEx && scriptURL.lastPathComponent().startsWith("pushdownload."_s)))
+    if (m_quirksData.isWebEx && scriptURL.lastPathComponent().startsWith("pushdownload."_s)) [[unlikely]]
         return "Object.defineProperty(window, 'Touch', { get: () => undefined });"_s;
 #endif
 #else
@@ -1776,14 +1778,14 @@ bool Quirks::needsFacebookStoriesCreationFormQuirk(const Element& element, const
 
     Ref document = element.document();
     RefPtr loader = document->loader();
-    if (UNLIKELY(!loader))
+    if (!loader) [[unlikely]]
         return false;
 
     if (loader->metaViewportPolicy() != MetaViewportPolicy::Ignore)
         return false;
 
     RefPtr view = document->view();
-    if (UNLIKELY(!view))
+    if (!view) [[unlikely]]
         return false;
 
     float width = view->sizeForCSSDefaultViewportUnits().width();
@@ -1855,7 +1857,7 @@ bool Quirks::shouldSupportHoverMediaQueries() const
 
 URL Quirks::topDocumentURL() const
 {
-    if (UNLIKELY(!m_topDocumentURLForTesting.isEmpty()))
+    if (!m_topDocumentURLForTesting.isEmpty()) [[unlikely]]
         return m_topDocumentURLForTesting;
 
     return m_document->topURL();

--- a/Source/WebCore/page/RemoteDOMWindow.cpp
+++ b/Source/WebCore/page/RemoteDOMWindow.cpp
@@ -141,7 +141,7 @@ void RemoteDOMWindow::setLocation(LocalDOMWindow& activeWindow, const URL& compl
         return;
 
     RefPtr frame = this->frame();
-    if (UNLIKELY(navigationState != CanNavigateState::Able))
+    if (navigationState != CanNavigateState::Able) [[unlikely]]
         navigationState = activeDocument->canNavigate(frame.get(), completedURL);
     if (navigationState == CanNavigateState::Unable)
         return;

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -224,7 +224,7 @@ static inline void merge(Item& destinationItem, Item&& sourceItem)
 static inline FloatRect rootViewBounds(Node& node)
 {
     auto view = node.document().protectedView();
-    if (UNLIKELY(!view))
+    if (!view) [[unlikely]]
         return { };
 
     CheckedPtr renderer = node.renderer();

--- a/Source/WebCore/page/writing-tools/WritingToolsController.mm
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.mm
@@ -245,7 +245,7 @@ void WritingToolsController::willBeginWritingToolsSession(const std::optional<Wr
     // Postcondition: the selected text character range must be a valid range within the
     // attributed string formed by the context range; the length of the entire context range
     // being equal to the length of the attributed string implies the range is valid.
-    if (UNLIKELY(attributedStringCharacterCount != contextRangeCharacterCount)) {
+    if (attributedStringCharacterCount != contextRangeCharacterCount) [[unlikely]] {
         RELEASE_LOG_ERROR(WritingTools, "WritingToolsController::willBeginWritingToolsSession (%s) => attributed string length (%u) != context range length (%llu)", session->identifier.toString().utf8().data(), attributedStringCharacterCount, contextRangeCharacterCount);
         ASSERT_NOT_REACHED();
         completionHandler({ });
@@ -600,7 +600,7 @@ void WritingToolsController::compositionSessionDidReceiveTextWithReplacementRang
 
     // Precondition: the range is always relative to the context's attributed text, so by definition it must
     // be strictly less than the length of the attributed string.
-    if (UNLIKELY(contextTextCharacterCount < range.location + range.length)) {
+    if (contextTextCharacterCount < range.location + range.length) [[unlikely]] {
         RELEASE_LOG_ERROR(WritingTools, "WritingToolsController::compositionSessionDidReceiveTextWithReplacementRange (%s) => trying to replace a range larger than the context range (context range length: %u, range.location %llu, range.length %llu)", state->session.identifier.toString().utf8().data(), contextTextCharacterCount, range.location, range.length);
         compositionSessionDidFinishReplacement();
         ASSERT_NOT_REACHED();
@@ -630,7 +630,7 @@ void WritingToolsController::compositionSessionDidReceiveTextWithReplacementRang
     auto sessionRange = state->reappliedCommands.last()->endingContextRange();
     auto sessionRangeCharacterCount = characterCount(sessionRange);
 
-    if (UNLIKELY(range.length + sessionRangeCharacterCount < contextTextCharacterCount)) {
+    if (range.length + sessionRangeCharacterCount < contextTextCharacterCount) [[unlikely]] {
         RELEASE_LOG_ERROR(WritingTools, "WritingToolsController::compositionSessionDidReceiveTextWithReplacementRange (%s) => the range offset by the character count delta must have a non-negative size (context range length: %u, range.length %llu, session length: %llu)", state->session.identifier.toString().utf8().data(), contextTextCharacterCount, range.length, sessionRangeCharacterCount);
         compositionSessionDidFinishReplacement();
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/LayoutUnit.h
+++ b/Source/WebCore/platform/LayoutUnit.h
@@ -144,7 +144,7 @@ public:
 
     int ceil() const
     {
-        if (UNLIKELY(m_value >= INT_MAX - kFixedPointDenominator + 1))
+        if (m_value >= INT_MAX - kFixedPointDenominator + 1) [[unlikely]]
             return intMaxForLayoutUnit;
         if (m_value >= 0)
             return (m_value + kFixedPointDenominator - 1) / kFixedPointDenominator;
@@ -158,7 +158,7 @@ public:
 
     int floor() const
     {
-        if (UNLIKELY(m_value <= INT_MIN + kFixedPointDenominator - 1))
+        if (m_value <= INT_MIN + kFixedPointDenominator - 1) [[unlikely]]
             return intMinForLayoutUnit;
         return m_value >> kLayoutUnitFractionalBits;
     }

--- a/Source/WebCore/platform/ThreadGlobalData.cpp
+++ b/Source/WebCore/platform/ThreadGlobalData.cpp
@@ -78,7 +78,7 @@ ThreadGlobalData& threadGlobalDataSlow()
 {
     auto& thread = Thread::currentSingleton();
     auto* clientData = thread.m_clientData.get();
-    if (UNLIKELY(clientData))
+    if (clientData) [[unlikely]]
         return *static_cast<ThreadGlobalData*>(clientData);
 
     auto data = adoptRef(*new ThreadGlobalData);
@@ -98,7 +98,7 @@ ThreadGlobalData& threadGlobalDataSlow()
 {
     auto& thread = Thread::currentSingleton();
     auto* clientData = thread.m_clientData.get();
-    if (UNLIKELY(clientData))
+    if (clientData) [[unlikely]]
         return *static_cast<ThreadGlobalData*>(clientData);
 
     auto data = adoptRef(*new ThreadGlobalData);

--- a/Source/WebCore/platform/ThreadGlobalData.h
+++ b/Source/WebCore/platform/ThreadGlobalData.h
@@ -57,28 +57,28 @@ public:
     const CachedResourceRequestInitiatorTypes& cachedResourceRequestInitiatorTypes()
     {
         ASSERT(!m_destroyed);
-        if (UNLIKELY(!m_cachedResourceRequestInitiatorTypes))
+        if (!m_cachedResourceRequestInitiatorTypes) [[unlikely]]
             initializeCachedResourceRequestInitiatorTypes();
         return *m_cachedResourceRequestInitiatorTypes;
     }
     EventNames& eventNames()
     {
         ASSERT(!m_destroyed);
-        if (UNLIKELY(!m_eventNames))
+        if (!m_eventNames) [[unlikely]]
             initializeEventNames();
         return *m_eventNames;
     }
     QualifiedNameCache& qualifiedNameCache()
     {
         ASSERT(!m_destroyed);
-        if (UNLIKELY(!m_qualifiedNameCache))
+        if (!m_qualifiedNameCache) [[unlikely]]
             initializeQualifiedNameCache();
         return *m_qualifiedNameCache;
     }
     const MIMETypeRegistryThreadGlobalData& mimeTypeRegistryThreadGlobalData()
     {
         ASSERT(!m_destroyed);
-        if (UNLIKELY(!m_MIMETypeRegistryThreadGlobalData))
+        if (!m_MIMETypeRegistryThreadGlobalData) [[unlikely]]
             initializeMimeTypeRegistryThreadGlobalData();
         return *m_MIMETypeRegistryThreadGlobalData;
     }
@@ -98,7 +98,7 @@ public:
     FontCache& fontCache()
     {
         ASSERT(!m_destroyed);
-        if (UNLIKELY(!m_fontCache))
+        if (!m_fontCache) [[unlikely]]
             initializeFontCache();
         return *m_fontCache;
     }
@@ -146,14 +146,14 @@ inline PURE_FUNCTION ThreadGlobalData& threadGlobalData()
 #endif
 {
 #if HAVE(FAST_TLS)
-    if (auto* thread = Thread::currentMayBeNull(); LIKELY(thread)) {
-        if (auto* clientData = thread->m_clientData.get(); LIKELY(clientData))
+    if (auto* thread = Thread::currentMayBeNull(); thread) [[likely]] {
+        if (auto* clientData = thread->m_clientData.get(); clientData) [[likely]]
             return *static_cast<ThreadGlobalData*>(clientData);
     }
 #else
     auto& thread = Thread::currentSingleton();
     auto* clientData = thread.m_clientData.get();
-    if (LIKELY(clientData))
+    if (clientData) [[likely]]
         return *static_cast<ThreadGlobalData*>(clientData);
 #endif
     return threadGlobalDataSlow();

--- a/Source/WebCore/platform/WebCorePersistentCoders.cpp
+++ b/Source/WebCore/platform/WebCorePersistentCoders.cpp
@@ -338,7 +338,7 @@ static std::optional<RetainPtr<CFDataRef>> decodeCFData(Decoder& decoder)
     std::optional<uint64_t> size;
     decoder >> size;
 
-    if (UNLIKELY(!isInBounds<size_t>(*size)))
+    if (!isInBounds<size_t>(*size)) [[unlikely]]
         return std::nullopt;
 
     auto buffer = decoder.bufferPointerForDirectRead(static_cast<size_t>(*size));

--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
@@ -182,7 +182,7 @@ AudioDestinationGStreamer::AudioDestinationGStreamer(const CreationOptions& opti
 AudioDestinationGStreamer::~AudioDestinationGStreamer()
 {
     GST_DEBUG_OBJECT(m_pipeline.get(), "Disposing");
-    if (LIKELY(m_src))
+    if (m_src) [[likely]]
         g_object_set(m_src.get(), "destination", nullptr, nullptr);
     unregisterPipeline(m_pipeline);
     disconnectSimpleBusMessageCallback(m_pipeline.get());

--- a/Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp
@@ -438,7 +438,7 @@ static GstStateChangeReturn webKitWebAudioSrcChangeState(GstElement* element, Gs
     }
 
     returnValue = GST_ELEMENT_CLASS(webkit_web_audio_src_parent_class)->change_state(element, transition);
-    if (UNLIKELY(returnValue == GST_STATE_CHANGE_FAILURE)) {
+    if (returnValue == GST_STATE_CHANGE_FAILURE) [[unlikely]] {
         GST_DEBUG_OBJECT(src, "State change failed");
         return returnValue;
     }

--- a/Source/WebCore/platform/graphics/FloatQuad.cpp
+++ b/Source/WebCore/platform/graphics/FloatQuad.cpp
@@ -79,7 +79,7 @@ inline bool isPointInTriangle(const FloatPoint& p, const FloatPoint& t1, const F
 
 static inline float clampToIntRange(float value)
 {
-    if (UNLIKELY(std::isinf(value) || std::abs(value) > (static_cast<float>(std::numeric_limits<int>::max()))))
+    if (std::isinf(value) || std::abs(value) > (static_cast<float>(std::numeric_limits<int>::max()))) [[unlikely]]
         return std::signbit(value) ? std::numeric_limits<int>::min() : (static_cast<float>(std::numeric_limits<int>::max()));
 
     return value;

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -435,10 +435,10 @@ ALWAYS_INLINE FloatRect Font::boundsForGlyph(Glyph glyph) const
 ALWAYS_INLINE Vector<FloatRect, Font::inlineGlyphRunCapacity> Font::boundsForGlyphs(std::span<const Glyph> glyphs) const
 {
     const auto glyphCount = glyphs.size();
-    if (UNLIKELY(!glyphCount))
+    if (!glyphCount) [[unlikely]]
         return { };
 
-    if (UNLIKELY(glyphCount == 1))
+    if (glyphCount == 1) [[unlikely]]
         return { boundsForGlyph(glyphs[0]) };
 
     Vector<Glyph, inlineGlyphRunCapacity> glyphsNeedingMeasurement;

--- a/Source/WebCore/platform/graphics/Region.cpp
+++ b/Source/WebCore/platform/graphics/Region.cpp
@@ -626,33 +626,33 @@ bool Region::Shape::isValidShape(std::span<const int> segments, std::span<const 
         return !segmentsSize;
     if (!segmentsSize)
         return !spansSize;
-    if (UNLIKELY(spansSize == 1))
+    if (spansSize == 1) [[unlikely]]
         return false;
-    if (UNLIKELY(segmentsSize % 2))
+    if (segmentsSize % 2) [[unlikely]]
         return false;
     for (size_t i = 0; i < spansSize; ++i) {
         auto& span = spans[i];
-        if (UNLIKELY(span.segmentIndex > segmentsSize))
+        if (span.segmentIndex > segmentsSize) [[unlikely]]
             return false;
-        if (UNLIKELY(span.segmentIndex % 2))
+        if (span.segmentIndex % 2) [[unlikely]]
             return false;
 
         if (i < spansSize - 1) {
             auto& nextSpan = spans[i + 1];
 
-            if (UNLIKELY(span.y >= nextSpan.y))
+            if (span.y >= nextSpan.y) [[unlikely]]
                 return false;
-            if (UNLIKELY(span.segmentIndex > nextSpan.segmentIndex))
+            if (span.segmentIndex > nextSpan.segmentIndex) [[unlikely]]
                 return false;
 
             std::span spanSegments = segmentsForSpanSegmentIndices(segments, span.segmentIndex, nextSpan.segmentIndex);
             int lastX = std::numeric_limits<int>::min();
             for (int segment : spanSegments) {
-                if (UNLIKELY(lastX > segment))
+                if (lastX > segment) [[unlikely]]
                     return false;
                 lastX = segment;
             }
-        } else if (UNLIKELY(span.segmentIndex != segments.size()))
+        } else if (span.segmentIndex != segments.size()) [[unlikely]]
             return false;
     }
     return true;

--- a/Source/WebCore/platform/graphics/WidthCache.h
+++ b/Source/WebCore/platform/graphics/WidthCache.h
@@ -120,7 +120,7 @@ public:
         unsigned length = text.length();
 
         // Do not allow length = 0. This allows SmallStringKey empty-value-is-zero.
-        if (UNLIKELY(!length))
+        if (!length) [[unlikely]]
             return nullptr;
 
         if (length > SmallStringKey::capacity())

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -2938,16 +2938,16 @@ void GraphicsContextGLANGLE::bindExternalImage(GCGLenum, GCGLExternalImage)
 
 void GraphicsContextGLANGLE::deleteExternalImage(GCGLExternalImage image)
 {
-    if (UNLIKELY(!image))
+    if (!image) [[unlikely]]
         return;
     auto eglImage = m_eglImages.take(image);
-    if (UNLIKELY(!eglImage)) {
+    if (!eglImage) [[unlikely]] {
         addError(GCGLErrorCode::InvalidOperation);
         return;
     }
     bool result = EGL_DestroyImageKHR(platformDisplay(), eglImage);
     ASSERT(result);
-    if (UNLIKELY(!result))
+    if (!result) [[unlikely]]
         addError(GCGLErrorCode::InvalidOperation);
 }
 
@@ -2960,16 +2960,16 @@ GCGLExternalSync GraphicsContextGLANGLE::createExternalSync(ExternalSyncSource&&
 
 void GraphicsContextGLANGLE::deleteExternalSync(GCGLExternalSync sync)
 {
-    if (UNLIKELY(!sync))
+    if (!sync) [[unlikely]]
         return;
     EGLSync eglSync = m_eglSyncs.take(sync);
-    if (UNLIKELY(!eglSync)) {
+    if (!eglSync) [[unlikely]] {
         addError(GCGLErrorCode::InvalidOperation);
         return;
     }
     bool result = EGL_DestroySync(platformDisplay(), eglSync);
     ASSERT(result);
-    if (UNLIKELY(!result))
+    if (!result) [[unlikely]]
         addError(GCGLErrorCode::InvalidOperation);
 }
 

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -436,7 +436,7 @@ void GraphicsLayerCA::initialize(Type layerType)
 
 GraphicsLayerCA::~GraphicsLayerCA()
 {
-    if (UNLIKELY(isTrackingDisplayListReplay()))
+    if (isTrackingDisplayListReplay()) [[unlikely]]
         layerDisplayListMap().remove(this);
 
     // We release our references to the PlatformCALayers here, but do not actively unparent them,
@@ -2019,7 +2019,7 @@ void GraphicsLayerCA::platformCALayerPaintContents(PlatformCALayer*, GraphicsCon
     if (m_displayList) {
         context.drawDisplayList(*m_displayList);
         
-        if (UNLIKELY(isTrackingDisplayListReplay())) {
+        if (isTrackingDisplayListReplay()) [[unlikely]] {
             // Original purpose of the code was to track playback time optimizations. However, there are no such things, and as such we
             // use the original.
             layerDisplayListMap().add(this, std::make_pair(clip, Ref { *m_displayList }));

--- a/Source/WebCore/platform/graphics/ca/TileGrid.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.cpp
@@ -599,7 +599,7 @@ IntRect TileGrid::ensureTilesForRect(const FloatRect& rect, HashSet<TileIndex>& 
 
             UncheckedKeyHashMap<TileIndex, TileInfo>::iterator it;
             constexpr size_t kMaxTileCountPerGrid = 6 * 1024;
-            if (UNLIKELY(m_tiles.size() >= kMaxTileCountPerGrid)) {
+            if (m_tiles.size() >= kMaxTileCountPerGrid) [[unlikely]] {
                 it = m_tiles.find(tileIndex);
                 if (it == m_tiles.end())
                     continue;

--- a/Source/WebCore/platform/graphics/cairo/RefPtrCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/RefPtrCairo.cpp
@@ -27,79 +27,79 @@ namespace WTF {
 
 cairo_t* DefaultRefDerefTraits<cairo_t>::refIfNotNull(cairo_t* ptr)
 {
-    if (LIKELY(ptr))
+    if (ptr) [[likely]]
         cairo_reference(ptr);
     return ptr;
 }
 
 void DefaultRefDerefTraits<cairo_t>::derefIfNotNull(cairo_t* ptr)
 {
-    if (LIKELY(ptr))
+    if (ptr) [[likely]]
         cairo_destroy(ptr);
 }
 
 cairo_surface_t* DefaultRefDerefTraits<cairo_surface_t>::refIfNotNull(cairo_surface_t* ptr)
 {
-    if (LIKELY(ptr))
+    if (ptr) [[likely]]
         cairo_surface_reference(ptr);
     return ptr;
 }
 
 void DefaultRefDerefTraits<cairo_surface_t>::derefIfNotNull(cairo_surface_t* ptr)
 {
-    if (LIKELY(ptr))
+    if (ptr) [[likely]]
         cairo_surface_destroy(ptr);
 }
 
 cairo_font_face_t* DefaultRefDerefTraits<cairo_font_face_t>::refIfNotNull(cairo_font_face_t* ptr)
 {
-    if (LIKELY(ptr))
+    if (ptr) [[likely]]
         cairo_font_face_reference(ptr);
     return ptr;
 }
 
 void DefaultRefDerefTraits<cairo_font_face_t>::derefIfNotNull(cairo_font_face_t* ptr)
 {
-    if (LIKELY(ptr))
+    if (ptr) [[likely]]
         cairo_font_face_destroy(ptr);
 }
 
 cairo_scaled_font_t* DefaultRefDerefTraits<cairo_scaled_font_t>::refIfNotNull(cairo_scaled_font_t* ptr)
 {
-    if (LIKELY(ptr))
+    if (ptr) [[likely]]
         cairo_scaled_font_reference(ptr);
     return ptr;
 }
 
 void DefaultRefDerefTraits<cairo_scaled_font_t>::derefIfNotNull(cairo_scaled_font_t* ptr)
 {
-    if (LIKELY(ptr))
+    if (ptr) [[likely]]
         cairo_scaled_font_destroy(ptr);
 }
 
 cairo_pattern_t* DefaultRefDerefTraits<cairo_pattern_t>::refIfNotNull(cairo_pattern_t* ptr)
 {
-    if (LIKELY(ptr))
+    if (ptr) [[likely]]
         cairo_pattern_reference(ptr);
     return ptr;
 }
 
 void DefaultRefDerefTraits<cairo_pattern_t>::derefIfNotNull(cairo_pattern_t* ptr)
 {
-    if (LIKELY(ptr))
+    if (ptr) [[likely]]
         cairo_pattern_destroy(ptr);
 }
 
 cairo_region_t* DefaultRefDerefTraits<cairo_region_t>::refIfNotNull(cairo_region_t* ptr)
 {
-    if (LIKELY(ptr))
+    if (ptr) [[likely]]
         cairo_region_reference(ptr);
     return ptr;
 }
 
 void DefaultRefDerefTraits<cairo_region_t>::derefIfNotNull(cairo_region_t* ptr)
 {
-    if (LIKELY(ptr))
+    if (ptr) [[likely]]
         cairo_region_destroy(ptr);
 }
 

--- a/Source/WebCore/platform/graphics/cg/PathCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/PathCG.cpp
@@ -581,11 +581,11 @@ static inline void addToCGContextPath(CGContextRef context, PathSegment anySegme
 
 void addToCGContextPath(CGContextRef context, const Path& path)
 {
-    if (auto* singleSegment = path.singleSegmentIfExists(); LIKELY(singleSegment)) {
+    if (auto* singleSegment = path.singleSegmentIfExists(); singleSegment) [[likely]] {
         addToCGContextPath(context, *singleSegment);
         return;
     }
-    if (auto* segments = path.segmentsIfExists(); LIKELY(segments)) {
+    if (auto* segments = path.segmentsIfExists(); segments) [[likely]] {
         for (auto& segment : *segments)
             addToCGContextPath(context, segment);
         return;

--- a/Source/WebCore/platform/graphics/cg/UTIRegistry.mm
+++ b/Source/WebCore/platform/graphics/cg/UTIRegistry.mm
@@ -186,7 +186,7 @@ String preferredExtensionForImageType(const String& uti)
 
     RetainPtr type = [UTType typeWithIdentifier:uti.createNSString().get()];
     String extension = type.get().preferredFilenameExtension;
-    if (UNLIKELY(oldExtension != extension)) {
+    if (oldExtension != extension) [[unlikely]] {
         std::array<uint64_t, 6> values { 0, 0, 0, 0, 0, 0 };
         auto utiInfo = makeString(uti, '~', oldExtension, '~', extension);
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -875,7 +875,7 @@ void GraphicsContextGLCocoa::insertFinishedSignalOrInvoke(Function<void()> signa
         blockSignal();
     }];
     auto sync = createExternalSync(event, signalValue);
-    if (UNLIKELY(!sync)) {
+    if (!sync) [[unlikely]] {
         event.signaledValue = signalValue;
         ASSERT_NOT_REACHED();
         return;

--- a/Source/WebCore/platform/graphics/filters/FilterImage.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.cpp
@@ -144,7 +144,7 @@ static void copyImageBytes(const PixelBuffer& sourcePixelBuffer, PixelBuffer& de
 
     auto destinationSize = destinationPixelBuffer.size();
     auto rowBytes = CheckedUint32(destinationSize.width()) * 4;
-    if (UNLIKELY(rowBytes.hasOverflowed()))
+    if (rowBytes.hasOverflowed()) [[unlikely]]
         return;
 
     ConstPixelBufferConversionView source { sourcePixelBuffer.format(), rowBytes, sourcePixelBuffer.bytes() };
@@ -184,7 +184,7 @@ static void copyImageBytes(const PixelBuffer& sourcePixelBuffer, PixelBuffer& de
     auto destinationOffset = destinationRect.y() * destinationBytesPerRow + CheckedUint32(destinationRect.x()) * 4;
     auto sourceOffset = sourceRectClipped.y() * sourceBytesPerRow + CheckedUint32(sourceRectClipped.x()) * 4;
 
-    if (UNLIKELY(size.hasOverflowed() || destinationBytesPerRow.hasOverflowed() || sourceBytesPerRow.hasOverflowed() || destinationOffset.hasOverflowed() || sourceOffset.hasOverflowed()))
+    if (size.hasOverflowed() || destinationBytesPerRow.hasOverflowed() || sourceBytesPerRow.hasOverflowed() || destinationOffset.hasOverflowed() || sourceOffset.hasOverflowed()) [[unlikely]]
         return;
 
     auto destinationPixel = destinationPixelBuffer.bytes().subspan(destinationOffset.value());

--- a/Source/WebCore/platform/graphics/freetype/RefPtrFontconfig.cpp
+++ b/Source/WebCore/platform/graphics/freetype/RefPtrFontconfig.cpp
@@ -27,27 +27,27 @@ namespace WTF {
 
 FcPattern* DefaultRefDerefTraits<FcPattern>::refIfNotNull(FcPattern* ptr)
 {
-    if (LIKELY(ptr))
+    if (ptr) [[likely]]
         FcPatternReference(ptr);
     return ptr;
 }
 
 void DefaultRefDerefTraits<FcPattern>::derefIfNotNull(FcPattern* ptr)
 {
-    if (LIKELY(ptr))
+    if (ptr) [[likely]]
         FcPatternDestroy(ptr);
 }
 
 FcConfig* DefaultRefDerefTraits<FcConfig>::refIfNotNull(FcConfig* ptr)
 {
-    if (LIKELY(ptr))
+    if (ptr) [[likely]]
         FcConfigReference(ptr);
     return ptr;
 }
 
 void DefaultRefDerefTraits<FcConfig>::derefIfNotNull(FcConfig* ptr)
 {
-    if (LIKELY(ptr))
+    if (ptr) [[likely]]
         FcConfigDestroy(ptr);
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1319,7 +1319,7 @@ static std::optional<RefPtr<JSON::Value>> gstStructureValueToJSON(const GValue* 
 #if USE(GSTREAMER_WEBRTC)
     if (valueType == GST_TYPE_WEBRTC_STATS_TYPE) {
         auto name = webrtcStatsTypeName(g_value_get_enum(value));
-        if (LIKELY(!name.isEmpty()))
+        if (!name.isEmpty()) [[likely]]
             return JSON::Value::create(makeString(name))->asValue();
     }
 #endif

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp
@@ -109,7 +109,9 @@ public:
             GstCaps* caps;
             gboolean needPool;
             gst_query_parse_allocation(query, &caps, &needPool);
-            if (UNLIKELY(!caps) || !needPool)
+            if (!caps) [[unlikely]]
+                return GST_PAD_PROBE_OK;
+            if (!needPool)
                 return GST_PAD_PROBE_OK;
 
             unsigned size;

--- a/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerCairo.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerCairo.cpp
@@ -44,7 +44,7 @@ ImageGStreamer::ImageGStreamer(GRefPtr<GstSample>&& sample)
     ASSERT(GST_VIDEO_INFO_IS_RGB(&videoInfo));
 
     GstBuffer* buffer = gst_sample_get_buffer(m_sample.get());
-    if (UNLIKELY(!GST_IS_BUFFER(buffer)))
+    if (!GST_IS_BUFFER(buffer)) [[unlikely]]
         return;
 
     m_frameMapped = gst_video_frame_map(&m_videoFrame, &videoInfo, buffer, GST_MAP_READ);

--- a/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerSkia.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerSkia.cpp
@@ -42,7 +42,7 @@ ImageGStreamer::ImageGStreamer(GRefPtr<GstSample>&& sample)
     : m_sample(WTFMove(sample))
 {
     GstBuffer* buffer = gst_sample_get_buffer(m_sample.get());
-    if (UNLIKELY(!GST_IS_BUFFER(buffer)))
+    if (!GST_IS_BUFFER(buffer)) [[unlikely]]
         return;
 
     GstMappedFrame videoFrame(m_sample, GST_MAP_READ);

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -936,7 +936,7 @@ bool MediaPlayerPrivateGStreamer::didLoadingProgress() const
         return didLoadingProgress;
     }
 
-    if (UNLIKELY(!m_pipeline || !duration() || (!isMediaSource() && !totalBytes())))
+    if (!m_pipeline || !duration() || (!isMediaSource() && !totalBytes())) [[unlikely]]
         return false;
 
     MediaTime currentMaxTimeLoaded = maxTimeLoaded();
@@ -1152,7 +1152,7 @@ void MediaPlayerPrivateGStreamer::syncOnClock(bool sync)
 template <typename TrackPrivateType>
 void MediaPlayerPrivateGStreamer::notifyPlayerOfTrack()
 {
-    if (UNLIKELY(!m_pipeline || !m_source))
+    if (!m_pipeline || !m_source) [[unlikely]]
         return;
 
     RefPtr player = m_player.get();
@@ -2677,7 +2677,7 @@ void MediaPlayerPrivateGStreamer::downloadBufferFileCreatedCallback(MediaPlayerP
     GUniqueOutPtr<char> downloadFile;
     g_object_get(player->m_downloadBuffer.get(), "temp-location", &downloadFile.outPtr(), nullptr);
 
-    if (UNLIKELY(!FileSystem::deleteFile(String::fromUTF8(downloadFile.get())))) {
+    if (!FileSystem::deleteFile(String::fromUTF8(downloadFile.get()))) [[unlikely]] {
         GST_WARNING("Couldn't unlink media temporary file %s after creation", downloadFile.get());
         return;
     }
@@ -2697,7 +2697,7 @@ void MediaPlayerPrivateGStreamer::purgeOldDownloadFiles(const String& downloadFi
             continue;
 
         auto filePath = FileSystem::pathByAppendingComponent(templateDirectory, fileName);
-        if (UNLIKELY(!FileSystem::deleteFile(filePath))) {
+        if (!FileSystem::deleteFile(filePath)) [[unlikely]] {
             GST_WARNING("Couldn't unlink legacy media temporary file: %s", filePath.utf8().data());
             continue;
         }
@@ -3405,7 +3405,7 @@ void MediaPlayerPrivateGStreamer::setupCodecProbe(GstElement* element)
             return GST_PAD_PROBE_REMOVE;
 
         std::optional<TrackID> streamId(getStreamIdFromPad(pad));
-        if (UNLIKELY(!streamId)) {
+        if (!streamId) [[unlikely]] {
             // FIXME: This is a workaround for https://bugs.webkit.org/show_bug.cgi?id=256428.
             GST_WARNING_OBJECT(player->pipeline(), "Caps event received before stream-start. This shouldn't happen!");
             return GST_PAD_PROBE_REMOVE;
@@ -3799,7 +3799,7 @@ void MediaPlayerPrivateGStreamer::triggerRepaint(GRefPtr<GstSample>&& sample)
                 return;
             }
 
-            if (UNLIKELY(!gst_caps_is_empty(caps.get()) && !gst_caps_is_any(caps.get()))) {
+            if (!gst_caps_is_empty(caps.get()) && !gst_caps_is_any(caps.get())) [[unlikely]] {
                 auto structure = gst_caps_get_structure(caps.get(), 0);
                 int framerateNumerator, framerateDenominator;
                 if (gst_structure_get_fraction(structure, "framerate", &framerateNumerator, &framerateDenominator)) {
@@ -4531,7 +4531,7 @@ void MediaPlayerPrivateGStreamer::audioOutputDeviceChanged()
 String MediaPlayerPrivateGStreamer::codecForStreamId(TrackID streamId)
 {
     Locker locker { m_codecsLock };
-    if (UNLIKELY(!m_codecs.contains(streamId)))
+    if (!m_codecs.contains(streamId)) [[unlikely]]
         return emptyString();
 
     return m_codecs.get(streamId);

--- a/Source/WebCore/platform/graphics/gstreamer/TextSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TextSinkGStreamer.cpp
@@ -56,7 +56,7 @@ static void webkitTextSinkHandleSample(WebKitTextSink* self, GRefPtr<GstSample>&
         priv->streamId = getStreamIdFromPad(pad.get());
     }
 
-    if (UNLIKELY(!priv->streamId)) {
+    if (!priv->streamId) [[unlikely]] {
         GST_WARNING_OBJECT(self, "Unable to handle sample with no stream start event.");
         return;
     }

--- a/Source/WebCore/platform/graphics/gstreamer/VideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoSinkGStreamer.cpp
@@ -103,7 +103,7 @@ public:
             sample = std::exchange(m_sample, nullptr);
         }
 
-        if (LIKELY(GST_IS_SAMPLE(sample.get())))
+        if (GST_IS_SAMPLE(sample.get())) [[likely]]
             webkitVideoSinkRepaintRequested(sink, sample.get());
 
         return true;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -427,7 +427,7 @@ void AppendPipeline::appsinkNewSample(const Track& track, GRefPtr<GstSample>&& s
 {
     ASSERT(isMainThread());
 
-    if (UNLIKELY(!gst_sample_get_buffer(sample.get()))) {
+    if (!gst_sample_get_buffer(sample.get())) [[unlikely]] {
         GST_WARNING_OBJECT(pipeline(), "Received sample without buffer from appsink.");
         return;
     }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -169,7 +169,7 @@ void MediaPlayerPrivateGStreamerMSE::pause()
     // the player, so without a playbackStateChanged notification here we would still observe an
     // active sleep disabler right after receiving the pause event on JS side.
     RefPtr player = m_player.get();
-    if (UNLIKELY(!player))
+    if (!player) [[unlikely]]
         return;
     player->playbackStateChanged();
 }
@@ -183,7 +183,7 @@ void MediaPlayerPrivateGStreamerMSE::checkPlayingConsistency()
 
     m_playbackStateChangedNotificationPending = false;
     RefPtr player = m_player.get();
-    if (UNLIKELY(!player))
+    if (!player) [[unlikely]]
         return;
 
     GstState state, pendingState;
@@ -207,7 +207,7 @@ void MediaPlayerPrivateGStreamerMSE::setShouldDisableSleep(bool shouldDisableSle
 
 MediaTime MediaPlayerPrivateGStreamerMSE::duration() const
 {
-    if (UNLIKELY(!m_pipeline || m_didErrorOccur))
+    if (!m_pipeline || m_didErrorOccur) [[unlikely]]
         return MediaTime();
 
     return m_mediaTimeDuration.isValid() ? m_mediaTimeDuration : MediaTime::zeroTime();
@@ -561,7 +561,7 @@ MediaPlayer::SupportsType MediaPlayerPrivateGStreamerMSE::supportsType(const Med
 
 MediaTime MediaPlayerPrivateGStreamerMSE::maxTimeSeekable() const
 {
-    if (UNLIKELY(m_didErrorOccur))
+    if (m_didErrorOccur) [[unlikely]]
         return MediaTime::zeroTime();
 
     GST_DEBUG("maxTimeSeekable");

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -447,7 +447,7 @@ static void webKitMediaSrcWaitForPadLinkedOrFlush(GstPad* pad, DataMutexLocker<S
 {
     {
         auto locker = GstObjectLocker(pad);
-        if (LIKELY(GST_PAD_IS_LINKED(pad)))
+        if (GST_PAD_IS_LINKED(pad)) [[likely]]
             return;
 
         GST_DEBUG_OBJECT(pad, "Waiting for the pad to be linked...");

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -161,7 +161,7 @@ void ImageBufferSkiaAcceleratedBackend::getPixelBuffer(const IntRect& srcRect, P
     SkPixmap pixmap(destinationInfo, destination.bytes().data(), destination.size().width() * 4);
 
     SkPixmap dstPixmap;
-    if (UNLIKELY(!pixmap.extractSubset(&dstPixmap, destinationRect)))
+    if (!pixmap.extractSubset(&dstPixmap, destinationRect)) [[unlikely]]
         return;
 
     m_surface->readPixels(dstPixmap, sourceRectClipped.x(), sourceRectClipped.y());
@@ -207,7 +207,7 @@ void ImageBufferSkiaAcceleratedBackend::putPixelBuffer(const PixelBufferSourceVi
     SkPixmap pixmap(pixelBufferInfo, pixelBuffer.bytes().data(), pixelBuffer.size().width() * 4);
 
     SkPixmap srcPixmap;
-    if (UNLIKELY(!pixmap.extractSubset(&srcPixmap, sourceRectClipped)))
+    if (!pixmap.extractSubset(&srcPixmap, sourceRectClipped)) [[unlikely]]
         return;
 
     const auto destAlphaType = (destFormat == AlphaPremultiplication::Premultiplied)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
@@ -168,7 +168,7 @@ OptionSet<CoordinatedBackingStoreProxy::UpdateResult> CoordinatedBackingStorePro
 #if USE(SKIA)
     // Record only once the whole layer.
     RefPtr<SkiaRecordingResult> recording;
-    if (LIKELY(dirtyTilesCount > 0 && layer.client().paintingEngine().useThreadedRendering()))
+    if (dirtyTilesCount > 0 && layer.client().paintingEngine().useThreadedRendering()) [[likely]]
         recording = layer.record(tileDirtyRectUnion);
 #endif
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp
@@ -52,7 +52,7 @@ namespace WebCore {
 std::unique_ptr<CoordinatedPlatformLayerBufferVideo> CoordinatedPlatformLayerBufferVideo::create(GstSample* sample, GstVideoInfo* videoInfo, std::optional<DMABufFormat> dmabufFormat, std::optional<GstVideoDecoderPlatform> videoDecoderPlatform, bool gstGLEnabled, OptionSet<TextureMapperFlags> flags)
 {
     auto* buffer = gst_sample_get_buffer(sample);
-    if (UNLIKELY(!GST_IS_BUFFER(buffer)))
+    if (!GST_IS_BUFFER(buffer)) [[unlikely]]
         return nullptr;
 
     return makeUnique<CoordinatedPlatformLayerBufferVideo>(buffer, videoInfo, dmabufFormat, videoDecoderPlatform, gstGLEnabled, flags);

--- a/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkBcmNexus.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkBcmNexus.cpp
@@ -30,7 +30,7 @@ namespace WebCore {
 
 bool GStreamerHolePunchQuirkBcmNexus::setHolePunchVideoRectangle(GstElement* videoSink, const IntRect& rect)
 {
-    if (UNLIKELY(!gstObjectHasProperty(videoSink, "rectangle"_s)))
+    if (!gstObjectHasProperty(videoSink, "rectangle"_s)) [[unlikely]]
         return false;
 
     auto rectString = makeString(rect.x(), ',', rect.y(), ',', rect.width(), ',', rect.height());

--- a/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkRialto.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkRialto.cpp
@@ -50,7 +50,7 @@ GstElement* GStreamerHolePunchQuirkRialto::createHolePunchVideoSink(bool isLegac
 
 bool GStreamerHolePunchQuirkRialto::setHolePunchVideoRectangle(GstElement* videoSink, const IntRect& rect)
 {
-    if (UNLIKELY(!gstObjectHasProperty(videoSink, "rectangle"_s)))
+    if (!gstObjectHasProperty(videoSink, "rectangle"_s)) [[unlikely]]
         return false;
 
     auto rectString = makeString(rect.x(), ',', rect.y(), ',', rect.width(), ',', rect.height());

--- a/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkWesteros.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkWesteros.cpp
@@ -53,7 +53,7 @@ GstElement* GStreamerHolePunchQuirkWesteros::createHolePunchVideoSink(bool isLeg
 
 bool GStreamerHolePunchQuirkWesteros::setHolePunchVideoRectangle(GstElement* videoSink, const IntRect& rect)
 {
-    if (UNLIKELY(!gstObjectHasProperty(videoSink, "rectangle"_s)))
+    if (!gstObjectHasProperty(videoSink, "rectangle"_s)) [[unlikely]]
         return false;
 
     auto rectString = makeString(rect.x(), ',', rect.y(), ',', rect.width(), ',', rect.height());

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
@@ -45,7 +45,7 @@ GStreamerQuirkRialto::GStreamerQuirkRialto()
 
     for (const auto* sink : rialtoSinks) {
         auto sinkFactory = adoptGRef(gst_element_factory_find(sink));
-        if (UNLIKELY(!sinkFactory))
+        if (!sinkFactory) [[unlikely]]
             continue;
 
         gst_object_unref(gst_plugin_feature_load(GST_PLUGIN_FEATURE(sinkFactory.get())));

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
@@ -36,7 +36,7 @@ GStreamerQuirkWesteros::GStreamerQuirkWesteros()
     GST_DEBUG_CATEGORY_INIT(webkit_westeros_quirks_debug, "webkitquirkswesteros", 0, "WebKit Westeros Quirks");
 
     auto westerosFactory = adoptGRef(gst_element_factory_find("westerossink"));
-    if (UNLIKELY(!westerosFactory))
+    if (!westerosFactory) [[unlikely]]
         return;
 
     gst_object_unref(gst_plugin_feature_load(GST_PLUGIN_FEATURE(westerosFactory.get())));

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
@@ -713,7 +713,7 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
             g_object_set(self->priv->parser.get(), "config-interval", 1, nullptr);
 
             const auto& encodedCaps = self->priv->encodedCaps;
-            if (LIKELY(!gst_caps_is_any(encodedCaps.get()) && !gst_caps_is_empty(encodedCaps.get()))) {
+            if (!gst_caps_is_any(encodedCaps.get()) && !gst_caps_is_empty(encodedCaps.get())) [[likely]] {
                 auto structure = gst_caps_get_structure(encodedCaps.get(), 0);
                 auto profile = gstStructureGetString(structure, "profile"_s);
 
@@ -993,7 +993,7 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
         [](WebKitVideoEncoder* self) {
             g_object_set(self->priv->encoder.get(), "key-int-max", 15, nullptr);
         }, "bitrate"_s, [](GObject* object, ASCIILiteral propertyName, int bitrate) {
-            if (UNLIKELY(!bitrate))
+            if (!bitrate) [[unlikely]]
                 return;
             setBitrateKbitPerSec(object, propertyName, bitrate);
             auto bitrateMode = GPOINTER_TO_INT(g_object_get_qdata(object, x265BitrateQuark));

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.h
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.h
@@ -68,9 +68,9 @@ public:
 
     std::optional<uint32_t> getBitRate(unsigned spatialLayerIndex, unsigned temporalLayerIndex) const
     {
-        if (UNLIKELY(spatialLayerIndex >= MaxSpatialLayers))
+        if (spatialLayerIndex >= MaxSpatialLayers) [[unlikely]]
             return std::nullopt;
-        if (UNLIKELY(temporalLayerIndex >= MaxTemporalLayers))
+        if (temporalLayerIndex >= MaxTemporalLayers) [[unlikely]]
             return std::nullopt;
         return m_bitRates[spatialLayerIndex][temporalLayerIndex];
     }

--- a/Source/WebCore/platform/mediastream/WebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/WebRTCProvider.cpp
@@ -311,7 +311,7 @@ void WebRTCProvider::setPortAllocatorRange(StringView range)
         return;
 
     auto components = range.toStringWithoutCopying().split(':');
-    if (UNLIKELY(components.size() != 2)) {
+    if (components.size() != 2) [[unlikely]] {
         WTFLogAlways("Invalid format for UDP port range. Should be \"min-port:max-port\"");
         ASSERT_NOT_REACHED();
         return;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
@@ -106,7 +106,7 @@ void GStreamerCapturer::setDevice(std::optional<GStreamerCaptureDevice>&& device
     tearDown(true);
     m_device = WTFMove(device);
 
-    if (UNLIKELY(!m_device))
+    if (!m_device) [[unlikely]]
         return;
 
     setupPipeline();

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerDisplayCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerDisplayCaptureDeviceManager.cpp
@@ -147,7 +147,7 @@ CaptureSourceOrError GStreamerDisplayCaptureDeviceManager::createDisplayCaptureS
 
 void GStreamerDisplayCaptureDeviceManager::stopSource(const String& persistentID)
 {
-    if (UNLIKELY(!m_portal))
+    if (!m_portal) [[unlikely]]
         return;
 
     auto session = m_sessions.take(persistentID);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
@@ -160,7 +160,7 @@ void GStreamerIncomingTrackProcessor::retrieveMediaStreamAndTrackIdFromSDP()
     unsigned mLineIndex;
     g_object_get(m_data.transceiver.get(), "mlineindex", &mLineIndex, nullptr);
     const auto media = gst_sdp_message_get_media(description->sdp, mLineIndex);
-    if (UNLIKELY(!media))
+    if (!media) [[unlikely]]
         return;
 
     const char* msidAttribute = gst_sdp_media_get_attribute_val(media, "msid");
@@ -303,7 +303,7 @@ void GStreamerIncomingTrackProcessor::installRtpBufferPadProbe(const GRefPtr<Gst
         auto buffer = GST_PAD_PROBE_INFO_BUFFER(info);
         {
             GstMappedRtpBuffer rtpBuffer(buffer, GST_MAP_READ);
-            if (UNLIKELY(!rtpBuffer))
+            if (!rtpBuffer) [[unlikely]]
                 return GST_PAD_PROBE_OK;
 
             // Do not process further if this packet doesn't mark the end of a frame.

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -1262,7 +1262,7 @@ void webkitMediaStreamSrcConfigureAudioTracks(WebKitMediaStreamSrc* self, float 
 {
     for (auto& source : self->priv->sources) {
         auto track = source->track();
-        if (UNLIKELY(!track))
+        if (!track) [[unlikely]]
             continue;
         if (track->isAudio())
             source->configureAudioTrack(volume, isMuted, isPlaying);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp
@@ -216,7 +216,7 @@ void GStreamerRTPPacketizer::setPayloadType(int pt)
 
 std::optional<int> GStreamerRTPPacketizer::payloadType() const
 {
-    if (LIKELY(m_payloadType))
+    if (m_payloadType) [[likely]]
         return m_payloadType;
 
     GValue value = G_VALUE_INIT;
@@ -263,7 +263,7 @@ int GStreamerRTPPacketizer::findLastExtensionId(const GstCaps* caps)
             return true;
 
         auto identifier = WTF::parseInteger<int>(name.substring(7));
-        if (UNLIKELY(!identifier))
+        if (!identifier) [[unlikely]]
             return true;
 
         holder->extensionId = std::max(holder->extensionId, *identifier);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
@@ -159,7 +159,7 @@ bool GStreamerVideoCapturer::setSize(const IntSize& size)
         return true;
     }
 
-    if (UNLIKELY(!m_capsfilter))
+    if (!m_capsfilter) [[unlikely]]
         return false;
 
     m_size = size;
@@ -191,7 +191,7 @@ bool GStreamerVideoCapturer::setFrameRate(double frameRate)
         return false;
     }
 
-    if (UNLIKELY(!m_capsfilter))
+    if (!m_capsfilter) [[unlikely]]
         return false;
 
     m_caps = adoptGRef(gst_caps_copy(m_caps.get()));

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
@@ -212,7 +212,7 @@ void GStreamerVideoRTPPacketizer::configure(const GstStructure* encodingParamete
 
 void GStreamerVideoRTPPacketizer::updateStats()
 {
-    if (UNLIKELY(!m_encoder))
+    if (!m_encoder) [[unlikely]]
         return;
 
     auto framesSent = gstStructureGet<uint64_t>(m_stats.get(), "frames-sent"_s).value_or(0);

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp
@@ -45,7 +45,7 @@ RealtimeIncomingSourceGStreamer::RealtimeIncomingSourceGStreamer(const CaptureDe
 bool RealtimeIncomingSourceGStreamer::setBin(const GRefPtr<GstElement>& bin)
 {
     ASSERT(!m_bin);
-    if (UNLIKELY(m_bin)) {
+    if (m_bin) [[unlikely]] {
         GST_ERROR_OBJECT(m_bin.get(), "Calling setBin twice on the same incoming source instance is not allowed");
         return false;
     }

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
@@ -355,7 +355,7 @@ void RealtimeOutgoingMediaSourceGStreamer::configure(GRefPtr<GstCaps>&& allowedC
         const auto encodingsValue = gst_structure_get_value(m_parameters.get(), "encodings");
         RELEASE_ASSERT(GST_VALUE_HOLDS_LIST(encodingsValue));
         unsigned encodingsSize = gst_value_list_get_size(encodingsValue);
-        if (UNLIKELY(!encodingsSize)) {
+        if (!encodingsSize) [[unlikely]] {
             GST_WARNING_OBJECT(m_bin.get(), "Encodings list is empty, cancelling configuration");
             return;
         }
@@ -370,7 +370,7 @@ void RealtimeOutgoingMediaSourceGStreamer::setParameters(GUniquePtr<GstStructure
     const auto encodingsValue = gst_structure_get_value(parameters.get(), "encodings");
     RELEASE_ASSERT(GST_VALUE_HOLDS_LIST(encodingsValue));
     unsigned encodingsSize = gst_value_list_get_size(encodingsValue);
-    if (UNLIKELY(!encodingsSize)) {
+    if (!encodingsSize) [[unlikely]] {
         GST_WARNING_OBJECT(m_bin.get(), "Encodings list is empty, cancelling re-configuration");
         return;
     }
@@ -427,7 +427,7 @@ bool RealtimeOutgoingMediaSourceGStreamer::linkSource()
 bool RealtimeOutgoingMediaSourceGStreamer::configurePacketizers(GRefPtr<GstCaps>&& codecPreferences)
 {
     GST_DEBUG_OBJECT(m_bin.get(), "Configuring packetizers for caps %" GST_PTR_FORMAT, codecPreferences.get());
-    if (UNLIKELY(gst_caps_is_empty(codecPreferences.get()) || gst_caps_is_any(codecPreferences.get())))
+    if (gst_caps_is_empty(codecPreferences.get()) || gst_caps_is_any(codecPreferences.get())) [[unlikely]]
         return false;
 
     if (m_outgoingSource) {
@@ -445,7 +445,7 @@ bool RealtimeOutgoingMediaSourceGStreamer::configurePacketizers(GRefPtr<GstCaps>
             const auto encodingsValue = gst_structure_get_value(m_parameters.get(), "encodings");
             RELEASE_ASSERT(GST_VALUE_HOLDS_LIST(encodingsValue));
             auto totalEncodings = gst_value_list_get_size(encodingsValue);
-            if (UNLIKELY(!totalEncodings)) {
+            if (!totalEncodings) [[unlikely]] {
                 auto packetizer = createPacketizer(m_ssrcGenerator, codecParameters, nullptr);
                 if (!packetizer)
                     continue;
@@ -466,7 +466,7 @@ bool RealtimeOutgoingMediaSourceGStreamer::configurePacketizers(GRefPtr<GstCaps>
                     continue;
 
                 auto rtpParameters = packetizer->rtpParameters();
-                if (UNLIKELY(!rtpParameters))
+                if (!rtpParameters) [[unlikely]]
                     continue;
 
                 codecIsValid = linkPacketizer(WTFMove(packetizer));
@@ -487,7 +487,7 @@ bool RealtimeOutgoingMediaSourceGStreamer::configurePacketizers(GRefPtr<GstCaps>
                 continue;
 
             auto rtpParameters = packetizer->rtpParameters();
-            if (UNLIKELY(!rtpParameters))
+            if (!rtpParameters) [[unlikely]]
                 continue;
             if (linkPacketizer(WTFMove(packetizer))) {
                 gst_caps_append_structure(rtpCaps.get(), rtpParameters.release());
@@ -563,7 +563,7 @@ RealtimeOutgoingMediaSourceGStreamer::ExtensionLookupResults RealtimeOutgoingMed
             return true;
 
         auto identifier = WTF::parseInteger<int>(name.substring(7)).value_or(0);
-        if (UNLIKELY(!identifier))
+        if (!identifier) [[unlikely]]
             return true;
 
         lookupResults.lastIdentifier = std::max(lookupResults.lastIdentifier, identifier);

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp
@@ -213,7 +213,7 @@ public:
         if (inputImage._encodedWidth && inputImage._encodedHeight)
             updateCapsFromImageSize(inputImage._encodedWidth, inputImage._encodedHeight);
 
-        if (UNLIKELY(!m_caps)) {
+        if (!m_caps) [[unlikely]] {
             GST_ERROR("Encoded image caps not set");
             ASSERT_NOT_REACHED();
             return WEBRTC_VIDEO_CODEC_UNINITIALIZED;

--- a/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
@@ -108,7 +108,7 @@ ResourceRequestPlatformData ResourceRequest::getResourceRequestPlatformData() co
     
     auto requestToSerialize = retainPtr(this->nsURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody));
 
-    if (Class requestClass = [requestToSerialize class]; UNLIKELY(requestClass != [NSURLRequest class] && requestClass != [NSMutableURLRequest class])) {
+    if (Class requestClass = [requestToSerialize class]; requestClass != [NSURLRequest class] && requestClass != [NSMutableURLRequest class]) [[unlikely]] {
         WebCore::ResourceRequest request(requestToSerialize.get());
         request.replacePlatformRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody);
         requestToSerialize = retainPtr(request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody));

--- a/Source/WebCore/platform/text/SegmentedString.h
+++ b/Source/WebCore/platform/text/SegmentedString.h
@@ -223,14 +223,14 @@ inline SegmentedString::SegmentedString(const String& string)
 ALWAYS_INLINE void SegmentedString::updateAdvanceFunctionPointersIfNecessary()
 {
     ASSERT(m_currentSubstring.length() >= 1);
-    if (UNLIKELY(m_currentSubstring.length() == 1))
+    if (m_currentSubstring.length() == 1) [[unlikely]]
         updateAdvanceFunctionPointersForSingleCharacterSubstring();
 }
 
 
 ALWAYS_INLINE void SegmentedString::advanceWithoutUpdatingLineNumber()
 {
-    if (LIKELY(m_fastPathFlags & Use8BitAdvance)) {
+    if (m_fastPathFlags & Use8BitAdvance) [[likely]] {
         skip(m_currentSubstring.s.currentCharacter8, 1);
         m_currentCharacter = m_currentSubstring.s.currentCharacter8[0];
         updateAdvanceFunctionPointersIfNecessary();
@@ -254,13 +254,13 @@ inline void SegmentedString::processPossibleNewline()
 
 inline void SegmentedString::advance()
 {
-    if (LIKELY(m_fastPathFlags & Use8BitAdvance)) {
+    if (m_fastPathFlags & Use8BitAdvance) [[likely]] {
         ASSERT(m_currentSubstring.length() > 1);
         bool lastCharacterWasNewline = m_currentCharacter == '\n';
         skip(m_currentSubstring.s.currentCharacter8, 1);
         m_currentCharacter = m_currentSubstring.s.currentCharacter8[0];
         bool haveOneCharacterLeft = m_currentSubstring.s.currentCharacter8.size() == 1;
-        if (LIKELY(!(lastCharacterWasNewline | haveOneCharacterLeft)))
+        if (!(lastCharacterWasNewline | haveOneCharacterLeft)) [[likely]]
             return;
         if (lastCharacterWasNewline & !!(m_fastPathFlags & Use8BitAdvanceAndUpdateLineNumbers))
             startNewLine();

--- a/Source/WebCore/rendering/AccessibilityRegionContext.cpp
+++ b/Source/WebCore/rendering/AccessibilityRegionContext.cpp
@@ -57,7 +57,7 @@ void AccessibilityRegionContext::takeBounds(const RenderInline& renderInline, La
 
 void AccessibilityRegionContext::takeBounds(const RenderBox& renderBox, LayoutPoint paintOffset)
 {
-    if (CheckedPtr renderView = dynamicDowncast<RenderView>(renderBox); UNLIKELY(renderView)) {
+    if (CheckedPtr renderView = dynamicDowncast<RenderView>(renderBox); renderView) [[unlikely]] {
         takeBounds(*renderView, WTFMove(paintOffset));
         return;
     }

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -513,7 +513,7 @@ void BackgroundPainter::paintFillLayer(const Color& color, const FillLayer& bgLa
 
 void BackgroundPainter::clipRoundedInnerRect(GraphicsContext& context, const FloatRoundedRect& clipRect)
 {
-    if (UNLIKELY(!clipRect.isRenderable())) {
+    if (!clipRect.isRenderable()) [[unlikely]] {
         auto adjustedClipRect = clipRect;
         adjustedClipRect.adjustRadii();
         context.clipRoundedRect(adjustedClipRect);

--- a/Source/WebCore/rendering/BreakLines.h
+++ b/Source/WebCore/rendering/BreakLines.h
@@ -409,7 +409,7 @@ inline BreakLines::BreakClass BreakLines::classify(UChar character)
             return kGL;
         if (character < 0x370)
             return kCM;
-        if (UNLIKELY(character == 0x037E))
+        if (character == 0x037E) [[unlikely]]
             return kWeird;
         return kAL;
     case 0x0380 / 0x80:
@@ -512,13 +512,13 @@ inline BreakLines::BreakClass BreakLines::classify(UChar character)
             // This block (0x3040-0x30FF) is tangled up and sensitive to 'line-break'.
             return kWeird;
         }
-        if (UNLIKELY((character & blockLast4) == 0x31F0)) // Small Kana.
+        if ((character & blockLast4) == 0x31F0) [[unlikely]] // Small Kana.
             return kWeird;
-        if (UNLIKELY((character & blockLast3) == 0x3248))
+        if ((character & blockLast3) == 0x3248) [[unlikely]]
             return kAL;
-        if (UNLIKELY((character & blockLast6) == 0x4DC0))
+        if ((character & blockLast6) == 0x4DC0) [[unlikely]]
             return kAL;
-        if (UNLIKELY(character == 0xA015))
+        if (character == 0xA015) [[unlikely]]
             return kWeird;
         return kID;
     }

--- a/Source/WebCore/rendering/LegacyInlineIterator.h
+++ b/Source/WebCore/rendering/LegacyInlineIterator.h
@@ -351,12 +351,12 @@ inline UChar LegacyInlineIterator::previousInSameNode() const
 
 ALWAYS_INLINE UCharDirection LegacyInlineIterator::direction() const
 {
-    if (UNLIKELY(!m_renderer))
+    if (!m_renderer) [[unlikely]]
         return U_OTHER_NEUTRAL;
 
-    if (auto* textRenderer = dynamicDowncast<RenderText>(*m_renderer); LIKELY(textRenderer)) {
+    if (auto* textRenderer = dynamicDowncast<RenderText>(*m_renderer); textRenderer) [[likely]] {
         UChar codeUnit = textRenderer->characterAt(m_pos);
-        if (LIKELY(U16_IS_SINGLE(codeUnit)))
+        if (U16_IS_SINGLE(codeUnit)) [[likely]]
             return u_charDirection(codeUnit);
         return surrogateTextDirection(codeUnit);
     }

--- a/Source/WebCore/rendering/LegacyLineLayout.cpp
+++ b/Source/WebCore/rendering/LegacyLineLayout.cpp
@@ -160,7 +160,7 @@ std::unique_ptr<LegacyRootInlineBox> LegacyLineLayout::createRootInlineBox()
 LegacyRootInlineBox* LegacyLineLayout::createAndAppendRootInlineBox()
 {
     m_legacyRootInlineBox = createRootInlineBox();
-    if (UNLIKELY(AXObjectCache::accessibilityEnabled())) {
+    if (AXObjectCache::accessibilityEnabled()) [[unlikely]] {
         if (AXObjectCache* cache = m_flow.document().existingAXObjectCache())
             cache->deferRecomputeIsIgnored(m_flow.element());
     }

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -1016,7 +1016,7 @@ void RenderBlockFlow::layoutBlockChild(RenderBox& child, MarginInfo& marginInfo,
     bool markDescendantsWithFloats = false;
     if (logicalTopEstimate != oldLogicalTop && !child.avoidsFloats() && childBlockFlow && childBlockFlow->containsFloats())
         markDescendantsWithFloats = true;
-    else if (UNLIKELY(logicalTopEstimate.mightBeSaturated()))
+    else if (logicalTopEstimate.mightBeSaturated()) [[unlikely]]
         // logicalTopEstimate, returned by estimateLogicalTopPosition, might be saturated for
         // very large elements. If it does the comparison with oldLogicalTop might yield a
         // false negative as adding and removing margins, borders etc from a saturated number

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -2688,7 +2688,7 @@ LayoutUnit RenderFlexibleBox::computeGap(RenderFlexibleBox::GapType gapType) con
     // row-gap is used for gaps between flex items in column flows or for gaps between lines in row flows.
     bool usesRowGap = (gapType == GapType::BetweenItems) == isColumnFlow();
     auto& gapLength = usesRowGap ? style().rowGap() : style().columnGap();
-    if (LIKELY(gapLength.isNormal()))
+    if (gapLength.isNormal()) [[likely]]
         return { };
 
     auto availableSize = usesRowGap ? availableLogicalHeightForPercentageComputation().value_or(0_lu) : contentBoxLogicalWidth();

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1165,12 +1165,12 @@ bool RenderLayer::ancestorLayerPositionStateChanged(OptionSet<UpdateLayerPositio
 #if ASSERT_ENABLED
 #if ENABLE(TREE_DEBUGGING)
 #define LAYER_POSITIONS_ASSERT(assertion, ...) do { \
-    if (UNLIKELY(!(assertion))) \
+    if (!(assertion)) [[unlikely]] \
         showLayerPositionTree(root(), this); \
     ASSERT(assertion, __VA_ARGS__); \
 } while (0)
 #define LAYER_POSITIONS_ASSERT_IMPLIES(condition, assertion) do { \
-    if (UNLIKELY(condition && !(assertion))) \
+    if (condition && !(assertion)) [[unlikely]] \
         showLayerPositionTree(root(), this); \
     ASSERT_IMPLIES(condition, assertion); \
 } while (0)

--- a/Source/WebCore/rendering/RenderTableCell.h
+++ b/Source/WebCore/rendering/RenderTableCell.h
@@ -237,7 +237,7 @@ inline unsigned RenderTableCell::rowSpan() const
 
 inline void RenderTableCell::setCol(unsigned column)
 {
-    if (UNLIKELY(column > maxColumnIndex))
+    if (column > maxColumnIndex) [[unlikely]]
         column = maxColumnIndex;
     m_column = column;
 }

--- a/Source/WebCore/rendering/RenderTableRow.h
+++ b/Source/WebCore/rendering/RenderTableRow.h
@@ -100,7 +100,7 @@ private:
 
 inline void RenderTableRow::setRowIndex(unsigned rowIndex)
 {
-    if (UNLIKELY(rowIndex > maxRowIndex))
+    if (rowIndex > maxRowIndex) [[unlikely]]
         CRASH();
     m_rowIndex = rowIndex;
 }

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -862,7 +862,7 @@ bool RenderTheme::paint(const RenderBox& box, const PaintInfo& paintInfo, const 
     
     auto appearance = box.style().usedAppearance();
 
-    if (UNLIKELY(!canPaint(paintInfo, box.settings(), appearance)))
+    if (!canPaint(paintInfo, box.settings(), appearance)) [[unlikely]]
         return false;
 
     float deviceScaleFactor = box.document().deviceScaleFactor();

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -262,7 +262,7 @@ Vector<StyledMarkedText> StyledMarkedText::subdivideAndResolve(const Vector<Mark
 
     auto markedTexts = MarkedText::subdivide(textsToSubdivide, OverlapStrategy::None);
     ASSERT(!markedTexts.isEmpty());
-    if (UNLIKELY(markedTexts.isEmpty()))
+    if (markedTexts.isEmpty()) [[unlikely]]
         return { };
 
     if (!markedTexts.isEmpty()) {

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1297,7 +1297,7 @@ inline static bool changedCustomPaintWatchedProperty(const RenderStyle& a, const
     auto& propertiesA = aData.customPaintWatchedProperties;
     auto& propertiesB = bData.customPaintWatchedProperties;
 
-    if (UNLIKELY(!propertiesA.isEmpty() || !propertiesB.isEmpty())) {
+    if (!propertiesA.isEmpty() || !propertiesB.isEmpty()) [[unlikely]] {
         // FIXME: We should not need to use ComputedStyleExtractor here.
         ComputedStyleExtractor extractor((Element*) nullptr);
 

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -857,7 +857,7 @@ inline bool RenderStyle::usesAnchorFunctions() const { return m_nonInheritedData
 
 inline Visibility RenderStyle::usedVisibility() const
 {
-    if (UNLIKELY(isInVisibilityAdjustmentSubtree()))
+    if (isInVisibilityAdjustmentSubtree()) [[unlikely]]
         return Visibility::Hidden;
     return static_cast<Visibility>(m_inheritedFlags.visibility);
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
@@ -172,7 +172,7 @@ static void removeFromCacheAndInvalidateDependencies(RenderElement& renderer, bo
             // We allow cycles in SVGDocumentExtensions reference sets in order to avoid expensive
             // reference graph adjustments on changes, so we need to break possible cycles here.
             static NeverDestroyed<WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData>> invalidatingDependencies;
-            if (UNLIKELY(!invalidatingDependencies.get().add(element.get()).isNewEntry)) {
+            if (!invalidatingDependencies.get().add(element.get()).isNewEntry) [[unlikely]] {
                 // Reference cycle: we are in process of invalidating this dependant.
                 continue;
             }

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -539,7 +539,7 @@ void RenderTreeUpdater::createRenderer(Element& element, RenderStyle&& style)
     m_builder.attach(insertionPosition.parent(), WTFMove(newRenderer), insertionPosition.nextSibling());
 
     auto* textManipulationController = m_document->textManipulationControllerIfExists();
-    if (UNLIKELY(textManipulationController))
+    if (textManipulationController) [[unlikely]]
         textManipulationController->didAddOrCreateRendererForNode(element);
 
     if (auto* cache = m_document->axObjectCache())
@@ -616,7 +616,7 @@ void RenderTreeUpdater::createTextRenderer(Text& textNode, const Style::TextUpda
     m_builder.attach(renderTreePosition.parent(), WTFMove(textRenderer), renderTreePosition.nextSibling());
 
     auto* textManipulationController = m_document->textManipulationControllerIfExists();
-    if (UNLIKELY(textManipulationController))
+    if (textManipulationController) [[unlikely]]
         textManipulationController->didAddOrCreateRendererForNode(textNode);
 }
 

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -574,7 +574,7 @@ void ElementRuleCollector::collectMatchingRulesForList(const RuleSet::RuleDataVe
         return;
 
     for (auto& ruleData : *rules) {
-        if (UNLIKELY(!ruleData.isEnabled()))
+        if (!ruleData.isEnabled()) [[unlikely]]
             continue;
 
         if (!ruleData.canMatchPseudoElement() && m_pseudoElementRequest)

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -643,7 +643,7 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
                 style.setHeight(WebCore::Length(200, LengthType::Fixed));
         }
 
-        if (UNLIKELY(m_element->visibilityAdjustment().contains(VisibilityAdjustment::Subtree) || m_parentStyle.isInVisibilityAdjustmentSubtree()))
+        if (m_element->visibilityAdjustment().contains(VisibilityAdjustment::Subtree) || m_parentStyle.isInVisibilityAdjustmentSubtree()) [[unlikely]]
             style.setIsInVisibilityAdjustmentSubtree();
     }
 

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -162,7 +162,7 @@ void Builder::applyLogicalGroupProperties()
 
 void Builder::applyProperties(int firstProperty, int lastProperty)
 {
-    if (LIKELY(m_cascade.customProperties().isEmpty()))
+    if (m_cascade.customProperties().isEmpty()) [[likely]]
         return applyPropertiesImpl<CustomPropertyCycleTracking::Disabled>(firstProperty, lastProperty);
 
     return applyPropertiesImpl<CustomPropertyCycleTracking::Enabled>(firstProperty, lastProperty);
@@ -414,7 +414,7 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
         return;
     }
 
-    if (UNLIKELY(id == CSSPropertySize && valueType == ApplyValueType::Value)) {
+    if (id == CSSPropertySize && valueType == ApplyValueType::Value) [[unlikely]] {
         applyPageSizeDescriptor(valueToApply.get());
         return;
     }

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -325,7 +325,7 @@ template<class ValueType>
 inline const ValueType* BuilderConverter::requiredDowncast(BuilderState& builderState, const CSSValue& value)
 {
     auto* typedValue = dynamicDowncast<ValueType>(value);
-    if (UNLIKELY(!typedValue)) {
+    if (!typedValue) [[unlikely]] {
         builderState.setCurrentPropertyInvalidAtComputedValueTime();
         return nullptr;
     }
@@ -336,13 +336,13 @@ template<class ValueType>
 inline std::optional<std::pair<const ValueType&, const ValueType&>> BuilderConverter::requiredPairDowncast(BuilderState& builderState, const CSSValue& value)
 {
     auto* pairValue = requiredDowncast<CSSValuePair>(builderState, value);
-    if (UNLIKELY(!pairValue))
+    if (!pairValue) [[unlikely]]
         return { };
     auto* firstValue = requiredDowncast<ValueType>(builderState, pairValue->first());
-    if (UNLIKELY(!firstValue))
+    if (!firstValue) [[unlikely]]
         return { };
     auto* secondValue = requiredDowncast<ValueType>(builderState, pairValue->second());
-    if (UNLIKELY(!secondValue))
+    if (!secondValue) [[unlikely]]
         return { };
     return { { *firstValue, *secondValue } };
 }
@@ -351,14 +351,14 @@ template<class ListType, class ValueType, unsigned minimumSize>
 inline auto BuilderConverter::requiredListDowncast(BuilderState& builderState, const CSSValue& value) -> std::optional<TypedList<ListType, ValueType>>
 {
     auto* listValue = requiredDowncast<ListType>(builderState, value);
-    if (UNLIKELY(!listValue))
+    if (!listValue) [[unlikely]]
         return { };
-    if (UNLIKELY(listValue->size() < minimumSize)) {
+    if (listValue->size() < minimumSize) [[unlikely]] {
         builderState.setCurrentPropertyInvalidAtComputedValueTime();
         return { };
     }
     for (auto& value : *listValue) {
-        if (UNLIKELY(!requiredDowncast<ValueType>(builderState, value)))
+        if (!requiredDowncast<ValueType>(builderState, value)) [[unlikely]]
             return { };
     }
     return TypedList<ListType, ValueType> { *listValue };
@@ -368,7 +368,7 @@ template<CSSValueID functionName, class ValueType, unsigned minimumSize>
 inline auto BuilderConverter::requiredFunctionDowncast(BuilderState& builderState, const CSSValue& value) -> std::optional<TypedList<CSSFunctionValue, ValueType>>
 {
     auto function = requiredListDowncast<CSSFunctionValue, ValueType, minimumSize>(builderState, value);
-    if (UNLIKELY(!function))
+    if (!function) [[unlikely]]
         return { };
     if (function->list->name() != functionName) {
         builderState.setCurrentPropertyInvalidAtComputedValueTime();

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -74,7 +74,7 @@ std::optional<DataRef<SVGPathByteStream::Data>> PathSegListCache::get(const Atom
 void PathSegListCache::add(const AtomString& attributeValue, DataRef<SVGPathByteStream::Data> data)
 {
     size_t newDataSize = data->size();
-    if (UNLIKELY(newDataSize > maxItemSizeInBytes))
+    if (newDataSize > maxItemSizeInBytes) [[unlikely]]
         return;
 
     m_sizeInBytes += newDataSize;

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -843,7 +843,7 @@ Element* SVGSVGElement::getElementById(const AtomString& id)
     if (id.isNull())
         return nullptr;
 
-    if (UNLIKELY(!isInTreeScope())) {
+    if (!isInTreeScope()) [[unlikely]] {
         for (auto& element : descendantsOfType<Element>(*this)) {
             if (element.getIdAttribute() == id)
                 return &element;

--- a/Source/WebCore/testing/js/WebCoreTestSupport.cpp
+++ b/Source/WebCore/testing/js/WebCoreTestSupport.cpp
@@ -267,7 +267,7 @@ void populateJITOperations()
         JSC::JITOperationList::populatePointersInEmbedder(&startOfJITOperationsInWebCoreTestSupport, &endOfJITOperationsInWebCoreTestSupport);
     });
 #if ENABLE(JIT_OPERATION_DISASSEMBLY)
-    if (UNLIKELY(JSC::Options::needDisassemblySupport()))
+    if (JSC::Options::needDisassemblySupport()) [[unlikely]]
         populateDisassemblyLabels();
 #endif
 }

--- a/Source/WebCore/workers/Worker.cpp
+++ b/Source/WebCore/workers/Worker.cpp
@@ -202,7 +202,7 @@ void Worker::didReceiveResponse(ScriptExecutionContextIdentifier mainContextIden
     if (!responseURL.protocolIsBlob() && !responseURL.protocolIsFile() && !SecurityOrigin::create(responseURL)->isOpaque())
         m_contentSecurityPolicyResponseHeaders = ContentSecurityPolicyResponseHeaders(response);
 
-    if (UNLIKELY(InspectorInstrumentation::hasFrontends())) {
+    if (InspectorInstrumentation::hasFrontends()) [[unlikely]] {
         ScriptExecutionContext::ensureOnContextThread(mainContextIdentifier, [identifier] (auto& mainContext) {
             InspectorInstrumentation::didReceiveScriptResponse(mainContext, *identifier);
         });
@@ -242,7 +242,7 @@ void Worker::notifyFinished(std::optional<ScriptExecutionContextIdentifier> main
     };
     m_contextProxy.startWorkerGlobalScope(m_scriptLoader->responseURL(), *sessionID, m_options.name, WTFMove(initializationData), m_scriptLoader->script(), contentSecurityPolicyResponseHeaders, m_shouldBypassMainWorldContentSecurityPolicy, m_scriptLoader->crossOriginEmbedderPolicy(), m_workerCreationTime, referrerPolicy, m_options.type, m_options.credentials, m_runtimeFlags);
 
-    if (UNLIKELY(InspectorInstrumentation::hasFrontends())) {
+    if (InspectorInstrumentation::hasFrontends()) [[unlikely]] {
         ScriptExecutionContext::ensureOnContextThread(*mainContextIdentifier, [identifier = m_scriptLoader->identifier(), script = m_scriptLoader->script().isolatedCopy()] (auto& mainContext) {
             InspectorInstrumentation::scriptImported(mainContext, identifier, script.toString());
         });

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -468,7 +468,7 @@ void WorkerGlobalScope::addConsoleMessage(std::unique_ptr<Inspector::ConsoleMess
     }
 
     auto sessionID = this->sessionID();
-    if (UNLIKELY(settingsValues().logsPageMessagesToSystemConsoleEnabled && sessionID && !sessionID->isEphemeral()))
+    if (settingsValues().logsPageMessagesToSystemConsoleEnabled && sessionID && !sessionID->isEphemeral()) [[unlikely]]
         PageConsoleClient::logMessageToSystemConsole(*message);
 
 #if ENABLE(WEBDRIVER_BIDI)

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -202,7 +202,7 @@ void WorkerMessagingProxy::postMessageToWorkerObject(MessageWithMessagePorts&& m
             auto scope = DECLARE_CATCH_SCOPE(vm);
             UserGestureIndicator userGestureIndicator(userGestureForwarder ? userGestureForwarder->userGestureToForward() : nullptr);
             auto event = MessageEvent::create(*globalObject, message.message.releaseNonNull(), { }, { }, { }, WTFMove(ports));
-            if (UNLIKELY(scope.exception())) {
+            if (scope.exception()) [[unlikely]] {
                 // Currently, we assume that the only way we can get here is if we have a termination.
                 RELEASE_ASSERT(vm.hasPendingTerminationException());
                 return;
@@ -248,7 +248,7 @@ void WorkerMessagingProxy::postMessageToWorkerGlobalScope(MessageWithMessagePort
 
         auto ports = MessagePort::entanglePorts(scriptContext, WTFMove(message.transferredPorts));
         auto event = MessageEvent::create(*globalObject, message.message.releaseNonNull(), { }, { }, std::nullopt, WTFMove(ports));
-        if (UNLIKELY(scope.exception())) {
+        if (scope.exception()) [[unlikely]] {
             // Currently, we assume that the only way we can get here is if we have a termination.
             RELEASE_ASSERT(vm.hasPendingTerminationException());
             return;

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
@@ -116,7 +116,7 @@ bool WorkerOrWorkletGlobalScope::isJSExecutionForbidden() const
 EventLoopTaskGroup& WorkerOrWorkletGlobalScope::eventLoop()
 {
     ASSERT(isContextThread());
-    if (UNLIKELY(!m_defaultTaskGroup)) {
+    if (!m_defaultTaskGroup) [[unlikely]] {
         m_eventLoop = WorkerEventLoop::create(*this);
         m_defaultTaskGroup = makeUnique<EventLoopTaskGroup>(*m_eventLoop);
         if (activeDOMObjectsAreStopped())

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
@@ -496,7 +496,7 @@ void WorkerOrWorkletScriptController::loadAndEvaluateModule(const URL& moduleURL
     auto scriptFetcher = WorkerScriptFetcher::create(WTFMove(parameters), credentials, globalScope->destination(), globalScope->referrerPolicy());
 
     auto* promise = JSExecState::loadModule(globalObject, moduleURL, JSC::JSScriptFetchParameters::create(vm, scriptFetcher->parameters()), JSC::JSScriptFetcher::create(vm, { scriptFetcher.ptr() }));
-    if (LIKELY(promise)) {
+    if (promise) [[likely]] {
         auto task = createSharedTask<void(std::optional<Exception>&&)>([completionHandler = WTFMove(completionHandler)](std::optional<Exception>&& exception) mutable {
             completionHandler(WTFMove(exception));
         });

--- a/Source/WebCore/workers/WorkerRunLoop.cpp
+++ b/Source/WebCore/workers/WorkerRunLoop.cpp
@@ -306,7 +306,7 @@ void WorkerDedicatedRunLoop::Task::performTask(WorkerOrWorkletGlobalScope* conte
         JSC::VM& vm = context->script()->vm();
         auto scope = DECLARE_CATCH_SCOPE(vm);
         m_task.performTask(*context);
-        if (UNLIKELY(context->script() && scope.exception())) {
+        if (context->script() && scope.exception()) [[unlikely]] {
             if (vm.hasPendingTerminationException()) {
                 context->script()->forbidExecution();
                 return;

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
@@ -468,7 +468,7 @@ void ServiceWorkerContainer::jobResolvedWithRegistration(ServiceWorkerJob& job, 
                 container->notifyRegistrationIsSettled(iterator->value);
                 container->m_ongoingSettledRegistrations.remove(iterator);
             });
-            if (UNLIKELY(promise->needsAbort()))
+            if (promise->needsAbort()) [[unlikely]]
                 return;
         }
 
@@ -479,7 +479,7 @@ void ServiceWorkerContainer::jobResolvedWithRegistration(ServiceWorkerJob& job, 
 void ServiceWorkerContainer::postMessage(MessageWithMessagePorts&& message, ServiceWorkerData&& sourceData, String&& sourceOrigin)
 {
     auto& context = *scriptExecutionContext();
-    if (UNLIKELY(context.isJSExecutionForbidden()))
+    if (context.isJSExecutionForbidden()) [[unlikely]]
         return;
 
     auto* globalObject = context.globalObject();
@@ -492,7 +492,7 @@ void ServiceWorkerContainer::postMessage(MessageWithMessagePorts&& message, Serv
     MessageEventSource source = RefPtr<ServiceWorker> { ServiceWorker::getOrCreate(context, WTFMove(sourceData)) };
 
     auto messageEvent = MessageEvent::create(*globalObject, message.message.releaseNonNull(), sourceOrigin, { }, WTFMove(source), MessagePort::entanglePorts(context, WTFMove(message.transferredPorts)));
-    if (UNLIKELY(scope.exception())) {
+    if (scope.exception()) [[unlikely]] {
         // Currently, we assume that the only way we can get here is if we have a termination.
         RELEASE_ASSERT(vm.hasPendingTerminationException());
         return;

--- a/Source/WebCore/worklets/PaintWorkletGlobalScope.cpp
+++ b/Source/WebCore/worklets/PaintWorkletGlobalScope.cpp
@@ -96,7 +96,7 @@ ExceptionOr<void> PaintWorkletGlobalScope::registerPaint(JSC::JSGlobalObject& gl
         Vector<AtomString> inputProperties;
         if (!inputPropertiesIterableValue.isUndefined()) {
             auto inputPropertiesConversionResult = convert<IDLSequence<IDLAtomStringAdaptor<IDLDOMString>>>(globalObject, inputPropertiesIterableValue);
-            if (UNLIKELY(inputPropertiesConversionResult.hasException(scope)))
+            if (inputPropertiesConversionResult.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
             inputProperties = inputPropertiesConversionResult.releaseReturnValue();
         }
@@ -109,7 +109,7 @@ ExceptionOr<void> PaintWorkletGlobalScope::registerPaint(JSC::JSGlobalObject& gl
         Vector<String> inputArguments;
         if (!inputArgumentsIterableValue.isUndefined()) {
             auto inputArgumentsConversionResult = convert<IDLSequence<IDLDOMString>>(globalObject, inputArgumentsIterableValue);
-            if (UNLIKELY(inputArgumentsConversionResult.hasException(scope)))
+            if (inputArgumentsConversionResult.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
             inputArguments = inputArgumentsConversionResult.releaseReturnValue();
         }
@@ -138,7 +138,7 @@ ExceptionOr<void> PaintWorkletGlobalScope::registerPaint(JSC::JSGlobalObject& gl
             return Exception { ExceptionCode::TypeError, "The class must have a paint method"_s };
 
         auto paintCallback = convert<IDLCallbackFunction<JSCSSPaintCallback>>(globalObject, paintValue, *jsCast<JSDOMGlobalObject*>(&globalObject));
-        if (UNLIKELY(paintCallback.hasException(scope)))
+        if (paintCallback.hasException(scope)) [[unlikely]]
             return Exception { ExceptionCode::ExistingExceptionError };
 
         auto paintDefinition = makeUnique<PaintDefinition>(name, paintConstructor.get(), paintCallback.releaseReturnValue(), WTFMove(inputProperties), WTFMove(inputArguments));

--- a/Source/WebCore/worklets/WorkletGlobalScope.cpp
+++ b/Source/WebCore/worklets/WorkletGlobalScope.cpp
@@ -126,7 +126,7 @@ URL WorkletGlobalScope::completeURL(const String& url, ForceUTF8) const
 
 void WorkletGlobalScope::logExceptionToConsole(const String& errorMessage, const String& sourceURL, int lineNumber, int columnNumber, RefPtr<ScriptCallStack>&& stack)
 {
-    if (UNLIKELY(settingsValues().logsPageMessagesToSystemConsoleEnabled)) {
+    if (settingsValues().logsPageMessagesToSystemConsoleEnabled) [[unlikely]] {
         if (stack) {
             Inspector::ConsoleMessage message { MessageSource::JS, MessageType::Log, MessageLevel::Error, errorMessage, *stack };
             PageConsoleClient::logMessageToSystemConsole(message);
@@ -143,7 +143,7 @@ void WorkletGlobalScope::logExceptionToConsole(const String& errorMessage, const
 
 void WorkletGlobalScope::addConsoleMessage(std::unique_ptr<Inspector::ConsoleMessage>&& message)
 {
-    if (UNLIKELY(settingsValues().logsPageMessagesToSystemConsoleEnabled && message))
+    if (settingsValues().logsPageMessagesToSystemConsoleEnabled && message) [[unlikely]]
         PageConsoleClient::logMessageToSystemConsole(*message);
 
     if (!m_document || isJSExecutionForbidden() || !message)

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -816,14 +816,14 @@ void XMLDocumentParser::startElementNs(const xmlChar* xmlLocalName, const xmlCha
     if (!m_parsingFragment) {
         if (auto* window = m_currentNode->document().domWindow()) {
             auto* registry = window->customElementRegistry();
-            if (UNLIKELY(registry))
+            if (registry) [[unlikely]]
                 willConstructCustomElement = registry->findInterface(qName);
         }
     }
 
     std::optional<ThrowOnDynamicMarkupInsertionCountIncrementer> markupInsertionCountIncrementer;
     std::optional<CustomElementReactionStack> customElementReactionStack;
-    if (UNLIKELY(willConstructCustomElement)) {
+    if (willConstructCustomElement) [[unlikely]] {
         markupInsertionCountIncrementer.emplace(m_currentNode->document());
         m_currentNode->document().eventLoop().performMicrotaskCheckpoint();
         customElementReactionStack.emplace(m_currentNode->document().globalObject());
@@ -846,7 +846,7 @@ void XMLDocumentParser::startElementNs(const xmlChar* xmlLocalName, const xmlCha
         return;
     }
 
-    if (UNLIKELY(willConstructCustomElement)) {
+    if (willConstructCustomElement) [[unlikely]] {
         customElementReactionStack.reset();
         markupInsertionCountIncrementer.reset();
     }


### PR DESCRIPTION
#### 2e88e497fa3835c8f26e2b9978f9d7fb7a9eeae6
<pre>
Start adopting C++20&apos;s [[likely]] / [[unlikely]] in WebCore/
<a href="https://bugs.webkit.org/show_bug.cgi?id=292418">https://bugs.webkit.org/show_bug.cgi?id=292418</a>

Reviewed by Darin Adler.

Adopt C++&apos;s [[likely]] / [[unlikely]] in WebCore/.

It is now part of the C++ language and has several benefits over
our macros. In particular, those annotations can be used for
`switch` cases and `else` statements.

* Source/WebCore/html/parser/AtomHTMLToken.h:
(WebCore::AtomHTMLToken::initializeAttributes):
(WebCore::AtomHTMLToken::AtomHTMLToken):
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::mergeAttributesFromTokenIntoElement):
(WebCore::HTMLConstructionSite::setCompatibilityModeFromDoctype):
(WebCore::HTMLConstructionSite::insertHTMLElementOrFindCustomElementInterface):
(WebCore::findBreakIndex):
(WebCore::HTMLConstructionSite::insertTextNode):
(WebCore::qualifiedNameForTag):
(WebCore::qualifiedNameForHTMLTag):
(WebCore::HTMLConstructionSite::createHTMLElementOrFindCustomElementInterface):
* Source/WebCore/html/parser/HTMLDocumentParser.cpp:
(WebCore::HTMLDocumentParser::pumpTokenizerLoop):
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::parseCompleteInput):
(WebCore::HTMLFastPathParser::scanText):
(WebCore::HTMLFastPathParser::scanEscapedText):
(WebCore::HTMLFastPathParser::scanTagName):
(WebCore::HTMLFastPathParser::scanAttributeName):
(WebCore::HTMLFastPathParser::scanAttributeValue):
(WebCore::HTMLFastPathParser::scanEscapedAttributeValue):
(WebCore::HTMLFastPathParser::scanHTMLCharacterReference):
(WebCore::HTMLFastPathParser::parseChildren):
(WebCore::HTMLFastPathParser::parseAttributes):
(WebCore::HTMLFastPathParser::parseContainerElement):
* Source/WebCore/html/parser/HTMLElementStack.cpp:
(WebCore::HTMLElementStack::pushCommon):
(WebCore::HTMLElementStack::popCommon):
(WebCore::HTMLElementStack::removeNonTopCommon):
* Source/WebCore/html/parser/HTMLParserIdioms.cpp:
(WebCore::parseHTMLInteger):
(WebCore::parseValidHTMLNonNegativeInteger):
(WebCore::parseValidHTMLFloatingPointNumber):
(WebCore::parseHTMLFloatingPointNumberValue):
(WebCore::parseHTMLListOfOfFloatingPointNumberValues):
(WebCore::parseMetaHTTPEquivRefresh):
* Source/WebCore/html/parser/HTMLParserScheduler.cpp:
(WebCore::HTMLParserScheduler::shouldYieldBeforeExecutingScript):
* Source/WebCore/html/parser/HTMLParserScheduler.h:
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::processAnyOtherEndTagForInBody):
* Source/WebCore/html/parser/InputStreamPreprocessor.h:
(WebCore::InputStreamPreprocessor::peek):
* Source/WebCore/inspector/InspectorFrontendHost.cpp:
(WebCore::InspectorFrontendHost::addSelfToGlobalObjectInWorld):
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::frameWindowDiscardedImpl):
(WebCore::InspectorInstrumentation::didReceiveResourceResponseImpl):
(WebCore::InspectorInstrumentation::didFailLoadingImpl):
(WebCore::InspectorInstrumentation::didCommitLoadImpl):
(WebCore::InspectorInstrumentation::addMessageToConsoleImpl):
(WebCore::InspectorInstrumentation::consoleCountImpl):
(WebCore::InspectorInstrumentation::consoleCountResetImpl):
(WebCore::InspectorInstrumentation::startConsoleTimingImpl):
(WebCore::InspectorInstrumentation::logConsoleTimingImpl):
(WebCore::InspectorInstrumentation::stopConsoleTimingImpl):
* Source/WebCore/inspector/InspectorInstrumentationPublic.h:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::buildObjectForEventListener):
* Source/WebCore/layout/LayoutState.cpp:
(WebCore::Layout::LayoutState::ensureGeometryForBoxSlow):
* Source/WebCore/layout/LayoutState.h:
(WebCore::Layout::LayoutState::hasBoxGeometry const):
(WebCore::Layout::LayoutState::ensureGeometryForBox):
(WebCore::Layout::LayoutState::geometryForBox const):
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::moveToNextNonWhitespacePosition):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::width):
(WebCore::Layout::TextUtil::breakWord):
* Source/WebCore/layout/layouttree/LayoutBox.cpp:
(WebCore::Layout::Box::~Box):
* Source/WebCore/loader/MixedContentChecker.cpp:
(WebCore::MixedContentChecker::frameAndAncestorsCanRunInsecureContent):
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::shouldIncludeCertificateInfo const):
* Source/WebCore/loader/SubresourceIntegrity.h:
(WebCore::matchIntegrityMetadata):
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::makeRevalidationDecision const):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::scriptRequiresTelemetry):
* Source/WebCore/page/DOMTimer.cpp:
(WebCore::DOMTimer::updateThrottlingStateIfNecessary):
* Source/WebCore/page/DebugPageOverlays.h:
(WebCore::DebugPageOverlays::doAfterUpdateRendering):
(WebCore::DebugPageOverlays::shouldPaintOverlayIntoLayerForRegionType):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusNavigationScope::parentInScope const):
(WebCore::FocusNavigationScope::nextSiblingInScope const):
(WebCore::FocusNavigationScope::previousSiblingInScope const):
(WebCore::FocusNavigationScope::firstNodeInScope const):
(WebCore::FocusNavigationScope::lastNodeInScope const):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::processPostMessage):
(WebCore::LocalDOMWindow::dispatchEvent):
(WebCore::LocalDOMWindow::setLocation):
* Source/WebCore/page/LocalFrameView.h:
(WebCore::LocalFrameView::incrementVisuallyNonEmptyPixelCount):
* Source/WebCore/page/OpportunisticTaskScheduler.cpp:
(WebCore::OpportunisticTaskScheduler::runLoopObserverFired):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateRendering):
* Source/WebCore/page/PageConsoleClient.cpp:
(WebCore::PageConsoleClient::addMessage):
(WebCore::PageConsoleClient::record):
(WebCore::PageConsoleClient::recordEnd):
(WebCore::PageConsoleClient::screenshot):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::scriptToEvaluateBeforeRunningScriptFromURL):
(WebCore::Quirks::needsFacebookStoriesCreationFormQuirk const):
(WebCore::Quirks::topDocumentURL const):
* Source/WebCore/page/RemoteDOMWindow.cpp:
(WebCore::RemoteDOMWindow::setLocation):
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::rootViewBounds):
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::willBeginWritingToolsSession):
(WebCore::WritingToolsController::compositionSessionDidReceiveTextWithReplacementRangeAsync):
* Source/WebCore/platform/LayoutUnit.h:
(WebCore::LayoutUnit::ceil const):
(WebCore::LayoutUnit::floor const):
* Source/WebCore/platform/ThreadGlobalData.cpp:
(WebCore::threadGlobalDataSlow):
* Source/WebCore/platform/ThreadGlobalData.h:
(WebCore::ThreadGlobalData::cachedResourceRequestInitiatorTypes):
(WebCore::ThreadGlobalData::eventNames):
(WebCore::ThreadGlobalData::qualifiedNameCache):
(WebCore::ThreadGlobalData::mimeTypeRegistryThreadGlobalData):
(WebCore::ThreadGlobalData::fontCache):
(WebCore::threadGlobalData):
* Source/WebCore/platform/WebCorePersistentCoders.cpp:
(WTF::Persistence::decodeCFData):
* Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp:
(WebCore::AudioDestinationGStreamer::~AudioDestinationGStreamer):
* Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp:
(webKitWebAudioSrcChangeState):
* Source/WebCore/platform/graphics/FloatQuad.cpp:
(WebCore::clampToIntRange):
* Source/WebCore/platform/graphics/Font.h:
(WebCore::Font::boundsForGlyphs const):
* Source/WebCore/platform/graphics/Region.cpp:
(WebCore::Region::Shape::isValidShape):
* Source/WebCore/platform/graphics/WidthCache.h:
(WebCore::WidthCache::add):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::deleteExternalImage):
(WebCore::GraphicsContextGLANGLE::deleteExternalSync):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::~GraphicsLayerCA):
(WebCore::GraphicsLayerCA::platformCALayerPaintContents):
* Source/WebCore/platform/graphics/ca/TileGrid.cpp:
(WebCore::TileGrid::ensureTilesForRect):
* Source/WebCore/platform/graphics/cairo/RefPtrCairo.cpp:
(WTF::DefaultRefDerefTraits&lt;cairo_t&gt;::refIfNotNull):
(WTF::DefaultRefDerefTraits&lt;cairo_t&gt;::derefIfNotNull):
(WTF::DefaultRefDerefTraits&lt;cairo_surface_t&gt;::refIfNotNull):
(WTF::DefaultRefDerefTraits&lt;cairo_surface_t&gt;::derefIfNotNull):
(WTF::DefaultRefDerefTraits&lt;cairo_font_face_t&gt;::refIfNotNull):
(WTF::DefaultRefDerefTraits&lt;cairo_font_face_t&gt;::derefIfNotNull):
(WTF::DefaultRefDerefTraits&lt;cairo_scaled_font_t&gt;::refIfNotNull):
(WTF::DefaultRefDerefTraits&lt;cairo_scaled_font_t&gt;::derefIfNotNull):
(WTF::DefaultRefDerefTraits&lt;cairo_pattern_t&gt;::refIfNotNull):
(WTF::DefaultRefDerefTraits&lt;cairo_pattern_t&gt;::derefIfNotNull):
(WTF::DefaultRefDerefTraits&lt;cairo_region_t&gt;::refIfNotNull):
(WTF::DefaultRefDerefTraits&lt;cairo_region_t&gt;::derefIfNotNull):
* Source/WebCore/platform/graphics/cg/PathCG.cpp:
(WebCore::addToCGContextPath):
* Source/WebCore/platform/graphics/cg/UTIRegistry.mm:
(WebCore::preferredExtensionForImageType):
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::insertFinishedSignalOrInvoke):
* Source/WebCore/platform/graphics/filters/FilterImage.cpp:
(WebCore::copyImageBytes):
* Source/WebCore/platform/graphics/freetype/RefPtrFontconfig.cpp:
(WTF::DefaultRefDerefTraits&lt;FcPattern&gt;::refIfNotNull):
(WTF::DefaultRefDerefTraits&lt;FcPattern&gt;::derefIfNotNull):
(WTF::DefaultRefDerefTraits&lt;FcConfig&gt;::refIfNotNull):
(WTF::DefaultRefDerefTraits&lt;FcConfig&gt;::derefIfNotNull):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::gstStructureValueToJSON):
* Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp:
(WebKitVideoSinkProbe::doProbe):
* Source/WebCore/platform/graphics/gstreamer/ImageGStreamerCairo.cpp:
(WebCore::ImageGStreamer::ImageGStreamer):
* Source/WebCore/platform/graphics/gstreamer/ImageGStreamerSkia.cpp:
(WebCore::ImageGStreamer::ImageGStreamer):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::didLoadingProgress const):
(WebCore::MediaPlayerPrivateGStreamer::notifyPlayerOfTrack):
(WebCore::MediaPlayerPrivateGStreamer::downloadBufferFileCreatedCallback):
(WebCore::MediaPlayerPrivateGStreamer::purgeOldDownloadFiles):
(WebCore::MediaPlayerPrivateGStreamer::setupCodecProbe):
(WebCore::MediaPlayerPrivateGStreamer::triggerRepaint):
(WebCore::MediaPlayerPrivateGStreamer::codecForStreamId):
* Source/WebCore/platform/graphics/gstreamer/TextSinkGStreamer.cpp:
(webkitTextSinkHandleSample):
* Source/WebCore/platform/graphics/gstreamer/VideoSinkGStreamer.cpp:
(VideoRenderRequestScheduler::requestRender):
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::appsinkNewSample):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::pause):
(WebCore::MediaPlayerPrivateGStreamerMSE::checkPlayingConsistency):
(WebCore::MediaPlayerPrivateGStreamerMSE::duration const):
(WebCore::MediaPlayerPrivateGStreamerMSE::maxTimeSeekable const):
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:
(webKitMediaSrcWaitForPadLinkedOrFlush):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::getPixelBuffer):
(WebCore::ImageBufferSkiaAcceleratedBackend::putPixelBuffer):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp:
(WebCore::CoordinatedBackingStoreProxy::updateIfNeeded):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp:
(WebCore::CoordinatedPlatformLayerBufferVideo::create):
* Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkBcmNexus.cpp:
(WebCore::GStreamerHolePunchQuirkBcmNexus::setHolePunchVideoRectangle):
* Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkRialto.cpp:
(WebCore::GStreamerHolePunchQuirkRialto::setHolePunchVideoRectangle):
* Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkWesteros.cpp:
(WebCore::GStreamerHolePunchQuirkWesteros::setHolePunchVideoRectangle):
* Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp:
(WebCore::GStreamerQuirkRialto::GStreamerQuirkRialto):
* Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp:
(WebCore::GStreamerQuirkWesteros::GStreamerQuirkWesteros):
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(webkit_video_encoder_class_init):
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.h:
(WebKitVideoEncoderBitRateAllocation::getBitRate const):
* Source/WebCore/platform/mediastream/WebRTCProvider.cpp:
(WebCore::WebRTCProvider::setPortAllocatorRange):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp:
(WebCore::GStreamerCapturer::setDevice):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerDisplayCaptureDeviceManager.cpp:
(WebCore::GStreamerDisplayCaptureDeviceManager::stopSource):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp:
(WebCore::GStreamerIncomingTrackProcessor::retrieveMediaStreamAndTrackIdFromSDP):
(WebCore::GStreamerIncomingTrackProcessor::installRtpBufferPadProbe):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
(webkitMediaStreamSrcConfigureAudioTracks):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp:
(WebCore::GStreamerRTPPacketizer::payloadType const):
(WebCore::GStreamerRTPPacketizer::findLastExtensionId):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp:
(WebCore::GStreamerVideoCapturer::setSize):
(WebCore::GStreamerVideoCapturer::setFrameRate):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp:
(WebCore::GStreamerVideoRTPPacketizer::updateStats):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp:
(WebCore::RealtimeIncomingSourceGStreamer::setBin):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::configure):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::setParameters):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::configurePacketizers):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::lookupRtpExtensions):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp:
* Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm:
(WebCore::ResourceRequest::getResourceRequestPlatformData const):
* Source/WebCore/platform/text/SegmentedString.h:
(WebCore::SegmentedString::updateAdvanceFunctionPointersIfNecessary):
(WebCore::SegmentedString::advanceWithoutUpdatingLineNumber):
(WebCore::SegmentedString::advance):
* Source/WebCore/rendering/AccessibilityRegionContext.cpp:
(WebCore::AccessibilityRegionContext::takeBounds):
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::clipRoundedInnerRect):
* Source/WebCore/rendering/BreakLines.h:
(WebCore::BreakLines::classify):
* Source/WebCore/rendering/LegacyInlineIterator.h:
(WebCore::LegacyInlineIterator::direction const):
* Source/WebCore/rendering/LegacyLineLayout.cpp:
(WebCore::LegacyLineLayout::createAndAppendRootInlineBox):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutBlockChild):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::computeGap const):
* Source/WebCore/rendering/RenderLayer.cpp:
* Source/WebCore/rendering/RenderObject.h:
(WebCore::Node::setRenderer):
* Source/WebCore/rendering/RenderTableCell.h:
(WebCore::RenderTableCell::setCol):
* Source/WebCore/rendering/RenderTableRow.h:
(WebCore::RenderTableRow::setRowIndex):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::paint):
* Source/WebCore/rendering/StyledMarkedText.cpp:
(WebCore::StyledMarkedText::subdivideAndResolve):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::changedCustomPaintWatchedProperty):
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::usedVisibility const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp:
(WebCore::removeFromCacheAndInvalidateDependencies):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::createRenderer):
(WebCore::RenderTreeUpdater::createTextRenderer):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::collectMatchingRulesForList):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyProperties):
(WebCore::Style::Builder::applyProperty):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::requiredDowncast):
(WebCore::Style::BuilderConverter::requiredPairDowncast):
(WebCore::Style::BuilderConverter::requiredListDowncast):
(WebCore::Style::BuilderConverter::requiredFunctionDowncast):
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::PathSegListCache::add):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::getElementById):
* Source/WebCore/testing/js/WebCoreTestSupport.cpp:
(WebCoreTestSupport::populateJITOperations):
* Source/WebCore/workers/Worker.cpp:
(WebCore::Worker::didReceiveResponse):
(WebCore::Worker::notifyFinished):
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::addConsoleMessage):
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::postMessageToWorkerObject):
(WebCore::WorkerMessagingProxy::postMessageToWorkerGlobalScope):
* Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp:
(WebCore::WorkerOrWorkletGlobalScope::eventLoop):
* Source/WebCore/workers/WorkerOrWorkletScriptController.cpp:
(WebCore::WorkerOrWorkletScriptController::loadAndEvaluateModule):
* Source/WebCore/workers/WorkerRunLoop.cpp:
(WebCore::WorkerDedicatedRunLoop::Task::performTask):
* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::jobResolvedWithRegistration):
(WebCore::ServiceWorkerContainer::postMessage):
* Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp:
(WebCore::SharedWorkerScriptLoader::didReceiveResponse):
(WebCore::SharedWorkerScriptLoader::notifyFinished):
* Source/WebCore/worklets/PaintWorkletGlobalScope.cpp:
(WebCore::PaintWorkletGlobalScope::registerPaint):
* Source/WebCore/worklets/WorkletGlobalScope.cpp:
(WebCore::WorkletGlobalScope::logExceptionToConsole):
(WebCore::WorkletGlobalScope::addConsoleMessage):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::startElementNs):

Canonical link: <a href="https://commits.webkit.org/294436@main">https://commits.webkit.org/294436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a0aa4cc88b279c1a5519ff578ceca0bc6c831c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101815 "294 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11799 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106973 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52449 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103855 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21791 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29989 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/77527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/34549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104822 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/16837 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91938 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/57865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16664 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/9956 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51800 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86518 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/10033 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109330 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28948 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/21322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29309 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88139 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/86080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21904 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30829 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8548 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23119 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28876 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34166 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28687 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32010 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30246 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->