### PR TITLE
[glib] (Re-)introduce LIFETIME_BOUND for GRefPtr.get()

### DIFF
--- a/Source/JavaScriptCore/API/glib/JSCContext.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCContext.cpp
@@ -1117,7 +1117,6 @@ JSCClass* jsc_context_register_class(JSCContext* context, const char* name, JSCC
     g_return_val_if_fail(name, nullptr);
     g_return_val_if_fail(!parentClass || JSC_IS_CLASS(parentClass), nullptr);
 
-    auto jscClass = jscClassCreate(context, name, parentClass, vtable, destroyFunction);
-    wrapperMap(context).registerClass(jscClass.get());
-    return jscClass.get();
+    return wrapperMap(context).registerClass(
+        jscClassCreate(context, name, parentClass, vtable, destroyFunction));
 }

--- a/Source/JavaScriptCore/API/glib/JSCWrapperMap.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCWrapperMap.cpp
@@ -64,11 +64,12 @@ void WrapperMap::unwrap(JSValueRef jsValue)
     m_cachedGObjectWrappers.remove(jsValue);
 }
 
-void WrapperMap::registerClass(JSCClass* jscClass)
+JSCClass* WrapperMap::registerClass(GRefPtr<JSCClass>&& jscClass)
 {
-    RefPtr jsClass = jscClassGetJSClass(jscClass);
-    ASSERT(!m_classMap.contains(jsClass.get()));
-    m_classMap.set(jsClass.get(), jscClass);
+    RefPtr jsClass = jscClassGetJSClass(jscClass.get());
+    auto result = m_classMap.set(jsClass.get(), jscClass);
+    ASSERT(result.isNewEntry);
+    return result.iterator->value.get();
 }
 
 JSCClass* WrapperMap::registeredClass(JSClassRef jsClass) const

--- a/Source/JavaScriptCore/API/glib/JSCWrapperMap.h
+++ b/Source/JavaScriptCore/API/glib/JSCWrapperMap.h
@@ -44,7 +44,7 @@ public:
     GRefPtr<JSCValue> gobjectWrapper(JSCContext*, JSValueRef);
     void unwrap(JSValueRef);
 
-    void registerClass(JSCClass*);
+    JSCClass* registerClass(GRefPtr<JSCClass>&&);
     JSCClass* registeredClass(JSClassRef) const;
 
     JSObject* createJSWrapper(JSGlobalContextRef, JSClassRef, JSValueRef prototype, gpointer, GDestroyNotify);

--- a/Source/WTF/wtf/glib/GRefPtr.h
+++ b/Source/WTF/wtf/glib/GRefPtr.h
@@ -143,7 +143,13 @@ public:
     // Borrows the raw pointer from GRefPtr.
     // The pointer is guaranteed to be valid for as long as GRefPtr holds an owning reference
     // to that object.
-    T* /* (transfer none) */ get() const { return m_ptr; }
+    T* /* (transfer none) */ get() const LIFETIME_BOUND { return m_ptr; }
+    // Same as get(), but clang won't complain if you return the pointer to your callee.
+    // Generally unsafe: to use, you must guarantee that the object will still have strong
+    // references by the time your function returns.
+    // Only used for C API functions returning (transfer none) of objects where the above
+    // can be established, e.g. objects stored in a global dictionary.
+    T* /* (transfer none) */ getUncheckedLifetime() const { return m_ptr; }
     T& operator*() const { return *m_ptr; }
     ALWAYS_INLINE T* operator->() const { return m_ptr; }
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitBackForwardList.cpp
@@ -96,14 +96,14 @@ static WebKitBackForwardListItem* webkitBackForwardListGetOrCreateItem(WebKitBac
         return 0;
 
     WebKitBackForwardListPrivate* priv = list->priv;
-    GRefPtr<WebKitBackForwardListItem> listItem = priv->itemsMap.get(webListItem);
+    WebKitBackForwardListItem* listItem = priv->itemsMap.get(webListItem);
     if (listItem)
-        return listItem.get();
+        return listItem;
 
     listItem = webkitBackForwardListItemGetOrCreate(webListItem);
     priv->itemsMap.set(webListItem, listItem);
 
-    return listItem.get();
+    return listItem;
 }
 
 static GList* webkitBackForwardListCreateList(WebKitBackForwardList* list, API::Array* backForwardItems)

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
@@ -183,9 +183,9 @@ void PageClientImpl::setCursor(const WebCore::Cursor& cursor)
     // so don't re-set the cursor if it's already set to the target value.
 #if USE(GTK4)
     GdkCursor* currentCursor = gtk_widget_get_cursor(m_viewWidget);
-    GdkCursor* newCursor = cursor.platformCursor().get();
-    if (currentCursor != newCursor)
-        gtk_widget_set_cursor(m_viewWidget, newCursor);
+    GRefPtr<GdkCursor> newCursor = cursor.platformCursor();
+    if (currentCursor != newCursor.get())
+        gtk_widget_set_cursor(m_viewWidget, newCursor.get());
 #else
     GdkWindow* window = gtk_widget_get_window(m_viewWidget);
     GdkCursor* currentCursor = gdk_window_get_cursor(window);

--- a/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
@@ -370,7 +370,7 @@ GVariant* wpe_settings_get_value(WPESettings* settingsObject, const char* key, G
         return nullptr;
     }
 
-    return iter->value.value().get();
+    return iter->value.value().getUncheckedLifetime();
 }
 
 #define g_variant_get_string(str) g_variant_get_string(str, nullptr)


### PR DESCRIPTION
#### 45ee5a5e7caa1d809c29ce742a6ee21bae07741f
<pre>
[glib] (Re-)introduce LIFETIME_BOUND for GRefPtr.get()
<a href="https://bugs.webkit.org/show_bug.cgi?id=292424">https://bugs.webkit.org/show_bug.cgi?id=292424</a>

Reviewed by Carlos Garcia Campos and Michael Catanzaro.

This patch adds LIFETIME_BOUND annotation to GRefPtr, which was
temporarily reverted in <a href="https://github.com/WebKit/WebKit/pull/44595">https://github.com/WebKit/WebKit/pull/44595</a> due
to build issues.

A new method, GRefPtr.getUnchekedLifetime() is added that doesn&apos;t use
LIFETIME_BOUND, especifically for situations where returning a raw
pointer of a GRefPtr about to be destroyed is necessary -- of course,
this is only safe when the object is guaranteed to have at least one
other strong references.

Changes are made to the few functions where the introduction of
LIFETIME_BOUND made them not compile. These changes have also reduced
the number of unnecessary refcount temporary increases in the affected
code.

* Source/JavaScriptCore/API/glib/JSCContext.cpp:
(jsc_context_register_class):
* Source/JavaScriptCore/API/glib/JSCWrapperMap.cpp:
(JSC::WrapperMap::registerClass):
* Source/JavaScriptCore/API/glib/JSCWrapperMap.h:
* Source/WTF/wtf/glib/GRefPtr.h:
(WTF::GRefPtr::getUncheckedLifetime const):
(WTF::GRefPtr::get const): Deleted.
* Source/WebKit/UIProcess/API/glib/WebKitBackForwardList.cpp:
(webkitBackForwardListGetOrCreateItem):
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp:
(WebKit::PageClientImpl::setCursor):
* Source/WebKit/WPEPlatform/wpe/WPESettings.cpp:
(wpe_settings_get_value):

Canonical link: <a href="https://commits.webkit.org/294782@main">https://commits.webkit.org/294782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f3d0e33dc01530a1c72ef7192d46b491de63a76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106925 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52401 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29939 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77486 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34508 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104774 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16798 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91900 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57824 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16623 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9918 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51752 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94439 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86479 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109281 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100377 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28900 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21282 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86466 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29261 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88101 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86037 "Found 102 new API test failures: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/javascript-dialogs, /TestWebKit:WebKit.DOMWindowExtensionCrashOnReload, /TestWebKit:WebKit.PageLoadBasic, /TestWebKit:WebKit.NewFirstVisuallyNonEmptyLayoutFails, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /TestWebKit:WebKit.InjectedBundleBasic, /TestWebKit:WebKit.PreventEmptyUserAgent, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/select-all/non-editable ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22129 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30790 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8511 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23065 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28828 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34118 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124001 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28639 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34448 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31962 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30198 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->