### PR TITLE
Start adopting C++20's [[likely]] / [[unlikely]] in JSC

### DIFF
--- a/Source/JavaScriptCore/API/APIUtils.h
+++ b/Source/JavaScriptCore/API/APIUtils.h
@@ -40,7 +40,7 @@ enum class ExceptionStatus {
 inline ExceptionStatus handleExceptionIfNeeded(JSC::CatchScope& scope, JSContextRef ctx, JSValueRef* returnedExceptionRef)
 {
     JSC::JSGlobalObject* globalObject = toJS(ctx);
-    if (UNLIKELY(scope.exception())) {
+    if (scope.exception()) [[unlikely]] {
         JSC::Exception* exception = scope.exception();
         if (returnedExceptionRef)
             *returnedExceptionRef = toRef(globalObject, exception->value());

--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
@@ -188,7 +188,7 @@ JSInternalPromise* JSAPIGlobalObject::moduleLoaderFetch(JSGlobalObject* globalOb
     Identifier moduleKey = key.toPropertyKey(globalObject);
     RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(globalObject, scope));
 
-    if (UNLIKELY(![context moduleLoaderDelegate])) {
+    if (![context moduleLoaderDelegate]) [[unlikely]] {
         scope.release();
         promise->reject(globalObject, createError(globalObject, "No module loader provided."_s));
         return promise;
@@ -206,18 +206,18 @@ JSInternalPromise* JSAPIGlobalObject::moduleLoaderFetch(JSGlobalObject* globalOb
             return encodedJSUndefined();
         };
 
-        if (UNLIKELY(![script isKindOfClass:[JSScript class]]))
+        if (![script isKindOfClass:[JSScript class]]) [[unlikely]]
             return rejectPromise("First argument of resolution callback is not a JSScript"_s);
 
         JSScript* jsScript = static_cast<JSScript *>(script);
 
         JSSourceCode* source = [jsScript jsSourceCode];
-        if (UNLIKELY([jsScript type] != kJSScriptTypeModule))
+        if ([jsScript type] != kJSScriptTypeModule) [[unlikely]]
             return rejectPromise("The JSScript that was provided did not have expected type of kJSScriptTypeModule."_s);
 
         NSURL *sourceURL = [jsScript sourceURL];
         String oldModuleKey { [sourceURL absoluteString] };
-        if (UNLIKELY(Identifier::fromString(vm, oldModuleKey) != moduleKey))
+        if (Identifier::fromString(vm, oldModuleKey) != moduleKey) [[unlikely]]
             return rejectPromise(makeString("The same JSScript was provided for two different identifiers, previously: "_s, oldModuleKey, " and now: "_s, moduleKey.string()));
 
         strongPromise.get()->resolve(globalObject, source);

--- a/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
+++ b/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
@@ -249,7 +249,7 @@ EncodedJSValue JSCallbackObject<Parent>::customToPrimitive(JSGlobalObject* globa
                 return throwVMError(globalObject, scope, toJS(globalObject, exception));
             if (result) {
                 JSValue jsResult = toJS(globalObject, result);
-                if (UNLIKELY(jsResult.isObject()))
+                if (jsResult.isObject()) [[unlikely]]
                     return JSValue::encode(asObject(jsResult)->ordinaryToPrimitive(globalObject, hint));
                 return JSValue::encode(jsResult);
             }
@@ -271,7 +271,7 @@ bool JSCallbackObject<Parent>::put(JSCell* cell, JSGlobalObject* globalObject, P
     RefPtr<OpaqueJSString> propertyNameRef;
     JSValueRef valueRef = toRef(globalObject, value);
 
-    if (UNLIKELY(isThisValueAltered(slot, thisObject)))
+    if (isThisValueAltered(slot, thisObject)) [[unlikely]]
         RELEASE_AND_RETURN(scope, Parent::put(thisObject, globalObject, propertyName, value, slot));
     
     if (StringImpl* name = propertyName.uid()) {

--- a/Source/JavaScriptCore/API/JSContextRef.cpp
+++ b/Source/JavaScriptCore/API/JSContextRef.cpp
@@ -128,7 +128,7 @@ JSGlobalContextRef JSGlobalContextCreate(JSClassRef globalObjectClass)
         if (NSVersionOfLinkTimeLibrary("JavaScriptCore") <= webkitFirstVersionWithConcurrentGlobalContexts)
             s_sharedVM = &VM::createContextGroup().leakRef();
     });
-    if (UNLIKELY(s_sharedVM))
+    if (s_sharedVM) [[unlikely]]
         return JSGlobalContextCreateInGroup(toRef(s_sharedVM), globalObjectClass);
 #endif // OS(DARWIN)
 
@@ -509,11 +509,11 @@ JSStringRef JSContextGroupTakeSamplesFromSamplingProfiler(JSContextGroupRef grou
 
 #if ENABLE(SAMPLING_PROFILER)
     auto json = vm.takeSamplingProfilerSamplesAsJSON();
-    if (UNLIKELY(!json))
+    if (!json) [[unlikely]]
         return nullptr;
 
     auto jsonData = json->toJSONString();
-    if (UNLIKELY(jsonData.isNull()))
+    if (jsonData.isNull()) [[unlikely]]
         return nullptr;
 
     return OpaqueJSString::tryCreate(WTFMove(jsonData)).leakRef();

--- a/Source/JavaScriptCore/API/JSManagedValue.mm
+++ b/Source/JavaScriptCore/API/JSManagedValue.mm
@@ -185,7 +185,7 @@ static JSManagedValueHandleOwner& managedValueHandleOwner()
 
 bool JSManagedValueHandleOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown>, void* context, JSC::AbstractSlotVisitor& visitor, ASCIILiteral* reason)
 {
-    if (UNLIKELY(reason))
+    if (reason) [[unlikely]]
         *reason = "JSManagedValue is opaque root"_s;
     JSManagedValue *managedValue = (__bridge JSManagedValue *)context;
     return visitor.containsOpaqueRoot((__bridge void*)managedValue);

--- a/Source/JavaScriptCore/API/JSObjectRef.cpp
+++ b/Source/JavaScriptCore/API/JSObjectRef.cpp
@@ -148,7 +148,7 @@ JSObjectRef JSObjectMakeFunction(JSContextRef ctx, JSStringRef name, unsigned pa
     for (unsigned i = 0; i < parameterCount; i++)
         args.append(jsString(vm, parameterNames[i]->string()));
     args.append(jsString(vm, body->string()));
-    if (UNLIKELY(args.hasOverflowed())) {
+    if (args.hasOverflowed()) [[unlikely]] {
         auto throwScope = DECLARE_THROW_SCOPE(vm);
         throwOutOfMemoryError(globalObject, throwScope);
         handleExceptionIfNeeded(scope, ctx, exception);
@@ -179,7 +179,7 @@ JSObjectRef JSObjectMakeArray(JSContextRef ctx, size_t argumentCount, const JSVa
         argList.ensureCapacity(argumentCount);
         for (size_t i = 0; i < argumentCount; ++i)
             argList.append(toJS(globalObject, arguments[i]));
-        if (UNLIKELY(argList.hasOverflowed())) {
+        if (argList.hasOverflowed()) [[unlikely]] {
             auto throwScope = DECLARE_THROW_SCOPE(vm);
             throwOutOfMemoryError(globalObject, throwScope);
             handleExceptionIfNeeded(scope, ctx, exception);
@@ -211,7 +211,7 @@ JSObjectRef JSObjectMakeDate(JSContextRef ctx, size_t argumentCount, const JSVal
     argList.ensureCapacity(argumentCount);
     for (size_t i = 0; i < argumentCount; ++i)
         argList.append(toJS(globalObject, arguments[i]));
-    if (UNLIKELY(argList.hasOverflowed())) {
+    if (argList.hasOverflowed()) [[unlikely]] {
         auto throwScope = DECLARE_THROW_SCOPE(vm);
         throwOutOfMemoryError(globalObject, throwScope);
         handleExceptionIfNeeded(scope, ctx, exception);
@@ -262,7 +262,7 @@ JSObjectRef JSObjectMakeRegExp(JSContextRef ctx, size_t argumentCount, const JSV
     argList.ensureCapacity(argumentCount);
     for (size_t i = 0; i < argumentCount; ++i)
         argList.append(toJS(globalObject, arguments[i]));
-    if (UNLIKELY(argList.hasOverflowed())) {
+    if (argList.hasOverflowed()) [[unlikely]] {
         auto throwScope = DECLARE_THROW_SCOPE(vm);
         throwOutOfMemoryError(globalObject, throwScope);
         handleExceptionIfNeeded(scope, ctx, exception);
@@ -379,7 +379,7 @@ void JSObjectSetProperty(JSContextRef ctx, JSObjectRef object, JSStringRef prope
     JSValue jsValue = toJS(globalObject, value);
 
     bool doesNotHaveProperty = attributes && !jsObject->hasProperty(globalObject, name);
-    if (LIKELY(!scope.exception())) {
+    if (!scope.exception()) [[likely]] {
         if (doesNotHaveProperty) {
             PropertyDescriptor desc(jsValue, attributes);
             jsObject->methodTable()->defineOwnProperty(jsObject, globalObject, name, desc, false);
@@ -454,7 +454,7 @@ void JSObjectSetPropertyForKey(JSContextRef ctx, JSObjectRef object, JSValueRef 
         return;
 
     bool doesNotHaveProperty = attributes && !jsObject->hasProperty(globalObject, ident);
-    if (LIKELY(!scope.exception())) {
+    if (!scope.exception()) [[likely]] {
         if (doesNotHaveProperty) {
             PropertyDescriptor desc(jsValue, attributes);
             jsObject->methodTable()->defineOwnProperty(jsObject, globalObject, ident, desc, false);
@@ -726,7 +726,7 @@ JSValueRef JSObjectCallAsFunction(JSContextRef ctx, JSObjectRef object, JSObject
     argList.ensureCapacity(argumentCount);
     for (size_t i = 0; i < argumentCount; i++)
         argList.append(toJS(globalObject, arguments[i]));
-    if (UNLIKELY(argList.hasOverflowed())) {
+    if (argList.hasOverflowed()) [[unlikely]] {
         auto throwScope = DECLARE_THROW_SCOPE(vm);
         throwOutOfMemoryError(globalObject, throwScope);
         handleExceptionIfNeeded(scope, ctx, exception);
@@ -773,7 +773,7 @@ JSObjectRef JSObjectCallAsConstructor(JSContextRef ctx, JSObjectRef object, size
     argList.ensureCapacity(argumentCount);
     for (size_t i = 0; i < argumentCount; i++)
         argList.append(toJS(globalObject, arguments[i]));
-    if (UNLIKELY(argList.hasOverflowed())) {
+    if (argList.hasOverflowed()) [[unlikely]] {
         auto throwScope = DECLARE_THROW_SCOPE(vm);
         throwOutOfMemoryError(globalObject, throwScope);
         handleExceptionIfNeeded(scope, ctx, exception);

--- a/Source/JavaScriptCore/assembler/ARM64Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64Assembler.h
@@ -3489,7 +3489,7 @@ public:
     AssemblerLabel label()
     {
         AssemblerLabel result = m_buffer.label();
-        while (UNLIKELY(static_cast<int>(result.offset()) < m_indexOfTailOfLastWatchpoint)) {
+        while (static_cast<int>(result.offset()) < m_indexOfTailOfLastWatchpoint) [[unlikely]] {
             nop();
             result = m_buffer.label();
         }

--- a/Source/JavaScriptCore/assembler/ARMv7Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARMv7Assembler.h
@@ -2487,8 +2487,8 @@ public:
     AssemblerLabel label()
     {
         AssemblerLabel result = m_formatter.label();
-        while (UNLIKELY(static_cast<int>(result.offset()) < m_indexOfTailOfLastWatchpoint)) {
-            if (UNLIKELY(static_cast<int>(result.offset()) + 4 <= m_indexOfTailOfLastWatchpoint))
+        while (static_cast<int>(result.offset()) < m_indexOfTailOfLastWatchpoint) [[unlikely]] {
+            if (static_cast<int>(result.offset()) + 4 <= m_indexOfTailOfLastWatchpoint) [[unlikely]]
                 nopw();
             else
                 nop();

--- a/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
@@ -59,7 +59,7 @@ namespace DFG {
 struct OSRExit;
 }
 
-#define JIT_COMMENT(jit, ...) do { if (UNLIKELY(Options::needDisassemblySupport())) { (jit).comment(__VA_ARGS__); } else { (void) jit; } } while (0)
+#define JIT_COMMENT(jit, ...) do { if (Options::needDisassemblySupport()) [[unlikely]] { (jit).comment(__VA_ARGS__); } else { (void) jit; } } while (0)
 
 class AbstractMacroAssemblerBase {
     WTF_MAKE_TZONE_NON_HEAP_ALLOCATABLE(AbstractMacroAssemblerBase);
@@ -1112,7 +1112,7 @@ public:
     template<typename... Types>
     void comment(const Types&... values)
     {
-        if (LIKELY(!Options::needDisassemblySupport()))
+        if (!Options::needDisassemblySupport()) [[likely]]
             return;
         StringPrintStream s;
         s.print(values...);

--- a/Source/JavaScriptCore/assembler/AssemblerBuffer.h
+++ b/Source/JavaScriptCore/assembler/AssemblerBuffer.h
@@ -468,7 +468,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         void putIntegral(IntegralType value)
         {
             unsigned nextIndex = m_index + sizeof(IntegralType);
-            if (UNLIKELY(nextIndex > m_storage.capacity()))
+            if (nextIndex > m_storage.capacity()) [[unlikely]]
                 outOfLineGrow();
             putIntegralUnchecked<IntegralType>(value);
         }

--- a/Source/JavaScriptCore/assembler/AssemblyComments.h
+++ b/Source/JavaScriptCore/assembler/AssemblyComments.h
@@ -49,8 +49,11 @@ public:
 
     void registerCodeRange(void* start, void* end, CommentMap&& map)
     {
-        if (LIKELY(!Options::needDisassemblySupport()) || !map.size())
+        if (!Options::needDisassemblySupport()) [[likely]]
             return;
+        if (!map.size())
+            return;
+
         Locker locker { m_lock };
 
         auto newStart = std::bit_cast<uintptr_t>(start);
@@ -74,7 +77,7 @@ public:
 
     void unregisterCodeRange(void* start, void* end)
     {
-        if (LIKELY(!Options::needDisassemblySupport()))
+        if (!Options::needDisassemblySupport()) [[likely]]
             return;
         Locker locker { m_lock };
 
@@ -89,7 +92,7 @@ public:
 
     inline std::optional<String> comment(void* in)
     {
-        if (LIKELY(!Options::needDisassemblySupport()))
+        if (!Options::needDisassemblySupport()) [[likely]]
             return { };
         Locker locker { m_lock };
         auto it = m_comments.lower_bound(orderedKey(in));

--- a/Source/JavaScriptCore/assembler/JITOperationList.cpp
+++ b/Source/JavaScriptCore/assembler/JITOperationList.cpp
@@ -97,7 +97,7 @@ void JITOperationList::populatePointersInJavaScriptCore()
         if (Options::useJIT())
             jitOperationList->addPointers(&startOfJITOperationsInJSC, &endOfJITOperationsInJSC);
 #if ENABLE(JIT_OPERATION_DISASSEMBLY)
-        if (UNLIKELY(Options::needDisassemblySupport()))
+        if (Options::needDisassemblySupport()) [[unlikely]]
             populateDisassemblyLabelsInJavaScriptCore();
 #endif
     });
@@ -230,7 +230,7 @@ void JITOperationList::populatePointersInJavaScriptCoreForLLInt()
             jitOperationList->addPointers(list.operations, list.operations + list.numberOfOperations);
         }
 #if ENABLE(JIT_OPERATION_DISASSEMBLY)
-        if (UNLIKELY(Options::needDisassemblySupport()))
+        if (Options::needDisassemblySupport()) [[unlikely]]
             JITOperationList::populateDisassemblyLabelsInJavaScriptCoreForLLInt();
 #endif
     });
@@ -285,7 +285,7 @@ void JITOperationList::populateDisassemblyLabelsInJavaScriptCoreForLLInt()
 
 void JITOperationList::populateDisassemblyLabelsInEmbedder(const JITOperationAnnotation* beginOperations, const JITOperationAnnotation* endOperations)
 {
-    if (LIKELY(!Options::needDisassemblySupport()))
+    if (!Options::needDisassemblySupport()) [[likely]]
         return;
     if (Options::useJIT())
         addDisassemblyLabels(beginOperations, endOperations);

--- a/Source/JavaScriptCore/assembler/JITOperationList.h
+++ b/Source/JavaScriptCore/assembler/JITOperationList.h
@@ -122,13 +122,13 @@ inline JITOperationList& JITOperationList::singleton()
 
 ALWAYS_INLINE void JITOperationList::populatePointersInJavaScriptCore()
 {
-    if (UNLIKELY(Options::needDisassemblySupport()))
+    if (Options::needDisassemblySupport()) [[unlikely]]
         populateDisassemblyLabelsInJavaScriptCore();
 }
 
 ALWAYS_INLINE void JITOperationList::populatePointersInJavaScriptCoreForLLInt()
 {
-    if (UNLIKELY(Options::needDisassemblySupport()))
+    if (Options::needDisassemblySupport()) [[unlikely]]
         populateDisassemblyLabelsInJavaScriptCoreForLLInt();
 }
 

--- a/Source/JavaScriptCore/assembler/LinkBuffer.cpp
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.cpp
@@ -66,7 +66,7 @@ LinkBuffer::CodeRef<LinkBufferPtrTag> LinkBuffer::finalizeCodeWithoutDisassembly
     ASSERT(m_didAllocate);
     CodeRef<LinkBufferPtrTag> codeRef(m_executableMemory ? CodeRef<LinkBufferPtrTag>(*m_executableMemory) : CodeRef<LinkBufferPtrTag>::createSelfManagedCodeRef(m_code));
 
-    if (UNLIKELY(Options::useJITDump()))
+    if (Options::useJITDump()) [[unlikely]]
         logJITCodeForJITDump(codeRef, simpleName);
 
     return codeRef;
@@ -427,7 +427,7 @@ void LinkBuffer::copyCompactAndLinkCode(MacroAssembler& macroAssembler, JITCompi
 #if ENABLE(JIT)
     if (g_jscConfig.useFastJITPermissions) {
         ASSERT(codeOutData == outData);
-        if (UNLIKELY(Options::dumpJITMemoryPath()))
+        if (Options::dumpJITMemoryPath()) [[unlikely]]
             dumpJITMemory(outData, outData, m_size);
     } else {
         ASSERT(codeOutData != outData);
@@ -521,7 +521,9 @@ void LinkBuffer::allocate(MacroAssembler& macroAssembler, JITCompilationEffort e
 
 void LinkBuffer::linkComments(MacroAssembler& assembler)
 {
-    if (LIKELY(!Options::needDisassemblySupport()) || !m_executableMemory)
+    if (!Options::needDisassemblySupport()) [[likely]]
+        return;
+    if (!m_executableMemory)
         return;
     AssemblyCommentRegistry::CommentMap map;
     for (auto& comment : assembler.m_comments) {

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -1045,7 +1045,7 @@ public:
 
     void lshift64(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
+        if (!imm.m_value) [[unlikely]]
             return move(src, dest);
         m_assembler.lsl<64>(dest, src, imm.m_value & 0x3f);
     }
@@ -1407,7 +1407,7 @@ public:
 
     void rotateRight64(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
+        if (!imm.m_value) [[unlikely]]
             return move(src, dest);
         m_assembler.ror<64>(dest, src, imm.m_value & 63);
     }
@@ -1455,7 +1455,7 @@ public:
     
     void rshift64(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
+        if (!imm.m_value) [[unlikely]]
             return move(src, dest);
         m_assembler.asr<64>(dest, src, imm.m_value & 0x3f);
     }
@@ -1625,7 +1625,7 @@ public:
     
     void urshift64(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
+        if (!imm.m_value) [[unlikely]]
             return move(src, dest);
         m_assembler.lsr<64>(dest, src, imm.m_value & 0x3f);
     }

--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
@@ -694,7 +694,7 @@ public:
 
     void lshift64(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
+        if (!imm.m_value) [[unlikely]]
             return move(src, dest);
         m_assembler.slliInsn(dest, src, uint32_t(imm.m_value & ((1 << 6) - 1)));
     }
@@ -753,7 +753,7 @@ public:
 
     void rshift64(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
+        if (!imm.m_value) [[unlikely]]
             return move(src, dest);
         m_assembler.sraiInsn(dest, src, uint32_t(imm.m_value & ((1 << 6) - 1)));
     }
@@ -812,7 +812,7 @@ public:
 
     void urshift64(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
+        if (!imm.m_value) [[unlikely]]
             return move(src, dest);
         m_assembler.srliInsn(dest, src, uint32_t(imm.m_value & ((1 << 6) - 1)));
     }

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -5235,7 +5235,7 @@ public:
 
     void lshift64(TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
+        if (!imm.m_value) [[unlikely]]
             return;
         m_assembler.shlq_i8r(imm.m_value, dest);
     }
@@ -5302,7 +5302,7 @@ public:
 
     void rshift64(TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
+        if (!imm.m_value) [[unlikely]]
             return;
         m_assembler.sarq_i8r(imm.m_value, dest);
     }
@@ -5341,7 +5341,7 @@ public:
 
     void urshift64(TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
+        if (!imm.m_value) [[unlikely]]
             return;
         m_assembler.shrq_i8r(imm.m_value, dest);
     }
@@ -5380,7 +5380,7 @@ public:
 
     void rotateRight64(TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
+        if (!imm.m_value) [[unlikely]]
             return;
         m_assembler.rorq_i8r(imm.m_value, dest);
     }
@@ -5419,7 +5419,7 @@ public:
 
     void rotateLeft64(TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
+        if (!imm.m_value) [[unlikely]]
             return;
         m_assembler.rolq_i8r(imm.m_value, dest);
     }
@@ -5637,7 +5637,7 @@ public:
             return;
         }
 
-        if (UNLIKELY(imm.m_value == INT32_MIN)) {
+        if (imm.m_value == INT32_MIN) [[unlikely]] {
             move(a, dest);
             sub64(imm, dest);
         } else

--- a/Source/JavaScriptCore/assembler/ProbeStack.cpp
+++ b/Source/JavaScriptCore/assembler/ProbeStack.cpp
@@ -138,7 +138,7 @@ Page* Stack::ensurePageFor(void* address)
     // before allocating a new one,
     void* baseAddress = Page::baseAddressFor(address);
     auto it = m_pages.find(baseAddress);
-    if (LIKELY(it != m_pages.end()))
+    if (it != m_pages.end()) [[likely]]
         m_lastAccessedPage = it->value.get();
     else {
         std::unique_ptr<Page> page = makeUnique<Page>(baseAddress);

--- a/Source/JavaScriptCore/assembler/ProbeStack.h
+++ b/Source/JavaScriptCore/assembler/ProbeStack.h
@@ -202,7 +202,7 @@ public:
 private:
     Page* pageFor(void* address)
     {
-        if (LIKELY(Page::baseAddressFor(address) == m_lastAccessedPageBaseAddress))
+        if (Page::baseAddressFor(address) == m_lastAccessedPageBaseAddress) [[likely]]
             return m_lastAccessedPage;
         return ensurePageFor(address);
     }

--- a/Source/JavaScriptCore/assembler/RISCV64Assembler.h
+++ b/Source/JavaScriptCore/assembler/RISCV64Assembler.h
@@ -1564,7 +1564,7 @@ public:
     AssemblerLabel label()
     {
         AssemblerLabel result = m_buffer.label();
-        while (UNLIKELY(static_cast<int>(result.offset()) < m_indexOfTailOfLastWatchpoint)) {
+        while (static_cast<int>(result.offset()) < m_indexOfTailOfLastWatchpoint) [[unlikely]] {
             nop();
             result = m_buffer.label();
         }

--- a/Source/JavaScriptCore/assembler/SecureARM64EHashPinsInlines.h
+++ b/Source/JavaScriptCore/assembler/SecureARM64EHashPinsInlines.h
@@ -103,7 +103,7 @@ ALWAYS_INLINE auto SecureARM64EHashPins::findFirstEntry() -> FindResult
 
 ALWAYS_INLINE uint64_t SecureARM64EHashPins::pinForCurrentThread()
 {
-    if (LIKELY(g_jscConfig.useFastJITPermissions))
+    if (g_jscConfig.useFastJITPermissions) [[likely]]
         return findFirstEntry().entry->pin;
     return 1;
 }

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -6087,7 +6087,7 @@ public:
     AssemblerLabel label()
     {
         AssemblerLabel result = m_formatter.label();
-        while (UNLIKELY(static_cast<int>(result.offset()) < m_indexOfTailOfLastWatchpoint)) {
+        while (static_cast<int>(result.offset()) < m_indexOfTailOfLastWatchpoint) [[unlikely]] {
             nop();
             result = m_formatter.label();
         }

--- a/Source/JavaScriptCore/b3/B3CanonicalizePrePostIncrements.cpp
+++ b/Source/JavaScriptCore/b3/B3CanonicalizePrePostIncrements.cpp
@@ -89,7 +89,7 @@ bool canonicalizePrePostIncrements(Procedure& proc)
                     // Double check the base and offset.
                     Value* addressBase = address->child(0);
                     MemoryValue::OffsetType addressOffset = static_cast<Value::OffsetType>(address->child(1)->asIntPtr());
-                    if (UNLIKELY(base != addressBase || offset != addressOffset))
+                    if (base != addressBase || offset != addressOffset) [[unlikely]]
                         continue;
                     // Skip the address if it's used before the memory.
                     auto uses = addressUses.find(address);

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -96,7 +96,7 @@ class IntRange {
 
 #define DUMP_INT_RANGE_AND_RETURN(range)                           \
     do {                                                           \
-        if (UNLIKELY(B3ReduceStrengthInternal::verbose))           \
+        if (B3ReduceStrengthInternal::verbose) [[unlikely]]        \
             dataLogLn("    IntRange for ", *value, " is ", range); \
         return range;                                              \
     } while (false);

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -666,11 +666,11 @@ private:
         case Jump:
         case Oops:
         case EntrySwitch:
-            if (UNLIKELY(numArgs))
+            if (numArgs) [[unlikely]]
                 badKind(kind, numArgs);
             return Zero;
         case Return:
-            if (UNLIKELY(numArgs > 1))
+            if (numArgs > 1) [[unlikely]]
                 badKind(kind, numArgs);
             return numArgs ? One : Zero;
         case Identity:
@@ -722,7 +722,7 @@ private:
         case VectorExtaddPairwise:
         case VectorDupElement:
         case VectorRelaxedTruncSat:
-            if (UNLIKELY(numArgs != 1))
+            if (numArgs != 1) [[unlikely]]
                 badKind(kind, numArgs);
             return One;
         case Add:
@@ -790,7 +790,7 @@ private:
         case VectorShiftByVector:
         case VectorRelaxedSwizzle:
         case Stitch:
-            if (UNLIKELY(numArgs != 2))
+            if (numArgs != 2) [[unlikely]]
                 badKind(kind, numArgs);
             return Two;
         case Select:
@@ -798,7 +798,7 @@ private:
         case VectorRelaxedMAdd:
         case VectorRelaxedNMAdd:
         case VectorRelaxedLaneSelect:
-            if (UNLIKELY(numArgs != 3))
+            if (numArgs != 3) [[unlikely]]
                 badKind(kind, numArgs);
             return Three;
         default:

--- a/Source/JavaScriptCore/b3/air/AirEmitShuffle.cpp
+++ b/Source/JavaScriptCore/b3/air/AirEmitShuffle.cpp
@@ -90,7 +90,7 @@ Bank ShufflePair::bank() const
 
 Vector<Inst, 2> ShufflePair::insts(Code& code, Value* origin) const
 {
-    if (UNLIKELY(src().isMemory() && dst().isMemory()))
+    if (src().isMemory() && dst().isMemory()) [[unlikely]]
         return { Inst(moveFor(bank(), width()), origin, src(), dst(), code.newTmp(bank())) };
 
     if (isValidForm(moveFor(bank(), width()), src().kind(), dst().kind()))

--- a/Source/JavaScriptCore/b3/air/AirLowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerMacros.cpp
@@ -75,7 +75,7 @@ void lowerMacros(Code& code)
                 }
                 ASSERT(offset = inst.args.size());
                 
-                if (UNLIKELY(hasRegisterSource))
+                if (hasRegisterSource) [[unlikely]]
                     insertionSet.insertInst(instIndex, createShuffle(inst.origin, Vector<ShufflePair>(shufflePairs)));
                 else {
                     // If none of the inputs are registers, then we can efficiently lower this

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -1014,7 +1014,7 @@ int main(int argc, char** argv)
     JSC::JITOperationList::populatePointersInEmbedder(&startOfJITOperationsInTestB3, &endOfJITOperationsInTestB3);
 #endif
 #if ENABLE(JIT_OPERATION_DISASSEMBLY)
-    if (UNLIKELY(JSC::Options::needDisassemblySupport()))
+    if (JSC::Options::needDisassemblySupport()) [[unlikely]]
         JSC::JITOperationList::populateDisassemblyLabelsInEmbedder(&startOfJITOperationsInTestB3, &endOfJITOperationsInTestB3);
 #endif
 

--- a/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
@@ -218,7 +218,7 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const S
     metadata.overrideName(name);
     metadata.setEndPosition(positionBeforeLastNewline);
 
-    if (UNLIKELY(ASSERT_ENABLED || Options::validateBytecode())) {
+    if (ASSERT_ENABLED || Options::validateBytecode()) [[unlikely]] {
         JSTextPosition positionBeforeLastNewlineFromParser;
         ParserError error;
         JSParserBuiltinMode builtinMode = isBuiltinDefaultClassConstructor ? JSParserBuiltinMode::NotBuiltin : JSParserBuiltinMode::Builtin;

--- a/Source/JavaScriptCore/bytecode/ArrayAllocationProfile.cpp
+++ b/Source/JavaScriptCore/bytecode/ArrayAllocationProfile.cpp
@@ -58,7 +58,7 @@ void ArrayAllocationProfile::updateProfile()
     IndexingTypeAndVectorLength current = storage.type();
     if (!lastArray)
         return;
-    if (LIKELY(Options::useArrayAllocationProfiling())) {
+    if (Options::useArrayAllocationProfiling()) [[likely]] {
         // The basic model here is that we will upgrade ourselves to whatever the CoW version of lastArray is except ArrayStorage since we don't have CoW ArrayStorage.
         IndexingType indexingType = leastUpperBoundOfIndexingTypes(current.indexingType() & IndexingTypeMask, lastArray->indexingType());
         if (isCopyOnWrite(current.indexingType())) {

--- a/Source/JavaScriptCore/bytecode/ArrayAllocationProfile.h
+++ b/Source/JavaScriptCore/bytecode/ArrayAllocationProfile.h
@@ -50,9 +50,10 @@ public:
     IndexingType selectIndexingType()
     {
         ASSERT(!isCompilationThread());
-        JSArray* lastArray = m_storage.pointer();
-        if (lastArray && UNLIKELY(lastArray->indexingType() != current().indexingType()))
-            updateProfile();
+        if (JSArray* lastArray = m_storage.pointer()) {
+            if (lastArray->indexingType() != current().indexingType()) [[unlikely]]
+                updateProfile();
+        }
         return current().indexingType();
     }
 

--- a/Source/JavaScriptCore/bytecode/BytecodeGeneratorification.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeGeneratorification.cpp
@@ -290,7 +290,7 @@ void BytecodeGeneratorification::run()
 
 void performGeneratorification(BytecodeGenerator& bytecodeGenerator, UnlinkedCodeBlockGenerator* codeBlock, JSInstructionStreamWriter& instructions, SymbolTable* generatorFrameSymbolTable, int generatorFrameSymbolTableIndex)
 {
-    if (UNLIKELY(Options::dumpBytecodesBeforeGeneratorification())) {
+    if (Options::dumpBytecodesBeforeGeneratorification()) [[unlikely]] {
         dataLogLn("Bytecodes before generatorification");
         CodeBlockBytecodeDumper<UnlinkedCodeBlockGenerator>::dumpBlock(codeBlock, instructions, WTF::dataFile());
     }
@@ -298,7 +298,7 @@ void performGeneratorification(BytecodeGenerator& bytecodeGenerator, UnlinkedCod
     BytecodeGeneratorification pass(bytecodeGenerator, codeBlock, instructions, generatorFrameSymbolTable, generatorFrameSymbolTableIndex);
     pass.run();
 
-    if (UNLIKELY(Options::dumpBytecodesBeforeGeneratorification())) {
+    if (Options::dumpBytecodesBeforeGeneratorification()) [[unlikely]] {
         dataLogLn("Bytecodes after generatorification");
         CodeBlockBytecodeDumper<UnlinkedCodeBlockGenerator>::dumpBlock(codeBlock, instructions, WTF::dataFile());
     }

--- a/Source/JavaScriptCore/bytecode/BytecodeLivenessAnalysis.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeLivenessAnalysis.cpp
@@ -43,7 +43,7 @@ BytecodeLivenessAnalysis::BytecodeLivenessAnalysis(CodeBlock* codeBlock)
 {
     runLivenessFixpoint(codeBlock, codeBlock->instructions(), m_graph);
 
-    if (UNLIKELY(Options::dumpBytecodeLivenessResults()))
+    if (Options::dumpBytecodeLivenessResults()) [[unlikely]]
         dumpResults(codeBlock);
 }
 

--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
@@ -240,7 +240,7 @@ void DataOnlyCallLinkInfo::initialize(VM& vm, CodeBlock* owner, CallType callTyp
     m_codeOrigin = codeOrigin;
     m_callType = callType;
     m_mode = static_cast<unsigned>(Mode::Init);
-    if (UNLIKELY(!Options::useLLIntICs()))
+    if (!Options::useLLIntICs()) [[unlikely]]
         setVirtualCall(vm);
 }
 
@@ -269,7 +269,7 @@ void CallLinkInfo::reset(VM&)
 
 void CallLinkInfo::revertCall(VM& vm)
 {
-    if (UNLIKELY(!Options::useLLIntICs() && type() == CallLinkInfo::Type::DataOnly))
+    if (!Options::useLLIntICs() && type() == CallLinkInfo::Type::DataOnly) [[unlikely]]
         setVirtualCall(vm);
     else
         reset(vm);

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -898,10 +898,10 @@ CodeBlock::~CodeBlock()
         jitCode()->dfgCommon()->clearWatchpoints();
 #endif
 
-    if (UNLIKELY(vm.m_perBytecodeProfiler))
+    if (vm.m_perBytecodeProfiler) [[unlikely]]
         vm.m_perBytecodeProfiler->notifyDestruction(this);
 
-    if (LIKELY(!vm.heap.isShuttingDown())) {
+    if (!vm.heap.isShuttingDown()) [[likely]] {
         // FIXME: This check should really not be necessary, see https://webkit.org/b/272787
         ASSERT(!m_metadata || m_metadata->unlinkedMetadata());
         if (m_metadata && !m_metadata->isDestroyed()) {
@@ -974,7 +974,7 @@ CodeBlock::~CodeBlock()
                     return;
                 auto* prev = watchpoint.prev();
                 auto* next = watchpoint.next();
-                if (UNLIKELY(!Integrity::isSanePointer(prev) || !Integrity::isSanePointer(next))) {
+                if (!Integrity::isSanePointer(prev) || !Integrity::isSanePointer(next)) [[unlikely]] {
                     uintptr_t status = 0;
                     if (Integrity::isSanePointer(prev))
                         status |= 0x5;
@@ -1211,7 +1211,7 @@ bool CodeBlock::shouldVisitStrongly(const ConcurrentJSLocker& locker, Visitor& v
         return false;
     }
 
-    if (UNLIKELY(m_visitChildrenSkippedDueToOldAge)) {
+    if (m_visitChildrenSkippedDueToOldAge) [[unlikely]] {
         RELEASE_ASSERT(Options::verifyGC());
         return false;
     }
@@ -1237,7 +1237,7 @@ bool CodeBlock::shouldJettisonDueToWeakReference(VM& vm)
 
 static Seconds timeToLive(JITType jitType)
 {
-    if (UNLIKELY(Options::useEagerCodeBlockJettisonTiming())) {
+    if (Options::useEagerCodeBlockJettisonTiming()) [[unlikely]] {
         switch (jitType) {
         case JITType::InterpreterThunk:
             return 10_ms;
@@ -1274,7 +1274,7 @@ ALWAYS_INLINE bool CodeBlock::shouldJettisonDueToOldAge(const ConcurrentJSLocker
     if (visitor.isMarked(this))
         return false;
 
-    if (UNLIKELY(Options::forceCodeBlockToJettisonDueToOldAge()))
+    if (Options::forceCodeBlockToJettisonDueToOldAge()) [[unlikely]]
         return true;
     
     if (timeSinceCreation() < timeToLive(jitType()))
@@ -2332,7 +2332,7 @@ void CodeBlock::jettison(Profiler::JettisonReason reason, ReoptimizationMode mod
     
     if (reason != Profiler::JettisonDueToOldAge) {
         Profiler::Compilation* compilation = jitCode()->dfgCommon()->compilation.get();
-        if (UNLIKELY(compilation))
+        if (compilation) [[unlikely]]
             compilation->setJettisonReason(reason, detail);
         
         // This accomplishes (1), and does its own book-keeping about whether it has already happened.
@@ -3702,7 +3702,7 @@ namespace WTF {
     
 void printInternal(PrintStream& out, JSC::CodeBlock* codeBlock)
 {
-    if (UNLIKELY(!codeBlock)) {
+    if (!codeBlock) [[unlikely]] {
         out.print("<null codeBlock>");
         return;
     }

--- a/Source/JavaScriptCore/bytecode/CodeOrigin.h
+++ b/Source/JavaScriptCore/bytecode/CodeOrigin.h
@@ -84,10 +84,10 @@ public:
     CodeOrigin& operator=(const CodeOrigin& other)
     {
         if (this != &other) {
-            if (UNLIKELY(isOutOfLine()))
+            if (isOutOfLine()) [[unlikely]]
                 delete outOfLineCodeOrigin();
             
-            if (UNLIKELY(other.isOutOfLine()))
+            if (other.isOutOfLine()) [[unlikely]]
                 m_compositeValue = buildCompositeValue(other.inlineCallFrame(), other.bytecodeIndex());
             else
                 m_compositeValue = other.m_compositeValue;
@@ -97,7 +97,7 @@ public:
     CodeOrigin& operator=(CodeOrigin&& other)
     {
         if (this != &other) {
-            if (UNLIKELY(isOutOfLine()))
+            if (isOutOfLine()) [[unlikely]]
                 delete outOfLineCodeOrigin();
 
             m_compositeValue = std::exchange(other.m_compositeValue, 0);
@@ -109,7 +109,7 @@ public:
     {
         // We don't use the member initializer list because it would not let us optimize the common case where there is no out-of-line storage
         // (in which case we don't have to extract the components of the composite value just to reassemble it).
-        if (UNLIKELY(other.isOutOfLine()))
+        if (other.isOutOfLine()) [[unlikely]]
             m_compositeValue = buildCompositeValue(other.inlineCallFrame(), other.bytecodeIndex());
         else
             m_compositeValue = other.m_compositeValue;
@@ -121,7 +121,7 @@ public:
 
     ~CodeOrigin()
     {
-        if (UNLIKELY(isOutOfLine()))
+        if (isOutOfLine()) [[unlikely]]
             delete outOfLineCodeOrigin();
     }
 #endif
@@ -180,7 +180,7 @@ public:
 #if CPU(ADDRESS64)
         if (!isSet())
             return BytecodeIndex();
-        if (UNLIKELY(isOutOfLine()))
+        if (isOutOfLine()) [[unlikely]]
             return outOfLineCodeOrigin()->bytecodeIndex;
         return BytecodeIndex::fromBits(m_compositeValue >> (64 - s_freeBitsAtTop));
 #else
@@ -191,7 +191,7 @@ public:
     InlineCallFrame* inlineCallFrame() const
     {
 #if CPU(ADDRESS64)
-        if (UNLIKELY(isOutOfLine()))
+        if (isOutOfLine()) [[unlikely]]
             return outOfLineCodeOrigin()->inlineCallFrame;
         return std::bit_cast<InlineCallFrame*>(m_compositeValue & s_maskCompositeValueForPointer);
 #else
@@ -247,7 +247,7 @@ private:
         if (!bytecodeIndex)
             return std::bit_cast<uintptr_t>(inlineCallFrame) | s_maskIsBytecodeIndexInvalid;
 
-        if (UNLIKELY(bytecodeIndex.asBits() >= 1 << s_freeBitsAtTop)) {
+        if (bytecodeIndex.asBits() >= 1 << s_freeBitsAtTop) [[unlikely]] {
             auto* outOfLine = new OutOfLineCodeOrigin(inlineCallFrame, bytecodeIndex);
             return std::bit_cast<uintptr_t>(outOfLine) | s_maskIsOutOfLine;
         }

--- a/Source/JavaScriptCore/bytecode/InternalFunctionAllocationProfile.h
+++ b/Source/JavaScriptCore/bytecode/InternalFunctionAllocationProfile.h
@@ -65,7 +65,7 @@ inline Structure* InternalFunctionAllocationProfile::createAllocationStructureFr
     // function Foo() { }
     // Reflect.construct(Promise, [], Foo);
     // Reflect.construct(Int8Array, [], Foo);
-    if (UNLIKELY(m_structureID && m_structureID.value() != structure->id()))
+    if (m_structureID && m_structureID.value() != structure->id()) [[unlikely]]
         watchpointSet.fireAll(vm, "InternalFunctionAllocationProfile rotated to a new structure");
 
     m_structureID.set(vm, owner, structure);

--- a/Source/JavaScriptCore/bytecode/ObjectAllocationProfileInlines.h
+++ b/Source/JavaScriptCore/bytecode/ObjectAllocationProfileInlines.h
@@ -136,7 +136,7 @@ ALWAYS_INLINE void ObjectAllocationProfileBase<Derived>::initializeProfile(VM& v
     WTF::storeStoreFence();
 
     // The watchpoint should have been fired already but it's prudent to be safe here.
-    if (UNLIKELY(functionRareData && m_structure && m_structure.get() != structure)) {
+    if (functionRareData && m_structure && m_structure.get() != structure) [[unlikely]] {
         ASSERT(functionRareData->allocationProfileWatchpointSet().hasBeenInvalidated());
         functionRareData->allocationProfileWatchpointSet().fireAll(vm, "Clearing to be safe because structure has changed");
     }

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -87,7 +87,7 @@ void linkMonomorphicCall(VM& vm, JSCell* owner, CallLinkInfo& callLinkInfo, Code
     CodeBlock* callerCodeBlock = jsDynamicCast<CodeBlock*>(owner); // WebAssembly -> JS stubs don't have a valid CodeBlock.
     ASSERT(owner);
 
-    if (UNLIKELY(Options::forceICFailure()))
+    if (Options::forceICFailure()) [[unlikely]]
         return;
 
     ASSERT(!callLinkInfo.isLinked());

--- a/Source/JavaScriptCore/bytecode/RepatchInlines.h
+++ b/Source/JavaScriptCore/bytecode/RepatchInlines.h
@@ -40,7 +40,7 @@ inline void* throwNotAFunctionErrorFromCallIC(JSGlobalObject* globalObject, JSCe
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto errorMessage = constructErrorMessage(globalObject, callee, "is not a function"_s);
     RETURN_IF_EXCEPTION(scope, nullptr);
-    if (UNLIKELY(!errorMessage)) {
+    if (!errorMessage) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return nullptr;
     }
@@ -62,7 +62,7 @@ inline void* throwNotAConstructorErrorFromCallIC(JSGlobalObject* globalObject, J
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto errorMessage = constructErrorMessage(globalObject, callee, "is not a constructor"_s);
     RETURN_IF_EXCEPTION(scope, nullptr);
-    if (UNLIKELY(!errorMessage)) {
+    if (!errorMessage) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return nullptr;
     }
@@ -92,7 +92,7 @@ inline void* handleHostCall(VM& vm, JSCell* owner, CallFrame* calleeFrame, JSVal
             calleeFrame->setCallee(asObject(callee));
             vm.encodedHostCallReturnValue = callData.native.function(asObject(callee)->globalObject(), calleeFrame);
             AssertNoGC assertNoGC;
-            if (UNLIKELY(scope.exception()))
+            if (scope.exception()) [[unlikely]]
                 return nullptr;
             return LLInt::getHostCallReturnValueEntrypoint().code().taggedPtr();
         }
@@ -113,7 +113,7 @@ inline void* handleHostCall(VM& vm, JSCell* owner, CallFrame* calleeFrame, JSVal
         calleeFrame->setCallee(asObject(callee));
         vm.encodedHostCallReturnValue = constructData.native.function(asObject(callee)->globalObject(), calleeFrame);
         AssertNoGC assertNoGC;
-        if (UNLIKELY(scope.exception()))
+        if (scope.exception()) [[unlikely]]
             return nullptr;
         return LLInt::getHostCallReturnValueEntrypoint().code().taggedPtr();
     }
@@ -232,7 +232,7 @@ ALWAYS_INLINE void* virtualForWithFunction(VM& vm, JSCell* owner, CallFrame* cal
 
     JSValue calleeAsValue = calleeFrame->guaranteedJSValueCallee();
     calleeAsFunctionCell = getJSFunction(calleeAsValue);
-    if (UNLIKELY(!calleeAsFunctionCell)) {
+    if (!calleeAsFunctionCell) [[unlikely]] {
         if (jsDynamicCast<InternalFunction*>(calleeAsValue)) {
             CodePtr<JSEntryPtrTag> codePtr = vm.getCTIInternalFunctionTrampolineFor(kind);
             ASSERT(!!codePtr);

--- a/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
@@ -583,7 +583,7 @@ SpeculatedType speculationFromStructure(Structure* structure)
 SpeculatedType speculationFromCell(JSCell* cell)
 {
     // FIXME: rdar://69036888: remove isSanePointer checks when no longer needed.
-    if (UNLIKELY(!Integrity::isSanePointer(cell))) {
+    if (!Integrity::isSanePointer(cell)) [[unlikely]] {
         ASSERT_NOT_REACHED();
         return SpecNone;
     }
@@ -591,7 +591,7 @@ SpeculatedType speculationFromCell(JSCell* cell)
     if (cell->isString()) {
         JSString* string = jsCast<JSString*>(cell);
         if (const StringImpl* impl = string->tryGetValueImpl()) {
-            if (UNLIKELY(!Integrity::isSanePointer(impl))) {
+            if (!Integrity::isSanePointer(impl)) [[unlikely]] {
                 ASSERT_NOT_REACHED();
                 return SpecNone;
             }

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
@@ -223,7 +223,7 @@ bool UnlinkedCodeBlock::typeProfilerExpressionInfoForBytecodeOffset(unsigned byt
 
 UnlinkedCodeBlock::~UnlinkedCodeBlock()
 {
-    if (UNLIKELY(Options::returnEarlyFromInfiniteLoopsForFuzzing())) {
+    if (Options::returnEarlyFromInfiniteLoopsForFuzzing()) [[unlikely]] {
         if (auto* instructions = m_instructions.get()) {
             VM& vm = this->vm();
             for (const auto& instruction : *instructions) {

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.cpp
@@ -90,7 +90,7 @@ void UnlinkedCodeBlockGenerator::finalize(std::unique_ptr<JSInstructionStream> i
             m_codeBlock->m_rareData->m_constantIdentifierSets = WTFMove(m_constantIdentifierSets);
         }
 
-        if (UNLIKELY(Options::returnEarlyFromInfiniteLoopsForFuzzing()))
+        if (Options::returnEarlyFromInfiniteLoopsForFuzzing()) [[unlikely]]
             m_codeBlock->initializeLoopHintExecutionCounter();
     }
     m_vm.writeBarrier(m_codeBlock.get());

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
@@ -193,17 +193,17 @@ FunctionExecutable* UnlinkedFunctionExecutable::link(VM& vm, ScriptExecutable* t
     SourceCode source = linkedSourceCode(passedParentSource);
     FunctionOverrides::OverrideInfo overrideInfo;
     bool hasFunctionOverride = false;
-    if (UNLIKELY(Options::functionOverrides()))
+    if (Options::functionOverrides()) [[unlikely]]
         hasFunctionOverride = FunctionOverrides::initializeOverrideFor(source, overrideInfo);
 
-    if (UNLIKELY(SourceProfiler::g_profilerHook))
+    if (SourceProfiler::g_profilerHook) [[unlikely]]
         SourceProfiler::profile(SourceProfiler::Type::Function, source);
 
     FunctionExecutable* result = FunctionExecutable::create(vm, topLevelExecutable, source, this, intrinsic, isInsideOrdinaryFunction);
     if (overrideLineNumber)
         result->setOverrideLineNumber(*overrideLineNumber);
 
-    if (UNLIKELY(hasFunctionOverride))
+    if (hasFunctionOverride) [[unlikely]]
         result->overrideInfo(overrideInfo);
 
     return result;

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
@@ -331,7 +331,7 @@ private:
 
     RareData& ensureRareData()
     {
-        if (LIKELY(m_rareData))
+        if (m_rareData) [[likely]]
             return *m_rareData;
         return ensureRareDataSlow();
     }

--- a/Source/JavaScriptCore/bytecode/Watchpoint.h
+++ b/Source/JavaScriptCore/bytecode/Watchpoint.h
@@ -222,7 +222,7 @@ public:
     template <typename T>
     void fireAll(VM& vm, T& fireDetails)
     {
-        if (LIKELY(m_state != IsWatched))
+        if (m_state != IsWatched) [[likely]]
             return;
         fireAllSlow(vm, fireDetails);
     }
@@ -439,7 +439,7 @@ public:
     // if they collect a Vector of WatchpointSet*.
     WatchpointSet* inflate()
     {
-        if (LIKELY(isFat()))
+        if (isFat()) [[likely]]
             return fat();
         return inflateSlow();
     }

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -197,7 +197,7 @@ void BytecodeGenerator::asyncFuncParametersTryCatchWrap(const EmitBytecodeFuncto
 
 ParserError BytecodeGenerator::generate(unsigned& size)
 {
-    if (UNLIKELY(m_outOfMemoryDuringConstruction))
+    if (m_outOfMemoryDuringConstruction) [[unlikely]]
         return ParserError(ParserError::OutOfMemory);
 
     bool callingNonCallableConstructor = false;
@@ -603,7 +603,7 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, FunctionNode* functionNode, Unlinke
         if (capturesAnyParameterByName) {
             ASSERT(m_lexicalEnvironmentRegister);
             bool success = functionSymbolTable->trySetArgumentsLength(vm, parameters.size());
-            if (UNLIKELY(!success)) {
+            if (!success) [[unlikely]] {
                 m_outOfMemoryDuringConstruction = true;
                 return;
             }
@@ -615,7 +615,7 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, FunctionNode* functionNode, Unlinke
             for (unsigned i = 0; i < parameters.size(); ++i) {
                 ScopeOffset offset = functionSymbolTable->takeNextScopeOffset(NoLockingNecessary);
                 bool success = functionSymbolTable->trySetArgumentOffset(vm, i, offset);
-                if (UNLIKELY(!success)) {
+                if (!success) [[unlikely]] {
                     m_outOfMemoryDuringConstruction = true;
                     return;
                 }
@@ -1392,7 +1392,7 @@ void BytecodeGenerator::emitEnter()
 {
     OpEnter::emit(this);
 
-    if (LIKELY(Options::optimizeRecursiveTailCalls())) {
+    if (Options::optimizeRecursiveTailCalls()) [[likely]] {
         // We must add the end of op_enter as a potential jump target, because the bytecode parser may decide to split its basic block
         // to have somewhere to jump to if there is a recursive tail-call that points to this function.
         m_codeBlock->addJumpTarget(instructions().size());
@@ -4009,7 +4009,7 @@ void BytecodeGenerator::emitPopWithScope()
 
 void BytecodeGenerator::emitDebugHook(DebugHookType debugHookType, const JSTextPosition& divot, RegisterID* data)
 {
-    if (LIKELY(!shouldEmitDebugHooks()))
+    if (!shouldEmitDebugHooks()) [[likely]]
         return;
 
     if (m_lastDebugHook.position == divot && m_lastDebugHook.type == debugHookType)

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -381,7 +381,7 @@ namespace JSC {
         static ParserError generate(VM& vm, Node* node, const SourceCode& sourceCode, UnlinkedCodeBlock* unlinkedCodeBlock, OptionSet<CodeGenerationMode> codeGenerationMode, const RefPtr<TDZEnvironmentLink>& parentScopeTDZVariables, const FixedVector<Identifier>* generatorOrAsyncWrapperFunctionParameterNames, const PrivateNameEnvironment* privateNameEnvironment)
         {
             MonotonicTime before;
-            if (UNLIKELY(Options::reportBytecodeCompileTimes()))
+            if (Options::reportBytecodeCompileTimes()) [[unlikely]]
                 before = MonotonicTime::now();
 
             DeferGC deferGC(vm);
@@ -389,7 +389,7 @@ namespace JSC {
             unsigned size;
             auto result = bytecodeGenerator->generate(size);
 
-            if (UNLIKELY(Options::reportBytecodeCompileTimes())) {
+            if (Options::reportBytecodeCompileTimes()) [[unlikely]] {
                 MonotonicTime after = MonotonicTime::now();
                 dataLogLn(result.isValid() ? "Failed to compile #" : "Compiled #", CodeBlockHash(sourceCode, unlinkedCodeBlock->isConstructor() ? CodeForConstruct : CodeForCall), " into bytecode ", size, " instructions in ", (after - before).milliseconds(), " ms.");
             }
@@ -486,11 +486,11 @@ namespace JSC {
         {
             // Node::emitCode assumes that dst, if provided, is either a local or a referenced temporary.
             ASSERT(!dst || dst == ignoredResult() || !dst->isTemporary() || dst->refCount());
-            if (UNLIKELY(!m_vm.isSafeToRecurse())) {
+            if (!m_vm.isSafeToRecurse()) [[unlikely]] {
                 emitThrowExpressionTooDeepException();
                 return;
             }
-            if (UNLIKELY(n->needsDebugHook()))
+            if (n->needsDebugHook()) [[unlikely]]
                 emitDebugHook(n);
             n->emitBytecode(*this, dst);
         }
@@ -545,9 +545,9 @@ namespace JSC {
         {
             // Node::emitCode assumes that dst, if provided, is either a local or a referenced temporary.
             ASSERT(!dst || dst == ignoredResult() || !dst->isTemporary() || dst->refCount());
-            if (UNLIKELY(!m_vm.isSafeToRecurse()))
+            if (!m_vm.isSafeToRecurse()) [[unlikely]]
                 return emitThrowExpressionTooDeepException();
-            if (UNLIKELY(n->needsDebugHook()))
+            if (n->needsDebugHook()) [[unlikely]]
                 emitDebugHook(n);
             return n->emitBytecode(*this, dst);
         }
@@ -565,9 +565,9 @@ namespace JSC {
         RegisterID* emitDefineClassElements(PropertyListNode* n, RegisterID* constructor, RegisterID* prototype, Vector<UnlinkedFunctionExecutable::ClassElementDefinition>& instanceElementDefinitions, Vector<UnlinkedFunctionExecutable::ClassElementDefinition>& staticElementDefinitions)
         {
             ASSERT(constructor->refCount() && prototype->refCount());
-            if (UNLIKELY(!m_vm.isSafeToRecurse()))
+            if (!m_vm.isSafeToRecurse()) [[unlikely]]
                 return emitThrowExpressionTooDeepException();
-            if (UNLIKELY(n->needsDebugHook()))
+            if (n->needsDebugHook()) [[unlikely]]
                 emitDebugHook(n);
             return n->emitBytecode(*this, constructor, prototype, &instanceElementDefinitions, &staticElementDefinitions);
         }
@@ -588,7 +588,7 @@ namespace JSC {
 
         void emitNodeInConditionContext(ExpressionNode* n, Label& trueTarget, Label& falseTarget, FallThroughMode fallThroughMode)
         {
-            if (UNLIKELY(!m_vm.isSafeToRecurse())) {
+            if (!m_vm.isSafeToRecurse()) [[unlikely]] {
                 emitThrowExpressionTooDeepException();
                 return;
             }

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -106,10 +106,10 @@ void ConstantNode::emitBytecodeInConditionContext(BytecodeGenerator& generator, 
 {
     TriState value = TriState::Indeterminate;
     JSValue constant = jsValue(generator);
-    if (LIKELY(constant))
+    if (constant) [[likely]]
         value = constant.pureToBoolean();
 
-    if (UNLIKELY(needsDebugHook())) {
+    if (needsDebugHook()) [[unlikely]] {
         if (value != TriState::Indeterminate)
             generator.emitDebugHook(this);
     }
@@ -129,7 +129,7 @@ RegisterID* ConstantNode::emitBytecode(BytecodeGenerator& generator, RegisterID*
     if (dst == generator.ignoredResult())
         return nullptr;
     JSValue constant = jsValue(generator);
-    if (UNLIKELY(!constant)) {
+    if (!constant) [[unlikely]] {
         // This can happen if we try to parse a string or BigInt so enormous that we OOM.
         return generator.emitThrowExpressionTooDeepException();
     }
@@ -433,7 +433,7 @@ RegisterID* ArrayNode::emitBytecode(BytecodeGenerator& generator, RegisterID* ds
             hadVariableExpression = true;
         else {
             JSValue constant = static_cast<ConstantNode*>(firstPutElement->value())->jsValue(generator);
-            if (UNLIKELY(!constant))
+            if (!constant) [[unlikely]]
                 hadVariableExpression = true;
             else {
                 recommendedIndexingType = leastUpperBoundOfIndexingTypeAndValue(recommendedIndexingType, constant);
@@ -1413,7 +1413,7 @@ RegisterID* StaticBlockFunctionCallNode::emitBytecode(BytecodeGenerator& generat
 RegisterID* FunctionCallResolveNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
 {
     if (!ASSERT_ENABLED) {
-        if (UNLIKELY(m_ident == generator.vm().propertyNames->builtinNames().assertPrivateName()))
+        if (m_ident == generator.vm().propertyNames->builtinNames().assertPrivateName()) [[unlikely]]
             return generator.move(dst, generator.emitLoad(nullptr, jsUndefined()));
     }
 
@@ -3311,7 +3311,7 @@ RegisterID* UnaryPlusNode::emitBytecode(BytecodeGenerator& generator, RegisterID
 
 void LogicalNotNode::emitBytecodeInConditionContext(BytecodeGenerator& generator, Label& trueTarget, Label& falseTarget, FallThroughMode fallThroughMode)
 {
-    if (UNLIKELY(needsDebugHook()))
+    if (needsDebugHook()) [[unlikely]]
         generator.emitDebugHook(this);
 
     // Reverse the true and false targets.
@@ -3444,7 +3444,7 @@ void BinaryOpNode::emitBytecodeInConditionContext(BytecodeGenerator& generator, 
     ExpressionNode* branchExpression;
     tryFoldToBranch(generator, branchCondition, branchExpression);
 
-    if (UNLIKELY(needsDebugHook())) {
+    if (needsDebugHook()) [[unlikely]] {
         if (branchCondition != TriState::Indeterminate)
             generator.emitDebugHook(this);
     }
@@ -3491,7 +3491,7 @@ void BinaryOpNode::tryFoldToBranch(BytecodeGenerator& generator, TriState& branc
 
     OpcodeID opcodeID = this->opcodeID();
     JSValue value = constant->jsValue(generator);
-    if (UNLIKELY(!value))
+    if (!value) [[unlikely]]
         return;
     bool canFoldToBranch = JSC::canFoldToBranch(opcodeID, branchExpression, value);
     if (!canFoldToBranch)
@@ -3725,7 +3725,7 @@ RegisterID* LogicalOpNode::emitBytecode(BytecodeGenerator& generator, RegisterID
 
 void LogicalOpNode::emitBytecodeInConditionContext(BytecodeGenerator& generator, Label& trueTarget, Label& falseTarget, FallThroughMode fallThroughMode)
 {
-    if (UNLIKELY(needsDebugHook()))
+    if (needsDebugHook()) [[unlikely]]
         generator.emitDebugHook(this);
 
     Ref<Label> afterExpr1 = generator.newLabel();

--- a/Source/JavaScriptCore/debugger/DebuggerCallFrame.cpp
+++ b/Source/JavaScriptCore/debugger/DebuggerCallFrame.cpp
@@ -59,7 +59,7 @@ private:
 
 Ref<DebuggerCallFrame> DebuggerCallFrame::create(VM& vm, CallFrame* callFrame)
 {
-    if (UNLIKELY(!callFrame)) {
+    if (!callFrame) [[unlikely]] {
         ShadowChicken::Frame emptyFrame;
         RELEASE_ASSERT(!emptyFrame.isTailDeleted);
         return adoptRef(*new DebuggerCallFrame(vm, callFrame, emptyFrame));
@@ -250,7 +250,7 @@ JSValue DebuggerCallFrame::evaluateWithScopeExtension(VM& vm, const String& scri
     JSScope::collectClosureVariablesUnderTDZ(scope(vm)->jsScope(), variablesUnderTDZ, privateNameEnvironment);
 
     auto* eval = DirectEvalExecutable::create(globalObject, makeSource(script, callFrame->callerSourceOrigin(vm), SourceTaintedOrigin::Untainted), codeBlock->ownerExecutable()->lexicallyScopedFeatures(), codeBlock->unlinkedCodeBlock()->derivedContextType(), codeBlock->unlinkedCodeBlock()->needsClassFieldInitializer(), codeBlock->unlinkedCodeBlock()->privateBrandRequirement(), codeBlock->unlinkedCodeBlock()->isArrowFunction(), codeBlock->ownerExecutable()->isInsideOrdinaryFunction(), evalContextType, &variablesUnderTDZ, &privateNameEnvironment);
-    if (UNLIKELY(catchScope.exception())) {
+    if (catchScope.exception()) [[unlikely]] {
         exception = catchScope.exception();
         catchScope.clearException();
         return jsUndefined();
@@ -263,7 +263,7 @@ JSValue DebuggerCallFrame::evaluateWithScopeExtension(VM& vm, const String& scri
     }
 
     JSValue result = vm.interpreter.executeEval(eval, debuggerCallFrame->thisValue(vm), debuggerCallFrame->scope(vm)->jsScope());
-    if (UNLIKELY(catchScope.exception())) {
+    if (catchScope.exception()) [[unlikely]] {
         exception = catchScope.exception();
         catchScope.clearException();
     }

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -968,7 +968,7 @@ private:
                 prediction = codeBlock->valueProfilePredictionForBytecodeIndex(locker, codeOrigin.bytecodeIndex(), specFailValue);
             }
             auto* fuzzerAgent = m_vm->fuzzerAgent();
-            if (UNLIKELY(fuzzerAgent))
+            if (fuzzerAgent) [[unlikely]]
                 return fuzzerAgent->getPrediction(codeBlock, codeOrigin, prediction) & SpecBytecodeTop;
 
             return prediction;
@@ -1450,7 +1450,7 @@ ByteCodeParser::Terminality ByteCodeParser::handleCall(
             return Terminal;
         case CallOptimizationResult::Inlined:
         case CallOptimizationResult::InlinedTerminal:
-            if (UNLIKELY(m_graph.compilation()))
+            if (m_graph.compilation()) [[unlikely]]
                 m_graph.compilation()->noticeInlinedCall();
             return optimizationResult == CallOptimizationResult::InlinedTerminal ? Terminal : NonTerminal;
         case CallOptimizationResult::DidNothing:
@@ -1490,7 +1490,7 @@ ByteCodeParser::Terminality ByteCodeParser::handleVarargsCall(const JSInstructio
             callLinkStatus, firstFreeReg, bytecode.m_thisValue, bytecode.m_arguments,
             firstVarArgOffset, op,
             InlineCallFrame::varargsKindFor(callMode))) {
-            if (UNLIKELY(m_graph.compilation()))
+            if (m_graph.compilation()) [[unlikely]]
                 m_graph.compilation()->noticeInlinedCall();
             return NonTerminal;
         }
@@ -1561,7 +1561,7 @@ void ByteCodeParser::emitArgumentPhantoms(int registerOffset, int argumentCountI
 template<typename ChecksFunctor>
 bool ByteCodeParser::handleRecursiveTailCall(Node* callTargetNode, CallVariant callVariant, int registerOffset, int argumentCountIncludingThis, const ChecksFunctor& emitFunctionCheckIfNeeded)
 {
-    if (UNLIKELY(!Options::optimizeRecursiveTailCalls()))
+    if (!Options::optimizeRecursiveTailCalls()) [[unlikely]]
         return false;
 
     // This optimisation brings more performance if it only runs in FTL, probably because it interferes with tier-up.
@@ -4813,7 +4813,7 @@ bool ByteCodeParser::handleProxyObjectLoad(VirtualRegister destination, Speculat
         return false;
     JSGlobalObject* globalObject = m_inlineStackTop->m_codeBlock->globalObject();
     auto* function = globalObject->performProxyObjectGetFunctionConcurrently();
-    if (UNLIKELY(!function))
+    if (!function) [[unlikely]]
         return false;
 
     Node* functionNode = weakJSConstant(function);
@@ -4828,7 +4828,7 @@ bool ByteCodeParser::handleIndexedProxyObjectLoad(VirtualRegister destination, S
         return false;
     JSGlobalObject* globalObject = m_inlineStackTop->m_codeBlock->globalObject();
     auto* function = globalObject->performProxyObjectGetByValFunctionConcurrently();
-    if (UNLIKELY(!function))
+    if (!function) [[unlikely]]
         return false;
 
     Node* functionNode = weakJSConstant(function);
@@ -4842,7 +4842,7 @@ bool ByteCodeParser::handleProxyObjectStore(Node* base, Node* value, ECMAMode ec
         return false;
     JSGlobalObject* globalObject = m_inlineStackTop->m_codeBlock->globalObject();
     auto* function = ecmaMode.isStrict() ? globalObject->performProxyObjectSetStrictFunctionConcurrently() : globalObject->performProxyObjectSetSloppyFunctionConcurrently();
-    if (UNLIKELY(!function))
+    if (!function) [[unlikely]]
         return false;
 
     Node* functionNode = weakJSConstant(function);
@@ -4857,7 +4857,7 @@ bool ByteCodeParser::handleIndexedProxyObjectStore(Node* base, Node* propertyNam
         return false;
     JSGlobalObject* globalObject = m_inlineStackTop->m_codeBlock->globalObject();
     auto* function = ecmaMode.isStrict() ? globalObject->performProxyObjectSetByValStrictFunctionConcurrently() : globalObject->performProxyObjectSetByValSloppyFunctionConcurrently();
-    if (UNLIKELY(!function))
+    if (!function) [[unlikely]]
         return false;
 
     Node* functionNode = weakJSConstant(function);
@@ -4871,7 +4871,7 @@ bool ByteCodeParser::handleProxyObjectIn(VirtualRegister destination, Node* base
         return false;
     JSGlobalObject* globalObject = m_inlineStackTop->m_codeBlock->globalObject();
     auto* function = globalObject->performProxyObjectHasFunctionConcurrently();
-    if (UNLIKELY(!function))
+    if (!function) [[unlikely]]
         return false;
 
     Node* functionNode = weakJSConstant(function);
@@ -4886,7 +4886,7 @@ bool ByteCodeParser::handleIndexedProxyObjectIn(VirtualRegister destination, Nod
         return false;
     JSGlobalObject* globalObject = m_inlineStackTop->m_codeBlock->globalObject();
     auto* function = globalObject->performProxyObjectHasByValFunctionConcurrently();
-    if (UNLIKELY(!function))
+    if (!function) [[unlikely]]
         return false;
 
     Node* functionNode = weakJSConstant(function);
@@ -5655,14 +5655,14 @@ void ByteCodeParser::handleGetById(
     if (getById != TryGetById) {
         if (getByStatus.isModuleNamespace()) {
             if (handleModuleNamespaceLoad(destination, prediction, base, getByStatus)) {
-                if (UNLIKELY(m_graph.compilation()))
+                if (m_graph.compilation()) [[unlikely]]
                     m_graph.compilation()->noticeInlinedGetById();
                 return;
             }
         }
         if (getByStatus.isProxyObject()) {
             if (handleProxyObjectLoad(destination, prediction, base, getByStatus, osrExitIndex)) {
-                if (UNLIKELY(m_graph.compilation()))
+                if (m_graph.compilation()) [[unlikely]]
                     m_graph.compilation()->noticeInlinedGetById();
                 return;
             }
@@ -5687,7 +5687,7 @@ void ByteCodeParser::handleGetById(
                 if (Options::useDOMJIT() && variant.domAttribute()) {
                     ASSERT(!getByStatus.makesCalls());
                     if (handleDOMJITGetter(destination, variant, base, unwrapped, identifierNumber, prediction)) {
-                        if (UNLIKELY(m_graph.compilation()))
+                        if (m_graph.compilation()) [[unlikely]]
                             m_graph.compilation()->noticeInlinedGetById();
                         return;
                     }
@@ -5700,7 +5700,7 @@ void ByteCodeParser::handleGetById(
                     return;
                 }
 
-                if (UNLIKELY(m_graph.compilation()))
+                if (m_graph.compilation()) [[unlikely]]
                     m_graph.compilation()->noticeInlinedGetById();
 
                 addToGraph(FilterGetByStatus, OpInfo(m_graph.m_plan.recordedStatuses().addGetByStatus(currentCodeOrigin(), getByStatus)), base);
@@ -5767,7 +5767,7 @@ void ByteCodeParser::handleGetById(
             cases.append(MultiGetByOffsetCase(*m_graph.addStructureSet(variant.structureSet()), method));
         }
 
-        if (UNLIKELY(m_graph.compilation()))
+        if (m_graph.compilation()) [[unlikely]]
             m_graph.compilation()->noticeInlinedGetById();
     
         // 2) Emit a MultiGetByOffset
@@ -5805,7 +5805,7 @@ void ByteCodeParser::handleGetById(
         };
 
         if (handleIntrinsicGetter(destination, prediction, variant, base, unwrapped, addChecks)) {
-            if (UNLIKELY(m_graph.compilation()))
+            if (m_graph.compilation()) [[unlikely]]
                 m_graph.compilation()->noticeInlinedGetById();
             addToGraph(Phantom, base);
             return;
@@ -5820,7 +5820,7 @@ void ByteCodeParser::handleGetById(
         }
     }
 
-    if (UNLIKELY(m_graph.compilation()))
+    if (m_graph.compilation()) [[unlikely]]
         m_graph.compilation()->noticeInlinedGetById();
 
     if (!variant.callLinkStatus()) {
@@ -5907,7 +5907,7 @@ void ByteCodeParser::handleGetPrivateNameById(
             cases.append(MultiGetByOffsetCase(*m_graph.addStructureSet(variant.structureSet()), method));
         }
 
-        if (UNLIKELY(m_graph.compilation()))
+        if (m_graph.compilation()) [[unlikely]]
             m_graph.compilation()->noticeInlinedGetById();
 
         // 2) Emit a MultiGetByOffset
@@ -5934,7 +5934,7 @@ void ByteCodeParser::handleGetPrivateNameById(
         return;
     }
 
-    if (UNLIKELY(m_graph.compilation()))
+    if (m_graph.compilation()) [[unlikely]]
         m_graph.compilation()->noticeInlinedGetById();
 
     ASSERT(!variant.callLinkStatus());
@@ -6126,7 +6126,7 @@ void ByteCodeParser::handlePutById(
                 // Special path for custom accessors since custom's offset does not have any meanings.
                 // So, this is completely different from Simple one. But we have a chance to optimize it.
                 auto variant = putByStatus[0];
-                if (UNLIKELY(m_graph.compilation()))
+                if (m_graph.compilation()) [[unlikely]]
                     m_graph.compilation()->noticeInlinedPutById();
                 addToGraph(FilterPutByStatus, OpInfo(m_graph.m_plan.recordedStatuses().addPutByStatus(currentCodeOrigin(), putByStatus)), base);
                 if (!check(variant.conditionSet())) {
@@ -6176,7 +6176,7 @@ void ByteCodeParser::handlePutById(
             }
         }
         
-        if (UNLIKELY(m_graph.compilation()))
+        if (m_graph.compilation()) [[unlikely]]
             m_graph.compilation()->noticeInlinedPutById();
 
         addToGraph(FilterPutByStatus, OpInfo(m_graph.m_plan.recordedStatuses().addPutByStatus(currentCodeOrigin(), putByStatus)), base);
@@ -6203,7 +6203,7 @@ void ByteCodeParser::handlePutById(
         addToGraph(FilterPutByStatus, OpInfo(m_graph.m_plan.recordedStatuses().addPutByStatus(currentCodeOrigin(), putByStatus)), base);
 
         replace(unwrapped, identifierNumber, variant, value);
-        if (UNLIKELY(m_graph.compilation()))
+        if (m_graph.compilation()) [[unlikely]]
             m_graph.compilation()->noticeInlinedPutById();
         return;
     }
@@ -6270,7 +6270,7 @@ void ByteCodeParser::handlePutById(
         // https://bugs.webkit.org/show_bug.cgi?id=142924.
         addToGraph(PutStructure, OpInfo(transition), unwrapped);
 
-        if (UNLIKELY(m_graph.compilation()))
+        if (m_graph.compilation()) [[unlikely]]
             m_graph.compilation()->noticeInlinedPutById();
         return;
     }
@@ -6352,7 +6352,7 @@ void ByteCodeParser::handlePutPrivateNameById(
             return;
         }
         
-        if (UNLIKELY(m_graph.compilation()))
+        if (m_graph.compilation()) [[unlikely]]
             m_graph.compilation()->noticeInlinedPutById();
     
         addToGraph(FilterPutByStatus, OpInfo(m_graph.m_plan.recordedStatuses().addPutByStatus(currentCodeOrigin(), putByStatus)), base);
@@ -6380,7 +6380,7 @@ void ByteCodeParser::handlePutPrivateNameById(
         addToGraph(FilterPutByStatus, OpInfo(m_graph.m_plan.recordedStatuses().addPutByStatus(currentCodeOrigin(), putByStatus)), base);
     
         replace(base, identifierNumber, variant, value);
-        if (UNLIKELY(m_graph.compilation()))
+        if (m_graph.compilation()) [[unlikely]]
             m_graph.compilation()->noticeInlinedPutById();
         return;
     }
@@ -6447,7 +6447,7 @@ void ByteCodeParser::handlePutPrivateNameById(
         // https://bugs.webkit.org/show_bug.cgi?id=142924.
         addToGraph(PutStructure, OpInfo(transition), base);
     
-        if (UNLIKELY(m_graph.compilation()))
+        if (m_graph.compilation()) [[unlikely]]
             m_graph.compilation()->noticeInlinedPutById();
         return;
     }
@@ -6601,7 +6601,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
 
         VERBOSE_LOG("    parsing ", currentCodeOrigin(), ": ", opcodeID, "\n");
         
-        if (UNLIKELY(m_graph.compilation())) {
+        if (m_graph.compilation()) [[unlikely]] {
             addToGraph(CountExecution, OpInfo(m_graph.compilation()->executionCounterFor(
                 Profiler::OriginStack(*m_vm->m_perBytecodeProfiler, m_codeBlock, currentCodeOrigin()))));
         }
@@ -10312,12 +10312,12 @@ void ByteCodeParser::parseCodeBlock()
     
     CodeBlock* codeBlock = m_inlineStackTop->m_codeBlock;
     
-    if (UNLIKELY(m_graph.compilation())) {
+    if (m_graph.compilation()) [[unlikely]] {
         m_graph.compilation()->addProfiledBytecodes(
             *m_vm->m_perBytecodeProfiler, m_inlineStackTop->m_profiledBlock);
     }
     
-    if (UNLIKELY(Options::dumpSourceAtDFGTime())) {
+    if (Options::dumpSourceAtDFGTime()) [[unlikely]] {
         Vector<DeferredSourceDump>& deferredSourceDump = m_graph.m_plan.callback()->ensureDeferredSourceDump();
         if (inlineCallFrame()) {
             DeferredSourceDump dump(codeBlock->baselineVersion(), m_codeBlock, JITType::DFGJIT, inlineCallFrame()->directCaller.bytecodeIndex());
@@ -10326,7 +10326,7 @@ void ByteCodeParser::parseCodeBlock()
             deferredSourceDump.append(DeferredSourceDump(codeBlock->baselineVersion()));
     }
 
-    if (UNLIKELY(Options::dumpBytecodeAtDFGTime())) {
+    if (Options::dumpBytecodeAtDFGTime()) [[unlikely]] {
         WTF::dataFile().atomically([&](auto&) {
             dataLog("Parsing ", *codeBlock);
             if (inlineCallFrame()) {
@@ -10341,7 +10341,7 @@ void ByteCodeParser::parseCodeBlock()
 
     Vector<JSInstructionStream::Offset, 32> jumpTargets;
     computePreciseJumpTargets(codeBlock, jumpTargets);
-    if (UNLIKELY(Options::dumpBytecodeAtDFGTime())) {
+    if (Options::dumpBytecodeAtDFGTime()) [[unlikely]] {
         WTF::dataFile().atomically([&](auto&) {
             dataLog("Jump targets: ");
             CommaPrinter comma;

--- a/Source/JavaScriptCore/dfg/DFGCFAPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCFAPhase.cpp
@@ -203,14 +203,14 @@ private:
             injectOSR(block);
         
         m_state.beginBasicBlock(block);
-        if (UNLIKELY(m_verbose)) {
+        if (m_verbose) [[unlikely]] {
             dataLogLn("      head vars: ", block->valuesAtHead);
             if (m_graph.m_form == SSA)
                 dataLogLn("      head regs: ", nodeValuePairListDump(block->ssa->valuesAtHead));
         }
         for (unsigned i = 0; i < block->size(); ++i) {
             Node* node = block->at(i);
-            if (UNLIKELY(m_verbose)) {
+            if (m_verbose) [[unlikely]] {
                 WTF::dataFile().atomically([&](auto&) {
                     dataLog("      ", Graph::opName(node->op()), " @", node->index(), ": ");
                     if (!safeToExecute(m_state, m_graph, node))

--- a/Source/JavaScriptCore/dfg/DFGCommonData.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCommonData.cpp
@@ -65,7 +65,7 @@ bool CommonData::invalidateLinkedCode()
     if (!m_isStillValid)
         return false;
 
-    if (UNLIKELY(m_hasVMTrapsBreakpointsInstalled)) {
+    if (m_hasVMTrapsBreakpointsInstalled) [[unlikely]] {
         Locker locker { pcCodeBlockMapLock };
         auto& map = pcCodeBlockMap();
         for (auto& jumpReplacement : m_jumpReplacements)
@@ -84,7 +84,7 @@ CommonData::~CommonData()
 {
     if (m_isUnlinked)
         return;
-    if (UNLIKELY(m_hasVMTrapsBreakpointsInstalled)) {
+    if (m_hasVMTrapsBreakpointsInstalled) [[unlikely]] {
         Locker locker { pcCodeBlockMapLock };
         auto& map = pcCodeBlockMap();
         for (auto& jumpReplacement : m_jumpReplacements)

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -1558,7 +1558,7 @@ void Graph::visitChildren(SlotVisitor& visitor) { visitChildrenImpl(visitor); }
 FrozenValue* Graph::freeze(JSValue value)
 {
     RELEASE_ASSERT(!m_plan.isInSafepoint());
-    if (UNLIKELY(!value))
+    if (!value) [[unlikely]]
         return FrozenValue::emptySingleton();
 
     // There are weird relationships in how optimized CodeBlocks
@@ -1568,7 +1568,7 @@ FrozenValue* Graph::freeze(JSValue value)
     RELEASE_ASSERT(!jsDynamicCast<CodeBlock*>(value));
     
     auto result = m_frozenValueMap.add(JSValue::encode(value), nullptr);
-    if (LIKELY(!result.isNewEntry))
+    if (!result.isNewEntry) [[likely]]
         return result.iterator->value;
 
     if (value.isUInt32())

--- a/Source/JavaScriptCore/dfg/DFGInsertionSet.h
+++ b/Source/JavaScriptCore/dfg/DFGInsertionSet.h
@@ -50,7 +50,7 @@ public:
     // a stable sort on the insertions.
     Node* insert(const Insertion& insertion)
     {
-        if (LIKELY(!m_insertions.size() || m_insertions.last().index() <= insertion.index()))
+        if (!m_insertions.size() || m_insertions.last().index() <= insertion.index()) [[likely]]
             m_insertions.append(insertion);
         else
             insertSlow(insertion);

--- a/Source/JavaScriptCore/dfg/DFGIntegerCheckCombiningPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGIntegerCheckCombiningPhase.cpp
@@ -281,7 +281,7 @@ private:
                 
             case ArrayBounds:
                 ASSERT(node->op() == CheckInBounds);
-                if (UNLIKELY(Options::validateBoundsCheckElimination()))
+                if (Options::validateBoundsCheckElimination()) [[unlikely]]
                     m_insertionSet.insertNode(nodeIndex, SpecNone, AssertInBounds, node->origin, node->child1(), node->child2());
                 node->convertToIdentityOn(m_map.get(data.m_key).m_dependency);
                 m_changed = true;

--- a/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
@@ -1442,8 +1442,10 @@ public:
                     
                     if (nonNegative && lessThanLength) {
                         executeNode(block->at(nodeIndex));
-                        if (UNLIKELY(Options::validateBoundsCheckElimination()) && node->op() == CheckInBounds)
-                            m_insertionSet.insertNode(nodeIndex, SpecNone, AssertInBounds, node->origin, node->child1(), node->child2());
+                        if (Options::validateBoundsCheckElimination()) [[unlikely]] {
+                            if (node->op() == CheckInBounds)
+                                m_insertionSet.insertNode(nodeIndex, SpecNone, AssertInBounds, node->origin, node->child1(), node->child2());
+                        }
                         // We just need to make sure we are a value-producing node.
                         node->convertToIdentityOn(node->child1().node());
                         changed = true;

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
@@ -55,7 +55,7 @@ JITCompiler::JITCompiler(Graph& dfg)
     , m_blockHeads(dfg.numBlocks())
     , m_pcToCodeOriginMapBuilder(dfg.m_vm)
 {
-    if (UNLIKELY(shouldDumpDisassembly() || m_graph.m_vm.m_perBytecodeProfiler))
+    if (shouldDumpDisassembly() || m_graph.m_vm.m_perBytecodeProfiler) [[unlikely]]
         m_disassembler = makeUniqueWithoutFastMallocCheck<Disassembler>(dfg);
 #if ENABLE(FTL_JIT)
     m_jitCode->tierUpInLoopHierarchy = WTFMove(m_graph.m_plan.tierUpInLoopHierarchy());
@@ -69,7 +69,7 @@ JITCompiler::~JITCompiler() = default;
 void JITCompiler::linkOSRExits()
 {
     ASSERT(m_osrExit.size() == m_exitCompilationInfo.size());
-    if (UNLIKELY(m_graph.compilation())) {
+    if (m_graph.compilation()) [[unlikely]] {
         for (unsigned i = 0; i < m_osrExit.size(); ++i) {
             OSRExitCompilationInfo& info = m_exitCompilationInfo[i];
             Vector<Label> labels;
@@ -320,7 +320,7 @@ void JITCompiler::link(LinkBuffer& linkBuffer)
         ASSERT(m_jitCode->common.m_jumpReplacements.isEmpty());
 #endif
     
-    if (UNLIKELY(m_graph.compilation())) {
+    if (m_graph.compilation()) [[unlikely]] {
         ASSERT(m_exitSiteLabels.size() == m_osrExit.size());
         for (unsigned i = 0; i < m_exitSiteLabels.size(); ++i) {
             Vector<Label>& labels = m_exitSiteLabels[i];
@@ -368,7 +368,7 @@ void JITCompiler::disassemble(LinkBuffer& linkBuffer)
         linkBuffer.didAlreadyDisassemble();
     }
 
-    if (UNLIKELY(m_graph.m_plan.compilation()))
+    if (m_graph.m_plan.compilation()) [[unlikely]]
         m_disassembler->reportToProfiler(m_graph.m_plan.compilation(), linkBuffer);
 }
 
@@ -461,7 +461,7 @@ void JITCompiler::appendExceptionHandlingOSRExit(SpeculativeJIT* speculative, Ex
 void JITCompiler::setEndOfMainPath(CodeOrigin semanticOrigin)
 {
     m_pcToCodeOriginMapBuilder.appendItem(labelIgnoringWatchpoints(), semanticOrigin);
-    if (LIKELY(!m_disassembler))
+    if (!m_disassembler) [[likely]]
         return;
     m_disassembler->setEndOfMainPath(labelIgnoringWatchpoints());
 }
@@ -469,7 +469,7 @@ void JITCompiler::setEndOfMainPath(CodeOrigin semanticOrigin)
 void JITCompiler::setEndOfCode()
 {
     m_pcToCodeOriginMapBuilder.appendItem(labelIgnoringWatchpoints(), PCToCodeOriginMapBuilder::defaultCodeOrigin());
-    if (LIKELY(!m_disassembler))
+    if (!m_disassembler) [[likely]]
         return;
     m_disassembler->setEndOfCode(labelIgnoringWatchpoints());
 }

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.h
@@ -101,21 +101,21 @@ public:
     void setStartOfCode()
     {
         m_pcToCodeOriginMapBuilder.appendItem(labelIgnoringWatchpoints(), CodeOrigin(BytecodeIndex(0)));
-        if (LIKELY(!m_disassembler))
+        if (!m_disassembler) [[likely]]
             return;
         m_disassembler->setStartOfCode(labelIgnoringWatchpoints());
     }
     
     void setForBlockIndex(BlockIndex blockIndex)
     {
-        if (LIKELY(!m_disassembler))
+        if (!m_disassembler) [[likely]]
             return;
         m_disassembler->setForBlockIndex(blockIndex, labelIgnoringWatchpoints());
     }
     
     void setForNode(Node* node)
     {
-        if (LIKELY(!m_disassembler))
+        if (!m_disassembler) [[likely]]
             return;
         m_disassembler->setForNode(node, labelIgnoringWatchpoints());
     }

--- a/Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp
@@ -66,7 +66,7 @@ bool JITFinalizer::finalize()
     codeBlock->setJITCode(m_jitCode.copyRef());
 
     auto data = m_plan.tryFinalizeJITData(m_jitCode.get());
-    if (UNLIKELY(!data))
+    if (!data) [[unlikely]]
         return false;
     codeBlock->setDFGJITData(WTFMove(data));
 
@@ -74,7 +74,7 @@ bool JITFinalizer::finalize()
     m_jitCode->optimizeAfterWarmUp(codeBlock);
 #endif // ENABLE(FTL_JIT)
 
-    if (UNLIKELY(m_plan.compilation()))
+    if (m_plan.compilation()) [[unlikely]]
         vm.m_perBytecodeProfiler->addCompilation(codeBlock, *m_plan.compilation());
 
     if (!m_plan.willTryToTierUp())

--- a/Source/JavaScriptCore/dfg/DFGLICMPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLICMPhase.cpp
@@ -218,7 +218,7 @@ public:
                 if (nodeRef->op() == ForceOSRExit)
                     break;
                 for (unsigned stackIndex = loopStack.size(); stackIndex--;) {
-                    if (UNLIKELY(Options::useLICMFuzzing())) {
+                    if (Options::useLICMFuzzing()) [[unlikely]] {
                         bool shouldAttemptHoist = random.returnTrueWithProbability(Options::allowHoistingLICMProbability());
                         if (!shouldAttemptHoist && !nodeRef->isCheckNode())
                             continue;

--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
@@ -113,7 +113,7 @@ public:
     {
         ASSERT(m_graph.m_form == ThreadedCPS);
 
-        if (UNLIKELY(!functionAllowlist().contains(m_graph.m_codeBlock)))
+        if (!functionAllowlist().contains(m_graph.m_codeBlock)) [[unlikely]]
             return false;
 
         dataLogIf(Options::verboseLoopUnrolling(), "Graph before Loop Unrolling Phase:\n", m_graph);
@@ -178,7 +178,7 @@ public:
 
     bool tryUnroll(const NaturalLoop* loop)
     {
-        if (UNLIKELY(Options::verboseLoopUnrolling())) {
+        if (Options::verboseLoopUnrolling()) [[unlikely]] {
             const NaturalLoop* outerLoop = m_graph.m_cpsNaturalLoops->innerMostOuterLoop(*loop);
             dataLogLnIf(Options::verboseLoopUnrolling(), "\nTry unroll innerMostLoop=", *loop, " with innerMostOuterLoop=", outerLoop ? *outerLoop : NaturalLoop());
         }
@@ -506,7 +506,7 @@ public:
             }
         }
 
-        if (UNLIKELY(Options::verboseLoopUnrolling()))
+        if (Options::verboseLoopUnrolling()) [[unlikely]]
             dumpLoopNodeTypeStats(data);
 
         return data.isProfitableToUnroll();

--- a/Source/JavaScriptCore/dfg/DFGOSREntry.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSREntry.cpp
@@ -227,7 +227,7 @@ void* prepareOSREntry(VM& vm, CallFrame* callFrame, CodeBlock* codeBlock, Byteco
     //    would have otherwise just kept running albeit less quickly.
     
     unsigned frameSizeForCheck = jitCode->common.requiredRegisterCountForExecutionAndExit();
-    if (UNLIKELY(!vm.ensureStackCapacityFor(&callFrame->registers()[virtualRegisterForLocal(frameSizeForCheck - 1).offset()]))) {
+    if (!vm.ensureStackCapacityFor(&callFrame->registers()[virtualRegisterForLocal(frameSizeForCheck - 1).offset()])) [[unlikely]] {
         dataLogLnIf(Options::verboseOSR(), "    OSR failed because stack growth failed.");
         return nullptr;
     }
@@ -398,7 +398,7 @@ CodePtr<ExceptionHandlerPtrTag> prepareCatchOSREntry(VM& vm, CallFrame* callFram
     }
 
     unsigned frameSizeForCheck = dfgCommon->requiredRegisterCountForExecutionAndExit();
-    if (UNLIKELY(!vm.ensureStackCapacityFor(&callFrame->registers()[virtualRegisterForLocal(frameSizeForCheck).offset()])))
+    if (!vm.ensureStackCapacityFor(&callFrame->registers()[virtualRegisterForLocal(frameSizeForCheck).offset()])) [[unlikely]]
         return nullptr;
 
     auto instruction = baselineCodeBlock->instructions().at(callFrame->bytecodeIndex());

--- a/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
@@ -194,7 +194,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompileOSRExit, void, (CallFrame* cal
 
         jit.jitAssertHasValidCallFrame();
 
-        if (UNLIKELY(vm.m_perBytecodeProfiler && codeBlock->jitCode()->dfgCommon()->compilation)) {
+        if (vm.m_perBytecodeProfiler && codeBlock->jitCode()->dfgCommon()->compilation) [[unlikely]] {
             Profiler::Database& database = *vm.m_perBytecodeProfiler;
             Profiler::Compilation* compilation = codeBlock->jitCode()->dfgCommon()->compilation.get();
 
@@ -270,7 +270,7 @@ IGNORE_WARNINGS_END
 void OSRExit::compileExit(CCallHelpers& jit, VM& vm, const OSRExit& exit, const Operands<ValueRecovery>& operands, SpeculationRecovery* recovery, uint32_t osrExitIndex)
 {
     // Pro-forma stuff.
-    if (UNLIKELY(Options::printEachOSRExit())) {
+    if (Options::printEachOSRExit()) [[unlikely]] {
         SpeculationFailureDebugInfo* debugInfo = new SpeculationFailureDebugInfo;
         debugInfo->codeBlock = jit.codeBlock();
         debugInfo->kind = exit.m_kind;
@@ -767,7 +767,7 @@ void OSRExit::compileExit(CCallHelpers& jit, VM& vm, const OSRExit& exit, const 
 #if USE(JSVALUE64)
             EncodedJSValue currentConstant = JSValue::encode(recovery.constant());
             if (currentConstant == encodedJSUndefined()) {
-                if (UNLIKELY(!undefinedGPRIsInitialized)) {
+                if (!undefinedGPRIsInitialized) [[unlikely]] {
                     jit.move(CCallHelpers::TrustedImm64(encodedJSUndefined()), undefinedGPR);
                     undefinedGPRIsInitialized = true;
                 }

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -837,7 +837,7 @@ private:
         m_combinedLiveness = CombinedLiveness(m_graph);
 
         CString graphBeforeSinking;
-        if (UNLIKELY(Options::verboseValidationFailure() && Options::validateGraphAtEachPhase())) {
+        if (Options::verboseValidationFailure() && Options::validateGraphAtEachPhase()) [[unlikely]] {
             StringPrintStream out;
             m_graph.dump(out);
             graphBeforeSinking = out.toCString();
@@ -864,7 +864,7 @@ private:
         removeICStatusFilters();
         fixUpsilonEdge();
 
-        if (UNLIKELY(Options::validateGraphAtEachPhase()))
+        if (Options::validateGraphAtEachPhase()) [[unlikely]]
             DFG::validate(m_graph, DumpGraph, graphBeforeSinking);
         return true;
     }
@@ -2007,7 +2007,7 @@ escapeChildren:
                     // We're materializing `identifier` at this point, and the unmaterialized
                     // version is inside `location`. We track which SSA variable this belongs
                     // to in case we also need a PutHint for the Phi.
-                    if (UNLIKELY(validationEnabled())) {
+                    if (validationEnabled()) [[unlikely]] {
                         RELEASE_ASSERT(m_sinkCandidates.contains(location.base()));
                         RELEASE_ASSERT(m_sinkCandidates.contains(identifier));
 

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -473,10 +473,10 @@ Plan::CompilationPath Plan::compileInThreadImpl()
         FTL::State state(dfg);
         FTL::lowerDFGToB3(state);
 
-        if (UNLIKELY(computeCompileTimes()))
+        if (computeCompileTimes()) [[unlikely]]
             m_timeBeforeFTL = MonotonicTime::now();
         
-        if (UNLIKELY(Options::b3AlwaysFailsBeforeCompile())) {
+        if (Options::b3AlwaysFailsBeforeCompile()) [[unlikely]] {
             FTL::fail(state);
             return FTLPath;
         }
@@ -485,7 +485,7 @@ Plan::CompilationPath Plan::compileInThreadImpl()
         if (safepointResult.didGetCancelled())
             return CancelPath;
         
-        if (UNLIKELY(Options::b3AlwaysFailsBeforeLink())) {
+        if (Options::b3AlwaysFailsBeforeLink()) [[unlikely]] {
             FTL::fail(state);
             return FTLPath;
         }
@@ -607,7 +607,7 @@ CompilationResult Plan::finalize()
             return CompilationInvalidated;
         }
 
-        if (UNLIKELY(validationEnabled())) {
+        if (validationEnabled()) [[unlikely]] {
             TrackedReferences trackedReferences;
 
             for (WriteBarrier<JSCell>& reference : m_codeBlock->jitCode()->dfgCommon()->m_weakReferences)

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -129,7 +129,7 @@ static void emitStackOverflowCheck(JITCompiler& jit, MacroAssembler::JumpList& s
     jit.addPtr(MacroAssembler::TrustedImm32(frameTopOffset), GPRInfo::callFrameRegister, GPRInfo::regT1);
 #if !CPU(ADDRESS64)
     unsigned maxFrameSize = -frameTopOffset;
-    if (UNLIKELY(maxFrameSize > Options::reservedZoneSize()))
+    if (maxFrameSize > Options::reservedZoneSize()) [[unlikely]]
         stackOverflow.append(jit.branchPtr(MacroAssembler::Above, GPRInfo::regT1, GPRInfo::callFrameRegister));
 #endif
     stackOverflow.append(jit.branchPtr(MacroAssembler::GreaterThan, MacroAssembler::AbsoluteAddress(jit.vm().addressOfSoftStackLimit()), GPRInfo::regT1));
@@ -652,7 +652,7 @@ void SpeculativeJIT::runSlowPathGenerators(PCToCodeOriginMapBuilder& pcToCodeOri
 {
     auto markSlowPathIfNeeded = [&] (Node* node) {
         std::optional<JITSizeStatistics::Marker> sizeMarker;
-        if (UNLIKELY(Options::dumpDFGJITSizeStatistics())) {
+        if (Options::dumpDFGJITSizeStatistics()) [[unlikely]] {
             String id = makeString("DFG_slow_"_s, m_graph.opName(node->op()));
             sizeMarker = vm().jitSizeStatistics->markStart(id, *this);
         }
@@ -665,7 +665,7 @@ void SpeculativeJIT::runSlowPathGenerators(PCToCodeOriginMapBuilder& pcToCodeOri
 
         slowPathGenerator->generate(this);
 
-        if (UNLIKELY(sizeMarker))
+        if (sizeMarker) [[unlikely]]
             vm().jitSizeStatistics->markEnd(WTFMove(*sizeMarker), *this, m_graph.m_plan);
     }
     for (auto& slowPathLambda : m_slowPathLambdas) {
@@ -678,7 +678,7 @@ void SpeculativeJIT::runSlowPathGenerators(PCToCodeOriginMapBuilder& pcToCodeOri
         slowPathLambda.generator();
         ASSERT(!m_underSilentSpill);
         m_outOfLineStreamIndex = std::nullopt;
-        if (UNLIKELY(sizeMarker))
+        if (sizeMarker) [[unlikely]]
             vm().jitSizeStatistics->markEnd(WTFMove(*sizeMarker), *this, m_graph.m_plan);
     }
 }
@@ -1927,7 +1927,7 @@ void SpeculativeJIT::noticeOSRBirth(Node* node)
 
 void SpeculativeJIT::compileLoopHint(Node* node)
 {
-    if (UNLIKELY(Options::returnEarlyFromInfiniteLoopsForFuzzing())) {
+    if (Options::returnEarlyFromInfiniteLoopsForFuzzing()) [[unlikely]] {
         bool emitEarlyReturn = true;
         node->origin.semantic.walkUpInlineStack([&](CodeOrigin origin) {
             CodeBlock* baselineCodeBlock = m_graph.baselineCodeBlockFor(origin);
@@ -2122,14 +2122,14 @@ void SpeculativeJIT::compileCurrentBlock()
         }
 
         std::optional<JITSizeStatistics::Marker> sizeMarker;
-        if (UNLIKELY(Options::dumpDFGJITSizeStatistics())) {
+        if (Options::dumpDFGJITSizeStatistics()) [[unlikely]] {
             String id = makeString("DFG_fast_"_s, m_graph.opName(m_currentNode->op()));
             sizeMarker = vm().jitSizeStatistics->markStart(id, *this);
         }
 
         compile(m_currentNode);
 
-        if (UNLIKELY(sizeMarker))
+        if (sizeMarker) [[unlikely]]
             vm().jitSizeStatistics->markEnd(WTFMove(*sizeMarker), *this, m_graph.m_plan);
 
         if (belongsInMinifiedGraph(m_currentNode->op()))
@@ -2287,7 +2287,7 @@ void SpeculativeJIT::linkOSREntries(LinkBuffer& linkBuffer)
 
     ASSERT(osrEntryIndex == m_osrEntryHeads.size());
     
-    if (UNLIKELY(verboseCompilationEnabled())) {
+    if (verboseCompilationEnabled()) [[unlikely]] {
         WTF::dataFile().atomically([&](auto& out) {
             DumpContext dumpContext;
             dataLogLn("OSR Entries:");

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -2441,7 +2441,7 @@ public:
 
     ~FPRTemporary()
     {
-        if (LIKELY(m_jit))
+        if (m_jit) [[likely]]
             m_jit->unlock(fpr());
     }
 

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -1205,7 +1205,7 @@ private:
             size_t searchStringLength = searchString.length();
             size_t matchEnd = matchStart + searchStringLength;
             String result = tryMakeReplacedString<StringReplaceSubstitutions::Yes>(string, replace, matchStart, matchEnd);
-            if (UNLIKELY(!result))
+            if (!result) [[unlikely]]
                 break;
 
             m_changed = true;

--- a/Source/JavaScriptCore/dfg/DFGValidateUnlinked.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValidateUnlinked.cpp
@@ -65,7 +65,7 @@ bool ValidateUnlinked::validateNode(Node* node)
 {
     JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
     if (globalObject != m_graph.m_codeBlock->globalObject()) {
-        if (UNLIKELY(Options::dumpUnlinkedDFGValidation())) {
+        if (Options::dumpUnlinkedDFGValidation()) [[unlikely]] {
             m_graph.logAssertionFailure(node, __FILE__, __LINE__, WTF_PRETTY_FUNCTION, "Bad GlobalObject");
             dataLogLn(RawPointer(globalObject), " != ", RawPointer(m_graph.m_codeBlock->globalObject()));
         }

--- a/Source/JavaScriptCore/dfg/DFGVariableEventStream.cpp
+++ b/Source/JavaScriptCore/dfg/DFGVariableEventStream.cpp
@@ -241,7 +241,7 @@ unsigned VariableEventStream::reconstruct(
         MinifiedGenerationInfo info = generationInfos.get(source.id());
         if (!info.alive) {
             dataLogLnIf(verbose, "Operand ", valueRecoveries.operandForIndex(i), " is dead.");
-            if (UNLIKELY(Options::poisonDeadOSRExitVariables())) {
+            if (Options::poisonDeadOSRExitVariables()) [[unlikely]] {
                 valueRecoveries[i] = ValueRecovery::constant(JSValue::decode(poisonedDeadOSRExitValue));
                 continue;
             }

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeap.cpp
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeap.cpp
@@ -158,7 +158,7 @@ const AbstractHeap& IndexedAbstractHeap::atSlow(ptrdiff_t index)
 {
     ASSERT(static_cast<size_t>(index) >= m_smallIndices.size());
     
-    if (UNLIKELY(!m_largeIndices))
+    if (!m_largeIndices) [[unlikely]]
         m_largeIndices = makeUnique<MapType>();
 
     std::unique_ptr<AbstractHeap>& field = m_largeIndices->add(index, nullptr).iterator->value;

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeap.h
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeap.h
@@ -141,7 +141,7 @@ public:
 private:
     const AbstractHeap& returnInitialized(AbstractHeap& field, ptrdiff_t index)
     {
-        if (UNLIKELY(!field.isInitialized()))
+        if (!field.isInitialized()) [[unlikely]]
             initialize(field, index);
         return field;
     }

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.cpp
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.cpp
@@ -146,7 +146,7 @@ void AbstractHeapRepository::computeRangesAndDecorateInstructions()
     using namespace B3;
     root.compute();
 
-    if (UNLIKELY(verboseCompilationEnabled())) {
+    if (verboseCompilationEnabled()) [[unlikely]] {
         WTF::dataFile().atomically([&](auto&) {
             dataLogLn("Abstract Heap Repository:");
             root.deepDump(WTF::dataFile());

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -518,7 +518,7 @@ CapabilityLevel canCompile(Graph& graph)
         return CannotCompile;
     }
     
-    if (UNLIKELY(graph.m_codeBlock->ownerExecutable()->neverFTLOptimize())) {
+    if (graph.m_codeBlock->ownerExecutable()->neverFTLOptimize()) [[unlikely]] {
         dataLogLnIf(verboseCapabilities(), "FTL rejecting ", *graph.m_codeBlock, " because it is marked as never FTL compile.");
         return CannotCompile;
     }
@@ -600,7 +600,7 @@ CapabilityLevel canCompile(Graph& graph)
                     break;
                 default:
                     // Don't know how to handle anything else.
-                    if (UNLIKELY(verboseCapabilities())) {
+                    if (verboseCapabilities()) [[unlikely]] {
                         WTF::dataFile().atomically([&](auto&) {
                             dataLogLn("FTL rejecting node in ", *graph.m_codeBlock, " because of bad use kind: ", edge.useKind(), " in node:");
                             graph.dump(WTF::dataFile(), "    ", node);
@@ -612,7 +612,7 @@ CapabilityLevel canCompile(Graph& graph)
             
             switch (canCompile(node)) {
             case CannotCompile: 
-                if (UNLIKELY(verboseCapabilities())) {
+                if (verboseCapabilities()) [[unlikely]] {
                     WTF::dataFile().atomically([&](auto&) {
                         dataLogLn("FTL rejecting node in ", *graph.m_codeBlock, ":");
                         graph.dump(WTF::dataFile(), "    ", node);
@@ -621,7 +621,7 @@ CapabilityLevel canCompile(Graph& graph)
                 return CannotCompile;
                 
             case CanCompile:
-                if (UNLIKELY(result == CanCompileAndOSREnter && verboseCompilationEnabled())) {
+                if (result == CanCompileAndOSREnter && verboseCompilationEnabled()) [[unlikely]] {
                     WTF::dataFile().atomically([&](auto&) {
                         dataLogLn("FTL disabling OSR entry because of node:");
                         graph.dump(WTF::dataFile(), "    ", node);

--- a/Source/JavaScriptCore/ftl/FTLCompile.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCompile.cpp
@@ -224,7 +224,7 @@ void compile(State& state, Safepoint::Result& safepointResult)
         state.dumpDisassembly(WTF::dataFile(), *state.b3CodeLinkBuffer);
 
     Profiler::Compilation* compilation = graph.compilation();
-    if (UNLIKELY(compilation)) {
+    if (compilation) [[unlikely]] {
         compilation->addDescription(
             Profiler::OriginStack(),
             toCString("Generated FTL DFG IR for ", CodeBlockWithJITType(codeBlock, JITType::FTLJIT), ", instructions size = ", graph.m_codeBlock->instructionsSize(), ":\n"));

--- a/Source/JavaScriptCore/ftl/FTLJITFinalizer.cpp
+++ b/Source/JavaScriptCore/ftl/FTLJITFinalizer.cpp
@@ -62,7 +62,7 @@ bool JITFinalizer::finalize()
     m_jitCode->setSize(m_codeSize);
     codeBlock->setJITCode(*m_jitCode);
 
-    if (UNLIKELY(Options::dumpFTLCodeSize())) {
+    if (Options::dumpFTLCodeSize()) [[unlikely]] {
         auto* baselineCodeBlock = codeBlock->baselineAlternative();
         size_t baselineCodeSize = 0;
         if (auto jitCode = baselineCodeBlock->jitCode())
@@ -70,7 +70,7 @@ bool JITFinalizer::finalize()
         dataLogLn("FTL: codeSize:(", m_jitCode->size(), "),nodes:(", m_jitCode->numberOfCompiledDFGNodes(), "),baselineCodeSize:(", baselineCodeSize, "),bytecodeCost:(", baselineCodeBlock->bytecodeCost(), ")");
     }
 
-    if (UNLIKELY(m_plan.compilation()))
+    if (m_plan.compilation()) [[unlikely]]
         vm.m_perBytecodeProfiler->addCompilation(codeBlock, *m_plan.compilation());
 
     // The codeBlock is now responsible for keeping many things alive (e.g. frozen values)

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -167,7 +167,7 @@ public:
         , m_state(state.graph)
         , m_interpreter(state.graph, m_state)
     {
-        if (UNLIKELY(Options::validateAbstractInterpreterState())) {
+        if (Options::validateAbstractInterpreterState()) [[unlikely]] {
             performGraphPackingAndLivenessAnalysis(m_graph);
             performCFA(m_graph);
 
@@ -721,7 +721,7 @@ private:
         m_interpreter.startExecuting();
         m_interpreter.executeKnownEdgeTypes(m_node);
 
-        if (UNLIKELY(Options::validateAbstractInterpreterState()))
+        if (Options::validateAbstractInterpreterState()) [[unlikely]]
             validateAIState(m_node);
 
         if constexpr (validateDFGDoesGC) {
@@ -19746,7 +19746,7 @@ IGNORE_CLANG_WARNINGS_END
 
     void compileLoopHint()
     {
-        if (LIKELY(!Options::returnEarlyFromInfiniteLoopsForFuzzing()))
+        if (!Options::returnEarlyFromInfiniteLoopsForFuzzing()) [[likely]]
             return;
 
         bool emitEarlyReturn = true;
@@ -24289,7 +24289,7 @@ IGNORE_CLANG_WARNINGS_END
                 exitValue);
         }
 
-        if (UNLIKELY(verboseCompilationEnabled())) {
+        if (verboseCompilationEnabled()) [[unlikely]] {
             WTF::dataFile().atomically([&](auto&) {
                 dataLogLn("        Exit values: ", exitDescriptor->m_values);
                 if (!exitDescriptor->m_materializations.isEmpty()) {

--- a/Source/JavaScriptCore/ftl/FTLOSREntry.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOSREntry.cpp
@@ -130,7 +130,7 @@ void* prepareOSREntry(
     }
     
     int stackFrameSize = entryCode->common.requiredRegisterCountForExecutionAndExit();
-    if (UNLIKELY(!vm.ensureStackCapacityFor(&callFrame->registers()[virtualRegisterForLocal(stackFrameSize - 1).offset()]))) {
+    if (!vm.ensureStackCapacityFor(&callFrame->registers()[virtualRegisterForLocal(stackFrameSize - 1).offset()])) [[unlikely]] {
         dataLogLnIf(Options::verboseOSR(), "    OSR failed because stack growth failed.");
         return nullptr;
     }

--- a/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
@@ -152,7 +152,7 @@ static void compileStub(VM& vm, unsigned exitID, JITCode* jitCode, OSRExit& exit
 
     CCallHelpers jit(codeBlock);
 
-    if (UNLIKELY(Options::printEachOSRExit())) {
+    if (Options::printEachOSRExit()) [[unlikely]] {
         SpeculationFailureDebugInfo* debugInfo = new SpeculationFailureDebugInfo;
         debugInfo->codeBlock = jit.codeBlock();
         debugInfo->kind = exit.m_kind;
@@ -240,7 +240,7 @@ static void compileStub(VM& vm, unsigned exitID, JITCode* jitCode, OSRExit& exit
     jit.popToRestore(GPRInfo::regT0);
     jit.checkStackPointerAlignment();
     
-    if (UNLIKELY(vm.m_perBytecodeProfiler && jitCode->dfgCommon()->compilation)) {
+    if (vm.m_perBytecodeProfiler && jitCode->dfgCommon()->compilation) [[unlikely]] {
         Profiler::Database& database = *vm.m_perBytecodeProfiler;
         Profiler::Compilation* compilation = jitCode->dfgCommon()->compilation.get();
         
@@ -388,13 +388,13 @@ static void compileStub(VM& vm, unsigned exitID, JITCode* jitCode, OSRExit& exit
             if (value.dataFormat() == DataFormatJS) {
                 switch (value.kind()) {
                 case ExitValueDead:
-                    if (UNLIKELY(Options::poisonDeadOSRExitVariables())) {
+                    if (Options::poisonDeadOSRExitVariables()) [[unlikely]] {
                         spooler.moveConstant(poisonedDeadOSRExitValue);
                         spooler.storeGPR(index * sizeof(EncodedJSValue));
                         break;
                     }
 
-                    if (UNLIKELY(!undefinedGPR)) {
+                    if (!undefinedGPR) [[unlikely]] {
                         jit.move(CCallHelpers::TrustedImm64(JSValue::encode(jsUndefined())), GPRInfo::regT4);
                         undefinedGPR = GPRInfo::regT4;
                     }
@@ -405,7 +405,7 @@ static void compileStub(VM& vm, unsigned exitID, JITCode* jitCode, OSRExit& exit
                 case ExitValueConstant: {
                     EncodedJSValue currentConstant = JSValue::encode(value.constant());
                     if (currentConstant == encodedJSUndefined()) {
-                        if (UNLIKELY(!undefinedGPR)) {
+                        if (!undefinedGPR) [[unlikely]] {
                             jit.move(CCallHelpers::TrustedImm64(JSValue::encode(jsUndefined())), GPRInfo::regT4);
                             undefinedGPR = GPRInfo::regT4;
                         }

--- a/Source/JavaScriptCore/ftl/FTLOperations.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOperations.cpp
@@ -240,7 +240,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, JSCell*, (JSG
         Structure* structure = globalObject->arrayStructureForIndexingTypeDuringAllocation(materialization->indexingType());
 
         JSArray* result = JSArray::tryCreate(vm, structure, size);
-        if (UNLIKELY(!result)) {
+        if (!result) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
             OPERATION_RETURN(scope, nullptr);
         }
@@ -651,7 +651,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, JSCell*, (JSG
         ASSERT(isCopyOnWrite(indexingMode));
         ASSERT(!structure->outOfLineCapacity());
 
-        if (UNLIKELY(immutableButterfly->indexingMode() != indexingMode)) {
+        if (immutableButterfly->indexingMode() != indexingMode) [[unlikely]] {
             auto* newButterfly = JSImmutableButterfly::create(vm, indexingMode, immutableButterfly->length());
             for (unsigned i = 0; i < immutableButterfly->length(); ++i)
                 newButterfly->setIndex(vm, i, immutableButterfly->get(i));

--- a/Source/JavaScriptCore/ftl/FTLSlowPathCall.cpp
+++ b/Source/JavaScriptCore/ftl/FTLSlowPathCall.cpp
@@ -119,7 +119,7 @@ SlowPathCallContext::~SlowPathCallContext()
 SlowPathCallKey SlowPathCallContext::keyWithTarget(CodePtr<CFunctionPtrTag> callTarget) const
 {
     uint8_t numberOfUsedArgumentRegistersIfClobberingCheckIsEnabled = 0;
-    if (UNLIKELY(Options::clobberAllRegsInFTLICSlowPath()))
+    if (Options::clobberAllRegsInFTLICSlowPath()) [[unlikely]]
         numberOfUsedArgumentRegistersIfClobberingCheckIsEnabled = std::min(NUMBER_OF_ARGUMENT_REGISTERS, m_numArgs);
     return SlowPathCallKey(m_thunkSaveSet, callTarget, numberOfUsedArgumentRegistersIfClobberingCheckIsEnabled, m_offset, 0);
 }
@@ -127,7 +127,7 @@ SlowPathCallKey SlowPathCallContext::keyWithTarget(CodePtr<CFunctionPtrTag> call
 SlowPathCallKey SlowPathCallContext::keyWithTarget(CCallHelpers::Address address) const
 {
     uint8_t numberOfUsedArgumentRegistersIfClobberingCheckIsEnabled = 0;
-    if (UNLIKELY(Options::clobberAllRegsInFTLICSlowPath()))
+    if (Options::clobberAllRegsInFTLICSlowPath()) [[unlikely]]
         numberOfUsedArgumentRegistersIfClobberingCheckIsEnabled = std::min(NUMBER_OF_ARGUMENT_REGISTERS, m_numArgs);
     return SlowPathCallKey(m_thunkSaveSet, nullptr, numberOfUsedArgumentRegistersIfClobberingCheckIsEnabled, m_offset, address.offset);
 }

--- a/Source/JavaScriptCore/ftl/FTLThunks.cpp
+++ b/Source/JavaScriptCore/ftl/FTLThunks.cpp
@@ -201,7 +201,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> slowPathCallThunkGenerator(VM& vm, const S
     jit.storePtr(GPRInfo::nonArgGPR1, AssemblyHelpers::Address(MacroAssembler::stackPointerRegister, key.offset()));
     jit.prepareCallOperation(vm);
     
-    if (UNLIKELY(Options::clobberAllRegsInFTLICSlowPath())) {
+    if (Options::clobberAllRegsInFTLICSlowPath()) [[unlikely]] {
         auto dontClobber = key.argumentRegistersIfClobberingCheckIsEnabled();
         if (!key.callTarget())
             dontClobber.add(GPRInfo::nonArgGPR0, IgnoreVectors);

--- a/Source/JavaScriptCore/heap/AbstractSlotVisitorInlines.h
+++ b/Source/JavaScriptCore/heap/AbstractSlotVisitorInlines.h
@@ -130,7 +130,7 @@ inline bool AbstractSlotVisitor::addOpaqueRoot(void* ptr)
         return false;
     if (!m_opaqueRoots.add(ptr))
         return false;
-    if (UNLIKELY(m_needsExtraOpaqueRootHandling))
+    if (m_needsExtraOpaqueRootHandling) [[unlikely]]
         didAddOpaqueRoot(ptr);
     m_visitCount++;
     return true;
@@ -139,7 +139,7 @@ inline bool AbstractSlotVisitor::addOpaqueRoot(void* ptr)
 inline bool AbstractSlotVisitor::containsOpaqueRoot(void* ptr) const
 {
     bool found = m_opaqueRoots.contains(ptr);
-    if (UNLIKELY(found && m_needsExtraOpaqueRootHandling)) {
+    if (found && m_needsExtraOpaqueRootHandling) [[unlikely]] {
         auto* nonConstThis = const_cast<AbstractSlotVisitor*>(this);
         nonConstThis->didFindOpaqueRoot(ptr);
     }

--- a/Source/JavaScriptCore/heap/BlockDirectory.cpp
+++ b/Source/JavaScriptCore/heap/BlockDirectory.cpp
@@ -204,7 +204,7 @@ void BlockDirectory::stopAllocating()
 
 #if ASSERT_ENABLED
     assertIsMutatorOrMutatorIsStopped();
-    if (UNLIKELY(!inUseBitsView().isEmpty())) {
+    if (!inUseBitsView().isEmpty()) [[unlikely]] {
         dataLogLn("Not all inUse bits are clear at stopAllocating");
         dataLogLn(*this);
         dumpBits();
@@ -226,7 +226,7 @@ void BlockDirectory::prepareForAllocation()
     assertSweeperIsSuspended();
     edenBits().clearAll();
 
-    if (UNLIKELY(Options::useImmortalObjects())) {
+    if (Options::useImmortalObjects()) [[unlikely]] {
         // FIXME: Make this work again.
         // https://bugs.webkit.org/show_bug.cgi?id=162296
         RELEASE_ASSERT_NOT_REACHED();
@@ -282,7 +282,7 @@ void BlockDirectory::endMarking()
     allocatedBits().clearAll();
     
 #if ASSERT_ENABLED
-    if (UNLIKELY(!inUseBitsView().isEmpty())) {
+    if (!inUseBitsView().isEmpty()) [[unlikely]] {
         dataLogLn("Block is inUse at end marking.");
         dataLogLn(*this);
         dumpBits();
@@ -435,7 +435,7 @@ void BlockDirectory::didFinishUsingBlock(MarkedBlock::Handle* handle)
 
 void BlockDirectory::didFinishUsingBlock(AbstractLocker&, MarkedBlock::Handle* handle)
 {
-    if (UNLIKELY(!isInUse(handle))) {
+    if (!isInUse(handle)) [[unlikely]] {
         dataLogLn("Finish using on a block that's not in use: ", handle->index());
         dumpBits();
         RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/heap/CompleteSubspace.cpp
+++ b/Source/JavaScriptCore/heap/CompleteSubspace.cpp
@@ -106,7 +106,7 @@ Allocator CompleteSubspace::allocatorForSlow(size_t size)
 void* CompleteSubspace::allocateSlow(VM& vm, size_t size, GCDeferralContext* deferralContext, AllocationFailureMode failureMode)
 {
     void* result = tryAllocateSlow(vm, size, deferralContext);
-    if (UNLIKELY(!result))
+    if (!result) [[unlikely]]
         RELEASE_ASSERT_RESOURCE_AVAILABLE(failureMode != AllocationFailureMode::Assert, MemoryExhaustion, "Crash intentionally because memory is exhausted.");
     return result;
 }
@@ -129,7 +129,7 @@ void* CompleteSubspace::tryAllocateSlow(VM& vm, size_t size, GCDeferralContext* 
     }
     
     vm.heap.collectIfNecessaryOrDefer(deferralContext);
-    if (UNLIKELY(Options::maxHeapSizeAsRAMSizeMultiple())) {
+    if (Options::maxHeapSizeAsRAMSizeMultiple()) [[unlikely]] {
         if (vm.heap.capacity() > static_cast<uint64_t>(Options::maxHeapSizeAsRAMSizeMultiple()) * static_cast<uint64_t>(WTF::ramSize()))
             return nullptr;
     }
@@ -161,7 +161,7 @@ void* CompleteSubspace::reallocatePreciseAllocationNonVirtual(VM& vm, HeapCell* 
 
     sanitizeStackForVM(vm);
 
-    if (UNLIKELY(size <= Options::preciseAllocationCutoff() && size <= MarkedSpace::largeCutoff)) {
+    if (size <= Options::preciseAllocationCutoff() && size <= MarkedSpace::largeCutoff) [[unlikely]] {
         dataLog("FATAL: attampting to allocate small object using large allocation.\n");
         dataLog("Requested allocation size: ", size, "\n");
         RELEASE_ASSERT_NOT_REACHED();
@@ -176,7 +176,7 @@ void* CompleteSubspace::reallocatePreciseAllocationNonVirtual(VM& vm, HeapCell* 
         oldAllocation->remove();
 
     PreciseAllocation* allocation = oldAllocation->tryReallocate(size, this);
-    if (UNLIKELY(!allocation)) {
+    if (!allocation) [[unlikely]] {
         RELEASE_ASSERT_RESOURCE_AVAILABLE(failureMode != AllocationFailureMode::Assert, MemoryExhaustion, "Crash intentionally because memory is exhausted.");
         m_preciseAllocations.append(oldAllocation);
         return nullptr;

--- a/Source/JavaScriptCore/heap/ConservativeRoots.cpp
+++ b/Source/JavaScriptCore/heap/ConservativeRoots.cpp
@@ -197,7 +197,7 @@ inline void ConservativeRoots::genericAddPointer(char* pointer, HeapVersion mark
     };
 
     if (isJSCellKind(cellKind)) {
-        if (LIKELY(MarkedBlock::isAtomAligned(pointer))) {
+        if (MarkedBlock::isAtomAligned(pointer)) [[likely]] {
             if (tryPointer(pointer))
                 return;
         }

--- a/Source/JavaScriptCore/heap/FreeList.cpp
+++ b/Source/JavaScriptCore/heap/FreeList.cpp
@@ -48,7 +48,7 @@ void FreeList::clear()
 
 void FreeList::initialize(FreeCell* start, uint64_t secret, unsigned bytes)
 {
-    if (UNLIKELY(!start)) {
+    if (!start) [[unlikely]] {
         clear();
         return;
     }

--- a/Source/JavaScriptCore/heap/FreeListInlines.h
+++ b/Source/JavaScriptCore/heap/FreeListInlines.h
@@ -35,14 +35,14 @@ namespace JSC {
 template<typename Func>
 ALWAYS_INLINE HeapCell* FreeList::allocateWithCellSize(const Func& slowPath, size_t cellSize)
 {
-    if (LIKELY(m_intervalStart < m_intervalEnd)) {
+    if (m_intervalStart < m_intervalEnd) [[likely]] {
         char* result = m_intervalStart;
         m_intervalStart += cellSize;
         return std::bit_cast<HeapCell*>(result);
     }
     
     FreeCell* cell = nextInterval();
-    if (UNLIKELY(isSentinel(cell)))
+    if (isSentinel(cell)) [[unlikely]]
         return slowPath();
 
     FreeCell::advance(m_secret, m_nextInterval, m_intervalStart, m_intervalEnd);

--- a/Source/JavaScriptCore/heap/GCDeferralContextInlines.h
+++ b/Source/JavaScriptCore/heap/GCDeferralContextInlines.h
@@ -40,7 +40,7 @@ ALWAYS_INLINE GCDeferralContext::~GCDeferralContext()
     if constexpr (validateDFGDoesGC)
         m_vm.verifyCanGC();
 
-    if (UNLIKELY(m_shouldGC))
+    if (m_shouldGC) [[unlikely]]
         m_vm.heap.collectIfNecessaryOrDefer();
 }
 

--- a/Source/JavaScriptCore/heap/HeapInlines.h
+++ b/Source/JavaScriptCore/heap/HeapInlines.h
@@ -108,7 +108,7 @@ inline void Heap::writeBarrier(const JSCell* from, JSCell* to)
 #endif
     if (!from)
         return;
-    if (LIKELY(!to))
+    if (!to) [[likely]]
         return;
     if (!isWithinThreshold(from->cellState(), barrierThreshold()))
         return;
@@ -120,7 +120,7 @@ inline void Heap::writeBarrier(const JSCell* from)
     ASSERT_GC_OBJECT_LOOKS_VALID(const_cast<JSCell*>(from));
     if (!from)
         return;
-    if (UNLIKELY(isWithinThreshold(from->cellState(), barrierThreshold())))
+    if (isWithinThreshold(from->cellState(), barrierThreshold())) [[unlikely]]
         writeBarrierSlowPath(from);
 }
 
@@ -133,7 +133,7 @@ inline void Heap::mutatorFence()
         return;
     }
 
-    if (UNLIKELY(mutatorShouldBeFenced()))
+    if (mutatorShouldBeFenced()) [[unlikely]]
         WTF::storeStoreFence();
 }
 

--- a/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
+++ b/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
@@ -418,7 +418,7 @@ String HeapSnapshotBuilder::json()
                     nodeLabel.append(description);
                 }
 
-                if (UNLIKELY(nodeLabel.hasOverflowed())) {
+                if (nodeLabel.hasOverflowed()) [[unlikely]] {
                     m_hasOverflowed = true;
                     return;
                 }

--- a/Source/JavaScriptCore/heap/IncrementalSweeper.cpp
+++ b/Source/JavaScriptCore/heap/IncrementalSweeper.cpp
@@ -70,7 +70,7 @@ void IncrementalSweeper::doWork(VM& vm)
 void IncrementalSweeper::doSweep(VM& vm, MonotonicTime deadline, SweepTrigger trigger)
 {
     std::optional<TraceScope> traceScope;
-    if (UNLIKELY(Options::useTracePoints()))
+    if (Options::useTracePoints()) [[unlikely]]
         traceScope.emplace(IncrementalSweepStart, IncrementalSweepEnd, vm.heap.size(), vm.heap.capacity());
 
     while (sweepNextBlock(vm, trigger)) {

--- a/Source/JavaScriptCore/heap/IsoCellSetInlines.h
+++ b/Source/JavaScriptCore/heap/IsoCellSetInlines.h
@@ -42,7 +42,7 @@ inline bool IsoCellSet::add(HeapCell* cell)
     AtomIndices atomIndices(cell);
     auto& bitsPtrRef = m_bits[atomIndices.blockIndex];
     auto* bits = bitsPtrRef.get();
-    if (UNLIKELY(!bits))
+    if (!bits) [[unlikely]]
         bits = addSlow(atomIndices.blockIndex);
     return !bits->concurrentTestAndSet(atomIndices.atomNumber);
 }

--- a/Source/JavaScriptCore/heap/LocalAllocator.cpp
+++ b/Source/JavaScriptCore/heap/LocalAllocator.cpp
@@ -126,12 +126,12 @@ void* LocalAllocator::allocateSlowCase(JSC::Heap& heap, size_t cellSize, GCDefer
     
     // Goofy corner case: the GC called a callback and now this directory has a currentBlock. This only
     // happens when running WebKit tests, which inject a callback into the GC's finalization.
-    if (UNLIKELY(m_currentBlock))
+    if (m_currentBlock) [[unlikely]]
         return allocate(heap, cellSize, deferralContext, failureMode);
     
     void* result = tryAllocateWithoutCollecting(cellSize);
     
-    if (LIKELY(result != nullptr))
+    if (result) [[likely]]
         return result;
 
     // FIXME GlobalGC: Need to synchronize here to when allocating from the BlockDirectory in the server.
@@ -258,7 +258,7 @@ void* LocalAllocator::tryAllocateIn(MarkedBlock::Handle* block, size_t cellSize)
 
 void LocalAllocator::doTestCollectionsIfNeeded(JSC::Heap& heap, GCDeferralContext* deferralContext)
 {
-    if (LIKELY(!Options::slowPathAllocsBetweenGCs()))
+    if (!Options::slowPathAllocsBetweenGCs()) [[likely]]
         return;
 
     static unsigned allocationCount = 0;

--- a/Source/JavaScriptCore/heap/MachineStackMarker.cpp
+++ b/Source/JavaScriptCore/heap/MachineStackMarker.cpp
@@ -116,7 +116,7 @@ void MachineThreads::tryCopyOtherThreadStack(const ThreadSuspendLocker& locker, 
     // This is a workaround for <rdar://problem/27607384>. libdispatch recycles work
     // queue threads without running pthread exit destructors. This can cause us to scan a
     // thread during work queue initialization, when the stack pointer is null.
-    if (UNLIKELY(!MachineContext::stackPointer(registers))) {
+    if (!MachineContext::stackPointer(registers)) [[unlikely]] {
         *size = 0;
         return;
     }

--- a/Source/JavaScriptCore/heap/MarkedBlock.cpp
+++ b/Source/JavaScriptCore/heap/MarkedBlock.cpp
@@ -259,7 +259,7 @@ void MarkedBlock::aboutToMarkSlow(HeapVersion markingVersion, HeapCell* cell)
         return;
 
     MarkedBlock::Handle* handle = header().handlePointerForNullCheck();
-    if (UNLIKELY(!handle))
+    if (!handle) [[unlikely]]
         dumpInfoAndCrashForInvalidHandleV2(locker, cell);
 
     BlockDirectory* directory = handle->directory();

--- a/Source/JavaScriptCore/heap/MarkedBlock.h
+++ b/Source/JavaScriptCore/heap/MarkedBlock.h
@@ -597,7 +597,7 @@ inline Dependency MarkedBlock::aboutToMark(HeapVersion markingVersion, HeapCell*
 {
     HeapVersion version;
     Dependency dependency = Dependency::loadAndFence(&header().m_markingVersion, version);
-    if (UNLIKELY(version != markingVersion))
+    if (version != markingVersion) [[unlikely]]
         aboutToMarkSlow(markingVersion, cell);
     return dependency;
 }
@@ -616,7 +616,7 @@ inline bool MarkedBlock::isMarked(HeapVersion markingVersion, const void* p)
 {
     HeapVersion version;
     Dependency dependency = Dependency::loadAndFence(&header().m_markingVersion, version);
-    if (UNLIKELY(version != markingVersion))
+    if (version != markingVersion) [[unlikely]]
         return false;
     return header().m_marks.get(atomNumber(p), dependency);
 }
@@ -696,7 +696,7 @@ inline void MarkedBlock::noteMarked()
     MarkCountBiasType biasedMarkCount = header().m_biasedMarkCount;
     ++biasedMarkCount;
     header().m_biasedMarkCount = biasedMarkCount;
-    if (UNLIKELY(!biasedMarkCount))
+    if (!biasedMarkCount) [[unlikely]]
         noteMarkedSlow();
 }
 

--- a/Source/JavaScriptCore/heap/MarkedBlockInlines.h
+++ b/Source/JavaScriptCore/heap/MarkedBlockInlines.h
@@ -328,7 +328,7 @@ void MarkedBlock::Handle::specializedSweep(FreeList* freeList, MarkedBlock::Hand
                 destroy(cell);
         }
         if (sweepMode == SweepToFreeList) {
-            if (UNLIKELY(scribbleMode == Scribble))
+            if (scribbleMode == Scribble) [[unlikely]]
                 scribble(payloadBegin, payloadEnd - payloadBegin);
             FreeCell* interval = reinterpret_cast_ptr<FreeCell*>(payloadBegin);
             interval->makeLast(payloadEnd - payloadBegin, secret);
@@ -364,7 +364,7 @@ void MarkedBlock::Handle::specializedSweep(FreeList* freeList, MarkedBlock::Hand
         if (destructionMode != BlockHasNoDestructors)
             destroy(cell);
         if (sweepMode == SweepToFreeList) {
-            if (UNLIKELY(scribbleMode == Scribble))
+            if (scribbleMode == Scribble) [[unlikely]]
                 scribble(cell, cellSize);
 
             // The following check passing implies there was at least one live cell
@@ -373,7 +373,7 @@ void MarkedBlock::Handle::specializedSweep(FreeList* freeList, MarkedBlock::Hand
             if (i + m_atomsPerCell < previousDeadCell) {
                 size_t intervalLength = currentInterval * atomSize;
                 FreeCell* cell = reinterpret_cast_ptr<FreeCell*>(&block.atoms()[previousDeadCell]);
-                if (LIKELY(head))
+                if (head) [[likely]]
                     cell->setNext(head, intervalLength, secret);
                 else
                     cell->makeLast(intervalLength, secret);
@@ -391,7 +391,7 @@ void MarkedBlock::Handle::specializedSweep(FreeList* freeList, MarkedBlock::Hand
             size_t intervalLength = currentInterval * atomSize;
             FreeCell* cell = reinterpret_cast_ptr<FreeCell*>(&block.atoms()[previousDeadCell]);
 
-            if (LIKELY(head))
+            if (head) [[likely]]
                 cell->setNext(head, intervalLength, secret);
             else
                 cell->makeLast(intervalLength, secret);

--- a/Source/JavaScriptCore/heap/MarkedSpace.cpp
+++ b/Source/JavaScriptCore/heap/MarkedSpace.cpp
@@ -41,7 +41,7 @@ static Vector<size_t> sizeClasses()
 {
     Vector<size_t> result;
 
-    if (UNLIKELY(Options::dumpSizeClasses())) {
+    if (Options::dumpSizeClasses()) [[unlikely]] {
         dataLog("Block size: ", MarkedBlock::blockSize, "\n");
         dataLog("Header size: ", sizeof(MarkedBlock::Header), "\n");
     }
@@ -433,7 +433,7 @@ void MarkedSpace::beginMarking()
                 return IterationStatus::Continue;
             });
 
-        if (UNLIKELY(nextVersion(m_markingVersion) == initialVersion)) {
+        if (nextVersion(m_markingVersion) == initialVersion) [[unlikely]] {
             forEachBlock(
                 [&] (MarkedBlock::Handle* handle) {
                     handle->block().resetMarks();
@@ -463,7 +463,7 @@ void MarkedSpace::beginMarking()
 
 void MarkedSpace::endMarking()
 {
-    if (UNLIKELY(nextVersion(m_newlyAllocatedVersion) == initialVersion)) {
+    if (nextVersion(m_newlyAllocatedVersion) == initialVersion) [[unlikely]] {
         forEachBlock(
             [&] (MarkedBlock::Handle* handle) {
                 handle->block().resetAllocated();

--- a/Source/JavaScriptCore/heap/PreciseAllocation.cpp
+++ b/Source/JavaScriptCore/heap/PreciseAllocation.cpp
@@ -91,7 +91,7 @@ PreciseAllocation* PreciseAllocation::tryCreate(JSC::Heap& heap, size_t size, Su
 
     unsigned adjustment = halfAlignment;
     space = std::bit_cast<void*>(std::bit_cast<uintptr_t>(space) + halfAlignment);
-    if (UNLIKELY(!isAlignedForPreciseAllocation(space))) {
+    if (!isAlignedForPreciseAllocation(space)) [[unlikely]] {
         space = std::bit_cast<void*>(std::bit_cast<uintptr_t>(space) - halfAlignment);
         adjustment -= halfAlignment;
         ASSERT(isAlignedForPreciseAllocation(space));
@@ -104,7 +104,7 @@ PreciseAllocation* PreciseAllocation::tryCreate(JSC::Heap& heap, size_t size, Su
         ASSERT(isAlignedForPreciseAllocation(space));
     }
 
-    if (UNLIKELY(scribbleFreeCells()))
+    if (scribbleFreeCells()) [[unlikely]]
         scribble(space, size);
     return new (NotNull, space) PreciseAllocation(heap, size, subspace, indexInSpace, adjustment);
 }
@@ -128,7 +128,7 @@ PreciseAllocation* PreciseAllocation::tryReallocate(size_t size, Subspace* subsp
     void* newBasePointer = newSpace;
     unsigned newAdjustment = halfAlignment;
     newBasePointer = std::bit_cast<void*>(std::bit_cast<uintptr_t>(newBasePointer) + halfAlignment);
-    if (UNLIKELY(!isAlignedForPreciseAllocation(newBasePointer))) {
+    if (!isAlignedForPreciseAllocation(newBasePointer)) [[unlikely]] {
         newBasePointer = std::bit_cast<void*>(std::bit_cast<uintptr_t>(newBasePointer) - halfAlignment);
         newAdjustment -= halfAlignment;
         ASSERT(isAlignedForPreciseAllocation(newBasePointer));
@@ -169,7 +169,7 @@ PreciseAllocation* PreciseAllocation::tryCreateForLowerTierPrecise(JSC::Heap& he
 
     unsigned adjustment = halfAlignment;
     space = std::bit_cast<void*>(std::bit_cast<uintptr_t>(space) + halfAlignment);
-    if (UNLIKELY(!isAlignedForPreciseAllocation(space))) {
+    if (!isAlignedForPreciseAllocation(space)) [[unlikely]] {
         space = std::bit_cast<void*>(std::bit_cast<uintptr_t>(space) - halfAlignment);
         adjustment -= halfAlignment;
         ASSERT(isAlignedForPreciseAllocation(space));
@@ -182,7 +182,7 @@ PreciseAllocation* PreciseAllocation::tryCreateForLowerTierPrecise(JSC::Heap& he
         ASSERT(isAlignedForPreciseAllocation(space));
     }
 
-    if (UNLIKELY(scribbleFreeCells()))
+    if (scribbleFreeCells()) [[unlikely]]
         scribble(space, size);
     PreciseAllocation* preciseAllocation = new (NotNull, space) PreciseAllocation(heap, size, subspace, 0, adjustment);
     preciseAllocation->m_lowerTierPreciseIndex = lowerTierPreciseIndex;

--- a/Source/JavaScriptCore/heap/SlotVisitor.cpp
+++ b/Source/JavaScriptCore/heap/SlotVisitor.cpp
@@ -227,7 +227,7 @@ void SlotVisitor::appendJSCellOrAuxiliary(HeapCell* heapCell)
 
 void SlotVisitor::appendSlow(JSCell* cell, Dependency dependency)
 {
-    if (UNLIKELY(m_heapAnalyzer))
+    if (m_heapAnalyzer) [[unlikely]]
         m_heapAnalyzer->analyzeEdge(m_currentCell, cell, rootMarkReason());
 
     appendHiddenSlowImpl(cell, dependency);
@@ -281,8 +281,8 @@ ALWAYS_INLINE void SlotVisitor::appendToMarkStack(ContainerType& container, JSCe
 {
     ASSERT(m_heap.isMarked(cell));
 #if CPU(X86_64)
-    if (UNLIKELY(Options::dumpZappedCellCrashData())) {
-        if (UNLIKELY(cell->isZapped()))
+    if (Options::dumpZappedCellCrashData()) [[unlikely]] {
+        if (cell->isZapped()) [[unlikely]]
             reportZappedCellAndCrash(m_heap, cell);
     }
 #endif
@@ -386,9 +386,9 @@ ALWAYS_INLINE void SlotVisitor::visitChildren(const JSCell* cell)
         // FIXME: This could be so much better.
         // https://bugs.webkit.org/show_bug.cgi?id=162462
 #if CPU(X86_64)
-        if (UNLIKELY(Options::dumpZappedCellCrashData())) {
+        if (Options::dumpZappedCellCrashData()) [[unlikely]] {
             Structure* structure = cell->structure();
-            if (LIKELY(structure)) {
+            if (structure) [[likely]] {
                 const MethodTable* methodTable = &structure->classInfoForCells()->methodTable;
                 methodTable->visitChildren(const_cast<JSCell*>(cell), *this);
                 break;
@@ -400,7 +400,7 @@ ALWAYS_INLINE void SlotVisitor::visitChildren(const JSCell* cell)
         break;
     }
 
-    if (UNLIKELY(m_heapAnalyzer)) {
+    if (m_heapAnalyzer) [[unlikely]] {
         if (m_isFirstVisit)
             m_heapAnalyzer->analyzeNode(const_cast<JSCell*>(cell));
     }

--- a/Source/JavaScriptCore/heap/SlotVisitorInlines.h
+++ b/Source/JavaScriptCore/heap/SlotVisitorInlines.h
@@ -50,16 +50,16 @@ ALWAYS_INLINE void SlotVisitor::appendUnbarriered(JSCell* cell)
         return;
     
     Dependency dependency;
-    if (UNLIKELY(cell->isPreciseAllocation())) {
-        if (LIKELY(cell->preciseAllocation().isMarked())) {
-            if (LIKELY(!m_heapAnalyzer))
+    if (cell->isPreciseAllocation()) [[unlikely]] {
+        if (cell->preciseAllocation().isMarked()) [[likely]] {
+            if (!m_heapAnalyzer) [[likely]]
                 return;
         }
     } else {
         MarkedBlock& block = cell->markedBlock();
         dependency = block.aboutToMark(m_markingVersion, cell);
-        if (LIKELY(block.isMarked(cell, dependency))) {
-            if (LIKELY(!m_heapAnalyzer))
+        if (block.isMarked(cell, dependency)) [[likely]] {
+            if (!m_heapAnalyzer) [[likely]]
                 return;
         }
     }
@@ -88,13 +88,13 @@ ALWAYS_INLINE void SlotVisitor::appendHiddenUnbarriered(JSCell* cell)
         return;
     
     Dependency dependency;
-    if (UNLIKELY(cell->isPreciseAllocation())) {
-        if (LIKELY(cell->preciseAllocation().isMarked()))
+    if (cell->isPreciseAllocation()) [[unlikely]] {
+        if (cell->preciseAllocation().isMarked()) [[likely]]
             return;
     } else {
         MarkedBlock& block = cell->markedBlock();
         dependency = block.aboutToMark(m_markingVersion, cell);
-        if (LIKELY(block.isMarked(cell, dependency)))
+        if (block.isMarked(cell, dependency)) [[likely]]
             return;
     }
     

--- a/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
@@ -108,7 +108,7 @@ public:
         // Don't use the first page because zero is used as the empty StructureID and the first allocation will conflict.
 #if !USE(SYSTEM_MALLOC)
         m_useDebugHeap = !bmalloc::api::isEnabled();
-        if (LIKELY(!m_useDebugHeap)) {
+        if (!m_useDebugHeap) [[likely]] {
             bmalloc_force_auxiliary_heap_into_reserved_memory(&structureHeap, reinterpret_cast<uintptr_t>(g_jscConfig.startOfStructureHeap) + MarkedBlock::blockSize, reinterpret_cast<uintptr_t>(g_jscConfig.startOfStructureHeap) + g_jscConfig.sizeOfStructureHeap);
             return;
         }
@@ -119,7 +119,7 @@ public:
     void* tryMallocStructureBlock()
     {
 #if !USE(SYSTEM_MALLOC)
-        if (LIKELY(!m_useDebugHeap))
+        if (!m_useDebugHeap) [[likely]]
             return bmalloc_try_allocate_auxiliary_with_alignment_inline(&structureHeap, MarkedBlock::blockSize, MarkedBlock::blockSize, pas_maybe_compact_allocation_mode);
 #endif
 
@@ -145,7 +145,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     void freeStructureBlock(void* blockPtr)
     {
 #if !USE(SYSTEM_MALLOC)
-        if (LIKELY(!m_useDebugHeap)) {
+        if (!m_useDebugHeap) [[likely]] {
             bmalloc_deallocate_inline(blockPtr);
             return;
         }

--- a/Source/JavaScriptCore/heap/WeakBlock.cpp
+++ b/Source/JavaScriptCore/heap/WeakBlock.cpp
@@ -120,7 +120,7 @@ void WeakBlock::specializedVisit(ContainerType& container, Visitor& visitor)
         
         ASCIILiteral reason = ""_s;
         ASCIILiteral* reasonPtr = nullptr;
-        if (UNLIKELY(heapAnalyzer))
+        if (heapAnalyzer) [[unlikely]]
             reasonPtr = &reason;
 
         typename Visitor::ReferrerContext context(visitor, Visitor::OpaqueRoot);
@@ -130,7 +130,7 @@ void WeakBlock::specializedVisit(ContainerType& container, Visitor& visitor)
 
         visitor.appendUnbarriered(jsValue);
 
-        if (UNLIKELY(heapAnalyzer)) {
+        if (heapAnalyzer) [[unlikely]] {
             if (jsValue.isCell())
                 heapAnalyzer->setOpaqueRootReachabilityReasonForCell(jsValue.asCell(), *reasonPtr);
         }

--- a/Source/JavaScriptCore/heap/WeakSetInlines.h
+++ b/Source/JavaScriptCore/heap/WeakSetInlines.h
@@ -36,7 +36,7 @@ inline WeakImpl* WeakSet::allocate(JSValue jsValue, WeakHandleOwner* weakHandleO
     ASSERT(container.vm().currentThreadIsHoldingAPILock());
     WeakSet& weakSet = container.weakSet();
     WeakBlock::FreeCell* allocator = weakSet.m_allocator;
-    if (UNLIKELY(!allocator))
+    if (!allocator) [[unlikely]]
         allocator = weakSet.findAllocator(container);
     weakSet.m_allocator = allocator->next;
 

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectConsoleClient.cpp
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectConsoleClient.cpp
@@ -67,7 +67,7 @@ void JSGlobalObjectConsoleClient::messageWithTypeAndLevel(MessageType type, Mess
     if (JSGlobalObjectConsoleClient::logToSystemConsole())
         ConsoleClient::printConsoleMessageWithArguments(MessageSource::ConsoleAPI, type, level, globalObject, arguments.copyRef());
 
-    if (LIKELY(!m_consoleAgent->developerExtrasEnabled()))
+    if (!m_consoleAgent->developerExtrasEnabled()) [[likely]]
         return;
 
     String message;
@@ -82,7 +82,7 @@ void JSGlobalObjectConsoleClient::messageWithTypeAndLevel(MessageType type, Mess
 
 void JSGlobalObjectConsoleClient::count(JSGlobalObject* globalObject, const String& label)
 {
-    if (LIKELY(!m_consoleAgent->developerExtrasEnabled()))
+    if (!m_consoleAgent->developerExtrasEnabled()) [[likely]]
         return;
 
     m_consoleAgent->count(globalObject, label);
@@ -90,7 +90,7 @@ void JSGlobalObjectConsoleClient::count(JSGlobalObject* globalObject, const Stri
 
 void JSGlobalObjectConsoleClient::countReset(JSGlobalObject* globalObject, const String& label)
 {
-    if (LIKELY(!m_consoleAgent->developerExtrasEnabled()))
+    if (!m_consoleAgent->developerExtrasEnabled()) [[likely]]
         return;
 
     m_consoleAgent->countReset(globalObject, label);
@@ -98,7 +98,7 @@ void JSGlobalObjectConsoleClient::countReset(JSGlobalObject* globalObject, const
 
 void JSGlobalObjectConsoleClient::profile(JSC::JSGlobalObject*, const String& title)
 {
-    if (LIKELY(!m_consoleAgent->enabled()))
+    if (!m_consoleAgent->enabled()) [[likely]]
         return;
 
     // Allow duplicate unnamed profiles. Disallow duplicate named profiles.
@@ -119,7 +119,7 @@ void JSGlobalObjectConsoleClient::profile(JSC::JSGlobalObject*, const String& ti
 
 void JSGlobalObjectConsoleClient::profileEnd(JSC::JSGlobalObject*, const String& title)
 {
-    if (LIKELY(!m_consoleAgent->enabled()))
+    if (!m_consoleAgent->enabled()) [[likely]]
         return;
 
     // Stop profiles in reverse order. If the title is empty, then stop the last profile.
@@ -160,7 +160,7 @@ void JSGlobalObjectConsoleClient::stopConsoleProfile()
 
 void JSGlobalObjectConsoleClient::takeHeapSnapshot(JSC::JSGlobalObject*, const String& title)
 {
-    if (LIKELY(!m_consoleAgent->developerExtrasEnabled()))
+    if (!m_consoleAgent->developerExtrasEnabled()) [[likely]]
         return;
 
     m_consoleAgent->takeHeapSnapshot(title);
@@ -168,7 +168,7 @@ void JSGlobalObjectConsoleClient::takeHeapSnapshot(JSC::JSGlobalObject*, const S
 
 void JSGlobalObjectConsoleClient::time(JSGlobalObject* globalObject, const String& label)
 {
-    if (LIKELY(!m_consoleAgent->developerExtrasEnabled()))
+    if (!m_consoleAgent->developerExtrasEnabled()) [[likely]]
         return;
 
     m_consoleAgent->startTiming(globalObject, label);
@@ -176,7 +176,7 @@ void JSGlobalObjectConsoleClient::time(JSGlobalObject* globalObject, const Strin
 
 void JSGlobalObjectConsoleClient::timeLog(JSGlobalObject* globalObject, const String& label, Ref<ScriptArguments>&& arguments)
 {
-    if (LIKELY(!m_consoleAgent->developerExtrasEnabled()))
+    if (!m_consoleAgent->developerExtrasEnabled()) [[likely]]
         return;
 
     m_consoleAgent->logTiming(globalObject, label, WTFMove(arguments));
@@ -184,7 +184,7 @@ void JSGlobalObjectConsoleClient::timeLog(JSGlobalObject* globalObject, const St
 
 void JSGlobalObjectConsoleClient::timeEnd(JSGlobalObject* globalObject, const String& label)
 {
-    if (LIKELY(!m_consoleAgent->developerExtrasEnabled()))
+    if (!m_consoleAgent->developerExtrasEnabled()) [[likely]]
         return;
 
     m_consoleAgent->stopTiming(globalObject, label);
@@ -192,7 +192,7 @@ void JSGlobalObjectConsoleClient::timeEnd(JSGlobalObject* globalObject, const St
 
 void JSGlobalObjectConsoleClient::timeStamp(JSGlobalObject*, Ref<ScriptArguments>&&)
 {
-    if (LIKELY(!m_consoleAgent->developerExtrasEnabled()))
+    if (!m_consoleAgent->developerExtrasEnabled()) [[likely]]
         return;
 
     warnUnimplemented("console.timeStamp"_s);
@@ -200,7 +200,7 @@ void JSGlobalObjectConsoleClient::timeStamp(JSGlobalObject*, Ref<ScriptArguments
 
 void JSGlobalObjectConsoleClient::record(JSGlobalObject*, Ref<ScriptArguments>&&)
 {
-    if (LIKELY(!m_consoleAgent->developerExtrasEnabled()))
+    if (!m_consoleAgent->developerExtrasEnabled()) [[likely]]
         return;
 
     warnUnimplemented("console.record"_s);
@@ -208,7 +208,7 @@ void JSGlobalObjectConsoleClient::record(JSGlobalObject*, Ref<ScriptArguments>&&
 
 void JSGlobalObjectConsoleClient::recordEnd(JSGlobalObject*, Ref<ScriptArguments>&&)
 {
-    if (LIKELY(!m_consoleAgent->developerExtrasEnabled()))
+    if (!m_consoleAgent->developerExtrasEnabled()) [[likely]]
         return;
 
     warnUnimplemented("console.recordEnd"_s);
@@ -216,7 +216,7 @@ void JSGlobalObjectConsoleClient::recordEnd(JSGlobalObject*, Ref<ScriptArguments
 
 void JSGlobalObjectConsoleClient::screenshot(JSGlobalObject*, Ref<ScriptArguments>&&)
 {
-    if (LIKELY(!m_consoleAgent->developerExtrasEnabled()))
+    if (!m_consoleAgent->developerExtrasEnabled()) [[likely]]
         return;
 
     warnUnimplemented("console.screenshot"_s);

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
@@ -256,7 +256,7 @@ JSValue JSInjectedScriptHost::functionDetails(JSGlobalObject* globalObject, Call
     auto* targetFunction = function;
     while (auto* boundFunction = jsDynamicCast<JSBoundFunction*>(targetFunction)) {
         auto* nextTargetFunction = jsDynamicCast<JSFunction*>(boundFunction->targetFunction());
-        if (UNLIKELY(!nextTargetFunction))
+        if (!nextTargetFunction) [[unlikely]]
             break;
         targetFunction = nextTargetFunction;
     }
@@ -755,7 +755,9 @@ JSValue JSInjectedScriptHost::iteratorEntries(JSGlobalObject* globalObject, Call
 
     for (unsigned i = 0; i < numberToFetch; ++i) {
         JSValue next = iteratorStep(globalObject, iterationRecord);
-        if (UNLIKELY(scope.exception()) || next.isFalse())
+        if (scope.exception()) [[unlikely]]
+            break;
+        if (next.isFalse())
             break;
 
         JSValue nextValue = iteratorValue(globalObject, next);
@@ -764,7 +766,7 @@ JSValue JSInjectedScriptHost::iteratorEntries(JSGlobalObject* globalObject, Call
         JSObject* entry = constructEmptyObject(globalObject);
         entry->putDirect(vm, Identifier::fromString(vm, "value"_s), nextValue);
         array->putDirectIndex(globalObject, i, entry);
-        if (UNLIKELY(scope.exception())) {
+        if (scope.exception()) [[unlikely]] {
             scope.release();
             iteratorClose(globalObject, iterationRecord.iterator);
             break;

--- a/Source/JavaScriptCore/inspector/JSJavaScriptCallFrame.cpp
+++ b/Source/JavaScriptCore/inspector/JSJavaScriptCallFrame.cpp
@@ -191,7 +191,7 @@ JSValue JSJavaScriptCallFrame::scopeChain(JSGlobalObject* globalObject) const
         list.append(iter.get());
         ++iter;
     } while (iter != end);
-    if (UNLIKELY(list.hasOverflowed())) {
+    if (list.hasOverflowed()) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return { };
     }

--- a/Source/JavaScriptCore/inspector/ScriptFunctionCall.cpp
+++ b/Source/JavaScriptCore/inspector/ScriptFunctionCall.cpp
@@ -119,7 +119,7 @@ Expected<JSValue, NakedPtr<Exception>> ScriptFunctionCall::call()
 
     JSValue function = thisObject->get(m_globalObject, Identifier::fromString(vm, m_name));
     Exception* exception = scope.exception();
-    if (UNLIKELY(exception)) {
+    if (exception) [[unlikely]] {
         scope.clearException();
         return makeExceptionResult(exception);
     }

--- a/Source/JavaScriptCore/interpreter/InterpreterInlines.h
+++ b/Source/JavaScriptCore/interpreter/InterpreterInlines.h
@@ -113,7 +113,7 @@ ALWAYS_INLINE JSValue Interpreter::executeCachedCall(CachedCall& cachedCall)
     // so the called JS function always handles it.
 
     auto* entry = cachedCall.m_addressForCall;
-    if (UNLIKELY(!entry)) {
+    if (!entry) [[unlikely]] {
         DeferTraps deferTraps(vm); // We can't jettison this code if we're about to run it.
         cachedCall.relink();
         RETURN_IF_EXCEPTION(throwScope, throwScope.exception());
@@ -145,7 +145,7 @@ ALWAYS_INLINE JSValue Interpreter::tryCallWithArguments(CachedCall& cachedCall, 
     // so the called JS function always handles it.
 
     auto* entry = cachedCall.m_addressForCall;
-    if (UNLIKELY(!entry))
+    if (!entry) [[unlikely]]
         return { };
 
     // Execute the code:

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -370,7 +370,7 @@ AssemblyHelpers::Jump AssemblyHelpers::emitJumpIfException(VM& vm)
 
 AssemblyHelpers::Jump AssemblyHelpers::emitExceptionCheck(VM& vm, ExceptionCheckKind kind, ExceptionJumpWidth width, GPRReg exceptionReg)
 {
-    if (UNLIKELY(Options::useExceptionFuzz()))
+    if (Options::useExceptionFuzz()) [[unlikely]]
         callExceptionFuzz(vm, exceptionReg);
 
     if (width == FarJumpWidth)

--- a/Source/JavaScriptCore/jit/ExecutableAllocationFuzz.h
+++ b/Source/JavaScriptCore/jit/ExecutableAllocationFuzz.h
@@ -38,7 +38,7 @@ ExecutableAllocationFuzzResult doExecutableAllocationFuzzing();
 
 inline ExecutableAllocationFuzzResult doExecutableAllocationFuzzingIfEnabled()
 {
-    if (LIKELY(!Options::useExecutableAllocationFuzz()))
+    if (!Options::useExecutableAllocationFuzz()) [[likely]]
         return AllowNormalExecutableAllocation;
     
     return doExecutableAllocationFuzzing();

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.h
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.h
@@ -198,7 +198,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 // once we know we're going to crash and thus can afford the
 // overhead.
 #define RELEASE_ASSERT_ZERO_CHECK(zeroCount, dstBuff, srcBuff, buffSize, nextIndex) do { \
-        if (UNLIKELY(zeroCount > maxZeroByteRunLength)) { \
+        if (zeroCount > maxZeroByteRunLength) [[unlikely]] { \
             size_t firstZeroIndex = nextIndex - zeroCount; \
             auto dstBuffZeroes = reinterpret_cast<const char*>(dstBuff) + firstZeroIndex; \
             auto srcBuffZeroes = reinterpret_cast<const char*>(srcBuff) + firstZeroIndex; \
@@ -223,7 +223,7 @@ static ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n
 
 #if ENABLE(JIT_SCAN_ASSEMBLER_BUFFER_FOR_ZEROES)
         auto checkForZeroes = [dst, src, n] () {
-            if (UNLIKELY(Options::zeroExecutableMemoryOnFree()))
+            if (Options::zeroExecutableMemoryOnFree()) [[unlikely]]
                 return;
             // On x86-64, the maximum immediate size is 8B, no opcodes/prefixes have 0x00
             // On other architectures this could be smaller
@@ -264,7 +264,7 @@ static ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n
         };
 #endif
 
-        if (UNLIKELY(Options::dumpJITMemoryPath()))
+        if (Options::dumpJITMemoryPath()) [[unlikely]]
             dumpJITMemory(dst, src, n);
 
 #if ENABLE(MPROTECT_RX_TO_RWX)

--- a/Source/JavaScriptCore/jit/JITExceptions.cpp
+++ b/Source/JavaScriptCore/jit/JITExceptions.cpp
@@ -43,7 +43,7 @@ void genericUnwind(VM& vm, CallFrame* callFrame)
 {
     auto scope = DECLARE_CATCH_SCOPE(vm);
     CallFrame* topJSCallFrame = vm.topJSCallFrame();
-    if (UNLIKELY(Options::breakOnThrow())) {
+    if (Options::breakOnThrow()) [[unlikely]] {
         CodeBlock* codeBlock = topJSCallFrame->isNativeCalleeFrame() ? nullptr : topJSCallFrame->codeBlock();
         dataLog("In call frame ", RawPointer(topJSCallFrame), " for code block ", codeBlock, "\n");
         WTFBreakpointTrap();

--- a/Source/JavaScriptCore/jit/JITOpcodes.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes.cpp
@@ -1673,7 +1673,7 @@ void JIT::emit_op_debug(const JSInstruction* currentInstruction)
 
 void JIT::emit_op_loop_hint(const JSInstruction* instruction)
 {
-    if (UNLIKELY(Options::returnEarlyFromInfiniteLoopsForFuzzing() && m_unlinkedCodeBlock->loopHintsAreEligibleForFuzzingEarlyReturn())) {
+    if (Options::returnEarlyFromInfiniteLoopsForFuzzing() && m_unlinkedCodeBlock->loopHintsAreEligibleForFuzzingEarlyReturn()) [[unlikely]] {
         uintptr_t* ptr = vm().getLoopHintExecutionCounter(instruction);
         loadPtr(ptr, regT0);
         auto skipEarlyReturn = branchPtr(Below, regT0, TrustedImmPtr(Options::earlyReturnFromInfiniteLoopsLimit()));


### PR DESCRIPTION
#### 0e0b92f5e0efacefe3f82c8d07dd846f00ba4dad
<pre>
Start adopting C++20&apos;s [[likely]] / [[unlikely]] in JSC
<a href="https://bugs.webkit.org/show_bug.cgi?id=292459">https://bugs.webkit.org/show_bug.cgi?id=292459</a>

Reviewed by Yusuke Suzuki.

Start adopting C++20&apos;s [[likely]] / [[unlikely]] in JSC.

It is now part of the C++ language and has several benefits over
our macros. In particular, those annotations can be used for
`switch` cases and `else` statements.

* Source/JavaScriptCore/API/APIUtils.h:
(handleExceptionIfNeeded):
* Source/JavaScriptCore/API/JSAPIGlobalObject.mm:
(JSC::JSAPIGlobalObject::moduleLoaderFetch):
* Source/JavaScriptCore/API/JSCallbackObjectFunctions.h:
(JSC::JSCallbackObject&lt;Parent&gt;::customToPrimitive):
(JSC::JSCallbackObject&lt;Parent&gt;::put):
* Source/JavaScriptCore/API/JSContextRef.cpp:
(JSGlobalContextCreate):
(JSContextGroupTakeSamplesFromSamplingProfiler):
* Source/JavaScriptCore/API/JSManagedValue.mm:
(JSManagedValueHandleOwner::isReachableFromOpaqueRoots):
* Source/JavaScriptCore/API/JSObjectRef.cpp:
(JSObjectMakeFunction):
(JSObjectMakeArray):
(JSObjectMakeDate):
(JSObjectMakeRegExp):
(JSObjectSetProperty):
(JSObjectSetPropertyForKey):
(JSObjectCallAsFunction):
(JSObjectCallAsConstructor):
* Source/JavaScriptCore/assembler/ARM64Assembler.h:
* Source/JavaScriptCore/assembler/ARMv7Assembler.h:
(JSC::ARMv7Assembler::label):
* Source/JavaScriptCore/assembler/AbstractMacroAssembler.h:
(JSC::AbstractMacroAssembler::comment):
* Source/JavaScriptCore/assembler/AssemblerBuffer.h:
(JSC::AssemblerBuffer::putIntegral):
* Source/JavaScriptCore/assembler/AssemblyComments.h:
(JSC::AssemblyCommentRegistry::registerCodeRange):
(JSC::AssemblyCommentRegistry::unregisterCodeRange):
(JSC::AssemblyCommentRegistry::comment):
* Source/JavaScriptCore/assembler/JITOperationList.cpp:
(JSC::JITOperationList::populatePointersInJavaScriptCore):
(JSC::JITOperationList::populatePointersInJavaScriptCoreForLLInt):
(JSC::JITOperationList::populateDisassemblyLabelsInEmbedder):
* Source/JavaScriptCore/assembler/JITOperationList.h:
(JSC::JITOperationList::populatePointersInJavaScriptCore):
(JSC::JITOperationList::populatePointersInJavaScriptCoreForLLInt):
* Source/JavaScriptCore/assembler/LinkBuffer.cpp:
(JSC::LinkBuffer::finalizeCodeWithoutDisassemblyImpl):
(JSC::LinkBuffer::copyCompactAndLinkCode):
(JSC::LinkBuffer::linkComments):
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::lshift64):
(JSC::MacroAssemblerARM64::rotateRight64):
(JSC::MacroAssemblerARM64::rshift64):
(JSC::MacroAssemblerARM64::urshift64):
* Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h:
(JSC::MacroAssemblerRISCV64::lshift64):
(JSC::MacroAssemblerRISCV64::rshift64):
(JSC::MacroAssemblerRISCV64::urshift64):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::lshift64):
(JSC::MacroAssemblerX86_64::rshift64):
(JSC::MacroAssemblerX86_64::urshift64):
(JSC::MacroAssemblerX86_64::rotateRight64):
(JSC::MacroAssemblerX86_64::rotateLeft64):
(JSC::MacroAssemblerX86_64::sub64):
* Source/JavaScriptCore/assembler/ProbeStack.cpp:
(JSC::Probe::Stack::ensurePageFor):
* Source/JavaScriptCore/assembler/ProbeStack.h:
(JSC::Probe::Stack::pageFor):
* Source/JavaScriptCore/assembler/RISCV64Assembler.h:
(JSC::RISCV64Assembler::label):
* Source/JavaScriptCore/assembler/SecureARM64EHashPinsInlines.h:
(JSC::SecureARM64EHashPins::pinForCurrentThread):
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::label):
* Source/JavaScriptCore/b3/B3CanonicalizePrePostIncrements.cpp:
(JSC::B3::canonicalizePrePostIncrements):
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::RegisterRange::forEachConflict):
(JSC::B3::Air::Greedy::GreedyAllocator::adjustedBlockFrequency):
(JSC::B3::Air::Greedy::GreedyAllocator::buildLiveRanges):
(JSC::B3::Air::Greedy::GreedyAllocator::tryEvict):
* Source/JavaScriptCore/b3/air/AirEmitShuffle.cpp:
(JSC::B3::Air::ShufflePair::insts const):
* Source/JavaScriptCore/b3/air/AirLowerMacros.cpp:
(JSC::B3::Air::lowerMacros):
* Source/JavaScriptCore/b3/testb3_1.cpp:
(main):
* Source/JavaScriptCore/builtins/BuiltinExecutables.cpp:
(JSC::BuiltinExecutables::createExecutable):
* Source/JavaScriptCore/bytecode/ArrayAllocationProfile.cpp:
(JSC::ArrayAllocationProfile::updateProfile):
* Source/JavaScriptCore/bytecode/ArrayAllocationProfile.h:
(JSC::ArrayAllocationProfile::selectIndexingType):
* Source/JavaScriptCore/bytecode/BytecodeGeneratorification.cpp:
(JSC::performGeneratorification):
* Source/JavaScriptCore/bytecode/BytecodeLivenessAnalysis.cpp:
(JSC::BytecodeLivenessAnalysis::BytecodeLivenessAnalysis):
* Source/JavaScriptCore/bytecode/CallLinkInfo.cpp:
(JSC::DataOnlyCallLinkInfo::initialize):
(JSC::CallLinkInfo::revertCall):
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::~CodeBlock):
(JSC::CodeBlock::shouldVisitStrongly):
(JSC::timeToLive):
(JSC::CodeBlock::shouldJettisonDueToOldAge):
(JSC::CodeBlock::jettison):
(WTF::printInternal):
* Source/JavaScriptCore/bytecode/CodeOrigin.h:
(JSC::CodeOrigin::operator=):
(JSC::CodeOrigin::CodeOrigin):
(JSC::CodeOrigin::~CodeOrigin):
(JSC::CodeOrigin::bytecodeIndex const):
(JSC::CodeOrigin::inlineCallFrame const):
(JSC::CodeOrigin::buildCompositeValue):
* Source/JavaScriptCore/bytecode/InternalFunctionAllocationProfile.h:
(JSC::InternalFunctionAllocationProfile::createAllocationStructureFromBase):
* Source/JavaScriptCore/bytecode/ObjectAllocationProfileInlines.h:
(JSC::ObjectAllocationProfileBase&lt;Derived&gt;::initializeProfile):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::linkMonomorphicCall):
* Source/JavaScriptCore/bytecode/RepatchInlines.h:
(JSC::throwNotAFunctionErrorFromCallIC):
(JSC::throwNotAConstructorErrorFromCallIC):
(JSC::handleHostCall):
(JSC::virtualForWithFunction):
* Source/JavaScriptCore/bytecode/SpeculatedType.cpp:
(JSC::speculationFromCell):
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp:
(JSC::UnlinkedCodeBlock::~UnlinkedCodeBlock):
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.cpp:
(JSC::UnlinkedCodeBlockGenerator::finalize):
* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp:
(JSC::UnlinkedFunctionExecutable::link):
* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h:
* Source/JavaScriptCore/bytecode/Watchpoint.h:
(JSC::WatchpointSet::fireAll):
(JSC::InlineWatchpointSet::inflate):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::generate):
(JSC::BytecodeGenerator::BytecodeGenerator):
(JSC::BytecodeGenerator::emitEnter):
(JSC::BytecodeGenerator::emitDebugHook):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
(JSC::BytecodeGenerator::generate):
(JSC::BytecodeGenerator::emitNodeInTailPosition):
(JSC::BytecodeGenerator::emitDefineClassElements):
(JSC::BytecodeGenerator::emitNodeInConditionContext):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::ConstantNode::emitBytecodeInConditionContext):
(JSC::ConstantNode::emitBytecode):
(JSC::ArrayNode::emitBytecode):
(JSC::FunctionCallResolveNode::emitBytecode):
(JSC::LogicalNotNode::emitBytecodeInConditionContext):
(JSC::BinaryOpNode::emitBytecodeInConditionContext):
(JSC::BinaryOpNode::tryFoldToBranch):
(JSC::LogicalOpNode::emitBytecodeInConditionContext):
* Source/JavaScriptCore/debugger/DebuggerCallFrame.cpp:
(JSC::DebuggerCallFrame::create):
(JSC::DebuggerCallFrame::evaluateWithScopeExtension):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::getPredictionWithoutOSRExit):
(JSC::DFG::ByteCodeParser::handleCall):
(JSC::DFG::ByteCodeParser::handleVarargsCall):
(JSC::DFG::ByteCodeParser::handleRecursiveTailCall):
(JSC::DFG::ByteCodeParser::handleProxyObjectLoad):
(JSC::DFG::ByteCodeParser::handleIndexedProxyObjectLoad):
(JSC::DFG::ByteCodeParser::handleProxyObjectStore):
(JSC::DFG::ByteCodeParser::handleIndexedProxyObjectStore):
(JSC::DFG::ByteCodeParser::handleProxyObjectIn):
(JSC::DFG::ByteCodeParser::handleIndexedProxyObjectIn):
(JSC::DFG::ByteCodeParser::handleGetById):
(JSC::DFG::ByteCodeParser::handleGetPrivateNameById):
(JSC::DFG::ByteCodeParser::handlePutById):
(JSC::DFG::ByteCodeParser::handlePutPrivateNameById):
(JSC::DFG::ByteCodeParser::parseBlock):
(JSC::DFG::ByteCodeParser::parseCodeBlock):
* Source/JavaScriptCore/dfg/DFGCFAPhase.cpp:
(JSC::DFG::CFAPhase::performBlockCFA):
* Source/JavaScriptCore/dfg/DFGCommonData.cpp:
(JSC::DFG::CommonData::invalidateLinkedCode):
(JSC::DFG::CommonData::~CommonData):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::freeze):
* Source/JavaScriptCore/dfg/DFGInsertionSet.h:
(JSC::DFG::InsertionSet::insert):
* Source/JavaScriptCore/dfg/DFGIntegerCheckCombiningPhase.cpp:
(JSC::DFG::IntegerCheckCombiningPhase::handleBlock):
* Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGJITCompiler.cpp:
(JSC::DFG::JITCompiler::JITCompiler):
(JSC::DFG::JITCompiler::linkOSRExits):
(JSC::DFG::JITCompiler::link):
(JSC::DFG::JITCompiler::disassemble):
(JSC::DFG::JITCompiler::setEndOfMainPath):
(JSC::DFG::JITCompiler::setEndOfCode):
* Source/JavaScriptCore/dfg/DFGJITCompiler.h:
(JSC::DFG::JITCompiler::setStartOfCode):
(JSC::DFG::JITCompiler::setForBlockIndex):
(JSC::DFG::JITCompiler::setForNode):
* Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp:
(JSC::DFG::JITFinalizer::finalize):
* Source/JavaScriptCore/dfg/DFGLICMPhase.cpp:
(JSC::DFG::LICMPhase::run):
* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
(JSC::DFG::LoopUnrollingPhase::run):
(JSC::DFG::LoopUnrollingPhase::tryUnroll):
(JSC::DFG::LoopUnrollingPhase::isLoopBodyUnrollable):
* Source/JavaScriptCore/dfg/DFGOSREntry.cpp:
(JSC::DFG::prepareOSREntry):
(JSC::DFG::prepareCatchOSREntry):
* Source/JavaScriptCore/dfg/DFGOSRExit.cpp:
(JSC::DFG::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
(JSC::DFG::OSRExit::compileExit):
* Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::parseIntResult):
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
(JSC::DFG::getByValCellInt):
(JSC::DFG::arraySpliceImpl):
(JSC::DFG::newArrayWithSpeciesImpl):
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::compileInThreadImpl):
(JSC::DFG::Plan::finalize):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::emitStackOverflowCheck):
(JSC::DFG::SpeculativeJIT::runSlowPathGenerators):
(JSC::DFG::SpeculativeJIT::compileLoopHint):
(JSC::DFG::SpeculativeJIT::compileCurrentBlock):
(JSC::DFG::SpeculativeJIT::linkOSREntries):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
(JSC::DFG::FPRTemporary::~FPRTemporary):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/dfg/DFGValidateUnlinked.cpp:
(JSC::DFG::ValidateUnlinked::validateNode):
* Source/JavaScriptCore/dfg/DFGVariableEventStream.cpp:
(JSC::DFG::VariableEventStream::reconstruct const):
* Source/JavaScriptCore/ftl/FTLAbstractHeap.cpp:
(JSC::FTL::IndexedAbstractHeap::atSlow):
* Source/JavaScriptCore/ftl/FTLAbstractHeap.h:
(JSC::FTL::IndexedAbstractHeap::returnInitialized):
* Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.cpp:
(JSC::FTL::AbstractHeapRepository::computeRangesAndDecorateInstructions):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLCompile.cpp:
(JSC::FTL::compile):
* Source/JavaScriptCore/ftl/FTLJITFinalizer.cpp:
(JSC::FTL::JITFinalizer::finalize):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::LowerDFGToB3):
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/ftl/FTLOSREntry.cpp:
(JSC::FTL::prepareOSREntry):
* Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp:
(JSC::FTL::compileStub):
* Source/JavaScriptCore/ftl/FTLOperations.cpp:
(JSC::FTL::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/ftl/FTLSlowPathCall.cpp:
(JSC::FTL::SlowPathCallContext::keyWithTarget const):
* Source/JavaScriptCore/ftl/FTLThunks.cpp:
(JSC::FTL::slowPathCallThunkGenerator):
* Source/JavaScriptCore/heap/AbstractSlotVisitorInlines.h:
(JSC::AbstractSlotVisitor::addOpaqueRoot):
(JSC::AbstractSlotVisitor::containsOpaqueRoot const):
* Source/JavaScriptCore/heap/BlockDirectory.cpp:
(JSC::BlockDirectory::stopAllocating):
(JSC::BlockDirectory::prepareForAllocation):
(JSC::BlockDirectory::endMarking):
(JSC::BlockDirectory::didFinishUsingBlock):
* Source/JavaScriptCore/heap/CompleteSubspace.cpp:
(JSC::CompleteSubspace::allocateSlow):
(JSC::CompleteSubspace::tryAllocateSlow):
(JSC::CompleteSubspace::reallocatePreciseAllocationNonVirtual):
* Source/JavaScriptCore/heap/ConservativeRoots.cpp:
(JSC::ConservativeRoots::genericAddPointer):
* Source/JavaScriptCore/heap/FreeList.cpp:
(JSC::FreeList::initialize):
* Source/JavaScriptCore/heap/FreeListInlines.h:
(JSC::FreeList::allocateWithCellSize):
* Source/JavaScriptCore/heap/GCDeferralContextInlines.h:
(JSC::GCDeferralContext::~GCDeferralContext):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::lastChanceToFinalize):
(JSC::Heap::reportExtraMemoryAllocatedPossiblyFromAlreadyMarkedCell):
(JSC::Heap::reportExtraMemoryAllocatedSlowCase):
(JSC::Heap::sweepSynchronously):
(JSC::Heap::collect):
(JSC::Heap::collectNow):
(JSC::Heap::collectAsync):
(JSC::Heap::collectSync):
(JSC::Heap::runBeginPhase):
(JSC::Heap::runFixpointPhase):
(JSC::Heap::runReloopPhase):
(JSC::Heap::runEndPhase):
(JSC::Heap::finalize):
(JSC::Heap::willStartCollection):
(JSC::Heap::didFinishCollection):
(JSC::Heap::writeBarrierSlowPath):
(JSC::Heap::collectIfNecessaryOrDefer):
(JSC::visitSamplingProfiler):
(JSC::Heap::addCoreConstraints):
(JSC::Heap::notifyIsSafeToCollect):
(JSC::Heap::verifyGC):
* Source/JavaScriptCore/heap/HeapInlines.h:
(JSC::Heap::writeBarrier):
(JSC::Heap::mutatorFence):
* Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp:
(JSC::HeapSnapshotBuilder::json):
* Source/JavaScriptCore/heap/IncrementalSweeper.cpp:
(JSC::IncrementalSweeper::doSweep):
* Source/JavaScriptCore/heap/IsoCellSetInlines.h:
(JSC::IsoCellSet::add):
* Source/JavaScriptCore/heap/LocalAllocator.cpp:
(JSC::LocalAllocator::allocateSlowCase):
(JSC::LocalAllocator::doTestCollectionsIfNeeded):
* Source/JavaScriptCore/heap/MachineStackMarker.cpp:
(JSC::MachineThreads::tryCopyOtherThreadStack):
* Source/JavaScriptCore/heap/MarkedBlock.cpp:
(JSC::MarkedBlock::aboutToMarkSlow):
* Source/JavaScriptCore/heap/MarkedBlock.h:
(JSC::MarkedBlock::aboutToMark):
(JSC::MarkedBlock::isMarked):
(JSC::MarkedBlock::noteMarked):
* Source/JavaScriptCore/heap/MarkedBlockInlines.h:
(JSC::MarkedBlock::Handle::specializedSweep):
* Source/JavaScriptCore/heap/MarkedSpace.cpp:
(JSC::MarkedSpace::beginMarking):
(JSC::MarkedSpace::endMarking):
* Source/JavaScriptCore/heap/PreciseAllocation.cpp:
(JSC::PreciseAllocation::tryCreate):
(JSC::PreciseAllocation::tryReallocate):
(JSC::PreciseAllocation::tryCreateForLowerTierPrecise):
* Source/JavaScriptCore/heap/SlotVisitor.cpp:
(JSC::SlotVisitor::appendSlow):
(JSC::SlotVisitor::appendToMarkStack):
(JSC::SlotVisitor::visitChildren):
* Source/JavaScriptCore/heap/SlotVisitorInlines.h:
(JSC::SlotVisitor::appendUnbarriered):
(JSC::SlotVisitor::appendHiddenUnbarriered):
* Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp:
(JSC::StructureMemoryManager::StructureMemoryManager):
(JSC::StructureMemoryManager::tryMallocStructureBlock):
(JSC::StructureMemoryManager::freeStructureBlock):
* Source/JavaScriptCore/heap/VerifierSlotVisitor.cpp:
(JSC::VerifierSlotVisitor::appendUnbarriered):
(JSC::VerifierSlotVisitor::testAndSetMarked):
* Source/JavaScriptCore/heap/WeakBlock.cpp:
(JSC::WeakBlock::specializedVisit):
* Source/JavaScriptCore/heap/WeakSetInlines.h:
(JSC::WeakSet::allocate):
* Source/JavaScriptCore/inspector/JSGlobalObjectConsoleClient.cpp:
(Inspector::JSGlobalObjectConsoleClient::messageWithTypeAndLevel):
(Inspector::JSGlobalObjectConsoleClient::count):
(Inspector::JSGlobalObjectConsoleClient::countReset):
(Inspector::JSGlobalObjectConsoleClient::profile):
(Inspector::JSGlobalObjectConsoleClient::profileEnd):
(Inspector::JSGlobalObjectConsoleClient::takeHeapSnapshot):
(Inspector::JSGlobalObjectConsoleClient::time):
(Inspector::JSGlobalObjectConsoleClient::timeLog):
(Inspector::JSGlobalObjectConsoleClient::timeEnd):
(Inspector::JSGlobalObjectConsoleClient::timeStamp):
(Inspector::JSGlobalObjectConsoleClient::record):
(Inspector::JSGlobalObjectConsoleClient::recordEnd):
(Inspector::JSGlobalObjectConsoleClient::screenshot):
* Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp:
(Inspector::JSInjectedScriptHost::functionDetails):
(Inspector::JSInjectedScriptHost::iteratorEntries):
* Source/JavaScriptCore/inspector/JSJavaScriptCallFrame.cpp:
(Inspector::JSJavaScriptCallFrame::scopeChain const):
* Source/JavaScriptCore/inspector/ScriptFunctionCall.cpp:
(Inspector::ScriptFunctionCall::call):
* Source/JavaScriptCore/interpreter/CachedCall.h:
(JSC::CachedCall::CachedCall):
(JSC::CachedCall::callWithArguments):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::eval):
(JSC::sizeOfVarargs):
(JSC::sizeFrameForForwardArguments):
(JSC::sizeFrameForVarargs):
(JSC::loadVarargs):
(JSC::UnwindFunctor::notifyDebuggerOfUnwinding):
(JSC::Interpreter::executeProgram):
(JSC::Interpreter::executeBoundCall):
(JSC::Interpreter::executeCallImpl):
(JSC::Interpreter::executeConstruct):
(JSC::Interpreter::executeEval):
(JSC::Interpreter::executeModuleProgram):
(JSC::Interpreter::debug):
* Source/JavaScriptCore/interpreter/InterpreterInlines.h:
(JSC::Interpreter::executeCachedCall):
(JSC::Interpreter::tryCallWithArguments):
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::emitExceptionCheck):
* Source/JavaScriptCore/jit/ExecutableAllocationFuzz.h:
(JSC::doExecutableAllocationFuzzingIfEnabled):
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::dumpJITMemory):
(JSC::ExecutableMemoryHandle::~ExecutableMemoryHandle):
* Source/JavaScriptCore/jit/ExecutableAllocator.h:
(JSC::performJITMemcpy):
* Source/JavaScriptCore/jit/JIT.cpp:
(JSC::JIT::privateCompileMainPass):
(JSC::JIT::privateCompileSlowCases):
(JSC::JIT::compileAndLinkWithoutFinalizing):
(JSC::JIT::link):
* Source/JavaScriptCore/jit/JITExceptions.cpp:
(JSC::genericUnwind):
* Source/JavaScriptCore/jit/JITOpcodes.cpp:
(JSC::JIT::emit_op_loop_hint):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::JSC_DEFINE_JIT_OPERATION):
(JSC::getByIdMegamorphic):
(JSC::inByIdMegamorphic):
(JSC::inByValMegamorphic):
(JSC::putByIdMegamorphic):
(JSC::putByValMegamorphic):
(JSC::getByVal):
(JSC::getByValWithThis):
(JSC::getByValMegamorphic):
(JSC::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):

Canonical link: <a href="https://commits.webkit.org/294469@main">https://commits.webkit.org/294469@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b7845fe76897ea333107ee0a0fe9036b112fc9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101875 "530 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107033 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52509 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30050 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77569 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34581 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104882 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91989 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57906 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16713 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10012 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51861 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94547 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86564 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10087 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109392 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100485 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29008 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21366 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86543 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29369 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88193 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86120 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21918 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30875 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8595 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23179 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28936 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34231 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124110 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28747 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34474 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32070 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30306 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->