### PR TITLE
[JSC] MultiGetByVal should be able to return Int32 directly

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2985,7 +2985,9 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         if (node->hasDoubleResult()) {
             // We say SpecFullDouble since it will involve Float16 / Float32 / Float64 TypedArrays.
             setNonCellTypeForNode(node, SpecFullDouble);
-        } else if (node->hasInt52Result())
+        } else if (node->hasInt32Result())
+            setNonCellTypeForNode(node, SpecInt32Only);
+        else if (node->hasInt52Result())
             setNonCellTypeForNode(node, SpecInt52Any);
         else {
             if (mayIncludeNonNumber)

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -1390,6 +1390,7 @@ public:
         case ValuePow:
         case DoubleAsInt32:
         case Int52Rep:
+        case MultiGetByVal:
             return result;
         default:
             return result & ~NodeBytecodeNeedsNegZero;

--- a/Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp
@@ -52,6 +52,7 @@ public:
         bool changed = false;
         changed |= convertValueRepsToUnboxed<DoubleRepUse>();
         changed |= convertValueRepsToUnboxed<Int52RepUse>();
+        changed |= convertValueRepsToUnboxed<Int32Use>();
         return changed;
     }
 
@@ -64,6 +65,9 @@ private:
             for (Node* node : *block) {
                 switch (node->op()) {
                 case ValueRep: {
+                    if constexpr (useKind != DoubleRepUse && useKind != Int52RepUse)
+                        break;
+
                     if (node->child1().useKind() == useKind)
                         candidates.add(node);
                     break;
@@ -136,6 +140,53 @@ private:
                     break;
                 }
 
+                case ValueToInt32: {
+                    if constexpr (useKind != Int32Use)
+                        break;
+
+                    Edge& child1 = node->child1();
+                    switch (child1->op()) {
+                    case MultiGetByVal: {
+                        if (child1->arrayMode().isOutOfBounds())
+                            break;
+
+                        if (child1->arrayMode().isInBoundsSaneChain())
+                            break;
+
+                        if (!bytecodeCanTruncateInteger(child1->arithNodeFlags()))
+                            break;
+
+                        if (!bytecodeCanIgnoreNaNAndInfinity(child1->arithNodeFlags()))
+                            break;
+
+                        if (!bytecodeCanIgnoreNegativeZero(child1->arithNodeFlags()))
+                            break;
+
+                        constexpr ArrayModes supportedArrays = 0
+                            | asArrayModesIgnoringTypedArrays(ArrayWithInt32)
+                            | asArrayModesIgnoringTypedArrays(ArrayWithDouble)
+                            | Int8ArrayMode
+                            | Int16ArrayMode
+                            | Int32ArrayMode
+                            | Uint8ArrayMode
+                            | Uint8ClampedArrayMode
+                            | Uint16ArrayMode
+                            | Uint32ArrayMode
+                            | 0;
+
+                        if (!(child1->arrayModes() & supportedArrays))
+                            break;
+
+                        if (child1->origin.exitOK)
+                            candidates.add(child1.node());
+                        break;
+                    }
+                    default:
+                        break;
+                    }
+                    break;
+                }
+
                 default:
                     break;
                 }
@@ -174,7 +225,7 @@ private:
                 }
 
                 case MultiGetByVal: {
-                    if constexpr (useKind != Int52RepUse)
+                    if constexpr (useKind != Int52RepUse && useKind != Int32Use)
                         break;
 
                     if (candidates.contains(node))
@@ -183,6 +234,9 @@ private:
                 }
 
                 case ValueRep: {
+                    if constexpr (useKind != DoubleRepUse && useKind != Int52RepUse)
+                        break;
+
                     if (candidates.contains(node))
                         usersOf.add(node, Vector<Node*>());
                     break;
@@ -283,6 +337,12 @@ private:
                                     dumpEscape("Phi Incoming JSConstant not a anyint: ", node);
                                 }
                             }
+                            if constexpr (useKind == Int32Use) {
+                                if (!node->asJSValue().isInt32AsAnyInt()) {
+                                    ok = false;
+                                    dumpEscape("Phi Incoming JSConstant not a int32: ", node);
+                                }
+                            }
                             break;
                         }
 
@@ -306,7 +366,7 @@ private:
                         }
 
                         case MultiGetByVal: {
-                            if constexpr (useKind != Int52RepUse) {
+                            if constexpr (useKind != Int52RepUse && useKind != Int32Use) {
                                 ok = false;
                                 dumpEscape("Phi Incoming Get is escaped: ", node);
                                 break;
@@ -321,6 +381,12 @@ private:
                         }
 
                         case ValueRep: {
+                            if constexpr (useKind != DoubleRepUse && useKind != Int52RepUse) {
+                                ok = false;
+                                dumpEscape("Phi Incoming ValueRep not DoubleRepUse / Int52RepUse: ", node);
+                                break;
+                            }
+
                             if (node->child1().useKind() != useKind) {
                                 ok = false;
                                 dumpEscape("Phi Incoming ValueRep not DoubleRepUse / Int52RepUse: ", node);
@@ -386,6 +452,15 @@ private:
                             dumpEscape("Int52Rep escape: ", user);
                             break;
                         }
+                        }
+                        break;
+                    }
+
+                    case ValueToInt32: {
+                        if constexpr (useKind != Int32Use) {
+                            ok = false;
+                            dumpEscape("Int32Use escape: ", user);
+                            break;
                         }
                         break;
                     }
@@ -465,6 +540,11 @@ private:
                             newChild = m_insertionSet.insertConstant(0, originForConstant, jsNumber(number), Int52Constant);
                             break;
                         }
+                        if constexpr (useKind == Int32Use) {
+                            int32_t number = incomingValue->asJSValue().asInt32AsAnyInt();
+                            newChild = m_insertionSet.insertConstant(0, originForConstant, jsNumber(number), JSConstant);
+                            break;
+                        }
                         break;
                     }
                     case ValueRep: {
@@ -505,6 +585,8 @@ private:
                     candidate->setResult(NodeResultDouble);
                 if constexpr (useKind == Int52RepUse)
                     candidate->setResult(NodeResultInt52);
+                if constexpr (useKind == Int32Use)
+                    candidate->setResult(NodeResultInt32);
                 break;
             }
 
@@ -524,7 +606,10 @@ private:
             }
 
             case MultiGetByVal: {
-                candidate->setResult(NodeResultInt52);
+                if constexpr (useKind == Int52RepUse)
+                    candidate->setResult(NodeResultInt52);
+                if constexpr (useKind == Int32Use)
+                    candidate->setResult(NodeResultInt32);
                 resultNode = candidate;
                 break;
             }
@@ -550,12 +635,23 @@ private:
                     break;
                 }
 
+                case ValueToInt32: {
+                    user->convertToIdentityOn(resultNode);
+                    break;
+                }
+
                 case PutHint:
-                    user->child2() = Edge(resultNode, useKind);
+                    if constexpr (useKind != DoubleRepUse && useKind != Int52RepUse)
+                        user->child2() = Edge(resultNode, UntypedUse);
+                    else
+                        user->child2() = Edge(resultNode, useKind);
                     break;
 
                 case MovHint:
-                    user->child1() = Edge(resultNode, useKind);
+                    if constexpr (useKind != DoubleRepUse && useKind != Int52RepUse)
+                        user->child1() = Edge(resultNode, UntypedUse);
+                    else
+                        user->child1() = Edge(resultNode, useKind);
                     break;
 
                 case PutByOffset:


### PR DESCRIPTION
#### c9e6a9e68ba57971a0bd1c4ed267d1291e3df04e
<pre>
[JSC] MultiGetByVal should be able to return Int32 directly
<a href="https://bugs.webkit.org/show_bug.cgi?id=292469">https://bugs.webkit.org/show_bug.cgi?id=292469</a>
<a href="https://rdar.apple.com/problem/150561746">rdar://problem/150561746</a>

Reviewed by Yijia Huang.

We would like to put Int32 trunc operation into MultiGetByVal itself
when we have ValueToInt32(MultiGetByVal) because it would avoid boxing
and unboxing double / non-double into JSValue. This patch detects the
pattern that,

1. MultiGetByVal is used by ValueToInt32
2. MultiGetByVal is only used by ValueToInt32, MovHint, and PutHint
3. MultiGetByVal is annotated with bytecodeCanTruncateInteger,
   bytecodeCanIgnoreNaNAndInfinity, and bytecodeCanIgnoreNegativeZero.

Then we can safely trunc in MultiGetByVal instead of ValueToInt32.

* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp:
(JSC::DFG::ValueRepReductionPhase::run):
(JSC::DFG::ValueRepReductionPhase::convertValueRepsToUnboxed):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileMultiGetByVal):

Canonical link: <a href="https://commits.webkit.org/294673@main">https://commits.webkit.org/294673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ee361df9e1f2518e637d9457bab59854edba616

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22242 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107734 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53210 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30748 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78025 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35005 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105579 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17468 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92582 "Found 1 new API test failure: TestWebKitAPI.WebKit.PrintFrame (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58360 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17306 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10611 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52567 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/95244 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87117 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10680 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110109 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/101182 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29705 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21903 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87003 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30069 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88777 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86608 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31433 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9163 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23955 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16665 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29633 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34945 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124816 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29444 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34625 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32767 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31003 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->