### PR TITLE
MediaSession needs to wait for SVG icons with subresources

### DIFF
--- a/LayoutTests/fast/mediasession/metadata/artworkdownload-svg-expected.html
+++ b/LayoutTests/fast/mediasession/metadata/artworkdownload-svg-expected.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<style>
+img {
+  width: 200px;
+  height: 200px;
+  background-color: red;
+}
+</style>
+<img src="../../../svg/as-image/resources/image-with-nested-rects.svg">

--- a/LayoutTests/fast/mediasession/metadata/artworkdownload-svg.html
+++ b/LayoutTests/fast/mediasession/metadata/artworkdownload-svg.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<img id=result src="" style="image-rendering: pixelated;">
+<script>
+if (window.internals && window.testRunner) {
+  testRunner.waitUntilDone();
+
+  const canvas = document.createElement('canvas');
+  canvas.width = 200;
+  canvas.height = 200;
+  const context = canvas.getContext('2d');
+
+  context.fillStyle = "red";
+  context.fillRect(0, 0, canvas.width, canvas.height);
+
+  internals.loadArtworkImage("../../../svg/as-image/resources/image-with-nested-data-uri-images.svg").then(data => {
+    context.drawImage(data, 0, 0);
+    const image = document.getElementById("result");
+    image.src = canvas.toDataURL();
+    image.onload = () => testRunner.notifyDone();
+  });
+}
+</script>

--- a/LayoutTests/fast/mediasession/metadata/artworkdownload.html
+++ b/LayoutTests/fast/mediasession/metadata/artworkdownload.html
@@ -11,8 +11,8 @@ promise_test((test) => {
     if (!window.internals)
         return Promise.rejects("Test needs internals");
     return internals.loadArtworkImage(IMAGE_SRC).then((data) => {
-        assert_equals(data.width, 16);
-        assert_equals(data.height, 16);
+        assert_equals(data.codedWidth, 16);
+        assert_equals(data.codedHeight, 16);
     });
 }, "ensure loading artwork image method operates properly");
 

--- a/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
@@ -84,7 +84,10 @@ void ArtworkImageLoader::notifyFinished(CachedResource& resource, const NetworkL
         m_callback(nullptr);
         return;
     }
-    m_callback(m_cachedImage->image());
+    Ref image = *m_cachedImage->image();
+    image->subresourcesAreFinished(nullptr, [image, callback = std::exchange(m_callback, { })]() mutable {
+        callback(image.ptr());
+    });
 }
 
 ExceptionOr<Ref<MediaMetadata>> MediaMetadata::create(ScriptExecutionContext& context, std::optional<MediaMetadataInit>&& init)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -333,6 +333,11 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutio
     return WebCodecsVideoFrame::create(context, videoFrame.releaseNonNull(), WTFMove(init));
 }
 
+ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutionContext& context, Ref<NativeImage>&& image)
+{
+    return initializeFrameWithResourceAndSize(context, WTFMove(image), { });
+}
+
 Ref<WebCodecsVideoFrame> WebCodecsVideoFrame::create(ScriptExecutionContext& context, Ref<VideoFrame>&& videoFrame, BufferInit&& init)
 {
     ASSERT(isValidVideoFrameBufferInit(init));

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
@@ -101,6 +101,7 @@ public:
     static ExceptionOr<Ref<WebCodecsVideoFrame>> create(ScriptExecutionContext&, Ref<WebCodecsVideoFrame>&&, Init&&);
     static ExceptionOr<Ref<WebCodecsVideoFrame>> create(ScriptExecutionContext&, BufferSource&&, BufferInit&&);
     static ExceptionOr<Ref<WebCodecsVideoFrame>> create(ScriptExecutionContext&, ImageBuffer&, IntSize, Init&&);
+    WEBCORE_EXPORT static ExceptionOr<Ref<WebCodecsVideoFrame>> create(ScriptExecutionContext&, Ref<NativeImage>&&);
     static Ref<WebCodecsVideoFrame> create(ScriptExecutionContext&, Ref<VideoFrame>&&, BufferInit&&);
     static Ref<WebCodecsVideoFrame> create(ScriptExecutionContext& context, WebCodecsVideoFrameData&& data) { return adoptRef(*new WebCodecsVideoFrame(context, WTFMove(data))); }
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.idl
@@ -38,6 +38,7 @@ typedef (HTMLImageElement
 
 // FIXME: Support Serializable and Transferable.
 [
+    ExportMacro=WEBCORE_EXPORT,
     Conditional=WEB_CODECS,
     EnabledBySetting=WebCodecsVideoEnabled,
     Exposed=(Window,DedicatedWorker),

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -110,7 +110,6 @@ rendering/updating/RenderTreeUpdater.cpp
 style/Styleable.cpp
 style/values/StyleValueTypes.h
 style/values/images/StyleGradient.cpp
-testing/Internals.cpp
 testing/MockMediaSessionCoordinator.cpp
 workers/Worker.cpp
 workers/WorkerMessagingProxy.cpp

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -74,7 +74,6 @@ namespace WebCore {
 class AccessibilityObject;
 class AbstractRange;
 class AnimationTimeline;
-class ArtworkImageLoader;
 class AudioContext;
 class AudioTrack;
 class BaseAudioContext;
@@ -187,6 +186,8 @@ class PlatformSpeechSynthesizerMock;
 #endif
 
 #if ENABLE(WEB_CODECS)
+class ArtworkImageLoader;
+class WebCodecsVideoFrame;
 class WebCodecsVideoDecoder;
 #endif
 
@@ -1459,8 +1460,10 @@ public:
     ExceptionOr<double> currentMediaSessionPosition(const MediaSession&);
     ExceptionOr<void> sendMediaSessionAction(MediaSession&, const MediaSessionActionDetails&);
 
-        using ArtworkImagePromise = DOMPromiseDeferred<IDLInterface<ImageData>>;
+#if ENABLE(WEB_CODECS)
+    using ArtworkImagePromise = DOMPromiseDeferred<IDLInterface<WebCodecsVideoFrame>>;
     void loadArtworkImage(String&&, ArtworkImagePromise&&);
+#endif
     ExceptionOr<Vector<String>> platformSupportedCommands() const;
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
@@ -1616,7 +1619,7 @@ private:
     RefPtr<RealtimeMediaSource> m_trackSource;
     int m_trackVideoRotation { 0 };
 #endif
-#if ENABLE(MEDIA_SESSION)
+#if ENABLE(MEDIA_SESSION) && ENABLE(WEB_CODECS)
     std::unique_ptr<ArtworkImageLoader> m_artworkLoader;
     std::unique_ptr<ArtworkImagePromise> m_artworkImagePromise;
 #endif

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1379,7 +1379,7 @@ enum ContentsFormat {
 
     [Conditional=MEDIA_SESSION] double currentMediaSessionPosition(MediaSession session);
     [Conditional=MEDIA_SESSION] undefined sendMediaSessionAction(MediaSession session, MediaSessionActionDetails actionDetails);
-    [Conditional=MEDIA_SESSION] Promise<ImageData> loadArtworkImage(DOMString url);
+    [Conditional=MEDIA_SESSION&WEB_CODECS] Promise<WebCodecsVideoFrame> loadArtworkImage(DOMString url);
     [Conditional=MEDIA_SESSION] sequence<DOMString> platformSupportedCommands();
 
     [Conditional=MEDIA_SESSION_COORDINATOR, CallWith=CurrentScriptExecutionContext] undefined registerMockMediaSessionCoordinator(StringCallback callback);


### PR DESCRIPTION
#### 25d372ccf31cc6e72f7017bc8d94a50a33b23820
<pre>
MediaSession needs to wait for SVG icons with subresources
<a href="https://bugs.webkit.org/show_bug.cgi?id=292431">https://bugs.webkit.org/show_bug.cgi?id=292431</a>

Reviewed by Youenn Fablet.

This initially landed as 294334@main, but got backed out in 294341@main
due to breakage.

* LayoutTests/fast/mediasession/metadata/artworkdownload-svg-expected.html: Added.
* LayoutTests/fast/mediasession/metadata/artworkdownload-svg.html: Added.

Make sure SVG image has the correct pixels. Use pixelated rendering for
iOS to account for a slight difference in rendering.

* LayoutTests/fast/mediasession/metadata/artworkdownload.html:

Modify existing test to account for it now getting a VideoFrame.

* Source/WebCore/Modules/mediasession/MediaMetadata.cpp:
(WebCore::ArtworkImageLoader::notifyFinished):

Fix the actual bug by using subresourcesAreFinished().

* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::WebCodecsVideoFrame::create):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.idl:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::~Internals):
(WebCore::Internals::loadArtworkImage):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Update test infrastructure so the fix can be tested and be extra
careful with the directives this time around.

Canonical link: <a href="https://commits.webkit.org/294499@main">https://commits.webkit.org/294499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf11d4f3690052700b6eb399d049bef95d760125

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101790 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11774 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106948 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52424 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103830 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29963 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77508 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34526 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16819 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91918 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57846 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16645 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9936 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51775 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86500 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10013 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109305 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28923 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21303 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86487 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29284 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88119 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86058 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30811 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8529 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23093 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16591 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28851 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34141 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28662 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31985 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30221 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->