### PR TITLE
[JSC] Enable

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGBasicBlock.h
+++ b/Source/JavaScriptCore/dfg/DFGBasicBlock.h
@@ -264,6 +264,11 @@ public:
     };
     std::unique_ptr<SSAData> ssa;
 
+    // Indicates this block was synthetically generated (e.g., via loop unrolling or
+    // additional jump pad insertion due to loop unrolling) and should not contribute
+    // to FTL inlining code size heuristics.
+    bool isExcludedFromFTLCodeSizeEstimation { false };
+
 #if ASSERT_ENABLED
     // Points to the original block this one was cloned from during loop unrolling.
     BasicBlock* cloneSource { nullptr };

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.h
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.h
@@ -112,6 +112,7 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
 #if ASSERT_ENABLED
     clone->cloneSource = block;
 #endif
+    clone->isExcludedFromFTLCodeSizeEstimation = true;
     return clone;
 }
 

--- a/Source/JavaScriptCore/dfg/DFGCriticalEdgeBreakingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCriticalEdgeBreakingPhase.cpp
@@ -127,6 +127,8 @@ public:
                 }
                 }
             }
+
+            pad->isExcludedFromFTLCodeSizeEstimation = true;
         }
     }
 private:

--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
@@ -82,6 +82,23 @@ public:
         // Returns true if the node would emit code when lowered to B3.
         // Used to estimate unrolling cost more precisely, skipping Phantom-like ops.
         bool isMaterialNode(Graph&, Node*);
+        bool isNumericComputationNode(Node*);
+        bool isLocalAccessNode(Node*);
+
+        uint32_t nonPadBlockCount()
+        {
+            uint32_t count = 0;
+            for (uint32_t i = 0; i < loopSize(); ++i) {
+                if (!loopBody(i)->isJumpPad())
+                    ++count;
+            }
+            return count;
+        }
+
+        // Ratio of this count to total material node count
+        double ratio(uint32_t count) { return materialNodeCount ? static_cast<double>(count) / materialNodeCount : 0.0; }
+
+        uint32_t maxAllowedUnrollSize() { return shouldFullyUnroll() ? Options::maxLoopUnrollingBodyNodeSize() : Options::maxPartialLoopUnrollingBodyNodeSize(); }
 
         const NaturalLoop* loop { nullptr };
         BasicBlock* preHeader { nullptr };
@@ -101,6 +118,8 @@ public:
         uint32_t materialNodeCount { 0 };
         uint32_t putByValCount { 0 };
         uint32_t getByValCount { 0 };
+        uint32_t numericComputationCount { 0 };
+        uint32_t localAccessCount { 0 };
     };
 
     LoopUnrollingPhase(Graph& graph)
@@ -472,7 +491,6 @@ public:
 
     bool isLoopBodyUnrollable(LoopData& data)
     {
-        uint32_t maxLoopUnrollingBodyNodeSize = data.shouldFullyUnroll() ? Options::maxLoopUnrollingBodyNodeSize() : Options::maxPartialLoopUnrollingBodyNodeSize();
         for (uint32_t i = 0; i < data.loopSize(); ++i) {
             BasicBlock* body = data.loopBody(i);
             if (!body->isReachable) {
@@ -486,10 +504,6 @@ public:
 
             HashSet<Node*> cloneableCache;
             for (Node* node : *body) {
-                if (data.materialNodeCount > maxLoopUnrollingBodyNodeSize) {
-                    dataLogLnIf(Options::verboseLoopUnrolling(), "Skipping loop with header ", *data.header(), " and loop node count=", data.materialNodeCount, " since maxLoopUnrollingBodyNodeSize=", maxLoopUnrollingBodyNodeSize);
-                    return false;
-                }
 
                 if (!CloneHelper::isNodeCloneable(m_graph, cloneableCache, node)) {
                     dataLogLnIf(Options::verboseLoopUnrolling(), "Skipping loop with header ", *data.header(), " since ", node, "<", node->op(), "> is not cloneable");
@@ -604,6 +618,23 @@ bool performLoopUnrolling(Graph& graph)
 
 bool LoopUnrollingPhase::LoopData::isProfitableToUnroll()
 {
+    auto matchesNumericHotLoopPattern = [&]() {
+        // Unroll hot loops dominated by numeric computations and local access
+        return nonPadBlockCount() == 1
+            && ratio(numericComputationCount) > 0.3
+            && ratio(localAccessCount) > 0.4
+            && materialNodeCount > 160
+            && materialNodeCount < 225;
+    };
+
+    if (matchesNumericHotLoopPattern())
+        return true;
+
+    if (materialNodeCount > maxAllowedUnrollSize()) {
+        dataLogLnIf(Options::verboseLoopUnrolling(), "Skipping loop with header ", *header(), " and loop node count=", materialNodeCount, " since maxAllowedUnrollSize=", maxAllowedUnrollSize());
+        return false;
+    }
+
     if (putByValCount && !getByValCount) {
         // Avoid unrolling loops that only perform stores. These tend to increase code size
         // without improving performance, since they are often memory-bound and unrolling
@@ -628,6 +659,11 @@ void LoopUnrollingPhase::LoopData::analyzeLoopNode(Graph& graph, Node* node)
         ++putByValCount;
     if (node->op() == GetByVal)
         ++getByValCount;
+
+    if (isNumericComputationNode(node))
+        ++numericComputationCount;
+    if (isLocalAccessNode(node))
+        ++localAccessCount;
 }
 
 void LoopUnrollingPhase::dumpLoopNodeTypeStats(LoopData& data)
@@ -642,11 +678,11 @@ void LoopUnrollingPhase::dumpLoopNodeTypeStats(LoopData& data)
 
     for (uint32_t i = 0; i < counter.size(); i++) {
         uint32_t count = counter[i];
-        if (count) {
-            double ratio = data.materialNodeCount ? static_cast<double>(count) / data.materialNodeCount : 0.0;
-            dataLogLn("  ", static_cast<NodeType>(i), ": count = ", count, ", ratio = ", ratio);
-        }
+        if (count)
+            dataLogLn("  ", static_cast<NodeType>(i), ": count = ", count, ", ratio = ", data.ratio(count));
     }
+    dataLogLn("  numericComputationCount=", data.numericComputationCount, ", ratio=", data.ratio(data.numericComputationCount));
+    dataLogLn("  localAccessCount=", data.localAccessCount, ", ratio=", data.ratio(data.localAccessCount));
 }
 
 void LoopUnrollingPhase::LoopData::dump(PrintStream& out) const
@@ -835,6 +871,67 @@ bool LoopUnrollingPhase::LoopData::isMaterialNode(Graph& graph, Node* node)
         break;
     }
     return true;
+}
+
+bool LoopUnrollingPhase::LoopData::isNumericComputationNode(Node* node)
+{
+    switch (node->op()) {
+    // Arithmetic operations
+    case ArithBitNot:
+    case ArithBitAnd:
+    case ArithBitOr:
+    case ArithBitXor:
+    case ArithBitLShift:
+    case ArithBitRShift:
+    case ArithAdd:
+    case ArithClz32:
+    case ArithSub:
+    case ArithNegate:
+    case ArithMul:
+    case ArithIMul:
+    case ArithDiv:
+    case ArithMod:
+    case ArithAbs:
+    case ArithMin:
+    case ArithMax:
+    case ArithFRound:
+    case ArithF16Round:
+    case ArithPow:
+    case ArithRandom:
+    case ArithRound:
+    case ArithFloor:
+    case ArithCeil:
+    case ArithTrunc:
+    case ArithSqrt:
+    case ArithUnary:
+
+    // Representations
+    case DoubleRep:
+    case Int52Rep:
+    case ValueRep:
+
+    // Numeric constants
+    case DoubleConstant:
+    case Int52Constant:
+        return true;
+    case JSConstant:
+        if (node->isNumberConstant())
+            return true;
+        FALLTHROUGH;
+    default:
+        return false;
+    }
+}
+
+bool LoopUnrollingPhase::LoopData::isLocalAccessNode(Node* node)
+{
+    switch (node->op()) {
+    case GetLocal:
+    case SetLocal:
+        return true;
+    default:
+        return false;
+    }
 }
 
 FunctionAllowlist& LoopUnrollingPhase::functionAllowlist()

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -538,8 +538,11 @@ private:
             if (result == CodeGenerationResult::Generated)
                 ++codeGeneratedNodes;
             if (!notTerminated)
-                return codeGeneratedNodes;
+                break;
         }
+
+        if (block->isExcludedFromFTLCodeSizeEstimation)
+            return 0;
         return codeGeneratedNodes;
     }
 

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -632,6 +632,12 @@ static void overrideDefaults()
     // So, we need a much larger ReservedZoneSize to allow stack overflow handlers to execute.
     Options::reservedZoneSize() = 3 * Options::reservedZoneSize();
 #endif
+
+#if PLATFORM(IOS_FAMILY)
+    // This is used to mitigate performance regression rdar://150522186.
+    if (Options::usePartialLoopUnrolling())
+        Options::maxPartialLoopUnrollingBodyNodeSize() = 50;
+#endif
 }
 
 bool Options::setAllJITCodeValidations(const char* valueStr)

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -593,13 +593,13 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, dumpBaselineJITSizeStatistics, false, Normal, nullptr) \
     v(Bool, dumpDFGJITSizeStatistics, false, Normal, nullptr) \
     v(Bool, useLoopUnrolling, true, Normal, nullptr) \
-    v(Bool, usePartialLoopUnrolling, false, Normal, nullptr) \
+    v(Bool, usePartialLoopUnrolling, true, Normal, nullptr) \
     v(Bool, verboseLoopUnrolling, false, Normal, nullptr) \
     v(Bool, disallowLoopUnrollingForNonInnermost, true, Normal, nullptr) \
-    v(Unsigned, maxLoopUnrollingCount, 2, Normal, nullptr) \
+    v(Unsigned, maxLoopUnrollingCount, 5, Normal, nullptr) \
     v(Unsigned, maxLoopUnrollingBodyNodeSize, 200, Normal, nullptr) \
     v(Unsigned, maxLoopUnrollingIterationCount, 4, Normal, nullptr) \
-    v(Unsigned, maxPartialLoopUnrollingBodyNodeSize, 200, Normal, nullptr) \
+    v(Unsigned, maxPartialLoopUnrollingBodyNodeSize, 70, Normal, nullptr) \
     v(Unsigned, maxPartialLoopUnrollingIterationCount, 4, Normal, nullptr) \
     v(Bool, printEachUnrolledLoop, false, Normal, nullptr) \
     v(Bool, verboseExecutablePoolAllocation, false, Normal, nullptr) \


### PR DESCRIPTION
#### fb56461956eb9eb93bdc6746d9521afc004dbeb2
<pre>
[JSC] Enable unrolling for numeric-local loops exceeding FTL inlining threshold

This patch introduces a new loop unrolling heuristic for tight, numeric-heavy loops
that exceed the FTL function inlining threshold. These loops are common in scalar
math kernels and utility code, and while they are too large to be inlined,
they can still benefit from loop unrolling.

Specifically, we unroll loops that:
- Have only one non-jump pad block
- Contain ≥30% numeric computation nodes (e.g., ArithAdd, Int52Rep, constants)
- Contain ≥40% local access nodes (GetLocal, SetLocal)
- Have a material node count between 160 and 225

Since FTL inlining is governed by the total function size
(`maximumFunctionForCallInlineCandidateBytecodeCostForFTL`, currently 170),
loops with body sizes above 160 are unlikely to be inlined. Therefore, unrolling
them doesn&apos;t harm inlining decisions but may still yield performance benefits.

Additional changes:
- Introduced `isNumericComputationNode()` to capture arithmetic ops, conversions, and numeric constants
- Introduced `isLocalAccessNode()` for local get/set detection
- Added helpers for ratio tracking and max unroll size computation
- Improved stats reporting for debug tracing

This expands our loop unrolling strategy safely and with a performance-aware focus.
</pre>
----------------------------------------------------------------------
#### 56dd9cfff79e476279a258635d7d3e7102cb72c8
<pre>
[JSC] Enable partial loop unrolling with inlining-aware code size exclusion
<a href="https://bugs.webkit.org/show_bug.cgi?id=292302">https://bugs.webkit.org/show_bug.cgi?id=292302</a>
<a href="https://rdar.apple.com/150321349">rdar://150321349</a>

Reviewed by NOBODY (OOPS!).

This patch enables partial loop unrolling by default and lowers the threshold
(maxPartialLoopUnrollingBodyNodeSize) from 200 to 70. However, unrolling may
inflate the callee’s JITed code size and negatively impact FTL inlining heuristics.

To mitigate this, we introduce `BasicBlock::isExcludedFromFTLCodeSizeEstimation`.
Blocks generated during loop unrolling and jump pad insertion are flagged as excluded.
These are skipped in FTL’s code size estimation to avoid penalizing inlining.

Additionally:
- Skips unrolling loops that only contain PutByVal operations without corresponding GetByVal,
  since they tend to be memory-bound and unprofitable for unrolling (<a href="https://rdar.apple.com/150524264">rdar://150524264</a>).
- Applies a more conservative partial unrolling threshold (50) on iOS to mitigate a known regression (<a href="https://rdar.apple.com/150522186">rdar://150522186</a>).
- Disables loop unrolling for `StringFromCharCode` due to a specific performance regression (<a href="https://rdar.apple.com/150526635">rdar://150526635</a>).

This allows loop unrolling optimizations to proceed without degrading inlining-based performance.

* Source/JavaScriptCore/dfg/DFGBasicBlock.h:
* Source/JavaScriptCore/dfg/DFGCloneHelper.h:
(JSC::DFG::CloneHelper::cloneBlock):
* Source/JavaScriptCore/dfg/DFGCriticalEdgeBreakingPhase.cpp:
(JSC::DFG::CriticalEdgeBreakingPhase::performFixJumpPadAvailability):
* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
(JSC::DFG::LoopUnrollingPhase::isLoopBodyUnrollable):
(JSC::DFG::LoopUnrollingPhase::LoopData::isProfitableToUnroll):
(JSC::DFG::LoopUnrollingPhase::LoopData::analyzeLoopNode):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileBlock):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::overrideDefaults):
* Source/JavaScriptCore/runtime/OptionsList.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb56461956eb9eb93bdc6746d9521afc004dbeb2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101843 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21511 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107001 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52477 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30018 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77541 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34564 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104850 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16858 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91964 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57879 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16685 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9985 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51828 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94515 "Found 2 jsc stress test failures: sunspider-1.0/crypto-md5.js.ftl-eager-no-cjit, sunspider-1.0/crypto-md5.js.ftl-eager-no-cjit-b3o1") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86538 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10061 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109359 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100453 "Found 2 new JSC stress test failures: sunspider-1.0/crypto-md5.js.ftl-eager-no-cjit, sunspider-1.0/crypto-md5.js.ftl-eager-no-cjit-b3o1 (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28976 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21345 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86520 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29337 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88167 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86093 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30851 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8573 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23147 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28904 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34195 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124078 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28715 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34465 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32038 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30274 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->