### PR TITLE
AX: Named hidden elements are being announced with VoiceOver

### DIFF
--- a/LayoutTests/accessibility/mac/hidden-related-object-exposure-expected.txt
+++ b/LayoutTests/accessibility/mac/hidden-related-object-exposure-expected.txt
@@ -1,0 +1,11 @@
+This test ensures we don't include hidden elements in the accessibility tree.
+
+PASS: !hiddenDiv || hiddenDiv.isIgnored === undefined
+PASS: !heading || heading.isIgnored === undefined
+PASS: hiddenDiv.isIgnored === false
+PASS: heading.isIgnored === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hidden

--- a/LayoutTests/accessibility/mac/hidden-related-object-exposure.html
+++ b/LayoutTests/accessibility/mac/hidden-related-object-exposure.html
@@ -1,0 +1,41 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="hidden-div" aria-labelledby="heading" hidden>
+    <h2 id="heading">Hidden</h2>
+</div>
+
+<script>
+var output = "This test ensures we don't include hidden elements in the accessibility tree.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var hiddenDiv = accessibilityController.accessibleElementById("hidden-div");
+    output += expect("!hiddenDiv || hiddenDiv.isIgnored");
+    var heading = accessibilityController.accessibleElementById("heading");
+    output += expect("!heading || heading.isIgnored");
+
+    document.getElementById("hidden-div").removeAttribute("hidden");
+    setTimeout(async function() {
+        await waitFor(() => {
+            hiddenDiv = accessibilityController.accessibleElementById("hidden-div");
+            heading = accessibilityController.accessibleElementById("heading");
+            return hiddenDiv && heading;
+        });
+        output += await expectAsync("hiddenDiv.isIgnored", "false");
+        output += await expectAsync("heading.isIgnored", "false");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1275,6 +1275,29 @@ void AXObjectCache::onRendererCreated(Element& element)
     }
 }
 
+void AXObjectCache::onRendererCreated(Text& textNode)
+{
+    if (!textNode.renderer()) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    // If we created an AccessibilityNodeObject for this Text, remove it since there should
+    // be a new AccessibilityRenderObject created using the renderer.
+    if (auto axID = m_nodeObjectMapping.get(textNode)) {
+        if (RefPtr nodeObject = get(textNode)) {
+            if (auto* parent = nodeObject->parentObject()) {
+                remove(textNode);
+                childrenChanged(parent);
+                return;
+            }
+            // We don't need to add nodeObject to m_deferredReplacedObjects, as that currently
+            // only serves to repair relationships for replaced objects, which text nodes cannot
+            // possibly be part of (because they are not elements).
+        }
+    }
+}
+
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 static bool isClickEvent(const AtomString& eventType)
 {

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -417,6 +417,10 @@ public:
     // an AXNodeObject. This occurs when an Element with no renderer is
     // re-parented into a subtree that does have a renderer.
     void onRendererCreated(Element&);
+    // Similar to the above, but for when a RenderText is created for a Text node.
+    // We may have already created an AccessibilityNodeObject for the Text, so this
+    // method allows us to make any appropriate changes now that the Text has a renderer.
+    void onRendererCreated(Text&);
 #if PLATFORM(MAC)
     void onDocumentRenderTreeCreation(const Document&);
 #endif

--- a/Source/WebCore/accessibility/AccessibilityImageMapLink.cpp
+++ b/Source/WebCore/accessibility/AccessibilityImageMapLink.cpp
@@ -68,7 +68,14 @@ AccessibilityRole AccessibilityImageMapLink::determineAccessibilityRole()
 
     return !url().isEmpty() ? AccessibilityRole::WebCoreLink : AccessibilityRole::Generic;
 }
-    
+
+bool AccessibilityImageMapLink::computeIsIgnored() const
+{
+    if (!node())
+        return true;
+    return defaultObjectInclusion() == AccessibilityObjectInclusion::IgnoreObject ? true : false;
+}
+
 Element* AccessibilityImageMapLink::actionElement() const
 {
     return anchorElement();

--- a/Source/WebCore/accessibility/AccessibilityImageMapLink.h
+++ b/Source/WebCore/accessibility/AccessibilityImageMapLink.h
@@ -41,6 +41,7 @@ public:
     virtual ~AccessibilityImageMapLink();
     
     AccessibilityRole determineAccessibilityRole() final;
+    bool computeIsIgnored() const final;
     bool isEnabled() const final { return true; }
 
     Element* anchorElement() const final;

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -618,6 +618,9 @@ void RenderTreeUpdater::createTextRenderer(Text& textNode, const Style::TextUpda
     auto* textManipulationController = m_document->textManipulationControllerIfExists();
     if (textManipulationController) [[unlikely]]
         textManipulationController->didAddOrCreateRendererForNode(textNode);
+
+    if (CheckedPtr cache = m_document->axObjectCache())
+        cache->onRendererCreated(textNode);
 }
 
 void RenderTreeUpdater::updateTextRenderer(Text& text, const Style::TextUpdate* textUpdate, const ContainerNode* root)


### PR DESCRIPTION
#### e7d986a7c77c78d6ab265f0ebdf5a4f22b378059
<pre>
AX: Named hidden elements are being announced with VoiceOver
<a href="https://bugs.webkit.org/show_bug.cgi?id=292212">https://bugs.webkit.org/show_bug.cgi?id=292212</a>
<a href="https://rdar.apple.com/150219368">rdar://150219368</a>

Reviewed by Joshua Hoffman.

With this commit, AccessibilityNodeObjects are now properly ignored when within display:none, visibility:hidden, and
content-visibility:hidden subtrees.

This required adding some overrides for objects that are known to be hidden by default via user-agent styles, but still
should be exposed — namely, AccessibilityImageMapLink and anything within a canvas subtree.

This change also exposed a bug in how we manage Text nodes that initially start in display:none subtrees. These Text
nodes don&apos;t have renderers, so we will create them as AccessibilityNodeObjects. But when they gain renderers, e.g.
because their containing element loses display:none, we never turned them into AccessibilityRenderObject. This is
critical, since the RenderText is how we get lots of information (e.g. style). This change exposed the failure
because now AccessibilityNodeObject::computeIsIgnored checks the style via isRenderHidden(), and because it was an
AccessibilityNodeObject subclass that wasn&apos;t an element, we always returned nullptr style, and thus always returned
isRenderHidden. This test that exposed this was accessibility/aria-controlled-table-row-visibility.html.

With this commit, we now replace AccessibilityNodeObjects from Text nodes when they gain a renderer.

* LayoutTests/accessibility/mac/hidden-related-object-exposure-expected.txt: Added.
* LayoutTests/accessibility/mac/hidden-related-object-exposure.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::onRendererCreated):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityImageMapLink.cpp:
(WebCore::AccessibilityImageMapLink::computeIsIgnored const):
* Source/WebCore/accessibility/AccessibilityImageMapLink.h:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::computeIsIgnored const):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::createTextRenderer):

Canonical link: <a href="https://commits.webkit.org/294470@main">https://commits.webkit.org/294470@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3fc703d5faf611d6d2f475885b215dc2e3de49b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107023 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52499 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103905 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21841 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30040 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77560 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34576 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91981 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57898 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16702 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10004 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51851 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86554 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109382 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28998 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21358 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86540 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29359 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88185 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86117 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21919 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30866 "Found 1 new test failure: resize-observer/contain-instrinsic-size-should-not-leak-nodes.html (failure)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8588 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23169 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28926 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34221 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28737 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32060 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30296 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->