### PR TITLE
Optimize RenderStyle::changeRequiresRepaint() cases where currentColor differs

### DIFF
--- a/Source/WebCore/rendering/style/BorderData.cpp
+++ b/Source/WebCore/rendering/style/BorderData.cpp
@@ -35,19 +35,27 @@
 
 namespace WebCore {
 
+bool BorderData::containsCurrentColor() const
+{
+    return m_edges.anyOf([](const auto& edge) {
+        return edge.isVisible() && edge.color().containsCurrentColor();
+    });
+}
+
 bool BorderData::isEquivalentForPainting(const BorderData& other, bool currentColorDiffers) const
 {
-    if (!arePointingToEqualData(this, &other))
+    if (this == &other) {
+        ASSERT(currentColorDiffers);
+        return !containsCurrentColor();
+    }
+
+    if (*this != other)
         return false;
 
     if (!currentColorDiffers)
         return true;
 
-    auto visibleBorderHasCurrentColor = m_edges.anyOf([](const auto& edge) {
-        return edge.isVisible() && edge.color().containsCurrentColor();
-    });
-
-    return !visibleBorderHasCurrentColor;
+    return !containsCurrentColor();
 }
 
 TextStream& operator<<(TextStream& ts, const BorderValue& borderValue)

--- a/Source/WebCore/rendering/style/BorderData.h
+++ b/Source/WebCore/rendering/style/BorderData.h
@@ -105,6 +105,8 @@ public:
     void dump(TextStream&, DumpStyleValues = DumpStyleValues::All) const;
 
 private:
+    bool containsCurrentColor() const;
+
     RectEdges<BorderValue> m_edges;
     NinePieceImage m_image;
     RectCorners<LengthSize> m_radii { LengthSize { LengthType::Fixed, LengthType::Fixed } };

--- a/Source/WebCore/rendering/style/SVGRenderStyle.cpp
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.cpp
@@ -187,6 +187,15 @@ bool SVGRenderStyle::changeRequiresLayout(const SVGRenderStyle& other) const
 
 bool SVGRenderStyle::changeRequiresRepaint(const SVGRenderStyle& other, bool currentColorDiffers) const
 {
+    if (this == &other) {
+        ASSERT(currentColorDiffers);
+        return containsCurrentColor(m_strokeData->paintColor)
+            || containsCurrentColor(m_strokeData->visitedLinkPaintColor)
+            || containsCurrentColor(m_miscData->floodColor)
+            || containsCurrentColor(m_miscData->lightingColor)
+            || containsCurrentColor(m_fillData->paintColor);
+    }
+
     if (m_strokeData->opacity != other.m_strokeData->opacity
         || colorChangeRequiresRepaint(m_strokeData->paintColor, other.m_strokeData->paintColor, currentColorDiffers)
         || colorChangeRequiresRepaint(m_strokeData->visitedLinkPaintColor, other.m_strokeData->visitedLinkPaintColor, currentColorDiffers))

--- a/Source/WebCore/rendering/style/StyleBackgroundData.cpp
+++ b/Source/WebCore/rendering/style/StyleBackgroundData.cpp
@@ -57,6 +57,11 @@ bool StyleBackgroundData::operator==(const StyleBackgroundData& other) const
 
 bool StyleBackgroundData::isEquivalentForPainting(const StyleBackgroundData& other, bool currentColorDiffers) const
 {
+    if (this == &other) {
+        ASSERT(currentColorDiffers);
+        return !containsCurrentColor();
+    }
+
     if (background != other.background || color != other.color)
         return false;
     if (currentColorDiffers && color.containsCurrentColor())
@@ -66,6 +71,12 @@ bool StyleBackgroundData::isEquivalentForPainting(const StyleBackgroundData& oth
     if (currentColorDiffers && outline.color().containsCurrentColor())
         return false;
     return outline == other.outline;
+}
+
+bool StyleBackgroundData::containsCurrentColor() const
+{
+    return color.containsCurrentColor()
+        || outline.color().containsCurrentColor();
 }
 
 void StyleBackgroundData::dump(TextStream& ts, DumpStyleValues behavior) const

--- a/Source/WebCore/rendering/style/StyleBackgroundData.h
+++ b/Source/WebCore/rendering/style/StyleBackgroundData.h
@@ -61,6 +61,8 @@ public:
 private:
     StyleBackgroundData();
     StyleBackgroundData(const StyleBackgroundData&);
+
+    bool containsCurrentColor() const;
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const StyleBackgroundData&);


### PR DESCRIPTION
#### c0a9fe94832e4075b7b9eafb62616650f04ff56c
<pre>
Optimize RenderStyle::changeRequiresRepaint() cases where currentColor differs
<a href="https://bugs.webkit.org/show_bug.cgi?id=292466">https://bugs.webkit.org/show_bug.cgi?id=292466</a>
<a href="https://rdar.apple.com/150557529">rdar://150557529</a>

Reviewed by Matthieu Dubet.

If style contains currentColor, we need to do more extensive testing in `RenderStyle::changeRequiresRepaint()`,
because the objects can be the same, but contain currentColor. However, we can optimize for this case by
only testing whether any colors contain `currentColor`, rather than running the entire diff.

* Source/WebCore/rendering/style/BorderData.cpp:
(WebCore::BorderData::containsCurrentColor const):
(WebCore::BorderData::isEquivalentForPainting const):
* Source/WebCore/rendering/style/BorderData.h:
* Source/WebCore/rendering/style/SVGRenderStyle.cpp:
(WebCore::SVGRenderStyle::changeRequiresRepaint const):
* Source/WebCore/rendering/style/StyleBackgroundData.cpp:
(WebCore::StyleBackgroundData::isEquivalentForPainting const):
(WebCore::StyleBackgroundData::containsCurrentColor const):
* Source/WebCore/rendering/style/StyleBackgroundData.h:

Canonical link: <a href="https://commits.webkit.org/294476@main">https://commits.webkit.org/294476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9581658a63b788d17ddcaca7dc0e5ca28ffdc9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21559 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107050 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52525 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103931 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30066 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77580 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34586 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92003 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57917 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16725 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10026 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51880 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86572 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10101 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109415 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29024 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21374 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86556 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29385 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88207 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86133 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21922 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30896 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8609 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23195 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28952 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34247 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28763 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32086 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30322 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->