### PR TITLE
Do further adoption of [[likely]] / [[unlikely]] in JSC

### DIFF
--- a/Source/JavaScriptCore/jit/JITPlan.cpp
+++ b/Source/JavaScriptCore/jit/JITPlan.cpp
@@ -195,7 +195,7 @@ static inline void* signpostId(JITPlan& plan)
 
 CString JITPlan::signpostMessage()
 {
-    if (LIKELY(!Options::useCompilerSignpost()))
+    if (!Options::useCompilerSignpost()) [[likely]]
         return CString();
     StringPrintStream stream;
     stream.print(m_mode, " ", *m_codeBlock);
@@ -254,7 +254,7 @@ void JITPlan::compileInThread(JITWorklistThread* thread)
     CString codeBlockName;
 
     bool computeCompileTimes = this->computeCompileTimes();
-    if (UNLIKELY(computeCompileTimes)) {
+    if (computeCompileTimes) [[unlikely]] {
         before = MonotonicTime::now();
         if (reportCompileTimes())
             codeBlockName = toCString(*m_codeBlock);
@@ -263,14 +263,14 @@ void JITPlan::compileInThread(JITWorklistThread* thread)
     CompilationScope compilationScope;
 
 #if ENABLE(DFG_JIT)
-    if (UNLIKELY(DFG::logCompilationChanges(m_mode) || Options::logPhaseTimes()))
+    if (DFG::logCompilationChanges(m_mode) || Options::logPhaseTimes()) [[unlikely]]
         dataLog("DFG(Plan) compiling ", *m_codeBlock, " with ", m_mode, ", instructions size = ", m_codeBlock->instructionsSize(), "\n");
 #endif // ENABLE(DFG_JIT)
 
     CompilationPath path = compileInThreadImpl();
     RELEASE_ASSERT((path == CancelPath) == (m_stage == JITPlanStage::Canceled));
 
-    if (LIKELY(!computeCompileTimes))
+    if (!computeCompileTimes) [[likely]]
         return;
 
     MonotonicTime after = MonotonicTime::now();
@@ -326,7 +326,7 @@ void JITPlan::compileInThread(JITWorklistThread* thread)
             break;
         }
     }
-    if (UNLIKELY(reportCompileTimes())) {
+    if (reportCompileTimes()) [[unlikely]] {
         dataLog("Optimized ", codeBlockName, " using ", m_mode, " with ", pathName, " into ", codeSize(), " bytes in ", (after - before).milliseconds(), " ms");
         if (path == FTLPath)
             dataLog(" (DFG: ", (m_timeBeforeFTL - before).milliseconds(), ", B3: ", (after - m_timeBeforeFTL).milliseconds(), ")");

--- a/Source/JavaScriptCore/jit/JITPlan.h
+++ b/Source/JavaScriptCore/jit/JITPlan.h
@@ -113,13 +113,13 @@ public:
 
     void beginSignpost()
     {
-        if (UNLIKELY(Options::useCompilerSignpost()))
+        if (Options::useCompilerSignpost()) [[unlikely]]
             beginSignpostImpl();
     }
 
     void endSignpost(SignpostDetail detail = SignpostDetail::None)
     {
-        if (UNLIKELY(Options::useCompilerSignpost()))
+        if (Options::useCompilerSignpost()) [[unlikely]]
             endSignpostImpl(detail);
     }
 

--- a/Source/JavaScriptCore/jit/JITWorklistThread.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklistThread.cpp
@@ -85,7 +85,7 @@ auto JITWorklistThread::poll(const AbstractLocker& locker) -> PollResult
             continue;
 
         m_plan = queue.takeFirst();
-        if (UNLIKELY(!m_plan)) {
+        if (!m_plan) [[unlikely]] {
             if (Options::verboseCompilationQueue()) {
                 m_worklist.dump(locker, WTF::dataFile());
                 dataLog(": Thread shutting down\n");

--- a/Source/JavaScriptCore/jit/RegisterSet.h
+++ b/Source/JavaScriptCore/jit/RegisterSet.h
@@ -66,7 +66,7 @@ public:
         ASSERT_UNDER_CONSTEXPR_CONTEXT(!!reg);
         m_bits.set(reg.index());
 
-        if (UNLIKELY(width > conservativeWidthWithoutVectors(reg) && conservativeWidth(reg) > conservativeWidthWithoutVectors(reg)))
+        if (width > conservativeWidthWithoutVectors(reg) && conservativeWidth(reg) > conservativeWidthWithoutVectors(reg)) [[unlikely]]
             m_upperBits.set(reg.index());
         return *this;
     }
@@ -238,7 +238,9 @@ public:
     inline constexpr bool contains(Reg reg, Width width) const
     {
         ASSERT_UNDER_CONSTEXPR_CONTEXT(m_bits.count() >= m_upperBits.count());
-        if (LIKELY(width < conservativeWidth(reg)) || conservativeWidth(reg) <= conservativeWidthWithoutVectors(reg))
+        if (width < conservativeWidth(reg)) [[likely]]
+            return m_bits.get(reg.index());
+        if (conservativeWidth(reg) <= conservativeWidthWithoutVectors(reg))
             return m_bits.get(reg.index());
         return m_bits.get(reg.index()) && m_upperBits.get(reg.index());
     }
@@ -362,7 +364,7 @@ public:
         ASSERT_UNDER_CONSTEXPR_CONTEXT(!!reg);
         m_bits.set(reg.index());
 
-        if (UNLIKELY(width > conservativeWidthWithoutVectors(reg) && conservativeWidth(reg) > conservativeWidthWithoutVectors(reg)))
+        if (width > conservativeWidthWithoutVectors(reg) && conservativeWidth(reg) > conservativeWidthWithoutVectors(reg)) [[unlikely]]
             m_upperBits.set(reg.index());
         return *this;
     }

--- a/Source/JavaScriptCore/jit/ThunkGenerators.cpp
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.cpp
@@ -81,20 +81,20 @@ MacroAssemblerCodeRef<JITThunkPtrTag> checkExceptionGenerator(VM& vm)
     // This thunk is tail called from other thunks, and the return address is always already tagged
 
     // Exception fuzzing can call a runtime function. So, we need to preserve the return address here.
-    if (UNLIKELY(Options::useExceptionFuzz()))
+    if (Options::useExceptionFuzz()) [[unlikely]]
         jit.emitCTIThunkPrologue(/* returnAddressAlreadyTagged: */ true);
 
     CCallHelpers::Jump handleException = jit.emitNonPatchableExceptionCheck(vm);
 
-    if (UNLIKELY(Options::useExceptionFuzz()))
+    if (Options::useExceptionFuzz()) [[unlikely]]
         jit.emitCTIThunkEpilogue();
     jit.ret();
 
     auto jumpTarget = CodeLocationLabel { vm.getCTIStub(CommonJITThunkID::HandleException).retaggedCode<NoPtrTag>() };
-    if (UNLIKELY(Options::useExceptionFuzz()))
+    if (Options::useExceptionFuzz()) [[unlikely]]
         jumpTarget = CodeLocationLabel { vm.getCTIStub(popThunkStackPreservesAndHandleExceptionGenerator).retaggedCode<NoPtrTag>() };
 #if CPU(X86_64)
-    if (LIKELY(!Options::useExceptionFuzz())) {
+    if (!Options::useExceptionFuzz()) [[likely]] {
         handleException.link(&jit);
         jit.addPtr(CCallHelpers::TrustedImm32(sizeof(CPURegister)), X86Registers::esp); // pop return address.
         handleException = jit.jump();

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -2631,7 +2631,7 @@ JSC_DEFINE_HOST_FUNCTION(functionDollarAgentReceiveBroadcast, (JSGlobalObject* g
     MarkedArgumentBuffer args;
     args.append(result);
     args.append(jsNumber(message->index()));
-    if (UNLIKELY(args.hasOverflowed()))
+    if (args.hasOverflowed()) [[unlikely]]
         return JSValue::encode(throwOutOfMemoryError(globalObject, scope));
     RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, callback, callData, jsNull(), args)));
 }
@@ -4463,7 +4463,7 @@ int jscmain(int argc, char** argv)
     JSC::JITOperationList::populatePointersInEmbedder(&startOfJITOperationsInShell, &endOfJITOperationsInShell);
 #endif
 #if ENABLE(JIT_OPERATION_DISASSEMBLY)
-    if (UNLIKELY(Options::needDisassemblySupport()))
+    if (Options::needDisassemblySupport()) [[unlikely]]
         JSC::JITOperationList::populateDisassemblyLabelsInEmbedder(&startOfJITOperationsInShell, &endOfJITOperationsInShell);
 #endif
 

--- a/Source/JavaScriptCore/llint/LLIntData.cpp
+++ b/Source/JavaScriptCore/llint/LLIntData.cpp
@@ -99,7 +99,7 @@ void initialize()
 
 #else // !ENABLE(C_LOOP)
 
-    if (UNLIKELY(g_jscConfig.vmEntryDisallowed))
+    if (g_jscConfig.vmEntryDisallowed) [[unlikely]]
         neuterOpcodeMaps();
     else {
         llint_entry(&g_opcodeMap, &g_opcodeMapWide16, &g_opcodeMapWide32);

--- a/Source/JavaScriptCore/llint/LLIntExceptions.cpp
+++ b/Source/JavaScriptCore/llint/LLIntExceptions.cpp
@@ -42,7 +42,7 @@ JSInstruction* returnToThrow(VM& vm)
 {
     UNUSED_PARAM(vm);
 #if LLINT_TRACING
-    if (UNLIKELY(Options::traceLLIntSlowPath())) {
+    if (Options::traceLLIntSlowPath()) [[unlikely]] {
         auto scope = DECLARE_CATCH_SCOPE(vm);
         dataLog("Throwing exception ", JSValue(scope.exception()), " (returnToThrow).\n");
     }
@@ -54,7 +54,7 @@ WasmInstruction* wasmReturnToThrow(VM& vm)
 {
     UNUSED_PARAM(vm);
 #if LLINT_TRACING
-    if (UNLIKELY(Options::traceLLIntSlowPath())) {
+    if (Options::traceLLIntSlowPath()) [[unlikely]] {
         auto scope = DECLARE_CATCH_SCOPE(vm);
         dataLog("Throwing exception ", JSValue(scope.exception()), " (returnToThrow).\n");
     }
@@ -66,7 +66,7 @@ MacroAssemblerCodeRef<ExceptionHandlerPtrTag> callToThrow(VM& vm)
 {
     UNUSED_PARAM(vm);
 #if LLINT_TRACING
-    if (UNLIKELY(Options::traceLLIntSlowPath())) {
+    if (Options::traceLLIntSlowPath()) [[unlikely]] {
         auto scope = DECLARE_CATCH_SCOPE(vm);
         dataLog("Throwing exception ", JSValue(scope.exception()), " (callToThrow).\n");
     }

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -116,8 +116,8 @@ static inline JSValue getOperand(CallFrame* callFrame, VirtualRegister operand) 
 
 #define LLINT_CHECK_EXCEPTION() do {                    \
         doExceptionFuzzingIfEnabled(globalObject, throwScope, "LLIntSlowPaths", pc);    \
-        if (UNLIKELY(throwScope.exception())) {         \
-            pc = returnToThrow(vm);                   \
+        if (throwScope.exception()) [[unlikely]] {      \
+            pc = returnToThrow(vm);                     \
             LLINT_END_IMPL();                           \
         }                                               \
     } while (false)
@@ -175,7 +175,7 @@ static inline JSValue getOperand(CallFrame* callFrame, VirtualRegister operand) 
 #define LLINT_CALL_CHECK_EXCEPTION(globalObject) do {               \
         JSGlobalObject* __cce_globalObject = (globalObject);                                 \
         doExceptionFuzzingIfEnabled(__cce_globalObject, throwScope, "LLIntSlowPaths/call", nullptr); \
-        if (UNLIKELY(throwScope.exception()))                           \
+        if (throwScope.exception()) [[unlikely]]                           \
             LLINT_CALL_END_IMPL(nullptr, callToThrow(vm).code().taggedPtr(), ExceptionHandlerPtrTag); \
     } while (false)
 
@@ -483,7 +483,7 @@ LLINT_SLOW_PATH_DECL(loop_osr)
             *codeBlock, ": Entered loop_osr with executeCounter = ",
             codeBlock->llintExecuteCounter());
 
-    if (UNLIKELY(Options::returnEarlyFromInfiniteLoopsForFuzzing() && codeBlock->loopHintsAreEligibleForFuzzingEarlyReturn())) {
+    if (Options::returnEarlyFromInfiniteLoopsForFuzzing() && codeBlock->loopHintsAreEligibleForFuzzingEarlyReturn()) [[unlikely]] {
         uintptr_t* ptr = vm.getLoopHintExecutionCounter(pc);
         *ptr += codeBlock->llintExecuteCounter().m_activeThreshold;
         if (*ptr >= Options::earlyReturnFromInfiniteLoopsLimit())
@@ -567,9 +567,9 @@ LLINT_SLOW_PATH_DECL(stack_check)
     // throw the StackOverflowError unconditionally.
 #if ENABLE(C_LOOP)
     Register* topOfFrame = callFrame->topOfFrame();
-    if (LIKELY(topOfFrame < reinterpret_cast<Register*>(callFrame))) {
+    if (topOfFrame < reinterpret_cast<Register*>(callFrame)) [[likely]] {
         ASSERT(!vm.interpreter.cloopStack().containsAddress(topOfFrame));
-        if (LIKELY(vm.ensureStackCapacityFor(topOfFrame)))
+        if (vm.ensureStackCapacityFor(topOfFrame)) [[likely]]
             LLINT_RETURN_TWO(pc, 0);
     }
 #endif
@@ -591,7 +591,7 @@ extern "C" UGPRPair SYSV_ABI llint_default_call(CallFrame* calleeFrame, CallLink
     calleeFrame->setCodeBlock(nullptr);
     void* callTarget = linkFor(vm, owner, calleeFrame, callLinkInfo);
     ensureStillAliveHere(owner);
-    if (UNLIKELY(scope.exception()))
+    if (scope.exception()) [[unlikely]]
         return encodeResult(callTarget, std::bit_cast<void*>(&vm));
     return encodeResult(callTarget, nullptr);
 }
@@ -607,7 +607,7 @@ extern "C" UGPRPair SYSV_ABI llint_virtual_call(CallFrame* calleeFrame, CallLink
     calleeFrame->setCodeBlock(nullptr);
     void* callTarget = virtualForWithFunction(vm, owner, calleeFrame, callLinkInfo, calleeAsFunctionCellIgnored);
     ensureStillAliveHere(owner);
-    if (UNLIKELY(scope.exception()))
+    if (scope.exception()) [[unlikely]]
         return encodeResult(callTarget, std::bit_cast<void*>(&vm));
     return encodeResult(callTarget, nullptr);
 }
@@ -622,11 +622,11 @@ extern "C" UGPRPair SYSV_ABI llint_polymorphic_call(CallFrame* calleeFrame, Call
     JSCell* calleeAsFunctionCell;
     calleeFrame->setCodeBlock(nullptr);
     void* callTarget = virtualForWithFunction(vm, owner, calleeFrame, callLinkInfo, calleeAsFunctionCell);
-    if (UNLIKELY(scope.exception()))
+    if (scope.exception()) [[unlikely]]
         return encodeResult(callTarget, std::bit_cast<void*>(&vm));
     linkPolymorphicCall(vm, owner, calleeFrame, *callLinkInfo, CallVariant(calleeAsFunctionCell));
     ensureStillAliveHere(owner);
-    if (UNLIKELY(scope.exception()))
+    if (scope.exception()) [[unlikely]]
         return encodeResult(callTarget, std::bit_cast<void*>(&vm));
     return encodeResult(callTarget, nullptr);
 }
@@ -923,7 +923,7 @@ static JSValue performLLIntGetByID(BytecodeIndex bytecodeIndex, CodeBlock* codeB
                 metadata.defaultMode.cachedOffset = slot.cachedOffset();
                 vm.writeBarrier(codeBlock);
             }
-        } else if (UNLIKELY(metadata.hitCountForLLIntCaching && slot.isValue())) {
+        } else if (metadata.hitCountForLLIntCaching && slot.isValue()) [[unlikely]] {
             ASSERT(slot.slotBase() != baseValue);
 
             if (!(--metadata.hitCountForLLIntCaching))
@@ -1192,7 +1192,7 @@ static ALWAYS_INLINE JSValue getByVal(VM& vm, JSGlobalObject* globalObject, Code
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (LIKELY(baseValue.isCell() && subscript.isString())) {
+    if (baseValue.isCell() && subscript.isString()) [[likely]] {
         Structure& structure = *baseValue.asCell()->structure();
         if (JSCell::canUseFastGetOwnProperty(structure)) {
             auto existingAtomString = asString(subscript)->toExistingAtomString(globalObject);
@@ -1240,7 +1240,7 @@ static ALWAYS_INLINE JSValue getByVal(VM& vm, JSGlobalObject* globalObject, Code
         ArrayProfile* arrayProfile = &metadata.m_arrayProfile;
         arrayProfile->setOutOfBounds();
         if (subscript == jsNumber(-1)) {
-            if (auto* array = jsDynamicCast<JSArray*>(baseValue.asCell()); LIKELY(array && array->definitelyNegativeOneMiss()))
+            if (auto* array = jsDynamicCast<JSArray*>(baseValue.asCell()); array && array->definitelyNegativeOneMiss()) [[likely]]
                 return jsUndefined();
         }
     }
@@ -1387,7 +1387,7 @@ LLINT_SLOW_PATH_DECL(slow_path_put_by_val_direct)
 
     // Don't put to an object if toString threw an exception.
     auto property = subscript.toPropertyKey(globalObject);
-    if (UNLIKELY(throwScope.exception()))
+    if (throwScope.exception()) [[unlikely]]
         LLINT_END();
 
     if (std::optional<uint32_t> index = parseIndex(property))
@@ -2503,7 +2503,7 @@ static void throwArityCheckStackOverflowError(JSGlobalObject* globalObject, Thro
     JSObject* error = createStackOverflowError(globalObject);
     throwException(globalObject, scope, error);
 #if LLINT_TRACING
-    if (UNLIKELY(Options::traceLLIntSlowPath()))
+    if (Options::traceLLIntSlowPath()) [[unlikely]]
         dataLog("Throwing exception ", JSValue(scope.exception()), ".\n");
 #endif
 }
@@ -2529,7 +2529,7 @@ static ALWAYS_INLINE int arityCheckFor(VM& vm, CallFrame* callFrame, CodeBlock* 
 
     Register* newStack = callFrame->registers() - WTF::roundUpToMultipleOf(stackAlignmentRegisters(), padding);
 
-    if (UNLIKELY(!vm.ensureStackCapacityFor(newStack)))
+    if (!vm.ensureStackCapacityFor(newStack)) [[unlikely]]
         return -1;
     return padding;
 }
@@ -2538,7 +2538,7 @@ LLINT_SLOW_PATH_DECL(slow_path_arityCheck)
 {
     LLINT_BEGIN();
     int slotsToAdd = arityCheckFor(vm, callFrame, codeBlock);
-    if (UNLIKELY(slotsToAdd < 0)) {
+    if (slotsToAdd < 0) [[unlikely]] {
         callFrame->convertToStackOverflowFrame(vm, codeBlock);
         SlowPathFrameTracer tracer(vm, callFrame);
         ErrorHandlingScope errorScope(vm);

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
@@ -254,7 +254,7 @@ JSValue CLoop::execute(OpcodeID entryOpcodeID, void* executableAddress, VM* vm, 
     // caller (or one of its ancestors) is responsible for ensuring that this
     // is only called once during the initialization of the VM before threads
     // are at play.
-    if (UNLIKELY(isInitializationPass)) {
+    if (isInitializationPass) [[unlikely]] {
         Opcode* opcodeMap = LLInt::opcodeMap();
         Opcode* opcodeMapWide16 = LLInt::opcodeMapWide16();
         Opcode* opcodeMapWide32 = LLInt::opcodeMapWide32();

--- a/Source/JavaScriptCore/parser/Lexer.h
+++ b/Source/JavaScriptCore/parser/Lexer.h
@@ -103,7 +103,7 @@ public:
 
         m_buffer8.shrink(0);
         m_buffer16.shrink(0);
-        if (LIKELY(m_code < m_codeEnd))
+        if (m_code < m_codeEnd) [[likely]]
             m_current = *m_code;
         else
             m_current = 0;

--- a/Source/JavaScriptCore/parser/ModuleAnalyzer.cpp
+++ b/Source/JavaScriptCore/parser/ModuleAnalyzer.cpp
@@ -147,7 +147,7 @@ Expected<JSModuleRecord*, std::tuple<ErrorType, String>> ModuleAnalyzer::analyze
     for (const auto& pair : m_moduleRecord->lexicalVariables())
         exportVariable(moduleProgramNode, pair.key, pair.value);
 
-    if (UNLIKELY(Options::dumpModuleRecord()))
+    if (Options::dumpModuleRecord()) [[unlikely]]
         m_moduleRecord->dump();
 
     return m_moduleRecord;

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -1733,7 +1733,7 @@ private:
 
         // In the case of Generator or Async function bodies, also check the wrapper function, whose name or
         // arguments may be invalid.
-        if (UNLIKELY((m_scopeStack[i].isGeneratorFunctionBoundary() || m_scopeStack[i].isAsyncFunctionBoundary()) && i))
+        if ((m_scopeStack[i].isGeneratorFunctionBoundary() || m_scopeStack[i].isAsyncFunctionBoundary()) && i) [[unlikely]]
             return m_scopeStack[i - 1].isValidStrictMode();
         return true;
     }
@@ -2279,7 +2279,7 @@ std::unique_ptr<ParsedNode> parse(
     ASSERT(!source.provider()->source().isNull());
 
     MonotonicTime before;
-    if (UNLIKELY(Options::reportParseTimes()))
+    if (Options::reportParseTimes()) [[unlikely]]
         before = MonotonicTime::now();
 
     std::unique_ptr<ParsedNode> result;
@@ -2298,10 +2298,10 @@ std::unique_ptr<ParsedNode> parse(
         result = parser.parse<ParsedNode>(error, name, ParsingContext::Normal, std::nullopt, parentScopePrivateNames, classElementDefinitions);
     }
 
-    if (UNLIKELY(Options::countParseTimes()))
+    if (Options::countParseTimes()) [[unlikely]]
         globalParseCount++;
 
-    if (UNLIKELY(Options::reportParseTimes())) {
+    if (Options::reportParseTimes()) [[unlikely]] {
         MonotonicTime after = MonotonicTime::now();
         ParseHash hash(source);
         dataLogLn(result ? "Parsed #" : "Failed to parse #", hash.hashForCall(), "/#", hash.hashForConstruct(), " in ", (after - before).milliseconds(), " ms.");
@@ -2324,7 +2324,7 @@ std::unique_ptr<ParsedNode> parseRootNode(
     ASSERT(!source.provider()->source().isNull());
 
     MonotonicTime before;
-    if (UNLIKELY(Options::reportParseTimes()))
+    if (Options::reportParseTimes()) [[unlikely]]
         before = MonotonicTime::now();
 
     Identifier name;
@@ -2344,10 +2344,10 @@ std::unique_ptr<ParsedNode> parseRootNode(
         result = parser.parse<ParsedNode>(error, name, ParsingContext::Normal);
     }
 
-    if (UNLIKELY(Options::countParseTimes()))
+    if (Options::countParseTimes()) [[unlikely]]
         globalParseCount++;
 
-    if (UNLIKELY(Options::reportParseTimes())) {
+    if (Options::reportParseTimes()) [[unlikely]] {
         MonotonicTime after = MonotonicTime::now();
         ParseHash hash(source);
         dataLogLn(result ? "Parsed #" : "Failed to parse #", hash.hashForCall(), "/#", hash.hashForConstruct(), " in ", (after - before).milliseconds(), " ms.");
@@ -2361,7 +2361,7 @@ inline std::unique_ptr<ProgramNode> parseFunctionForFunctionConstructor(VM& vm, 
     ASSERT(!source.provider()->source().isNull());
 
     MonotonicTime before;
-    if (UNLIKELY(Options::reportParseTimes()))
+    if (Options::reportParseTimes()) [[unlikely]]
         before = MonotonicTime::now();
 
     Identifier name;
@@ -2379,10 +2379,10 @@ inline std::unique_ptr<ProgramNode> parseFunctionForFunctionConstructor(VM& vm, 
             *positionBeforeLastNewline = parser.positionBeforeLastNewline();
     }
 
-    if (UNLIKELY(Options::countParseTimes()))
+    if (Options::countParseTimes()) [[unlikely]]
         globalParseCount++;
 
-    if (UNLIKELY(Options::reportParseTimes())) {
+    if (Options::reportParseTimes()) [[unlikely]] {
         MonotonicTime after = MonotonicTime::now();
         ParseHash hash(source);
         dataLogLn(result ? "Parsed #" : "Failed to parse #", hash.hashForCall(), "/#", hash.hashForConstruct(), " in ", (after - before).milliseconds(), " ms.");

--- a/Source/JavaScriptCore/parser/ParserArena.h
+++ b/Source/JavaScriptCore/parser/ParserArena.h
@@ -169,7 +169,7 @@ namespace JSC {
             ASSERT(size <= freeablePoolSize);
             size_t alignedSize = alignSize(size);
             ASSERT(alignedSize <= freeablePoolSize);
-            if (UNLIKELY(static_cast<size_t>(m_freeablePoolEnd - m_freeableMemory) < alignedSize))
+            if (static_cast<size_t>(m_freeablePoolEnd - m_freeableMemory) < alignedSize) [[unlikely]]
                 allocateFreeablePool();
             void* block = m_freeableMemory;
             m_freeableMemory += alignedSize;

--- a/Source/JavaScriptCore/parser/SourceProvider.cpp
+++ b/Source/JavaScriptCore/parser/SourceProvider.cpp
@@ -53,9 +53,9 @@ void SourceProvider::getID()
 
 const String& SourceProvider::sourceURLStripped()
 {
-    if (UNLIKELY(m_sourceURL.isNull()))
+    if (m_sourceURL.isNull()) [[unlikely]]
         return m_sourceURLStripped;
-    if (LIKELY(!m_sourceURLStripped.isNull()))
+    if (!m_sourceURLStripped.isNull()) [[likely]]
         return m_sourceURLStripped;
     m_sourceURLStripped = URL(m_sourceURL).strippedForUseAsReport();
     return m_sourceURLStripped;

--- a/Source/JavaScriptCore/runtime/AggregateError.cpp
+++ b/Source/JavaScriptCore/runtime/AggregateError.cpp
@@ -50,7 +50,7 @@ ErrorInstance* createAggregateError(JSGlobalObject* globalObject, VM& vm, Struct
     MarkedArgumentBuffer errorsList;
     forEachInIterable(globalObject, errors, [&] (VM&, JSGlobalObject*, JSValue nextValue) {
         errorsList.append(nextValue);
-        if (UNLIKELY(errorsList.hasOverflowed()))
+        if (errorsList.hasOverflowed()) [[unlikely]]
             throwOutOfMemoryError(globalObject, scope);
     });
     RETURN_IF_EXCEPTION(scope, nullptr);

--- a/Source/JavaScriptCore/runtime/ArgList.cpp
+++ b/Source/JavaScriptCore/runtime/ArgList.cpp
@@ -74,7 +74,7 @@ auto MarkedVectorBase::slowEnsureCapacity(size_t requestedCapacity) -> Status
 {
     setNeedsOverflowCheck();
     auto checkedNewCapacity = CheckedInt32(requestedCapacity);
-    if (UNLIKELY(checkedNewCapacity.hasOverflowed()))
+    if (checkedNewCapacity.hasOverflowed()) [[unlikely]]
         return Status::Overflowed;
     return expandCapacity(checkedNewCapacity);
 }
@@ -83,7 +83,7 @@ auto MarkedVectorBase::expandCapacity() -> Status
 {
     setNeedsOverflowCheck();
     auto checkedNewCapacity = CheckedInt32(m_capacity) * 2;
-    if (UNLIKELY(checkedNewCapacity.hasOverflowed()))
+    if (checkedNewCapacity.hasOverflowed()) [[unlikely]]
         return Status::Overflowed;
     return expandCapacity(checkedNewCapacity);
 }
@@ -93,7 +93,7 @@ auto MarkedVectorBase::expandCapacity(unsigned newCapacity) -> Status
     setNeedsOverflowCheck();
     ASSERT(m_capacity < newCapacity);
     auto checkedSize = CheckedSize(newCapacity) * sizeof(EncodedJSValue);
-    if (UNLIKELY(checkedSize.hasOverflowed()))
+    if (checkedSize.hasOverflowed()) [[unlikely]]
         return Status::Overflowed;
     EncodedJSValue* newBuffer = static_cast<EncodedJSValue*>(FastMalloc::tryMalloc(checkedSize));
     if (!newBuffer)

--- a/Source/JavaScriptCore/runtime/ArgList.h
+++ b/Source/JavaScriptCore/runtime/ArgList.h
@@ -229,7 +229,7 @@ public:
         if (OverflowHandler::hasOverflowed())
             return;
         if (!isUsingInlineBuffer()) {
-            if (LIKELY(!m_markSet)) {
+            if (!m_markSet) [[likely]] {
                 m_markSet = &vm.heap.markListSet();
                 m_markSet->add(this);
             }

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
@@ -434,7 +434,7 @@ void ArrayBuffer::notifyDetaching(VM& vm)
 Expected<int64_t, GrowFailReason> ArrayBuffer::grow(VM& vm, size_t newByteLength)
 {
     auto shared = m_contents.m_shared;
-    if (UNLIKELY(!shared))
+    if (!shared) [[unlikely]]
         return makeUnexpected(GrowFailReason::GrowSharedUnavailable);
     auto result = shared->grow(vm, newByteLength);
     if (result && result.value() > 0)
@@ -445,7 +445,7 @@ Expected<int64_t, GrowFailReason> ArrayBuffer::grow(VM& vm, size_t newByteLength
 Expected<int64_t, GrowFailReason> ArrayBuffer::resize(VM& vm, size_t newByteLength)
 {
     auto memoryHandle = m_contents.m_memoryHandle;
-    if (UNLIKELY(!memoryHandle || m_contents.m_shared))
+    if (!memoryHandle || m_contents.m_shared) [[unlikely]]
         return makeUnexpected(GrowFailReason::GrowSharedUnavailable);
 
     int64_t deltaByteLength = 0;

--- a/Source/JavaScriptCore/runtime/ArrayBufferView.h
+++ b/Source/JavaScriptCore/runtime/ArrayBufferView.h
@@ -87,10 +87,10 @@ public:
 
     size_t byteOffset() const
     {
-        if (UNLIKELY(isDetached()))
+        if (isDetached()) [[unlikely]]
             return 0;
 
-        if (LIKELY(!isResizableOrGrowableShared()))
+        if (!isResizableOrGrowableShared()) [[likely]]
             return byteOffsetRaw();
 
         size_t bufferByteLength = m_buffer->byteLength(std::memory_order_seq_cst);
@@ -100,7 +100,7 @@ public:
             byteOffsetEnd = bufferByteLength;
         else
             byteOffsetEnd = byteOffsetStart + byteLengthRaw();
-        if (UNLIKELY(byteOffsetStart > bufferByteLength || byteOffsetEnd > bufferByteLength))
+        if (byteOffsetStart > bufferByteLength || byteOffsetEnd > bufferByteLength) [[unlikely]]
             return 0;
         return byteOffsetRaw();
     }
@@ -109,10 +109,10 @@ public:
 
     size_t byteLength() const
     {
-        if (UNLIKELY(isDetached()))
+        if (isDetached()) [[unlikely]]
             return 0;
 
-        if (LIKELY(!isResizableOrGrowableShared()))
+        if (!isResizableOrGrowableShared()) [[likely]]
             return byteLengthRaw();
 
         size_t bufferByteLength = m_buffer->byteLength(std::memory_order_seq_cst);
@@ -122,7 +122,7 @@ public:
             byteOffsetEnd = bufferByteLength;
         else
             byteOffsetEnd = byteOffsetStart + byteLengthRaw();
-        if (UNLIKELY(byteOffsetStart > bufferByteLength || byteOffsetEnd > bufferByteLength))
+        if (byteOffsetStart > bufferByteLength || byteOffsetEnd > bufferByteLength) [[unlikely]]
             return 0;
         if (!isAutoLength())
             return byteLengthRaw();

--- a/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
@@ -114,7 +114,7 @@ static ALWAYS_INLINE bool isArraySlowInline(JSGlobalObject* globalObject, ProxyO
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     while (true) {
-        if (UNLIKELY(proxy->isRevoked())) {
+        if (proxy->isRevoked()) [[unlikely]] {
             auto* callFrame = vm.topJSCallFrame();
             auto* callee = callFrame && !callFrame->isNativeCalleeFrame() ? callFrame->jsCallee() : nullptr;
             ASCIILiteral calleeName = "Array.isArray"_s;

--- a/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
@@ -92,12 +92,12 @@ ALWAYS_INLINE std::pair<SpeciesConstructResult, JSObject*> speciesConstructArray
     JSValue constructor = jsUndefined();
     bool thisIsArray = isArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, exceptionResult);
-    if (LIKELY(thisIsArray)) {
+    if (thisIsArray) [[likely]] {
         // Fast path in the normal case where the user has not set an own constructor and the Array.prototype.constructor is normal.
         // We need prototype check for subclasses of Array, which are Array objects but have a different prototype by default.
         bool isValid = arraySpeciesWatchpointIsValid(vm, thisObject);
         RETURN_IF_EXCEPTION(scope, exceptionResult);
-        if (LIKELY(isValid))
+        if (isValid) [[likely]]
             return std::pair { SpeciesConstructResult::FastPath, nullptr };
 
         constructor = thisObject->get(globalObject, vm.propertyNames->constructor);
@@ -135,8 +135,8 @@ ALWAYS_INLINE void setLength(JSGlobalObject* globalObject, VM& vm, JSObject* obj
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
     static constexpr bool throwException = true;
-    if (LIKELY(isJSArray(obj))) {
-        if (UNLIKELY(value > UINT32_MAX)) {
+    if (isJSArray(obj)) [[likely]] {
+        if (value > UINT32_MAX) [[unlikely]] {
             throwRangeError(globalObject, scope, "Invalid array length"_s);
             return;
         }
@@ -255,7 +255,7 @@ inline void unshift(JSGlobalObject* globalObject, JSObject* thisObj, uint64_t he
         } else {
             bool success = thisObj->deleteProperty(globalObject, to);
             RETURN_IF_EXCEPTION(scope, void());
-            if (UNLIKELY(!success)) {
+            if (!success) [[unlikely]] {
                 throwTypeError(globalObject, scope, UnableToDeletePropertyError);
                 return;
             }

--- a/Source/JavaScriptCore/runtime/AtomicsObject.cpp
+++ b/Source/JavaScriptCore/runtime/AtomicsObject.cpp
@@ -126,7 +126,7 @@ static unsigned validateAtomicAccess(JSGlobalObject* globalObject, VM& vm, JSArr
     auto scope = DECLARE_THROW_SCOPE(vm);
     unsigned accessIndex = 0;
     size_t length = typedArrayView->length();
-    if (LIKELY(accessIndexValue.isUInt32()))
+    if (accessIndexValue.isUInt32()) [[likely]]
         accessIndex = accessIndexValue.asUInt32();
     else {
         accessIndex = accessIndexValue.toIndex(globalObject, "accessIndex"_s);
@@ -549,7 +549,7 @@ JSC_DEFINE_HOST_FUNCTION(atomicsFuncPause, (JSGlobalObject* globalObject, CallFr
 
     JSValue argument = callFrame->argument(0);
     if (!argument.isUndefined()) {
-        if (UNLIKELY(!argument.isNumber() || !isInteger(argument.asNumber())))
+        if (!argument.isNumber() || !isInteger(argument.asNumber())) [[unlikely]]
             return throwVMTypeError(globalObject, scope, "Atomics.pause argument needs to be either undefined or integer number"_s);
         // Right now, argument integer is not used.
     }

--- a/Source/JavaScriptCore/runtime/BooleanPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/BooleanPrototype.cpp
@@ -73,7 +73,7 @@ JSC_DEFINE_HOST_FUNCTION(booleanProtoFuncToString, (JSGlobalObject* globalObject
         return JSValue::encode(vm.smallStrings.trueString());
 
     auto* thisObject = jsDynamicCast<BooleanObject*>(thisValue);
-    if (UNLIKELY(!thisObject))
+    if (!thisObject) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     Integrity::auditStructureID(thisObject->structureID());
@@ -93,7 +93,7 @@ JSC_DEFINE_HOST_FUNCTION(booleanProtoFuncValueOf, (JSGlobalObject* globalObject,
         return JSValue::encode(thisValue);
 
     auto* thisObject = jsDynamicCast<BooleanObject*>(thisValue);
-    if (UNLIKELY(!thisObject))
+    if (!thisObject) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     Integrity::auditStructureID(thisObject->structureID());

--- a/Source/JavaScriptCore/runtime/ButterflyInlines.h
+++ b/Source/JavaScriptCore/runtime/ButterflyInlines.h
@@ -80,7 +80,7 @@ inline Butterfly* Butterfly::tryCreateUninitialized(VM& vm, JSObject*, size_t pr
 {
     size_t size = totalSize(preCapacity, propertyCapacity, hasIndexingHeader, indexingPayloadSizeInBytes);
     void* base = vm.auxiliarySpace().allocate(vm, size, deferralContext, AllocationFailureMode::ReturnNull);
-    if (UNLIKELY(!base))
+    if (!base) [[unlikely]]
         return nullptr;
 
     Butterfly* result = fromBase(base, preCapacity, propertyCapacity);

--- a/Source/JavaScriptCore/runtime/CallData.cpp
+++ b/Source/JavaScriptCore/runtime/CallData.cpp
@@ -62,7 +62,7 @@ JSValue call(JSGlobalObject* globalObject, JSValue functionObject, const CallDat
     VM& vm = globalObject->vm();
     auto scope = DECLARE_CATCH_SCOPE(vm);
     JSValue result = call(globalObject, functionObject, callData, thisValue, args);
-    if (UNLIKELY(scope.exception())) {
+    if (scope.exception()) [[unlikely]] {
         returnedException = scope.exception();
         scope.clearException();
         return jsUndefined();

--- a/Source/JavaScriptCore/runtime/CatchScope.h
+++ b/Source/JavaScriptCore/runtime/CatchScope.h
@@ -77,7 +77,7 @@ ALWAYS_INLINE void CatchScope::clearException()
 
 ALWAYS_INLINE bool CatchScope::clearExceptionExceptTermination()
 {
-    if (UNLIKELY(m_vm.hasPendingTerminationException())) {
+    if (m_vm.hasPendingTerminationException()) [[unlikely]] {
 #if ENABLE(EXCEPTION_SCOPE_VERIFICATION)
         m_vm.exception();
 #endif
@@ -88,7 +88,7 @@ ALWAYS_INLINE bool CatchScope::clearExceptionExceptTermination()
 }
 
 #define CLEAR_AND_RETURN_IF_EXCEPTION(scope__, value__) do { \
-        if (UNLIKELY((scope__).exception())) { \
+        if ((scope__).exception()) [[unlikely]] { \
             (scope__).clearException(); \
             return value__; \
         } \

--- a/Source/JavaScriptCore/runtime/ClonedArguments.cpp
+++ b/Source/JavaScriptCore/runtime/ClonedArguments.cpp
@@ -48,10 +48,10 @@ ClonedArguments* ClonedArguments::createEmpty(VM& vm, JSGlobalObject* nullOrGlob
     if (vectorLength > MAX_STORAGE_VECTOR_LENGTH)
         return nullptr;
 
-    if (UNLIKELY(structure->mayInterceptIndexedAccesses() || structure->storedPrototypeObject()->needsSlowPutIndexing())) {
+    if (structure->mayInterceptIndexedAccesses() || structure->storedPrototypeObject()->needsSlowPutIndexing()) [[unlikely]] {
         if (!butterfly) {
             butterfly = tryCreateArrayStorageButterfly(vm, nullptr, structure, length, vectorLength);
-            if (UNLIKELY(!butterfly)) {
+            if (!butterfly) [[unlikely]] {
                 if (nullOrGlobalObjectForOOM) {
                     auto scope = DECLARE_THROW_SCOPE(vm);
                     throwOutOfMemoryError(nullOrGlobalObjectForOOM, scope);
@@ -66,7 +66,7 @@ ClonedArguments* ClonedArguments::createEmpty(VM& vm, JSGlobalObject* nullOrGlob
             indexingHeader.setVectorLength(vectorLength);
             indexingHeader.setPublicLength(length);
             butterfly = Butterfly::tryCreate(vm, nullptr, 0, structure->outOfLineCapacity(), true, indexingHeader, vectorLength * sizeof(EncodedJSValue));
-            if (UNLIKELY(!butterfly)) {
+            if (!butterfly) [[unlikely]] {
                 if (nullOrGlobalObjectForOOM) {
                     auto scope = DECLARE_THROW_SCOPE(vm);
                     throwOutOfMemoryError(nullOrGlobalObjectForOOM, scope);
@@ -311,7 +311,7 @@ void ClonedArguments::copyToArguments(JSGlobalObject* globalObject, JSValue* fir
         unsigned i;
         for (i = offset; i < limit; ++i) {
             JSValue value = data[i].get();
-            if (UNLIKELY(!value)) {
+            if (!value) [[unlikely]] {
                 value = get(globalObject, i);
                 RETURN_IF_EXCEPTION(scope, void());
             }
@@ -349,13 +349,13 @@ bool ClonedArguments::isIteratorProtocolFastAndNonObservable()
     if (structure->didTransition())
         return false;
 
-    if (UNLIKELY(structure->mayInterceptIndexedAccesses() || structure->storedPrototypeObject()->needsSlowPutIndexing()))
+    if (structure->mayInterceptIndexedAccesses() || structure->storedPrototypeObject()->needsSlowPutIndexing()) [[unlikely]]
         return false;
 
     // Even though Structure is not transitioned, it is possible that length property is replaced with random value.
     // To avoid side-effect, we need to ensure that this value is Int32.
     JSValue lengthValue = getDirect(clonedArgumentsLengthPropertyOffset);
-    if (LIKELY(lengthValue.isInt32() && lengthValue.asInt32() >= 0))
+    if (lengthValue.isInt32() && lengthValue.asInt32() >= 0) [[likely]]
         return true;
 
     return false;

--- a/Source/JavaScriptCore/runtime/ClonedArguments.h
+++ b/Source/JavaScriptCore/runtime/ClonedArguments.h
@@ -58,9 +58,9 @@ public:
         auto scope = DECLARE_THROW_SCOPE(vm);
 
         JSValue lengthValue;
-        if (LIKELY(!structure()->didTransition())) {
+        if (!structure()->didTransition()) [[likely]] {
             lengthValue = getDirect(clonedArgumentsLengthPropertyOffset);
-            if (LIKELY(lengthValue.isInt32()))
+            if (lengthValue.isInt32()) [[likely]]
                 return std::max(lengthValue.asInt32(), 0);
         } else {
             lengthValue = get(globalObject, vm.propertyNames->length);

--- a/Source/JavaScriptCore/runtime/CodeCache.cpp
+++ b/Source/JavaScriptCore/runtime/CodeCache.cpp
@@ -234,7 +234,7 @@ UnlinkedFunctionExecutable* CodeCache::getUnlinkedGlobalFunctionExecutable(VM& v
 
     // This function assumes an input string that would result in a single function declaration.
     StatementNode* funcDecl = program->singleStatement();
-    if (UNLIKELY(!funcDecl)) {
+    if (!funcDecl) [[unlikely]] {
         JSToken token;
         error = ParserError(ParserError::SyntaxError, ParserError::SyntaxErrorIrrecoverable, token, "Parser error"_s, -1);
         return nullptr;

--- a/Source/JavaScriptCore/runtime/CodeCache.h
+++ b/Source/JavaScriptCore/runtime/CodeCache.h
@@ -166,7 +166,7 @@ private:
     {
         if constexpr (std::is_base_of_v<UnlinkedCodeBlock, UnlinkedCodeBlockType> && !std::is_same_v<UnlinkedCodeBlockType, UnlinkedEvalCodeBlock>) {
             UnlinkedCodeBlockType* codeBlock = fetchFromDiskImpl<UnlinkedCodeBlockType>(vm, key);
-            if (UNLIKELY(Options::forceDiskCache())) {
+            if (Options::forceDiskCache()) [[unlikely]] {
                 if (isMainThread())
                     RELEASE_ASSERT(codeBlock);
             }

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
@@ -102,10 +102,10 @@ namespace JSC {
 
 #define CHECK_EXCEPTION() do {                    \
         doExceptionFuzzingIfEnabled(globalObject, throwScope, "CommonSlowPaths", pc);   \
-        if (UNLIKELY(throwScope.exception())) {   \
-            RETURN_TO_THROW(pc);            \
-            END_IMPL();                           \
-        }                                         \
+        if (throwScope.exception()) [[unlikely]] {   \
+            RETURN_TO_THROW(pc);                     \
+            END_IMPL();                              \
+        }                                            \
     } while (false)
 
 #define END() do {                        \
@@ -523,7 +523,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_to_object)
     BEGIN();
     auto bytecode = pc->as<OpToObject>();
     JSValue argument = GET_C(bytecode.m_operand).jsValue();
-    if (UNLIKELY(argument.isUndefinedOrNull())) {
+    if (argument.isUndefinedOrNull()) [[unlikely]] {
         const Identifier& ident = codeBlock->identifier(bytecode.m_message);
         if (!ident.isEmpty())
             THROW(createTypeError(globalObject, ident.impl()));
@@ -911,7 +911,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_enter)
     BEGIN();
     Heap::heap(codeBlock)->writeBarrier(codeBlock);
     GET(codeBlock->scopeRegister()) = jsCast<JSCallee*>(callFrame->jsCallee())->scope();
-    if (UNLIKELY(codeBlock->couldBeTainted()))
+    if (codeBlock->couldBeTainted()) [[unlikely]]
         vm.setMightBeExecutingTaintedCode();
     END();
 }
@@ -1159,7 +1159,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_get_by_val_with_this)
     JSValue thisValue = GET_C(bytecode.m_thisValue).jsValue();
     JSValue subscript = GET_C(bytecode.m_property).jsValue();
 
-    if (LIKELY(baseValue.isCell() && subscript.isString())) {
+    if (baseValue.isCell() && subscript.isString()) [[likely]] {
         Structure& structure = *baseValue.asCell()->structure();
         if (JSCell::canUseFastGetOwnProperty(structure)) {
             auto existingAtomString = asString(subscript)->toExistingAtomString(globalObject);
@@ -1299,17 +1299,17 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_new_array_with_spread)
         } else
             checkedArraySize += 1;
     }
-    if (UNLIKELY(checkedArraySize.hasOverflowed()))
+    if (checkedArraySize.hasOverflowed()) [[unlikely]]
         THROW(createOutOfMemoryError(globalObject));
 
     unsigned arraySize = checkedArraySize;
-    if (UNLIKELY(arraySize >= MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH))
+    if (arraySize >= MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH) [[unlikely]]
         THROW(createOutOfMemoryError(globalObject));
 
     Structure* structure = globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous);
 
     JSArray* result = JSArray::tryCreate(vm, structure, arraySize);
-    if (UNLIKELY(!result))
+    if (!result) [[unlikely]]
         THROW(createOutOfMemoryError(globalObject));
     CHECK_EXCEPTION();
 
@@ -1350,11 +1350,11 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_new_array_with_species)
     std::pair<SpeciesConstructResult, JSObject*> speciesResult = speciesConstructArray(globalObject, array, length);
     EXCEPTION_ASSERT(!!throwScope.exception() == (speciesResult.first == SpeciesConstructResult::Exception));
 
-    if (UNLIKELY(speciesResult.first == SpeciesConstructResult::Exception))
+    if (speciesResult.first == SpeciesConstructResult::Exception) [[unlikely]]
         CHECK_EXCEPTION();
 
-    if (LIKELY(speciesResult.first == SpeciesConstructResult::FastPath)) {
-        if (UNLIKELY(length > std::numeric_limits<unsigned>::max()))
+    if (speciesResult.first == SpeciesConstructResult::FastPath) [[likely]] {
+        if (length > std::numeric_limits<unsigned>::max()) [[unlikely]]
             THROW(createRangeError(globalObject, ArrayInvalidLengthError));
 
         JSArray* result = constructEmptyArray(globalObject, &arrayAllocationProfile, static_cast<unsigned>(length));
@@ -1379,7 +1379,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_new_array_buffer)
     ASSERT(isCopyOnWrite(indexingMode));
     ASSERT(!structure->outOfLineCapacity());
 
-    if (UNLIKELY(immutableButterfly->indexingMode() != indexingMode)) {
+    if (immutableButterfly->indexingMode() != indexingMode) [[unlikely]] {
         auto* newButterfly = JSImmutableButterfly::create(vm, indexingMode, immutableButterfly->length());
         for (unsigned i = 0; i < immutableButterfly->length(); ++i)
             newButterfly->setIndex(vm, i, immutableButterfly->get(i));

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.h
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.h
@@ -66,8 +66,10 @@ inline JSValue opEnumeratorGetByVal(JSGlobalObject* globalObject, JSValue baseVa
 
     switch (mode) {
     case JSPropertyNameEnumerator::IndexedMode: {
-        if (arrayProfile && LIKELY(baseValue.isCell()))
-            arrayProfile->observeStructureID(baseValue.asCell()->structureID());
+        if (arrayProfile) {
+            if (baseValue.isCell()) [[likely]]
+                arrayProfile->observeStructureID(baseValue.asCell()->structureID());
+        }
         RELEASE_AND_RETURN(scope, baseValue.get(globalObject, static_cast<unsigned>(index)));
     }
     case JSPropertyNameEnumerator::OwnStructureMode: {
@@ -196,7 +198,7 @@ static ALWAYS_INLINE void putDirectWithReify(VM& vm, JSGlobalObject* globalObjec
     if (result)
         *result = structure;
 
-    if (LIKELY(canPutDirectFast(vm, structure, propertyName, isJSFunction))) {
+    if (canPutDirectFast(vm, structure, propertyName, isJSFunction)) [[likely]] {
         bool success = baseObject->putDirect(vm, propertyName, value, 0, slot);
         ASSERT_UNUSED(success, success);
     } else {
@@ -236,7 +238,7 @@ inline JSArray* allocateNewArrayBuffer(VM& vm, Structure* structure, JSImmutable
 
     JSArray* result = JSArray::createWithButterfly(vm, nullptr, originalStructure, immutableButterfly->toButterfly());
     // FIXME: This works but it's slow. If we cared enough about the perf when having a bad time then we could fix it.
-    if (UNLIKELY(originalStructure != structure)) {
+    if (originalStructure != structure) [[unlikely]] {
         ASSERT(hasSlowPutArrayStorage(structure->indexingMode()));
         ASSERT(globalObject->isHavingABadTime());
 

--- a/Source/JavaScriptCore/runtime/CommonSlowPathsInlines.h
+++ b/Source/JavaScriptCore/runtime/CommonSlowPathsInlines.h
@@ -167,25 +167,25 @@ ALWAYS_INLINE JSImmutableButterfly* trySpreadFast(JSGlobalObject* globalObject, 
 
     switch (iterable->type()) {
     case StringType: {
-        if (LIKELY(globalObject->isStringPrototypeIteratorProtocolFastAndNonObservable()))
+        if (globalObject->isStringPrototypeIteratorProtocolFastAndNonObservable()) [[likely]]
             return JSImmutableButterfly::createFromString(globalObject, jsCast<JSString*>(iterable));
         return nullptr;
     }
     case ClonedArgumentsType: {
         auto* arguments = jsCast<ClonedArguments*>(iterable);
-        if (LIKELY(arguments->isIteratorProtocolFastAndNonObservable()))
+        if (arguments->isIteratorProtocolFastAndNonObservable()) [[likely]]
             return JSImmutableButterfly::createFromClonedArguments(globalObject, arguments);
         return nullptr;
     }
     case DirectArgumentsType: {
         auto* arguments = jsCast<DirectArguments*>(iterable);
-        if (LIKELY(arguments->isIteratorProtocolFastAndNonObservable()))
+        if (arguments->isIteratorProtocolFastAndNonObservable()) [[likely]]
             return JSImmutableButterfly::createFromDirectArguments(globalObject, arguments);
         return nullptr;
     }
     case ScopedArgumentsType: {
         auto* arguments = jsCast<ScopedArguments*>(iterable);
-        if (LIKELY(arguments->isIteratorProtocolFastAndNonObservable()))
+        if (arguments->isIteratorProtocolFastAndNonObservable()) [[likely]]
             return JSImmutableButterfly::createFromScopedArguments(globalObject, arguments);
         return nullptr;
     }
@@ -201,14 +201,16 @@ inline void opEnumeratorPutByVal(JSGlobalObject* globalObject, JSValue baseValue
 
     switch (mode) {
     case JSPropertyNameEnumerator::IndexedMode: {
-        if (arrayProfile && LIKELY(baseValue.isCell()))
-            arrayProfile->observeStructureID(baseValue.asCell()->structureID());
+        if (arrayProfile) {
+            if (baseValue.isCell()) [[likely]]
+                arrayProfile->observeStructureID(baseValue.asCell()->structureID());
+        }
         scope.release();
         baseValue.putByIndex(globalObject, static_cast<unsigned>(index), value, ecmaMode.isStrict());
         return;
     }
     case JSPropertyNameEnumerator::OwnStructureMode: {
-        if (LIKELY(baseValue.isCell())) {
+        if (baseValue.isCell()) [[likely]] {
             auto* baseCell = baseValue.asCell();
             auto* structure = baseCell->structure();
             if (structure->id() == enumerator->cachedStructureID() && !structure->isWatchingReplacement() && !structure->hasReadOnlyOrGetterSetterPropertiesExcludingProto()) {

--- a/Source/JavaScriptCore/runtime/Completion.cpp
+++ b/Source/JavaScriptCore/runtime/Completion.cpp
@@ -137,7 +137,7 @@ JSValue evaluate(JSGlobalObject* globalObject, const SourceCode& source, JSValue
     JSObject* thisObj = jsCast<JSObject*>(thisValue.toThis(globalObject, ECMAMode::sloppy()));
     JSValue result = vm.interpreter.executeProgram(source, globalObject, thisObj);
 
-    if (UNLIKELY(scope.exception())) {
+    if (scope.exception()) [[unlikely]] {
         returnedException = scope.exception();
         scope.clearException();
         return jsUndefined();
@@ -278,7 +278,7 @@ UncheckedKeyHashMap<RefPtr<UniquedStringImpl>, String> retrieveImportAttributesF
         return { };
 
     auto* optionsObject = jsDynamicCast<JSObject*>(options);
-    if (UNLIKELY(!optionsObject)) {
+    if (!optionsObject) [[unlikely]] {
         throwTypeError(globalObject, scope, "dynamic import's options should be an object"_s);
         return { };
     }
@@ -290,7 +290,7 @@ UncheckedKeyHashMap<RefPtr<UniquedStringImpl>, String> retrieveImportAttributesF
         return { };
 
     auto* attributesObject = jsDynamicCast<JSObject*>(attributes);
-    if (UNLIKELY(!attributesObject)) {
+    if (!attributesObject) [[unlikely]] {
         throwTypeError(globalObject, scope, "dynamic import's options.with should be an object"_s);
         return { };
     }
@@ -304,7 +304,7 @@ UncheckedKeyHashMap<RefPtr<UniquedStringImpl>, String> retrieveImportAttributesF
         JSValue value = attributesObject->get(globalObject, key);
         RETURN_IF_EXCEPTION(scope, { });
 
-        if (UNLIKELY(!value.isString())) {
+        if (!value.isString()) [[unlikely]] {
             throwTypeError(globalObject, scope, "dynamic import's options.with includes non string property"_s);
             return { };
         }
@@ -316,7 +316,7 @@ UncheckedKeyHashMap<RefPtr<UniquedStringImpl>, String> retrieveImportAttributesF
     }
 
     for (auto& [key, value] : result) {
-        if (UNLIKELY(!supportedImportAttributes.contains(key.get()))) {
+        if (!supportedImportAttributes.contains(key.get())) [[unlikely]] {
             throwTypeError(globalObject, scope, makeString("dynamic import's options.with includes unsupported attribute \""_s, StringView(key.get()), "\""_s));
             return { };
         }

--- a/Source/JavaScriptCore/runtime/ConstructData.cpp
+++ b/Source/JavaScriptCore/runtime/ConstructData.cpp
@@ -44,7 +44,7 @@ JSObject* construct(JSGlobalObject* globalObject, JSValue constructorObject, JSV
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto constructData = JSC::getConstructData(constructorObject);
-    if (UNLIKELY(constructData.type == CallData::Type::None)) {
+    if (constructData.type == CallData::Type::None) [[unlikely]] {
         throwTypeError(globalObject, scope, errorMessage);
         return nullptr;
     }

--- a/Source/JavaScriptCore/runtime/DirectArguments.cpp
+++ b/Source/JavaScriptCore/runtime/DirectArguments.cpp
@@ -125,7 +125,7 @@ void DirectArguments::overrideThings(JSGlobalObject* globalObject)
     putDirect(vm, vm.propertyNames->iteratorSymbol, globalObject->arrayProtoValuesFunction(), static_cast<unsigned>(PropertyAttribute::DontEnum));
     
     void* backingStore = vm.gigacageAuxiliarySpace(m_mappedArguments.kind).allocate(vm, mappedArgumentsSize(), nullptr, AllocationFailureMode::ReturnNull);
-    if (UNLIKELY(!backingStore)) {
+    if (!backingStore) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return;
     }
@@ -182,7 +182,7 @@ bool DirectArguments::isIteratorProtocolFastAndNonObservable()
     if (!globalObject->isArgumentsPrototypeIteratorProtocolFastAndNonObservable())
         return false;
 
-    if (UNLIKELY(m_mappedArguments))
+    if (m_mappedArguments) [[unlikely]]
         return false;
 
     if (structure->didTransition())
@@ -196,19 +196,19 @@ JSArray* DirectArguments::fastSlice(JSGlobalObject* globalObject, DirectArgument
     if (count >= MIN_SPARSE_ARRAY_INDEX)
         return nullptr;
 
-    if (UNLIKELY(arguments->m_mappedArguments))
+    if (arguments->m_mappedArguments) [[unlikely]]
         return nullptr;
 
     if (startIndex + count > arguments->m_length)
         return nullptr;
 
     Structure* resultStructure = globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous);
-    if (UNLIKELY(hasAnyArrayStorage(resultStructure->indexingType())))
+    if (hasAnyArrayStorage(resultStructure->indexingType())) [[unlikely]]
         return nullptr;
 
     ObjectInitializationScope scope(globalObject->vm());
     JSArray* resultArray = JSArray::tryCreateUninitializedRestricted(scope, resultStructure, static_cast<uint32_t>(count));
-    if (UNLIKELY(!resultArray))
+    if (!resultArray) [[unlikely]]
         return nullptr;
 
     auto& resultButterfly = *resultArray->butterfly();

--- a/Source/JavaScriptCore/runtime/DirectArguments.h
+++ b/Source/JavaScriptCore/runtime/DirectArguments.h
@@ -78,7 +78,7 @@ public:
     {
         VM& vm = getVM(globalObject);
         auto scope = DECLARE_THROW_SCOPE(vm);
-        if (UNLIKELY(m_mappedArguments)) {
+        if (m_mappedArguments) [[unlikely]] {
             JSValue value = get(globalObject, vm.propertyNames->length);
             RETURN_IF_EXCEPTION(scope, { });
             RELEASE_AND_RETURN(scope, value.toUInt32(globalObject));

--- a/Source/JavaScriptCore/runtime/ExceptionFuzz.h
+++ b/Source/JavaScriptCore/runtime/ExceptionFuzz.h
@@ -40,7 +40,7 @@ void doExceptionFuzzing(JSGlobalObject*, ThrowScope&, ASCIILiteral where, const 
 // This is what you should call if you don't know if fuzzing is enabled.
 ALWAYS_INLINE void doExceptionFuzzingIfEnabled(JSGlobalObject* globalObject, ThrowScope& scope, ASCIILiteral where, const void* returnPC)
 {
-    if (LIKELY(!Options::useExceptionFuzz()))
+    if (!Options::useExceptionFuzz()) [[likely]]
         return;
     doExceptionFuzzing(globalObject, scope, where, returnPC);
 }

--- a/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
@@ -271,7 +271,7 @@ JSObject* createError(JSGlobalObject* globalObject, JSValue value, const String&
     auto scope = DECLARE_CATCH_SCOPE(vm);
 
     auto errorMessage = constructErrorMessage(globalObject, value, message);
-    if (UNLIKELY(scope.exception() || !errorMessage)) {
+    if (scope.exception() || !errorMessage) [[unlikely]] {
         // When we see an exception, we're not returning immediately because
         // we're in a CatchScope, i.e. no exceptions are thrown past this scope.
         // We're using a CatchScope because the contract for createError() is

--- a/Source/JavaScriptCore/runtime/ExceptionScope.h
+++ b/Source/JavaScriptCore/runtime/ExceptionScope.h
@@ -116,14 +116,14 @@ protected:
 #define RETURN_IF_EXCEPTION(scope__, value__) do { \
         SUPPRESS_UNCOUNTED_LOCAL JSC::VM& vm = (scope__).vm(); \
         EXCEPTION_ASSERT(!!(scope__).exception() == vm.traps().needHandling(JSC::VMTraps::NeedExceptionHandling)); \
-        if (UNLIKELY(vm.traps().maybeNeedHandling())) { \
+        if (vm.traps().maybeNeedHandling()) [[unlikely]] { \
             if (vm.hasExceptionsAfterHandlingTraps()) \
                 return value__; \
         } \
     } while (false)
 
 #define RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope__, value__) do { \
-        if (UNLIKELY((scope__).exception())) \
+        if ((scope__).exception()) [[unlikely]] \
             return value__; \
     } while (false)
 

--- a/Source/JavaScriptCore/runtime/FinalizationRegistryPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/FinalizationRegistryPrototype.cpp
@@ -53,13 +53,13 @@ ALWAYS_INLINE static JSFinalizationRegistry* getFinalizationRegistry(VM& vm, JSG
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (UNLIKELY(!value.isObject())) {
+    if (!value.isObject()) [[unlikely]] {
         throwTypeError(globalObject, scope, "Called FinalizationRegistry function on non-object"_s);
         return nullptr;
     }
 
     auto* group = jsDynamicCast<JSFinalizationRegistry*>(asObject(value));
-    if (LIKELY(group))
+    if (group) [[likely]]
         return group;
 
     throwTypeError(globalObject, scope, "Called FinalizationRegistry function on a non-FinalizationRegistry object"_s);
@@ -75,15 +75,15 @@ JSC_DEFINE_HOST_FUNCTION(protoFuncFinalizationRegistryRegister, (JSGlobalObject*
     RETURN_IF_EXCEPTION(scope, { });
 
     JSValue target = callFrame->argument(0);
-    if (UNLIKELY(!canBeHeldWeakly(target)))
+    if (!canBeHeldWeakly(target)) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "register requires an object or a non-registered symbol as the target"_s);
 
     JSValue holdings = callFrame->argument(1);
-    if (UNLIKELY(target == holdings))
+    if (target == holdings) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "register expects the target object and the holdings parameter are not the same. Otherwise, the target can never be collected"_s);
 
     JSValue unregisterToken = callFrame->argument(2);
-    if (UNLIKELY(!unregisterToken.isUndefined() && !canBeHeldWeakly(unregisterToken)))
+    if (!unregisterToken.isUndefined() && !canBeHeldWeakly(unregisterToken)) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "register requires an object or a non-registered symbol as the unregistration token"_s);
 
     group->registerTarget(vm, target.asCell(), holdings, unregisterToken);
@@ -99,7 +99,7 @@ JSC_DEFINE_HOST_FUNCTION(protoFuncFinalizationRegistryUnregister, (JSGlobalObjec
     RETURN_IF_EXCEPTION(scope, { });
 
     JSValue token = callFrame->argument(0);
-    if (UNLIKELY(!canBeHeldWeakly(token)))
+    if (!canBeHeldWeakly(token)) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "unregister requires an object or a non-registered symbol as the unregistration token"_s);
 
     bool result = group->unregister(vm, token.asCell());

--- a/Source/JavaScriptCore/runtime/FunctionPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionPrototype.cpp
@@ -109,7 +109,7 @@ JSC_DEFINE_HOST_FUNCTION(functionProtoFuncBind, (JSGlobalObject* globalObject, C
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isCallable()))
+    if (!thisValue.isCallable()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "|this| is not a function inside Function.prototype.bind"_s);
     JSObject* target = asObject(thisValue);
 
@@ -129,7 +129,7 @@ JSC_DEFINE_HOST_FUNCTION(functionProtoFuncBind, (JSGlobalObject* globalObject, C
     double length = 0;
     JSString* name = nullptr;
     JSFunction* function = jsDynamicCast<JSFunction*>(target);
-    if (LIKELY(function && function->canAssumeNameAndLengthAreOriginal(vm))) {
+    if (function && function->canAssumeNameAndLengthAreOriginal(vm)) [[likely]] {
         // Do nothing! 'length' and 'name' computation are lazily done.
         // And this is totally OK since we know that wrapped functions have canAssumeNameAndLengthAreOriginal condition
         // at the time of creation of JSBoundFunction.


### PR DESCRIPTION
#### 3d0b49a194e77e51964de0058e938880b611ff46
<pre>
Do further adoption of [[likely]] / [[unlikely]] in JSC
<a href="https://bugs.webkit.org/show_bug.cgi?id=292480">https://bugs.webkit.org/show_bug.cgi?id=292480</a>

Reviewed by Yusuke Suzuki.

* Source/JavaScriptCore/jit/JITPlan.cpp:
(JSC::JITPlan::signpostMessage):
(JSC::JITPlan::compileInThread):
* Source/JavaScriptCore/jit/JITPlan.h:
(JSC::JITPlan::beginSignpost):
(JSC::JITPlan::endSignpost):
* Source/JavaScriptCore/jit/JITWorklistThread.cpp:
(JSC::JITWorklistThread::poll):
* Source/JavaScriptCore/jit/RegisterSet.h:
* Source/JavaScriptCore/jit/ThunkGenerators.cpp:
(JSC::checkExceptionGenerator):
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
(jscmain):
* Source/JavaScriptCore/llint/LLIntData.cpp:
(JSC::LLInt::initialize):
* Source/JavaScriptCore/llint/LLIntExceptions.cpp:
(JSC::LLInt::returnToThrow):
(JSC::LLInt::wasmReturnToThrow):
(JSC::LLInt::callToThrow):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::LLINT_SLOW_PATH_DECL):
(JSC::LLInt::llint_default_call):
(JSC::LLInt::llint_virtual_call):
(JSC::LLInt::llint_polymorphic_call):
(JSC::LLInt::performLLIntGetByID):
(JSC::LLInt::getByVal):
(JSC::LLInt::throwArityCheckStackOverflowError):
(JSC::LLInt::arityCheckFor):
* Source/JavaScriptCore/llint/LowLevelInterpreter.cpp:
(JSC::CLoop::execute):
* Source/JavaScriptCore/parser/Lexer.cpp:
(JSC::Lexer&lt;T&gt;::setCode):
(JSC::Lexer&lt;T&gt;::shift):
(JSC::Lexer&lt;CharacterType&gt;::parseUnicodeEscape):
(JSC::isSingleCharacterIdentStart):
(JSC::cannotBeIdentStart):
(JSC::isSingleCharacterIdentPart):
(JSC::cannotBeIdentPartOrEscapeStart):
(JSC::Lexer&lt;UChar&gt;::currentCodePoint const):
(JSC::Lexer&lt;LChar&gt;::parseIdentifier):
(JSC::Lexer&lt;UChar&gt;::parseIdentifier):
(JSC::Lexer&lt;CharacterType&gt;::parseIdentifierSlowCase):
(JSC::Lexer&lt;T&gt;::parseString):
(JSC::Lexer&lt;T&gt;::parseStringSlowCase):
(JSC::Lexer&lt;T&gt;::parseTemplateLiteral):
(JSC::Lexer&lt;T&gt;::parseHex):
(JSC::Lexer&lt;T&gt;::parseBinary):
(JSC::Lexer&lt;T&gt;::parseOctal):
(JSC::Lexer&lt;T&gt;::parseDecimal):
(JSC::Lexer&lt;T&gt;::parseNumberAfterDecimalPoint):
(JSC::Lexer&lt;T&gt;::parseNumberAfterExponentIndicator):
(JSC::Lexer&lt;T&gt;::parseMultilineComment):
(JSC::Lexer&lt;T&gt;::lexWithoutClearingLineTerminator):
(JSC::Lexer&lt;T&gt;::scanRegExp):
(JSC::Lexer&lt;T&gt;::scanTemplateString):
* Source/JavaScriptCore/parser/Lexer.h:
(JSC::Lexer::setOffset):
* Source/JavaScriptCore/parser/ModuleAnalyzer.cpp:
(JSC::ModuleAnalyzer::analyze):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseInner):
(JSC::Parser&lt;LexerType&gt;::parseSingleFunction):
(JSC::Parser&lt;LexerType&gt;::parseStatementListItem):
(JSC::Parser&lt;LexerType&gt;::parseVariableDeclarationList):
(JSC::Parser&lt;LexerType&gt;::declareRestOrNormalParameter):
(JSC::Parser&lt;LexerType&gt;::parseObjectRestAssignmentElement):
(JSC::Parser&lt;LexerType&gt;::parseObjectRestElement):
(JSC::Parser&lt;LexerType&gt;::parseDestructuringPattern):
(JSC::Parser&lt;LexerType&gt;::parseBreakStatement):
(JSC::Parser&lt;LexerType&gt;::parseContinueStatement):
(JSC::Parser&lt;LexerType&gt;::parseStatement):
(JSC::Parser&lt;LexerType&gt;::parseFormalParameters):
(JSC::Parser&lt;LexerType&gt;::parseFunctionParameters):
(JSC::Parser&lt;LexerType&gt;::parseFunctionInfo):
(JSC::Parser&lt;LexerType&gt;::parseClass):
(JSC::Parser&lt;LexerType&gt;::parseExpressionStatement):
(JSC::Parser&lt;LexerType&gt;::parseImportDeclaration):
(JSC::Parser&lt;LexerType&gt;::parseExportDeclaration):
(JSC::Parser&lt;LexerType&gt;::parseAssignmentExpression):
(JSC::Parser&lt;LexerType&gt;::parseProperty):
(JSC::Parser&lt;LexerType&gt;::parseGetterSetter):
(JSC::Parser&lt;LexerType&gt;::recordPauseLocation):
(JSC::Parser&lt;LexerType&gt;::recordFunctionEntryLocation):
(JSC::Parser&lt;LexerType&gt;::recordFunctionLeaveLocation):
(JSC::Parser&lt;LexerType&gt;::parseArrayLiteral):
(JSC::Parser&lt;LexerType&gt;::tryParseArgumentsDotLengthForFastPath):
(JSC::Parser&lt;LexerType&gt;::parsePrimaryExpression):
(JSC::Parser&lt;LexerType&gt;::parseArguments):
(JSC::Parser&lt;LexerType&gt;::parseArgument):
(JSC::Parser&lt;LexerType&gt;::parseMemberExpression):
(JSC::Parser&lt;LexerType&gt;::parseUnaryExpression):
* Source/JavaScriptCore/parser/Parser.h:
(JSC::Parser::isValidStrictMode):
(JSC::parse):
(JSC::parseRootNode):
(JSC::parseFunctionForFunctionConstructor):
* Source/JavaScriptCore/parser/ParserArena.h:
(JSC::ParserArena::allocateFreeable):
* Source/JavaScriptCore/parser/SourceProvider.cpp:
(JSC::SourceProvider::sourceURLStripped):
* Source/JavaScriptCore/runtime/AggregateError.cpp:
(JSC::createAggregateError):
* Source/JavaScriptCore/runtime/ArgList.cpp:
(JSC::MarkedVectorBase::slowEnsureCapacity):
(JSC::MarkedVectorBase::expandCapacity):
* Source/JavaScriptCore/runtime/ArgList.h:
(JSC::MarkedVector::fill):
* Source/JavaScriptCore/runtime/ArrayBuffer.cpp:
(JSC::ArrayBuffer::grow):
(JSC::ArrayBuffer::resize):
* Source/JavaScriptCore/runtime/ArrayBufferView.h:
(JSC::ArrayBufferView::byteOffset const):
(JSC::ArrayBufferView::byteLength const):
* Source/JavaScriptCore/runtime/ArrayConstructor.cpp:
(JSC::isArraySlowInline):
* Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h:
(JSC::setLength):
(JSC::unshift):
* Source/JavaScriptCore/runtime/AtomicsObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/BooleanPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ButterflyInlines.h:
(JSC::Butterfly::tryCreateUninitialized):
* Source/JavaScriptCore/runtime/CallData.cpp:
(JSC::call):
* Source/JavaScriptCore/runtime/CatchScope.h:
(JSC::CatchScope::clearExceptionExceptTermination):
* Source/JavaScriptCore/runtime/ClonedArguments.cpp:
(JSC::ClonedArguments::createEmpty):
(JSC::ClonedArguments::copyToArguments):
(JSC::ClonedArguments::isIteratorProtocolFastAndNonObservable):
* Source/JavaScriptCore/runtime/ClonedArguments.h:
* Source/JavaScriptCore/runtime/CodeCache.cpp:
(JSC::CodeCache::getUnlinkedGlobalFunctionExecutable):
* Source/JavaScriptCore/runtime/CodeCache.h:
(JSC::CodeCacheMap::fetchFromDisk):
* Source/JavaScriptCore/runtime/CommonSlowPaths.cpp:
(JSC::JSC_DEFINE_COMMON_SLOW_PATH):
* Source/JavaScriptCore/runtime/CommonSlowPaths.h:
(JSC::CommonSlowPaths::opEnumeratorGetByVal):
(JSC::CommonSlowPaths::putDirectWithReify):
(JSC::CommonSlowPaths::allocateNewArrayBuffer):
* Source/JavaScriptCore/runtime/CommonSlowPathsInlines.h:
(JSC::CommonSlowPaths::trySpreadFast):
(JSC::CommonSlowPaths::opEnumeratorPutByVal):
* Source/JavaScriptCore/runtime/Completion.cpp:
(JSC::evaluate):
(JSC::retrieveImportAttributesFromDynamicImportOptions):
* Source/JavaScriptCore/runtime/ConstructData.cpp:
(JSC::construct):
* Source/JavaScriptCore/runtime/DirectArguments.cpp:
(JSC::DirectArguments::overrideThings):
(JSC::DirectArguments::isIteratorProtocolFastAndNonObservable):
(JSC::DirectArguments::fastSlice):
* Source/JavaScriptCore/runtime/DirectArguments.h:
* Source/JavaScriptCore/runtime/ExceptionFuzz.h:
(JSC::doExceptionFuzzingIfEnabled):
* Source/JavaScriptCore/runtime/ExceptionHelpers.cpp:
(JSC::createError):
* Source/JavaScriptCore/runtime/ExceptionScope.h:
* Source/JavaScriptCore/runtime/FinalizationRegistryPrototype.cpp:
(JSC::getFinalizationRegistry):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/FunctionPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/294477@main">https://commits.webkit.org/294477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed697b0aa3d7efdde46bef77b7445918cc5e1403

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101925 "291 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107084 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52559 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21901 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77605 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34608 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16928 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92027 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57941 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16755 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10050 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51918 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94597 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86599 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10125 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109452 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100535 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29058 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21397 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86578 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29419 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88231 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86156 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21924 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30916 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8632 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23229 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28986 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34281 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124160 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28797 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34486 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32120 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30356 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->