### PR TITLE
Auto appearance for slider thumbs is always horizontal

### DIFF
--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -462,8 +462,14 @@ StyleAppearance RenderTheme::autoAppearanceForElement(RenderStyle& style, const 
                 return StyleAppearance::SearchFieldResultsButton;
         }
 
-        if (part == UserAgentParts::webkitSliderThumb())
+        if (part == UserAgentParts::webkitSliderThumb()) {
+            if (RefPtr shadowHost = elementPtr->shadowHost()) {
+                if (CheckedPtr shadowStyles = shadowHost->computedStyle(); shadowStyles
+                    && shadowStyles->usedAppearance() == StyleAppearance::SliderVertical)
+                    return StyleAppearance::SliderThumbVertical;
+            }
             return StyleAppearance::SliderThumbHorizontal;
+        }
 
         if (part == UserAgentParts::webkitInnerSpinButton())
             return StyleAppearance::InnerSpinButton;


### PR DESCRIPTION
#### abb4bd5b4b9d64d8fb08805423579a981cd224f5
<pre>
Auto appearance for slider thumbs is always horizontal
<a href="https://bugs.webkit.org/show_bug.cgi?id=292445">https://bugs.webkit.org/show_bug.cgi?id=292445</a>
<a href="https://rdar.apple.com/150534395">rdar://150534395</a>

Reviewed by NOBODY (OOPS!).

When `RenderTheme::autoAppearanceForElement` is called
for a slider thumb element, we now check the shadow host&apos;s
used appearance. If it is &apos;SliderVertical&apos;, we return
&apos;SliderThumbVertical&apos; for the auto appearance. Otherwise,
return &apos;SliderThumbHorizontal&apos;.

* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::autoAppearanceForElement const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abb4bd5b4b9d64d8fb08805423579a981cd224f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101845 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107003 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52479 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103885 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21821 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30020 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77543 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34565 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104852 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16855 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91959 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57881 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16682 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9978 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51830 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86535 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10054 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109361 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28978 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21346 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86522 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29339 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88160 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86095 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30849 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8569 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23149 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28906 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34197 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28717 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32040 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30276 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->