### PR TITLE
AX: To avoid confusing ATs, WebKit should avoid exposing listboxes as listboxes if they don't have any option descendants

### DIFF
--- a/LayoutTests/accessibility/mac/invalid-list-box-expected.txt
+++ b/LayoutTests/accessibility/mac/invalid-list-box-expected.txt
@@ -1,0 +1,14 @@
+This test ensures we don't expose invalid role='listbox' elements as platform-role listboxes, as that can cause bad behavior for ATs.
+
+PASS: accessibilityController.accessibleElementById('listbox').role === 'AXRole: AXGroup'
+PASS: accessibilityController.accessibleElementById('listbox').role === 'AXRole: AXList'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Explore products
+Category A
+Category B
+Category C
+Foo
+

--- a/LayoutTests/accessibility/mac/invalid-list-box.html
+++ b/LayoutTests/accessibility/mac/invalid-list-box.html
@@ -1,0 +1,58 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div role="group" aria-label="container">
+    <div id="listbox" role="listbox" aria-label="Submenu for Products">
+        <ul>
+            <li><a href=#>Explore products</a></li>
+        </ul>
+        <ul>
+            <li><a href=#>Category A</a></li>
+            <li><a href=#>Category B</a></li>
+            <li><a href=#>Category C</a></li>
+        </ul>
+    </div>
+</div>
+
+<div id="option-wrapper">
+    <!-- Add some generic elements in-between to ensure our algorithm is smart enough to traverse through them to find an options. -->
+    <div>
+        <div>
+            <span>
+                <div role="group" aria-label="i'm a group that contains an option, which is a valid child for a listbox">
+                    <div role="option">Foo</div>
+                </div>
+            </span>
+        </div>
+    </div>
+</div>
+
+<script>
+var output = "This test ensures we don't expose invalid role='listbox' elements as platform-role listboxes, as that can cause bad behavior for ATs.\n\n";
+// A concrete example of this was on ikea.com, which had product submenus with markup similar to that present in this test.
+// VoiceOver was not able to navigate inside of it because VoiceOver expected a certain structure and behavior from a listbox.
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    // The listbox in its initial state is invalid — it has no `option` descendants. We should map it to group.
+    output += expect("accessibilityController.accessibleElementById('listbox').role", "'AXRole: AXGroup'");
+
+    // Let's add an option descendant and ensure the role is now reported to be a proper listbox.
+    document.getElementById("listbox").appendChild(document.getElementById("option-wrapper"));
+    setTimeout(async function() {
+        output += await expectAsync("accessibilityController.accessibleElementById('listbox').role", "'AXRole: AXList'");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -824,6 +824,9 @@ public:
     bool isCheckbox() const { return roleValue() == AccessibilityRole::Checkbox; }
     bool isRadioButton() const { return roleValue() == AccessibilityRole::RadioButton; }
     bool isListBox() const { return roleValue() == AccessibilityRole::ListBox; }
+    // The children of listboxes must be of specific roles. Returns true if at least one of those is present.
+    bool isValidListBox() const;
+    bool isInvalidListBox() const { return isListBox() && !isValidListBox(); }
     bool isListBoxOption() const { return roleValue() == AccessibilityRole::ListBoxOption; }
     virtual bool isAttachment() const = 0;
     bool isMenuRelated() const;

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -894,9 +894,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::IsKeyboardFocusable:
         stream << "IsKeyboardFocusable";
         break;
-    case AXProperty::IsListBox:
-        stream << "IsListBox";
-        break;
     case AXProperty::IsMathElement:
         stream << "IsMathElement";
         break;

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -325,7 +325,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     } else if (role == AccessibilityRole::Canvas && firstUnignoredChild() && !containsOnlyStaticText()) {
         // If this is a canvas with fallback content (one or more non-text thing), re-map to group.
         role = AccessibilityRole::Group;
-    }
+    } else if (isInvalidListBox())
+        role = AccessibilityRole::Group;
 
     return Accessibility::roleToPlatformString(role);
 }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -176,7 +176,6 @@ enum class AXProperty : uint16_t {
     IsRadioInput,
     IsInputImage,
     IsKeyboardFocusable,
-    IsListBox,
     IsMathElement,
     IsMathFraction,
     IsMathFenced,


### PR DESCRIPTION
#### 98548924f48f6e5eb83ca120f38b8bcbe720c580
<pre>
AX: To avoid confusing ATs, WebKit should avoid exposing listboxes as listboxes if they don&apos;t have any option descendants
<a href="https://bugs.webkit.org/show_bug.cgi?id=292443">https://bugs.webkit.org/show_bug.cgi?id=292443</a>
<a href="https://rdar.apple.com/150533266">rdar://150533266</a>

Reviewed by Joshua Hoffman.

If a role=&quot;listbox&quot; has no options, we should just call it a group to avoid confusing assistive technologies who expect
listboxes to have a certain structure. Said confusion can have adverse side effects, like VoiceOver failing to navigate
content within an invalid listbox.

This commit also removes unused AXProperty::IsListBox.

* LayoutTests/accessibility/mac/invalid-list-box-expected.txt: Added.
* LayoutTests/accessibility/mac/invalid-list-box.html: Added.
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::isValidListBox const):
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::isInvalidListBox const):
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::AXCoreObject::rolePlatformString):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:

Canonical link: <a href="https://commits.webkit.org/294459@main">https://commits.webkit.org/294459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/452f4719f4f5d9557e53e57e2ca35d4cc61269ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107006 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52482 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103888 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30023 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77547 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34566 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104855 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91968 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57884 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9989 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51837 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86546 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109364 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28981 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21347 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86524 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29342 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88171 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86097 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21915 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30856 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8577 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23152 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28909 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34200 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28720 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32043 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30279 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->