### PR TITLE
Do more [[likely]] / [[unlikely]] adoption in WebCore/

### DIFF
--- a/Source/WebCore/contentextensions/DFABytecodeInterpreter.cpp
+++ b/Source/WebCore/contentextensions/DFABytecodeInterpreter.cpp
@@ -250,7 +250,7 @@ auto DFABytecodeInterpreter::interpret(const String& urlString, ResourceFlags fl
 {
     CString urlCString;
     std::span<const LChar> url;
-    if (LIKELY(urlString.is8Bit()))
+    if (urlString.is8Bit()) [[likely]]
         url = urlString.span8();
     else {
         // FIXME: Stuffing a UTF-8 string into a Latin1 buffer seems wrong.

--- a/Source/WebCore/crypto/SubtleCrypto.cpp
+++ b/Source/WebCore/crypto/SubtleCrypto.cpp
@@ -128,13 +128,13 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
     auto& value = std::get<JSC::Strong<JSC::JSObject>>(algorithmIdentifier);
 
     auto params = convertDictionary<CryptoAlgorithmParameters>(state, value.get());
-    if (UNLIKELY(params.hasException(scope)))
+    if (params.hasException(scope)) [[unlikely]]
         return Exception { ExceptionCode::ExistingExceptionError };
     if (params.returnValue().name == "RSAES-PKCS1-v1_5"_s || params.returnValue().name == "rsaes-pkcs1-v1_5"_s)
         return Exception { ExceptionCode::NotSupportedError, "RSAES-PKCS1-v1_5 support is deprecated"_s };
 
     auto identifier = CryptoAlgorithmRegistry::singleton().identifier(params.returnValue().name);
-    if (UNLIKELY(!identifier))
+    if (!identifier) [[unlikely]]
         return Exception { ExceptionCode::NotSupportedError };
 
     if (*identifier == CryptoAlgorithmIdentifier::Ed25519 && !isSafeCurvesEnabled(state))
@@ -152,7 +152,7 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
             return Exception { ExceptionCode::NotSupportedError, "RSAES-PKCS1-v1_5 support is deprecated"_s };
         case CryptoAlgorithmIdentifier::RSA_OAEP: {
             auto params = convertDictionary<CryptoAlgorithmRsaOaepParams>(state, value.get());
-            if (UNLIKELY(params.hasException(scope)))
+            if (params.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
             result = makeUnique<CryptoAlgorithmRsaOaepParams>(params.releaseReturnValue());
             break;
@@ -163,21 +163,21 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
             [[fallthrough]];
         case CryptoAlgorithmIdentifier::AES_CBC: {
             auto params = convertDictionary<CryptoAlgorithmAesCbcCfbParams>(state, value.get());
-            if (UNLIKELY(params.hasException(scope)))
+            if (params.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
             result = makeUnique<CryptoAlgorithmAesCbcCfbParams>(params.releaseReturnValue());
             break;
         }
         case CryptoAlgorithmIdentifier::AES_CTR: {
             auto params = convertDictionary<CryptoAlgorithmAesCtrParams>(state, value.get());
-            if (UNLIKELY(params.hasException(scope)))
+            if (params.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
             result = makeUnique<CryptoAlgorithmAesCtrParams>(params.releaseReturnValue());
             break;
         }
         case CryptoAlgorithmIdentifier::AES_GCM: {
             auto params = convertDictionary<CryptoAlgorithmAesGcmParams>(state, value.get());
-            if (UNLIKELY(params.hasException(scope)))
+            if (params.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
             result = makeUnique<CryptoAlgorithmAesGcmParams>(params.releaseReturnValue());
             break;
@@ -196,10 +196,10 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
             break;
         case CryptoAlgorithmIdentifier::ECDSA: {
             auto params = convertDictionary<CryptoAlgorithmEcdsaParams>(state, value.get());
-            if (UNLIKELY(params.hasException(scope)))
+            if (params.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
             auto hashIdentifier = toHashIdentifier(state, params.returnValue().hash);
-            if (UNLIKELY(hashIdentifier.hasException()))
+            if (hashIdentifier.hasException()) [[unlikely]]
                 return hashIdentifier.releaseException();
             auto paramsAndHash = params.releaseReturnValue();
             paramsAndHash.hashIdentifier = hashIdentifier.releaseReturnValue();
@@ -208,7 +208,7 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
         }
         case CryptoAlgorithmIdentifier::RSA_PSS: {
             auto params = convertDictionary<CryptoAlgorithmRsaPssParams>(state, value.get());
-            if (UNLIKELY(params.hasException(scope)))
+            if (params.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
             result = makeUnique<CryptoAlgorithmRsaPssParams>(params.releaseReturnValue());
             break;
@@ -239,10 +239,10 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
         case CryptoAlgorithmIdentifier::RSA_PSS:
         case CryptoAlgorithmIdentifier::RSA_OAEP: {
             auto params = convertDictionary<CryptoAlgorithmRsaHashedKeyGenParams>(state, value.get());
-            if (UNLIKELY(params.hasException(scope)))
+            if (params.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
             auto hashIdentifier = toHashIdentifier(state, params.returnValue().hash);
-            if (UNLIKELY(hashIdentifier.hasException()))
+            if (hashIdentifier.hasException()) [[unlikely]]
                 return hashIdentifier.releaseException();
             auto paramsAndHash = params.releaseReturnValue();
             paramsAndHash.hashIdentifier = hashIdentifier.releaseReturnValue();
@@ -258,17 +258,17 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
         case CryptoAlgorithmIdentifier::AES_GCM:
         case CryptoAlgorithmIdentifier::AES_KW: {
             auto params = convertDictionary<CryptoAlgorithmAesKeyParams>(state, value.get());
-            if (UNLIKELY(params.hasException(scope)))
+            if (params.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
             result = makeUnique<CryptoAlgorithmAesKeyParams>(params.releaseReturnValue());
             break;
         }
         case CryptoAlgorithmIdentifier::HMAC: {
             auto params = convertDictionary<CryptoAlgorithmHmacKeyParams>(state, value.get());
-            if (UNLIKELY(params.hasException(scope)))
+            if (params.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
             auto hashIdentifier = toHashIdentifier(state, params.returnValue().hash);
-            if (UNLIKELY(hashIdentifier.hasException()))
+            if (hashIdentifier.hasException()) [[unlikely]]
                 return hashIdentifier.releaseException();
             auto paramsAndHash = params.releaseReturnValue();
             paramsAndHash.hashIdentifier = hashIdentifier.releaseReturnValue();
@@ -278,7 +278,7 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
         case CryptoAlgorithmIdentifier::ECDSA:
         case CryptoAlgorithmIdentifier::ECDH: {
             auto params = convertDictionary<CryptoAlgorithmEcKeyParams>(state, value.get());
-            if (UNLIKELY(params.hasException(scope)))
+            if (params.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
             result = makeUnique<CryptoAlgorithmEcKeyParams>(params.releaseReturnValue());
             break;
@@ -306,7 +306,7 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
             newValue->putDirect(vm, Identifier::fromString(vm, "publicKey"_s), publicValue);
 
             auto params = convertDictionary<CryptoAlgorithmEcdhKeyDeriveParams>(state, newValue);
-            if (UNLIKELY(params.hasException(scope)))
+            if (params.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
             result = makeUnique<CryptoAlgorithmEcdhKeyDeriveParams>(params.releaseReturnValue());
             break;
@@ -320,17 +320,17 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
             newValue->putDirect(vm, Identifier::fromString(vm, "publicKey"_s), publicValue);
 
             auto params = convertDictionary<CryptoAlgorithmX25519Params>(state, newValue);
-            if (UNLIKELY(params.hasException(scope)))
+            if (params.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
             result = makeUnique<CryptoAlgorithmX25519Params>(params.releaseReturnValue());
             break;
         }
         case CryptoAlgorithmIdentifier::HKDF: {
             auto params = convertDictionary<CryptoAlgorithmHkdfParams>(state, value.get());
-            if (UNLIKELY(params.hasException(scope)))
+            if (params.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
             auto hashIdentifier = toHashIdentifier(state, params.returnValue().hash);
-            if (UNLIKELY(hashIdentifier.hasException()))
+            if (hashIdentifier.hasException()) [[unlikely]]
                 return hashIdentifier.releaseException();
             auto paramsAndHash = params.releaseReturnValue();
             paramsAndHash.hashIdentifier = hashIdentifier.releaseReturnValue();
@@ -339,10 +339,10 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
         }
         case CryptoAlgorithmIdentifier::PBKDF2: {
             auto params = convertDictionary<CryptoAlgorithmPbkdf2Params>(state, value.get());
-            if (UNLIKELY(params.hasException(scope)))
+            if (params.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
             auto hashIdentifier = toHashIdentifier(state, params.returnValue().hash);
-            if (UNLIKELY(hashIdentifier.hasException()))
+            if (hashIdentifier.hasException()) [[unlikely]]
                 return hashIdentifier.releaseException();
             auto paramsAndHash = params.releaseReturnValue();
             paramsAndHash.hashIdentifier = hashIdentifier.releaseReturnValue();
@@ -361,10 +361,10 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
         case CryptoAlgorithmIdentifier::RSA_PSS:
         case CryptoAlgorithmIdentifier::RSA_OAEP: {
             auto params = convertDictionary<CryptoAlgorithmRsaHashedImportParams>(state, value.get());
-            if (UNLIKELY(params.hasException(scope)))
+            if (params.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
             auto hashIdentifier = toHashIdentifier(state, params.returnValue().hash);
-            if (UNLIKELY(hashIdentifier.hasException()))
+            if (hashIdentifier.hasException()) [[unlikely]]
                 return hashIdentifier.releaseException();
             auto paramsAndHash = params.releaseReturnValue();
             paramsAndHash.hashIdentifier = hashIdentifier.releaseReturnValue();
@@ -384,10 +384,10 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
             break;
         case CryptoAlgorithmIdentifier::HMAC: {
             auto params = convertDictionary<CryptoAlgorithmHmacKeyParams>(state, value.get());
-            if (UNLIKELY(params.hasException(scope)))
+            if (params.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
             auto hashIdentifier = toHashIdentifier(state, params.returnValue().hash);
-            if (UNLIKELY(hashIdentifier.hasException()))
+            if (hashIdentifier.hasException()) [[unlikely]]
                 return hashIdentifier.releaseException();
             auto paramsAndHash = params.releaseReturnValue();
             paramsAndHash.hashIdentifier = hashIdentifier.releaseReturnValue();
@@ -397,7 +397,7 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
         case CryptoAlgorithmIdentifier::ECDSA:
         case CryptoAlgorithmIdentifier::ECDH: {
             auto params = convertDictionary<CryptoAlgorithmEcKeyParams>(state, value.get());
-            if (UNLIKELY(params.hasException(scope)))
+            if (params.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
             result = makeUnique<CryptoAlgorithmEcKeyParams>(params.releaseReturnValue());
             break;
@@ -440,17 +440,17 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
         case CryptoAlgorithmIdentifier::AES_GCM:
         case CryptoAlgorithmIdentifier::AES_KW: {
             auto params = convertDictionary<CryptoAlgorithmAesKeyParams>(state, value.get());
-            if (UNLIKELY(params.hasException(scope)))
+            if (params.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
             result = makeUnique<CryptoAlgorithmAesKeyParams>(params.releaseReturnValue());
             break;
         }
         case CryptoAlgorithmIdentifier::HMAC: {
             auto params = convertDictionary<CryptoAlgorithmHmacKeyParams>(state, value.get());
-            if (UNLIKELY(params.hasException(scope)))
+            if (params.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
             auto hashIdentifier = toHashIdentifier(state, params.returnValue().hash);
-            if (UNLIKELY(hashIdentifier.hasException()))
+            if (hashIdentifier.hasException()) [[unlikely]]
                 return hashIdentifier.releaseException();
             auto paramsAndHash = params.releaseReturnValue();
             paramsAndHash.hashIdentifier = hashIdentifier.releaseReturnValue();
@@ -1216,13 +1216,13 @@ void SubtleCrypto::unwrapKey(JSC::JSGlobalObject& state, KeyFormat format, Buffe
     }
 
     auto importAlgorithm = CryptoAlgorithmRegistry::singleton().create(unwrappedKeyAlgorithm->identifier);
-    if (UNLIKELY(!importAlgorithm)) {
+    if (!importAlgorithm) [[unlikely]] {
         promise->reject(Exception { ExceptionCode::NotSupportedError });
         return;
     }
 
     auto unwrapAlgorithm = CryptoAlgorithmRegistry::singleton().create(unwrappingKey.algorithmIdentifier());
-    if (UNLIKELY(!unwrapAlgorithm)) {
+    if (!unwrapAlgorithm) [[unlikely]] {
         promise->reject(Exception { ExceptionCode::NotSupportedError });
         return;
     }
@@ -1256,7 +1256,7 @@ void SubtleCrypto::unwrapKey(JSC::JSGlobalObject& state, KeyFormat format, Buffe
                 return;
             }
             auto jwkConversionResult = convert<IDLDictionary<JsonWebKey>>(state, jwkObject);
-            if (UNLIKELY(jwkConversionResult.hasException(scope)))
+            if (jwkConversionResult.hasException(scope)) [[unlikely]]
                 return;
             auto jwk = jwkConversionResult.releaseReturnValue();
 

--- a/Source/WebCore/crypto/cocoa/CryptoKeyECMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyECMac.cpp
@@ -167,7 +167,7 @@ Vector<uint8_t> CryptoKeyEC::platformExportRaw() const
 #else
     Vector<uint8_t> result(expectedSize);
     size_t size = result.size();
-    if (UNLIKELY(CCECCryptorExportKey(kCCImportKeyBinary, result.data(), &size, ccECKeyPublic, platformKey().get()) || size != expectedSize))
+    if (CCECCryptorExportKey(kCCImportKeyBinary, result.data(), &size, ccECKeyPublic, platformKey().get()) || size != expectedSize) [[unlikely]]
         return { };
     return result;
 #endif
@@ -235,7 +235,7 @@ bool CryptoKeyEC::platformAddFieldElements(JsonWebKey& jwk) const
         ASSERT_NOT_REACHED();
         return false;
     }
-    if (UNLIKELY((result.size() != publicKeySize) && (result.size() != privateKeySize)))
+    if ((result.size() != publicKeySize) && (result.size() != privateKeySize)) [[unlikely]]
         return false;
     jwk.x = base64URLEncodeToString(result.subspan(1, keySizeInBytes));
     jwk.y = base64URLEncodeToString(result.subspan(keySizeInBytes + 1, keySizeInBytes));
@@ -246,11 +246,11 @@ bool CryptoKeyEC::platformAddFieldElements(JsonWebKey& jwk) const
     size_t size = result.size();
     switch (type()) {
     case CryptoKeyType::Public:
-        if (UNLIKELY(CCECCryptorExportKey(kCCImportKeyBinary, result.data(), &size, ccECKeyPublic, platformKey().get())))
+        if (CCECCryptorExportKey(kCCImportKeyBinary, result.data(), &size, ccECKeyPublic, platformKey().get())) [[unlikely]]
             return false;
         break;
     case CryptoKeyType::Private:
-        if (UNLIKELY(CCECCryptorExportKey(kCCImportKeyBinary, result.data(), &size, ccECKeyPrivate, platformKey().get())))
+        if (CCECCryptorExportKey(kCCImportKeyBinary, result.data(), &size, ccECKeyPrivate, platformKey().get())) [[unlikely]]
             return false;
         break;
     default:
@@ -258,7 +258,7 @@ bool CryptoKeyEC::platformAddFieldElements(JsonWebKey& jwk) const
         return false;
     }
 
-    if (UNLIKELY((size != publicKeySize) && (size != privateKeySize)))
+    if ((size != publicKeySize) && (size != privateKeySize)) [[unlikely]]
         return false;
     jwk.x = base64URLEncodeToString(result.subspan(1, keySizeInBytes));
     jwk.y = base64URLEncodeToString(result.subspan(keySizeInBytes + 1, keySizeInBytes));
@@ -346,7 +346,7 @@ Vector<uint8_t> CryptoKeyEC::platformExportSpki() const
     keyBytes = WTFMove(rv.result);
     keySize = expectedKeySize;
 #else
-    if (UNLIKELY(CCECCryptorExportKey(kCCImportKeyBinary, keyBytes.data(), &keySize, ccECKeyPublic, platformKey().get()) || keySize != expectedKeySize))
+    if (CCECCryptorExportKey(kCCImportKeyBinary, keyBytes.data(), &keySize, ccECKeyPublic, platformKey().get()) || keySize != expectedKeySize) [[unlikely]]
         return { };
 #endif
     // The following adds SPKI header to a raw EC public key.
@@ -455,7 +455,7 @@ Vector<uint8_t> CryptoKeyEC::platformExportPkcs8() const
     keyBytes = WTFMove(rv.result);
 #else
     size_t keySize = keyBytes.size();
-    if (UNLIKELY(CCECCryptorExportKey(kCCImportKeyBinary, keyBytes.data(), &keySize, ccECKeyPrivate, platformKey().get()) || keySize != expectedKeySize))
+    if (CCECCryptorExportKey(kCCImportKeyBinary, keyBytes.data(), &keySize, ccECKeyPrivate, platformKey().get()) || keySize != expectedKeySize) [[unlikely]]
         return { };
 #endif
     // The following addes PKCS8 header to a raw EC private key.

--- a/Source/WebCore/crypto/gcrypt/CryptoKeyOKPGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoKeyOKPGCrypt.cpp
@@ -89,7 +89,7 @@ static std::optional<std::pair<Vector<uint8_t>, Vector<uint8_t>>> gcryptGenerate
 
     auto q = mpiData(qMpi);
     auto d = mpiData(dMpi);
-    if (UNLIKELY(!q || !d))
+    if (!q || !d) [[unlikely]]
         return std::nullopt;
     return std::make_pair(WTFMove(*q), WTFMove(*d));
 }
@@ -100,12 +100,12 @@ static std::optional<std::pair<Vector<uint8_t>, Vector<uint8_t>>> gcryptGenerate
     PAL::GCrypt::Handle<gcry_mpi_t> mpi(gcry_mpi_new(256));
     gcry_mpi_randomize(mpi, 256, GCRY_STRONG_RANDOM);
     auto q = mpiData(mpi);
-    if (UNLIKELY(!q))
+    if (!q) [[unlikely]]
         return std::nullopt;
 
     // public key being X25519(a, 9), as defined in [RFC7748], section 6.1.
     auto d = GCrypt::RFC7748::X25519(*q, GCrypt::RFC7748::c_X25519BasePointU);
-    if (UNLIKELY(!d))
+    if (!d) [[unlikely]]
         return std::nullopt;
 
     return std::make_pair(WTFMove(*q), WTFMove(*d));

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -165,7 +165,7 @@ SelectorSpecificity simpleSelectorSpecificity(const CSSSelector& simpleSelector,
 {
     ASSERT_WITH_MESSAGE(!simpleSelector.isForPage(), "At the time of this writing, page selectors are not treated as real selectors that are matched. The value computed here only account for real selectors.");
 
-    if (UNLIKELY(simpleSelector.isImplicit()))
+    if (simpleSelector.isImplicit()) [[unlikely]]
         return 0;
 
     switch (simpleSelector.match()) {

--- a/Source/WebCore/css/CSSStyleProperties.cpp
+++ b/Source/WebCore/css/CSSStyleProperties.cpp
@@ -434,7 +434,7 @@ ExceptionOr<void> PropertySetCSSStyleProperties::setProperty(const String& prope
         return { };
 
     bool changed;
-    if (UNLIKELY(propertyID == CSSPropertyCustom))
+    if (propertyID == CSSPropertyCustom) [[unlikely]]
         changed = m_propertySet->setCustomProperty(propertyName, value, cssParserContext(), important ? IsImportant::Yes : IsImportant::No);
     else
         changed = m_propertySet->setProperty(propertyID, value, cssParserContext(), important ? IsImportant::Yes : IsImportant::No);

--- a/Source/WebCore/css/CSSStyleSheetObservableArray.cpp
+++ b/Source/WebCore/css/CSSStyleSheetObservableArray.cpp
@@ -53,7 +53,7 @@ bool CSSStyleSheetObservableArray::setValueAt(JSC::JSGlobalObject* lexicalGlobal
     RELEASE_ASSERT(index <= m_sheets.size());
 
     auto sheetConversionResult = convert<IDLInterface<CSSStyleSheet>>(*lexicalGlobalObject, value);
-    if (UNLIKELY(sheetConversionResult.hasException(scope)))
+    if (sheetConversionResult.hasException(scope)) [[unlikely]]
         return false;
 
     if (auto exception = shouldThrowWhenAddingSheet(*sheetConversionResult.returnValue())) {

--- a/Source/WebCore/css/CSSToStyleMap.cpp
+++ b/Source/WebCore/css/CSSToStyleMap.cpp
@@ -618,7 +618,7 @@ void CSSToStyleMap::mapNinePieceImageWidth(const CSSBorderImageWidthValue& value
 
 LengthBox CSSToStyleMap::mapNinePieceImageQuad(const CSSValue& value)
 {
-    if (LIKELY(value.isQuad()))
+    if (value.isQuad()) [[likely]]
         return mapNinePieceImageQuad(value.quad());
 
     // Values coming from CSS Typed OM may not have been converted to a Quad yet.

--- a/Source/WebCore/css/DOMCSSPaintWorklet.cpp
+++ b/Source/WebCore/css/DOMCSSPaintWorklet.cpp
@@ -75,7 +75,7 @@ void PaintWorklet::addModule(const String& moduleURL, WorkletOptions&&, DOMPromi
     // https://bugs.webkit.org/show_bug.cgi?id=191136
     // PaintWorklets don't have access to any sensitive APIs so we don't bother tracking taintedness there.
     auto maybeContext = PaintWorkletGlobalScope::tryCreate(*document, ScriptSourceCode(moduleURL, JSC::SourceTaintedOrigin::Untainted));
-    if (UNLIKELY(!maybeContext)) {
+    if (!maybeContext) [[unlikely]] {
         promise.reject(Exception { ExceptionCode::OutOfMemoryError });
         return;
     }

--- a/Source/WebCore/css/SelectorFilter.cpp
+++ b/Source/WebCore/css/SelectorFilter.cpp
@@ -104,7 +104,7 @@ void SelectorFilter::pushParent(Element* parent)
 
 void SelectorFilter::pushParentInitializingIfNeeded(Element& parent)
 {
-    if (UNLIKELY(m_parentStack.isEmpty())) {
+    if (m_parentStack.isEmpty()) [[unlikely]] {
         initializeParentStack(parent);
         return;
     }

--- a/Source/WebCore/css/StyleAttributeMutationScope.h
+++ b/Source/WebCore/css/StyleAttributeMutationScope.h
@@ -58,7 +58,7 @@ public:
         if (m_mutationRecipients && m_mutationRecipients->isOldValueRequested())
             shouldReadOldValue = true;
 
-        if (UNLIKELY(m_element->isDefinedCustomElement())) {
+        if (m_element->isDefinedCustomElement()) [[unlikely]] {
             auto* reactionQueue = m_element->reactionQueue();
             if (reactionQueue && reactionQueue->observesStyleAttribute()) {
                 m_isCustomElement = true;

--- a/Source/WebCore/css/parser/CSSTokenizer.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizer.cpp
@@ -95,7 +95,7 @@ CSSTokenizer::CSSTokenizer(const String& string, CSSParserObserverWrapper* wrapp
 
     // To avoid resizing we err on the side of reserving too much space.
     // Most strings we tokenize have about 3.5 to 5 characters per token.
-    if (UNLIKELY(!m_tokens.tryReserveInitialCapacity(string.length() / 3))) {
+    if (!m_tokens.tryReserveInitialCapacity(string.length() / 3)) [[unlikely]] {
         // When constructionSuccessPtr is null, our policy is to crash on failure.
         RELEASE_ASSERT(constructionSuccessPtr);
         *constructionSuccessPtr = false;
@@ -111,7 +111,7 @@ CSSTokenizer::CSSTokenizer(const String& string, CSSParserObserverWrapper* wrapp
             if (wrapper)
                 wrapper->addComment(offset, m_input.offset(), m_tokens.size());
         } else {
-            if (UNLIKELY(!m_tokens.tryAppend(token))) {
+            if (!m_tokens.tryAppend(token)) [[unlikely]] {
                 // When constructionSuccessPtr is null, our policy is to crash on failure.
                 RELEASE_ASSERT(constructionSuccessPtr);
                 *constructionSuccessPtr = false;

--- a/Source/WebCore/dom/CharacterData.cpp
+++ b/Source/WebCore/dom/CharacterData.cpp
@@ -111,7 +111,7 @@ void CharacterData::parserAppendData(StringView string)
     notifyParentAfterChange(childChange);
 
     auto mutationRecipients = MutationObserverInterestGroup::createForCharacterDataMutation(*this);
-    if (UNLIKELY(mutationRecipients))
+    if (mutationRecipients) [[unlikely]]
         mutationRecipients->enqueueMutationRecord(MutationRecord::createCharacterData(*this, oldData));
 }
 

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -107,7 +107,7 @@ ALWAYS_INLINE auto ContainerNode::removeAllChildrenWithScriptAssertion(ChildChan
     ASSERT(children.isEmpty());
     collectChildNodes(*this, children);
 
-    if (UNLIKELY(isDocumentFragmentForInnerOuterHTML())) {
+    if (isDocumentFragmentForInnerOuterHTML()) [[unlikely]] {
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
         RELEASE_ASSERT(!connectedSubframeCount() && !hasRareData() && !wrapper());
         bool hadElementChild = false;
@@ -130,7 +130,7 @@ ALWAYS_INLINE auto ContainerNode::removeAllChildrenWithScriptAssertion(ChildChan
     } else {
         ASSERT(source == ChildChange::Source::Parser);
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
-        if (UNLIKELY(document().hasMutationObserversOfType(MutationObserverOptionType::ChildList))) {
+        if (document().hasMutationObserversOfType(MutationObserverOptionType::ChildList)) [[unlikely]] {
             ChildListMutationScope mutation(*this);
             for (auto& child : children)
                 mutation.willRemoveChild(child.get());
@@ -150,7 +150,7 @@ ALWAYS_INLINE auto ContainerNode::removeAllChildrenWithScriptAssertion(ChildChan
     {
         Style::ChildChangeInvalidation styleInvalidation(*this, childChange);
 
-        if (UNLIKELY(isShadowRoot() || isInShadowTree()))
+        if (isShadowRoot() || isInShadowTree()) [[unlikely]]
             containingShadowRoot()->willRemoveAllChildren(*this);
 
         Ref<Document> { document() }->nodeChildrenWillBeRemoved(*this);
@@ -241,7 +241,7 @@ ALWAYS_INLINE bool ContainerNode::removeNodeWithScriptAssertion(Node& childToRem
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
         Style::ChildChangeInvalidation styleInvalidation(*this, childChange);
 
-        if (UNLIKELY(isShadowRoot() || isInShadowTree()))
+        if (isShadowRoot() || isInShadowTree()) [[unlikely]]
             containingShadowRoot()->resolveSlotsBeforeNodeInsertionOrRemoval();
 
         Ref<Document> { document() }->nodeWillBeRemoved(childToRemove);
@@ -312,7 +312,7 @@ static ALWAYS_INLINE void executeNodeInsertionWithScriptAssertion(ContainerNode&
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
         Style::ChildChangeInvalidation styleInvalidation(containerNode, childChange);
 
-        if (UNLIKELY(containerNode.isShadowRoot() || containerNode.isInShadowTree()))
+        if (containerNode.isShadowRoot() || containerNode.isInShadowTree()) [[unlikely]]
             containerNode.containingShadowRoot()->resolveSlotsBeforeNodeInsertionOrRemoval();
 
         doNodeInsertion();
@@ -339,7 +339,7 @@ static ALWAYS_INLINE void executeParserNodeInsertionIntoIsolatedTreeWithoutNotif
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
         ASSERT(!containerNode.inRenderedDocument());
 
-        if (UNLIKELY(containerNode.isShadowRoot() || containerNode.isInShadowTree()))
+        if (containerNode.isShadowRoot() || containerNode.isInShadowTree()) [[unlikely]]
             containerNode.containingShadowRoot()->resolveSlotsBeforeNodeInsertionOrRemoval();
 
         doNodeInsertion();
@@ -504,7 +504,7 @@ ExceptionOr<void> ContainerNode::ensurePreInsertionValidity(Node& newChild, Node
 // https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity when node is a new DocumentFragment created in "converting nodes into a node"
 ExceptionOr<void> ContainerNode::ensurePreInsertionValidityForPhantomDocumentFragment(NodeVector& newChildren, Node* refChild)
 {
-    if (UNLIKELY(is<Document>(*this))) {
+    if (is<Document>(*this)) [[unlikely]] {
         bool hasSeenElement = false;
         for (auto& child : newChildren) {
             if (!is<Element>(child))
@@ -763,7 +763,7 @@ void ContainerNode::removeBetween(Node* previousChild, Node* nextChild, Node& ol
 
     destroyRenderTreeIfNeeded(oldChild);
 
-    if (UNLIKELY(hasShadowRootContainingSlots()))
+    if (hasShadowRootContainingSlots()) [[unlikely]]
         shadowRoot()->willRemoveAssignedNode(oldChild);
 
     if (nextChild) {

--- a/Source/WebCore/dom/CustomElementReactionQueue.h
+++ b/Source/WebCore/dom/CustomElementReactionQueue.h
@@ -228,7 +228,7 @@ public:
 
     ALWAYS_INLINE ~CustomElementReactionStack()
     {
-        if (UNLIKELY(!m_queue.isEmpty()))
+        if (!m_queue.isEmpty()) [[unlikely]]
             m_queue.processQueue(m_state);
         s_currentProcessingStack = m_previousProcessingStack;
     }

--- a/Source/WebCore/dom/CustomElementRegistry.h
+++ b/Source/WebCore/dom/CustomElementRegistry.h
@@ -71,7 +71,7 @@ public:
     {
         if (element.usesNullCustomElementRegistry())
             return nullptr;
-        if (UNLIKELY(element.usesScopedCustomElementRegistryMap()))
+        if (element.usesScopedCustomElementRegistryMap()) [[unlikely]]
             return scopedCustomElementRegistryMap().get(element);
         return element.treeScope().customElementRegistry();
     }
@@ -82,7 +82,7 @@ public:
             ASSERT(is<Element>(node) || node.isTreeScope() || node.isDocumentFragment());
             return nullptr;
         }
-        if (auto* element = dynamicDowncast<Element>(node); UNLIKELY(element && element->usesScopedCustomElementRegistryMap()))
+        if (auto* element = dynamicDowncast<Element>(node); element && element->usesScopedCustomElementRegistryMap()) [[unlikely]]
             return scopedCustomElementRegistryMap().get(*element);
         return treeScope.customElementRegistry();
     }

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1161,7 +1161,7 @@ void Document::setMarkupUnsafe(const String& markup, OptionSet<ParserContentPoli
         auto body = HTMLBodyElement::create(*this);
         html->appendChild(body);
         body->beginParsingChildren();
-        if (LIKELY(tryFastParsingHTMLFragment(StringView { markup }.substring(markup.find(isNotASCIIWhitespace<UChar>)), *this, body, body, policy))) {
+        if (tryFastParsingHTMLFragment(StringView { markup }.substring(markup.find(isNotASCIIWhitespace<UChar>)), *this, body, body, policy)) [[likely]] {
             body->finishParsingChildren();
             auto head = HTMLHeadElement::create(*this);
             html->insertBefore(head, body.ptr());
@@ -1518,7 +1518,7 @@ template<typename NameType>
 static ExceptionOr<Ref<Element>> createHTMLElementWithNameValidation(Document& document, const NameType& name, CustomElementRegistry* registry)
 {
     RefPtr element = HTMLElementFactory::createKnownElement(name, document);
-    if (LIKELY(element))
+    if (element) [[likely]]
         return Ref<Element> { element.releaseNonNull() };
 
     if (!registry)
@@ -1529,7 +1529,7 @@ static ExceptionOr<Ref<Element>> createHTMLElementWithNameValidation(Document& d
             return elementInterface->constructElementWithFallback(document, *registry, name);
     }
 
-    if (UNLIKELY(!isValidHTMLElementName(name)))
+    if (!isValidHTMLElementName(name)) [[unlikely]]
         return Exception { ExceptionCode::InvalidCharacterError };
 
     return Ref<Element> { createUpgradeCandidateElement(document, registry, name) };
@@ -1539,7 +1539,7 @@ ExceptionOr<Ref<Element>> Document::createElementForBindings(const AtomString& n
 {
     Ref document = *this;
     RefPtr<CustomElementRegistry> registry;
-    if (UNLIKELY(argument)) {
+    if (argument) [[unlikely]] {
         if (auto* options = std::get_if<ElementCreationOptions>(&*argument))
             registry = options->customElementRegistry;
     }
@@ -1559,7 +1559,7 @@ ExceptionOr<Ref<Element>> Document::createElementForBindings(const AtomString& n
 
     if (result.hasException())
         return result;
-    if (UNLIKELY(registry && registry->isScoped())) {
+    if (registry && registry->isScoped()) [[unlikely]] {
         Ref element = result.releaseReturnValue();
         CustomElementRegistry::addToScopedCustomElementRegistryMap(element, *registry);
         return element;
@@ -1736,7 +1736,7 @@ Ref<Element> Document::createElement(const QualifiedName& name, bool createdByPa
     // FIXME: Use registered namespaces and look up in a hash to find the right factory.
     if (name.namespaceURI() == xhtmlNamespaceURI) {
         element = HTMLElementFactory::createKnownElement(name, *this, nullptr, createdByParser);
-        if (UNLIKELY(!element))
+        if (!element) [[unlikely]]
             element = createFallbackHTMLElement(*this, registry, name);
     } else if (name.namespaceURI() == SVGNames::svgNamespaceURI)
         element = SVGElementFactory::createElement(name, *this, createdByParser);
@@ -1750,7 +1750,7 @@ Ref<Element> Document::createElement(const QualifiedName& name, bool createdByPa
     else
         element = Element::create(name, *this);
 
-    if (UNLIKELY(registry && registry->isScoped()))
+    if (registry && registry->isScoped()) [[unlikely]]
         CustomElementRegistry::addToScopedCustomElementRegistryMap(*element, *registry);
 
     if (!registry && usesNullCustomElementRegistry())
@@ -1878,7 +1878,7 @@ static ALWAYS_INLINE CustomElementNameValidationStatus validateCustomElementName
         return CustomElementNameValidationStatus::FirstCharacterIsNotLowercaseASCIILetter;
 
     bool containsHyphen = false;
-    if (LIKELY(localName.is8Bit())) {
+    if (localName.is8Bit()) [[likely]] {
         for (auto character : localName.string().span8()) {
             switch (customElementNameCharacterKind(character)) {
             case CustomElementNameCharacterKind::Invalid:
@@ -1949,7 +1949,7 @@ ExceptionOr<Ref<Element>> Document::createElementNS(const AtomString& namespaceU
 {
     Ref document = *this;
     RefPtr<CustomElementRegistry> registry;
-    if (UNLIKELY(argument)) {
+    if (argument) [[unlikely]] {
         if (auto* options = std::get_if<ElementCreationOptions>(&*argument))
             registry = options->customElementRegistry;
     }
@@ -1967,7 +1967,7 @@ ExceptionOr<Ref<Element>> Document::createElementNS(const AtomString& namespaceU
     })();
 
     auto result = [&]() -> ExceptionOr<Ref<Element>> {
-        if (LIKELY(opportunisticallyMatchedBuiltinElement))
+        if (opportunisticallyMatchedBuiltinElement) [[likely]]
             return opportunisticallyMatchedBuiltinElement.releaseNonNull();
 
         auto parseResult = Document::parseQualifiedName(namespaceURI, qualifiedName);
@@ -1985,7 +1985,7 @@ ExceptionOr<Ref<Element>> Document::createElementNS(const AtomString& namespaceU
 
     if (result.hasException())
         return result;
-    if (UNLIKELY(registry && registry->isScoped())) {
+    if (registry && registry->isScoped()) [[unlikely]] {
         Ref element = result.releaseReturnValue();
         CustomElementRegistry::addToScopedCustomElementRegistryMap(element, *registry);
         return element;
@@ -2479,7 +2479,7 @@ void Document::setTitle(String&& title)
         Ref titleElement = *m_titleElement;
         titleElement->setTextContent(String { title });
         CheckedPtr textManipulationController = textManipulationControllerIfExists();
-        if (UNLIKELY(textManipulationController)) {
+        if (textManipulationController) [[unlikely]] {
             if (!oldTitle)
                 textManipulationController->didAddOrCreateRendererForNode(titleElement);
             else if (*oldTitle != title)
@@ -3888,7 +3888,7 @@ ExceptionOr<Document&> Document::openForBindings(Document* entryDocument, const 
         return Exception { ExceptionCode::InvalidStateError };
 
     auto result = open(entryDocument);
-    if (UNLIKELY(result.hasException()))
+    if (result.hasException()) [[unlikely]]
         return result.releaseException();
 
     return *this;
@@ -4308,7 +4308,7 @@ ExceptionOr<void> Document::write(Document* entryDocument, SegmentedString&& tex
 
     if (!hasInsertionPoint) {
         auto result = open(entryDocument);
-        if (UNLIKELY(result.hasException()))
+        if (result.hasException()) [[unlikely]]
             return result.releaseException();
     }
 
@@ -7188,7 +7188,7 @@ ExceptionOr<std::pair<AtomString, AtomString>> Document::parseQualifiedName(cons
     unsigned colonPosition = 0;
 
     bool isValidLocalName = qualifiedName.is8Bit() && isValidNameASCIIWithoutColon(qualifiedName.span8());
-    if (LIKELY(isValidLocalName))
+    if (isValidLocalName) [[likely]]
         return std::pair<AtomString, AtomString> { { }, { qualifiedName } };
 
     for (unsigned i = 0; i < length; ) {
@@ -7266,7 +7266,7 @@ bool Document::shouldMaskURLForBindingsInternal(const URL& urlToMask) const
         return false;
 
     RefPtr page = this->page();
-    if (UNLIKELY(!page))
+    if (!page) [[unlikely]]
         return false;
 
     auto& maskedURLSchemes = page->maskedURLSchemes();
@@ -7569,7 +7569,7 @@ static Editor::Command command(Document* document, const String& commandName, bo
 
 ExceptionOr<bool> Document::execCommand(const String& commandName, bool userInterface, const Variant<String, RefPtr<TrustedHTML>>& value)
 {
-    if (UNLIKELY(!isHTMLDocument() && !isXHTMLDocument()))
+    if (!isHTMLDocument() && !isXHTMLDocument()) [[unlikely]]
         return Exception { ExceptionCode::InvalidStateError, "execCommand is only supported on HTML documents."_s };
 
     auto stringValueHolder = WTF::switchOn(value,
@@ -7592,35 +7592,35 @@ ExceptionOr<bool> Document::execCommand(const String& commandName, bool userInte
 
 ExceptionOr<bool> Document::queryCommandEnabled(const String& commandName)
 {
-    if (UNLIKELY(!isHTMLDocument() && !isXHTMLDocument()))
+    if (!isHTMLDocument() && !isXHTMLDocument()) [[unlikely]]
         return Exception { ExceptionCode::InvalidStateError, "queryCommandEnabled is only supported on HTML documents."_s };
     return command(this, commandName).isEnabled();
 }
 
 ExceptionOr<bool> Document::queryCommandIndeterm(const String& commandName)
 {
-    if (UNLIKELY(!isHTMLDocument() && !isXHTMLDocument()))
+    if (!isHTMLDocument() && !isXHTMLDocument()) [[unlikely]]
         return Exception { ExceptionCode::InvalidStateError, "queryCommandIndeterm is only supported on HTML documents."_s };
     return command(this, commandName).state() == TriState::Indeterminate;
 }
 
 ExceptionOr<bool> Document::queryCommandState(const String& commandName)
 {
-    if (UNLIKELY(!isHTMLDocument() && !isXHTMLDocument()))
+    if (!isHTMLDocument() && !isXHTMLDocument()) [[unlikely]]
         return Exception { ExceptionCode::InvalidStateError, "queryCommandState is only supported on HTML documents."_s };
     return command(this, commandName).state() == TriState::True;
 }
 
 ExceptionOr<bool> Document::queryCommandSupported(const String& commandName)
 {
-    if (UNLIKELY(!isHTMLDocument() && !isXHTMLDocument()))
+    if (!isHTMLDocument() && !isXHTMLDocument()) [[unlikely]]
         return Exception { ExceptionCode::InvalidStateError, "queryCommandSupported is only supported on HTML documents."_s };
     return command(this, commandName).isSupported();
 }
 
 ExceptionOr<String> Document::queryCommandValue(const String& commandName)
 {
-    if (UNLIKELY(!isHTMLDocument() && !isXHTMLDocument()))
+    if (!isHTMLDocument() && !isXHTMLDocument()) [[unlikely]]
         return Exception { ExceptionCode::InvalidStateError, "queryCommandValue is only supported on HTML documents."_s };
     return command(this, commandName).value();
 }
@@ -8424,7 +8424,7 @@ void Document::pendingTasksTimerFired()
 EventLoopTaskGroup& Document::eventLoop()
 {
     ASSERT(isMainThread());
-    if (UNLIKELY(!m_documentTaskGroup)) {
+    if (!m_documentTaskGroup) [[unlikely]] {
         m_documentTaskGroup = makeUnique<EventLoopTaskGroup>(windowEventLoop());
         if (activeDOMObjectsAreStopped())
             m_documentTaskGroup->markAsReadyToStop();
@@ -8437,7 +8437,7 @@ EventLoopTaskGroup& Document::eventLoop()
 WindowEventLoop& Document::windowEventLoop()
 {
     ASSERT(isMainThread());
-    if (UNLIKELY(!m_eventLoop)) {
+    if (!m_eventLoop) [[unlikely]] {
         m_eventLoop = WindowEventLoop::eventLoopForSecurityOrigin(securityOrigin());
         m_eventLoop->addAssociatedContext(*this);
     }
@@ -9568,9 +9568,9 @@ Document& Document::ensureTemplateDocument()
 
 Ref<DocumentFragment> Document::documentFragmentForInnerOuterHTML()
 {
-    if (UNLIKELY(!m_documentFragmentForInnerOuterHTML))
+    if (!m_documentFragmentForInnerOuterHTML) [[unlikely]]
         m_documentFragmentForInnerOuterHTML = DocumentFragment::createForInnerOuterHTML(*this);
-    else if (UNLIKELY(m_documentFragmentForInnerOuterHTML->hasChildNodes()))
+    else if (m_documentFragmentForInnerOuterHTML->hasChildNodes()) [[unlikely]]
         Ref { *m_documentFragmentForInnerOuterHTML }->removeChildren();
     return *m_documentFragmentForInnerOuterHTML;
 }
@@ -9653,7 +9653,7 @@ OptionSet<StyleColorOptions> Document::styleColorOptions(const RenderStyle* styl
 
 CompositeOperator Document::compositeOperatorForBackgroundColor(const Color& color, const RenderElement& renderer) const
 {
-    if (LIKELY(!settings().punchOutWhiteBackgroundsInDarkMode() || !Color::isWhiteColor(color) || !renderer.useDarkAppearance()))
+    if (!settings().punchOutWhiteBackgroundsInDarkMode() || !Color::isWhiteColor(color) || !renderer.useDarkAppearance()) [[likely]]
         return CompositeOperator::SourceOver;
 
     RefPtr frameView = view();

--- a/Source/WebCore/dom/DocumentInlines.h
+++ b/Source/WebCore/dom/DocumentInlines.h
@@ -150,7 +150,7 @@ bool Document::hasNodeIterators() const
 
 inline void Document::invalidateAccessKeyCache()
 {
-    if (UNLIKELY(m_accessKeyCache))
+    if (m_accessKeyCache) [[unlikely]]
         invalidateAccessKeyCacheSlowCase();
 }
 
@@ -165,14 +165,14 @@ inline bool Document::isSameOriginAsTopDocument() const { return protectedSecuri
 
 inline bool Document::shouldMaskURLForBindings(const URL& urlToMask) const
 {
-    if (LIKELY(urlToMask.protocolIsInHTTPFamily()))
+    if (urlToMask.protocolIsInHTTPFamily()) [[likely]]
         return false;
     return shouldMaskURLForBindingsInternal(urlToMask);
 }
 
 inline const URL& Document::maskedURLForBindingsIfNeeded(const URL& url) const
 {
-    if (UNLIKELY(shouldMaskURLForBindings(url)))
+    if (shouldMaskURLForBindings(url)) [[unlikely]]
         return maskedURLForBindings();
     return url;
 }

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -1043,7 +1043,7 @@ inline void Element::clearAfterPseudoElement()
 inline void Element::disconnectFromIntersectionObservers()
 {
     auto* observerData = intersectionObserverDataIfExists();
-    if (LIKELY(!observerData))
+    if (!observerData) [[likely]]
         return;
     disconnectFromIntersectionObserversSlow(*observerData);
 }
@@ -1051,7 +1051,7 @@ inline void Element::disconnectFromIntersectionObservers()
 inline void Element::disconnectFromResizeObservers()
 {
     auto* observerData = resizeObserverDataIfExists();
-    if (LIKELY(!observerData))
+    if (!observerData) [[likely]]
         return;
     disconnectFromResizeObserversSlow(*observerData);
 }

--- a/Source/WebCore/dom/ElementInlines.h
+++ b/Source/WebCore/dom/ElementInlines.h
@@ -227,7 +227,7 @@ inline bool isInTopLayerOrBackdrop(const RenderStyle& style, const Element* elem
 inline void Element::hideNonce()
 {
     // In the common case, Elements don't have a nonce parameter to hide.
-    if (LIKELY(!isConnected() || !hasAttributeWithoutSynchronization(HTMLNames::nonceAttr)))
+    if (!isConnected() || !hasAttributeWithoutSynchronization(HTMLNames::nonceAttr)) [[likely]]
         return;
     hideNonceSlow();
 }

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -395,7 +395,7 @@ inline RefPtr<ShadowRoot> Node::protectedShadowRoot() const
 inline void Element::removeShadowRoot()
 {
     RefPtr shadowRoot = this->shadowRoot();
-    if (LIKELY(!shadowRoot))
+    if (!shadowRoot) [[likely]]
         return;
     removeShadowRootSlow(*shadowRoot);
 }

--- a/Source/WebCore/dom/EventContext.cpp
+++ b/Source/WebCore/dom/EventContext.cpp
@@ -79,7 +79,7 @@ void EventContext::handleLocalEvents(Event& event, EventInvokePhase phase) const
         return;
     }
 
-    if (UNLIKELY(m_contextNodeIsFormElement)) {
+    if (m_contextNodeIsFormElement) [[unlikely]] {
         ASSERT(is<HTMLFormElement>(*m_node));
         auto& eventNames = WebCore::eventNames();
         if ((event.type() == eventNames.submitEvent || event.type() == eventNames.resetEvent)

--- a/Source/WebCore/dom/EventListenerMap.cpp
+++ b/Source/WebCore/dom/EventListenerMap.cpp
@@ -135,7 +135,7 @@ bool EventListenerMap::add(const AtomString& eventType, Ref<EventListener>&& lis
 static bool removeListenerFromVector(EventListenerVector& listeners, EventListener& listener, bool useCapture)
 {
     size_t indexOfRemovedListener = findListener(listeners, listener, useCapture);
-    if (UNLIKELY(indexOfRemovedListener == notFound))
+    if (indexOfRemovedListener == notFound) [[unlikely]]
         return false;
 
     listeners[indexOfRemovedListener]->markAsRemoved();

--- a/Source/WebCore/dom/EventPath.cpp
+++ b/Source/WebCore/dom/EventPath.cpp
@@ -113,7 +113,7 @@ void EventPath::buildPath(Node& originalTarget, Event& event)
             }
 
             RefPtr parent = node->parentNode();
-            if (UNLIKELY(!parent)) {
+            if (!parent) [[unlikely]] {
                 // https://dom.spec.whatwg.org/#interface-document
                 if (auto* document = dynamicDowncast<Document>(*node); document && event.type() != eventNames().loadEvent) {
                     ASSERT(target);
@@ -125,7 +125,7 @@ void EventPath::buildPath(Node& originalTarget, Event& event)
                 return;
             }
 
-            if (RefPtr shadowRootOfParent = parent->shadowRoot(); UNLIKELY(shadowRootOfParent)) {
+            if (RefPtr shadowRootOfParent = parent->shadowRoot(); shadowRootOfParent) [[unlikely]] {
                 if (RefPtr assignedSlot = shadowRootOfParent->findAssignedSlot(*node)) {
                     if (shadowRootOfParent->mode() != ShadowRootMode::Open)
                         closedShadowDepth++;
@@ -167,18 +167,18 @@ void EventPath::setRelatedTarget(Node& origin, Node& relatedNode)
 
         Ref currentTarget = *context.node();
         Ref currentTreeScope = currentTarget->treeScope();
-        if (UNLIKELY(previousTreeScope && currentTreeScope.ptr() != previousTreeScope))
+        if (previousTreeScope && currentTreeScope.ptr() != previousTreeScope) [[unlikely]]
             retargeter.moveToNewTreeScope(previousTreeScope.get(), currentTreeScope);
 
         RefPtr currentRelatedNode = retargeter.currentNode(currentTarget);
-        if (UNLIKELY(!originIsRelatedTarget && context.target() == currentRelatedNode)) {
+        if (!originIsRelatedTarget && context.target() == currentRelatedNode) [[unlikely]] {
             m_path.shrink(contextIndex);
             break;
         }
 
         context.setRelatedTarget(WTFMove(currentRelatedNode));
 
-        if (UNLIKELY(originIsRelatedTarget && context.node() == rootNodeInOriginTreeScope.ptr())) {
+        if (originIsRelatedTarget && context.node() == rootNodeInOriginTreeScope.ptr()) [[unlikely]] {
             m_path.shrink(contextIndex + 1);
             break;
         }
@@ -211,7 +211,7 @@ void EventPath::retargetTouch(EventContext::TouchListType type, const Touch& tou
     for (auto& context : m_path) {
         Ref currentTarget = *context.node();
         Ref currentTreeScope = currentTarget->treeScope();
-        if (UNLIKELY(previousTreeScope && currentTreeScope.ptr() != previousTreeScope))
+        if (previousTreeScope && currentTreeScope.ptr() != previousTreeScope) [[unlikely]]
             retargeter.moveToNewTreeScope(previousTreeScope.get(), currentTreeScope);
 
         if (context.isTouchEventContext()) {
@@ -309,7 +309,7 @@ RelatedNodeRetargeter::RelatedNodeRetargeter(Ref<Node>&& relatedNode, Node& targ
 {
     auto& targetTreeScope = target.treeScope();
     RefPtr currentTreeScope = &m_relatedNode->treeScope();
-    if (LIKELY(currentTreeScope == &targetTreeScope && target.isConnected() && m_relatedNode->isConnected()))
+    if (currentTreeScope == &targetTreeScope && target.isConnected() && m_relatedNode->isConnected()) [[likely]]
         return;
 
     if (&currentTreeScope->documentScope() != &targetTreeScope.documentScope()

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -334,7 +334,7 @@ void EventTarget::innerInvokeEventListeners(Event& event, EventListenerVector li
     InspectorInstrumentation::willDispatchEvent(context, event);
 
     for (auto& registeredListener : listeners) {
-        if (UNLIKELY(registeredListener->wasRemoved()))
+        if (registeredListener->wasRemoved()) [[unlikely]]
             continue;
 
         if (phase == EventInvokePhase::Capturing && !registeredListener->useCapture())
@@ -357,7 +357,7 @@ void EventTarget::innerInvokeEventListeners(Event& event, EventListenerVector li
         JSC::EnsureStillAliveScope wrapperProtector(callback->wrapper());
         JSC::EnsureStillAliveScope jsFunctionProtector(callback->jsFunction());
 
-        if (UNLIKELY(event.isAutofillEvent())) {
+        if (event.isAutofillEvent()) [[unlikely]] {
             if (!worldForDOMObject(*callback->jsFunction()).allowAutofill())
                 continue; // webkitrequestautofill only fires in a world with autofill capability.
         }

--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -112,7 +112,7 @@ static const AtomString& imageOverlayBlockClass()
 bool hasOverlay(const HTMLElement& element)
 {
     RefPtr shadowRoot = element.shadowRoot();
-    if (LIKELY(!shadowRoot || shadowRoot->mode() != ShadowRootMode::UserAgent))
+    if (!shadowRoot || shadowRoot->mode() != ShadowRootMode::UserAgent) [[likely]]
         return false;
 
     return shadowRoot->hasElementWithId(imageOverlayElementIdentifier());

--- a/Source/WebCore/dom/InternalObserverLast.cpp
+++ b/Source/WebCore/dom/InternalObserverLast.cpp
@@ -66,7 +66,7 @@ private:
     {
         InternalObserver::complete();
 
-        if (UNLIKELY(!m_lastValue))
+        if (!m_lastValue) [[unlikely]]
             return protectedPromise()->reject(Exception { ExceptionCode::RangeError, "No values in Observable"_s });
 
         protectedPromise()->resolve<IDLAny>(m_lastValue.getValue());

--- a/Source/WebCore/dom/InternalObserverReduce.cpp
+++ b/Source/WebCore/dom/InternalObserverReduce.cpp
@@ -91,7 +91,7 @@ private:
     {
         InternalObserver::complete();
 
-        if (UNLIKELY(!m_accumulator)) {
+        if (!m_accumulator) [[unlikely]] {
             protectedPromise()->reject(Exception { ExceptionCode::TypeError, "No inital value for Observable with no values"_s });
             return;
         }
@@ -114,7 +114,7 @@ private:
         , m_callback(WTFMove(callback))
         , m_promise(WTFMove(promise))
     {
-        if (UNLIKELY(!initialValue.isUndefined()))
+        if (!initialValue.isUndefined()) [[unlikely]]
             m_accumulator.setWeakly(initialValue);
     }
 

--- a/Source/WebCore/dom/MessageEvent.cpp
+++ b/Source/WebCore/dom/MessageEvent.cpp
@@ -75,7 +75,7 @@ auto MessageEvent::create(JSC::JSGlobalObject& globalObject, Ref<SerializedScrip
     bool didFail = false;
 
     auto deserialized = data->deserialize(globalObject, &globalObject, ports, SerializationErrorMode::NonThrowing, &didFail);
-    if (UNLIKELY(catchScope.exception()))
+    if (catchScope.exception()) [[unlikely]]
         deserialized = jsUndefined();
     JSC::Strong<JSC::Unknown> strongData(vm, deserialized);
 

--- a/Source/WebCore/dom/Microtasks.cpp
+++ b/Source/WebCore/dom/Microtasks.cpp
@@ -71,17 +71,17 @@ void MicrotaskQueue::runJSMicrotask(JSC::JSGlobalObject* globalObject, JSC::VM& 
 {
     auto scope = DECLARE_CATCH_SCOPE(vm);
 
-    if (UNLIKELY(!task.job().isObject()))
+    if (!task.job().isObject()) [[unlikely]]
         return;
 
     auto* job = JSC::asObject(task.job());
 
-    if (UNLIKELY(!scope.clearExceptionExceptTermination()))
+    if (!scope.clearExceptionExceptTermination()) [[unlikely]]
         return;
 
     auto* lexicalGlobalObject = job->globalObject();
     auto callData = JSC::getCallData(job);
-    if (UNLIKELY(!scope.clearExceptionExceptTermination()))
+    if (!scope.clearExceptionExceptTermination()) [[unlikely]]
         return;
     ASSERT(callData.type != JSC::CallData::Type::None);
 
@@ -99,9 +99,9 @@ void MicrotaskQueue::runJSMicrotask(JSC::JSGlobalObject* globalObject, JSC::VM& 
     }
 
     NakedPtr<JSC::Exception> returnedException = nullptr;
-    if (LIKELY(!vm.hasPendingTerminationException())) {
+    if (!vm.hasPendingTerminationException()) [[likely]] {
         JSC::profiledCall(lexicalGlobalObject, JSC::ProfilingReason::Microtask, job, callData, JSC::jsUndefined(), JSC::ArgList { std::bit_cast<JSC::EncodedJSValue*>(task.arguments().data()), count }, returnedException);
-        if (UNLIKELY(returnedException))
+        if (returnedException) [[unlikely]]
             reportException(lexicalGlobalObject, returnedException);
         scope.clearExceptionExceptTermination();
     }
@@ -128,7 +128,7 @@ void MicrotaskQueue::performMicrotaskCheckpoint()
         m_microtaskQueue.performMicrotaskCheckpoint(vm,
             [&](JSC::QueuedTask& task) ALWAYS_INLINE_LAMBDA {
                 RefPtr dispatcher = downcast<WebCoreMicrotaskDispatcher>(task.dispatcher());
-                if (UNLIKELY(!dispatcher))
+                if (!dispatcher) [[unlikely]]
                     return JSC::QueuedTask::Result::Discard;
 
                 auto result = dispatcher->currentRunnability();
@@ -167,14 +167,14 @@ void MicrotaskQueue::performMicrotaskCheckpoint()
             }
 
             checkpointTask->execute();
-            if (UNLIKELY(!catchScope.clearExceptionExceptTermination()))
+            if (!catchScope.clearExceptionExceptTermination()) [[unlikely]]
                 break; // Encountered termination.
         }
     }
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint (step 4).
     Ref { *m_eventLoop }->forEachAssociatedContext([vm = vm.copyRef()](auto& context) {
-        if (UNLIKELY(vm->executionForbidden()))
+        if (vm->executionForbidden()) [[unlikely]]
             return;
         auto catchScope = DECLARE_CATCH_SCOPE(vm);
         if (CheckedPtr tracker = context.rejectedPromiseTracker())

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -657,7 +657,7 @@ ExceptionOr<NodeVector> Node::convertNodesOrStringsIntoNodeVector(FixedVector<No
         ASSERT(std::holds_alternative<RefPtr<Node>>(variant));
         RefPtr node = WTFMove(std::get<RefPtr<Node>>(variant));
         ASSERT(node);
-        if (auto* fragment = dynamicDowncast<DocumentFragment>(node.get()); UNLIKELY(fragment)) {
+        if (auto* fragment = dynamicDowncast<DocumentFragment>(node.get()); fragment) [[unlikely]] {
             for (auto* child = fragment->firstChild(); child; child = child->nextSibling())
                 nodeVector.append(*child);
         } else
@@ -824,7 +824,7 @@ Ref<Node> Node::cloneNode(bool deep)
 
 ExceptionOr<Ref<Node>> Node::cloneNodeForBindings(bool deep)
 {
-    if (UNLIKELY(isShadowRoot()))
+    if (isShadowRoot()) [[unlikely]]
         return Exception { ExceptionCode::NotSupportedError };
     return cloneNode(deep);
 }
@@ -2297,7 +2297,7 @@ void Node::moveTreeToNewScope(Node& root, TreeScope& oldScope, TreeScope& newSco
             if (newScopeIsUAShadowTree)
                 node.setEventTargetFlag(EventTargetFlag::HasBeenInUserAgentShadowTree);
             node.setTreeScope(newScope);
-            if (UNLIKELY(!node.hasRareData()))
+            if (!node.hasRareData()) [[likely]]
                 return;
             if (auto* nodeLists = node.rareData()->nodeLists())
                 nodeLists->adoptTreeScope();
@@ -2361,7 +2361,7 @@ void Node::moveNodeToNewDocumentSlowCase(Document& oldDocument, Document& newDoc
     }
 
     auto* textManipulationController = oldDocument.textManipulationControllerIfExists();
-    if (UNLIKELY(textManipulationController))
+    if (textManipulationController) [[unlikely]]
         textManipulationController->removeNode(*this);
 
     if (hasEventTargetData()) {

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -890,7 +890,7 @@ ALWAYS_INLINE void Node::setStyleFlag(NodeStyleFlag flag)
 inline void EventTarget::ref()
 {
     auto* node = dynamicDowncast<Node>(*this);
-    if (LIKELY(node))
+    if (node) [[likely]]
         node->ref();
     else
         refEventTarget();
@@ -899,7 +899,7 @@ inline void EventTarget::ref()
 inline void EventTarget::deref()
 {
     auto* node = dynamicDowncast<Node>(*this);
-    if (LIKELY(node))
+    if (node) [[likely]]
         node->deref();
     else
         derefEventTarget();

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -258,7 +258,7 @@ ALWAYS_INLINE void SelectorDataList::executeFastPathForIdSelector(const Containe
     ASSERT(idSelector);
 
     const AtomString& idToMatch = idSelector->value();
-    if (UNLIKELY(rootNode.treeScope().containsMultipleElementsWithId(idToMatch))) {
+    if (rootNode.treeScope().containsMultipleElementsWithId(idToMatch)) [[unlikely]] {
         auto* elements = rootNode.treeScope().getAllElementsById(idToMatch);
         ASSERT(elements);
         bool rootNodeIsTreeScopeRoot = rootNode.isTreeScope();
@@ -301,7 +301,7 @@ static ContainerNode& filterRootById(ContainerNode& rootNode, const CSSSelector&
         if (canBeUsedForIdFastPath(*selector)) {
             const AtomString& idToMatch = selector->value();
             if (RefPtr<ContainerNode> searchRoot = rootNode.treeScope().getElementById(idToMatch)) {
-                if (LIKELY(!rootNode.treeScope().containsMultipleElementsWithId(idToMatch))) {
+                if (!rootNode.treeScope().containsMultipleElementsWithId(idToMatch)) [[likely]] {
                     if (inAdjacentChain)
                         searchRoot = searchRoot->parentNode();
                     if (searchRoot && (rootNode.isTreeScope() || searchRoot->isInclusiveDescendantOf(rootNode)))

--- a/Source/WebCore/dom/SlotAssignment.cpp
+++ b/Source/WebCore/dom/SlotAssignment.cpp
@@ -80,7 +80,7 @@ static HTMLSlotElement* findSlotElement(ShadowRoot& shadowRoot, const AtomString
 static HTMLSlotElement* nextSlotElementSkippingSubtree(ContainerNode& startingNode, ContainerNode* skippedSubtree)
 {
     auto nextNode = [&](Node& node) {
-        if (UNLIKELY(&node == skippedSubtree))
+        if (&node == skippedSubtree) [[unlikely]]
             return NodeTraversal::nextSkippingChildren(node);
         return NodeTraversal::next(node);
     };
@@ -324,7 +324,7 @@ void NamedSlotAssignment::didChangeSlot(const AtomString& slotAttrValue, ShadowR
         slotElement->updateAccessibilityOnSlotChange();
     }
 
-    if (UNLIKELY(InspectorInstrumentation::hasFrontends())) {
+    if (InspectorInstrumentation::hasFrontends()) [[unlikely]] {
         for (auto& weakAssignedNode : assignedNodes) {
             if (RefPtr assignedNode = weakAssignedNode.get())
                 InspectorInstrumentation::didChangeAssignedSlot(*assignedNode);
@@ -417,7 +417,7 @@ void NamedSlotAssignment::assignSlots(ShadowRoot& shadowRoot)
     for (auto& entry : m_slots) {
         auto assignedNodes = std::exchange(entry.value->assignedNodes, { });
 
-        if (UNLIKELY(InspectorInstrumentation::hasFrontends())) {
+        if (InspectorInstrumentation::hasFrontends()) [[unlikely]] {
             for (auto& weakAssignedNode : assignedNodes) {
                 if (RefPtr assignedNode = weakAssignedNode.get())
                     InspectorInstrumentation::didChangeAssignedSlot(*assignedNode);

--- a/Source/WebCore/dom/SlotAssignment.h
+++ b/Source/WebCore/dom/SlotAssignment.h
@@ -187,31 +187,31 @@ inline void SlotAssignment::willRemoveAllChildren()
 
 inline void ShadowRoot::resolveSlotsBeforeNodeInsertionOrRemoval()
 {
-    if (UNLIKELY(m_slotAssignment))
+    if (m_slotAssignment) [[unlikely]]
         m_slotAssignment->resolveSlotsBeforeNodeInsertionOrRemoval();
 }
 
 inline void ShadowRoot::willRemoveAllChildren(ContainerNode&)
 {
-    if (UNLIKELY(m_slotAssignment))
+    if (m_slotAssignment) [[unlikely]]
         m_slotAssignment->willRemoveAllChildren();
 }
 
 inline void ShadowRoot::didRemoveAllChildrenOfShadowHost()
 {
-    if (UNLIKELY(m_slotAssignment))
+    if (m_slotAssignment) [[unlikely]]
         m_slotAssignment->didRemoveAllChildrenOfShadowHost(*this);
 }
 
 inline void ShadowRoot::didMutateTextNodesOfShadowHost()
 {
-    if (UNLIKELY(m_slotAssignment))
+    if (m_slotAssignment) [[unlikely]]
         m_slotAssignment->didMutateTextNodesOfShadowHost(*this);
 }
 
 inline void ShadowRoot::hostChildElementDidChange(const Element& childElement)
 {
-    if (UNLIKELY(m_slotAssignment))
+    if (m_slotAssignment) [[unlikely]]
         m_slotAssignment->hostChildElementDidChange(childElement, *this);
 }
 

--- a/Source/WebCore/dom/Text.cpp
+++ b/Source/WebCore/dom/Text.cpp
@@ -241,7 +241,7 @@ void Text::setDataAndUpdate(const String& newData, unsigned offsetOfReplacedData
     if (!offsetOfReplacedData) {
         Ref document = this->document();
         CheckedPtr textManipulationController = document->textManipulationControllerIfExists();
-        if (UNLIKELY(textManipulationController && oldData != newData))
+        if (textManipulationController && oldData != newData) [[unlikely]]
             textManipulationController->didUpdateContentForNode(*this);
     }
 }

--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -238,7 +238,7 @@ void TreeScope::removeElementByName(const AtomString& name, Element& element)
 Ref<Node> TreeScope::retargetToScope(Node& node) const
 {
     auto& scope = node.treeScope();
-    if (LIKELY(this == &scope || !node.isInShadowTree()))
+    if (this == &scope || !node.isInShadowTree()) [[likely]]
         return node;
     ASSERT(is<ShadowRoot>(scope.rootNode()));
 
@@ -612,7 +612,7 @@ RadioButtonGroups& TreeScope::radioButtonGroups()
 
 CSSStyleSheetObservableArray& TreeScope::ensureAdoptedStyleSheets()
 {
-    if (UNLIKELY(!m_adoptedStyleSheets))
+    if (!m_adoptedStyleSheets) [[unlikely]]
         m_adoptedStyleSheets = CSSStyleSheetObservableArray::create(m_rootNode.get());
     return *m_adoptedStyleSheets;
 }

--- a/Source/WebCore/dom/WindowEventLoop.cpp
+++ b/Source/WebCore/dom/WindowEventLoop.cpp
@@ -76,7 +76,7 @@ Ref<WindowEventLoop> WindowEventLoop::eventLoopForSecurityOrigin(const SecurityO
         return create({ });
 
     auto addResult = windowEventLoopMap().add(key, nullptr);
-    if (UNLIKELY(addResult.isNewEntry)) {
+    if (addResult.isNewEntry) [[unlikely]] {
         auto newEventLoop = create(key);
         addResult.iterator->value = newEventLoop.ptr();
         return newEventLoop;

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -675,7 +675,7 @@ void FrameSelection::nodeWillBeRemoved(Node& node)
         removingNodeRemovesPosition(node, m_selection.base()), removingNodeRemovesPosition(node, m_selection.extent()),
         removingNodeRemovesPosition(node, m_selection.start()), removingNodeRemovesPosition(node, m_selection.end()));
 
-    if (UNLIKELY(node.contains(m_previousCaretNode.get()))) {
+    if (node.contains(m_previousCaretNode.get())) [[unlikely]] {
         m_previousCaretNode = m_selection.start().anchorNode();
         setCaretRectNeedsUpdate();
     }

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -172,10 +172,12 @@ static inline void appendCharactersReplacingEntitiesInternal(StringBuilder& resu
     for (size_t i = 0; i < length; ++i) {
         CharacterType character = text[i];
         uint8_t substitution = character < std::size(entityMap) ? entityMap[character] : static_cast<uint8_t>(EntitySubstitutionIndex::Null);
-        if (UNLIKELY(substitution != EntitySubstitutionIndex::Null) && entityMask.contains(*entitySubstitutionList[substitution].mask)) {
-            result.appendSubstring(source, offset + positionAfterLastEntity, i - positionAfterLastEntity);
-            result.append(entitySubstitutionList[substitution].characters);
-            positionAfterLastEntity = i + 1;
+        if (substitution != EntitySubstitutionIndex::Null) [[unlikely]] {
+            if (entityMask.contains(*entitySubstitutionList[substitution].mask)) {
+                result.appendSubstring(source, offset + positionAfterLastEntity, i - positionAfterLastEntity);
+                result.append(entitySubstitutionList[substitution].characters);
+                positionAfterLastEntity = i + 1;
+            }
         }
     }
     result.appendSubstring(source, offset + positionAfterLastEntity, length - positionAfterLastEntity);

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -404,35 +404,35 @@ TextIterator::~TextIterator() = default;
 // FIXME: Use ComposedTreeIterator instead. These functions are more expensive because they might do O(n) work.
 static inline Node* firstChild(TextIteratorBehaviors options, Node& node)
 {
-    if (UNLIKELY(options.contains(TextIteratorBehavior::TraversesFlatTree)))
+    if (options.contains(TextIteratorBehavior::TraversesFlatTree)) [[unlikely]]
         return firstChildInComposedTreeIgnoringUserAgentShadow(node);
     return node.firstChild();
 }
 
 static inline Node* nextSibling(TextIteratorBehaviors options, Node& node)
 {
-    if (UNLIKELY(options.contains(TextIteratorBehavior::TraversesFlatTree)))
+    if (options.contains(TextIteratorBehavior::TraversesFlatTree)) [[unlikely]]
         return nextSiblingInComposedTreeIgnoringUserAgentShadow(node);
     return node.nextSibling();
 }
 
 static inline Node* nextNode(TextIteratorBehaviors options, Node& node)
 {
-    if (UNLIKELY(options.contains(TextIteratorBehavior::TraversesFlatTree)))
+    if (options.contains(TextIteratorBehavior::TraversesFlatTree)) [[unlikely]]
         return nextInComposedTreeIgnoringUserAgentShadow(node);
     return NodeTraversal::next(node);
 }
 
 static inline bool isDescendantOf(TextIteratorBehaviors options, Node& node, Node& possibleAncestor)
 {
-    if (UNLIKELY(options.contains(TextIteratorBehavior::TraversesFlatTree)))
+    if (options.contains(TextIteratorBehavior::TraversesFlatTree)) [[unlikely]]
         return node.isShadowIncludingDescendantOf(&possibleAncestor);
     return node.isDescendantOf(&possibleAncestor);
 }
 
 static inline Node* parentNodeOrShadowHost(TextIteratorBehaviors options, Node& node)
 {
-    if (UNLIKELY(options.contains(TextIteratorBehavior::TraversesFlatTree)))
+    if (options.contains(TextIteratorBehavior::TraversesFlatTree)) [[unlikely]]
         return node.parentInComposedTree();
     return node.parentOrShadowHostNode();
 }

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -341,7 +341,7 @@ public:
 
     ContainerNode* parentNode(Node& node)
     {
-        if (UNLIKELY(m_useComposedTree))
+        if (m_useComposedTree) [[unlikely]]
             return node.parentInComposedTree();
         return node.parentOrShadowHostNode();
     }
@@ -420,35 +420,35 @@ private:
 
     Node* firstChild(Node& node)
     {
-        if (UNLIKELY(m_useComposedTree))
+        if (m_useComposedTree) [[unlikely]]
             return firstChildInComposedTreeIgnoringUserAgentShadow(node);
         return node.firstChild();
     }
 
     Node* nextSibling(Node& node)
     {
-        if (UNLIKELY(m_useComposedTree))
+        if (m_useComposedTree) [[unlikely]]
             return nextSiblingInComposedTreeIgnoringUserAgentShadow(node);
         return node.nextSibling();
     }
     
     Node* nextSkippingChildren(Node& node)
     {
-        if (UNLIKELY(m_useComposedTree))
+        if (m_useComposedTree) [[unlikely]]
             return nextSkippingChildrenInComposedTreeIgnoringUserAgentShadow(node);
         return NodeTraversal::nextSkippingChildren(node);
     }
 
     bool hasChildNodes(Node& node)
     {
-        if (UNLIKELY(m_useComposedTree))
+        if (m_useComposedTree) [[unlikely]]
             return firstChildInComposedTreeIgnoringUserAgentShadow(node);
         return node.hasChildNodes();
     }
 
     bool isDescendantOf(Node& node, Node& possibleAncestor)
     {
-        if (UNLIKELY(m_useComposedTree))
+        if (m_useComposedTree) [[unlikely]]
             return node.isShadowIncludingDescendantOf(&possibleAncestor);
         return node.isDescendantOf(&possibleAncestor);
     }
@@ -705,7 +705,7 @@ StyledMarkupAccumulator::SpanReplacementType StyledMarkupAccumulator::spanReplac
 void StyledMarkupAccumulator::appendStartTag(StringBuilder& out, const Element& element, bool addDisplayInline, RangeFullySelectsNode rangeFullySelectsNode)
 {
     auto replacementType = spanReplacementForElement(element);
-    if (UNLIKELY(replacementType != SpanReplacementType::None))
+    if (replacementType != SpanReplacementType::None) [[unlikely]]
         out.append("<span"_s);
     else
         appendOpenTag(out, element, nullptr);
@@ -780,7 +780,7 @@ void StyledMarkupAccumulator::appendStartTag(StringBuilder& out, const Element& 
 
 void StyledMarkupAccumulator::appendEndTag(StringBuilder& out, const Element& element)
 {
-    if (UNLIKELY(spanReplacementForElement(element) != SpanReplacementType::None))
+    if (spanReplacementForElement(element) != SpanReplacementType::None) [[unlikely]]
         out.append("</span>"_s);
     else
         MarkupAccumulator::appendEndTag(out, element);
@@ -814,9 +814,11 @@ RefPtr<Node> StyledMarkupAccumulator::traverseNodesForSerialization(Node& startN
 
     unsigned depth = 0;
     auto enterNode = [&] (Node& node) {
-        if (UNLIKELY(m_shouldPreserveMSOList) && shouldEmit) {
-            if (appendNodeToPreserveMSOList(node))
-                return false;
+        if (m_shouldPreserveMSOList) [[unlikely]] {
+            if (shouldEmit) {
+                if (appendNodeToPreserveMSOList(node))
+                    return false;
+            }
         }
 
         RefPtr element = dynamicDowncast<Element>(node);

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -196,7 +196,7 @@ WebCoreOpaqueRoot root(CanvasBase*);
 
 inline const CSSParserContext& CanvasBase::cssParserContext() const
 {
-    if (UNLIKELY(!m_cssParserContext))
+    if (!m_cssParserContext) [[unlikely]]
         m_cssParserContext = createCSSParserContext();
     return *m_cssParserContext;
 }

--- a/Source/WebCore/html/EmailInputType.cpp
+++ b/Source/WebCore/html/EmailInputType.cpp
@@ -106,7 +106,7 @@ ValueOrReference<String> EmailInputType::sanitizeValue(const String& proposedVal
 {
     // Passing a lambda instead of a function name helps the compiler inline isHTMLLineBreak.
     String noLineBreakValue = proposedValue;
-    if (UNLIKELY(containsHTMLLineBreak(proposedValue))) {
+    if (containsHTMLLineBreak(proposedValue)) [[unlikely]] {
         noLineBreakValue = proposedValue.removeCharacters([](auto character) {
             return isHTMLLineBreak(character);
         });

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -277,7 +277,7 @@ ExceptionOr<std::optional<RenderingContext>> HTMLCanvasElement::getContext(JSC::
         auto scope = DECLARE_THROW_SCOPE(vm);
 
         auto settings = convert<IDLDictionary<CanvasRenderingContext2DSettings>>(state, arguments.isEmpty() ? JSC::jsUndefined() : (arguments[0].isObject() ? arguments[0].get() : JSC::jsNull()));
-        if (UNLIKELY(settings.hasException(scope)))
+        if (settings.hasException(scope)) [[unlikely]]
             return Exception { ExceptionCode::ExistingExceptionError };
 
         RefPtr context = createContext2d(contextId, settings.releaseReturnValue());
@@ -291,7 +291,7 @@ ExceptionOr<std::optional<RenderingContext>> HTMLCanvasElement::getContext(JSC::
         auto scope = DECLARE_THROW_SCOPE(vm);
 
         auto settings = convert<IDLDictionary<ImageBitmapRenderingContextSettings>>(state, arguments.isEmpty() ? JSC::jsUndefined() : (arguments[0].isObject() ? arguments[0].get() : JSC::jsNull()));
-        if (UNLIKELY(settings.hasException(scope)))
+        if (settings.hasException(scope)) [[unlikely]]
             return Exception { ExceptionCode::ExistingExceptionError };
 
         RefPtr context = createContextBitmapRenderer(contextId, settings.releaseReturnValue());
@@ -306,7 +306,7 @@ ExceptionOr<std::optional<RenderingContext>> HTMLCanvasElement::getContext(JSC::
         auto scope = DECLARE_THROW_SCOPE(vm);
 
         auto attributes = convert<IDLDictionary<WebGLContextAttributes>>(state, arguments.isEmpty() ? JSC::jsUndefined() : (arguments[0].isObject() ? arguments[0].get() : JSC::jsNull()));
-        if (UNLIKELY(attributes.hasException(scope)))
+        if (attributes.hasException(scope)) [[unlikely]]
             return Exception { ExceptionCode::ExistingExceptionError };
 
         RefPtr context = createContextWebGL(toWebGLVersion(contextId), attributes.releaseReturnValue());
@@ -659,7 +659,7 @@ void HTMLCanvasElement::paint(GraphicsContext& context, const LayoutRect& r)
         }
     }
 
-    if (UNLIKELY(m_context->hasActiveInspectorCanvasCallTracer()))
+    if (m_context->hasActiveInspectorCanvasCallTracer()) [[unlikely]]
         InspectorInstrumentation::didFinishRecordingCanvasFrame(*m_context);
 }
 

--- a/Source/WebCore/html/HTMLDocument.cpp
+++ b/Source/WebCore/html/HTMLDocument.cpp
@@ -115,14 +115,14 @@ std::optional<Variant<RefPtr<WindowProxy>, RefPtr<Element>, RefPtr<HTMLCollectio
     if (name.isNull() || !hasDocumentNamedItem(name))
         return std::nullopt;
 
-    if (UNLIKELY(documentNamedItemContainsMultipleElements(name))) {
+    if (documentNamedItemContainsMultipleElements(name)) [[unlikely]] {
         auto collection = documentNamedItems(name);
         ASSERT(collection->length() > 1);
         return Variant<RefPtr<WindowProxy>, RefPtr<Element>, RefPtr<HTMLCollection>> { RefPtr<HTMLCollection> { WTFMove(collection) } };
     }
 
     Ref element = *documentNamedItem(name);
-    if (auto* iframe = dynamicDowncast<HTMLIFrameElement>(element.get()); UNLIKELY(iframe)) {
+    if (auto* iframe = dynamicDowncast<HTMLIFrameElement>(element.get()); iframe) [[unlikely]] {
         if (RefPtr domWindow = iframe->contentWindow())
             return Variant<RefPtr<WindowProxy>, RefPtr<Element>, RefPtr<HTMLCollection>> { WTFMove(domWindow) };
     }

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -122,7 +122,7 @@ String HTMLElement::nodeName() const
     // FIXME: Would be nice to have an AtomString lookup based off uppercase
     // ASCII characters that does not have to copy the string on a hit in the hash.
     if (document().isHTMLDocument()) {
-        if (LIKELY(!tagQName().hasPrefix()))
+        if (!tagQName().hasPrefix()) [[likely]]
             return tagQName().localNameUppercase();
         return Element::nodeName().convertToASCIIUppercase();
     }

--- a/Source/WebCore/html/HTMLFrameElementBase.cpp
+++ b/Source/WebCore/html/HTMLFrameElementBase.cpp
@@ -96,8 +96,10 @@ void HTMLFrameElementBase::openURL(LockHistory lockHistory, LockBackForwardList 
         return;
 
     auto frameName = getNameAttribute();
-    if (frameName.isNull() && UNLIKELY(document().settings().needsFrameNameFallbackToIdQuirk()))
-        frameName = getIdAttribute();
+    if (frameName.isNull()) {
+        if (document().settings().needsFrameNameFallbackToIdQuirk()) [[unlikely]]
+            frameName = getIdAttribute();
+    }
 
     auto completeURL = document().completeURL(m_frameURL);
     auto finishOpeningURL = [weakThis = WeakPtr { *this }, frameName, lockHistory, lockBackForwardList, parentFrame = WTFMove(parentFrame), completeURL] {

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -563,7 +563,7 @@ void HTMLInputElement::updateType(const AtomString& typeAttributeValue)
     if (oldType == InputType::Type::Telephone || m_inputType->type() == InputType::Type::Telephone || (hasAutoTextDirectionState() && didDirAutoUseValue != m_inputType->dirAutoUsesValue()))
         updateEffectiveTextDirection();
 
-    if (UNLIKELY(didSupportReadOnly != willSupportReadOnly && hasAttributeWithoutSynchronization(readonlyAttr))) {
+    if (didSupportReadOnly != willSupportReadOnly && hasAttributeWithoutSynchronization(readonlyAttr)) [[unlikely]] {
         emplace(readWriteInvalidation, *this, { { CSSSelector::PseudoClass::ReadWrite, !willSupportReadOnly }, { CSSSelector::PseudoClass::ReadOnly, willSupportReadOnly } });
         readOnlyStateChanged();
     }
@@ -2423,7 +2423,7 @@ String HTMLInputElement::placeholder() const
     // According to the HTML5 specification, we need to remove CR and LF from
     // the attribute value.
     String attributeValue = attributeWithoutSynchronization(placeholderAttr);
-    if (LIKELY(!containsHTMLLineBreak(attributeValue)))
+    if (!containsHTMLLineBreak(attributeValue)) [[likely]]
         return attributeValue;
 
     return attributeValue.removeCharacters([](UChar character) {

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1122,7 +1122,9 @@ void HTMLMediaElement::pauseAfterDetachedTask()
             RETURN_IF_EXCEPTION(scope, false);
 
             auto functionValue = controllerObject->get(&lexicalGlobalObject, JSC::Identifier::fromString(vm, "deinitialize"_s));
-            if (UNLIKELY(scope.exception()) || functionValue.isUndefinedOrNull())
+            if (scope.exception()) [[unlikely]]
+                return false;
+            if (functionValue.isUndefinedOrNull())
                 return false;
 
             auto* function = functionValue.toObject(&lexicalGlobalObject);
@@ -8821,7 +8823,9 @@ bool HTMLMediaElement::ensureMediaControls()
             RETURN_IF_EXCEPTION(scope, false);
 
             auto functionValue = controllerObject->get(&lexicalGlobalObject, JSC::Identifier::fromString(vm, "reinitialize"_s));
-            if (UNLIKELY(scope.exception()) || functionValue.isUndefinedOrNull())
+            if (scope.exception()) [[unlikely]]
+                return false;
+            if (functionValue.isUndefinedOrNull())
                 return false;
 
             if (!m_mediaControlsHost)
@@ -8897,7 +8901,9 @@ String HTMLMediaElement::getCurrentMediaControlsStatus()
         RETURN_IF_EXCEPTION(scope, false);
 
         auto functionValue = controllerObject->get(&lexicalGlobalObject, JSC::Identifier::fromString(vm, "getCurrentControlsStatus"_s));
-        if (UNLIKELY(scope.exception()) || functionValue.isUndefinedOrNull())
+        if (scope.exception()) [[unlikely]]
+            return false;
+        if (functionValue.isUndefinedOrNull())
             return false;
 
         auto* function = functionValue.toObject(&lexicalGlobalObject);
@@ -9786,7 +9792,9 @@ void HTMLMediaElement::setShowingStats(bool shouldShowStats)
         RETURN_IF_EXCEPTION(scope, false);
 
         auto functionValue = controllerObject->get(&lexicalGlobalObject, JSC::Identifier::fromString(vm, "setShowingStats"_s));
-        if (UNLIKELY(scope.exception()) || functionValue.isUndefinedOrNull())
+        if (scope.exception()) [[unlikely]]
+            return false;
+        if (functionValue.isUndefinedOrNull())
             return false;
 
         auto* function = functionValue.toObject(&lexicalGlobalObject);

--- a/Source/WebCore/html/HTMLSlotElement.cpp
+++ b/Source/WebCore/html/HTMLSlotElement.cpp
@@ -135,7 +135,7 @@ static void flattenAssignedNodes(Vector<Ref<Node>>& nodes, const HTMLSlotElement
         return;
     }
     for (auto& weakNode : *assignedNodes) {
-        if (UNLIKELY(!weakNode)) {
+        if (!weakNode) [[unlikely]] {
             ASSERT_NOT_REACHED();
             continue;
         }

--- a/Source/WebCore/html/HTMLTableElement.cpp
+++ b/Source/WebCore/html/HTMLTableElement.cpp
@@ -94,7 +94,7 @@ RefPtr<HTMLTableSectionElement> HTMLTableElement::tHead() const
 
 ExceptionOr<void> HTMLTableElement::setTHead(RefPtr<HTMLTableSectionElement>&& newHead)
 {
-    if (UNLIKELY(newHead && !newHead->hasTagName(theadTag)))
+    if (newHead && !newHead->hasTagName(theadTag)) [[unlikely]]
         return Exception { ExceptionCode::HierarchyRequestError };
 
     deleteTHead();
@@ -121,7 +121,7 @@ RefPtr<HTMLTableSectionElement> HTMLTableElement::tFoot() const
 
 ExceptionOr<void> HTMLTableElement::setTFoot(RefPtr<HTMLTableSectionElement>&& newFoot)
 {
-    if (UNLIKELY(newFoot && !newFoot->hasTagName(tfootTag)))
+    if (newFoot && !newFoot->hasTagName(tfootTag)) [[unlikely]]
         return Exception { ExceptionCode::HierarchyRequestError };
     deleteTFoot();
     if (!newFoot)

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -163,7 +163,7 @@ static inline std::pair<const AtomString&, InputTypeFactory*> findFactory(const 
     static NeverDestroyed factoryMap = createInputTypeFactoryMap();
     auto& map = factoryMap.get();
     auto it = map.find(typeName);
-    if (UNLIKELY(it == map.end())) {
+    if (it == map.end()) [[unlikely]] {
         it = map.find(typeName.convertToASCIILowercase());
         if (it == map.end())
             return { nullAtom(), nullptr };
@@ -177,7 +177,7 @@ RefPtr<InputType> InputType::createIfDifferent(HTMLInputElement& element, const 
         auto& currentTypeName = currentInputType ? currentInputType->formControlType() : nullAtom();
         if (typeName == currentTypeName)
             return nullptr;
-        if (auto factory = findFactory(typeName); LIKELY(factory.second)) {
+        if (auto factory = findFactory(typeName); factory.second) [[likely]] {
             if (factory.first == currentTypeName)
                 return nullptr;
             if (!factory.second->conditionalFunction || std::invoke(factory.second->conditionalFunction, element.document().settings()))

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -200,7 +200,7 @@ ExceptionOr<std::optional<OffscreenRenderingContext>> OffscreenCanvas::getContex
             auto scope = DECLARE_THROW_SCOPE(state.vm());
 
             auto settings = convert<IDLDictionary<CanvasRenderingContext2DSettings>>(state, arguments.isEmpty() ? JSC::jsUndefined() : (arguments[0].isObject() ? arguments[0].get() : JSC::jsNull()));
-            if (UNLIKELY(settings.hasException(scope)))
+            if (settings.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
 
             m_context = OffscreenCanvasRenderingContext2D::create(*this, settings.releaseReturnValue());
@@ -214,7 +214,7 @@ ExceptionOr<std::optional<OffscreenRenderingContext>> OffscreenCanvas::getContex
             auto scope = DECLARE_THROW_SCOPE(state.vm());
 
             auto settings = convert<IDLDictionary<ImageBitmapRenderingContextSettings>>(state, arguments.isEmpty() ? JSC::jsUndefined() : (arguments[0].isObject() ? arguments[0].get() : JSC::jsNull()));
-            if (UNLIKELY(settings.hasException(scope)))
+            if (settings.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
 
             m_context = ImageBitmapRenderingContext::create(*this, settings.releaseReturnValue());
@@ -252,7 +252,7 @@ ExceptionOr<std::optional<OffscreenRenderingContext>> OffscreenCanvas::getContex
             auto scope = DECLARE_THROW_SCOPE(state.vm());
 
             auto attributes = convert<IDLDictionary<WebGLContextAttributes>>(state, arguments.isEmpty() ? JSC::jsUndefined() : (arguments[0].isObject() ? arguments[0].get() : JSC::jsNull()));
-            if (UNLIKELY(attributes.hasException(scope)))
+            if (attributes.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
 
             auto* scriptExecutionContext = this->scriptExecutionContext();

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -472,7 +472,7 @@ void TextFieldInputType::createDataListDropdownIndicator()
 
 static ValueOrReference<String> limitLength(const String& string LIFETIME_BOUND, unsigned maxLength)
 {
-    if (LIKELY(string.length() <= maxLength))
+    if (string.length() <= maxLength) [[likely]]
         return string;
 
     unsigned newLength = maxLength;
@@ -558,7 +558,7 @@ static bool isAutoFillButtonTypeChanged(const AtomString& attribute, AutoFillBut
 
 ValueOrReference<String> TextFieldInputType::sanitizeValue(const String& proposedValue LIFETIME_BOUND) const
 {
-    if (LIKELY(!containsHTMLLineBreak(proposedValue)))
+    if (!containsHTMLLineBreak(proposedValue)) [[likely]]
         return limitLength(proposedValue, HTMLInputElement::maxEffectiveLength);
 
     // Passing a lambda instead of a function name helps the compiler inline isHTMLLineBreak.

--- a/Source/WebCore/html/canvas/CanvasPath.cpp
+++ b/Source/WebCore/html/canvas/CanvasPath.cpp
@@ -63,7 +63,7 @@ void CanvasPath::moveTo(float x, float y)
 {
     if (!std::isfinite(x) || !std::isfinite(y))
         return;
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return;
     m_path.moveTo(FloatPoint(x, y));
 }
@@ -77,7 +77,7 @@ void CanvasPath::lineTo(float x, float y)
 {
     if (!std::isfinite(x) || !std::isfinite(y))
         return;
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return;
 
     FloatPoint p1 = FloatPoint(x, y);
@@ -91,7 +91,7 @@ void CanvasPath::quadraticCurveTo(float cpx, float cpy, float x, float y)
 {
     if (!std::isfinite(cpx) || !std::isfinite(cpy) || !std::isfinite(x) || !std::isfinite(y))
         return;
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return;
     if (m_path.isEmpty())
         m_path.moveTo(FloatPoint(cpx, cpy));
@@ -106,7 +106,7 @@ void CanvasPath::bezierCurveTo(float cp1x, float cp1y, float cp2x, float cp2y, f
 {
     if (!std::isfinite(cp1x) || !std::isfinite(cp1y) || !std::isfinite(cp2x) || !std::isfinite(cp2y) || !std::isfinite(x) || !std::isfinite(y))
         return;
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return;
     if (m_path.isEmpty())
         m_path.moveTo(FloatPoint(cp1x, cp1y));
@@ -126,7 +126,7 @@ ExceptionOr<void> CanvasPath::arcTo(float x1, float y1, float x2, float y2, floa
     if (r < 0)
         return Exception { ExceptionCode::IndexSizeError };
 
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return { };
 
     FloatPoint p1 = FloatPoint(x1, y1);
@@ -167,7 +167,7 @@ ExceptionOr<void> CanvasPath::arc(float x, float y, float radius, float startAng
     if (radius < 0)
         return Exception { ExceptionCode::IndexSizeError };
 
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return { };
 
     normalizeAngles(startAngle, endAngle, anticlockwise);
@@ -190,7 +190,7 @@ ExceptionOr<void> CanvasPath::ellipse(float x, float y, float radiusX, float rad
     if (radiusX < 0 || radiusY < 0)
         return Exception { ExceptionCode::IndexSizeError };
 
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return { };
 
     normalizeAngles(startAngle, endAngle, anticlockwise);
@@ -227,7 +227,7 @@ ExceptionOr<void> CanvasPath::ellipse(float x, float y, float radiusX, float rad
 
 void CanvasPath::rect(float x, float y, float width, float height)
 {
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return;
 
     if (!std::isfinite(x) || !std::isfinite(y) || !std::isfinite(width) || !std::isfinite(height))

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -851,7 +851,7 @@ void CanvasRenderingContext2DBase::scale(double sx, double sy)
     GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return;
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return;
 
     if (!std::isfinite(sx) || !std::isfinite(sy))
@@ -879,7 +879,7 @@ void CanvasRenderingContext2DBase::rotate(double angleInRadians)
     GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return;
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return;
 
     if (!std::isfinite(angleInRadians))
@@ -902,7 +902,7 @@ void CanvasRenderingContext2DBase::translate(double tx, double ty)
     GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return;
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return;
 
     if (!std::isfinite(tx) || !std::isfinite(ty))
@@ -925,7 +925,7 @@ void CanvasRenderingContext2DBase::transform(double m11, double m12, double m21,
     GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return;
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return;
 
     if (!std::isfinite(m11) || !std::isfinite(m21) || !std::isfinite(dx) || !std::isfinite(m12) || !std::isfinite(m22) || !std::isfinite(dy))
@@ -1155,7 +1155,7 @@ void CanvasRenderingContext2DBase::fillInternal(const Path& path, CanvasFillRule
     auto* c = effectiveDrawingContext();
     if (!c)
         return;
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return;
 
     // If gradient size is zero, then paint nothing.
@@ -1198,7 +1198,7 @@ void CanvasRenderingContext2DBase::strokeInternal(const Path& path)
     auto* c = effectiveDrawingContext();
     if (!c)
         return;
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return;
 
     // If gradient size is zero, then paint nothing.
@@ -1232,7 +1232,7 @@ void CanvasRenderingContext2DBase::clipInternal(const Path& path, CanvasFillRule
     auto* c = effectiveDrawingContext();
     if (!c)
         return;
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return;
 
     realizeSaves();
@@ -1282,7 +1282,7 @@ bool CanvasRenderingContext2DBase::isPointInPathInternal(const Path& path, doubl
     
     if (!effectiveDrawingContext())
         return false;
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return false;
 
     auto& state = this->state();
@@ -1299,7 +1299,7 @@ bool CanvasRenderingContext2DBase::isPointInStrokeInternal(const Path& path, dou
 
     if (!effectiveDrawingContext())
         return false;
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return false;
 
     auto& state = this->state();
@@ -1326,7 +1326,7 @@ void CanvasRenderingContext2DBase::clearRect(double x, double y, double width, d
     auto* context = effectiveDrawingContext();
     if (!context)
         return;
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return;
     FloatRect rect(x, y, width, height);
 
@@ -1368,7 +1368,7 @@ void CanvasRenderingContext2DBase::fillRect(double x, double y, double width, do
     auto* c = effectiveDrawingContext();
     if (!c)
         return;
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return;
 
     // from the HTML5 Canvas spec:
@@ -1420,7 +1420,7 @@ void CanvasRenderingContext2DBase::strokeRect(double x, double y, double width, 
     auto* c = effectiveDrawingContext();
     if (!c)
         return;
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return;
     if (!(state().lineWidth >= 0))
         return;
@@ -1734,7 +1734,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(Document& document, Ca
     GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return { };
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return { };
 
     RefPtr<Image> image = cachedImage.imageForRenderer(renderer);
@@ -1815,7 +1815,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(CanvasBase& sourceCanv
     GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return { };
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return { };
 
     Ref protectedCanvas { sourceCanvas };
@@ -1877,7 +1877,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(HTMLVideoElement& vide
     GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return { };
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return { };
 
     checkOrigin(&video);
@@ -1929,7 +1929,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(ImageBitmap& imageBitm
     GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return { };
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return { };
 
     RefPtr buffer = imageBitmap.buffer();
@@ -2376,7 +2376,7 @@ void CanvasRenderingContext2DBase::didDraw(std::optional<FloatRect> rect, Option
     if (dirtyRect.isEmpty())
         return;
 
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return;
 
     if (options.contains(DidDrawOption::ApplyTransform))
@@ -2801,7 +2801,7 @@ bool CanvasRenderingContext2DBase::canDrawText(double x, double y, bool fill, st
     auto* c = effectiveDrawingContext();
     if (!c)
         return false;
-    if (UNLIKELY(!hasInvertibleTransform()))
+    if (!hasInvertibleTransform()) [[unlikely]]
         return false;
     if (!std::isfinite(x) || !std::isfinite(y))
         return false;

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -5623,7 +5623,7 @@ void WebGLRenderingContextBase::prepareForDisplay()
     m_compositingResultsNeedUpdating = false;
     m_canvasBufferContents = std::nullopt;
 
-    if (UNLIKELY(hasActiveInspectorCanvasCallTracer()))
+    if (hasActiveInspectorCanvasCallTracer()) [[unlikely]]
         InspectorInstrumentation::didFinishRecordingCanvasFrame(*this);
 }
 

--- a/Source/WebCore/html/canvas/WebGLUtilities.cpp
+++ b/Source/WebCore/html/canvas/WebGLUtilities.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 bool ScopedInspectorShaderProgramHighlight::shouldApply(WebGLRenderingContextBase& context)
 {
     RefPtr currentProgram = context.m_currentProgram;
-    if (LIKELY(!currentProgram || !InspectorInstrumentation::isWebGLProgramHighlighted(context, *currentProgram)))
+    if (!currentProgram || !InspectorInstrumentation::isWebGLProgramHighlighted(context, *currentProgram)) [[likely]]
         return false;
     if (context.m_framebufferBinding)
         return false;

--- a/Source/WebCore/html/canvas/WebGLUtilities.h
+++ b/Source/WebCore/html/canvas/WebGLUtilities.h
@@ -36,14 +36,14 @@ public:
     ScopedInspectorShaderProgramHighlight(WebGLRenderingContextBase& context)
        : m_context(shouldApply(context) ? &context : nullptr) // NOLINT
     {
-        if (LIKELY(!m_context))
+        if (!m_context) [[likely]]
             return;
         showHighlight();
     }
 
     ~ScopedInspectorShaderProgramHighlight()
     {
-        if (LIKELY(!m_context))
+        if (!m_context) [[likely]]
             return;
         hideHighlight();
     }


### PR DESCRIPTION
#### cbf24c0d5470db8030d01b052f7d963474fcfe59
<pre>
Do more [[likely]] / [[unlikely]] adoption in WebCore/
<a href="https://bugs.webkit.org/show_bug.cgi?id=292477">https://bugs.webkit.org/show_bug.cgi?id=292477</a>

Reviewed by Ryosuke Niwa.

Do more [[likely]] / [[unlikely]] adoption in WebCore/.

It is now part of the C++ language and has several benefits over
our macros. In particular, those annotations can be used for
`switch` cases and `else` statements.

* Source/WebCore/contentextensions/DFABytecodeInterpreter.cpp:
(WebCore::ContentExtensions::DFABytecodeInterpreter::interpret):
* Source/WebCore/crypto/SubtleCrypto.cpp:
(WebCore::normalizeCryptoAlgorithmParameters):
(WebCore::SubtleCrypto::unwrapKey):
* Source/WebCore/crypto/cocoa/CryptoKeyECMac.cpp:
(WebCore::CryptoKeyEC::platformExportRaw const):
(WebCore::CryptoKeyEC::platformAddFieldElements const):
(WebCore::CryptoKeyEC::platformExportSpki const):
(WebCore::CryptoKeyEC::platformExportPkcs8 const):
* Source/WebCore/crypto/gcrypt/CryptoKeyOKPGCrypt.cpp:
(WebCore::gcryptGenerateEd25519Keys):
(WebCore::gcryptGenerateX25519Keys):
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::simpleSelectorSpecificity):
* Source/WebCore/css/CSSStyleProperties.cpp:
(WebCore::PropertySetCSSStyleProperties::setProperty):
* Source/WebCore/css/CSSStyleSheetObservableArray.cpp:
(WebCore::CSSStyleSheetObservableArray::setValueAt):
* Source/WebCore/css/CSSToStyleMap.cpp:
(WebCore::CSSToStyleMap::mapNinePieceImageQuad):
* Source/WebCore/css/DOMCSSPaintWorklet.cpp:
(WebCore::PaintWorklet::addModule):
* Source/WebCore/css/SelectorFilter.cpp:
(WebCore::SelectorFilter::pushParentInitializingIfNeeded):
* Source/WebCore/css/StyleAttributeMutationScope.h:
(WebCore::StyleAttributeMutationScope::StyleAttributeMutationScope):
* Source/WebCore/css/parser/CSSTokenizer.cpp:
(WebCore::CSSTokenizer::tryCreate):
(WebCore::CSSTokenizer::CSSTokenizer):
* Source/WebCore/dom/CharacterData.cpp:
(WebCore::CharacterData::parserAppendData):
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::removeAllChildrenWithScriptAssertion):
(WebCore::ContainerNode::removeNodeWithScriptAssertion):
(WebCore::executeNodeInsertionWithScriptAssertion):
(WebCore::executeParserNodeInsertionIntoIsolatedTreeWithoutNotifyingParent):
(WebCore::ContainerNode::ensurePreInsertionValidityForPhantomDocumentFragment):
(WebCore::ContainerNode::removeBetween):
* Source/WebCore/dom/CustomElementReactionQueue.h:
(WebCore::CustomElementReactionStack::~CustomElementReactionStack):
* Source/WebCore/dom/CustomElementRegistry.h:
(WebCore::CustomElementRegistry::registryForElement):
(WebCore::CustomElementRegistry::registryForNodeOrTreeScope):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setMarkupUnsafe):
(WebCore::createHTMLElementWithNameValidation):
(WebCore::Document::createElementForBindings):
(WebCore::Document::createElement):
(WebCore::validateCustomElementNameWithoutCheckingStandardElementNames):
(WebCore::Document::createElementNS):
(WebCore::Document::setTitle):
(WebCore::Document::write):
(WebCore::Document::parseQualifiedName):
(WebCore::Document::shouldMaskURLForBindingsInternal const):
(WebCore::Document::execCommand):
(WebCore::Document::queryCommandEnabled):
(WebCore::Document::queryCommandIndeterm):
(WebCore::Document::queryCommandState):
(WebCore::Document::queryCommandSupported):
(WebCore::Document::queryCommandValue):
(WebCore::Document::eventLoop):
(WebCore::Document::windowEventLoop):
(WebCore::Document::documentFragmentForInnerOuterHTML):
(WebCore::Document::compositeOperatorForBackgroundColor const):
* Source/WebCore/dom/DocumentInlines.h:
(WebCore::Document::invalidateAccessKeyCache):
(WebCore::Document::shouldMaskURLForBindings const):
(WebCore::Document::maskedURLForBindingsIfNeeded const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::~Element):
(WebCore::Element::synchronizeAttribute const):
(WebCore::Element::notifyAttributeChanged):
(WebCore::getElementByIdIncludingDisconnected):
(WebCore::Element::didMoveToNewDocument):
(WebCore::Element::updateEffectiveTextDirectionIfNeeded):
(WebCore::Element::insertedIntoAncestor):
(WebCore::Element::removedFromAncestor):
(WebCore::Element::childrenChanged):
(WebCore::Element::removeAttribute):
(WebCore::Element::setOuterHTML):
(WebCore::Element::insertAdjacentHTML):
* Source/WebCore/dom/Element.h:
(WebCore::Element::disconnectFromIntersectionObservers):
(WebCore::Element::disconnectFromResizeObservers):
* Source/WebCore/dom/ElementInlines.h:
(WebCore::Element::hideNonce):
* Source/WebCore/dom/ElementRareData.h:
(WebCore::Element::removeShadowRoot):
* Source/WebCore/dom/EventContext.cpp:
(WebCore::EventContext::handleLocalEvents const):
* Source/WebCore/dom/EventListenerMap.cpp:
(WebCore::removeListenerFromVector):
* Source/WebCore/dom/EventPath.cpp:
(WebCore::EventPath::buildPath):
(WebCore::EventPath::setRelatedTarget):
(WebCore::EventPath::retargetTouch):
(WebCore::RelatedNodeRetargeter::RelatedNodeRetargeter):
* Source/WebCore/dom/EventTarget.cpp:
(WebCore::EventTarget::innerInvokeEventListeners):
* Source/WebCore/dom/ImageOverlay.cpp:
(WebCore::ImageOverlay::hasOverlay):
* Source/WebCore/dom/InternalObserverEvery.cpp:
* Source/WebCore/dom/InternalObserverFind.cpp:
* Source/WebCore/dom/InternalObserverForEach.cpp:
* Source/WebCore/dom/InternalObserverInspect.cpp:
* Source/WebCore/dom/InternalObserverLast.cpp:
* Source/WebCore/dom/InternalObserverReduce.cpp:
* Source/WebCore/dom/InternalObserverSome.cpp:
* Source/WebCore/dom/MessageEvent.cpp:
(WebCore::MessageEvent::create):
* Source/WebCore/dom/Microtasks.cpp:
(WebCore::MicrotaskQueue::runJSMicrotask):
(WebCore::MicrotaskQueue::performMicrotaskCheckpoint):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::convertNodesOrStringsIntoNodeVector):
(WebCore::Node::cloneNodeForBindings):
(WebCore::Node::moveTreeToNewScope):
(WebCore::Node::moveNodeToNewDocumentSlowCase):
* Source/WebCore/dom/Node.h:
(WebCore::EventTarget::ref):
(WebCore::EventTarget::deref):
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::SelectorDataList::executeFastPathForIdSelector const):
(WebCore::filterRootById):
* Source/WebCore/dom/SlotAssignment.cpp:
(WebCore::nextSlotElementSkippingSubtree):
(WebCore::NamedSlotAssignment::didChangeSlot):
(WebCore::NamedSlotAssignment::assignSlots):
* Source/WebCore/dom/SlotAssignment.h:
(WebCore::ShadowRoot::resolveSlotsBeforeNodeInsertionOrRemoval):
(WebCore::ShadowRoot::willRemoveAllChildren):
(WebCore::ShadowRoot::didRemoveAllChildrenOfShadowHost):
(WebCore::ShadowRoot::didMutateTextNodesOfShadowHost):
(WebCore::ShadowRoot::hostChildElementDidChange):
* Source/WebCore/dom/Text.cpp:
(WebCore::Text::setDataAndUpdate):
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::retargetToScope const):
(WebCore::TreeScope::ensureAdoptedStyleSheets):
* Source/WebCore/dom/WindowEventLoop.cpp:
(WebCore::WindowEventLoop::eventLoopForSecurityOrigin):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::nodeWillBeRemoved):
* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::appendCharactersReplacingEntitiesInternal):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::firstChild):
(WebCore::nextSibling):
(WebCore::nextNode):
(WebCore::isDescendantOf):
(WebCore::parentNodeOrShadowHost):
* Source/WebCore/editing/markup.cpp:
(WebCore::StyledMarkupAccumulator::appendStartTag):
(WebCore::StyledMarkupAccumulator::appendEndTag):
(WebCore::StyledMarkupAccumulator::traverseNodesForSerialization):
* Source/WebCore/html/CanvasBase.h:
(WebCore::CanvasBase::cssParserContext const):
* Source/WebCore/html/EmailInputType.cpp:
(WebCore::EmailInputType::sanitizeValue const):
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::getContext):
(WebCore::HTMLCanvasElement::paint):
* Source/WebCore/html/HTMLDocument.cpp:
(WebCore::HTMLDocument::namedItem):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::nodeName const):
* Source/WebCore/html/HTMLFrameElementBase.cpp:
(WebCore::HTMLFrameElementBase::openURL):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::updateType):
(WebCore::HTMLInputElement::placeholder const):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::pauseAfterDetachedTask):
(WebCore::HTMLMediaElement::ensureMediaControls):
(WebCore::HTMLMediaElement::getCurrentMediaControlsStatus):
(WebCore::HTMLMediaElement::setShowingStats):
* Source/WebCore/html/HTMLSlotElement.cpp:
(WebCore::flattenAssignedNodes):
* Source/WebCore/html/HTMLTableElement.cpp:
(WebCore::HTMLTableElement::setTHead):
(WebCore::HTMLTableElement::setTFoot):
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::createIfDifferent):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::getContext):
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::limitLength):
(WebCore::TextFieldInputType::sanitizeValue const):
* Source/WebCore/html/canvas/CanvasPath.cpp:
(WebCore::CanvasPath::moveTo):
(WebCore::CanvasPath::lineTo):
(WebCore::CanvasPath::quadraticCurveTo):
(WebCore::CanvasPath::bezierCurveTo):
(WebCore::CanvasPath::arcTo):
(WebCore::CanvasPath::arc):
(WebCore::CanvasPath::ellipse):
(WebCore::CanvasPath::rect):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::scale):
(WebCore::CanvasRenderingContext2DBase::rotate):
(WebCore::CanvasRenderingContext2DBase::translate):
(WebCore::CanvasRenderingContext2DBase::transform):
(WebCore::CanvasRenderingContext2DBase::fillInternal):
(WebCore::CanvasRenderingContext2DBase::strokeInternal):
(WebCore::CanvasRenderingContext2DBase::clipInternal):
(WebCore::CanvasRenderingContext2DBase::isPointInPathInternal):
(WebCore::CanvasRenderingContext2DBase::isPointInStrokeInternal):
(WebCore::CanvasRenderingContext2DBase::clearRect):
(WebCore::CanvasRenderingContext2DBase::fillRect):
(WebCore::CanvasRenderingContext2DBase::strokeRect):
(WebCore::CanvasRenderingContext2DBase::drawImage):
(WebCore::CanvasRenderingContext2DBase::didDraw):
(WebCore::CanvasRenderingContext2DBase::canDrawText):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::prepareForDisplay):
* Source/WebCore/html/canvas/WebGLUtilities.cpp:
(WebCore::ScopedInspectorShaderProgramHighlight::shouldApply):
* Source/WebCore/html/canvas/WebGLUtilities.h:
(WebCore::ScopedInspectorShaderProgramHighlight::ScopedInspectorShaderProgramHighlight):
(WebCore::ScopedInspectorShaderProgramHighlight::~ScopedInspectorShaderProgramHighlight):

Canonical link: <a href="https://commits.webkit.org/294487@main">https://commits.webkit.org/294487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d7610643ea6e459e71ec2896de20ddcb14721b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107198 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/52673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22015 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30214 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/77665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/52673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105046 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17028 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92127 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/58001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/16857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10152 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52032 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86695 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10225 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109571 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29172 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21491 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29534 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88331 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/86215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21931 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/31012 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8731 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/23371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29100 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34395 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28911 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/32234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30470 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->