### PR TITLE
Avoid deserializing WebFilterEvaluator when UsesWebContentRestrictionsForFilter is enabled

### DIFF
--- a/Source/WebCore/platform/ContentFilterUnblockHandler.h
+++ b/Source/WebCore/platform/ContentFilterUnblockHandler.h
@@ -75,7 +75,7 @@ public:
 
     WEBCORE_EXPORT bool needsUIProcess() const;
     WEBCORE_EXPORT bool canHandleRequest(const ResourceRequest&) const;
-    WEBCORE_EXPORT void requestUnblockAsync(DecisionHandlerFunction) const;
+    WEBCORE_EXPORT void requestUnblockAsync(DecisionHandlerFunction);
     void wrapWithDecisionHandler(const DecisionHandlerFunction&);
 
     const String& unblockURLHost() const { return m_unblockURLHost; }
@@ -98,7 +98,8 @@ public:
 
 private:
 #if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
-    static RetainPtr<WebFilterEvaluator> unpackWebFilterEvaluatorData(Vector<uint8_t>&&);
+    bool hasWebFilterEvaluator() const;
+    RetainPtr<WebFilterEvaluator> webFilterEvaluator();
 #endif
 
     String m_unblockURLHost;
@@ -111,6 +112,7 @@ private:
     String m_configurationPath;
 #endif
 #if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
+    Vector<uint8_t> m_webFilterEvaluatorData;
     RetainPtr<WebFilterEvaluator> m_webFilterEvaluator;
 #endif
     bool m_unblockedAfterRequest { false };

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -260,6 +260,15 @@ void WebPageProxy::beginSafeBrowsingCheck(const URL& url, bool forMainFrameNavig
 #if ENABLE(CONTENT_FILTERING)
 void WebPageProxy::contentFilterDidBlockLoadForFrame(IPC::Connection& connection, const WebCore::ContentFilterUnblockHandler& unblockHandler, FrameIdentifier frameID)
 {
+#if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
+    bool usesWebContentRestrictions = false;
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    usesWebContentRestrictions = protectedPreferences()->usesWebContentRestrictionsForFilter();
+#endif
+    if (usesWebContentRestrictions)
+        MESSAGE_CHECK(unblockHandler.webFilterEvaluatorData().isEmpty(), connection);
+#endif
+
     RefPtr process = dynamicDowncast<WebProcessProxy>(AuxiliaryProcessProxy::fromConnection(connection));
     contentFilterDidBlockLoadForFrameShared(*process, unblockHandler, frameID);
 }

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -639,8 +639,20 @@ void ProvisionalPageProxy::bindAccessibilityTree(const String& plugID)
 #if ENABLE(CONTENT_FILTERING)
 void ProvisionalPageProxy::contentFilterDidBlockLoadForFrame(const WebCore::ContentFilterUnblockHandler& unblockHandler, FrameIdentifier frameID)
 {
-    if (RefPtr page = m_page.get())
-        page->contentFilterDidBlockLoadForFrameShared(protectedProcess(), unblockHandler, frameID);
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+#if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
+    bool usesWebContentRestrictions = false;
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    usesWebContentRestrictions = page->protectedPreferences()->usesWebContentRestrictionsForFilter();
+#endif
+    if (usesWebContentRestrictions)
+        MESSAGE_CHECK(unblockHandler.webFilterEvaluatorData().isEmpty());
+#endif
+
+    page->contentFilterDidBlockLoadForFrameShared(protectedProcess(), unblockHandler, frameID);
 }
 #endif
 


### PR DESCRIPTION
#### bbeb0db15bc83092fc5700ac28e018af0fb456d7
<pre>
Avoid deserializing WebFilterEvaluator when UsesWebContentRestrictionsForFilter is enabled
<a href="https://rdar.apple.com/150334101">rdar://150334101</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292455">https://bugs.webkit.org/show_bug.cgi?id=292455</a>

Reviewed by Per Arne Vollan.

When ContentFilterUnblockHandler is created from IPC message payload, WebFilterEvaluator will be deserialized from
bytes (see ContentFilterUnblockHandler() and unpackWebFilterEvaluatorData() in ContentFilterUnblockHandler). For better
security, we should avoid the deserialization in UI process if it knows WebFilterEvaluator is not in use (i.e. when
UsesWebContentRestrictionsForFilter is enabled). To achieve that, this patch makes ContentFilterUnblockHandler not
deserialize WebFilterEvaluator from bytes in constructor (but only stores the bytes), and adds message checks to
ensure the bytes in ContentFilterUnblockHandler are empty (so that no deserialization will be performed) if
UsesWebContentRestrictionsForFilter is enabled.

* Source/WebCore/platform/ContentFilterUnblockHandler.h:
* Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm:
(WebCore::ContentFilterUnblockHandler::ContentFilterUnblockHandler):
(WebCore::ContentFilterUnblockHandler::webFilterEvaluatorData const):
(WebCore::unpackWebFilterEvaluatorData):
(WebCore::ContentFilterUnblockHandler::hasWebFilterEvaluator const):
(WebCore::ContentFilterUnblockHandler::webFilterEvaluator):
(WebCore::ContentFilterUnblockHandler::wrapWithDecisionHandler):
(WebCore::ContentFilterUnblockHandler::needsUIProcess const):
(WebCore::ContentFilterUnblockHandler::canHandleRequest const):
(WebCore::ContentFilterUnblockHandler::requestUnblockAsync):
(WebCore::ContentFilterUnblockHandler::unpackWebFilterEvaluatorData): Deleted.
(WebCore::ContentFilterUnblockHandler::requestUnblockAsync const): Deleted.
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::contentFilterDidBlockLoadForFrame):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::contentFilterDidBlockLoadForFrame):

Canonical link: <a href="https://commits.webkit.org/294624@main">https://commits.webkit.org/294624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd1e92e303153aa886dae58d48c2914ad5ffb946

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102328 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21997 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107489 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52964 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104367 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30503 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77861 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34851 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17272 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92372 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58199 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17106 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10400 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52322 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86932 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109864 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29460 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21722 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86844 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29824 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88568 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86459 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22016 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31247 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8963 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23702 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29388 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34684 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29199 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32522 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30758 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->