### PR TITLE
[JSC] Fix incorrect early return in isNodeCloneable and add debug cycle check

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.cpp
@@ -56,10 +56,18 @@ NodeCloneStatus nodeCloneStatusFor(NodeType op)
 
 } // anonymous namespace
 
-bool CloneHelper::isNodeCloneable(Graph& graph, HashSet<Node*>& cloneableCache, Node* node)
+bool CloneHelper::isNodeCloneable(Graph& graph, UncheckedKeyHashSet<Node*>& cloneableCache, Node* node)
 {
     if (cloneableCache.contains(node))
         return true;
+
+#if ASSERT_ENABLED
+    UncheckedKeyHashSet<Node*>& visiting = CloneHelper::debugVisitingSet();
+    ASSERT(visiting.add(node).isNewEntry);
+    auto exitScope = makeScopeExit([&] {
+        visiting.remove(node);
+    });
+#endif
 
     bool result = true;
     switch (nodeCloneStatusFor(node->op())) {
@@ -71,12 +79,15 @@ bool CloneHelper::isNodeCloneable(Graph& graph, HashSet<Node*>& cloneableCache, 
             result = false;
             return IterationStatus::Done;
         });
-        return result;
+        break;
     }
     case NodeCloneStatus::PreCloned:
         break;
     case NodeCloneStatus::Unsupported:
         result = false;
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
     }
 
     if (result)

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.h
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.h
@@ -41,7 +41,19 @@ public:
         ASSERT(graph.m_form == ThreadedCPS || graph.m_form == LoadStore);
     }
 
-    static bool isNodeCloneable(Graph&, HashSet<Node*>&, Node*);
+    static bool isNodeCloneable(Graph&, UncheckedKeyHashSet<Node*>&, Node*);
+
+#if ASSERT_ENABLED
+    static UncheckedKeyHashSet<Node*>& debugVisitingSet()
+    {
+        static LazyNeverDestroyed<ThreadSpecific<UncheckedKeyHashSet<Node*>, WTF::CanBeGCThread::True>> s_visitingSet;
+        static std::once_flag onceFlag;
+        std::call_once(onceFlag, [] {
+            s_visitingSet.construct();
+        });
+        return *s_visitingSet.get();
+    }
+#endif
 
     template<typename CustomizeSuccessors>
     BasicBlock* cloneBlock(BasicBlock* const, const CustomizeSuccessors&);


### PR DESCRIPTION
#### af07422edd14f9c95f376af6c9df4264690a250e
<pre>
[JSC] Fix incorrect early return in isNodeCloneable and add debug cycle check
<a href="https://bugs.webkit.org/show_bug.cgi?id=292462">https://bugs.webkit.org/show_bug.cgi?id=292462</a>
<a href="https://rdar.apple.com/150555146">rdar://150555146</a>

Reviewed by Yusuke Suzuki.

Previously, the NodeCloneStatus::Special/Common node case in isNodeCloneable()
returned early, skipping cloneableCache update and potential cleanup. This
patch changes it to break and ensures the result flows through the unified return path.

Also adds a debug-only ThreadSpecific visiting set to detect accidental
cycles during recursion. This check is safe because Phi-like nodes are
categorized as NodeCloneStatus::PreCloned and are not recursively visited.

The visiting set is fully cleared after each cloneability check pass,
ensuring no state leakage between invocations.

Uses UncheckedKeyHashSet for cloneableCache and visiting for better performance.

* Source/JavaScriptCore/dfg/DFGCloneHelper.cpp:
(JSC::DFG::CloneHelper::isNodeCloneable):
* Source/JavaScriptCore/dfg/DFGCloneHelper.h:
* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
(JSC::DFG::LoopUnrollingPhase::isLoopBodyUnrollable):

Canonical link: <a href="https://commits.webkit.org/294474@main">https://commits.webkit.org/294474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32ab0d3ff94816819c42869423d56f2ca81a9d12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101926 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107085 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52560 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30101 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77599 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34602 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104933 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16925 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92029 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57936 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16752 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10052 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51917 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94598 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86596 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109453 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100536 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29059 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21396 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86573 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29420 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88233 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86151 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21920 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30914 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8634 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23230 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28987 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34282 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124161 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28798 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34487 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32121 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30357 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->