### PR TITLE
[Viewport Clipping] REGRESSION (294368@main): washingtonpost.com front page is blank

### DIFF
--- a/LayoutTests/compositing/cocoa/clip-nested-sticky-elements-expected.html
+++ b/LayoutTests/compositing/cocoa/clip-nested-sticky-elements-expected.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ContentInsetBackgroundFillEnabled=false ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width">
+<script src="../../resources/ui-helper.js"></script>
+<style>
+html, body {
+    margin: 0;
+}
+
+body {
+    height: 200vh;
+}
+
+.container {
+    position: sticky;
+    top: 0;
+    width: 100%;
+}
+
+.tall {
+    height: 400px;
+}
+
+nav {
+    position: sticky;
+    top: 0;
+    background-color: tomato;
+    width: 100%;
+    height: 100px;
+}
+
+::-webkit-scrollbar {
+    display: none;
+}
+</style>
+<script>
+addEventListener("load", async () => {
+    window.testRunner?.waitUntilDone();
+    await UIHelper.setObscuredInsets(100, 0, 0, 0);
+    await UIHelper.renderingUpdate();
+    scrollBy(0, document.body.scrollHeight);
+    await UIHelper.renderingUpdate();
+    window.testRunner?.notifyDone();
+});
+</script>
+</head>
+<body>
+    <div class="container">
+        <div class="tall"></div>
+        <nav></nav>
+        <div class="tall"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/cocoa/clip-nested-sticky-elements.html
+++ b/LayoutTests/compositing/cocoa/clip-nested-sticky-elements.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ContentInsetBackgroundFillEnabled=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width">
+<script src="../../resources/ui-helper.js"></script>
+<style>
+html, body {
+    margin: 0;
+}
+
+body {
+    height: 200vh;
+}
+
+.container {
+    position: sticky;
+    top: 0;
+    width: 100%;
+}
+
+.tall {
+    height: 400px;
+}
+
+nav {
+    position: sticky;
+    top: 0;
+    background-color: tomato;
+    width: 100%;
+    height: 100px;
+}
+
+::-webkit-scrollbar {
+    display: none;
+}
+</style>
+<script>
+addEventListener("load", async () => {
+    window.testRunner?.waitUntilDone();
+    await UIHelper.setObscuredInsets(100, 0, 0, 0);
+    await UIHelper.renderingUpdate();
+    scrollBy(0, document.body.scrollHeight);
+    await UIHelper.renderingUpdate();
+    window.testRunner?.notifyDone();
+});
+</script>
+</head>
+<body>
+    <div class="container">
+        <div class="tall"></div>
+        <nav></nav>
+        <div class="tall"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/cocoa/clip-sticky-element-with-overflow-clip-on-root-expected.html
+++ b/LayoutTests/compositing/cocoa/clip-sticky-element-with-overflow-clip-on-root-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ContentInsetBackgroundFillEnabled=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width">
+<script src="../../resources/ui-helper.js"></script>
+<style>
+html, body {
+    margin: 0;
+    overflow-x: clip;
+}
+
+nav {
+    margin-top: 1em;
+    position: sticky;
+    top: 0;
+    background-color: tomato;
+    width: 100%;
+    height: 100px;
+    color: white;
+    z-index: 100;
+}
+</style>
+<script>
+addEventListener("load", async () => {
+    window.testRunner?.waitUntilDone();
+    await UIHelper.setObscuredInsets(100, 0, 0, 0);
+    await UIHelper.renderingUpdate();
+    window.testRunner?.notifyDone();
+});
+</script>
+</head>
+<body><nav></nav></body>
+</html>

--- a/LayoutTests/compositing/cocoa/clip-sticky-element-with-overflow-clip-on-root.html
+++ b/LayoutTests/compositing/cocoa/clip-sticky-element-with-overflow-clip-on-root.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ContentInsetBackgroundFillEnabled=false ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width">
+<script src="../../resources/ui-helper.js"></script>
+<style>
+html, body {
+    margin: 0;
+    overflow-x: clip;
+}
+
+nav {
+    margin-top: 1em;
+    position: sticky;
+    top: 0;
+    background-color: tomato;
+    width: 100%;
+    height: 100px;
+    color: white;
+    z-index: 100;
+}
+</style>
+<script>
+addEventListener("load", async () => {
+    window.testRunner?.waitUntilDone();
+    await UIHelper.setObscuredInsets(100, 0, 0, 0);
+    await UIHelper.renderingUpdate();
+    window.testRunner?.notifyDone();
+});
+</script>
+</head>
+<body><nav></nav></body>
+</html>

--- a/LayoutTests/compositing/ios/clip-sticky-element-with-no-anchor-expected.html
+++ b/LayoutTests/compositing/ios/clip-sticky-element-with-no-anchor-expected.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ContentInsetBackgroundFillEnabled=false showsScrollIndicators=false ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width">
+<script src="../../resources/ui-helper.js"></script>
+<style>
+html, body {
+    margin: 0;
+}
+
+main {
+    position: sticky;
+    box-sizing: border-box;
+    width: 100%;
+    line-height: 1.8;
+    padding: 1em;
+    background: gray;
+    height: 4000vh;
+}
+
+nav {
+    position: fixed;
+    top: -150px;
+    width: 100%;
+    height: 200px;
+    background: white;
+    z-index: 100;
+}
+</style>
+<script>
+addEventListener("load", async () => {
+    window.testRunner?.waitUntilDone();
+    await UIHelper.setObscuredInsets(100, 0, 0, 0);
+    await UIHelper.renderingUpdate();
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(150, 300)
+        .move(150, 100, 0.25)
+        .end()
+        .takeResult());
+    await UIHelper.waitForZoomingOrScrollingToEnd();
+    window.testRunner?.notifyDone();
+});
+</script>
+</head>
+<body>
+    <nav></nav>
+    <main></main>
+</body>
+</html>

--- a/LayoutTests/compositing/ios/clip-sticky-element-with-no-anchor.html
+++ b/LayoutTests/compositing/ios/clip-sticky-element-with-no-anchor.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ContentInsetBackgroundFillEnabled=true showsScrollIndicators=false ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width">
+<script src="../../resources/ui-helper.js"></script>
+<style>
+html, body {
+    margin: 0;
+}
+
+main {
+    position: sticky;
+    box-sizing: border-box;
+    width: 100%;
+    line-height: 1.8;
+    padding: 1em;
+    background: gray;
+    height: 4000vh;
+}
+
+nav {
+    position: fixed;
+    top: -150px;
+    width: 100%;
+    height: 200px;
+    background: white;
+    z-index: 100;
+}
+</style>
+<script>
+addEventListener("load", async () => {
+    window.testRunner?.waitUntilDone();
+    await UIHelper.setObscuredInsets(100, 0, 0, 0);
+    await UIHelper.renderingUpdate();
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(150, 300)
+        .move(150, 100, 0.25)
+        .end()
+        .takeResult());
+    await UIHelper.waitForZoomingOrScrollingToEnd();
+    window.testRunner?.notifyDone();
+});
+</script>
+</head>
+<body>
+    <nav></nav>
+    <main></main>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1855,6 +1855,9 @@ window.UIHelper = class UIHelper {
 
     static async setObscuredInsets(top, right, bottom, left)
     {
+        if (!window.testRunner)
+            return Promise.resolve();
+
         if (this.isWebKit2() && this.isIOSFamily()) {
             const scriptToRun = `uiController.setObscuredInsets(${top}, ${right}, ${bottom}, ${left})`;
             await new Promise(resolve => testRunner.runUIScript(scriptToRun, resolve));

--- a/Source/WebCore/page/scrolling/ScrollingConstraints.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingConstraints.cpp
@@ -44,14 +44,14 @@ FloatPoint ViewportConstraints::viewportRelativeLayerPosition(const FloatRect& v
 {
     FloatSize offset;
 
-    if (hasAnchorEdge(AnchorEdgeLeft))
+    if (hasAnchorEdge(AnchorEdgeLeft) || !hasAnchorEdge(AnchorEdgeRight))
         offset.setWidth(viewportRect.x() - m_viewportRectAtLastLayout.x());
-    else if (hasAnchorEdge(AnchorEdgeRight))
+    else
         offset.setWidth(viewportRect.maxX() - m_viewportRectAtLastLayout.maxX());
 
-    if (hasAnchorEdge(AnchorEdgeTop))
+    if (hasAnchorEdge(AnchorEdgeTop) || !hasAnchorEdge(AnchorEdgeBottom))
         offset.setHeight(viewportRect.y() - m_viewportRectAtLastLayout.y());
-    else if (hasAnchorEdge(AnchorEdgeBottom))
+    else
         offset.setHeight(viewportRect.maxY() - m_viewportRectAtLastLayout.maxY());
 
     return m_layerPositionAtLastLayout + offset;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1171,7 +1171,7 @@ bool RenderLayerBacking::updateConfiguration(const RenderLayer* compositingAnces
     if (updateTransformFlatteningLayer(compositingAncestor))
         layerConfigChanged = true;
 
-    if (updateViewportConstrainedSublayers(compositor.viewportConstrainedSublayers(m_owningLayer)))
+    if (updateViewportConstrainedSublayers(compositor.viewportConstrainedSublayers(m_owningLayer, compositingAncestor)))
         layerConfigChanged = true;
 
     setBackgroundLayerPaintsFixedRootBackground(compositor.needsFixedRootBackgroundLayer(m_owningLayer));
@@ -1572,7 +1572,14 @@ void RenderLayerBacking::updateGeometry(const RenderLayer* compositedAncestor)
 
     if (m_viewportAnchorLayer) {
         if (m_viewportClippingLayer) {
+            ASSERT(compositedAncestor == renderer().view().layer());
             auto fixedPositionRect = renderer().view().frameView().rectForFixedPositionLayout();
+            if (m_ancestorClippingStack) {
+                for (auto& entry : m_ancestorClippingStack->stack()) {
+                    if (entry.clippingLayer)
+                        fixedPositionRect.moveBy(-LayoutPoint { entry.clippingLayer->position() });
+                }
+            }
             m_viewportClippingLayer->setPosition(fixedPositionRect.location());
             m_viewportClippingLayer->setSize(fixedPositionRect.size());
             primaryLayerPosition.moveBy(-fixedPositionRect.location());

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -4186,7 +4186,7 @@ bool RenderLayerCompositor::isAsyncScrollableStickyLayer(const RenderLayer& laye
 #endif
 }
 
-ViewportConstrainedSublayers RenderLayerCompositor::viewportConstrainedSublayers(const RenderLayer& layer) const
+ViewportConstrainedSublayers RenderLayerCompositor::viewportConstrainedSublayers(const RenderLayer& layer, const RenderLayer* compositingAncestor) const
 {
     using enum ViewportConstrainedSublayers;
 
@@ -4195,6 +4195,9 @@ ViewportConstrainedSublayers RenderLayerCompositor::viewportConstrainedSublayers
             return Anchor;
 
         if (!isMainFrameCompositor())
+            return Anchor;
+
+        if (compositingAncestor != m_renderView.layer())
             return Anchor;
 
         return ClippingAndAnchor;
@@ -5521,7 +5524,7 @@ void RenderLayerCompositor::detachScrollCoordinatedLayer(RenderLayer& layer, Opt
 OptionSet<ScrollCoordinationRole> RenderLayerCompositor::coordinatedScrollingRolesForLayer(const RenderLayer& layer, const RenderLayer* compositingAncestor) const
 {
     OptionSet<ScrollCoordinationRole> coordinationRoles;
-    if (viewportConstrainedSublayers(layer) != ViewportConstrainedSublayers::None)
+    if (viewportConstrainedSublayers(layer, compositingAncestor) != ViewportConstrainedSublayers::None)
         coordinationRoles.add(ScrollCoordinationRole::ViewportConstrained);
 
     if (useCoordinatedScrollingForLayer(layer))

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -378,7 +378,7 @@ public:
 
     void updateRootContentsLayerBackgroundColor();
 
-    ViewportConstrainedSublayers viewportConstrainedSublayers(const RenderLayer&) const;
+    ViewportConstrainedSublayers viewportConstrainedSublayers(const RenderLayer&, const RenderLayer* compositingAncestor) const;
 
     // FIXME: make the coordinated/async terminology consistent.
     bool useCoordinatedScrollingForLayer(const RenderLayer&) const;


### PR DESCRIPTION
#### 2a3405c74969648f102e2ae52476b4c31b371dc8
<pre>
[Viewport Clipping] REGRESSION (294368@main): washingtonpost.com front page is blank
<a href="https://bugs.webkit.org/show_bug.cgi?id=292492">https://bugs.webkit.org/show_bug.cgi?id=292492</a>
<a href="https://rdar.apple.com/150570579">rdar://150570579</a>

Reviewed by Richard Robinson.

Make several followup fixes to viewport clipping logic, following enablement in 294368@main:

1.  Account for the ancestor clipping stack when positioning the viewport clipping layer. Currently,
    logic for positioning the viewport clipping layer places it at `rectForFixedPositionLayout`.
    This only works if the ancestor of the viewport clipping layer is in the same coordinate space
    as the root layer; the presence of any ancestor clipping layers between the root and the
    viewport clipping layer will cause the viewport-constrained object to become incorrectly
    clipped. This can happen — for instance — to a `position: sticky;` element underneath a root
    with `overflow-x: clip;`, since the viewport clipping layer will be placed directly underneath a
    very tall (2^21 px) clipping layer with a very large negative offset (-2^20 px). To fix this,
    account for these interstitial ancestor clipping layers when computing the position of the
    viewport clipping layer in `updateGeometry`.

2.  In the case where a sticky container is anchored to *neither* the top *nor* the bottom edge,
    logic to determine the viewport-relative layer position in `ViewportConstraints` will fall
    through and end up returning `m_layerPositionAtLastLayout` without accounting for the delta
    between the current viewport and the last viewport rect after layout. If we&apos;re computing the
    viewport clipping rect position for a sticky element, this means the viewport clipping rect
    remains stationary relative to the page after scrolling, instead of scrolling along with the
    visual viewport, until layout forces another geometry update.

    Note that this does not happen for fixed-position elements because fixed elements automatically
    anchor to the top or left, in the case where both the top/bottom or left/right offsets
    (respectively) are `auto` (see `RenderLayerCompositor::computeFixedViewportConstraints`). While
    we could address this by implementing similar code in `computeStickyPositionConstraints`, I
    decided on a more targeted fix in `viewportRelativeLayerPosition` to prevent changing behavior
    in `StickinessAdjustmentData::computeStickinessAdjustmentData`, in the case where the sticky
    element is not anchored to the top/bottom or left/right edges.

    Also, note that this does not change any behavior for fixed elements (since they always have
    one anchored edge per axis), and also does not change any behavior for sticky elements without a
    clipping layer, since we only use `Scrolling{Tree|State}StickyNode::computeAnchorLayerPosition`
    to position the anchor layer in that case, which instead goes through
    `StickyPositionViewportConstraints::anchorLayerPositionForConstrainingRect`.

3.  We also limit viewport clipping to objects directly under the root (render view&apos;s) layer; this
    allows us to avoid placing redundant clip rects for nested fixed or sticky elements. While this
    policy is a bit more conservative than necessary (since a fixed element with no fixed or sticky
    ancestors could be nested beneath a composited descendant that&apos;s _not_ the root layer), it&apos;s
    less risky with respect to performance impact (avoiding the need to walk up the layer tree in
    search of a fixed/sticky ancestor), and there are also currently no known websites that would
    benefit from viewport clipping on a layer whose immediate composited ancestor is not the root.

    In a future patch, we could revisit this by refactoring the logic to efficiently track whether
    or not the layer is already underneath a viewport clipping layer, and using it to only apply
    the viewport clipping layer to top-level fixed/sticky elements.

* LayoutTests/compositing/cocoa/clip-nested-sticky-elements-expected.html: Added.
* LayoutTests/compositing/cocoa/clip-nested-sticky-elements.html: Added.

Add a test for [3] above.

* LayoutTests/compositing/cocoa/clip-sticky-element-with-overflow-clip-on-root-expected.html: Added.
* LayoutTests/compositing/cocoa/clip-sticky-element-with-overflow-clip-on-root.html: Added.

Add a test for [1] above.

* LayoutTests/compositing/ios/clip-sticky-element-with-no-anchor-expected.html: Added.
* LayoutTests/compositing/ios/clip-sticky-element-with-no-anchor.html: Added.

Add a test for [2] above.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async setObscuredInsets):

Drive-by fix: fail gracefully in the case where `window.testRunner` isn&apos;t defined instead of
throwing an exception, to make it easier to manually check these test cases outside of the test
runner.

* Source/WebCore/page/scrolling/ScrollingConstraints.cpp:
(WebCore::ViewportConstraints::viewportRelativeLayerPosition const):

See [2] above.

* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateConfiguration):
(WebCore::RenderLayerBacking::updateGeometry):

See [1] above.

* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::viewportConstrainedSublayers const):

See [3] above.

(WebCore::RenderLayerCompositor::coordinatedScrollingRolesForLayer const):
* Source/WebCore/rendering/RenderLayerCompositor.h:

Pass in the `compositedAncestor` to `viewportConstrainedSublayers` (see [3] above).

Canonical link: <a href="https://commits.webkit.org/294491@main">https://commits.webkit.org/294491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5cc5cbbb534b30ed84eed071c9593564167b8be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21644 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107135 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52610 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104016 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30151 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77635 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34640 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104983 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16974 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57971 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16801 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10100 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51969 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86642 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10173 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109507 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29109 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21443 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86608 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29470 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88279 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86187 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21932 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30961 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8680 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23300 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29037 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34332 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28848 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32171 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30407 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->