### PR TITLE
[WTF] Remove remaining use of LIKELY / UNLIKELY except for headers used in C

### DIFF
--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -628,7 +628,7 @@ using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
 void operator delete(T* object, std::destroying_delete_t, size_t size) { \
     ASSERT_UNUSED(size, sizeof(T) == size); \
     object->T::~T(); \
-    if (UNLIKELY(object->checkedPtrCountWithoutThreadCheck())) { \
+    if (object->checkedPtrCountWithoutThreadCheck()) [[unlikely]] { \
         zeroBytes(object); \
         return; \
     } \

--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -297,7 +297,7 @@ enum WTFOSSignpostType {
 // By default, os_signpost always emits signpost data to logd. We want to avoid that for WebKit
 // signposts. Instead, we use kdebug_is_enabled to make WebKit's os_signposts behave like kdebug
 // trace points (i.e. we only enable them if a tracing tool is active).
-#define WTFSignpostsEnabled() UNLIKELY(kdebug_is_enabled(KDBG_EVENTID(DBG_APPS, DBG_APPS_WEBKIT_MISC, 0)))
+#define WTFSignpostsEnabled() kdebug_is_enabled(KDBG_EVENTID(DBG_APPS, DBG_APPS_WEBKIT_MISC, 0))
 #else
 #define WTFSignpostsEnabled() true
 #endif
@@ -346,7 +346,7 @@ enum WTFOSSignpostType {
 
 #define WTFEmitSignpostWithType(type, emitMacro, pointer, name, timeDelta, timeFormat, format, ...) \
     do { \
-        if (WTFSignpostsEnabled()) \
+        if (WTFSignpostsEnabled()) [[unlikely]] \
             WTFEmitSignpostAlwaysWithType(type, emitMacro, pointer, name, timeDelta, timeFormat, format, ##__VA_ARGS__); \
     } while (0)
 

--- a/Source/WTF/wtf/text/AtomString.cpp
+++ b/Source/WTF/wtf/text/AtomString.cpp
@@ -51,9 +51,16 @@ ALWAYS_INLINE AtomString AtomString::convertASCIICase() const
         auto characters = impl->span8();
         unsigned failingIndex;
         for (unsigned i = 0; i < length; ++i) {
-            if (type == CaseConvertType::Lower ? UNLIKELY(isASCIIUpper(characters[i])) : LIKELY(isASCIILower(characters[i]))) {
-                failingIndex = i;
-                goto SlowPath;
+            if constexpr (type == CaseConvertType::Lower) {
+                if (isASCIIUpper(characters[i])) [[unlikely]] {
+                    failingIndex = i;
+                    goto SlowPath;
+                }
+            } else {
+                if (isASCIILower(characters[i])) [[likely]] {
+                    failingIndex = i;
+                    goto SlowPath;
+                }
             }
         }
         return *this;

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -729,9 +729,16 @@ ALWAYS_INLINE Ref<StringImpl> StringImpl::convertASCIICase(StringImpl& impl, std
     size_t failingIndex;
     for (size_t i = 0; i < data.size(); ++i) {
         CharacterType character = data[i];
-        if (type == CaseConvertType::Lower ? UNLIKELY(isASCIIUpper(character)) : LIKELY(isASCIILower(character))) {
-            failingIndex = i;
-            goto SlowPath;
+        if constexpr (type == CaseConvertType::Lower) {
+            if (isASCIIUpper(character)) [[unlikely]] {
+                failingIndex = i;
+                goto SlowPath;
+            }
+        } else {
+            if (isASCIILower(character)) [[likely]] {
+                failingIndex = i;
+                goto SlowPath;
+            }
         }
     }
     return impl;

--- a/Source/WTF/wtf/text/WYHash.h
+++ b/Source/WTF/wtf/text/WYHash.h
@@ -271,11 +271,11 @@ private:
     ALWAYS_INLINE static constexpr void handleGreaterThan8CharactersCase(T*& p, unsigned& i, NOESCAPE const Read8Functor& wyr8, uint64_t& seed, uint64_t see1, uint64_t see2)
     {
         if (i > 24) [[unlikely]] {
-            do {
+            do [[likely]] {
                 consume24Characters(p, wyr8, seed, see1, see2);
                 p += 24;
                 i -= 24;
-            } while (LIKELY(i > 24));
+            } while (i > 24);
             seed ^= see1 ^ see2;
         }
         while (i > 8) [[unlikely]] {


### PR DESCRIPTION
#### e340a3c2b4175ca8534208b0fd76781f9d565590
<pre>
[WTF] Remove remaining use of LIKELY / UNLIKELY except for headers used in C
<a href="https://bugs.webkit.org/show_bug.cgi?id=292439">https://bugs.webkit.org/show_bug.cgi?id=292439</a>
<a href="https://rdar.apple.com/150527300">rdar://150527300</a>

Reviewed by Chris Dumez.

Use [[likely]] and [[unlikely]].

* Source/WTF/wtf/FastMalloc.h:
* Source/WTF/wtf/SystemTracing.h:
* Source/WTF/wtf/text/AtomString.cpp:
(WTF::AtomString::convertASCIICase const):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::convertASCIICase):
* Source/WTF/wtf/text/WYHash.h:
(WTF::WYHash::handleGreaterThan8CharactersCase):

Canonical link: <a href="https://commits.webkit.org/294455@main">https://commits.webkit.org/294455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a51b4886d54e96c6fad60766cd389c45a955303

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101829 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21497 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106987 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52463 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21805 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30004 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77545 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34562 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104836 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16852 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91955 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57883 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16679 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9974 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51814 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94501 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86532 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10050 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109380 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100439 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28962 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21336 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86537 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29323 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88156 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86113 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30844 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8565 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23133 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16573 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28890 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34181 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124064 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28701 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34463 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32024 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30260 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->