### PR TITLE
Model scale should update according to page scale

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -222,6 +222,8 @@ void HTMLModelElement::didMoveToNewDocument(Document& oldDocument, Document& new
     ActiveDOMObject::didMoveToNewDocument(newDocument);
     HTMLElement::didMoveToNewDocument(oldDocument, newDocument);
     sourcesChanged();
+    registerWithDocument(newDocument);
+    unregisterWithDocument(oldDocument);
 }
 
 // MARK: - Rendering overrides.
@@ -326,6 +328,8 @@ void HTMLModelElement::createModelPlayer()
         m_modelPlayer->setEnvironmentMap(m_environmentMapData.takeAsContiguous().get());
     else if (!m_environmentMapURL.isEmpty())
         environmentMapRequestResource();
+
+    registerWithDocument(document());
 #endif
 }
 
@@ -1183,6 +1187,28 @@ void HTMLModelElement::removedFromAncestor(RemovalType removalType, ContainerNod
         document().unregisterForVisibilityStateChangedCallbacks(*this);
         deleteModelPlayer();
     }
+}
+
+void HTMLModelElement::registerWithDocument(Document& document)
+{
+    document.registerModelElement(*this);
+}
+
+void HTMLModelElement::unregisterWithDocument(Document& document)
+{
+    document.unregisterModelElement(*this);
+}
+
+void HTMLModelElement::pageScaleFactorChanged()
+{
+    Page* page = document().page();
+    if (!page)
+        return;
+
+    if (!m_modelPlayer)
+        return;
+
+    m_modelPlayer->pageScaleFactorChanged(page->pageScaleFactor());
 }
 
 }

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -101,6 +101,8 @@ public:
 
     std::optional<PlatformLayerIdentifier> layerID() const;
 
+    void pageScaleFactorChanged();
+
 #if ENABLE(MODEL_PROCESS)
     RefPtr<ModelContext> modelContext() const;
 
@@ -145,6 +147,9 @@ public:
     bool isDraggableIgnoringAttributes() const final;
 
     bool isInteractive() const;
+
+    void registerWithDocument(Document&);
+    void unregisterWithDocument(Document&);
 
 #if ENABLE(MODEL_PROCESS)
     double playbackRate() const { return m_playbackRate; }

--- a/Source/WebCore/Modules/model-element/ModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.cpp
@@ -135,6 +135,10 @@ void ModelPlayer::renderingAbruptlyStopped()
 {
 }
 
+void ModelPlayer::pageScaleFactorChanged(float)
+{
+}
+
 #endif // ENABLE(MODEL_PROCESS)
 
 }

--- a/Source/WebCore/Modules/model-element/ModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.h
@@ -102,6 +102,7 @@ public:
     virtual void updateStageModeTransform(const TransformationMatrix&);
     virtual void endStageModeInteraction();
     virtual void renderingAbruptlyStopped();
+    virtual void pageScaleFactorChanged(float);
 #endif
 };
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -130,6 +130,7 @@
 #include "HTMLMaybeFormAssociatedCustomElement.h"
 #include "HTMLMediaElement.h"
 #include "HTMLMetaElement.h"
+#include "HTMLModelElement.h"
 #include "HTMLNameCollection.h"
 #include "HTMLPictureElement.h"
 #include "HTMLPlugInElement.h"
@@ -2630,6 +2631,26 @@ void Document::forEachMediaElement(NOESCAPE const Function<void(HTMLMediaElement
     });
 }
 
+#endif
+
+#if ENABLE(MODEL_PROCESS)
+void Document::registerModelElement(HTMLModelElement& element)
+{
+    m_modelElements.add(element);
+}
+
+void Document::unregisterModelElement(HTMLModelElement& element)
+{
+    m_modelElements.remove(element);
+}
+
+void Document::forEachModelElement(NOESCAPE const Function<void(HTMLModelElement&)>& function)
+{
+    ASSERT(!m_modelElements.hasNullReferences());
+    m_modelElements.forEach([&](auto& element) {
+        function(Ref { element });
+    });
+}
 #endif
 
 String Document::nodeName() const

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -170,6 +170,7 @@ class HTMLIFrameElement;
 class HTMLImageElement;
 class HTMLMapElement;
 class HTMLMediaElement;
+class HTMLModelElement;
 class HTMLMetaElement;
 class HTMLVideoElement;
 class HighlightRange;
@@ -1327,6 +1328,11 @@ public:
     void unregisterMediaElement(HTMLMediaElement&);
 #endif
 
+#if ENABLE(MODEL_PROCESS)
+    void registerModelElement(HTMLModelElement&);
+    void unregisterModelElement(HTMLModelElement&);
+#endif
+
     bool requiresUserGestureForAudioPlayback() const;
     bool requiresUserGestureForVideoPlayback() const;
     bool mediaDataLoadsAutomatically() const;
@@ -1849,6 +1855,10 @@ public:
     WEBCORE_EXPORT void forEachMediaElement(NOESCAPE const Function<void(HTMLMediaElement&)>&);
 #endif
 
+#if ENABLE(MODEL_PROCESS)
+    WEBCORE_EXPORT void forEachModelElement(NOESCAPE const Function<void(HTMLModelElement&)>&);
+#endif
+
 #if ENABLE(IOS_TOUCH_EVENTS)
     bool handlingTouchEvent() const { return m_handlingTouchEvent; }
 #endif
@@ -2317,6 +2327,10 @@ private:
 
 #if ENABLE(VIDEO)
     WeakHashSet<HTMLMediaElement> m_mediaElements;
+#endif
+
+#if ENABLE(MODEL_PROCESS)
+    WeakHashSet<HTMLModelElement, WeakPtrImplWithEventTargetData> m_modelElements;
 #endif
 
 #if ENABLE(VIDEO)

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -86,6 +86,7 @@
 #include "HTMLElement.h"
 #include "HTMLImageElement.h"
 #include "HTMLMediaElement.h"
+#include "HTMLModelElement.h"
 #include "HTMLTextAreaElement.h"
 #include "HTMLTextFormControlElement.h"
 #include "HistoryController.h"
@@ -1654,6 +1655,14 @@ void Page::setPageScaleFactor(float scale, const IntPoint& origin, bool inStable
         if (mainFrameView->delegatedScrollingMode() != DelegatedScrollingMode::DelegatedToNativeScrollView)
             mainFrameView->setScrollPosition(origin);
     }
+
+#if ENABLE(MODEL_PROCESS)
+    if (inStableState) {
+        forEachModelElement([] (HTMLModelElement& element) {
+            element.pageScaleFactorChanged();
+        });
+    }
+#endif
 
 #if ENABLE(VIDEO)
     if (inStableState) {
@@ -4411,6 +4420,15 @@ void Page::forEachMediaElement(NOESCAPE const Function<void(HTMLMediaElement&)>&
     UNUSED_PARAM(functor);
 #endif
 }
+
+#if ENABLE(MODEL_PROCESS)
+void Page::forEachModelElement(NOESCAPE const Function<void(HTMLModelElement&)>& functor)
+{
+    forEachDocument([&] (Document& document) {
+        document.forEachModelElement(functor);
+    });
+}
+#endif
 
 void Page::forEachLocalFrame(NOESCAPE const Function<void(LocalFrame&)>& functor)
 {

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1125,6 +1125,9 @@ public:
     bool findMatchingLocalDocument(NOESCAPE const Function<bool(Document&)>&) const;
     void forEachRenderableDocument(NOESCAPE const Function<void(Document&)>&) const;
     void forEachMediaElement(NOESCAPE const Function<void(HTMLMediaElement&)>&);
+#if ENABLE(MODEL_PROCESS)
+    void forEachModelElement(NOESCAPE const Function<void(HTMLModelElement&)>&);
+#endif
     static void forEachDocumentFromMainFrame(const Frame&, NOESCAPE const Function<void(Document&)>&);
     void forEachLocalFrame(NOESCAPE const Function<void(LocalFrame&)>&);
     void forEachWindowEventLoop(NOESCAPE const Function<void(WindowEventLoop&)>&);

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -136,6 +136,7 @@ public:
     void updateStageModeTransform(const WebCore::TransformationMatrix&) final;
     void endStageModeInteraction() final;
     void stageModeInteractionDidUpdateModel();
+    void pageScaleFactorChanged(float) final;
 
     USING_CAN_MAKE_WEAKPTR(WebCore::REModelLoaderClient);
 
@@ -167,6 +168,7 @@ private:
     simd_float3 m_originalBoundingBoxExtents { simd_make_float3(0, 0, 0) };
     float m_pitch { 0 };
     float m_yaw { 0 };
+    float m_pageScale { 1.0f };
 
     RESRT m_transformSRT; // SRT=Scaling/Rotation/Translation. This is stricter than a WebCore::TransformationMatrix.
 

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
@@ -42,6 +42,7 @@ messages -> ModelProcessModelPlayerProxy {
     BeginStageModeTransform(WebCore::TransformationMatrix transform)
     UpdateStageModeTransform(WebCore::TransformationMatrix transform)
     EndStageModeInteraction()
+    PageScaleFactorChanged(float pageScale)
 }
 
 #endif

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -338,9 +338,9 @@ void ModelProcessModelPlayerProxy::loadModel(Ref<WebCore::Model>&& model, WebCor
 
 // MARK: - RE stuff
 
-static inline simd_float2 makeMeterSizeFromPointSize(CGSize pointSize, CGFloat pointsPerMeter)
+static inline simd_float2 makeMeterSizeFromPointSize(CGSize pointSize, CGFloat pointsPerMeter, float pageScale)
 {
-    return simd_make_float2(pointSize.width / pointsPerMeter, pointSize.height / pointsPerMeter);
+    return simd_make_float2(pointSize.width / pointsPerMeter, pointSize.height / pointsPerMeter) / pageScale;
 }
 
 static void computeScaledExtentsAndCenter(simd_float2 boundsOfLayerInMeters, simd_float3& boundingBoxExtents, simd_float3& boundingBoxCenter)
@@ -355,9 +355,9 @@ static void computeScaledExtentsAndCenter(simd_float2 boundsOfLayerInMeters, sim
     }
 }
 
-static RESRT computeSRT(CALayer *layer, simd_float3 originalBoundingBoxExtents, simd_float3 originalBoundingBoxCenter, float boundingRadius, bool isPortal, CGFloat pointsPerMeter, WebCore::StageModeOperation operation, simd_quatf currentModelRotation)
+static RESRT computeSRT(CALayer *layer, simd_float3 originalBoundingBoxExtents, simd_float3 originalBoundingBoxCenter, float boundingRadius, bool isPortal, CGFloat pointsPerMeter, float pageScale, WebCore::StageModeOperation operation, simd_quatf currentModelRotation)
 {
-    auto boundsOfLayerInMeters = makeMeterSizeFromPointSize(layer.bounds.size, pointsPerMeter);
+    auto boundsOfLayerInMeters = makeMeterSizeFromPointSize(layer.bounds.size, pointsPerMeter, pageScale);
     simd_float3 boundingBoxExtents = originalBoundingBoxExtents;
     simd_float3 boundingBoxCenter = originalBoundingBoxCenter;
     computeScaledExtentsAndCenter(boundsOfLayerInMeters, boundingBoxExtents, boundingBoxCenter);
@@ -440,7 +440,7 @@ void ModelProcessModelPlayerProxy::computeTransform(bool setDefaultRotation)
     // FIXME: Use the value of the 'object-fit' property here to compute an appropriate SRT.
     float boundingRadius = [m_modelRKEntity boundingRadius];
     simd_quatf currentModelRotation = setDefaultRotation ? simd_quaternion(0, simd_make_float3(1, 0, 0)) : m_transformSRT.rotation;
-    RESRT newSRT = computeSRT(m_layer.get(), m_originalBoundingBoxExtents, m_originalBoundingBoxCenter, boundingRadius, m_hasPortal, effectivePointsPerMeter(m_layer.get()), m_stageModeOperation, currentModelRotation);
+    RESRT newSRT = computeSRT(m_layer.get(), m_originalBoundingBoxExtents, m_originalBoundingBoxCenter, boundingRadius, m_hasPortal, effectivePointsPerMeter(m_layer.get()), m_pageScale, m_stageModeOperation, currentModelRotation);
     m_transformSRT = newSRT;
 
     notifyModelPlayerOfEntityTransformChange();
@@ -865,6 +865,16 @@ void ModelProcessModelPlayerProxy::applyStageModeOperationToDriver()
         break;
     }
     }
+}
+
+void ModelProcessModelPlayerProxy::pageScaleFactorChanged(float newScale)
+{
+    m_pageScale = newScale;
+    if (!m_model || !m_layer)
+        return;
+
+    computeTransform(false);
+    updateTransform();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -377,6 +377,11 @@ void ModelProcessModelPlayer::renderingAbruptlyStopped()
         m_client->renderingAbruptlyStopped();
 }
 
+void ModelProcessModelPlayer::pageScaleFactorChanged(float pageScale)
+{
+    send(Messages::ModelProcessModelPlayerProxy::PageScaleFactorChanged(pageScale));
+}
+
 }
 
 #endif // ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -111,6 +111,7 @@ private:
     void beginStageModeTransform(const WebCore::TransformationMatrix&) final;
     void updateStageModeTransform(const WebCore::TransformationMatrix&) final;
     void endStageModeInteraction() final;
+    void pageScaleFactorChanged(float) final;
 
     WebCore::ModelPlayerIdentifier m_id;
     WeakPtr<WebPage> m_page;


### PR DESCRIPTION
#### c1d94cf63a0a9efc456886761feb61cab6961d21
<pre>
Model scale should update according to page scale
<a href="https://bugs.webkit.org/show_bug.cgi?id=292467">https://bugs.webkit.org/show_bug.cgi?id=292467</a>
<a href="https://rdar.apple.com/149428478">rdar://149428478</a>

Reviewed by NOBODY (OOPS!).

This PR updates the model transform based on the page scale change. The model
entity for some reason updates incorrectly on two handed window zoom. We need
the model player to update the model fit and then make sure the matrix reflects
that.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::didMoveToNewDocument):
(WebCore::HTMLModelElement::createModelPlayer):
(WebCore::HTMLModelElement::registerWithDocument):
(WebCore::HTMLModelElement::unregisterWithDocument):
(WebCore::HTMLModelElement::pageScaleFactorChanged):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/ModelPlayer.cpp:
(WebCore::ModelPlayer::pageScaleFactorChanged):
* Source/WebCore/Modules/model-element/ModelPlayer.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::registerModelElement):
(WebCore::Document::unregisterModelElement):
(WebCore::Document::forEachModelElement):
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setPageScaleFactor):
(WebCore::Page::forEachModelElement):
* Source/WebCore/page/Page.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::makeMeterSizeFromPointSize):
(WebKit::computeSRT):
(WebKit::ModelProcessModelPlayerProxy::computeTransform):
(WebKit::ModelProcessModelPlayerProxy::pageScaleFactorChanged):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::pageScaleFactorChanged):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1d94cf63a0a9efc456886761feb61cab6961d21

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101894 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21562 "Hash c1d94cf6 for PR 44877 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11878 "Hash c1d94cf6 for PR 44877 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107053 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52528 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103934 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21870 "Hash c1d94cf6 for PR 44877 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30069 "Hash c1d94cf6 for PR 44877 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77585 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34585 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104901 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/21870 "Hash c1d94cf6 for PR 44877 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/11878 "Hash c1d94cf6 for PR 44877 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57922 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/21870 "Hash c1d94cf6 for PR 44877 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/11878 "Hash c1d94cf6 for PR 44877 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51883 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/21870 "Hash c1d94cf6 for PR 44877 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/11878 "Hash c1d94cf6 for PR 44877 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109418 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29027 "Hash c1d94cf6 for PR 44877 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/30069 "Hash c1d94cf6 for PR 44877 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86555 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29388 "Hash c1d94cf6 for PR 44877 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/11878 "Hash c1d94cf6 for PR 44877 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86141 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/11878 "Hash c1d94cf6 for PR 44877 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23198 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28955 "Hash c1d94cf6 for PR 44877 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34250 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28766 "Hash c1d94cf6 for PR 44877 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32089 "Hash c1d94cf6 for PR 44877 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30325 "Hash c1d94cf6 for PR 44877 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->