### PR TITLE
build-and-analyze: add --enable-checkers and --disable-checkers switches to provide more granularity

### DIFF
--- a/Tools/Scripts/build-and-analyze
+++ b/Tools/Scripts/build-and-analyze
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (C) 2023-2024 Apple Inc. All rights reserved.
+# Copyright (C) 2023-2025 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -23,6 +23,7 @@
 
 import argparse
 import os
+import re
 import subprocess
 import sys
 
@@ -69,6 +70,14 @@ def make_analyzer_flags(output_dir, args):
             'optin.cplusplus.VirtualCall',
         ])
 
+    if args.disable_checkers:
+        delimiters = re.compile(r'[\s,]+')
+        checkers = [ value for value in delimiters.split(args.disable_checkers) if value ]
+        analyzer_flags.extend([
+            '-analyzer-disable-checker',
+            ','.join(checkers),
+        ])
+
     if args.enable_webkit_checkers:
         additional_checkers.extend([
             'webkit.NoUncountedMemberChecker',
@@ -78,6 +87,11 @@ def make_analyzer_flags(output_dir, args):
             'alpha.webkit.UncountedCallArgsChecker',
             'alpha.webkit.UncountedLocalVarsChecker'
         ])
+
+    if args.enable_checkers:
+        delimiters = re.compile(r'[\s,]+')
+        checkers = [ value for value in delimiters.split(args.enable_checkers) if value ]
+        additional_checkers.extend(checkers)
 
     if args.only_smart_pointers:
         additional_checkers.extend([
@@ -170,6 +184,8 @@ def main(args):
     ]
 
     if args.dry_run:
+        env_vars_to_show = ['ANALYZER_EXEC', 'ANALYZER_FLAGS', 'ANALYZER_OUTPUT']
+        print('\n'.join(f'{key}="{value}"' for key, value in os.environ.items() if key in env_vars_to_show))
         for command in commands:
             print('\n' + ' '.join(command))
         return 0
@@ -191,12 +207,16 @@ def parse_args():
     parser.add_argument('--analyzer-path', dest='analyzer_path',
                         type=str, default=None,
                         help='Override path to clang static analyzer in scan-build and set CC/CPLUSPLUS for Xcode.')
+    parser.add_argument('--disable-checkers', dest='disable_checkers',
+                        help='Disable specific checkers listed.')
     parser.add_argument('--disable-default-checkers', dest='disable_default_checkers',
                         action='store_true', default=False,
                         help='Disable all checkers by default to run only specific checkers.')
     parser.add_argument('--enable-webkit-checkers', dest='enable_webkit_checkers',
                         action='store_true', default=False,
                         help='Enable all WebKit-specific checkers.')
+    parser.add_argument('--enable-checkers', dest='enable_checkers',
+                        help='Enable specific checkers listed.')
     parser.add_argument('--only-smart-pointers', dest='only_smart_pointers',
                         action='store_true', default=False,
                         help='Enable only WebKit-specific checkers for Smart Pointers. '


### PR DESCRIPTION
#### 251671907ca2c2e7e7383efb6d0307696bee19cf
<pre>
build-and-analyze: add --enable-checkers and --disable-checkers switches to provide more granularity
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=292494">https://bugs.webkit.org/show_bug.cgi?id=292494</a>&gt;
&lt;<a href="https://rdar.apple.com/150602375">rdar://150602375</a>&gt;

Reviewed by Brianna Fan.

* Tools/Scripts/build-and-analyze:
(make_analyzer_flags):
- Add support for --disable-checkers by adding to `analyzer_flags`.
- Add support for --enable-checkers by adding checker arguments to
  `additional_checkers`.
(main):
- Print out relevant environment variables that are passed to
  Makefile.shared when using --dry-run switch.
(parse_args):
- Add support for --disable-checkers and --enable-checkers to argument
  parser.

Canonical link: <a href="https://commits.webkit.org/294521@main">https://commits.webkit.org/294521@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d34ec3089b5a9b025729bc07c970d369b459fcd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102182 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/21849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12165 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/107341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/52818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104221 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/22158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30357 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/107341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/52818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105188 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/22158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/92234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/107341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/22158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/10260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/52176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/22158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/10333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/109717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/29314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/21610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/109717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/29676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/88437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/109717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/8838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/23556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16603 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/29242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34537 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/29053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/32376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/30612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->