### PR TITLE
Use C++20 standard library features in wtf/FileSystem

### DIFF
--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -133,24 +133,13 @@ static inline bool shouldEscapeUChar(UChar character, UChar previousCharacter, U
 
 #if HAVE(STD_FILESYSTEM) || HAVE(STD_EXPERIMENTAL_FILESYSTEM)
 
-template<typename, typename = void> inline constexpr bool HasToTimeT = false;
-template<typename ClockType> inline constexpr bool HasToTimeT<ClockType, std::void_t<
-    std::enable_if_t<std::is_same_v<std::time_t, decltype(ClockType::to_time_t(std::filesystem::file_time_type()))>>
->> = true;
-
-template <typename FileTimeType>
-typename std::time_t toTimeT(FileTimeType fileTime)
-{
-    if constexpr (HasToTimeT<typename FileTimeType::clock>)
-        return decltype(fileTime)::clock::to_time_t(fileTime);
-    else
-        return std::chrono::system_clock::to_time_t(std::chrono::time_point_cast<std::chrono::system_clock::duration>(fileTime - decltype(fileTime)::clock::now() + std::chrono::system_clock::now()));
-}
-
 static WallTime toWallTime(std::filesystem::file_time_type fileTime)
 {
-    // FIXME: Use std::chrono::file_clock::to_sys() once we can use C++20.
-    return WallTime::fromRawSeconds(toTimeT(fileTime));
+#if defined(_WIN32) || defined(_WIN64)
+    return WallTime::fromRawSeconds(std::chrono::system_clock::to_time_t(std::chrono::clock_cast<std::chrono::system_clock>(fileTime)));
+#else
+    return WallTime::fromRawSeconds(std::chrono::system_clock::to_time_t(std::chrono::time_point_cast<std::chrono::system_clock::duration>(std::chrono::file_clock::to_sys(fileTime))));
+#endif
 }
 
 #endif // HAVE(STD_FILESYSTEM) || HAVE(STD_EXPERIMENTAL_FILESYSTEM)


### PR DESCRIPTION
#### 58f93a08f66b366a48b3bf24a18d95d6ed6f12d0
<pre>
Use C++ 20 standard library features in wtf/FileSystem
<a href="https://bugs.webkit.org/show_bug.cgi?id=292464">https://bugs.webkit.org/show_bug.cgi?id=292464</a>
<a href="https://rdar.apple.com/problem/150555621">rdar://problem/150555621</a>

Reviewed by NOBODY (OOPS!).

This improves code maintainability by leveraging more standard library features.

* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::toWallTime):
(WTF::FileSystemImpl::toTimeT): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58f93a08f66b366a48b3bf24a18d95d6ed6f12d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107152 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52627 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30168 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77643 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34644 "Found 60 new test failures: compositing/fixed-with-clip-stability.html fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-base-target-popup-not-allowed.html fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-target-popup-not-allowed.html fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-target.html fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-unicode.html fast/dom/HTMLAnchorElement/anchor-file-blob-download-no-extension.html fast/dom/HTMLAnchorElement/anchor-file-blob-download.html fast/forms/file/get-file-upload-using-open-panel.html fast/harness/sample-mismatch-reftest.html fetch/fetch-error-messages.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105000 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16986 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92085 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57979 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16813 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10110 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51986 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94665 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86654 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10183 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109525 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100603 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29126 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21457 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86615 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29487 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88289 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86194 "Found 102 new API test failures: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/javascript-dialogs, /TestWebKit:WebKit.DOMWindowExtensionCrashOnReload, /TestWebKit:WebKit.PageLoadBasic, /TestWebKit:WebKit.NewFirstVisuallyNonEmptyLayoutFails, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /TestWebKit:WebKit.InjectedBundleBasic, /TestWebKit:WebKit.PreventEmptyUserAgent, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/select-all/non-editable ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30971 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8690 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/23324 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29054 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34349 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124228 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28865 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34505 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/cc-int-to-int-no-jit.js.default-wasm (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32188 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30424 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->