### PR TITLE
Further adopt C++20's [[likely]] / [[unlikely]] in JSC

### DIFF
--- a/Source/JavaScriptCore/runtime/DatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/DatePrototype.cpp
@@ -102,7 +102,7 @@ static EncodedJSValue formateDateInstance(JSGlobalObject* globalObject, CallFram
 
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     Integrity::auditStructureID(thisDateObj->structureID());
@@ -315,7 +315,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToISOString, (JSGlobalObject* globalObject
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     Integrity::auditStructureID(thisDateObj->structureID());
@@ -392,7 +392,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetTime, (JSGlobalObject* globalObject, Ca
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     return JSValue::encode(jsNumber(thisDateObj->internalNumber()));
@@ -404,7 +404,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetFullYear, (JSGlobalObject* globalObject
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     const GregorianDateTime* gregorianDateTime = thisDateObj->gregorianDateTime(vm.dateCache);
@@ -419,7 +419,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetUTCFullYear, (JSGlobalObject* globalObj
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     const GregorianDateTime* gregorianDateTime = thisDateObj->gregorianDateTimeUTC(vm.dateCache);
@@ -434,7 +434,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetMonth, (JSGlobalObject* globalObject, C
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     const GregorianDateTime* gregorianDateTime = thisDateObj->gregorianDateTime(vm.dateCache);
@@ -449,7 +449,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetUTCMonth, (JSGlobalObject* globalObject
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     const GregorianDateTime* gregorianDateTime = thisDateObj->gregorianDateTimeUTC(vm.dateCache);
@@ -464,7 +464,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetDate, (JSGlobalObject* globalObject, Ca
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     const GregorianDateTime* gregorianDateTime = thisDateObj->gregorianDateTime(vm.dateCache);
@@ -479,7 +479,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetUTCDate, (JSGlobalObject* globalObject,
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     const GregorianDateTime* gregorianDateTime = thisDateObj->gregorianDateTimeUTC(vm.dateCache);
@@ -494,7 +494,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetDay, (JSGlobalObject* globalObject, Cal
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     const GregorianDateTime* gregorianDateTime = thisDateObj->gregorianDateTime(vm.dateCache);
@@ -509,7 +509,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetUTCDay, (JSGlobalObject* globalObject, 
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     const GregorianDateTime* gregorianDateTime = thisDateObj->gregorianDateTimeUTC(vm.dateCache);
@@ -524,7 +524,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetHours, (JSGlobalObject* globalObject, C
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     const GregorianDateTime* gregorianDateTime = thisDateObj->gregorianDateTime(vm.dateCache);
@@ -539,7 +539,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetUTCHours, (JSGlobalObject* globalObject
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     const GregorianDateTime* gregorianDateTime = thisDateObj->gregorianDateTimeUTC(vm.dateCache);
@@ -554,7 +554,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetMinutes, (JSGlobalObject* globalObject,
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     const GregorianDateTime* gregorianDateTime = thisDateObj->gregorianDateTime(vm.dateCache);
@@ -569,7 +569,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetUTCMinutes, (JSGlobalObject* globalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     const GregorianDateTime* gregorianDateTime = thisDateObj->gregorianDateTimeUTC(vm.dateCache);
@@ -584,7 +584,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetSeconds, (JSGlobalObject* globalObject,
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     const GregorianDateTime* gregorianDateTime = thisDateObj->gregorianDateTime(vm.dateCache);
@@ -599,7 +599,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetUTCSeconds, (JSGlobalObject* globalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     const GregorianDateTime* gregorianDateTime = thisDateObj->gregorianDateTimeUTC(vm.dateCache);
@@ -614,7 +614,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetMilliSeconds, (JSGlobalObject* globalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     double milli = thisDateObj->internalNumber();
@@ -633,7 +633,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetUTCMilliseconds, (JSGlobalObject* globa
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     double milli = thisDateObj->internalNumber();
@@ -652,7 +652,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetTimezoneOffset, (JSGlobalObject* global
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     const GregorianDateTime* gregorianDateTime = thisDateObj->gregorianDateTime(vm.dateCache);
@@ -667,7 +667,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetTime, (JSGlobalObject* globalObject, Ca
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     double milli = timeClip(callFrame->argument(0).toNumber(globalObject));
@@ -684,7 +684,7 @@ static EncodedJSValue setNewValueFromTimeArgs(JSGlobalObject* globalObject, Call
 
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     if (!callFrame->argumentCount()) {
@@ -735,7 +735,7 @@ static EncodedJSValue setNewValueFromDateArgs(JSGlobalObject* globalObject, Call
 
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     if (!callFrame->argumentCount()) {
@@ -853,7 +853,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetYear, (JSGlobalObject* globalObject, Ca
 
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     if (!callFrame->argumentCount()) { 
@@ -896,7 +896,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetYear, (JSGlobalObject* globalObject, Ca
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     const GregorianDateTime* gregorianDateTime = thisDateObj->gregorianDateTime(vm.dateCache);
@@ -938,7 +938,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToTemporalInstant, (JSGlobalObject* global
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     double epochMilliseconds = thisDateObj->internalNumber();
@@ -957,7 +957,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToLocaleString, (JSGlobalObject* globalObj
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     double milli = thisDateObj->internalNumber();
@@ -976,7 +976,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToLocaleDateString, (JSGlobalObject* globa
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     double milli = thisDateObj->internalNumber();
@@ -995,7 +995,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToLocaleTimeString, (JSGlobalObject* globa
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
     auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
-    if (UNLIKELY(!thisDateObj))
+    if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     double milli = thisDateObj->internalNumber();

--- a/Source/JavaScriptCore/runtime/FunctionExecutable.h
+++ b/Source/JavaScriptCore/runtime/FunctionExecutable.h
@@ -167,7 +167,7 @@ public:
     void setOverrideLineNumber(int overrideLineNumber)
     {
         if (overrideLineNumber == overrideLineNumberNotFound) {
-            if (UNLIKELY(m_rareData))
+            if (m_rareData) [[unlikely]]
                 m_rareData->m_overrideLineNumber = std::nullopt;
             return;
         }
@@ -176,21 +176,21 @@ public:
 
     std::optional<int> overrideLineNumber() const
     {
-        if (UNLIKELY(m_rareData))
+        if (m_rareData) [[unlikely]]
             return m_rareData->m_overrideLineNumber;
         return std::nullopt;
     }
 
     int lineCount() const
     {
-        if (UNLIKELY(m_rareData))
+        if (m_rareData) [[unlikely]]
             return m_rareData->m_lineCount;
         return m_unlinkedExecutable->lineCount();
     }
 
     int endColumn() const
     {
-        if (UNLIKELY(m_rareData))
+        if (m_rareData) [[unlikely]]
             return m_rareData->m_endColumn;
         return m_unlinkedExecutable->linkedEndColumn(m_source.startColumn().oneBasedInt());
     }
@@ -207,21 +207,21 @@ public:
 
     unsigned functionEnd() const
     {
-        if (UNLIKELY(m_rareData))
+        if (m_rareData) [[unlikely]]
             return m_rareData->m_functionEnd;
         return m_unlinkedExecutable->unlinkedFunctionEnd();
     }
 
     unsigned functionStart() const
     {
-        if (UNLIKELY(m_rareData))
+        if (m_rareData) [[unlikely]]
             return m_rareData->m_functionStart;
         return m_unlinkedExecutable->unlinkedFunctionStart();
     }
 
     unsigned parametersStartOffset() const
     {
-        if (UNLIKELY(m_rareData))
+        if (m_rareData) [[unlikely]]
             return m_rareData->m_parametersStartOffset;
         return m_unlinkedExecutable->parametersStartOffset();
     }
@@ -243,7 +243,7 @@ public:
     // Cached poly proto structure for the result of constructing this executable.
     Structure* cachedPolyProtoStructure()
     {
-        if (UNLIKELY(m_rareData))
+        if (m_rareData) [[unlikely]]
             return m_rareData->m_cachedPolyProtoStructureID.get();
         return nullptr;
     }
@@ -318,7 +318,7 @@ private:
 
     RareData& ensureRareData()
     {
-        if (LIKELY(m_rareData))
+        if (m_rareData) [[likely]]
             return *m_rareData;
         return ensureRareDataSlow();
     }

--- a/Source/JavaScriptCore/runtime/GenericArgumentsImplInlines.h
+++ b/Source/JavaScriptCore/runtime/GenericArgumentsImplInlines.h
@@ -136,7 +136,7 @@ bool GenericArgumentsImpl<Type>::put(JSCell* cell, JSGlobalObject* globalObject,
 
     // https://tc39.github.io/ecma262/#sec-arguments-exotic-objects-set-p-v-receiver
     // Fall back to the OrdinarySet when the receiver is altered from the thisObject.
-    if (UNLIKELY(slot.thisValue() != thisObject))
+    if (slot.thisValue() != thisObject) [[unlikely]]
         RELEASE_AND_RETURN(scope, Base::put(thisObject, globalObject, ident, value, slot));
 
     std::optional<uint32_t> index = parseIndex(ident);
@@ -279,7 +279,7 @@ void GenericArgumentsImpl<Type>::initModifiedArgumentsDescriptor(JSGlobalObject*
 
     if (argsLength) {
         void* backingStore = vm.gigacageAuxiliarySpace(m_modifiedArgumentsDescriptor.kind).allocate(vm, WTF::roundUpToMultipleOf<8>(argsLength), nullptr, AllocationFailureMode::ReturnNull);
-        if (UNLIKELY(!backingStore)) {
+        if (!backingStore) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
             return;
         }

--- a/Source/JavaScriptCore/runtime/ImportMap.cpp
+++ b/Source/JavaScriptCore/runtime/ImportMap.cpp
@@ -166,7 +166,7 @@ static String normalizeSpecifierKey(const String& specifierKey, const URL& baseU
 {
     // https://html.spec.whatwg.org/C#normalizing-a-specifier-key
 
-    if (UNLIKELY(specifierKey.isEmpty())) {
+    if (specifierKey.isEmpty()) [[unlikely]] {
         reporter.reportWarning("specifier key is empty"_s);
         return nullString();
     }
@@ -185,14 +185,14 @@ static ImportMap::SpecifierMap sortAndNormalizeSpecifierMap(Ref<JSON::Object> im
         AtomString normalizedSpecifierKey = AtomString(normalizeSpecifierKey(key, baseURL, reporter));
         if (normalizedSpecifierKey.isNull())
             continue;
-        if (auto valueAsString = value->asString(); LIKELY(!valueAsString.isNull())) {
+        if (auto valueAsString = value->asString(); !valueAsString.isNull()) [[likely]] {
             URL addressURL = parseURLLikeModuleSpecifier(valueAsString, baseURL);
-            if (UNLIKELY(!addressURL.isValid())) {
+            if (!addressURL.isValid()) [[unlikely]] {
                 reporter.reportWarning(makeString("value in specifier map cannot be parsed as URL "_s, valueAsString));
                 normalized.add(normalizedSpecifierKey, URL { });
                 continue;
             }
-            if (UNLIKELY(key.endsWith('/') && !addressURL.string().endsWith('/'))) {
+            if (key.endsWith('/') && !addressURL.string().endsWith('/')) [[unlikely]] {
                 reporter.reportWarning(makeString("address "_s, addressURL.string(), " does not end with '/' while key "_s, key, " ends with '/'"_s));
                 normalized.add(normalizedSpecifierKey, URL { });
                 continue;
@@ -251,7 +251,7 @@ std::optional<Ref<ImportMap>> ImportMap::parseImportMapString(const SourceCode& 
             }
             URL scopePrefixURL { baseURL, key }; // Do not use parseURLLikeModuleSpecifier since we should accept non relative path.
             dataLogLnIf(ImportMapInternal::verbose, "scope key ", key, " and URL ", scopePrefixURL);
-            if (UNLIKELY(!scopePrefixURL.isValid())) {
+            if (!scopePrefixURL.isValid()) [[unlikely]] {
                 reporter.reportWarning(makeString("scope key"_s, key, " was not parsable"_s));
                 continue;
             }
@@ -272,7 +272,7 @@ std::optional<Ref<ImportMap>> ImportMap::parseImportMapString(const SourceCode& 
         // https://html.spec.whatwg.org/C#normalizing-a-module-integrity-map
         for (auto& [key, value] : *integrityMap) {
             URL integrityURL = parseURLLikeModuleSpecifier(key, baseURL);
-            if (UNLIKELY(integrityURL.isNull())) {
+            if (integrityURL.isNull()) [[unlikely]] {
                 errorMessage.append("Integrity URL "_s);
                 errorMessage.append(key);
                 errorMessage.append(" is not a valid absolute URL nor a relative URL starting with '/', './' or '../'\n"_s);
@@ -280,7 +280,7 @@ std::optional<Ref<ImportMap>> ImportMap::parseImportMapString(const SourceCode& 
             }
 
             auto valueAsString = value->asString();
-            if (UNLIKELY(valueAsString.isNull())) {
+            if (valueAsString.isNull()) [[unlikely]] {
                 errorMessage.append("Integrity value of "_s);
                 errorMessage.append(key);
                 errorMessage.append(" is not a string\n"_s);

--- a/Source/JavaScriptCore/runtime/IndexingHeaderInlines.h
+++ b/Source/JavaScriptCore/runtime/IndexingHeaderInlines.h
@@ -33,7 +33,7 @@ namespace JSC {
 
 inline size_t IndexingHeader::preCapacity(Structure* structure)
 {
-    if (LIKELY(!hasAnyArrayStorage(structure->indexingType())))
+    if (!hasAnyArrayStorage(structure->indexingType())) [[likely]]
         return 0;
     
     return arrayStorage()->m_indexBias;

--- a/Source/JavaScriptCore/runtime/InferredValue.h
+++ b/Source/JavaScriptCore/runtime/InferredValue.h
@@ -111,14 +111,14 @@ public:
 
     void notifyWrite(VM& vm, JSCell* owner, JSCellType* value, const FireDetail& detail)
     {
-        if (LIKELY(state() == IsInvalidated))
+        if (state() == IsInvalidated) [[likely]]
             return;
         notifyWriteSlow(vm, owner, value, detail);
     }
     
     void notifyWrite(VM& vm, JSCell* owner, JSCellType* value, const char* reason)
     {
-        if (LIKELY(state() == IsInvalidated))
+        if (state() == IsInvalidated) [[likely]]
             return;
         notifyWriteSlow(vm, owner, value, reason);
     }
@@ -189,7 +189,7 @@ private:
     
     InferredValueWatchpointSet* inflate()
     {
-        if (LIKELY(isFat()))
+        if (isFat()) [[likely]]
             return fat();
         return inflateSlow();
     }

--- a/Source/JavaScriptCore/runtime/InternalFunction.cpp
+++ b/Source/JavaScriptCore/runtime/InternalFunction.cpp
@@ -148,11 +148,11 @@ Structure* InternalFunction::createSubclassStructure(JSGlobalObject* globalObjec
     // newTarget may be an InternalFunction if we were called from Reflect.construct.
     JSFunction* targetFunction = jsDynamicCast<JSFunction*>(newTarget);
 
-    if (UNLIKELY(!targetFunction || !targetFunction->canUseAllocationProfiles())) {
+    if (!targetFunction || !targetFunction->canUseAllocationProfiles()) [[unlikely]] {
         JSValue prototypeValue = newTarget->get(globalObject, vm.propertyNames->prototype);
         RETURN_IF_EXCEPTION(scope, nullptr);
         // .prototype getter could have triggered having a bad time so need to recheck array structures.
-        if (UNLIKELY(baseGlobalObject->isHavingABadTime())) {
+        if (baseGlobalObject->isHavingABadTime()) [[unlikely]] {
             if (baseGlobalObject->isOriginalArrayStructure(baseClass))
                 baseClass = baseGlobalObject->arrayStructureForIndexingTypeDuringAllocation(baseClass->indexingType());
         }
@@ -166,7 +166,7 @@ Structure* InternalFunction::createSubclassStructure(JSGlobalObject* globalObjec
 
     FunctionRareData* rareData = targetFunction->ensureRareData(vm);
     Structure* structure = rareData->internalFunctionAllocationStructure();
-    if (LIKELY(structure && structure->classInfoForCells() == baseClass->classInfoForCells() && structure->globalObject() == baseGlobalObject))
+    if (structure && structure->classInfoForCells() == baseClass->classInfoForCells() && structure->globalObject() == baseGlobalObject) [[likely]]
         return structure;
 
     // .prototype can't be a getter if we canUseAllocationProfiles().

--- a/Source/JavaScriptCore/runtime/IntlCollatorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlCollatorPrototype.cpp
@@ -84,7 +84,7 @@ JSC_DEFINE_HOST_FUNCTION(intlCollatorFuncCompare, (JSGlobalObject* globalObject,
     // 1. Let collator be the this value.
     // 2. Assert: Type(collator) is Object and collator has an [[initializedCollator]] internal slot whose value is true.
     IntlCollator* collator = jsDynamicCast<IntlCollator*>(callFrame->thisValue());
-    if (UNLIKELY(!collator))
+    if (!collator) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.Collator.prototype.compare called on value that's not a Collator"_s));
 
     // 3. If x is not provided, let x be undefined.
@@ -115,7 +115,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlCollatorPrototypeGetterCompare, (JSGlobalObject* gl
     // 10.3.3 Intl.Collator.prototype.compare (ECMA-402 2.0)
     // 1. Let collator be this Collator object.
     IntlCollator* collator = jsDynamicCast<IntlCollator*>(JSValue::decode(thisValue));
-    if (UNLIKELY(!collator))
+    if (!collator) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.Collator.prototype.compare called on value that's not a Collator"_s));
 
     JSBoundFunction* boundCompare = collator->boundCompare();
@@ -146,7 +146,7 @@ JSC_DEFINE_HOST_FUNCTION(intlCollatorPrototypeFuncResolvedOptions, (JSGlobalObje
 
     // 10.3.5 Intl.Collator.prototype.resolvedOptions() (ECMA-402 2.0)
     IntlCollator* collator = jsDynamicCast<IntlCollator*>(callFrame->thisValue());
-    if (UNLIKELY(!collator))
+    if (!collator) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.Collator.prototype.resolvedOptions called on value that's not a Collator"_s));
 
     RELEASE_AND_RETURN(scope, JSValue::encode(collator->resolvedOptions(globalObject)));

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -834,12 +834,12 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
             return UDAT_NONE;
         };
 
-        if (UNLIKELY(required == RequiredComponent::Date && m_timeStyle != DateTimeStyle::None)) {
+        if (required == RequiredComponent::Date && m_timeStyle != DateTimeStyle::None) [[unlikely]] {
             throwTypeError(globalObject, scope, "timeStyle is specified while formatting date is requested"_s);
             return;
         }
 
-        if (UNLIKELY(required == RequiredComponent::Time && m_dateStyle != DateTimeStyle::None)) {
+        if (required == RequiredComponent::Time && m_dateStyle != DateTimeStyle::None) [[unlikely]] {
             throwTypeError(globalObject, scope, "dateStyle is specified while formatting time is requested"_s);
             return;
         }

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormatPrototype.cpp
@@ -116,7 +116,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDateTimeFormatFuncFormatDateTime, (JSGlobalObject* 
     // https://tc39.github.io/ecma402/#sec-formatdatetime
 
     IntlDateTimeFormat* format = jsDynamicCast<IntlDateTimeFormat*>(callFrame->thisValue());
-    if (UNLIKELY(!format))
+    if (!format) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.DateTimeFormat.prototype.format called on value that's not a DateTimeFormat"_s));
 
     JSValue date = callFrame->argument(0);
@@ -136,7 +136,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlDateTimeFormatPrototypeGetterFormat, (JSGlobalObjec
     auto* dtf = IntlDateTimeFormat::unwrapForOldFunctions(globalObject, JSValue::decode(thisValue));
     RETURN_IF_EXCEPTION(scope, { });
     // 2. ReturnIfAbrupt(dtf).
-    if (UNLIKELY(!dtf))
+    if (!dtf) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.DateTimeFormat.prototype.format called on value that's not a DateTimeFormat"_s));
 
     JSBoundFunction* boundFormat = dtf->boundFormat();
@@ -169,7 +169,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDateTimeFormatPrototypeFuncFormatToParts, (JSGlobal
 
     // Do not use unwrapForOldFunctions.
     auto* dateTimeFormat = jsDynamicCast<IntlDateTimeFormat*>(callFrame->thisValue());
-    if (UNLIKELY(!dateTimeFormat))
+    if (!dateTimeFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.DateTimeFormat.prototype.formatToParts called on value that's not a DateTimeFormat"_s));
 
     JSValue date = callFrame->argument(0);
@@ -187,7 +187,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDateTimeFormatPrototypeFuncFormatRange, (JSGlobalOb
 
     // Do not use unwrapForOldFunctions.
     auto* dateTimeFormat = jsDynamicCast<IntlDateTimeFormat*>(callFrame->thisValue());
-    if (UNLIKELY(!dateTimeFormat))
+    if (!dateTimeFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.DateTimeFormat.prototype.formatRange called on value that's not a DateTimeFormat"_s));
 
     JSValue startDateValue = callFrame->argument(0);
@@ -212,7 +212,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDateTimeFormatPrototypeFuncFormatRangeToParts, (JSG
 
     // Do not use unwrapForOldFunctions.
     auto* dateTimeFormat = jsDynamicCast<IntlDateTimeFormat*>(callFrame->thisValue());
-    if (UNLIKELY(!dateTimeFormat))
+    if (!dateTimeFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.DateTimeFormat.prototype.formatRangeToParts called on value that's not a DateTimeFormat"_s));
 
     JSValue startDateValue = callFrame->argument(0);
@@ -238,7 +238,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDateTimeFormatPrototypeFuncResolvedOptions, (JSGlob
 
     auto* dateTimeFormat = IntlDateTimeFormat::unwrapForOldFunctions(globalObject, callFrame->thisValue());
     RETURN_IF_EXCEPTION(scope, { });
-    if (UNLIKELY(!dateTimeFormat))
+    if (!dateTimeFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.DateTimeFormat.prototype.resolvedOptions called on value that's not a DateTimeFormat"_s));
 
     RELEASE_AND_RETURN(scope, JSValue::encode(dateTimeFormat->resolvedOptions(globalObject)));

--- a/Source/JavaScriptCore/runtime/IntlDisplayNamesPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDisplayNamesPrototype.cpp
@@ -80,7 +80,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDisplayNamesPrototypeFuncOf, (JSGlobalObject* globa
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* displayNames = jsDynamicCast<IntlDisplayNames*>(callFrame->thisValue());
-    if (UNLIKELY(!displayNames))
+    if (!displayNames) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.DisplayNames.prototype.of called on value that's not a DisplayNames"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(displayNames->of(globalObject, callFrame->argument(0))));
@@ -93,7 +93,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDisplayNamesPrototypeFuncResolvedOptions, (JSGlobal
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* displayNames = jsDynamicCast<IntlDisplayNames*>(callFrame->thisValue());
-    if (UNLIKELY(!displayNames))
+    if (!displayNames) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.DisplayNames.prototype.resolvedOptions called on value that's not a DisplayNames"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(displayNames->resolvedOptions(globalObject)));

--- a/Source/JavaScriptCore/runtime/IntlDurationFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormatPrototype.cpp
@@ -83,11 +83,11 @@ JSC_DEFINE_HOST_FUNCTION(intlDurationFormatPrototypeFuncFormat, (JSGlobalObject*
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* durationFormat = jsDynamicCast<IntlDurationFormat*>(callFrame->thisValue());
-    if (UNLIKELY(!durationFormat))
+    if (!durationFormat) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.DurationFormat.prototype.format called on value that's not a DurationFormat"_s);
 
     JSValue argument = callFrame->argument(0);
-    if (UNLIKELY(!argument.isObject() && !argument.isString()))
+    if (!argument.isObject() && !argument.isString()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.DurationFormat.prototype.format argument needs to be an object or a string"_s);
 
     auto duration = TemporalDuration::toISO8601Duration(globalObject, argument);
@@ -103,11 +103,11 @@ JSC_DEFINE_HOST_FUNCTION(intlDurationFormatPrototypeFuncFormatToParts, (JSGlobal
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* durationFormat = jsDynamicCast<IntlDurationFormat*>(callFrame->thisValue());
-    if (UNLIKELY(!durationFormat))
+    if (!durationFormat) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.DurationFormat.prototype.formatToParts called on value that's not a DurationFormat"_s);
 
     JSValue argument = callFrame->argument(0);
-    if (UNLIKELY(!argument.isObject() && !argument.isString()))
+    if (!argument.isObject() && !argument.isString()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.DurationFormat.prototype.formatToParts argument needs to be an object or a string"_s);
 
     auto duration = TemporalDuration::toISO8601Duration(globalObject, argument);
@@ -123,7 +123,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDurationFormatPrototypeFuncResolvedOptions, (JSGlob
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* durationFormat = jsDynamicCast<IntlDurationFormat*>(callFrame->thisValue());
-    if (UNLIKELY(!durationFormat))
+    if (!durationFormat) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.DurationFormat.prototype.resolvedOptions called on value that's not a DurationFormat"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(durationFormat->resolvedOptions(globalObject)));

--- a/Source/JavaScriptCore/runtime/IntlListFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlListFormatPrototype.cpp
@@ -82,7 +82,7 @@ JSC_DEFINE_HOST_FUNCTION(intlListFormatPrototypeFuncFormat, (JSGlobalObject* glo
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* listFormat = jsDynamicCast<IntlListFormat*>(callFrame->thisValue());
-    if (UNLIKELY(!listFormat))
+    if (!listFormat) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.ListFormat.prototype.format called on value that's not a ListFormat"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(listFormat->format(globalObject, callFrame->argument(0))));
@@ -95,7 +95,7 @@ JSC_DEFINE_HOST_FUNCTION(intlListFormatPrototypeFuncFormatToParts, (JSGlobalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* listFormat = jsDynamicCast<IntlListFormat*>(callFrame->thisValue());
-    if (UNLIKELY(!listFormat))
+    if (!listFormat) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.ListFormat.prototype.formatToParts called on value that's not a ListFormat"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(listFormat->formatToParts(globalObject, callFrame->argument(0))));
@@ -108,7 +108,7 @@ JSC_DEFINE_HOST_FUNCTION(intlListFormatPrototypeFuncResolvedOptions, (JSGlobalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* listFormat = jsDynamicCast<IntlListFormat*>(callFrame->thisValue());
-    if (UNLIKELY(!listFormat))
+    if (!listFormat) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.ListFormat.prototype.resolvedOptions called on value that's not a ListFormat"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(listFormat->resolvedOptions(globalObject)));

--- a/Source/JavaScriptCore/runtime/IntlLocalePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocalePrototype.cpp
@@ -120,7 +120,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncMaximize, (JSGlobalObject* globa
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
-    if (UNLIKELY(!locale))
+    if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.maximize called on value that's not a Locale"_s);
 
     IntlLocale* newLocale = IntlLocale::create(vm, globalObject->localeStructure());
@@ -136,7 +136,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncMinimize, (JSGlobalObject* globa
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
-    if (UNLIKELY(!locale))
+    if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.minimize called on value that's not a Locale"_s);
 
     IntlLocale* newLocale = IntlLocale::create(vm, globalObject->localeStructure());
@@ -152,7 +152,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncToString, (JSGlobalObject* globa
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
-    if (UNLIKELY(!locale))
+    if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.toString called on value that's not a Locale"_s);
 
     const String& fullString = locale->toString();
@@ -166,7 +166,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterBaseName, (JSGlobalObject* glo
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
-    if (UNLIKELY(!locale))
+    if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.baseName called on value that's not a Locale"_s);
 
     const String& baseName = locale->baseName();
@@ -180,7 +180,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterCalendar, (JSGlobalObject* glo
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
-    if (UNLIKELY(!locale))
+    if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.calendar called on value that's not a Locale"_s);
 
     const String& calendar = locale->calendar();
@@ -194,7 +194,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetCalendars, (JSGlobalObject* g
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
-    if (UNLIKELY(!locale))
+    if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getCalendars called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(locale->calendars(globalObject)));
@@ -207,7 +207,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterCaseFirst, (JSGlobalObject* gl
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
-    if (UNLIKELY(!locale))
+    if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.caseFirst called on value that's not a Locale"_s);
 
     const String& caseFirst = locale->caseFirst();
@@ -221,7 +221,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterCollation, (JSGlobalObject* gl
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
-    if (UNLIKELY(!locale))
+    if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.collation called on value that's not a Locale"_s);
 
     const String& collation = locale->collation();
@@ -235,7 +235,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetCollations, (JSGlobalObject* 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
-    if (UNLIKELY(!locale))
+    if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getCollations called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(locale->collations(globalObject)));
@@ -248,7 +248,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterFirstDayOfWeek, (JSGlobalObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
-    if (UNLIKELY(!locale))
+    if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.firstDayOfWeek called on value that's not a Locale"_s);
 
     const String& firstDayOfWeek = locale->firstDayOfWeek();
@@ -262,7 +262,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterHourCycle, (JSGlobalObject* gl
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
-    if (UNLIKELY(!locale))
+    if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.hourCycle called on value that's not a Locale"_s);
 
     const String& hourCycle = locale->hourCycle();
@@ -276,7 +276,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetHourCycles, (JSGlobalObject* 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
-    if (UNLIKELY(!locale))
+    if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getHourCycles called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(locale->hourCycles(globalObject)));
@@ -289,7 +289,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterNumeric, (JSGlobalObject* glob
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
-    if (UNLIKELY(!locale))
+    if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.numeric called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(jsBoolean(locale->numeric() == TriState::True)));
@@ -302,7 +302,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterNumberingSystem, (JSGlobalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
-    if (UNLIKELY(!locale))
+    if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.numberingSystem called on value that's not a Locale"_s);
 
     const String& numberingSystem = locale->numberingSystem();
@@ -316,7 +316,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetNumberingSystems, (JSGlobalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
-    if (UNLIKELY(!locale))
+    if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getNumberingSystems called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(locale->numberingSystems(globalObject)));
@@ -329,7 +329,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterLanguage, (JSGlobalObject* glo
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
-    if (UNLIKELY(!locale))
+    if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.language called on value that's not a Locale"_s);
 
     const String& language = locale->language();
@@ -343,7 +343,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterScript, (JSGlobalObject* globa
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
-    if (UNLIKELY(!locale))
+    if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.script called on value that's not a Locale"_s);
 
     const String& script = locale->script();
@@ -357,7 +357,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterRegion, (JSGlobalObject* globa
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
-    if (UNLIKELY(!locale))
+    if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.region called on value that's not a Locale"_s);
 
     const String& region = locale->region();
@@ -371,7 +371,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetTimeZones, (JSGlobalObject* g
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
-    if (UNLIKELY(!locale))
+    if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getTimeZones called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(locale->timeZones(globalObject)));
@@ -384,7 +384,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetTextInfo, (JSGlobalObject* gl
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
-    if (UNLIKELY(!locale))
+    if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getTextInfo called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(locale->textInfo(globalObject)));
@@ -397,7 +397,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetWeekInfo, (JSGlobalObject* gl
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
-    if (UNLIKELY(!locale))
+    if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getWeekInfo called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(locale->weekInfo(globalObject)));

--- a/Source/JavaScriptCore/runtime/IntlNumberFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormatPrototype.cpp
@@ -90,7 +90,7 @@ JSC_DEFINE_HOST_FUNCTION(intlNumberFormatFuncFormat, (JSGlobalObject* globalObje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* numberFormat = jsDynamicCast<IntlNumberFormat*>(callFrame->thisValue());
-    if (UNLIKELY(!numberFormat))
+    if (!numberFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.NumberFormat.prototype.format called on value that's not a NumberFormat"_s));
 
     auto value = toIntlMathematicalValue(globalObject, callFrame->argument(0));
@@ -111,7 +111,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlNumberFormatPrototypeGetterFormat, (JSGlobalObject*
     // 1. Let nf be this NumberFormat object.
     auto* nf = IntlNumberFormat::unwrapForOldFunctions(globalObject, JSValue::decode(thisValue));
     RETURN_IF_EXCEPTION(scope, { });
-    if (UNLIKELY(!nf))
+    if (!nf) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.NumberFormat.prototype.format called on value that's not a NumberFormat"_s));
 
     JSBoundFunction* boundFormat = nf->boundFormat();
@@ -141,7 +141,7 @@ JSC_DEFINE_HOST_FUNCTION(intlNumberFormatPrototypeFuncFormatRange, (JSGlobalObje
 
     // Do not use unwrapForOldFunctions.
     auto* numberFormat = jsDynamicCast<IntlNumberFormat*>(callFrame->thisValue());
-    if (UNLIKELY(!numberFormat))
+    if (!numberFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.NumberFormat.prototype.formatRange called on value that's not a NumberFormat"_s));
 
     JSValue startValue = callFrame->argument(0);
@@ -174,7 +174,7 @@ JSC_DEFINE_HOST_FUNCTION(intlNumberFormatPrototypeFuncFormatToParts, (JSGlobalOb
 
     // Do not use unwrapForOldFunctions.
     auto* numberFormat = jsDynamicCast<IntlNumberFormat*>(callFrame->thisValue());
-    if (UNLIKELY(!numberFormat))
+    if (!numberFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.NumberFormat.prototype.formatToParts called on value that's not a NumberFormat"_s));
 
     auto value = toIntlMathematicalValue(globalObject, callFrame->argument(0));
@@ -193,7 +193,7 @@ JSC_DEFINE_HOST_FUNCTION(intlNumberFormatPrototypeFuncFormatRangeToParts, (JSGlo
 
     // Do not use unwrapForOldFunctions.
     auto* numberFormat = jsDynamicCast<IntlNumberFormat*>(callFrame->thisValue());
-    if (UNLIKELY(!numberFormat))
+    if (!numberFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.NumberFormat.prototype.formatRangeToParts called on value that's not a NumberFormat"_s));
 
     JSValue startValue = callFrame->argument(0);
@@ -225,7 +225,7 @@ JSC_DEFINE_HOST_FUNCTION(intlNumberFormatPrototypeFuncResolvedOptions, (JSGlobal
 
     auto* numberFormat = IntlNumberFormat::unwrapForOldFunctions(globalObject, callFrame->thisValue());
     RETURN_IF_EXCEPTION(scope, { });
-    if (UNLIKELY(!numberFormat))
+    if (!numberFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.NumberFormat.prototype.resolvedOptions called on value that's not a NumberFormat"_s));
 
     RELEASE_AND_RETURN(scope, JSValue::encode(numberFormat->resolvedOptions(globalObject)));

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -803,7 +803,7 @@ Vector<String> canonicalizeLocaleList(JSGlobalObject* globalObject, JSValue loca
             }
 
             String errorMessage = tryMakeString("invalid language tag: "_s, tag);
-            if (UNLIKELY(!errorMessage)) {
+            if (!errorMessage) [[unlikely]] {
                 throwException(globalObject, scope, createOutOfMemoryError(globalObject));
                 return { };
             }

--- a/Source/JavaScriptCore/runtime/IntlObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/IntlObjectInlines.h
@@ -101,11 +101,11 @@ InstanceType* unwrapForLegacyIntlConstructor(JSGlobalObject* globalObject, JSVal
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSObject* thisObject = jsDynamicCast<JSObject*>(thisValue);
-    if (UNLIKELY(!thisObject))
+    if (!thisObject) [[unlikely]]
         return nullptr;
 
     auto* instance = jsDynamicCast<InstanceType*>(thisObject);
-    if (LIKELY(instance))
+    if (instance) [[likely]]
         return instance;
 
     ASSERT(!constructor->template inherits<JSBoundFunction>());
@@ -293,7 +293,7 @@ inline JSObject* intlGetOptionsObject(JSGlobalObject* globalObject, JSValue opti
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (options.isUndefined())
         return nullptr;
-    if (LIKELY(options.isObject()))
+    if (options.isObject()) [[likely]]
         return asObject(options);
     throwTypeError(globalObject, scope, "options argument is not an object or undefined"_s);
     return nullptr;

--- a/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
+++ b/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
@@ -175,7 +175,7 @@ JSObject* IntlPluralRules::resolvedOptions(JSGlobalObject* globalObject) const
     }
 
     JSArray* categories = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), 0);
-    if (UNLIKELY(!categories)) {
+    if (!categories) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return nullptr;
     }

--- a/Source/JavaScriptCore/runtime/IntlPluralRulesPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlPluralRulesPrototype.cpp
@@ -86,7 +86,7 @@ JSC_DEFINE_HOST_FUNCTION(intlPluralRulesPrototypeFuncSelect, (JSGlobalObject* gl
     // https://tc39.github.io/ecma402/#sec-intl.pluralrules.prototype.select
     IntlPluralRules* pluralRules = jsDynamicCast<IntlPluralRules*>(callFrame->thisValue());
 
-    if (UNLIKELY(!pluralRules))
+    if (!pluralRules) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.PluralRules.prototype.select called on value that's not a PluralRules"_s));
 
     double value = callFrame->argument(0).toNumber(globalObject);
@@ -102,7 +102,7 @@ JSC_DEFINE_HOST_FUNCTION(intlPluralRulesPrototypeFuncSelectRange, (JSGlobalObjec
 
     // https://tc39.es/proposal-intl-numberformat-v3/out/pluralrules/diff.html#sec-intl.pluralrules.prototype.selectrange
     IntlPluralRules* pluralRules = jsDynamicCast<IntlPluralRules*>(callFrame->thisValue());
-    if (UNLIKELY(!pluralRules))
+    if (!pluralRules) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.PluralRules.prototype.selectRange called on value that's not a PluralRules"_s));
 
     JSValue startValue = callFrame->argument(0);
@@ -129,7 +129,7 @@ JSC_DEFINE_HOST_FUNCTION(intlPluralRulesPrototypeFuncResolvedOptions, (JSGlobalO
     // https://tc39.github.io/ecma402/#sec-intl.pluralrules.prototype.resolvedoptions
     IntlPluralRules* pluralRules = jsDynamicCast<IntlPluralRules*>(callFrame->thisValue());
 
-    if (UNLIKELY(!pluralRules))
+    if (!pluralRules) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.PluralRules.prototype.resolvedOptions called on value that's not a PluralRules"_s));
 
     RELEASE_AND_RETURN(scope, JSValue::encode(pluralRules->resolvedOptions(globalObject)));

--- a/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp
@@ -132,7 +132,7 @@ void IntlRelativeTimeFormat::initializeRelativeTimeFormat(JSGlobalObject* global
 
     UErrorCode status = U_ZERO_ERROR;
     m_numberFormat = std::unique_ptr<UNumberFormat, UNumberFormatDeleter>(unum_open(UNUM_DECIMAL, nullptr, 0, dataLocaleWithExtensions.data(), nullptr, &status));
-    if (UNLIKELY(U_FAILURE(status))) {
+    if (U_FAILURE(status)) [[unlikely]] {
         throwTypeError(globalObject, scope, "failed to initialize RelativeTimeFormat"_s);
         return;
     }
@@ -157,13 +157,13 @@ void IntlRelativeTimeFormat::initializeRelativeTimeFormat(JSGlobalObject* global
     unum_setAttribute(m_numberFormat.get(), UNUM_MINIMUM_GROUPING_DIGITS, useLocaleDefault);
 
     UNumberFormat* clonedNumberFormat = unum_clone(m_numberFormat.get(), &status);
-    if (UNLIKELY(U_FAILURE(status))) {
+    if (U_FAILURE(status)) [[unlikely]] {
         throwTypeError(globalObject, scope, "failed to initialize RelativeTimeFormat"_s);
         return;
     }
 
     m_relativeDateTimeFormatter = std::unique_ptr<URelativeDateTimeFormatter, URelativeDateTimeFormatterDeleter>(ureldatefmt_open(dataLocaleWithExtensions.data(), clonedNumberFormat, icuStyle, UDISPCTX_CAPITALIZATION_FOR_STANDALONE, &status));
-    if (UNLIKELY(U_FAILURE(status))) {
+    if (U_FAILURE(status)) [[unlikely]] {
         throwTypeError(globalObject, scope, "failed to initialize RelativeTimeFormat"_s);
         return;
     }
@@ -248,7 +248,7 @@ String IntlRelativeTimeFormat::formatInternal(JSGlobalObject* globalObject, doub
 
     Vector<UChar, 32> result;
     auto status = callBufferProducingFunction(formatRelativeTime, m_relativeDateTimeFormatter.get(), value, unitType.value(), result);
-    if (UNLIKELY(U_FAILURE(status))) {
+    if (U_FAILURE(status)) [[unlikely]] {
         throwTypeError(globalObject, scope, "failed to format relative time"_s);
         return String();
     }

--- a/Source/JavaScriptCore/runtime/IntlRelativeTimeFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlRelativeTimeFormatPrototype.cpp
@@ -83,7 +83,7 @@ JSC_DEFINE_HOST_FUNCTION(intlRelativeTimeFormatPrototypeFuncFormat, (JSGlobalObj
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* relativeTimeFormat = jsDynamicCast<IntlRelativeTimeFormat*>(callFrame->thisValue());
-    if (UNLIKELY(!relativeTimeFormat))
+    if (!relativeTimeFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.RelativeTimeFormat.prototype.format called on value that's not a RelativeTimeFormat"_s));
 
     double value = callFrame->argument(0).toNumber(globalObject);
@@ -102,7 +102,7 @@ JSC_DEFINE_HOST_FUNCTION(intlRelativeTimeFormatPrototypeFuncFormatToParts, (JSGl
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* relativeTimeFormat = jsDynamicCast<IntlRelativeTimeFormat*>(callFrame->thisValue());
-    if (UNLIKELY(!relativeTimeFormat))
+    if (!relativeTimeFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.RelativeTimeFormat.prototype.formatToParts called on value that's not a RelativeTimeFormat"_s));
 
     double value = callFrame->argument(0).toNumber(globalObject);
@@ -121,7 +121,7 @@ JSC_DEFINE_HOST_FUNCTION(intlRelativeTimeFormatPrototypeFuncResolvedOptions, (JS
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* relativeTimeFormat = jsDynamicCast<IntlRelativeTimeFormat*>(callFrame->thisValue());
-    if (UNLIKELY(!relativeTimeFormat))
+    if (!relativeTimeFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.RelativeTimeFormat.prototype.resolvedOptions called on value that's not a RelativeTimeFormat"_s));
 
     RELEASE_AND_RETURN(scope, JSValue::encode(relativeTimeFormat->resolvedOptions(globalObject)));

--- a/Source/JavaScriptCore/runtime/IntlSegmentIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlSegmentIteratorPrototype.cpp
@@ -78,7 +78,7 @@ JSC_DEFINE_HOST_FUNCTION(intlSegmentIteratorPrototypeFuncNext, (JSGlobalObject* 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* segmentIterator = jsDynamicCast<IntlSegmentIterator*>(callFrame->thisValue());
-    if (UNLIKELY(!segmentIterator))
+    if (!segmentIterator) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.SegmentIterator.prototype.next called on value that's not a SegmentIterator"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(segmentIterator->next(globalObject)));

--- a/Source/JavaScriptCore/runtime/IntlSegmenterPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlSegmenterPrototype.cpp
@@ -80,7 +80,7 @@ JSC_DEFINE_HOST_FUNCTION(intlSegmenterPrototypeFuncSegment, (JSGlobalObject* glo
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* segmenter = jsDynamicCast<IntlSegmenter*>(callFrame->thisValue());
-    if (UNLIKELY(!segmenter))
+    if (!segmenter) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Segmenter.prototype.segment called on value that's not a Segmenter"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(segmenter->segment(globalObject, callFrame->argument(0))));
@@ -93,7 +93,7 @@ JSC_DEFINE_HOST_FUNCTION(intlSegmenterPrototypeFuncResolvedOptions, (JSGlobalObj
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* segmenter = jsDynamicCast<IntlSegmenter*>(callFrame->thisValue());
-    if (UNLIKELY(!segmenter))
+    if (!segmenter) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Segmenter.prototype.resolvedOptions called on value that's not a Segmenter"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(segmenter->resolvedOptions(globalObject)));

--- a/Source/JavaScriptCore/runtime/IntlSegmentsPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlSegmentsPrototype.cpp
@@ -79,7 +79,7 @@ JSC_DEFINE_HOST_FUNCTION(intlSegmentsPrototypeFuncContaining, (JSGlobalObject* g
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* segments = jsDynamicCast<IntlSegments*>(callFrame->thisValue());
-    if (UNLIKELY(!segments))
+    if (!segments) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "%Segments.prototype%.containing called on value that's not a Segments"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(segments->containing(globalObject, callFrame->argument(0))));
@@ -92,7 +92,7 @@ JSC_DEFINE_HOST_FUNCTION(intlSegmentsPrototypeFuncIterator, (JSGlobalObject* glo
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* segments = jsDynamicCast<IntlSegments*>(callFrame->thisValue());
-    if (UNLIKELY(!segments))
+    if (!segments) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "%Segments.prototype%[@@iterator] called on value that's not a Segments"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(segments->createSegmentIterator(globalObject)));

--- a/Source/JavaScriptCore/runtime/IteratorOperations.cpp
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.cpp
@@ -92,7 +92,7 @@ void iteratorClose(JSGlobalObject* globalObject, JSValue iterator)
     auto catchScope = DECLARE_CATCH_SCOPE(vm);
 
     Exception* exception = nullptr;
-    if (UNLIKELY(catchScope.exception())) {
+    if (catchScope.exception()) [[unlikely]] {
         exception = catchScope.exception();
         catchScope.clearException();
     }

--- a/Source/JavaScriptCore/runtime/IteratorOperations.h
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.h
@@ -73,7 +73,7 @@ static ALWAYS_INLINE void forEachInFastArray(JSGlobalObject* globalObject, JSVal
         JSValue nextValue = array->getIndex(globalObject, index);
         RETURN_IF_EXCEPTION(scope, void());
         callback(vm, globalObject, nextValue);
-        if (UNLIKELY(scope.exception())) {
+        if (scope.exception()) [[unlikely]] {
             scope.release();
             JSArrayIterator* iterator = JSArrayIterator::create(vm, globalObject->arrayIteratorStructure(), array, IterationKind::Values);
             iterator->internalField(JSArrayIterator::Field::Index).setWithoutWriteBarrier(jsNumber(index + 1));
@@ -91,14 +91,16 @@ static ALWAYS_INLINE void forEachInIterationRecord(JSGlobalObject* globalObject,
 
     while (true) {
         JSValue next = iteratorStep(globalObject, iterationRecord);
-        if (UNLIKELY(scope.exception()) || next.isFalse())
+        if (scope.exception()) [[unlikely]]
+            return;
+        if (next.isFalse())
             return;
 
         JSValue nextValue = iteratorValue(globalObject, next);
         RETURN_IF_EXCEPTION(scope, void());
 
         callback(vm, globalObject, nextValue);
-        if (UNLIKELY(scope.exception())) {
+        if (scope.exception()) [[unlikely]] {
             scope.release();
             iteratorClose(globalObject, iterationRecord.iterator);
             return;
@@ -137,7 +139,7 @@ void forEachInIterable(JSGlobalObject& globalObject, JSObject* iterable, JSValue
             JSValue nextValue = array->getIndex(&globalObject, index);
             RETURN_IF_EXCEPTION(scope, void());
             callback(vm, globalObject, nextValue);
-            if (UNLIKELY(scope.exception())) {
+            if (scope.exception()) [[unlikely]] {
                 scope.release();
                 JSArrayIterator* iterator = JSArrayIterator::create(vm, globalObject.arrayIteratorStructure(), array, IterationKind::Values);
                 iterator->internalField(JSArrayIterator::Field::Index).setWithoutWriteBarrier(jsNumber(index + 1));
@@ -152,14 +154,16 @@ void forEachInIterable(JSGlobalObject& globalObject, JSObject* iterable, JSValue
     RETURN_IF_EXCEPTION(scope, void());
     while (true) {
         JSValue next = iteratorStep(&globalObject, iterationRecord);
-        if (UNLIKELY(scope.exception()) || next.isFalse())
+        if (scope.exception()) [[unlikely]]
+            return;
+        if (next.isFalse())
             return;
 
         JSValue nextValue = iteratorValue(&globalObject, next);
         RETURN_IF_EXCEPTION(scope, void());
 
         callback(vm, globalObject, nextValue);
-        if (UNLIKELY(scope.exception())) {
+        if (scope.exception()) [[unlikely]] {
             scope.release();
             iteratorClose(&globalObject, iterationRecord.iterator);
             return;

--- a/Source/JavaScriptCore/runtime/JSArray.h
+++ b/Source/JavaScriptCore/runtime/JSArray.h
@@ -226,7 +226,7 @@ inline JSArray* JSArray::tryCreate(VM& vm, Structure* structure, unsigned initia
 
     Butterfly* butterfly;
     IndexingType indexingType = structure->indexingType();
-    if (LIKELY(!hasAnyArrayStorage(indexingType))) {
+    if (!hasAnyArrayStorage(indexingType)) [[likely]] {
         ASSERT(
             hasUndecided(indexingType)
             || hasInt32(indexingType)

--- a/Source/JavaScriptCore/runtime/JSArrayBufferConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferConstructor.cpp
@@ -124,7 +124,7 @@ EncodedJSValue JSGenericArrayBufferConstructor<sharingMode>::constructImpl(JSGlo
 
     if (!buffer) {
         buffer = ArrayBuffer::tryCreate(length, 1, maxByteLength);
-        if (UNLIKELY(!buffer))
+        if (!buffer) [[unlikely]]
             return JSValue::encode(throwOutOfMemoryError(globalObject, scope));
         if constexpr (sharingMode == ArrayBufferSharingMode::Shared)
             buffer->makeShared();
@@ -170,7 +170,7 @@ JSObject* constructArrayBufferWithSize(JSGlobalObject* globalObject, Structure* 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto buffer = ArrayBuffer::tryCreate(length, 1);
-    if (UNLIKELY(!buffer)) {
+    if (!buffer) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return nullptr;
     }

--- a/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
@@ -57,7 +57,7 @@ std::optional<JSValue> arrayBufferSpeciesConstructorSlow(JSGlobalObject* globalO
 
     bool isValid = speciesWatchpointIsValid(thisObject, mode);
     scope.assertNoException();
-    if (LIKELY(isValid))
+    if (isValid) [[likely]]
         return std::nullopt;
 
     JSValue constructor = thisObject->get(globalObject, vm.propertyNames->constructor);
@@ -110,7 +110,7 @@ static ALWAYS_INLINE std::pair<SpeciesConstructResult, JSArrayBuffer*> speciesCo
 
     // 17. Perform ? RequireInternalSlot(new, [[ArrayBufferData]]).
     JSArrayBuffer* result = jsDynamicCast<JSArrayBuffer*>(newObject);
-    if (UNLIKELY(!result)) {
+    if (!result) [[unlikely]] {
         throwTypeError(globalObject, scope, "Species construction does not create ArrayBuffer"_s);
         return errorResult;
     }
@@ -348,7 +348,7 @@ static JSArrayBuffer* arrayBufferCopyAndDetach(JSGlobalObject* globalObject, JSA
 
     // We should create a new ArrayBuffer and copy them since underlying ArrayBuffer characteristics are different.
     auto newBuffer = ArrayBuffer::tryCreate(newByteLength, 1, std::nullopt);
-    if (UNLIKELY(!newBuffer)) {
+    if (!newBuffer) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return nullptr;
     }

--- a/Source/JavaScriptCore/runtime/JSArrayBufferPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferPrototypeInlines.h
@@ -58,7 +58,7 @@ ALWAYS_INLINE std::optional<JSValue> arrayBufferSpeciesConstructor(JSGlobalObjec
 
     bool isValid = speciesWatchpointIsValid(thisObject, mode);
     scope.assertNoException();
-    if (LIKELY(isValid))
+    if (isValid) [[likely]]
         return std::nullopt;
 
     RELEASE_AND_RETURN(scope, arrayBufferSpeciesConstructorSlow(globalObject, thisObject, mode));

--- a/Source/JavaScriptCore/runtime/JSArrayBufferView.h
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferView.h
@@ -288,7 +288,7 @@ public:
     
     size_t byteOffset() const
     {
-        if (LIKELY(canUseRawFieldsDirectly()))
+        if (canUseRawFieldsDirectly()) [[likely]]
             return byteOffsetRaw();
 
         IdempotentArrayBufferByteLengthGetter<std::memory_order_seq_cst> getter;
@@ -301,7 +301,7 @@ public:
 
     size_t length() const
     {
-        if (LIKELY(canUseRawFieldsDirectly()))
+        if (canUseRawFieldsDirectly()) [[likely]]
             return lengthRaw();
 
         IdempotentArrayBufferByteLengthGetter<std::memory_order_seq_cst> getter;
@@ -314,7 +314,7 @@ public:
     {
         // The absence of overflow is already checked in the constructor, so I only add the extra sanity check when asserts are enabled.
         // https://tc39.es/proposal-resizablearraybuffer/#sec-get-%typedarray%.prototype.bytelength
-        if (LIKELY(canUseRawFieldsDirectly()))
+        if (canUseRawFieldsDirectly()) [[likely]]
             return byteLengthRaw();
 
         IdempotentArrayBufferByteLengthGetter<std::memory_order_seq_cst> getter;
@@ -335,7 +335,7 @@ public:
     bool isOutOfBounds() const
     {
         // https://tc39.es/proposal-resizablearraybuffer/#sec-isarraybufferviewoutofbounds
-        if (UNLIKELY(isDetached()))
+        if (isDetached()) [[unlikely]]
             return true;
         if (LIKELY(!isResizableNonShared()))
             return false;

--- a/Source/JavaScriptCore/runtime/JSArrayInlines.h
+++ b/Source/JavaScriptCore/runtime/JSArrayInlines.h
@@ -208,7 +208,7 @@ ALWAYS_INLINE void JSArray::pushInline(JSGlobalObject* globalObject, JSValue val
             return;
         }
 
-        if (UNLIKELY(length > MAX_ARRAY_INDEX)) {
+        if (length > MAX_ARRAY_INDEX) [[unlikely]] {
             methodTable()->putByIndex(this, globalObject, length, value, true);
             if (!scope.exception())
                 throwException(globalObject, scope, createRangeError(globalObject, LengthExceededTheMaximumArrayLengthError));
@@ -230,7 +230,7 @@ ALWAYS_INLINE void JSArray::pushInline(JSGlobalObject* globalObject, JSValue val
             return;
         }
 
-        if (UNLIKELY(length > MAX_ARRAY_INDEX)) {
+        if (length > MAX_ARRAY_INDEX) [[unlikely]] {
             methodTable()->putByIndex(this, globalObject, length, value, true);
             if (!scope.exception())
                 throwException(globalObject, scope, createRangeError(globalObject, LengthExceededTheMaximumArrayLengthError));
@@ -266,7 +266,7 @@ ALWAYS_INLINE void JSArray::pushInline(JSGlobalObject* globalObject, JSValue val
             return;
         }
 
-        if (UNLIKELY(length > MAX_ARRAY_INDEX)) {
+        if (length > MAX_ARRAY_INDEX) [[unlikely]] {
             methodTable()->putByIndex(this, globalObject, length, value, true);
             if (!scope.exception())
                 throwException(globalObject, scope, createRangeError(globalObject, LengthExceededTheMaximumArrayLengthError));

--- a/Source/JavaScriptCore/runtime/JSBigInt.cpp
+++ b/Source/JavaScriptCore/runtime/JSBigInt.cpp
@@ -120,7 +120,7 @@ inline JSBigInt* JSBigInt::createWithLength(JSGlobalObject* nullOrGlobalObjectFo
 
     ASSERT(length <= maxLength);
     void* data = vm.primitiveGigacageAuxiliarySpace().allocate(vm, length * sizeof(Digit), nullptr, AllocationFailureMode::ReturnNull);
-    if (UNLIKELY(!data)) {
+    if (!data) [[unlikely]] {
         if (nullOrGlobalObjectForOOM) {
             auto scope = DECLARE_THROW_SCOPE(vm);
             throwOutOfMemoryError(nullOrGlobalObjectForOOM, scope);
@@ -1654,7 +1654,7 @@ bool JSBigInt::absoluteDivWithDigitDivisor(JSGlobalObject* nullOrGlobalObjectFor
     if (divisor == 1) {
         if (quotient) {
             JSBigInt* result = x.toHeapBigInt(nullOrGlobalObjectForOOM, vm);
-            if (UNLIKELY(!result))
+            if (!result) [[unlikely]]
                 return false;
             *quotient = result;
         }
@@ -1665,7 +1665,7 @@ bool JSBigInt::absoluteDivWithDigitDivisor(JSGlobalObject* nullOrGlobalObjectFor
     if (quotient) {
         if (*quotient == nullptr) {
             JSBigInt* result = createWithLength(nullOrGlobalObjectForOOM, vm, length);
-            if (UNLIKELY(!result))
+            if (!result) [[unlikely]]
                 return false;
             *quotient = result;
         }

--- a/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
@@ -88,7 +88,7 @@ JSC_DEFINE_HOST_FUNCTION(boundFunctionCall, (JSGlobalObject* globalObject, CallF
         }
         for (unsigned i = 0; i < callFrame->argumentCount(); ++i)
             args.append(callFrame->uncheckedArgument(i));
-        if (UNLIKELY(args.hasOverflowed())) {
+        if (args.hasOverflowed()) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
             return encodedJSValue();
         }
@@ -124,7 +124,7 @@ JSC_DEFINE_HOST_FUNCTION(boundFunctionConstruct, (JSGlobalObject* globalObject, 
         }
         for (unsigned i = 0; i < callFrame->argumentCount(); ++i)
             args.append(callFrame->uncheckedArgument(i));
-        if (UNLIKELY(args.hasOverflowed())) {
+        if (args.hasOverflowed()) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
             return encodedJSValue();
         }
@@ -199,7 +199,7 @@ JSBoundFunction* JSBoundFunction::create(VM& vm, JSGlobalObject* globalObject, J
                 boundArgs[index] = args.at(index);
         } else {
             JSImmutableButterfly* butterfly = JSImmutableButterfly::tryCreate(vm, vm.immutableButterflyStructure(CopyOnWriteArrayWithContiguous), args.size());
-            if (UNLIKELY(!butterfly)) {
+            if (!butterfly) [[unlikely]] {
                 throwOutOfMemoryError(globalObject, scope);
                 return nullptr;
             }
@@ -274,7 +274,7 @@ JSString* JSBoundFunction::nameSlow(VM& vm)
         ASSERT(cursor->inherits<JSFunction>()); // If this is not JSFunction, we eagerly materialized the name.
         if (!cursor->inherits<JSBoundFunction>()) {
             terminal = jsCast<JSFunction*>(cursor)->originalName(globalObject);
-            if (UNLIKELY(scope.exception())) {
+            if (scope.exception()) [[unlikely]] {
                 scope.clearException();
                 terminal = jsEmptyString(vm);
             }
@@ -293,7 +293,7 @@ JSString* JSBoundFunction::nameSlow(VM& vm)
         for (unsigned i = 0; i < nestingCount; ++i)
             builder.append("bound "_s);
         auto terminalString = terminal->value(globalObject); // Resolving rope.
-        if (UNLIKELY(scope.exception())) {
+        if (scope.exception()) [[unlikely]] {
             scope.clearException();
             terminal = jsEmptyString(vm);
         } else {
@@ -307,7 +307,7 @@ JSString* JSBoundFunction::nameSlow(VM& vm)
 
     if (terminal) {
         terminal->value(globalObject); // Resolving rope.
-        if (UNLIKELY(scope.exception())) {
+        if (scope.exception()) [[unlikely]] {
             scope.clearException();
             terminal = jsEmptyString(vm);
         }

--- a/Source/JavaScriptCore/runtime/JSCJSValue.cpp
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.cpp
@@ -220,7 +220,7 @@ bool JSValue::putToPrimitive(JSGlobalObject* globalObject, PropertyName property
     // Check if there are any setters or getters in the prototype chain
     JSObject* obj = synthesizePrototype(globalObject);
     EXCEPTION_ASSERT(!!scope.exception() == !obj);
-    if (UNLIKELY(!obj))
+    if (!obj) [[unlikely]]
         return false;
     RELEASE_AND_RETURN(scope, obj->methodTable()->put(obj, globalObject, propertyName, value, slot));
 }
@@ -237,7 +237,7 @@ bool JSValue::putToPrimitiveByIndex(JSGlobalObject* globalObject, unsigned prope
 
     JSObject* prototype = synthesizePrototype(globalObject);
     EXCEPTION_ASSERT(!!scope.exception() == !prototype);
-    if (UNLIKELY(!prototype))
+    if (!prototype) [[unlikely]]
         return false;
     bool putResult = false;
     bool success = prototype->attemptToInterceptPutByIndexOnHoleForPrototype(globalObject, *this, propertyName, value, shouldThrow, putResult);

--- a/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
@@ -1091,7 +1091,7 @@ ALWAYS_INLINE bool JSValue::getPropertySlot(JSGlobalObject* globalObject, Proper
     // If this is a primitive, we'll need to synthesize the prototype -
     // and if it's a string there are special properties to check first.
     JSObject* object;
-    if (UNLIKELY(!isObject())) {
+    if (!isObject()) [[unlikely]] {
         if (isString()) {
             bool hasProperty = asString(*this)->getStringPropertySlot(globalObject, propertyName, slot);
             RETURN_IF_EXCEPTION(scope, false);
@@ -1100,7 +1100,7 @@ ALWAYS_INLINE bool JSValue::getPropertySlot(JSGlobalObject* globalObject, Proper
         }
         object = synthesizePrototype(globalObject);
         EXCEPTION_ASSERT(!!scope.exception() == !object);
-        if (UNLIKELY(!object))
+        if (!object) [[unlikely]]
             return false;
     } else
         object = asObject(asCell());
@@ -1113,7 +1113,7 @@ ALWAYS_INLINE bool JSValue::getOwnPropertySlot(JSGlobalObject* globalObject, Pro
     // If this is a primitive, we'll need to synthesize the prototype -
     // and if it's a string there are special properties to check first.
     auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
-    if (UNLIKELY(!isObject())) {
+    if (!isObject()) [[unlikely]] {
         if (isString())
             RELEASE_AND_RETURN(scope, asString(*this)->getStringPropertySlot(globalObject, propertyName, slot));
 
@@ -1136,7 +1136,7 @@ ALWAYS_INLINE JSValue JSValue::get(JSGlobalObject* globalObject, unsigned proper
     // If this is a primitive, we'll need to synthesize the prototype -
     // and if it's a string there are special properties to check first.
     JSObject* object;
-    if (UNLIKELY(!isObject())) {
+    if (!isObject()) [[unlikely]] {
         if (isString()) {
             bool hasProperty = asString(*this)->getStringPropertySlot(globalObject, propertyName, slot);
             RETURN_IF_EXCEPTION(scope, { });
@@ -1145,7 +1145,7 @@ ALWAYS_INLINE JSValue JSValue::get(JSGlobalObject* globalObject, unsigned proper
         }
         object = synthesizePrototype(globalObject);
         EXCEPTION_ASSERT(!!scope.exception() == !object);
-        if (UNLIKELY(!object))
+        if (!object) [[unlikely]]
             return JSValue();
     } else
         object = asObject(asCell());
@@ -1178,7 +1178,7 @@ ALWAYS_INLINE T JSValue::getAs(JSGlobalObject* globalObject, PropertyNameType pr
 
 inline bool JSValue::put(JSGlobalObject* globalObject, PropertyName propertyName, JSValue value, PutPropertySlot& slot)
 {
-    if (UNLIKELY(!isCell()))
+    if (!isCell()) [[unlikely]]
         return putToPrimitive(globalObject, propertyName, value, slot);
 
     return asCell()->methodTable()->put(asCell(), globalObject, propertyName, value, slot);
@@ -1186,14 +1186,14 @@ inline bool JSValue::put(JSGlobalObject* globalObject, PropertyName propertyName
 
 ALWAYS_INLINE bool JSValue::putInline(JSGlobalObject* globalObject, PropertyName propertyName, JSValue value, PutPropertySlot& slot)
 {
-    if (UNLIKELY(!isCell()))
+    if (!isCell()) [[unlikely]]
         return putToPrimitive(globalObject, propertyName, value, slot);
     return asCell()->putInline(globalObject, propertyName, value, slot);
 }
 
 inline bool JSValue::putByIndex(JSGlobalObject* globalObject, unsigned propertyName, JSValue value, bool shouldThrow)
 {
-    if (UNLIKELY(!isCell()))
+    if (!isCell()) [[unlikely]]
         return putToPrimitiveByIndex(globalObject, propertyName, value, shouldThrow);
 
     return asCell()->methodTable()->putByIndex(asCell(), globalObject, propertyName, value, shouldThrow);

--- a/Source/JavaScriptCore/runtime/JSDataView.h
+++ b/Source/JavaScriptCore/runtime/JSDataView.h
@@ -60,10 +60,10 @@ public:
     {
         // https://tc39.es/proposal-resizablearraybuffer/#sec-isviewoutofbounds
         // https://tc39.es/proposal-resizablearraybuffer/#sec-getviewbytelength
-        if (UNLIKELY(isDetached()))
+        if (isDetached()) [[unlikely]]
             return std::nullopt;
 
-        if (LIKELY(canUseRawFieldsDirectly()))
+        if (canUseRawFieldsDirectly()) [[likely]]
             return byteLengthRaw();
 
         RefPtr<ArrayBuffer> buffer = possiblySharedBuffer();

--- a/Source/JavaScriptCore/runtime/JSDataViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSDataViewPrototype.cpp
@@ -155,7 +155,7 @@ EncodedJSValue getData(JSGlobalObject* globalObject, CallFrame* callFrame)
 
     IdempotentArrayBufferByteLengthGetter<std::memory_order_relaxed> getter;
     auto byteLengthValue = dataView->viewByteLength(getter);
-    if (UNLIKELY(!byteLengthValue))
+    if (!byteLengthValue) [[unlikely]]
         return throwVMTypeError(globalObject, scope, typedArrayBufferHasBeenDetachedErrorMessage);
 
     size_t byteLength = byteLengthValue.value();
@@ -203,7 +203,7 @@ EncodedJSValue setData(JSGlobalObject* globalObject, CallFrame* callFrame)
 
     IdempotentArrayBufferByteLengthGetter<std::memory_order_relaxed> getter;
     auto byteLengthValue = dataView->viewByteLength(getter);
-    if (UNLIKELY(!byteLengthValue))
+    if (!byteLengthValue) [[unlikely]]
         return throwVMTypeError(globalObject, scope, typedArrayBufferHasBeenDetachedErrorMessage);
 
     size_t byteLength = byteLengthValue.value();
@@ -241,12 +241,12 @@ JSC_DEFINE_HOST_FUNCTION(dataViewProtoGetterByteLength, (JSGlobalObject* globalO
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSDataView* view = jsDynamicCast<JSDataView*>(callFrame->thisValue());
-    if (UNLIKELY(!view))
+    if (!view) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "DataView.prototype.byteLength expects |this| to be a DataView object"_s);
 
     IdempotentArrayBufferByteLengthGetter<std::memory_order_seq_cst> getter;
     auto byteLengthValue = view->viewByteLength(getter);
-    if (UNLIKELY(!byteLengthValue))
+    if (!byteLengthValue) [[unlikely]]
         return throwVMTypeError(globalObject, scope, typedArrayBufferHasBeenDetachedErrorMessage);
 
     return JSValue::encode(jsNumber(byteLengthValue.value()));
@@ -263,7 +263,7 @@ JSC_DEFINE_CUSTOM_GETTER(dataViewProtoGetterByteOffset, (JSGlobalObject* globalO
 
     IdempotentArrayBufferByteLengthGetter<std::memory_order_seq_cst> getter;
     auto byteLengthValue = view->viewByteLength(getter);
-    if (UNLIKELY(!byteLengthValue))
+    if (!byteLengthValue) [[unlikely]]
         return throwVMTypeError(globalObject, scope, typedArrayBufferHasBeenDetachedErrorMessage);
 
     return JSValue::encode(jsNumber(view->byteOffsetRaw()));

--- a/Source/JavaScriptCore/runtime/JSFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSFunction.cpp
@@ -404,7 +404,7 @@ bool JSFunction::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName pr
             if (!isValidOffset(thisObject->getDirectOffset(vm, propertyName))) {
                 // For class constructors, prototype object is initialized from bytecode via defineOwnProperty().
                 ASSERT(!thisObject->jsExecutable()->isClassConstructorFunction());
-                if (UNLIKELY(slot.thisValue() != thisObject))
+                if (slot.thisValue() != thisObject) [[unlikely]]
                     RELEASE_AND_RETURN(scope, JSObject::definePropertyOnReceiver(globalObject, propertyName, value, slot));
                 thisObject->putDirect(vm, propertyName, value, prototypeAttributesForNonClass);
                 return true;

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp
@@ -41,7 +41,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayConstructorFromBase64, (JSGlobalObject* globa
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSString* jsString = jsDynamicCast<JSString*>(callFrame->argument(0));
-    if (UNLIKELY(!jsString))
+    if (!jsString) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Uint8Array.fromBase64 requires a string"_s);
 
     auto alphabet = WTF::Alphabet::Base64;
@@ -57,7 +57,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayConstructorFromBase64, (JSGlobalObject* globa
         RETURN_IF_EXCEPTION(scope, { });
         if (!alphabetValue.isUndefined()) {
             JSString* alphabetString = jsDynamicCast<JSString*>(alphabetValue);
-            if (UNLIKELY(!alphabetString))
+            if (!alphabetString) [[unlikely]]
                 return throwVMTypeError(globalObject, scope, "Uint8Array.fromBase64 requires that alphabet be \"base64\" or \"base64url\""_s);
 
             auto alphabetStringView = alphabetString->view(globalObject);
@@ -216,7 +216,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayConstructorFromHex, (JSGlobalObject* globalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSString* jsString = jsDynamicCast<JSString*>(callFrame->argument(0));
-    if (UNLIKELY(!jsString))
+    if (!jsString) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Uint8Array.fromHex requires a string"_s);
     if (UNLIKELY(jsString->length() % 2))
         return JSValue::encode(throwSyntaxError(globalObject, scope, "Uint8Array.fromHex requires a string of even length"_s));
@@ -238,7 +238,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayConstructorFromHex, (JSGlobalObject* globalOb
     else
         success = decodeHex(view.span16(), result) == WTF::notFound;
 
-    if (UNLIKELY(!success))
+    if (!success) [[unlikely]]
         return JSValue::encode(throwSyntaxError(globalObject, scope, "Uint8Array.prototype.fromHex requires a string containing only \"0123456789abcdefABCDEF\""_s));
 
     return JSValue::encode(uint8Array);

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
@@ -98,7 +98,7 @@ inline JSObject* constructGenericTypedArrayViewFromIterator(JSGlobalObject* glob
 
     ViewClass* result = ViewClass::createUninitialized(globalObject, structure, storage.size());
     EXCEPTION_ASSERT(!!scope.exception() == !result);
-    if (UNLIKELY(!result))
+    if (!result) [[unlikely]]
         return nullptr;
 
     for (unsigned i = 0; i < storage.size(); ++i) {
@@ -168,7 +168,7 @@ inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* glo
 
             ViewClass* result = ViewClass::createUninitialized(globalObject, structure, length);
             EXCEPTION_ASSERT(!!scope.exception() == !result);
-            if (UNLIKELY(!result))
+            if (!result) [[unlikely]]
                 return nullptr;
 
             IdempotentArrayBufferByteLengthGetter<std::memory_order_seq_cst> getter;
@@ -228,7 +228,7 @@ inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* glo
 
         ViewClass* result = ViewClass::createUninitialized(globalObject, structure, length);
         EXCEPTION_ASSERT(!!scope.exception() == !result);
-        if (UNLIKELY(!result))
+        if (!result) [[unlikely]]
             return nullptr;
 
         scope.release();

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -504,7 +504,7 @@ bool JSGenericTypedArrayView<Adaptor>::setFromArrayLike(JSGlobalObject* globalOb
         RETURN_IF_EXCEPTION(scope, false);
         bool success = setIndex(globalObject, offset + i, value);
         EXCEPTION_ASSERT(!scope.exception() || !success);
-        if (UNLIKELY(!success))
+        if (!success) [[unlikely]]
             return false;
     }
     for (size_t i = safeLength; i < sourceLength; ++i) {
@@ -512,7 +512,7 @@ bool JSGenericTypedArrayView<Adaptor>::setFromArrayLike(JSGlobalObject* globalOb
         RETURN_IF_EXCEPTION(scope, false);
         bool success = setIndex(globalObject, offset + i, value);
         EXCEPTION_ASSERT(!scope.exception() || !success);
-        if (UNLIKELY(!success))
+        if (!success) [[unlikely]]
             return false;
     }
     return true;
@@ -772,7 +772,7 @@ DEFINE_VISIT_CHILDREN_WITH_MODIFIER(template<typename Adaptor>, JSGenericTypedAr
 template<typename Adaptor> inline size_t JSGenericTypedArrayView<Adaptor>::byteLength() const
 {
     // https://tc39.es/proposal-resizablearraybuffer/#sec-get-%typedarray%.prototype.bytelength
-    if (LIKELY(canUseRawFieldsDirectly()))
+    if (canUseRawFieldsDirectly()) [[likely]]
         return byteLengthRaw();
     IdempotentArrayBufferByteLengthGetter<std::memory_order_seq_cst> getter;
     return integerIndexedObjectByteLength(const_cast<JSGenericTypedArrayView*>(this), getter);
@@ -795,7 +795,7 @@ template<typename Adaptor> inline typename Adaptor::Type* JSGenericTypedArrayVie
 
 template<typename Adaptor> inline bool JSGenericTypedArrayView<Adaptor>::inBounds(size_t i) const
 {
-    if (LIKELY(canUseRawFieldsDirectly()))
+    if (canUseRawFieldsDirectly()) [[likely]]
         return i < lengthRaw();
     size_t bufferByteLength = const_cast<JSGenericTypedArrayView*>(this)->existingBufferInButterfly()->byteLength();
     size_t byteOffset = const_cast<JSGenericTypedArrayView*>(this)->byteOffsetRaw();

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp
@@ -43,11 +43,11 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeSetFromBase64, (JSGlobalObject* glob
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSUint8Array* uint8Array = jsDynamicCast<JSUint8Array*>(callFrame->thisValue());
-    if (UNLIKELY(!uint8Array))
+    if (!uint8Array) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.setFromBase64 requires that |this| be a Uint8Array"_s);
 
     JSString* jsString = jsDynamicCast<JSString*>(callFrame->argument(0));
-    if (UNLIKELY(!jsString))
+    if (!jsString) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.setFromBase64 requires a string"_s);
 
     auto alphabet = WTF::Alphabet::Base64;
@@ -63,7 +63,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeSetFromBase64, (JSGlobalObject* glob
         RETURN_IF_EXCEPTION(scope, { });
         if (!alphabetValue.isUndefined()) {
             JSString* alphabetString = jsDynamicCast<JSString*>(alphabetValue);
-            if (UNLIKELY(!alphabetString))
+            if (!alphabetString) [[unlikely]]
                 return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.setFromBase64 requires that alphabet be \"base64\" or \"base64url\""_s);
 
             auto alphabetStringView = alphabetString->view(globalObject);
@@ -93,7 +93,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeSetFromBase64, (JSGlobalObject* glob
     }
 
     IdempotentArrayBufferByteLengthGetter<std::memory_order_seq_cst> byteLengthGetter;
-    if (UNLIKELY(isIntegerIndexedObjectOutOfBounds(uint8Array, byteLengthGetter)))
+    if (isIntegerIndexedObjectOutOfBounds(uint8Array, byteLengthGetter)) [[unlikely]]
         return throwVMTypeError(globalObject, scope, typedArrayBufferHasBeenDetachedErrorMessage);
 
     auto gcOwnedData = jsString->view(globalObject);
@@ -118,15 +118,15 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeSetFromHex, (JSGlobalObject* globalO
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSUint8Array* uint8Array = jsDynamicCast<JSUint8Array*>(callFrame->thisValue());
-    if (UNLIKELY(!uint8Array))
+    if (!uint8Array) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.setFromHex requires that |this| be a Uint8Array"_s);
 
     IdempotentArrayBufferByteLengthGetter<std::memory_order_seq_cst> byteLengthGetter;
-    if (UNLIKELY(isIntegerIndexedObjectOutOfBounds(uint8Array, byteLengthGetter)))
+    if (isIntegerIndexedObjectOutOfBounds(uint8Array, byteLengthGetter)) [[unlikely]]
         return throwVMTypeError(globalObject, scope, typedArrayBufferHasBeenDetachedErrorMessage);
 
     JSString* jsString = jsDynamicCast<JSString*>(callFrame->argument(0));
-    if (UNLIKELY(!jsString))
+    if (!jsString) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.setFromHex requires a string"_s);
     if (UNLIKELY(jsString->length() % 2))
         return JSValue::encode(throwSyntaxError(globalObject, scope, "Uint8Array.prototype.setFromHex requires a string of even length"_s));
@@ -146,7 +146,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeSetFromHex, (JSGlobalObject* globalO
     else
         success = decodeHex(view.span16().first(readCount), result) == WTF::notFound;
 
-    if (UNLIKELY(!success))
+    if (!success) [[unlikely]]
         return JSValue::encode(throwSyntaxError(globalObject, scope, "Uint8Array.prototype.setFromHex requires a string containing only \"0123456789abcdefABCDEF\""_s));
 
     JSObject* resultObject = constructEmptyObject(globalObject);
@@ -161,7 +161,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeToBase64, (JSGlobalObject* globalObj
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSUint8Array* uint8Array = jsDynamicCast<JSUint8Array*>(callFrame->thisValue());
-    if (UNLIKELY(!uint8Array))
+    if (!uint8Array) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.toBase64 requires that |this| be a Uint8Array"_s);
 
     OptionSet<Base64EncodeOption> options;
@@ -176,7 +176,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeToBase64, (JSGlobalObject* globalObj
         RETURN_IF_EXCEPTION(scope, { });
         if (!alphabetValue.isUndefined()) {
             JSString* alphabetString = jsDynamicCast<JSString*>(alphabetValue);
-            if (UNLIKELY(!alphabetString))
+            if (!alphabetString) [[unlikely]]
                 return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.toBase64 requires that alphabet be \"base64\" or \"base64url\""_s);
 
             auto alphabetStringView = alphabetString->view(globalObject);
@@ -194,13 +194,13 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeToBase64, (JSGlobalObject* globalObj
     }
 
     IdempotentArrayBufferByteLengthGetter<std::memory_order_seq_cst> byteLengthGetter;
-    if (UNLIKELY(isIntegerIndexedObjectOutOfBounds(uint8Array, byteLengthGetter)))
+    if (isIntegerIndexedObjectOutOfBounds(uint8Array, byteLengthGetter)) [[unlikely]]
         return throwVMTypeError(globalObject, scope, typedArrayBufferHasBeenDetachedErrorMessage);
 
     const uint8_t* data = uint8Array->typedVector();
     size_t length = uint8Array->length();
     auto result = base64EncodeToStringReturnNullIfOverflow({ data, length }, options);
-    if (UNLIKELY(result.isNull())) {
+    if (result.isNull()) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope, "generated stirng is too long"_s);
         return { };
     }
@@ -214,11 +214,11 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeToHex, (JSGlobalObject* globalObject
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSUint8Array* uint8Array = jsDynamicCast<JSUint8Array*>(callFrame->thisValue());
-    if (UNLIKELY(!uint8Array))
+    if (!uint8Array) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.toHex requires that |this| be a Uint8Array"_s);
 
     IdempotentArrayBufferByteLengthGetter<std::memory_order_seq_cst> byteLengthGetter;
-    if (UNLIKELY(isIntegerIndexedObjectOutOfBounds(uint8Array, byteLengthGetter)))
+    if (isIntegerIndexedObjectOutOfBounds(uint8Array, byteLengthGetter)) [[unlikely]]
         return throwVMTypeError(globalObject, scope, typedArrayBufferHasBeenDetachedErrorMessage);
 
     const uint8_t* data = uint8Array->typedVector();

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1999,7 +1999,7 @@ bool JSGlobalObject::put(JSCell* cell, JSGlobalObject* globalObject, PropertyNam
     JSGlobalObject* thisObject = jsCast<JSGlobalObject*>(cell);
     ASSERT(!Heap::heap(value) || Heap::heap(value) == Heap::heap(thisObject));
 
-    if (UNLIKELY(isThisValueAltered(slot, thisObject))) {
+    if (isThisValueAltered(slot, thisObject)) [[unlikely]] {
         SymbolTableEntry::Fast entry = thisObject->symbolTable()->get(propertyName.uid());
         if (!entry.isNull()) {
             if (entry.isReadOnly())
@@ -2082,7 +2082,7 @@ void JSGlobalObject::createGlobalFunctionBinding(const Identifier& ident)
     PropertySlot slot(this, PropertySlot::InternalMethodType::GetOwnProperty);
     bool hasProperty = getOwnPropertySlot(this, this, ident, slot);
     scope.assertNoExceptionExceptTermination();
-    if (UNLIKELY(hasProperty)) {
+    if (hasProperty) [[unlikely]] {
         if (slot.attributes() & PropertyAttribute::DontDelete) {
             ASSERT(!(slot.attributes() & PropertyAttribute::ReadOnly));
             // Nothing to do here: there is either a symbol table entry or non-configurable writable property

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -135,7 +135,7 @@ static JSValue encode(JSGlobalObject* globalObject, const WTF::BitSet<256>& doNo
         }
     }
 
-    if (UNLIKELY(builder.hasOverflowed()))
+    if (builder.hasOverflowed()) [[unlikely]]
         return throwOutOfMemoryError(globalObject, scope);
     return jsString(vm, builder.toString());
 }
@@ -219,7 +219,7 @@ static JSValue decode(JSGlobalObject* globalObject, std::span<const CharType> ch
         ++k;
         builder.append(c);
     }
-    if (UNLIKELY(builder.hasOverflowed()))
+    if (builder.hasOverflowed()) [[unlikely]]
         return throwOutOfMemoryError(globalObject, scope);
     RELEASE_AND_RETURN(scope, jsString(vm, builder.toString()));
 }
@@ -636,7 +636,7 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncEscape, (JSGlobalObject* globalObject, CallFr
             }
         }
 
-        if (UNLIKELY(builder.hasOverflowed())) {
+        if (builder.hasOverflowed()) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
             return { };
         }
@@ -699,7 +699,7 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncUnescape, (JSGlobalObject* globalObject, Call
             }
         }
 
-        if (UNLIKELY(builder.hasOverflowed())) {
+        if (builder.hasOverflowed()) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
             return { };
         }
@@ -995,7 +995,7 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncCopyDataProperties, (JSGlobalObject* globalOb
             continue;
 
         JSValue value;
-        if (LIKELY(!slot.isTaintedByOpaqueObject()))
+        if (!slot.isTaintedByOpaqueObject()) [[likely]]
             value = slot.getValue(globalObject, propertyName);
         else
             value = source->get(globalObject, propertyName);
@@ -1079,7 +1079,7 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncCloneObject, (JSGlobalObject* globalObject, C
             continue;
 
         JSValue value;
-        if (LIKELY(!slot.isTaintedByOpaqueObject()))
+        if (!slot.isTaintedByOpaqueObject()) [[likely]]
             value = slot.getValue(globalObject, propertyName);
         else
             value = source->get(globalObject, propertyName);

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -289,7 +289,7 @@ inline JSArray* constructEmptyArray(JSGlobalObject* globalObject, ArrayAllocatio
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     JSArray* result = JSArray::tryCreate(vm, structure, initialLength);
-    if (UNLIKELY(!result)) {
+    if (!result) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return nullptr;
     }
@@ -322,7 +322,7 @@ inline JSArray* constructArrayNegativeIndexed(JSGlobalObject* globalObject, Arra
     RETURN_IF_EXCEPTION(scope, nullptr);
     scope.release();
     JSArray* array = constructArrayNegativeIndexed(globalObject, structure, values, length);
-    if (UNLIKELY(!array))
+    if (!array) [[unlikely]]
         return nullptr;
     return ArrayAllocationProfile::updateLastAllocationFor(profile, array);
 }
@@ -342,7 +342,7 @@ ALWAYS_INLINE JSArray* tryCreateContiguousArrayWithPattern(JSGlobalObject* globa
         vm,
         Butterfly::totalSize(0, 0, true, vectorLength * sizeof(EncodedJSValue)),
         nullptr, AllocationFailureMode::ReturnNull);
-    if (UNLIKELY(!temp))
+    if (!temp) [[unlikely]]
         return nullptr;
     Butterfly* butterfly = Butterfly::fromBase(temp, 0, 0);
     butterfly->setVectorLength(vectorLength);
@@ -561,7 +561,7 @@ inline void JSGlobalObject::createGlobalVarBinding(const Identifier& ident)
     PropertySlot slot(this, PropertySlot::InternalMethodType::GetOwnProperty);
     bool hasProperty = getOwnPropertySlot(this, this, ident, slot);
     scope.assertNoExceptionExceptTermination();
-    if (UNLIKELY(hasProperty))
+    if (hasProperty) [[unlikely]]
         return;
 
     ASSERT(isStructureExtensible());

--- a/Source/JavaScriptCore/runtime/JSImmutableButterfly.cpp
+++ b/Source/JavaScriptCore/runtime/JSImmutableButterfly.cpp
@@ -77,7 +77,7 @@ JSImmutableButterfly* JSImmutableButterfly::createFromClonedArguments(JSGlobalOb
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     JSImmutableButterfly* result = JSImmutableButterfly::tryCreate(vm, vm.immutableButterflyStructure(CopyOnWriteArrayWithContiguous), length);
-    if (UNLIKELY(!result)) {
+    if (!result) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return nullptr;
     }
@@ -125,7 +125,7 @@ static ALWAYS_INLINE JSImmutableButterfly* createFromNonClonedArguments(JSGlobal
     unsigned length = arguments->internalLength();
 
     JSImmutableButterfly* result = JSImmutableButterfly::tryCreate(vm, vm.immutableButterflyStructure(CopyOnWriteArrayWithContiguous), length);
-    if (UNLIKELY(!result)) {
+    if (!result) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return nullptr;
     }
@@ -169,7 +169,7 @@ JSImmutableButterfly* JSImmutableButterfly::createFromString(JSGlobalObject* glo
     unsigned length = holder->length();
     if (holder->is8Bit()) {
         JSImmutableButterfly* result = JSImmutableButterfly::tryCreate(vm, vm.immutableButterflyStructure(CopyOnWriteArrayWithContiguous), length);
-        if (UNLIKELY(!result)) {
+        if (!result) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
             return nullptr;
         }
@@ -212,7 +212,7 @@ JSImmutableButterfly* JSImmutableButterfly::createFromString(JSGlobalObject* glo
     });
 
     JSImmutableButterfly* result = JSImmutableButterfly::tryCreate(vm, vm.immutableButterflyStructure(CopyOnWriteArrayWithContiguous), codePointLength);
-    if (UNLIKELY(!result)) {
+    if (!result) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return nullptr;
     }
@@ -241,7 +241,7 @@ JSImmutableButterfly* JSImmutableButterfly::createFromString(JSGlobalObject* glo
 JSImmutableButterfly* JSImmutableButterfly::tryCreateFromArgList(VM& vm, ArgList argList)
 {
     JSImmutableButterfly* result = JSImmutableButterfly::tryCreate(vm, vm.immutableButterflyStructure(CopyOnWriteArrayWithContiguous), argList.size());
-    if (UNLIKELY(!result))
+    if (!result) [[unlikely]]
         return nullptr;
     gcSafeMemcpy(std::bit_cast<EncodedJSValue*>(result->toButterfly()->contiguous().data()), argList.data(), argList.size() * sizeof(EncodedJSValue));
     vm.writeBarrier(result);

--- a/Source/JavaScriptCore/runtime/JSImmutableButterfly.h
+++ b/Source/JavaScriptCore/runtime/JSImmutableButterfly.h
@@ -58,7 +58,7 @@ public:
 
         // Because of the above maximumLength requirement, allocationSize can never overflow.
         void* buffer = tryAllocateCell<JSImmutableButterfly>(vm, allocationSize(length));
-        if (UNLIKELY(!buffer))
+        if (!buffer) [[unlikely]]
             return nullptr;
         JSImmutableButterfly* result = new (NotNull, buffer) JSImmutableButterfly(vm, structure, length);
         result->finishCreation(vm);
@@ -91,7 +91,7 @@ public:
         }
 
         JSImmutableButterfly* result = JSImmutableButterfly::tryCreate(vm, vm.immutableButterflyStructure(CopyOnWriteArrayWithContiguous), length);
-        if (UNLIKELY(!result)) {
+        if (!result) [[unlikely]] {
             throwOutOfMemoryError(globalObject, throwScope);
             return nullptr;
         }

--- a/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
@@ -176,7 +176,7 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncForEach, (JSGlobalObject* globalObject
 
     uint64_t counter = 0;
 
-    if (LIKELY(callData.type == CallData::Type::JS)) {
+    if (callData.type == CallData::Type::JS) [[likely]] {
         CachedCall cachedCall(globalObject, jsCast<JSFunction*>(callbackArg), 2);
         RETURN_IF_EXCEPTION(scope, { });
 

--- a/Source/JavaScriptCore/runtime/JSLock.cpp
+++ b/Source/JavaScriptCore/runtime/JSLock.cpp
@@ -96,7 +96,7 @@ void JSLock::lock(intptr_t lockCount) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 #endif
 
     bool success = m_lock.tryLock();
-    if (UNLIKELY(!success)) {
+    if (!success) [[unlikely]] {
         if (currentThreadIsHoldingLock()) {
             m_lockCount += lockCount;
             return;
@@ -151,7 +151,7 @@ void JSLock::didAcquireLock()
 #if ENABLE(SAMPLING_PROFILER)
     {
         SamplingProfiler* samplingProfiler = m_vm->samplingProfiler();
-        if (UNLIKELY(samplingProfiler))
+        if (samplingProfiler) [[unlikely]]
             samplingProfiler->noticeJSLockAcquisition();
     }
 #endif

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -62,7 +62,7 @@ void runJSMicrotask(JSGlobalObject* globalObject, MicrotaskIdentifier identifier
         ++count;
     }
 
-    if (UNLIKELY(globalObject->hasDebugger())) {
+    if (globalObject->hasDebugger()) [[unlikely]] {
         DeferTerminationForAWhile deferTerminationForAWhile(vm);
         globalObject->debugger()->willRunMicrotask(globalObject, identifier);
         scope.clearException();
@@ -73,7 +73,7 @@ void runJSMicrotask(JSGlobalObject* globalObject, MicrotaskIdentifier identifier
         scope.clearExceptionExceptTermination();
     }
 
-    if (UNLIKELY(globalObject->hasDebugger())) {
+    if (globalObject->hasDebugger()) [[unlikely]] {
         DeferTerminationForAWhile deferTerminationForAWhile(vm);
         globalObject->debugger()->didRunMicrotask(globalObject, identifier);
         scope.clearException();

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -353,7 +353,7 @@ Stringifier::StringifyResult Stringifier::appendStringifiedValue(StringBuilder& 
     // Recursion is avoided by !holderStackWasEmpty check and do/while loop at the end of this method.
     // We're having this recursion check here as a fail safe in case the code
     // below get modified such that recursion is no longer avoided.
-    if (UNLIKELY(!vm.isSafeToRecurseSoft())) {
+    if (!vm.isSafeToRecurseSoft()) [[unlikely]] {
         throwStackOverflowError(m_globalObject, scope);
         return StringifyFailed;
     }
@@ -441,7 +441,7 @@ Stringifier::StringifyResult Stringifier::appendStringifiedValue(StringBuilder& 
         return StringifyFailedDueToUndefinedOrSymbolValue;
     }
 
-    if (UNLIKELY(builder.hasOverflowed()))
+    if (builder.hasOverflowed()) [[unlikely]]
         return StringifyFailed;
 
     // Handle cycle detection, and put the holder on the stack.
@@ -470,7 +470,7 @@ Stringifier::StringifyResult Stringifier::appendStringifiedValue(StringBuilder& 
         while (m_holderStack.last().appendNextProperty(*this, builder))
             RETURN_IF_EXCEPTION(scope, StringifyFailed);
         RETURN_IF_EXCEPTION(scope, StringifyFailed);
-        if (UNLIKELY(builder.hasOverflowed()))
+        if (builder.hasOverflowed()) [[unlikely]]
             return StringifyFailed;
         m_holderStack.removeLast();
         m_objectStack.removeLast();
@@ -568,7 +568,7 @@ bool Stringifier::Holder::appendNextProperty(Stringifier& stringifier, StringBui
         }
         stringifier.indent();
     }
-    if (UNLIKELY(builder.hasOverflowed()))
+    if (builder.hasOverflowed()) [[unlikely]]
         return false;
 
     // Last time through, finish up and return false.
@@ -1240,7 +1240,7 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
         return;
     }
 
-    if (UNLIKELY(!value.isCell())) {
+    if (!value.isCell()) [[unlikely]] {
         recordFailure("value type"_s);
         return;
     }
@@ -1334,7 +1334,7 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
             }
             m_checkedObjectPrototype = true;
         }
-        if (UNLIKELY(!hasRemainingCapacity())) {
+        if (!hasRemainingCapacity()) [[unlikely]] {
             recordBufferFull();
             return;
         }
@@ -1397,7 +1397,7 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
         });
         if (UNLIKELY(haveFailure()))
             return;
-        if (UNLIKELY(!hasRemainingCapacity())) {
+        if (!hasRemainingCapacity()) [[unlikely]] {
             recordBufferFull();
             return;
         }
@@ -1426,14 +1426,14 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
             if (haveFailure())
                 return;
         }
-        if (UNLIKELY(!hasRemainingCapacity())) {
+        if (!hasRemainingCapacity()) [[unlikely]] {
             recordBufferFull();
             return;
         }
         buffer()[m_length++] = '[';
         for (unsigned i = 0, length = array.length(); i < length; ++i) {
             if (i) {
-                if (UNLIKELY(!hasRemainingCapacity())) {
+                if (!hasRemainingCapacity()) [[unlikely]] {
                     recordBufferFull();
                     return;
                 }
@@ -1447,7 +1447,7 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
             if (UNLIKELY(haveFailure()))
                 return;
         }
-        if (UNLIKELY(!hasRemainingCapacity())) {
+        if (!hasRemainingCapacity()) [[unlikely]] {
             recordBufferFull();
             return;
         }
@@ -1973,7 +1973,7 @@ JSC_DEFINE_HOST_FUNCTION(jsonProtoFuncRawJSON, (JSGlobalObject* globalObject, Ca
             LiteralParser<LChar, JSONReviverMode::Disabled> jsonParser(globalObject, string.span8(), StrictJSON);
             result = jsonParser.tryLiteralParsePrimitiveValue();
             RETURN_IF_EXCEPTION(scope, { });
-            if (UNLIKELY(!result)) {
+            if (!result) [[unlikely]] {
                 throwSyntaxError(globalObject, scope, jsonParser.getErrorMessage());
                 return { };
             }
@@ -1981,14 +1981,14 @@ JSC_DEFINE_HOST_FUNCTION(jsonProtoFuncRawJSON, (JSGlobalObject* globalObject, Ca
             LiteralParser<UChar, JSONReviverMode::Disabled> jsonParser(globalObject, string.span16(), StrictJSON);
             result = jsonParser.tryLiteralParsePrimitiveValue();
             RETURN_IF_EXCEPTION(scope, { });
-            if (UNLIKELY(!result)) {
+            if (!result) [[unlikely]] {
                 throwSyntaxError(globalObject, scope, jsonParser.getErrorMessage());
                 return { };
             }
         }
     }
     auto* object = JSRawJSONObject::tryCreate(vm, globalObject->rawJSONObjectStructure(), jsString);
-    if (UNLIKELY(!object)) {
+    if (!object) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return { };
     }

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -507,7 +507,7 @@ String JSObject::calculatedClassName(JSObject* object)
     }
 
     EXCEPTION_ASSERT(!scope.exception() || constructorFunctionName.isNull());
-    if (UNLIKELY(scope.exception()))
+    if (scope.exception()) [[unlikely]]
         scope.clearException();
 
     // Get the display name of obj.__proto__.constructor.
@@ -534,7 +534,7 @@ String JSObject::calculatedClassName(JSObject* object)
     }
 
     EXCEPTION_ASSERT(!scope.exception() || constructorFunctionName.isNull());
-    if (UNLIKELY(scope.exception()))
+    if (scope.exception()) [[unlikely]]
         scope.clearException();
 
     if (constructorFunctionName.isNull() || constructorFunctionName == "Object"_s) {
@@ -545,14 +545,14 @@ String JSObject::calculatedClassName(JSObject* object)
                 JSValue value = slot.getValue(globalObject, vm.propertyNames->toStringTagSymbol);
                 if (value.isString()) {
                     auto tag = asString(value)->value(globalObject);
-                    if (UNLIKELY(scope.exception()))
+                    if (scope.exception()) [[unlikely]]
                         scope.clearException();
                     return tag;
                 }
             }
         }
 
-        if (UNLIKELY(scope.exception()))
+        if (scope.exception()) [[unlikely]]
             scope.clearException();
 
         String classInfoName = object->classInfo()->className;
@@ -812,7 +812,7 @@ bool JSObject::putInlineSlow(JSGlobalObject* globalObject, PropertyName property
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (UNLIKELY(!vm.isSafeToRecurseSoft())) {
+    if (!vm.isSafeToRecurseSoft()) [[unlikely]] {
         throwStackOverflowError(globalObject, scope);
         return false;
     }
@@ -1301,7 +1301,7 @@ static Butterfly* createArrayStorageButterflyImpl(VM& vm, JSObject* intendedOwne
     Butterfly* newButterfly = Butterfly::createOrGrowArrayRight(
         oldButterfly, vm, intendedOwner, structure, structure->outOfLineCapacity(), false, 0,
         ArrayStorage::sizeFor(vectorLength));
-    if (UNLIKELY(!newButterfly)) {
+    if (!newButterfly) [[unlikely]] {
         if (mode == AllocationFailureMode::Assert)
             RELEASE_ASSERT(newButterfly, length, vectorLength, oldButterfly);
         else {
@@ -1861,7 +1861,7 @@ ContiguousJSValues JSObject::tryMakeWritableInt32Slow(VM& vm)
     
     switch (indexingType()) {
     case ALL_BLANK_INDEXING_TYPES:
-        if (UNLIKELY(indexingShouldBeSparse() || needsSlowPutIndexing()))
+        if (indexingShouldBeSparse() || needsSlowPutIndexing()) [[unlikely]]
             return ContiguousJSValues();
         return createInitialInt32(vm, 0);
         
@@ -1899,7 +1899,7 @@ ContiguousDoubles JSObject::tryMakeWritableDoubleSlow(VM& vm)
     
     switch (indexingType()) {
     case ALL_BLANK_INDEXING_TYPES:
-        if (UNLIKELY(indexingShouldBeSparse() || needsSlowPutIndexing()))
+        if (indexingShouldBeSparse() || needsSlowPutIndexing()) [[unlikely]]
             return ContiguousDoubles();
         return createInitialDouble(vm, 0);
         
@@ -1938,7 +1938,7 @@ ContiguousJSValues JSObject::tryMakeWritableContiguousSlow(VM& vm)
     
     switch (indexingType()) {
     case ALL_BLANK_INDEXING_TYPES:
-        if (UNLIKELY(indexingShouldBeSparse() || needsSlowPutIndexing()))
+        if (indexingShouldBeSparse() || needsSlowPutIndexing()) [[unlikely]]
             return ContiguousJSValues();
         return createInitialContiguous(vm, 0);
         
@@ -2091,7 +2091,7 @@ void JSObject::setPrototypeDirect(VM& vm, JSValue prototype)
         Structure* newStructure = Structure::changePrototypeTransition(vm, structure(), prototype, deferred);
         setStructure(vm, newStructure);
         // Prototype-chain gets changed for the already cached structures. Invalidate the cache.
-        if (UNLIKELY(mayBePrototype()))
+        if (mayBePrototype()) [[unlikely]]
             vm.invalidateStructureChainIntegrity(VM::StructureChainIntegrityEvent::Prototype);
     } else
         putDirectOffset(vm, knownPolyProtoOffset, prototype);
@@ -2293,7 +2293,7 @@ bool JSObject::hasProperty(JSGlobalObject* globalObject, unsigned propertyName) 
 
 bool JSObject::hasProperty(JSGlobalObject* globalObject, uint64_t propertyName) const
 {
-    if (LIKELY(propertyName <= MAX_ARRAY_INDEX))
+    if (propertyName <= MAX_ARRAY_INDEX) [[likely]]
         return hasProperty(globalObject, static_cast<uint32_t>(propertyName));
     ASSERT(propertyName <= maxSafeInteger());
     return hasProperty(globalObject, Identifier::from(globalObject->vm(), propertyName));
@@ -2623,7 +2623,7 @@ bool JSObject::hasInstance(JSGlobalObject* globalObject, JSValue value, JSValue 
         RELEASE_AND_RETURN(scope, defaultHasInstance(globalObject, value, prototype));
     }
     if (info.implementsHasInstance()) {
-        if (UNLIKELY(!vm.isSafeToRecurseSoft())) {
+        if (!vm.isSafeToRecurseSoft()) [[unlikely]] {
             throwStackOverflowError(globalObject, scope);
             return false;
         }
@@ -4018,7 +4018,7 @@ void JSObject::convertToUncacheableDictionary(VM& vm)
         return;
     DeferredStructureTransitionWatchpointFire deferredWatchpointFire(vm, oldStructure);
     setStructure(vm, Structure::toUncacheableDictionaryTransition(vm, oldStructure, &deferredWatchpointFire));
-    if (UNLIKELY(mayBePrototype()))
+    if (mayBePrototype()) [[unlikely]]
         vm.invalidateStructureChainIntegrity(VM::StructureChainIntegrityEvent::Change);
 }
 
@@ -4033,7 +4033,7 @@ void JSObject::shiftButterflyAfterFlattening(const GCSafeConcurrentJSLocker&, VM
     size_t preCapacity;
     size_t indexingPayloadSizeInBytes;
     bool hasIndexingHeader = this->hasIndexingHeader();
-    if (UNLIKELY(hasIndexingHeader)) {
+    if (hasIndexingHeader) [[unlikely]] {
         preCapacity = oldButterfly->indexingHeader()->preCapacity(structure);
         indexingPayloadSizeInBytes = oldButterfly->indexingHeader()->indexingPayloadSizeInBytes(structure);
     } else {

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -281,7 +281,7 @@ public:
     ALWAYS_INLINE bool putByIndexInline(JSGlobalObject* globalObject, uint64_t propertyName, JSValue value, bool shouldThrow)
     {
         VM& vm = getVM(globalObject);
-        if (LIKELY(propertyName <= MAX_ARRAY_INDEX))
+        if (propertyName <= MAX_ARRAY_INDEX) [[likely]]
             return putByIndexInline(globalObject, static_cast<uint32_t>(propertyName), value, shouldThrow);
 
         ASSERT(propertyName <= maxSafeInteger());
@@ -330,7 +330,7 @@ public:
 
     ALWAYS_INLINE bool putDirectIndex(JSGlobalObject* globalObject, uint64_t propertyName, JSValue value, unsigned attributes, PutDirectIndexMode mode)
     {
-        if (LIKELY(propertyName <= MAX_ARRAY_INDEX))
+        if (propertyName <= MAX_ARRAY_INDEX) [[likely]]
             return putDirectIndex(globalObject, static_cast<uint32_t>(propertyName), value, attributes, mode);
         return putDirect(getVM(globalObject), Identifier::from(getVM(globalObject), propertyName), value, attributes);
     }
@@ -1696,7 +1696,7 @@ inline size_t JSObject::butterflyTotalSize()
     size_t indexingPayloadSizeInBytes;
     bool hasIndexingHeader = this->hasIndexingHeader();
 
-    if (UNLIKELY(hasIndexingHeader)) {
+    if (hasIndexingHeader) [[unlikely]] {
         preCapacity = butterfly->indexingHeader()->preCapacity(structure);
         indexingPayloadSizeInBytes = butterfly->indexingHeader()->indexingPayloadSizeInBytes(structure);
     } else {

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -158,7 +158,7 @@ ALWAYS_INLINE bool JSObject::getPropertySlot(JSGlobalObject* globalObject, unsig
 
 ALWAYS_INLINE bool JSObject::getPropertySlot(JSGlobalObject* globalObject, uint64_t propertyName, PropertySlot& slot)
 {
-    if (LIKELY(propertyName <= MAX_ARRAY_INDEX))
+    if (propertyName <= MAX_ARRAY_INDEX) [[likely]]
         return getPropertySlot(globalObject, static_cast<uint32_t>(propertyName), slot);
     return getPropertySlot(globalObject, Identifier::from(globalObject->vm(), propertyName), slot);
 }
@@ -291,7 +291,7 @@ ALWAYS_INLINE PropertyOffset JSObject::prepareToPutDirectWithoutTransition(VM& v
             ASSERT(!getDirect(offset) || !JSValue::encode(getDirect(offset)));
             result = offset;
         });
-    if (UNLIKELY(mayBePrototype()))
+    if (mayBePrototype()) [[unlikely]]
         vm.invalidateStructureChainIntegrity(VM::StructureChainIntegrityEvent::Add);
     return result;
 }
@@ -308,14 +308,14 @@ ALWAYS_INLINE bool JSObject::putInlineForJSObject(JSCell* cell, JSGlobalObject* 
     // Try indexed put first. This is required for correctness, since loads on property names that appear like
     // valid indices will never look in the named property storage.
     if (std::optional<uint32_t> index = parseIndex(propertyName)) {
-        if (UNLIKELY(isThisValueAltered(slot, thisObject)))
+        if (isThisValueAltered(slot, thisObject)) [[unlikely]]
             return ordinarySetSlow(globalObject, thisObject, propertyName, value, slot.thisValue(), slot.isStrictMode());
         return thisObject->methodTable()->putByIndex(thisObject, globalObject, index.value(), value, slot.isStrictMode());
     }
 
     if (!thisObject->canPerformFastPutInline(vm, propertyName))
         return thisObject->putInlineSlow(globalObject, propertyName, value, slot);
-    if (UNLIKELY(isThisValueAltered(slot, thisObject)))
+    if (isThisValueAltered(slot, thisObject)) [[unlikely]]
         return definePropertyOnReceiver(globalObject, propertyName, value, slot);
     if (UNLIKELY(thisObject->hasNonReifiedStaticProperties()))
         return thisObject->putInlineFastReplacingStaticPropertyIfNeeded(globalObject, propertyName, value, slot);
@@ -411,7 +411,7 @@ ALWAYS_INLINE ASCIILiteral JSObject::putDirectInternal(VM& vm, PropertyName prop
             if ((mode == PutModeDefineOwnProperty) && (newAttributes != attributes || (newAttributes & PropertyAttribute::AccessorOrCustomAccessorOrValue))) {
                 DeferredStructureTransitionWatchpointFire deferred(vm, structure);
                 setStructure(vm, Structure::attributeChangeTransition(vm, structure, propertyName, newAttributes, &deferred));
-                if (UNLIKELY(mayBePrototype()))
+                if (mayBePrototype()) [[unlikely]]
                     vm.invalidateStructureChainIntegrity(VM::StructureChainIntegrityEvent::Change);
             } else {
                 ASSERT(!(attributes & PropertyAttribute::AccessorOrCustomAccessorOrValue));
@@ -425,7 +425,7 @@ ALWAYS_INLINE ASCIILiteral JSObject::putDirectInternal(VM& vm, PropertyName prop
         slot.setNewProperty(this, offset);
         if (attributes & PropertyAttribute::ReadOnly)
             this->structure()->setContainsReadOnlyProperties();
-        if (UNLIKELY(mayBePrototype()))
+        if (mayBePrototype()) [[unlikely]]
             vm.invalidateStructureChainIntegrity(VM::StructureChainIntegrityEvent::Add);
         return { };
     }
@@ -450,7 +450,7 @@ ALWAYS_INLINE ASCIILiteral JSObject::putDirectInternal(VM& vm, PropertyName prop
             putDirectOffset(vm, offset, value);
             setStructure(vm, newStructure);
             slot.setNewProperty(this, offset);
-            if (UNLIKELY(mayBePrototype()))
+            if (mayBePrototype()) [[unlikely]]
                 vm.invalidateStructureChainIntegrity(VM::StructureChainIntegrityEvent::Add);
             return { };
         }
@@ -472,7 +472,7 @@ ALWAYS_INLINE ASCIILiteral JSObject::putDirectInternal(VM& vm, PropertyName prop
             // This allows adaptive watchpoints to observe if the new structure is the one we want.
             DeferredStructureTransitionWatchpointFire deferredWatchpointFire(vm, structure);
             setStructure(vm, Structure::attributeChangeTransition(vm, structure, propertyName, newAttributes, &deferredWatchpointFire));
-            if (UNLIKELY(mayBePrototype()))
+            if (mayBePrototype()) [[unlikely]]
                 vm.invalidateStructureChainIntegrity(VM::StructureChainIntegrityEvent::Change);
         } else {
             ASSERT(!(currentAttributes & PropertyAttribute::AccessorOrCustomAccessorOrValue));
@@ -510,7 +510,7 @@ ALWAYS_INLINE ASCIILiteral JSObject::putDirectInternal(VM& vm, PropertyName prop
     slot.setNewProperty(this, offset);
     if (newAttributes & PropertyAttribute::ReadOnly)
         newStructure->setContainsReadOnlyProperties();
-    if (UNLIKELY(mayBePrototype()))
+    if (mayBePrototype()) [[unlikely]]
         vm.invalidateStructureChainIntegrity(VM::StructureChainIntegrityEvent::Add);
     return { };
 }
@@ -707,7 +707,7 @@ inline bool JSObject::deleteProperty(JSGlobalObject* globalObject, uint32_t prop
 
 inline bool JSObject::deleteProperty(JSGlobalObject* globalObject, uint64_t propertyName)
 {
-    if (LIKELY(propertyName <= MAX_ARRAY_INDEX))
+    if (propertyName <= MAX_ARRAY_INDEX) [[likely]]
         return deleteProperty(globalObject, static_cast<uint32_t>(propertyName));
     ASSERT(propertyName <= maxSafeInteger());
     return deleteProperty(globalObject, Identifier::from(globalObject->vm(), propertyName));
@@ -715,7 +715,7 @@ inline bool JSObject::deleteProperty(JSGlobalObject* globalObject, uint64_t prop
 
 inline JSValue JSObject::get(JSGlobalObject* globalObject, uint64_t propertyName) const
 {
-    if (LIKELY(propertyName <= MAX_ARRAY_INDEX))
+    if (propertyName <= MAX_ARRAY_INDEX) [[likely]]
         return get(globalObject, static_cast<uint32_t>(propertyName));
     ASSERT(propertyName <= maxSafeInteger());
     return get(globalObject, Identifier::from(globalObject->vm(), propertyName));

--- a/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
@@ -104,7 +104,7 @@ JSC_DEFINE_HOST_FUNCTION(remoteFunctionCallForJSFunction, (JSGlobalObject* globa
         RETURN_IF_EXCEPTION(scope, clearArgOverflowCheckAndReturnAbortValue());
         args.append(wrappedValue);
     }
-    if (UNLIKELY(args.hasOverflowed())) {
+    if (args.hasOverflowed()) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return { };
     }
@@ -145,7 +145,7 @@ JSC_DEFINE_HOST_FUNCTION(remoteFunctionCallGeneric, (JSGlobalObject* globalObjec
         RETURN_IF_EXCEPTION(scope, clearArgOverflowCheckAndReturnAbortValue());
         args.append(wrappedValue);
     }
-    if (UNLIKELY(args.hasOverflowed())) {
+    if (args.hasOverflowed()) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return { };
     }
@@ -221,7 +221,7 @@ void JSRemoteFunction::copyNameAndLength(JSGlobalObject* globalObject)
 
     if (targetHasLength) {
         JSValue targetLength;
-        if (LIKELY(!slot.isTaintedByOpaqueObject()))
+        if (!slot.isTaintedByOpaqueObject()) [[likely]]
             targetLength = slot.getValue(globalObject, vm.propertyNames->length);
         else
             targetLength = m_targetFunction->get(globalObject, vm.propertyNames->length);

--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -173,7 +173,7 @@ inline JSValue jsMakeNontrivialString(JSGlobalObject* globalObject, StringType&&
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     String result = tryMakeString(std::forward<StringType>(string), std::forward<StringTypes>(strings)...);
-    if (UNLIKELY(!result))
+    if (!result) [[unlikely]]
         return throwOutOfMemoryError(globalObject, scope);
     ASSERT(result.length() <= JSString::MaxLength);
     return jsNontrivialString(vm, WTFMove(result));

--- a/Source/JavaScriptCore/runtime/JSStringJoiner.cpp
+++ b/Source/JavaScriptCore/runtime/JSStringJoiner.cpp
@@ -108,7 +108,7 @@ static inline String joinStrings(const JSStringJoiner::Entries& strings, std::sp
 
     std::span<OutputCharacterType> data;
     String result = StringImpl::tryCreateUninitialized(joinedLength, data);
-    if (UNLIKELY(result.isNull()))
+    if (result.isNull()) [[unlikely]]
         return result;
 
     unsigned size = strings.size();
@@ -176,7 +176,7 @@ static inline String joinStrings(JSGlobalObject* globalObject, const WriteBarrie
 
     std::span<OutputCharacterType> data;
     String result = StringImpl::tryCreateUninitialized(joinedLength, data);
-    if (UNLIKELY(result.isNull())) {
+    if (result.isNull()) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return { };
     }
@@ -260,7 +260,7 @@ JSValue JSStringJoiner::joinImpl(JSGlobalObject* globalObject)
             result = joinStrings<UChar>(m_strings, m_separator.span16(), length);
     }
 
-    if (UNLIKELY(result.isNull())) {
+    if (result.isNull()) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return { };
     }

--- a/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp
@@ -133,7 +133,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewPrivateFuncIsResizableOrGrowableSharedTyp
 
 static inline std::optional<JSType> isTypedArrayViewConstructor(JSValue value)
 {
-    if (UNLIKELY(!value.isCell()))
+    if (!value.isCell()) [[unlikely]]
         return std::nullopt;
     const auto* classInfo = value.asCell()->classInfo();
 
@@ -237,7 +237,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncSet, (JSGlobalObject* globalObje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncSet);
@@ -248,7 +248,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncCopyWithin, (JSGlobalObject* glo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncCopyWithin);
@@ -259,7 +259,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncForEach, (JSGlobalObject* global
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncForEach);
@@ -270,7 +270,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncFind, (JSGlobalObject* globalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncFind);
@@ -281,7 +281,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncFindIndex, (JSGlobalObject* glob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncFindIndex);
@@ -292,7 +292,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncFindLast, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncFindLast);
@@ -303,7 +303,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncFindLastIndex, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncFindLastIndex);
@@ -314,7 +314,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncEvery, (JSGlobalObject* globalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncEvery);
@@ -325,7 +325,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncSome, (JSGlobalObject* globalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncSome);
@@ -336,7 +336,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncSort, (JSGlobalObject* globalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncSort);
@@ -347,7 +347,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncIncludes, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMError(globalObject, scope, createTypeError(globalObject, "Receiver should be a typed array view but was not an object"_s));
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncIncludes);
@@ -358,7 +358,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncLastIndexOf, (JSGlobalObject* gl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncLastIndexOf);
@@ -369,7 +369,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncIndexOf, (JSGlobalObject* global
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncIndexOf);
@@ -380,7 +380,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncJoin, (JSGlobalObject* globalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncJoin);
@@ -391,7 +391,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncFill, (JSGlobalObject* globalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncFill);
@@ -402,7 +402,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoGetterFuncBuffer, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoGetterFuncBuffer);
@@ -413,7 +413,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoGetterFuncLength, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoGetterFuncLength);
@@ -424,7 +424,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoGetterFuncByteLength, (JSGlobalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoGetterFuncByteLength);
@@ -435,7 +435,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoGetterFuncByteOffset, (JSGlobalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoGetterFuncByteOffset);
@@ -446,7 +446,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncReverse, (JSGlobalObject* global
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncReverse);
@@ -457,7 +457,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncSubarray, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncSubarray);
@@ -468,7 +468,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncSlice, (JSGlobalObject* globalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncSlice);
@@ -517,7 +517,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncToReversed, (JSGlobalObject* glo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncToReversed);
@@ -528,7 +528,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncToSorted, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncToSorted);
@@ -539,7 +539,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncWith, (JSGlobalObject* globalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
     scope.release();
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncWith);

--- a/Source/JavaScriptCore/runtime/KeyAtomStringCacheInlines.h
+++ b/Source/JavaScriptCore/runtime/KeyAtomStringCacheInlines.h
@@ -53,7 +53,7 @@ ALWAYS_INLINE JSString* KeyAtomStringCache::make(VM& vm, Buffer& buffer, const F
     }
 
     JSString* result = func(vm, buffer);
-    if (LIKELY(result))
+    if (result) [[likely]]
         slot = result;
     return result;
 }

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -1353,7 +1353,7 @@ JSValue LiteralParser<CharType, reviverMode>::parseRecursively(VM& vm, uint8_t* 
             else
                 value = parsePrimitiveValue(vm);
             EXCEPTION_ASSERT((!!scope.exception() || !m_parseErrorMessage.isNull()) == !value);
-            if (UNLIKELY(!value))
+            if (!value) [[unlikely]]
                 return { };
 
             array->putDirectIndex(m_globalObject, index++, value);
@@ -1420,7 +1420,7 @@ JSValue LiteralParser<CharType, reviverMode>::parseRecursively(VM& vm, uint8_t* 
                 return makeIdentifier(vm, m_lexer.currentToken());
             }();
 
-            if (UNLIKELY(m_lexer.next() != TokColon)) {
+            if (m_lexer.next() != TokColon) [[unlikely]] {
                 setErrorMessageForToken(TokColon);
                 return { };
             }
@@ -1432,7 +1432,7 @@ JSValue LiteralParser<CharType, reviverMode>::parseRecursively(VM& vm, uint8_t* 
             else
                 value = parsePrimitiveValue(vm);
             EXCEPTION_ASSERT((!!scope.exception() || !m_parseErrorMessage.isNull()) == !value);
-            if (UNLIKELY(!value))
+            if (!value) [[unlikely]]
                 return { };
 
             // When creating JSON object in this fast path, we know the following.
@@ -1463,7 +1463,7 @@ JSValue LiteralParser<CharType, reviverMode>::parseRecursively(VM& vm, uint8_t* 
                 ASSERT(std::holds_alternative<Identifier>(property));
                 auto& ident = std::get<Identifier>(property);
                 if (UNLIKELY(parserMode != StrictJSON && ident == vm.propertyNames->underscoreProto)) {
-                    if (UNLIKELY(!m_visitedUnderscoreProto.add(object).isNewEntry)) {
+                    if (!m_visitedUnderscoreProto.add(object).isNewEntry) [[unlikely]] {
                         m_parseErrorMessage = "Attempted to redefine __proto__ property"_s;
                         return { };
                     }
@@ -1490,7 +1490,7 @@ JSValue LiteralParser<CharType, reviverMode>::parseRecursively(VM& vm, uint8_t* 
                 continue;
             }
 
-            if (UNLIKELY(type != TokRBrace)) {
+            if (type != TokRBrace) [[unlikely]] {
                 setErrorMessageForToken(TokRBrace);
                 return { };
             }
@@ -1500,7 +1500,7 @@ JSValue LiteralParser<CharType, reviverMode>::parseRecursively(VM& vm, uint8_t* 
         }
     }
 
-    if (UNLIKELY(type != TokRBrace)) {
+    if (type != TokRBrace) [[unlikely]] {
         setErrorMessageForToken(TokRBrace);
         return { };
     }
@@ -1606,7 +1606,7 @@ JSValue LiteralParser<CharType, reviverMode>::parse(VM& vm, ParserState initialS
                 while (true) {
                     Identifier ident = makeIdentifier(vm, m_lexer.currentToken());
 
-                    if (UNLIKELY(m_lexer.next() != TokColon)) {
+                    if (m_lexer.next() != TokColon) [[unlikely]] {
                         setErrorMessageForToken(TokColon);
                         return { };
                     }
@@ -1633,7 +1633,7 @@ JSValue LiteralParser<CharType, reviverMode>::parse(VM& vm, ParserState initialS
 
                     if (UNLIKELY(m_mode != StrictJSON && ident == vm.propertyNames->underscoreProto)) {
                         ASSERT(!sourceRanges);
-                        if (UNLIKELY(!m_visitedUnderscoreProto.add(object).isNewEntry)) {
+                        if (!m_visitedUnderscoreProto.add(object).isNewEntry) [[unlikely]] {
                             m_parseErrorMessage = "Attempted to redefine __proto__ property"_s;
                             return { };
                         }
@@ -1687,7 +1687,7 @@ JSValue LiteralParser<CharType, reviverMode>::parse(VM& vm, ParserState initialS
                 break;
             }
 
-            if (UNLIKELY(type != TokRBrace)) {
+            if (type != TokRBrace) [[unlikely]] {
                 setErrorMessageForToken(TokRBrace);
                 return { };
             }
@@ -1713,7 +1713,7 @@ JSValue LiteralParser<CharType, reviverMode>::parse(VM& vm, ParserState initialS
             m_identifierStack.append(makeIdentifier(vm, m_lexer.currentToken()));
 
             // Check for colon
-            if (UNLIKELY(m_lexer.next() != TokColon)) {
+            if (m_lexer.next() != TokColon) [[unlikely]] {
                 setErrorMessageForToken(TokColon);
                 return { };
             }
@@ -1728,7 +1728,7 @@ JSValue LiteralParser<CharType, reviverMode>::parse(VM& vm, ParserState initialS
             Identifier ident = m_identifierStack.takeLast();
             if (UNLIKELY(m_mode != StrictJSON && ident == vm.propertyNames->underscoreProto)) {
                 ASSERT(!sourceRanges);
-                if (UNLIKELY(!m_visitedUnderscoreProto.add(object).isNewEntry)) {
+                if (!m_visitedUnderscoreProto.add(object).isNewEntry) [[unlikely]] {
                     m_parseErrorMessage = "Attempted to redefine __proto__ property"_s;
                     return { };
                 }

--- a/Source/JavaScriptCore/runtime/MapPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/MapPrototype.cpp
@@ -114,7 +114,7 @@ ALWAYS_INLINE static JSMap* getMap(JSGlobalObject* globalObject, JSValue thisVal
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (UNLIKELY(!thisValue.isCell())) {
+    if (!thisValue.isCell()) [[unlikely]] {
         throwVMError(globalObject, scope, createNotAnObjectError(globalObject, thisValue));
         return nullptr;
     }
@@ -222,7 +222,7 @@ JSC_DEFINE_HOST_FUNCTION(mapProtoFuncGetOrInsertComputed, (JSGlobalObject* globa
         auto callData = JSC::getCallData(valueCallback);
         ASSERT(callData.type != CallData::Type::None);
 
-        if (LIKELY(callData.type == CallData::Type::JS)) {
+        if (callData.type == CallData::Type::JS) [[likely]] {
             CachedCall cachedCall(globalObject, jsCast<JSFunction*>(valueCallback), 1);
             RETURN_IF_EXCEPTION(scope, JSValue());
 

--- a/Source/JavaScriptCore/runtime/MathObject.cpp
+++ b/Source/JavaScriptCore/runtime/MathObject.cpp
@@ -277,7 +277,7 @@ JSC_DEFINE_HOST_FUNCTION(mathProtoFuncMax, (JSGlobalObject* globalObject, CallFr
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     unsigned argsCount = callFrame->argumentCount();
-    if (UNLIKELY(!argsCount))
+    if (!argsCount) [[unlikely]]
         return JSValue::encode(jsNumber(-std::numeric_limits<double>::infinity()));
 
     double result = callFrame->uncheckedArgument(0).toNumber(globalObject);
@@ -296,7 +296,7 @@ JSC_DEFINE_HOST_FUNCTION(mathProtoFuncMin, (JSGlobalObject* globalObject, CallFr
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     unsigned argsCount = callFrame->argumentCount();
-    if (UNLIKELY(!argsCount))
+    if (!argsCount) [[unlikely]]
         return JSValue::encode(jsNumber(std::numeric_limits<double>::infinity()));
 
     double result = callFrame->uncheckedArgument(0).toNumber(globalObject);

--- a/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
@@ -299,7 +299,7 @@ void objectAssignGeneric(JSGlobalObject* globalObject, VM& vm, JSObject* target,
             continue;
 
         JSValue value;
-        if (LIKELY(!slot.isTaintedByOpaqueObject()))
+        if (!slot.isTaintedByOpaqueObject()) [[likely]]
             value = slot.getValue(globalObject, propertyName);
         else
             value = source->get(globalObject, propertyName);
@@ -527,7 +527,7 @@ JSC_DEFINE_HOST_FUNCTION(objectConstructorEntries, (JSGlobalObject* globalObject
             return;
 
         JSValue value;
-        if (LIKELY(!slot.isTaintedByOpaqueObject()))
+        if (!slot.isTaintedByOpaqueObject()) [[likely]]
             value = slot.getValue(globalObject, propertyName);
         else
             value = target->get(globalObject, propertyName);
@@ -638,7 +638,7 @@ JSC_DEFINE_HOST_FUNCTION(objectConstructorValues, (JSGlobalObject* globalObject,
             return;
 
         JSValue value;
-        if (LIKELY(!slot.isTaintedByOpaqueObject()))
+        if (!slot.isTaintedByOpaqueObject()) [[likely]]
             value = slot.getValue(globalObject, propertyName);
         else
             value = target->get(globalObject, propertyName);
@@ -824,7 +824,7 @@ static JSValue definePropertiesSlow(JSGlobalObject* globalObject, JSObject* obje
     Vector<PropertyDescriptor> descriptors;
     MarkedArgumentBuffer markBuffer;
 #define RETURN_IF_EXCEPTION_CLEARING_OVERFLOW(value) do { \
-    if (UNLIKELY(scope.exception())) { \
+    if (scope.exception()) [[unlikely]] { \
         markBuffer.overflowCheckNotNeeded(); \
         return value; \
     } \
@@ -896,7 +896,7 @@ static JSValue defineProperties(JSGlobalObject* globalObject, JSObject* object, 
     descriptors.reserveInitialCapacity(numProperties);
 
 #define RETURN_IF_EXCEPTION_CLEARING_OVERFLOW(value) do { \
-    if (UNLIKELY(scope.exception())) { \
+    if (scope.exception()) [[unlikely]] { \
         markBuffer.overflowCheckNotNeeded(); \
         return value; \
     } \
@@ -1004,7 +1004,7 @@ bool setIntegrityLevel(JSGlobalObject* globalObject, VM& vm, JSObject* object)
 
     bool success = object->methodTable()->preventExtensions(object, globalObject);
     RETURN_IF_EXCEPTION(scope, false);
-    if (UNLIKELY(!success))
+    if (!success) [[unlikely]]
         return false;
 
     PropertyNameArray properties(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Exclude);
@@ -1099,7 +1099,7 @@ JSObject* objectConstructorSeal(JSGlobalObject* globalObject, JSObject* object)
 
     bool success = setIntegrityLevel<IntegrityLevel::Sealed>(globalObject, vm, object);
     RETURN_IF_EXCEPTION(scope, nullptr);
-    if (UNLIKELY(!success)) {
+    if (!success) [[unlikely]] {
         throwTypeError(globalObject, scope, "Unable to prevent extension in Object.seal"_s);
         return nullptr;
     }
@@ -1132,7 +1132,7 @@ JSObject* objectConstructorFreeze(JSGlobalObject* globalObject, JSObject* object
 
     bool success = setIntegrityLevel<IntegrityLevel::Frozen>(globalObject, vm, object);
     RETURN_IF_EXCEPTION(scope, nullptr);
-    if (UNLIKELY(!success)) {
+    if (!success) [[unlikely]] {
         throwTypeError(globalObject, scope, "Unable to prevent extension in Object.freeze"_s);
         return nullptr;
     }
@@ -1280,7 +1280,7 @@ JSArray* ownPropertyKeys(JSGlobalObject* globalObject, JSObject* object, Propert
             auto* cachedButterfly = structure->cachedPropertyNamesIgnoringSentinel(kind);
             if (cachedButterfly == StructureRareData::cachedPropertyNamesSentinel()) {
                 auto* newButterfly = JSImmutableButterfly::tryCreate(vm, CopyOnWriteArrayWithContiguous, numProperties);
-                if (UNLIKELY(!newButterfly)) {
+                if (!newButterfly) [[unlikely]] {
                     throwOutOfMemoryError(globalObject, scope);
                     return { };
                 }

--- a/Source/JavaScriptCore/runtime/ObjectInitializationScope.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectInitializationScope.cpp
@@ -78,7 +78,7 @@ void ObjectInitializationScope::verifyPropertiesAreInitialized(JSObject* object)
     unsigned vectorLength = butterfly->vectorLength();
     if (UNLIKELY(hasUndecided(indexingType)) || !hasIndexedProperties(indexingType)) {
         // Nothing to verify.
-    } else if (LIKELY(!hasAnyArrayStorage(indexingType))) {
+    } else if (!hasAnyArrayStorage(indexingType)) [[likely]] {
         auto data = butterfly->contiguous().data();
         for (unsigned i = 0; i < vectorLength; ++i) {
             if (isScribbledValue(data[i].get())) {

--- a/Source/JavaScriptCore/runtime/ObjectPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectPrototype.cpp
@@ -156,7 +156,7 @@ JSC_DEFINE_HOST_FUNCTION(objectProtoFuncIsPrototypeOf, (JSGlobalObject* globalOb
     JSValue thisValue = callFrame->thisValue().toThis(globalObject, ECMAMode::strict());
     JSObject* thisObj = thisValue.toObject(globalObject);
     EXCEPTION_ASSERT(!!scope.exception() == !thisObj);
-    if (UNLIKELY(!thisObj))
+    if (!thisObj) [[unlikely]]
         return encodedJSValue();
 
     JSValue v = asObject(callFrame->argument(0))->getPrototype(vm, globalObject);

--- a/Source/JavaScriptCore/runtime/ParseInt.h
+++ b/Source/JavaScriptCore/runtime/ParseInt.h
@@ -225,7 +225,7 @@ static ALWAYS_INLINE typename std::invoke_result<CallbackWhenNoException, String
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSString* string = value.toStringOrNull(globalObject);
     EXCEPTION_ASSERT(!!scope.exception() == !string);
-    if (UNLIKELY(!string))
+    if (!string) [[unlikely]]
         return { };
     auto view = string->view(globalObject);
     RETURN_IF_EXCEPTION(scope, { });

--- a/Source/JavaScriptCore/runtime/ProxyObject.cpp
+++ b/Source/JavaScriptCore/runtime/ProxyObject.cpp
@@ -155,7 +155,7 @@ static JSValue performProxyGet(JSGlobalObject* globalObject, ProxyObject* proxyO
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (UNLIKELY(!vm.isSafeToRecurseSoft())) {
+    if (!vm.isSafeToRecurseSoft()) [[unlikely]] {
         throwStackOverflowError(globalObject, scope);
         return { };
     }
@@ -267,7 +267,7 @@ bool ProxyObject::performInternalMethodGetOwnProperty(JSGlobalObject* globalObje
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (UNLIKELY(!vm.isSafeToRecurseSoft())) {
+    if (!vm.isSafeToRecurseSoft()) [[unlikely]] {
         throwStackOverflowError(globalObject, scope);
         return false;
     }
@@ -373,7 +373,7 @@ bool ProxyObject::performHasProperty(JSGlobalObject* globalObject, PropertyName 
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (UNLIKELY(!vm.isSafeToRecurseSoft())) {
+    if (!vm.isSafeToRecurseSoft()) [[unlikely]] {
         throwStackOverflowError(globalObject, scope);
         return false;
     }
@@ -454,7 +454,7 @@ bool ProxyObject::getOwnPropertySlotCommon(JSGlobalObject* globalObject, Propert
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (UNLIKELY(!vm.isSafeToRecurseSoft())) {
+    if (!vm.isSafeToRecurseSoft()) [[unlikely]] {
         throwStackOverflowError(globalObject, scope);
         return false;
     }
@@ -494,7 +494,7 @@ bool ProxyObject::performPut(JSGlobalObject* globalObject, JSValue putValue, JSV
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (UNLIKELY(!vm.isSafeToRecurseSoft())) {
+    if (!vm.isSafeToRecurseSoft()) [[unlikely]] {
         throwStackOverflowError(globalObject, scope);
         return false;
     }
@@ -604,7 +604,7 @@ JSC_DEFINE_HOST_FUNCTION(performProxyCall, (JSGlobalObject* globalObject, CallFr
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (UNLIKELY(!vm.isSafeToRecurseSoft())) {
+    if (!vm.isSafeToRecurseSoft()) [[unlikely]] {
         throwStackOverflowError(globalObject, scope);
         return encodedJSValue();
     }
@@ -653,7 +653,7 @@ JSC_DEFINE_HOST_FUNCTION(performProxyConstruct, (JSGlobalObject* globalObject, C
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (UNLIKELY(!vm.isSafeToRecurseSoft())) {
+    if (!vm.isSafeToRecurseSoft()) [[unlikely]] {
         throwStackOverflowError(globalObject, scope);
         return encodedJSValue();
     }
@@ -707,7 +707,7 @@ bool ProxyObject::performDelete(JSGlobalObject* globalObject, PropertyName prope
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (UNLIKELY(!vm.isSafeToRecurseSoft())) {
+    if (!vm.isSafeToRecurseSoft()) [[unlikely]] {
         throwStackOverflowError(globalObject, scope);
         return false;
     }
@@ -794,7 +794,7 @@ bool ProxyObject::performPreventExtensions(JSGlobalObject* globalObject)
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (UNLIKELY(!vm.isSafeToRecurseSoft())) {
+    if (!vm.isSafeToRecurseSoft()) [[unlikely]] {
         throwStackOverflowError(globalObject, scope);
         return false;
     }
@@ -845,7 +845,7 @@ bool ProxyObject::performIsExtensible(JSGlobalObject* globalObject)
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (UNLIKELY(!vm.isSafeToRecurseSoft())) {
+    if (!vm.isSafeToRecurseSoft()) [[unlikely]] {
         throwStackOverflowError(globalObject, scope);
         return false;
     }
@@ -902,7 +902,7 @@ bool ProxyObject::performDefineOwnProperty(JSGlobalObject* globalObject, Propert
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (UNLIKELY(!vm.isSafeToRecurseSoft())) {
+    if (!vm.isSafeToRecurseSoft()) [[unlikely]] {
         throwStackOverflowError(globalObject, scope);
         return false;
     }
@@ -1030,7 +1030,7 @@ void ProxyObject::performGetOwnPropertyNames(JSGlobalObject* globalObject, Prope
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (UNLIKELY(!vm.isSafeToRecurseSoft())) {
+    if (!vm.isSafeToRecurseSoft()) [[unlikely]] {
         throwStackOverflowError(globalObject, scope);
         return;
     }
@@ -1163,7 +1163,7 @@ bool ProxyObject::performSetPrototype(JSGlobalObject* globalObject, JSValue prot
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (UNLIKELY(!vm.isSafeToRecurseSoft())) {
+    if (!vm.isSafeToRecurseSoft()) [[unlikely]] {
         throwStackOverflowError(globalObject, scope);
         return false;
     }
@@ -1227,7 +1227,7 @@ JSValue ProxyObject::performGetPrototype(JSGlobalObject* globalObject)
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (UNLIKELY(!vm.isSafeToRecurseSoft())) {
+    if (!vm.isSafeToRecurseSoft()) [[unlikely]] {
         throwStackOverflowError(globalObject, scope);
         return { };
     }

--- a/Source/JavaScriptCore/runtime/ReflectObject.cpp
+++ b/Source/JavaScriptCore/runtime/ReflectObject.cpp
@@ -139,7 +139,7 @@ JSC_DEFINE_HOST_FUNCTION(reflectObjectDefineProperty, (JSGlobalObject* globalObj
     PropertyDescriptor descriptor;
     bool success = toPropertyDescriptor(globalObject, callFrame->argument(2), descriptor);
     EXCEPTION_ASSERT(!scope.exception() == success);
-    if (UNLIKELY(!success))
+    if (!success) [[unlikely]]
         return encodedJSValue();
     ASSERT((descriptor.attributes() & PropertyAttribute::Accessor) || (!descriptor.isAccessorDescriptor()));
     scope.assertNoException();

--- a/Source/JavaScriptCore/runtime/RegExpMatchesArray.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpMatchesArray.cpp
@@ -39,7 +39,7 @@ JSArray* createEmptyRegExpMatchesArray(JSGlobalObject* globalObject, JSString* i
     GCDeferralContext deferralContext(vm);
     ObjectInitializationScope scope(vm);
 
-    if (UNLIKELY(globalObject->isHavingABadTime())) {
+    if (globalObject->isHavingABadTime()) [[unlikely]] {
         array = JSArray::tryCreateUninitializedRestricted(scope, &deferralContext,
             regExp->hasIndices() ? globalObject->regExpMatchesArrayWithIndicesStructure() : globalObject->regExpMatchesArrayStructure(), regExp->numSubpatterns() + 1);
         // FIXME: we should probably throw an out of memory error here, but

--- a/Source/JavaScriptCore/runtime/RegExpMatchesArray.h
+++ b/Source/JavaScriptCore/runtime/RegExpMatchesArray.h
@@ -45,7 +45,7 @@ ALWAYS_INLINE JSArray* tryCreateUninitializedRegExpMatchesArray(ObjectInitializa
 
     const bool hasIndexingHeader = true;
     Butterfly* butterfly = Butterfly::tryCreateUninitialized(vm, nullptr, 0, structure->outOfLineCapacity(), hasIndexingHeader, vectorLength * sizeof(EncodedJSValue), deferralContext);
-    if (UNLIKELY(!butterfly))
+    if (!butterfly) [[unlikely]]
         return nullptr;
 
     butterfly->setVectorLength(vectorLength);
@@ -125,7 +125,7 @@ ALWAYS_INLINE JSArray* createRegExpMatchesArray(
         return result;
     };
 
-    if (UNLIKELY(globalObject->isHavingABadTime())) {
+    if (globalObject->isHavingABadTime()) [[unlikely]] {
         GCDeferralContext deferralContext(vm);
         ObjectInitializationScope matchesArrayScope(vm);
         ObjectInitializationScope indicesArrayScope(vm);

--- a/Source/JavaScriptCore/runtime/RegExpObject.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpObject.cpp
@@ -143,7 +143,7 @@ bool RegExpObject::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName 
         if (!thisObject->lastIndexIsWritable())
             return typeError(globalObject, scope, slot.isStrictMode(), ReadonlyPropertyWriteError);
 
-        if (UNLIKELY(slot.thisValue() != thisObject))
+        if (slot.thisValue() != thisObject) [[unlikely]]
             RELEASE_AND_RETURN(scope, JSObject::definePropertyOnReceiver(globalObject, propertyName, value, slot));
 
         bool result = thisObject->setLastIndex(globalObject, value, slot.isStrictMode());

--- a/Source/JavaScriptCore/runtime/RegExpObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/RegExpObjectInlines.h
@@ -163,14 +163,14 @@ JSValue collectMatches(VM& vm, JSGlobalObject* globalObject, JSString* string, S
         size_t end = result.end;
         size_t length = end - result.start;
         array->putDirectIndex(globalObject, arrayIndex++, jsSubstringOfResolved(vm, string, result.start, length));
-        if (UNLIKELY(scope.exception())) {
+        if (scope.exception()) [[unlikely]] {
             hasException = true;
             return;
         }
         if (!length)
             end = fixEnd(end);
         result = globalObject->regExpGlobalData().performMatch(globalObject, regExp, string, s, end);
-        if (UNLIKELY(scope.exception())) {
+        if (scope.exception()) [[unlikely]] {
             hasException = true;
             return;
         }
@@ -206,7 +206,7 @@ JSValue collectMatches(VM& vm, JSGlobalObject* globalObject, JSString* string, S
             do {
                 iterate();
                 EXCEPTION_ASSERT(!!scope.exception() == hasException);
-                if (UNLIKELY(hasException))
+                if (hasException) [[unlikely]]
                     return { };
             } while (result);
             
@@ -215,7 +215,7 @@ JSValue collectMatches(VM& vm, JSGlobalObject* globalObject, JSString* string, S
         
         iterate();
         EXCEPTION_ASSERT(!!scope.exception() == hasException);
-        if (UNLIKELY(hasException))
+        if (hasException) [[unlikely]]
             return { };
     } while (result);
     
@@ -287,7 +287,7 @@ ALWAYS_INLINE JSValue collectGlobalAtomMatches(JSGlobalObject* globalObject, JSS
         }
     }
 
-    if (UNLIKELY(numberOfMatches > MAX_STORAGE_VECTOR_LENGTH)) {
+    if (numberOfMatches > MAX_STORAGE_VECTOR_LENGTH) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return jsUndefined();
     }

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
@@ -96,7 +96,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncTest, (JSGlobalObject* globalObject, Cal
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "RegExp.prototype.test requires that |this| be an Object"_s);
     JSObject* thisObject = asObject(thisValue);
 
@@ -121,7 +121,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncTest, (JSGlobalObject* globalObject, Cal
     if (UNLIKELY(regExpExec != regExpBuiltinExec && regExpExec.isCallable())) {
         auto callData = JSC::getCallData(regExpExec);
         ASSERT(callData.type != CallData::Type::None);
-        if (LIKELY(callData.type == CallData::Type::JS)) {
+        if (callData.type == CallData::Type::JS) [[likely]] {
             CachedCall cachedCall(globalObject, jsCast<JSFunction*>(regExpExec), 1);
             RETURN_IF_EXCEPTION(scope, { });
             match = cachedCall.callWithArguments(globalObject, thisValue, str);
@@ -154,7 +154,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncExec, (JSGlobalObject* globalObject, Cal
 
     JSValue thisValue = callFrame->thisValue();
     auto* regexp = jsDynamicCast<RegExpObject*>(thisValue);
-    if (UNLIKELY(!regexp))
+    if (!regexp) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Builtin RegExp exec can only be called on a RegExp object"_s);
     JSString* string = callFrame->argument(0).toStringOrNull(globalObject);
     EXCEPTION_ASSERT(!!scope.exception() == !string);
@@ -247,7 +247,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncToString, (JSGlobalObject* globalObject,
     JSValue thisValue = callFrame->thisValue().toThis(globalObject, ECMAMode::strict());
     RETURN_IF_EXCEPTION(scope, { });
 
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     JSObject* thisObject = asObject(thisValue);
@@ -278,7 +278,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoGetterGlobal, (JSGlobalObject* globalObject,
 
     JSValue thisValue = callFrame->thisValue();
     auto* regexp = jsDynamicCast<RegExpObject*>(thisValue);
-    if (UNLIKELY(!regexp)) {
+    if (!regexp) [[unlikely]] {
         if (thisValue == globalObject->regExpPrototype())
             return JSValue::encode(jsUndefined());
         return throwVMTypeError(globalObject, scope, "The RegExp.prototype.global getter can only be called on a RegExp object"_s);
@@ -294,7 +294,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoGetterHasIndices, (JSGlobalObject* globalObj
 
     JSValue thisValue = callFrame->thisValue();
     auto* regexp = jsDynamicCast<RegExpObject*>(thisValue);
-    if (UNLIKELY(!regexp)) {
+    if (!regexp) [[unlikely]] {
         if (thisValue == globalObject->regExpPrototype())
             return JSValue::encode(jsUndefined());
         return throwVMTypeError(globalObject, scope, "The RegExp.prototype.hasIndices getter can only be called on a RegExp object"_s);
@@ -310,7 +310,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoGetterIgnoreCase, (JSGlobalObject* globalObj
 
     JSValue thisValue = callFrame->thisValue();
     auto* regexp = jsDynamicCast<RegExpObject*>(thisValue);
-    if (UNLIKELY(!regexp)) {
+    if (!regexp) [[unlikely]] {
         if (thisValue == globalObject->regExpPrototype())
             return JSValue::encode(jsUndefined());
         return throwVMTypeError(globalObject, scope, "The RegExp.prototype.ignoreCase getter can only be called on a RegExp object"_s);
@@ -326,7 +326,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoGetterMultiline, (JSGlobalObject* globalObje
 
     JSValue thisValue = callFrame->thisValue();
     auto* regexp = jsDynamicCast<RegExpObject*>(thisValue);
-    if (UNLIKELY(!regexp)) {
+    if (!regexp) [[unlikely]] {
         if (thisValue == globalObject->regExpPrototype())
             return JSValue::encode(jsUndefined());
         return throwVMTypeError(globalObject, scope, "The RegExp.prototype.multiline getter can only be called on a RegExp object"_s);
@@ -342,7 +342,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoGetterDotAll, (JSGlobalObject* globalObject,
     
     JSValue thisValue = callFrame->thisValue();
     auto* regexp = jsDynamicCast<RegExpObject*>(thisValue);
-    if (UNLIKELY(!regexp)) {
+    if (!regexp) [[unlikely]] {
         if (thisValue == globalObject->regExpPrototype())
             return JSValue::encode(jsUndefined());
         return throwVMTypeError(globalObject, scope, "The RegExp.prototype.dotAll getter can only be called on a RegExp object"_s);
@@ -358,7 +358,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoGetterSticky, (JSGlobalObject* globalObject,
 
     JSValue thisValue = callFrame->thisValue();
     auto* regexp = jsDynamicCast<RegExpObject*>(thisValue);
-    if (UNLIKELY(!regexp)) {
+    if (!regexp) [[unlikely]] {
         if (thisValue == globalObject->regExpPrototype())
             return JSValue::encode(jsUndefined());
         return throwVMTypeError(globalObject, scope, "The RegExp.prototype.sticky getter can only be called on a RegExp object"_s);
@@ -374,7 +374,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoGetterUnicode, (JSGlobalObject* globalObject
 
     JSValue thisValue = callFrame->thisValue();
     auto* regexp = jsDynamicCast<RegExpObject*>(thisValue);
-    if (UNLIKELY(!regexp)) {
+    if (!regexp) [[unlikely]] {
         if (thisValue == globalObject->regExpPrototype())
             return JSValue::encode(jsUndefined());
         return throwVMTypeError(globalObject, scope, "The RegExp.prototype.unicode getter can only be called on a RegExp object"_s);
@@ -390,7 +390,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoGetterUnicodeSets, (JSGlobalObject* globalOb
 
     JSValue thisValue = callFrame->thisValue();
     auto* regexp = jsDynamicCast<RegExpObject*>(thisValue);
-    if (UNLIKELY(!regexp)) {
+    if (!regexp) [[unlikely]] {
         if (thisValue == globalObject->regExpPrototype())
             return JSValue::encode(jsUndefined());
         return throwVMTypeError(globalObject, scope, "The RegExp.prototype.unicodeSets getter can only be called on a RegExp object"_s);
@@ -407,7 +407,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoGetterFlags, (JSGlobalObject* globalObject, 
     JSValue thisValue = callFrame->thisValue().toThis(globalObject, ECMAMode::strict());
     RETURN_IF_EXCEPTION(scope, { });
 
-    if (UNLIKELY(!thisValue.isObject()))
+    if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "The RegExp.prototype.flags getter can only be called on an object"_s);
 
     auto flags = flagsString(globalObject, asObject(thisValue));
@@ -423,7 +423,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoGetterSource, (JSGlobalObject* globalObject,
 
     JSValue thisValue = callFrame->thisValue();
     auto* regexp = jsDynamicCast<RegExpObject*>(thisValue);
-    if (UNLIKELY(!regexp)) {
+    if (!regexp) [[unlikely]] {
         if (thisValue == globalObject->regExpPrototype())
             return JSValue::encode(jsNontrivialString(vm, "(?:)"_s));
         return throwVMTypeError(globalObject, scope, "The RegExp.prototype.source getter can only be called on a RegExp object"_s);
@@ -617,7 +617,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncSplitFast, (JSGlobalObject* globalObject
     
     unsigned maxSizeForDirectPath = 100000;
     JSArray* result = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), 1);
-    if (UNLIKELY(!result)) {
+    if (!result) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return { };
     }

--- a/Source/JavaScriptCore/runtime/RegExpSubstringGlobalAtomCache.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpSubstringGlobalAtomCache.cpp
@@ -76,12 +76,12 @@ JSValue RegExpSubstringGlobalAtomCache::collectMatches(JSGlobalObject* globalObj
 
     auto regExpMatch = [&]() ALWAYS_INLINE_LAMBDA {
         MatchResult result = globalObject->regExpGlobalData().performMatch(globalObject, regExp, substring, input, startIndex);
-        if (UNLIKELY(scope.exception()))
+        if (scope.exception()) [[unlikely]]
             return;
 
         while (result) {
             lastResult = result;
-            if (UNLIKELY(numberOfMatches > MAX_STORAGE_VECTOR_LENGTH)) {
+            if (numberOfMatches > MAX_STORAGE_VECTOR_LENGTH) [[unlikely]] {
                 throwOutOfMemoryError(globalObject, scope);
                 return;
             }
@@ -92,7 +92,7 @@ JSValue RegExpSubstringGlobalAtomCache::collectMatches(JSGlobalObject* globalObj
                 startIndex++;
 
             result = globalObject->regExpGlobalData().performMatch(globalObject, regExp, substring, input, startIndex);
-            if (UNLIKELY(scope.exception()))
+            if (scope.exception()) [[unlikely]]
                 return;
         }
     };
@@ -108,7 +108,7 @@ JSValue RegExpSubstringGlobalAtomCache::collectMatches(JSGlobalObject* globalObj
                 }
             } else {
                 regExpMatch();
-                if (UNLIKELY(scope.exception()))
+                if (scope.exception()) [[unlikely]]
                     return { };
             }
         } else {
@@ -120,14 +120,14 @@ JSValue RegExpSubstringGlobalAtomCache::collectMatches(JSGlobalObject* globalObj
                 }
             } else {
                 regExpMatch();
-                if (UNLIKELY(scope.exception()))
+                if (scope.exception()) [[unlikely]]
                     return { };
             }
         }
     } else {
         if (input->is8Bit()) {
             regExpMatch();
-            if (UNLIKELY(scope.exception()))
+            if (scope.exception()) [[unlikely]]
                 return { };
         } else {
             if (pattern.length() == 1) {
@@ -138,13 +138,13 @@ JSValue RegExpSubstringGlobalAtomCache::collectMatches(JSGlobalObject* globalObj
                 }
             } else {
                 regExpMatch();
-                if (UNLIKELY(scope.exception()))
+                if (scope.exception()) [[unlikely]]
                     return { };
             }
         }
     }
 
-    if (UNLIKELY(numberOfMatches > MAX_STORAGE_VECTOR_LENGTH)) {
+    if (numberOfMatches > MAX_STORAGE_VECTOR_LENGTH) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return { };
     }

--- a/Source/JavaScriptCore/runtime/RuntimeType.cpp
+++ b/Source/JavaScriptCore/runtime/RuntimeType.cpp
@@ -34,7 +34,7 @@ namespace JSC {
 
 RuntimeType runtimeTypeForValue(JSValue value)
 {
-    if (UNLIKELY(!value))
+    if (!value) [[unlikely]]
         return TypeNothing;
 
     if (value.isUndefined())

--- a/Source/JavaScriptCore/runtime/ScopedArgumentsTable.cpp
+++ b/Source/JavaScriptCore/runtime/ScopedArgumentsTable.cpp
@@ -59,7 +59,7 @@ ScopedArgumentsTable* ScopedArgumentsTable::create(VM& vm)
 ScopedArgumentsTable* ScopedArgumentsTable::tryCreate(VM& vm, uint32_t length)
 {
     void* buffer = tryAllocateCell<ScopedArgumentsTable>(vm);
-    if (UNLIKELY(!buffer))
+    if (!buffer) [[unlikely]]
         return nullptr;
     ScopedArgumentsTable* result = new (NotNull, buffer) ScopedArgumentsTable(vm);
     result->finishCreation(vm);
@@ -75,7 +75,7 @@ ScopedArgumentsTable* ScopedArgumentsTable::tryCreate(VM& vm, uint32_t length)
 ScopedArgumentsTable* ScopedArgumentsTable::tryClone(VM& vm)
 {
     ScopedArgumentsTable* result = tryCreate(vm, m_length);
-    if (UNLIKELY(!result))
+    if (!result) [[unlikely]]
         return nullptr;
     for (unsigned i = m_length; i--;)
         result->at(i) = this->at(i);
@@ -98,7 +98,7 @@ ScopedArgumentsTable* ScopedArgumentsTable::trySetLength(VM& vm, uint32_t newLen
     }
     
     ScopedArgumentsTable* result = tryCreate(vm, newLength);
-    if (UNLIKELY(!result))
+    if (!result) [[unlikely]]
         return nullptr;
     m_watchpointSets.resize(newLength);
     for (unsigned i = std::min(m_length, newLength); i--;) {
@@ -115,7 +115,7 @@ ScopedArgumentsTable* ScopedArgumentsTable::trySet(VM& vm, uint32_t i, ScopeOffs
     ScopedArgumentsTable* result;
     if (UNLIKELY(m_locked)) {
         result = tryClone(vm);
-        if (UNLIKELY(!result))
+        if (!result) [[unlikely]]
             return nullptr;
     } else
         result = this;

--- a/Source/JavaScriptCore/runtime/SetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SetPrototype.cpp
@@ -105,7 +105,7 @@ ALWAYS_INLINE static JSSet* getSet(JSGlobalObject* globalObject, JSValue thisVal
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (UNLIKELY(!thisValue.isCell())) {
+    if (!thisValue.isCell()) [[unlikely]] {
         throwVMError(globalObject, scope, createNotAnObjectError(globalObject, thisValue));
         return nullptr;
     }

--- a/Source/JavaScriptCore/runtime/ShadowRealmPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ShadowRealmPrototype.cpp
@@ -122,7 +122,7 @@ JSC_DEFINE_HOST_FUNCTION(evalInRealm, (JSGlobalObject* globalObject, CallFrame* 
     RETURN_IF_EXCEPTION(scope, { });
 
     JSValue result = vm.interpreter.executeEval(eval, realmGlobalObject->globalThis(), realmGlobalObject->globalScope());
-    if (UNLIKELY(scope.exception())) {
+    if (scope.exception()) [[unlikely]] {
         NakedPtr<Exception> exception = scope.exception();
         JSValue error = exception->value();
         scope.clearException();

--- a/Source/JavaScriptCore/runtime/SimpleTypedArrayController.cpp
+++ b/Source/JavaScriptCore/runtime/SimpleTypedArrayController.cpp
@@ -64,7 +64,7 @@ bool SimpleTypedArrayController::isAtomicsWaitAllowedOnCurrentThread()
 
 bool SimpleTypedArrayController::JSArrayBufferOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, JSC::AbstractSlotVisitor& visitor, ASCIILiteral* reason)
 {
-    if (UNLIKELY(reason))
+    if (reason) [[unlikely]]
         *reason = "JSArrayBuffer is opaque root"_s;
     auto& wrapper = *JSC::jsCast<JSC::JSArrayBuffer*>(handle.slot()->asCell());
     return visitor.containsOpaqueRoot(wrapper.impl());

--- a/Source/JavaScriptCore/runtime/StringObject.cpp
+++ b/Source/JavaScriptCore/runtime/StringObject.cpp
@@ -70,7 +70,7 @@ bool StringObject::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName 
 
     if (propertyName == vm.propertyNames->length)
         return typeError(globalObject, scope, slot.isStrictMode(), ReadonlyPropertyWriteError);
-    if (UNLIKELY(slot.thisValue() != thisObject))
+    if (slot.thisValue() != thisObject) [[unlikely]]
         RELEASE_AND_RETURN(scope, JSObject::put(cell, globalObject, propertyName, value, slot));
     if (std::optional<uint32_t> index = parseIndex(propertyName)) 
         RELEASE_AND_RETURN(scope, putByIndex(cell, globalObject, index.value(), value, slot.isStrictMode()));

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -397,7 +397,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncCharAt, (JSGlobalObject* globalObject, C
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!checkObjectCoercible(thisValue)))
+    if (!checkObjectCoercible(thisValue)) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
     auto* thisString = thisValue.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
@@ -423,7 +423,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncCharCodeAt, (JSGlobalObject* globalObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!checkObjectCoercible(thisValue)))
+    if (!checkObjectCoercible(thisValue)) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
     auto* thisString = thisValue.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
@@ -460,7 +460,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncCodePointAt, (JSGlobalObject* globalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!checkObjectCoercible(thisValue)))
+    if (!checkObjectCoercible(thisValue)) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     String string = thisValue.toWTFString(globalObject);
@@ -490,7 +490,7 @@ static EncodedJSValue stringIndexOfImpl(JSGlobalObject* globalObject, CallFrame*
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!checkObjectCoercible(thisValue)))
+    if (!checkObjectCoercible(thisValue)) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     JSValue a0 = callFrame->argument(0);
@@ -550,7 +550,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncLastIndexOf, (JSGlobalObject* globalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!checkObjectCoercible(thisValue)))
+    if (!checkObjectCoercible(thisValue)) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     JSValue a0 = callFrame->argument(0);
@@ -595,7 +595,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSlice, (JSGlobalObject* globalObject, Ca
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!checkObjectCoercible(thisValue)))
+    if (!checkObjectCoercible(thisValue)) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
     JSString* string = thisValue.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
@@ -710,7 +710,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSplitFast, (JSGlobalObject* globalObject
             Structure* immutableButterflyStructure = makeAtomStringsArray ? vm.immutableButterflyOnlyAtomStringsStructure.get() : vm.immutableButterflyStructure(CopyOnWriteArrayWithContiguous);
 
             auto* newButterfly = JSImmutableButterfly::tryCreate(vm, immutableButterflyStructure, resultSize);
-            if (UNLIKELY(!newButterfly)) {
+            if (!newButterfly) [[unlikely]] {
                 throwOutOfMemoryError(globalObject, scope);
                 return { };
             }
@@ -779,7 +779,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSplitFast, (JSGlobalObject* globalObject
             Structure* immutableButterflyStructure = makeAtomStringsArray ? vm.immutableButterflyOnlyAtomStringsStructure.get() : vm.immutableButterflyStructure(CopyOnWriteArrayWithContiguous);
 
             auto* newButterfly = JSImmutableButterfly::tryCreate(vm, immutableButterflyStructure, resultSize);
-            if (UNLIKELY(!newButterfly)) {
+            if (!newButterfly) [[unlikely]] {
                 throwOutOfMemoryError(globalObject, scope);
                 return { };
             }
@@ -861,7 +861,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSubstr, (JSGlobalObject* globalObject, C
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!checkObjectCoercible(thisValue)))
+    if (!checkObjectCoercible(thisValue)) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
     unsigned len;
     JSString* jsString = nullptr;
@@ -905,7 +905,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSubstring, (JSGlobalObject* globalObject
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!checkObjectCoercible(thisValue)))
+    if (!checkObjectCoercible(thisValue)) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     JSString* jsString = thisValue.toString(globalObject);
@@ -953,7 +953,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncToLowerCase, (JSGlobalObject* globalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!checkObjectCoercible(thisValue)))
+    if (!checkObjectCoercible(thisValue)) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     JSString* sVal = thisValue.toString(globalObject);
@@ -989,7 +989,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncToUpperCase, (JSGlobalObject* globalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!checkObjectCoercible(thisValue)))
+    if (!checkObjectCoercible(thisValue)) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     JSString* sVal = thisValue.toString(globalObject);
@@ -1029,7 +1029,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncLocaleCompare, (JSGlobalObject* globalOb
 
     // 1. Let O be RequireObjectCoercible(this value).
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!checkObjectCoercible(thisValue)))
+    if (!checkObjectCoercible(thisValue)) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "String.prototype.localeCompare requires that |this| not be null or undefined"_s);
 
     // 2. Let S be ToString(O).
@@ -1068,7 +1068,7 @@ static EncodedJSValue toLocaleCase(JSGlobalObject* globalObject, CallFrame* call
 
     // 1. Let O be RequireObjectCoercible(this value).
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!checkObjectCoercible(thisValue)))
+    if (!checkObjectCoercible(thisValue)) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     // 2. Let S be ToString(O).
@@ -1170,7 +1170,7 @@ static inline JSValue trimString(JSGlobalObject* globalObject, JSValue thisValue
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (UNLIKELY(!checkObjectCoercible(thisValue)))
+    if (!checkObjectCoercible(thisValue)) [[unlikely]]
         return throwTypeError(globalObject, scope);
     String str = thisValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
@@ -1226,7 +1226,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncStartsWith, (JSGlobalObject* globalObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!checkObjectCoercible(thisValue)))
+    if (!checkObjectCoercible(thisValue)) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     String stringToSearchIn = thisValue.toWTFString(globalObject);
@@ -1260,7 +1260,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncEndsWith, (JSGlobalObject* globalObject,
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!checkObjectCoercible(thisValue)))
+    if (!checkObjectCoercible(thisValue)) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     String stringToSearchIn = thisValue.toWTFString(globalObject);
@@ -1311,7 +1311,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncIncludes, (JSGlobalObject* globalObject,
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!checkObjectCoercible(thisValue)))
+    if (!checkObjectCoercible(thisValue)) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     String stringToSearchIn = thisValue.toWTFString(globalObject);
@@ -1357,7 +1357,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncIterator, (JSGlobalObject* globalObject,
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!checkObjectCoercible(thisValue)))
+    if (!checkObjectCoercible(thisValue)) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
     JSString* string = thisValue.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
@@ -1436,7 +1436,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncNormalize, (JSGlobalObject* globalObject
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!checkObjectCoercible(thisValue)))
+    if (!checkObjectCoercible(thisValue)) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
     JSString* string = thisValue.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
@@ -1494,7 +1494,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncIsWellFormed, (JSGlobalObject* globalObj
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!checkObjectCoercible(thisValue)))
+    if (!checkObjectCoercible(thisValue)) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     // Latin-1 characters do not have surrogates.
@@ -1515,7 +1515,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncToWellFormed, (JSGlobalObject* globalObj
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!checkObjectCoercible(thisValue)))
+    if (!checkObjectCoercible(thisValue)) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     // Latin-1 characters do not have surrogates.
@@ -1586,7 +1586,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncAt, (JSGlobalObject* globalObject, CallF
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!checkObjectCoercible(thisValue)))
+    if (!checkObjectCoercible(thisValue)) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
     auto* thisString = thisValue.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -295,7 +295,7 @@ ALWAYS_INLINE String tryMakeReplacedString(const String& string, const String& r
             StringBuilder builder(OverflowPolicy::RecordOverflow);
             int ovector[2] = { static_cast<int>(matchStart), static_cast<int>(matchEnd) };
             substituteBackreferencesSlow(builder, replacement, string, ovector, nullptr, dollarPos);
-            if (UNLIKELY(builder.hasOverflowed()))
+            if (builder.hasOverflowed()) [[unlikely]]
                 return { };
             if (auto result = tryMakeString(StringView(string).substring(0, matchStart), builder.toString(), StringView(string).substring(matchEnd, string.length() - matchEnd)); LIKELY(!result.isNull()))
                 return result;
@@ -324,7 +324,7 @@ ALWAYS_INLINE JSString* stringReplaceStringString(JSGlobalObject* globalObject, 
     size_t searchLength = search.length();
     size_t matchEnd = matchStart + searchLength;
     auto result = tryMakeReplacedString<substitutions>(string, replacement, matchStart, matchEnd);
-    if (UNLIKELY(!result)) {
+    if (!result) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return nullptr;
     }
@@ -598,7 +598,7 @@ static ALWAYS_INLINE JSString* removeAllUsingRegExpSearch(VM& vm, JSGlobalObject
                 return lastFound;
 
             if (startIndex < sourceLen) {
-                if (UNLIKELY(!sourceRanges.tryConstructAndAppend(startIndex, sourceLen))) {
+                if (!sourceRanges.tryConstructAndAppend(startIndex, sourceLen)) [[unlikely]] {
                     throwOutOfMemoryError(globalObject, scope);
                     return notFound;
                 }
@@ -625,7 +625,7 @@ static ALWAYS_INLINE JSString* removeAllUsingRegExpSearch(VM& vm, JSGlobalObject
         } while (found != notFound);
 
         if (startIndex < sourceLen) {
-            if (UNLIKELY(!sourceRanges.tryConstructAndAppend(startIndex, sourceLen))) {
+            if (!sourceRanges.tryConstructAndAppend(startIndex, sourceLen)) [[unlikely]] {
                 throwOutOfMemoryError(globalObject, scope);
                 return notFound;
             }
@@ -664,7 +664,7 @@ static ALWAYS_INLINE JSString* removeAllUsingRegExpSearch(VM& vm, JSGlobalObject
             break;
 
         if (lastIndex < result.start) {
-            if (UNLIKELY(!sourceRanges.tryConstructAndAppend(lastIndex, result.start)))
+            if (!sourceRanges.tryConstructAndAppend(lastIndex, result.start)) [[unlikely]]
                 OUT_OF_MEMORY(globalObject, scope);
         }
         lastIndex = result.end;
@@ -682,7 +682,7 @@ static ALWAYS_INLINE JSString* removeAllUsingRegExpSearch(VM& vm, JSGlobalObject
         return string;
 
     if (static_cast<unsigned>(lastIndex) < sourceLen) {
-        if (UNLIKELY(!sourceRanges.tryConstructAndAppend(lastIndex, sourceLen)))
+        if (!sourceRanges.tryConstructAndAppend(lastIndex, sourceLen)) [[unlikely]]
             OUT_OF_MEMORY(globalObject, scope);
     }
     RELEASE_AND_RETURN(scope, jsSpliceSubstrings(globalObject, string, source, sourceRanges.span()));
@@ -748,7 +748,7 @@ ALWAYS_INLINE JSImmutableButterfly* addToRegExpSearchCache(VM& vm, JSGlobalObjec
         RELEASE_AND_RETURN(scope, nullptr);
 
     JSImmutableButterfly* result = JSImmutableButterfly::tryCreateFromArgList(vm, results);
-    if (UNLIKELY(!result)) {
+    if (!result) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return nullptr;
     }
@@ -820,7 +820,7 @@ static ALWAYS_INLINE JSString* replaceAllWithCacheUsingRegExpSearchThreeArgument
     if (sourceView.is8Bit() && replacementsAre8Bit) {
         std::span<LChar> buffer;
         auto impl = StringImpl::tryCreateUninitialized(totalLength, buffer);
-        if (UNLIKELY(!impl)) {
+        if (!impl) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
             return nullptr;
         }
@@ -855,7 +855,7 @@ static ALWAYS_INLINE JSString* replaceAllWithCacheUsingRegExpSearchThreeArgument
 
     std::span<UChar> buffer;
     auto impl = StringImpl::tryCreateUninitialized(totalLength, buffer);
-    if (UNLIKELY(!impl)) {
+    if (!impl) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return nullptr;
     }
@@ -965,7 +965,7 @@ static ALWAYS_INLINE JSString* replaceAllWithCacheUsingRegExpSearch(VM& vm, JSGl
         if (sourceView.is8Bit() && replacementsAre8Bit) {
             std::span<LChar> buffer;
             auto impl = StringImpl::tryCreateUninitialized(totalLength, buffer);
-            if (UNLIKELY(!impl)) {
+            if (!impl) [[unlikely]] {
                 throwOutOfMemoryError(globalObject, scope);
                 return nullptr;
             }
@@ -999,7 +999,7 @@ static ALWAYS_INLINE JSString* replaceAllWithCacheUsingRegExpSearch(VM& vm, JSGl
 
         std::span<UChar> buffer;
         auto impl = StringImpl::tryCreateUninitialized(totalLength, buffer);
-        if (UNLIKELY(!impl)) {
+        if (!impl) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
             return nullptr;
         }
@@ -1051,7 +1051,7 @@ static ALWAYS_INLINE JSString* replaceAllWithCacheUsingRegExpSearch(VM& vm, JSGl
         sourceRanges.constructAndAppend(lastIndex, start);
 
         cachedCall.setThis(jsUndefined());
-        if (UNLIKELY(cachedCall.hasOverflowedArguments())) {
+        if (cachedCall.hasOverflowedArguments()) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
             return nullptr;
         }
@@ -1140,7 +1140,7 @@ ALWAYS_INLINE JSString* replaceAllWithStringUsingRegExpSearchNoBackreferences(VM
         if (!result)
             break;
 
-        if (UNLIKELY(!sourceRanges.tryConstructAndAppend(lastIndex, result.start)))
+        if (!sourceRanges.tryConstructAndAppend(lastIndex, result.start)) [[unlikely]]
             OUT_OF_MEMORY(globalObject, scope);
 
         ++replacementCount;
@@ -1165,7 +1165,7 @@ ALWAYS_INLINE JSString* replaceAllWithStringUsingRegExpSearchNoBackreferences(VM
         return string;
 
     if (static_cast<unsigned>(lastIndex) < sourceLen) {
-        if (UNLIKELY(!sourceRanges.tryConstructAndAppend(lastIndex, sourceLen)))
+        if (!sourceRanges.tryConstructAndAppend(lastIndex, sourceLen)) [[unlikely]]
             OUT_OF_MEMORY(globalObject, scope);
     }
     RELEASE_AND_RETURN(scope, jsSpliceSubstringsWithSeparator(globalObject, string, source, sourceRanges.data(), sourceRanges.size(), replacementString, replacementCount));
@@ -1193,12 +1193,12 @@ ALWAYS_INLINE JSString* replaceAllWithStringUsingRegExpSearch(VM& vm, JSGlobalOb
         if (!result)
             break;
 
-        if (UNLIKELY(!sourceRanges.tryConstructAndAppend(lastIndex, result.start)))
+        if (!sourceRanges.tryConstructAndAppend(lastIndex, result.start)) [[unlikely]]
             OUT_OF_MEMORY(globalObject, scope);
 
         StringBuilder replacement(OverflowPolicy::RecordOverflow);
         substituteBackreferencesSlow(replacement, replacementString, source, ovector, regExp, dollarPos);
-        if (UNLIKELY(replacement.hasOverflowed()))
+        if (replacement.hasOverflowed()) [[unlikely]]
             OUT_OF_MEMORY(globalObject, scope);
         replacements.append(replacement.toString());
 
@@ -1222,7 +1222,7 @@ ALWAYS_INLINE JSString* replaceAllWithStringUsingRegExpSearch(VM& vm, JSGlobalOb
         return string;
 
     if (static_cast<unsigned>(lastIndex) < sourceLen) {
-        if (UNLIKELY(!sourceRanges.tryConstructAndAppend(lastIndex, sourceLen)))
+        if (!sourceRanges.tryConstructAndAppend(lastIndex, sourceLen)) [[unlikely]]
             OUT_OF_MEMORY(globalObject, scope);
     }
     RELEASE_AND_RETURN(scope, jsSpliceSubstringsWithSeparators(globalObject, string, source, sourceRanges.data(), sourceRanges.size(), replacements.data(), replacements.size()));
@@ -1247,7 +1247,7 @@ ALWAYS_INLINE JSString* replaceOneWithStringUsingRegExpSearch(VM& vm, JSGlobalOb
 
     StringBuilder replacement(OverflowPolicy::RecordOverflow);
     substituteBackreferencesSlow(replacement, replacementString, source, ovector, regExp, dollarPos);
-    if (UNLIKELY(replacement.hasOverflowed()))
+    if (replacement.hasOverflowed()) [[unlikely]]
         OUT_OF_MEMORY(globalObject, scope);
     RELEASE_AND_RETURN(scope, jsString(vm, makeString(before, StringView { replacement }, after)));
 }
@@ -1323,7 +1323,7 @@ ALWAYS_INLINE JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalO
             if (!result)
                 break;
 
-            if (UNLIKELY(!sourceRanges.tryConstructAndAppend(lastIndex, result.start)))
+            if (!sourceRanges.tryConstructAndAppend(lastIndex, result.start)) [[unlikely]]
                 OUT_OF_MEMORY(globalObject, scope);
 
             cachedCall.clearArguments();
@@ -1374,7 +1374,7 @@ ALWAYS_INLINE JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalO
                 cachedCall.appendArgument(groups);
 
             cachedCall.setThis(jsUndefined());
-            if (UNLIKELY(cachedCall.hasOverflowedArguments())) {
+            if (cachedCall.hasOverflowedArguments()) [[unlikely]] {
                 throwOutOfMemoryError(globalObject, scope);
                 return nullptr;
             }
@@ -1408,7 +1408,7 @@ ALWAYS_INLINE JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalO
             if (!result)
                 break;
 
-            if (UNLIKELY(!sourceRanges.tryConstructAndAppend(lastIndex, result.start)))
+            if (!sourceRanges.tryConstructAndAppend(lastIndex, result.start)) [[unlikely]]
                 OUT_OF_MEMORY(globalObject, scope);
 
             MarkedArgumentBuffer args;
@@ -1457,7 +1457,7 @@ ALWAYS_INLINE JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalO
             args.append(string);
             if (hasNamedCaptures)
                 args.append(groups);
-            if (UNLIKELY(args.hasOverflowed())) {
+            if (args.hasOverflowed()) [[unlikely]] {
                 throwOutOfMemoryError(globalObject, scope);
                 return nullptr;
             }
@@ -1490,7 +1490,7 @@ ALWAYS_INLINE JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalO
         return string;
 
     if (static_cast<unsigned>(lastIndex) < sourceLen) {
-        if (UNLIKELY(!sourceRanges.tryConstructAndAppend(lastIndex, sourceLen)))
+        if (!sourceRanges.tryConstructAndAppend(lastIndex, sourceLen)) [[unlikely]]
             OUT_OF_MEMORY(globalObject, scope);
     }
     RELEASE_AND_RETURN(scope, jsSpliceSubstringsWithSeparators(globalObject, string, source, sourceRanges.data(), sourceRanges.size(), replacements.data(), replacements.size()));
@@ -1530,7 +1530,7 @@ ALWAYS_INLINE JSString* replace(VM& vm, JSGlobalObject* globalObject, JSValue th
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (UNLIKELY(!checkObjectCoercible(thisValue))) {
+    if (!checkObjectCoercible(thisValue)) [[unlikely]] {
         throwVMTypeError(globalObject, scope);
         return nullptr;
     }

--- a/Source/JavaScriptCore/runtime/StringRecursionChecker.h
+++ b/Source/JavaScriptCore/runtime/StringRecursionChecker.h
@@ -50,7 +50,7 @@ private:
 inline JSValue StringRecursionChecker::performCheck()
 {
     VM& vm = getVM(m_globalObject);
-    if (UNLIKELY(!vm.isSafeToRecurseSoft()))
+    if (!vm.isSafeToRecurseSoft()) [[unlikely]]
         return throwStackOverflowError();
 
     bool alreadyVisited = false;

--- a/Source/JavaScriptCore/runtime/SymbolTable.h
+++ b/Source/JavaScriptCore/runtime/SymbolTable.h
@@ -368,7 +368,7 @@ private:
     
     FatEntry* inflate()
     {
-        if (LIKELY(isFat()))
+        if (isFat()) [[likely]]
             return fatEntry();
         return inflateSlow();
     }
@@ -668,12 +668,12 @@ public:
     {
         if (UNLIKELY(!m_arguments)) {
             ScopedArgumentsTable* table = ScopedArgumentsTable::tryCreate(vm, length);
-            if (UNLIKELY(!table))
+            if (!table) [[unlikely]]
                 return false;
             m_arguments.set(vm, this, table);
         } else {
             ScopedArgumentsTable* table = m_arguments->trySetLength(vm, length);
-            if (UNLIKELY(!table))
+            if (!table) [[unlikely]]
                 return false;
             m_arguments.set(vm, this, table);
         }

--- a/Source/JavaScriptCore/runtime/TemporalCalendarPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalCalendarPrototype.cpp
@@ -218,7 +218,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalCalendarPrototypeFuncFields, (JSGlobalObject* g
                 shouldAddEraAndEraYear = true;
         }
         fieldNames.append(value);
-        if (UNLIKELY(fieldNames.hasOverflowed()))
+        if (fieldNames.hasOverflowed()) [[unlikely]]
             throwStackOverflowError(globalObject, scope);
     });
     RETURN_IF_EXCEPTION(scope, { });
@@ -226,7 +226,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalCalendarPrototypeFuncFields, (JSGlobalObject* g
     if (shouldAddEraAndEraYear) {
         fieldNames.append(jsNontrivialString(vm, vm.propertyNames->era.impl()));
         fieldNames.append(jsNontrivialString(vm, vm.propertyNames->eraYear.impl()));
-        if (UNLIKELY(fieldNames.hasOverflowed()))
+        if (fieldNames.hasOverflowed()) [[unlikely]]
             throwStackOverflowError(globalObject, scope);
     }
 

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1333,7 +1333,7 @@ void VM::didExhaustMicrotaskQueue()
                 continue;
 
             callPromiseRejectionCallback(promise);
-            if (UNLIKELY(hasPendingTerminationException()))
+            if (hasPendingTerminationException()) [[unlikely]]
                 return;
         }
     } while (!m_aboutToBeNotifiedRejectedPromises.isEmpty());
@@ -1361,10 +1361,10 @@ void VM::drainMicrotasks()
                     runJSMicrotask(task.globalObject(), task.identifier(), task.job(), task.arguments());
                     return QueuedTask::Result::Executed;
                 });
-            if (UNLIKELY(hasPendingTerminationException()))
+            if (hasPendingTerminationException()) [[unlikely]]
                 return;
             didExhaustMicrotaskQueue();
-            if (UNLIKELY(hasPendingTerminationException()))
+            if (hasPendingTerminationException()) [[unlikely]]
                 return;
         } while (!m_defaultMicrotaskQueue.isEmpty());
     }
@@ -1536,12 +1536,12 @@ void VM::executeEntryScopeServicesOnEntry()
     dateCache.resetIfNecessary();
 
     RefPtr watchdog = this->watchdog();
-    if (UNLIKELY(watchdog))
+    if (watchdog) [[unlikely]]
         watchdog->enteredVM();
 
 #if ENABLE(SAMPLING_PROFILER)
     RefPtr samplingProfiler = this->samplingProfiler();
-    if (UNLIKELY(samplingProfiler))
+    if (samplingProfiler) [[unlikely]]
         samplingProfiler->noticeVMEntry();
 #endif
 
@@ -1555,7 +1555,7 @@ void VM::executeEntryScopeServicesOnExit()
         tracePoint(VMEntryScopeEnd);
 
     RefPtr watchdog = this->watchdog();
-    if (UNLIKELY(watchdog))
+    if (watchdog) [[unlikely]]
         watchdog->exitedVM();
 
     if (hasEntryScopeServiceRequest(EntryScopeService::PopListeners)) {

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -1164,7 +1164,7 @@ namespace WTF {
 template<> struct DefaultRefDerefTraits<JSC::VM> {
     static ALWAYS_INLINE JSC::VM* refIfNotNull(JSC::VM* ptr)
     {
-        if (LIKELY(ptr))
+        if (ptr) [[likely]]
             ptr->refSuppressingSaferCPPChecking();
         return ptr;
     }
@@ -1177,7 +1177,7 @@ template<> struct DefaultRefDerefTraits<JSC::VM> {
 
     static ALWAYS_INLINE void derefIfNotNull(JSC::VM* ptr)
     {
-        if (LIKELY(ptr))
+        if (ptr) [[likely]]
             ptr->derefSuppressingSaferCPPChecking();
     }
 };

--- a/Source/JavaScriptCore/runtime/WeakMapConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/WeakMapConstructor.cpp
@@ -96,7 +96,7 @@ JSC_DEFINE_HOST_FUNCTION(constructWeakMap, (JSGlobalObject* globalObject, CallFr
         RETURN_IF_EXCEPTION(scope, void());
 
         if (canPerformFastSet) {
-            if (UNLIKELY(!canBeHeldWeakly(key))) {
+            if (!canBeHeldWeakly(key)) [[unlikely]] {
                 throwTypeError(asObject(adderFunction)->globalObject(), scope, WeakMapInvalidKeyError);
                 return;
             }

--- a/Source/JavaScriptCore/runtime/WeakMapPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/WeakMapPrototype.cpp
@@ -67,7 +67,7 @@ ALWAYS_INLINE static JSWeakMap* getWeakMap(JSGlobalObject* globalObject, JSValue
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (UNLIKELY(!value.isObject())) {
+    if (!value.isObject()) [[unlikely]] {
         throwTypeError(globalObject, scope, "Called WeakMap function on non-object"_s);
         return nullptr;
     }
@@ -86,7 +86,7 @@ JSC_DEFINE_HOST_FUNCTION(protoFuncWeakMapDelete, (JSGlobalObject* globalObject, 
     if (!map)
         return JSValue::encode(jsUndefined());
     JSValue key = callFrame->argument(0);
-    if (UNLIKELY(!key.isCell()))
+    if (!key.isCell()) [[unlikely]]
         return JSValue::encode(jsBoolean(false));
     return JSValue::encode(jsBoolean(map->remove(key.asCell())));
 }
@@ -97,7 +97,7 @@ JSC_DEFINE_HOST_FUNCTION(protoFuncWeakMapGet, (JSGlobalObject* globalObject, Cal
     if (!map)
         return JSValue::encode(jsUndefined());
     JSValue key = callFrame->argument(0);
-    if (UNLIKELY(!key.isCell()))
+    if (!key.isCell()) [[unlikely]]
         return JSValue::encode(jsUndefined());
     return JSValue::encode(map->get(key.asCell()));
 }
@@ -108,7 +108,7 @@ JSC_DEFINE_HOST_FUNCTION(protoFuncWeakMapHas, (JSGlobalObject* globalObject, Cal
     if (!map)
         return JSValue::encode(jsUndefined());
     JSValue key = callFrame->argument(0);
-    if (UNLIKELY(!key.isCell()))
+    if (!key.isCell()) [[unlikely]]
         return JSValue::encode(jsBoolean(false));
     return JSValue::encode(jsBoolean(map->has(key.asCell())));
 }
@@ -123,7 +123,7 @@ JSC_DEFINE_HOST_FUNCTION(protoFuncWeakMapSet, (JSGlobalObject* globalObject, Cal
     if (!map)
         return JSValue::encode(jsUndefined());
     JSValue key = callFrame->argument(0);
-    if (UNLIKELY(!canBeHeldWeakly(key)))
+    if (!canBeHeldWeakly(key)) [[unlikely]]
         return throwVMTypeError(globalObject, scope, WeakMapInvalidKeyError);
     map->set(vm, key.asCell(), callFrame->argument(1));
     return JSValue::encode(callFrame->thisValue());
@@ -140,7 +140,7 @@ JSC_DEFINE_HOST_FUNCTION(protoFuncWeakMapGetOrInsert, (JSGlobalObject* globalObj
         return JSValue::encode(jsUndefined());
 
     JSValue key = callFrame->argument(0);
-    if (UNLIKELY(!canBeHeldWeakly(key)))
+    if (!canBeHeldWeakly(key)) [[unlikely]]
         return throwVMTypeError(globalObject, scope, WeakMapInvalidKeyError);
 
     JSCell* keyCell = key.asCell();
@@ -175,12 +175,12 @@ JSC_DEFINE_HOST_FUNCTION(protoFuncWeakMapGetOrInsertComputed, (JSGlobalObject* g
         return JSValue::encode(jsUndefined());
 
     JSValue key = callFrame->argument(0);
-    if (UNLIKELY(!canBeHeldWeakly(key)))
+    if (!canBeHeldWeakly(key)) [[unlikely]]
         return throwVMTypeError(globalObject, scope, WeakMapInvalidKeyError);
 
     JSValue valueCallback = callFrame->argument(1);
     auto callData = JSC::getCallData(valueCallback);
-    if (UNLIKELY(callData.type == CallData::Type::None))
+    if (callData.type == CallData::Type::None) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "WeakMap.prototype.getOrInsertComputed requires the callback argument to be callable."_s);
 
     JSCell* keyCell = key.asCell();
@@ -194,7 +194,7 @@ JSC_DEFINE_HOST_FUNCTION(protoFuncWeakMapGetOrInsertComputed, (JSGlobalObject* g
     }
 
     JSValue value;
-    if (LIKELY(callData.type == CallData::Type::JS)) {
+    if (callData.type == CallData::Type::JS) [[likely]] {
         CachedCall cachedCall(globalObject, jsCast<JSFunction*>(valueCallback), 1);
         RETURN_IF_EXCEPTION(scope, { });
 

--- a/Source/JavaScriptCore/runtime/WeakObjectRefPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/WeakObjectRefPrototype.cpp
@@ -51,7 +51,7 @@ ALWAYS_INLINE static JSWeakObjectRef* getWeakRef(JSGlobalObject* globalObject, J
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (UNLIKELY(!value.isObject())) {
+    if (!value.isObject()) [[unlikely]] {
         throwTypeError(globalObject, scope, "Called WeakRef function on non-object"_s);
         return nullptr;
     }

--- a/Source/JavaScriptCore/runtime/WeakSetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/WeakSetPrototype.cpp
@@ -57,7 +57,7 @@ ALWAYS_INLINE static JSWeakSet* getWeakSet(JSGlobalObject* globalObject, JSValue
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (UNLIKELY(!value.isObject())) {
+    if (!value.isObject()) [[unlikely]] {
         throwTypeError(globalObject, scope, "Called WeakSet function on non-object"_s);
         return nullptr;
     }
@@ -76,7 +76,7 @@ JSC_DEFINE_HOST_FUNCTION(protoFuncWeakSetDelete, (JSGlobalObject* globalObject, 
     if (!set)
         return JSValue::encode(jsUndefined());
     JSValue key = callFrame->argument(0);
-    if (UNLIKELY(!key.isCell()))
+    if (!key.isCell()) [[unlikely]]
         return JSValue::encode(jsBoolean(false));
     return JSValue::encode(jsBoolean(set->remove(key.asCell())));
 }
@@ -87,7 +87,7 @@ JSC_DEFINE_HOST_FUNCTION(protoFuncWeakSetHas, (JSGlobalObject* globalObject, Cal
     if (!set)
         return JSValue::encode(jsUndefined());
     JSValue key = callFrame->argument(0);
-    if (UNLIKELY(!key.isCell()))
+    if (!key.isCell()) [[unlikely]]
         return JSValue::encode(jsBoolean(false));
     return JSValue::encode(jsBoolean(set->has(key.asCell())));
 }
@@ -102,7 +102,7 @@ JSC_DEFINE_HOST_FUNCTION(protoFuncWeakSetAdd, (JSGlobalObject* globalObject, Cal
     if (!set)
         return JSValue::encode(jsUndefined());
     JSValue key = callFrame->argument(0);
-    if (UNLIKELY(!canBeHeldWeakly(key)))
+    if (!canBeHeldWeakly(key)) [[unlikely]]
         return throwVMTypeError(globalObject, scope, WeakSetInvalidValueError);
     set->add(vm, key.asCell());
     return JSValue::encode(callFrame->thisValue());

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -291,7 +291,7 @@ public:
     bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, ASCIILiteral* reason) final
     {
         DollarVMAssertScope assertScope;
-        if (UNLIKELY(reason))
+        if (reason) [[unlikely]]
             *reason = "JSC::Element is opaque root"_s;
         Element* element = jsCast<Element*>(handle.slot()->asCell());
         return visitor.containsOpaqueRoot(element->root());
@@ -3270,7 +3270,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateWasmStreamingCompilerForCompile, (JSGloba
     args.append(compiler);
     ASSERT(!args.hasOverflowed());
     call(globalObject, callback, jsUndefined(), args, "You shouldn't see this..."_s);
-    if (UNLIKELY(scope.exception()))
+    if (scope.exception()) [[unlikely]]
         scope.clearException();
     compiler->streamingCompiler().finalize(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
@@ -3290,7 +3290,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateWasmStreamingCompilerForInstantiate, (JSG
 
     JSValue importArgument = callFrame->argument(1);
     JSObject* importObject = importArgument.getObject();
-    if (UNLIKELY(!importArgument.isUndefined() && !importObject))
+    if (!importArgument.isUndefined() && !importObject) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     auto compiler = WasmStreamingCompiler::create(vm, globalObject, Wasm::CompilerMode::FullCompile, importObject);
@@ -3298,7 +3298,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateWasmStreamingCompilerForInstantiate, (JSG
     args.append(compiler);
     ASSERT(!args.hasOverflowed());
     call(globalObject, callback, jsUndefined(), args, "You shouldn't see this..."_s);
-    if (UNLIKELY(scope.exception()))
+    if (scope.exception()) [[unlikely]]
         scope.clearException();
     compiler->streamingCompiler().finalize(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
@@ -4284,7 +4284,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCachedCallFromCPP, (JSGlobalObject* globalObjec
         cachedCall.appendArgument(callFrame->argument(i));
     cachedCall.setThis(jsNull());
 
-    if (UNLIKELY(cachedCall.hasOverflowedArguments()))
+    if (cachedCall.hasOverflowedArguments()) [[unlikely]]
         return JSValue::encode(jsUndefined());
 
     for (int32_t i = 0; i < count; ++i) {

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -2142,14 +2142,14 @@ private:
             RegisterBinding& binding = m_generator.gprBindings()[reg];
             m_generator.m_gprLRU.lock(reg);
             if (m_preserved.contains(reg, IgnoreVectors) && !binding.isNone()) {
-                if (UNLIKELY(Options::verboseBBQJITAllocation()))
+                if (Options::verboseBBQJITAllocation()) [[unlikely]]
                     dataLogLn("BBQ\tPreserving GPR ", MacroAssembler::gprName(reg), " currently bound to ", binding);
                 return reg; // If the register is already bound, we don't need to preserve it ourselves.
             }
             ASSERT(binding.isNone());
             binding = RegisterBinding::scratch();
             m_generator.m_gprSet.remove(reg);
-            if (UNLIKELY(Options::verboseBBQJITAllocation()))
+            if (Options::verboseBBQJITAllocation()) [[unlikely]]
                 dataLogLn("BBQ\tReserving scratch GPR ", MacroAssembler::gprName(reg));
             return reg;
         }
@@ -2161,14 +2161,14 @@ private:
             RegisterBinding& binding = m_generator.fprBindings()[reg];
             m_generator.m_fprLRU.lock(reg);
             if (m_preserved.contains(reg, Width::Width128) && !binding.isNone()) {
-                if (UNLIKELY(Options::verboseBBQJITAllocation()))
+                if (Options::verboseBBQJITAllocation()) [[unlikely]]
                     dataLogLn("BBQ\tPreserving FPR ", MacroAssembler::fprName(reg), " currently bound to ", binding);
                 return reg; // If the register is already bound, we don't need to preserve it ourselves.
             }
             ASSERT(binding.isNone());
             binding = RegisterBinding::scratch();
             m_generator.m_fprSet.remove(reg);
-            if (UNLIKELY(Options::verboseBBQJITAllocation()))
+            if (Options::verboseBBQJITAllocation()) [[unlikely]]
                 dataLogLn("BBQ\tReserving scratch FPR ", MacroAssembler::fprName(reg));
             return reg;
         }
@@ -2179,7 +2179,7 @@ private:
                 return;
             RegisterBinding& binding = m_generator.gprBindings()[reg];
             m_generator.m_gprLRU.unlock(reg);
-            if (UNLIKELY(Options::verboseBBQJITAllocation()))
+            if (Options::verboseBBQJITAllocation()) [[unlikely]]
                 dataLogLn("BBQ\tReleasing GPR ", MacroAssembler::gprName(reg), " preserved? ", m_preserved.contains(reg, IgnoreVectors), " binding: ", binding);
             if (m_preserved.contains(reg, IgnoreVectors) && !binding.isScratch())
                 return; // It's okay if the register isn't bound to a scratch if we meant to preserve it - maybe it was just already bound to something.
@@ -2194,7 +2194,7 @@ private:
                 return;
             RegisterBinding& binding = m_generator.fprBindings()[reg];
             m_generator.m_fprLRU.unlock(reg);
-            if (UNLIKELY(Options::verboseBBQJITAllocation()))
+            if (Options::verboseBBQJITAllocation()) [[unlikely]]
                 dataLogLn("BBQ\tReleasing FPR ", MacroAssembler::fprName(reg), " preserved? ", m_preserved.contains(reg, Width::Width128), " binding: ", binding);
             if (m_preserved.contains(reg, Width::Width128) && !binding.isScratch())
                 return; // It's okay if the register isn't bound to a scratch if we meant to preserve it - maybe it was just already bound to something.

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -99,7 +99,7 @@ void BBQPlan::work()
     std::unique_ptr<InternalFunction> function = compileFunction(m_functionIndex, callee.get(), context, unlinkedWasmToWasmCalls);
 
     LinkBuffer linkBuffer(*context.wasmEntrypointJIT, callee.ptr(), LinkBuffer::Profile::WasmBBQ, JITCompilationCanFail);
-    if (UNLIKELY(linkBuffer.didFailToAllocate())) {
+    if (linkBuffer.didFailToAllocate()) [[unlikely]] {
         Locker locker { m_lock };
         Base::fail(makeString("Out of executable memory while tiering up function at index "_s, m_functionIndex.rawIndex()), Plan::Error::OutOfMemory);
         return;
@@ -189,7 +189,7 @@ std::unique_ptr<InternalFunction> BBQPlan::compileFunction(FunctionCodeIndex fun
     parseAndCompileResult = parseAndCompileBBQ(context, callee, function, signature, unlinkedWasmToWasmCalls, m_moduleInformation.get(), m_mode, functionIndex, m_hasExceptionHandlers, UINT32_MAX);
     endCompilerSignpost(callee);
 
-    if (UNLIKELY(!parseAndCompileResult)) {
+    if (!parseAndCompileResult) [[unlikely]] {
         Locker locker { m_lock };
         if (!m_errorMessage) {
             // Multiple compiles could fail simultaneously. We arbitrarily choose the first.

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
@@ -191,7 +191,7 @@ protected:
         return UnexpectedResult(makeString("WebAssembly.Module doesn't parse at byte "_s, String::number(m_parser->offset() + m_offsetInSource), ": "_s, makeString(args)...));
     }
 #define WASM_COMPILE_FAIL_IF(condition, ...) do { \
-        if (UNLIKELY(condition))                  \
+        if (condition) [[unlikely]]                  \
             return fail(__VA_ARGS__);             \
     } while (0)
 
@@ -313,7 +313,7 @@ public:
             result = arrayNew(m_instance, typeIndex, size, value.getVector());
         else
             result = arrayNew(m_instance, typeIndex, size, value.getValue());
-        if (UNLIKELY(result.isNull()))
+        if (result.isNull()) [[unlikely]]
             return ConstExprValue(InvalidConstExpr);
         return ConstExprValue(Strong<JSObject>(vm, asObject(result)));
     }
@@ -382,7 +382,7 @@ public:
     {
         VM& vm = m_instance->vm();
         EncodedJSValue obj = structNew(m_instance, typeIndex, static_cast<bool>(UseDefaultValue::Yes), nullptr);
-        if (UNLIKELY(!obj))
+        if (!obj) [[unlikely]]
             return ConstExprValue(InvalidConstExpr);
         return ConstExprValue(Strong<JSObject>(vm, JSValue::decode(obj).getObject()));
     }

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -360,7 +360,7 @@ private:
 
 
 #define WASM_VALIDATOR_FAIL_IF(condition, ...) do { \
-        if (UNLIKELY(condition)) \
+        if (condition) [[unlikely]] \
             return validationFail(__VA_ARGS__); \
     } while (0) \
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -217,7 +217,7 @@ public:
         return UnexpectedResult(makeString("WebAssembly.Module failed compiling: "_s, makeString(args)...));
     }
 #define WASM_COMPILE_FAIL_IF(condition, ...) do { \
-        if (UNLIKELY(condition))                  \
+        if (condition) [[unlikely]]                  \
             return fail(__VA_ARGS__);             \
     } while (0)
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -103,7 +103,7 @@ void IPIntPlan::compileFunction(FunctionCodeIndex functionIndex)
     auto parseAndCompileResult = parseAndCompileMetadata(function.data, signature, m_moduleInformation.get(), functionIndex);
     endCompilerSignpost(CompilationMode::IPIntMode, functionIndexSpace);
 
-    if (UNLIKELY(!parseAndCompileResult)) {
+    if (!parseAndCompileResult) [[unlikely]] {
         Locker locker { m_lock };
         if (!m_errorMessage) {
             // Multiple compiles could fail simultaneously. We arbitrarily choose the first.

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -681,7 +681,7 @@ WASM_IPINT_EXTERN_CPP_DECL(array_new_default, Wasm::TypeIndex type, uint32_t siz
         defaultValue = JSValue::encode(jsNull());
     } else if (elementType.unpacked().isV128()) {
         JSValue result = Wasm::arrayNew(instance, type, size, vectorAllZeros());
-        if (UNLIKELY(result.isNull()))
+        if (result.isNull()) [[unlikely]]
             IPINT_THROW(Wasm::ExceptionType::BadArrayNew);
         IPINT_RETURN(JSValue::encode(result));
     }
@@ -700,7 +700,7 @@ WASM_IPINT_EXTERN_CPP_DECL(array_new_fixed, Wasm::TypeIndex type, uint32_t size,
         arguments[i] = sp[i].i64;
 
     JSValue result = Wasm::arrayNewFixed(instance, type, size, arguments.data());
-    if (UNLIKELY(result.isNull()))
+    if (result.isNull()) [[unlikely]]
         IPINT_THROW(Wasm::ExceptionType::BadArrayNew);
 
     IPINT_RETURN(JSValue::encode(result));

--- a/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
@@ -105,7 +105,7 @@ void LLIntPlan::compileFunction(FunctionCodeIndex functionIndex)
     auto parseAndCompileResult = parseAndCompileBytecode(function.data, signature, m_moduleInformation.get(), functionIndex);
     endCompilerSignpost(CompilationMode::LLIntMode, functionIndexSpace);
 
-    if (UNLIKELY(!parseAndCompileResult)) {
+    if (!parseAndCompileResult) [[unlikely]] {
         Locker locker { m_lock };
         if (!m_errorMessage) {
             // Multiple compiles could fail simultaneously. We arbitrarily choose the first.

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -367,7 +367,7 @@ public:
         return UnexpectedResult(makeString("WebAssembly.Module failed compiling: "_s, makeString(args)...));
     }
 #define WASM_COMPILE_FAIL_IF(condition, ...) do { \
-        if (UNLIKELY(condition))                  \
+        if (condition) [[unlikely]]                  \
             return fail(__VA_ARGS__);             \
     } while (0)
 
@@ -2539,7 +2539,7 @@ auto OMGIRGenerator::atomicLoad(ExtAtomicOpType op, Type valueType, ExpressionTy
 {
     ASSERT(pointer->type() == Int32);
 
-    if (UNLIKELY(sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op)))) {
+    if (sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op))) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
         // as a runtime exception. However, this may change: https://bugs.webkit.org/show_bug.cgi?id=166435
         B3::PatchpointValue* throwException = m_currentBlock->appendNew<B3::PatchpointValue>(m_proc, B3::Void, origin());
@@ -2577,7 +2577,7 @@ auto OMGIRGenerator::atomicStore(ExtAtomicOpType op, Type valueType, ExpressionT
 {
     ASSERT(pointer->type() == Int32);
 
-    if (UNLIKELY(sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op)))) {
+    if (sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op))) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
         // as a runtime exception. However, this may change: https://bugs.webkit.org/show_bug.cgi?id=166435
         B3::PatchpointValue* throwException = m_currentBlock->appendNew<B3::PatchpointValue>(m_proc, B3::Void, origin());
@@ -2665,7 +2665,7 @@ auto OMGIRGenerator::atomicBinaryRMW(ExtAtomicOpType op, Type valueType, Express
 {
     ASSERT(pointer->type() == Int32);
 
-    if (UNLIKELY(sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op)))) {
+    if (sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op))) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
         // as a runtime exception. However, this may change: https://bugs.webkit.org/show_bug.cgi?id=166435
         B3::PatchpointValue* throwException = m_currentBlock->appendNew<B3::PatchpointValue>(m_proc, B3::Void, origin());
@@ -2776,7 +2776,7 @@ auto OMGIRGenerator::atomicCompareExchange(ExtAtomicOpType op, Type valueType, E
 {
     ASSERT(pointer->type() == Int32);
 
-    if (UNLIKELY(sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op)))) {
+    if (sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op))) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
         // as a runtime exception. However, this may change: https://bugs.webkit.org/show_bug.cgi?id=166435
         B3::PatchpointValue* throwException = m_currentBlock->appendNew<B3::PatchpointValue>(m_proc, B3::Void, origin());

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -477,7 +477,7 @@ public:
         return UnexpectedResult(makeString("WebAssembly.Module failed compiling: "_s, makeString(args)...));
     }
 #define WASM_COMPILE_FAIL_IF(condition, ...) do { \
-        if (UNLIKELY(condition))                  \
+        if (condition) [[unlikely]]                  \
             return fail(__VA_ARGS__);             \
     } while (0)
 
@@ -2879,7 +2879,7 @@ auto OMGIRGenerator::atomicLoad(ExtAtomicOpType op, Type valueType, ExpressionTy
 {
     ASSERT(pointer->type() == Int32);
 
-    if (UNLIKELY(sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op)))) {
+    if (sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op))) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
         // as a runtime exception. However, this may change: https://bugs.webkit.org/show_bug.cgi?id=166435
         B3::PatchpointValue* throwException = append<B3::PatchpointValue>(m_proc, B3::Void, origin());
@@ -2917,7 +2917,7 @@ auto OMGIRGenerator::atomicStore(ExtAtomicOpType op, Type valueType, ExpressionT
 {
     ASSERT(pointer->type() == Int32);
 
-    if (UNLIKELY(sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op)))) {
+    if (sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op))) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
         // as a runtime exception. However, this may change: https://bugs.webkit.org/show_bug.cgi?id=166435
         B3::PatchpointValue* throwException = append<B3::PatchpointValue>(m_proc, B3::Void, origin());
@@ -3005,7 +3005,7 @@ auto OMGIRGenerator::atomicBinaryRMW(ExtAtomicOpType op, Type valueType, Express
 {
     ASSERT(pointer->type() == Int32);
 
-    if (UNLIKELY(sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op)))) {
+    if (sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op))) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
         // as a runtime exception. However, this may change: https://bugs.webkit.org/show_bug.cgi?id=166435
         B3::PatchpointValue* throwException = append<B3::PatchpointValue>(m_proc, B3::Void, origin());
@@ -3117,7 +3117,7 @@ auto OMGIRGenerator::atomicCompareExchange(ExtAtomicOpType op, Type valueType, E
 {
     ASSERT(pointer->type() == Int32);
 
-    if (UNLIKELY(sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op)))) {
+    if (sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op))) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
         // as a runtime exception. However, this may change: https://bugs.webkit.org/show_bug.cgi?id=166435
         B3::PatchpointValue* throwException = append<B3::PatchpointValue>(m_proc, B3::Void, origin());

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -138,7 +138,7 @@ void OMGPlan::work()
     auto parseAndCompileResult = parseAndCompileOMG(context, callee.get(), function, signature, unlinkedCalls, m_calleeGroup.get(), m_moduleInformation.get(), m_mode, CompilationMode::OMGMode, m_functionIndex, m_hasExceptionHandlers, UINT32_MAX);
     endCompilerSignpost(callee.get());
 
-    if (UNLIKELY(!parseAndCompileResult)) {
+    if (!parseAndCompileResult) [[unlikely]] {
         Locker locker { m_lock };
         fail(makeString(parseAndCompileResult.error(), "when trying to tier up "_s, m_functionIndex.rawIndex()), Plan::Error::Parse);
         return;
@@ -146,7 +146,7 @@ void OMGPlan::work()
 
     Entrypoint omgEntrypoint;
     LinkBuffer linkBuffer(*context.wasmEntrypointJIT, callee.ptr(), LinkBuffer::Profile::WasmOMG, JITCompilationCanFail);
-    if (UNLIKELY(linkBuffer.didFailToAllocate())) {
+    if (linkBuffer.didFailToAllocate()) [[unlikely]] {
         Locker locker { m_lock };
         Base::fail(makeString("Out of executable memory while tiering up function at index "_s, m_functionIndex.rawIndex()), Plan::Error::OutOfMemory);
         return;

--- a/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
@@ -112,7 +112,7 @@ void OSREntryPlan::work()
     auto parseAndCompileResult = parseAndCompileOMG(context, callee.get(), function, signature, unlinkedCalls, m_calleeGroup.get(), m_moduleInformation.get(), m_mode, CompilationMode::OMGForOSREntryMode, m_functionIndex, m_hasExceptionHandlers, m_loopIndex);
     endCompilerSignpost(callee.get());
 
-    if (UNLIKELY(!parseAndCompileResult)) {
+    if (!parseAndCompileResult) [[unlikely]] {
         Locker locker { m_lock };
         fail(makeString(parseAndCompileResult.error(), "when trying to tier up "_s, m_functionIndex.rawIndex()));
         return;
@@ -120,7 +120,7 @@ void OSREntryPlan::work()
 
     Entrypoint omgEntrypoint;
     LinkBuffer linkBuffer(*context.wasmEntrypointJIT, callee.ptr(), LinkBuffer::Profile::WasmOMG, JITCompilationCanFail);
-    if (UNLIKELY(linkBuffer.didFailToAllocate())) {
+    if (linkBuffer.didFailToAllocate()) [[unlikely]] {
         Locker locker { m_lock };
         Base::fail(makeString("Out of executable memory while tiering up function at index "_s, m_functionIndex.rawIndex()));
         return;

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -548,7 +548,7 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, void, (void* 
                     JSValue value = JSValue::decode(std::bit_cast<EncodedJSValue>(returned));
                     WebAssemblyFunction* wasmFunction = nullptr;
                     WebAssemblyWrapperFunction* wasmWrapperFunction = nullptr;
-                    if (UNLIKELY(!isWebAssemblyHostFunction(value, wasmFunction, wasmWrapperFunction) && !value.isNull())) {
+                    if (!isWebAssemblyHostFunction(value, wasmFunction, wasmWrapperFunction) && !value.isNull()) [[unlikely]] {
                         throwTypeError(globalObject, scope, "Funcref value is not a function"_s);
                         OPERATION_RETURN(scope);
                     }
@@ -643,7 +643,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmToJSExitIterateResults, bool, (JS
     forEachInIterable(globalObject, result, [&](VM&, JSGlobalObject*, JSValue value) -> void {
         if (buffer.size() < signature->returnCount()) {
             buffer.append(value);
-            if (UNLIKELY(buffer.hasOverflowed()))
+            if (buffer.hasOverflowed()) [[unlikely]]
                 throwOutOfMemoryError(globalObject, scope);
         }
         ++iterationCount;
@@ -685,7 +685,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmToJSExitIterateResults, bool, (JS
                 } else if (isFuncref(returnType)) {
                     WebAssemblyFunction* wasmFunction = nullptr;
                     WebAssemblyWrapperFunction* wasmWrapperFunction = nullptr;
-                    if (UNLIKELY(!isWebAssemblyHostFunction(value, wasmFunction, wasmWrapperFunction) && !value.isNull())) {
+                    if (!isWebAssemblyHostFunction(value, wasmFunction, wasmWrapperFunction) && !value.isNull()) [[unlikely]] {
                         throwTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
                         return true;
                     }
@@ -1344,7 +1344,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationConvertToFuncref, EncodedJSValue, (JS
     JSValue value = JSValue::decode(v);
     WebAssemblyFunction* wasmFunction = nullptr;
     WebAssemblyWrapperFunction* wasmWrapperFunction = nullptr;
-    if (UNLIKELY(!isWebAssemblyHostFunction(value, wasmFunction, wasmWrapperFunction) && !value.isNull())) {
+    if (!isWebAssemblyHostFunction(value, wasmFunction, wasmWrapperFunction) && !value.isNull()) [[unlikely]] {
         throwTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
         return { };
     }
@@ -1416,7 +1416,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationIterateResults, bool, (JSWebAssemblyI
     forEachInIterable(globalObject, result, [&](VM&, JSGlobalObject*, JSValue value) -> void {
         if (buffer.size() < signature->returnCount()) {
             buffer.append(value);
-            if (UNLIKELY(buffer.hasOverflowed()))
+            if (buffer.hasOverflowed()) [[unlikely]]
                 throwOutOfMemoryError(globalObject, scope);
         }
         ++iterationCount;
@@ -1458,7 +1458,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationIterateResults, bool, (JSWebAssemblyI
                 } else if (isFuncref(returnType)) {
                     WebAssemblyFunction* wasmFunction = nullptr;
                     WebAssemblyWrapperFunction* wasmWrapperFunction = nullptr;
-                    if (UNLIKELY(!isWebAssemblyHostFunction(value, wasmFunction, wasmWrapperFunction) && !value.isNull())) {
+                    if (!isWebAssemblyHostFunction(value, wasmFunction, wasmWrapperFunction) && !value.isNull()) [[unlikely]] {
                         throwTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
                         return true;
                     }
@@ -1619,7 +1619,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmStructNewEmpty, EncodedJSValue, (
     NativeCallFrameTracer tracer(vm, callFrame);
     WebAssemblyGCStructure* structure = instance->gcObjectStructure(typeIndex).get();
     auto* result = JSWebAssemblyStruct::tryCreate(vm, structure);
-    if (UNLIKELY(!result))
+    if (!result) [[unlikely]]
         return JSValue::encode(jsNull());
     return JSValue::encode(result);
 }
@@ -1835,7 +1835,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmArrayNewEmpty, EncodedJSValue, (J
     ASSERT(typeIndex < instance->module().moduleInformation().typeCount());
     WebAssemblyGCStructure* structure = instance->gcObjectStructure(typeIndex).get();
     auto* array = JSWebAssemblyArray::tryCreate(vm, structure, size);
-    if (UNLIKELY(!array))
+    if (!array) [[unlikely]]
         return JSValue::encode(jsNull());
 
     // Create a default-initialized array with the right element type and length

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -95,7 +95,7 @@ inline JSValue arrayNew(JSWebAssemblyInstance* instance, uint32_t typeIndex, uin
     default:
         RELEASE_ASSERT_NOT_REACHED();
     }
-    if (UNLIKELY(!array))
+    if (!array) [[unlikely]]
         return jsNull();
     return array;
 }
@@ -113,7 +113,7 @@ inline JSValue arrayNew(JSWebAssemblyInstance* instance, uint32_t typeIndex, uin
     ASSERT_UNUSED(fieldType, fieldType.type.unpacked() == Wasm::Types::V128);
 
     auto* array = JSWebAssemblyArray::tryCreate(vm, structure, size);
-    if (UNLIKELY(!array))
+    if (!array) [[unlikely]]
         return jsNull();
 
     array->fill(vm, 0, value, size);
@@ -126,7 +126,7 @@ JSWebAssemblyArray* tryCopyElementsInReverse(JSWebAssemblyInstance* instance, We
     VM& vm = instance->vm();
 
     auto* array = JSWebAssemblyArray::tryCreate(vm, structure, size);
-    if (UNLIKELY(!array))
+    if (!array) [[unlikely]]
         return array;
 
     if (!size)
@@ -176,7 +176,7 @@ inline JSValue arrayNewFixed(JSWebAssemblyInstance* instance, uint32_t typeIndex
     default:
         RELEASE_ASSERT_NOT_REACHED();
     }
-    if (UNLIKELY(!array))
+    if (!array) [[unlikely]]
         return jsNull();
     return array;
 }
@@ -187,7 +187,7 @@ EncodedJSValue createArrayFromDataSegment(JSWebAssemblyInstance* instance, WebAs
     JSGlobalObject* globalObject = instance->globalObject();
     VM& vm = globalObject->vm();
     auto* array = JSWebAssemblyArray::tryCreate(vm, structure, arraySize);
-    if (UNLIKELY(!array))
+    if (!array) [[unlikely]]
         return JSValue::encode(jsNull());
 
     ASSERT(!array->elementsAreRefTypes());
@@ -277,7 +277,7 @@ inline EncodedJSValue arrayNewElem(JSWebAssemblyInstance* instance, uint32_t typ
     StorageType arrayType = structure->typeDefinition().as<ArrayType>()->elementType().type;
     ASSERT_UNUSED(arrayType, isSubtype(StorageType(element->elementType), arrayType));
     auto* array = JSWebAssemblyArray::tryCreate(vm, structure, arraySize);
-    if (UNLIKELY(!array))
+    if (!array) [[unlikely]]
         return JSValue::encode(jsNull());
     instance->copyElementSegment(array, instance->module().moduleInformation().elements[elemSegmentIndex], offset, arraySize, array->span<uint64_t>().data());
     ASSERT(Wasm::isRefType(element->elementType));

--- a/Source/JavaScriptCore/wasm/WasmParser.h
+++ b/Source/JavaScriptCore/wasm/WasmParser.h
@@ -112,7 +112,7 @@ protected:
         return UnexpectedResult(makeString("WebAssembly.Module doesn't parse at byte "_s, m_offset, ": "_s, makeString(args)...));
     }
 #define WASM_PARSER_FAIL_IF(condition, ...) do { \
-    if (UNLIKELY(condition))                     \
+    if (condition) [[unlikely]]                     \
         return fail(__VA_ARGS__);                \
     } while (0)
 

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -174,14 +174,14 @@ auto SectionParser::parseImport() -> PartialResult
             bool isImport = true;
             kindIndex = m_info->tables.size();
             PartialResult result = parseTableHelper(isImport);
-            if (UNLIKELY(!result))
+            if (!result) [[unlikely]]
                 return makeUnexpected(WTFMove(result.error()));
             break;
         }
         case ExternalKind::Memory: {
             bool isImport = true;
             PartialResult result = parseMemoryHelper(isImport);
-            if (UNLIKELY(!result))
+            if (!result) [[unlikely]]
                 return makeUnexpected(WTFMove(result.error()));
             break;
         }
@@ -341,7 +341,7 @@ auto SectionParser::parseTable() -> PartialResult
     for (unsigned i = 0; i < count; ++i) {
         bool isImport = false;
         PartialResult result = parseTableHelper(isImport);
-        if (UNLIKELY(!result))
+        if (!result) [[unlikely]]
             return makeUnexpected(WTFMove(result.error()));
     }
 

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -427,7 +427,7 @@ WASM_SLOW_PATH_DECL(array_new)
             value = JSValue::encode(jsNull());
         else if (elementType.unpacked().isV128()) {
             JSValue result = Wasm::arrayNew(instance, instruction.m_typeIndex, size, vectorAllZeros());
-            if (UNLIKELY(result.isNull()))
+            if (result.isNull()) [[unlikely]]
                 WASM_THROW(Wasm::ExceptionType::BadArrayNew);
             WASM_RETURN(JSValue::encode(result));
         }
@@ -438,14 +438,14 @@ WASM_SLOW_PATH_DECL(array_new)
         // so m_value being constant would be a bug.
         ASSERT(!instruction.m_value.isConstant());
         JSValue result = Wasm::arrayNewFixed(instance, instruction.m_typeIndex, size, reinterpret_cast<uint64_t*>(&callFrame->r(instruction.m_value)));
-        if (UNLIKELY(result.isNull()))
+        if (result.isNull()) [[unlikely]]
             WASM_THROW(Wasm::ExceptionType::BadArrayNew);
         WASM_RETURN(JSValue::encode(result));
     }
     }
     ASSERT(!elementType.unpacked().isV128());
     JSValue result = Wasm::arrayNew(instance, instruction.m_typeIndex, size, value);
-    if (UNLIKELY(result.isNull()))
+    if (result.isNull()) [[unlikely]]
         WASM_THROW(Wasm::ExceptionType::BadArrayNew);
     WASM_RETURN(JSValue::encode(result));
 }

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
@@ -157,7 +157,7 @@ void StreamingCompiler::didComplete()
             VM& vm = globalObject->vm();
             auto scope = DECLARE_THROW_SCOPE(vm);
 
-            if (UNLIKELY(!result.has_value())) {
+            if (!result.has_value()) [[unlikely]] {
                 throwException(globalObject, scope, createJSWebAssemblyCompileError(globalObject, vm, result.error()));
                 promise->rejectWithCaughtException(globalObject, scope);
                 return;
@@ -179,7 +179,7 @@ void StreamingCompiler::didComplete()
             VM& vm = globalObject->vm();
             auto scope = DECLARE_THROW_SCOPE(vm);
 
-            if (UNLIKELY(!result.has_value())) {
+            if (!result.has_value()) [[unlikely]] {
                 throwException(globalObject, scope, createJSWebAssemblyCompileError(globalObject, vm, result.error()));
                 promise->rejectWithCaughtException(globalObject, scope);
                 return;
@@ -187,7 +187,7 @@ void StreamingCompiler::didComplete()
 
             JSWebAssemblyModule* module = JSWebAssemblyModule::create(vm, globalObject->webAssemblyModuleStructure(), WTFMove(result.value()));
             JSWebAssembly::instantiateForStreaming(vm, globalObject, promise, module, importObject);
-            if (UNLIKELY(scope.exception())) {
+            if (scope.exception()) [[unlikely]] {
                 promise->rejectWithCaughtException(globalObject, scope);
                 return;
             }

--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -152,7 +152,7 @@ std::optional<uint32_t> Table::grow(uint32_t delta, JSValue defaultValue)
         bool success = checkedGrow(static_cast<ExternOrAnyRefTable*>(this)->m_jsValues, [&](auto& slot) {
             slot.set(vm, m_owner, defaultValue);
         });
-        if (UNLIKELY(!success))
+        if (!success) [[unlikely]]
             return std::nullopt;
         break;
     }
@@ -160,7 +160,7 @@ std::optional<uint32_t> Table::grow(uint32_t delta, JSValue defaultValue)
         bool success = checkedGrow(static_cast<FuncRefTable*>(this)->m_importableFunctions, [&](auto& slot) {
             slot.m_value.set(vm, m_owner, defaultValue);
         });
-        if (UNLIKELY(!success))
+        if (!success) [[unlikely]]
             return std::nullopt;
         break;
     }

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -779,7 +779,7 @@ CodePtr<JSEntryPtrTag> FunctionSignature::jsToWasmICEntrypoint() const
     jit.farJump(GPRInfo::returnValueGPR, ExceptionHandlerPtrTag);
 
     LinkBuffer linkBuffer(jit, nullptr, LinkBuffer::Profile::WasmThunk, JITCompilationCanFail);
-    if (UNLIKELY(linkBuffer.didFailToAllocate()))
+    if (linkBuffer.didFailToAllocate()) [[unlikely]]
         return nullptr;
 
     auto code = FINALIZE_WASM_CODE(linkBuffer, JSEntryPtrTag, nullptr, "JS->Wasm IC %s", WTF::toCString(*this).data());

--- a/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
@@ -156,7 +156,7 @@ void JSWebAssembly::webAssemblyModuleValidateAsync(JSGlobalObject* globalObject,
         vm.deferredWorkTimer->scheduleWorkSoon(ticket, [promise, globalObject, result = WTFMove(result), &vm](DeferredWorkTimer::Ticket) mutable {
             auto scope = DECLARE_THROW_SCOPE(vm);
 
-            if (UNLIKELY(!result.has_value())) {
+            if (!result.has_value()) [[unlikely]] {
                 throwException(globalObject, scope, createJSWebAssemblyCompileError(globalObject, vm, result.error()));
                 promise->rejectWithCaughtException(globalObject, scope);
                 return;
@@ -177,13 +177,13 @@ static void instantiate(VM& vm, JSGlobalObject* globalObject, JSPromise* promise
     // In order to avoid potentially recompiling a module. We first gather all the import/memory information prior to compiling code.
     // When called via the module loader, the memory is not available yet at this step, so we skip initializing the memory here.
     JSWebAssemblyInstance* instance = JSWebAssemblyInstance::tryCreate(vm, globalObject->webAssemblyInstanceStructure(), globalObject, moduleKey, module, importObject, creationMode);
-    if (UNLIKELY(scope.exception())) {
+    if (scope.exception()) [[unlikely]] {
         promise->rejectWithCaughtException(globalObject, scope);
         return;
     }
 
     instance->initializeImports(globalObject, importObject, creationMode);
-    if (UNLIKELY(scope.exception())) {
+    if (scope.exception()) [[unlikely]] {
         promise->rejectWithCaughtException(globalObject, scope);
         return;
     }
@@ -200,7 +200,7 @@ static void instantiate(VM& vm, JSGlobalObject* globalObject, JSPromise* promise
             auto scope = DECLARE_THROW_SCOPE(vm);
             JSGlobalObject* globalObject = instance->globalObject();
             instance->finalizeCreation(vm, globalObject, WTFMove(calleeGroup), creationMode);
-            if (UNLIKELY(scope.exception())) {
+            if (scope.exception()) [[unlikely]] {
                 promise->rejectWithCaughtException(globalObject, scope);
                 return;
             }
@@ -242,7 +242,7 @@ static void compileAndInstantiate(VM& vm, JSGlobalObject* globalObject, JSPromis
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     Vector<uint8_t> source = createSourceBufferFromValue(vm, globalObject, buffer);
-    if (UNLIKELY(scope.exception())) {
+    if (scope.exception()) [[unlikely]] {
         promise->rejectWithCaughtException(globalObject, scope);
         return;
     }
@@ -257,7 +257,7 @@ static void compileAndInstantiate(VM& vm, JSGlobalObject* globalObject, JSPromis
         vm.deferredWorkTimer->scheduleWorkSoon(ticket, [promise, importObject, moduleKeyCell, globalObject, result = WTFMove(result), resolveKind, creationMode, &vm](DeferredWorkTimer::Ticket) mutable {
             auto scope = DECLARE_THROW_SCOPE(vm);
 
-            if (UNLIKELY(!result.has_value())) {
+            if (!result.has_value()) [[unlikely]] {
                 throwException(globalObject, scope, createJSWebAssemblyCompileError(globalObject, vm, result.error()));
                 promise->rejectWithCaughtException(globalObject, scope);
                 return;
@@ -266,13 +266,13 @@ static void compileAndInstantiate(VM& vm, JSGlobalObject* globalObject, JSPromis
             JSWebAssemblyModule* module = JSWebAssemblyModule::create(vm, globalObject->webAssemblyModuleStructure(), WTFMove(result.value()));
 
             const Identifier moduleKey = JSValue(moduleKeyCell).toPropertyKey(globalObject);
-            if (UNLIKELY(scope.exception())) {
+            if (scope.exception()) [[unlikely]] {
                 promise->rejectWithCaughtException(globalObject, scope);
                 return;
             }
 
             instantiate(vm, globalObject, promise, module, importObject, moduleKey, resolveKind, creationMode, /* alwaysAsync */ false);
-            if (UNLIKELY(scope.exception())) {
+            if (scope.exception()) [[unlikely]] {
                 promise->rejectWithCaughtException(globalObject, scope);
                 return;
             }
@@ -299,7 +299,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyInstantiateFunc, (JSGlobalObject* globalObje
     auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
     JSValue importArgument = callFrame->argument(1);
     JSObject* importObject = importArgument.getObject();
-    if (UNLIKELY(!importArgument.isUndefined() && !importObject))
+    if (!importArgument.isUndefined() && !importObject) [[unlikely]]
         return JSValue::encode(JSPromise::rejectedPromise(globalObject, createTypeError(globalObject, "second argument to WebAssembly.instantiate must be undefined or an Object"_s, defaultSourceAppender, runtimeTypeForValue(importArgument))));
 
     JSValue firstArgument = callFrame->argument(0);
@@ -334,7 +334,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyInstantiateStreamingInternal, (JSGlobalObjec
 {
     JSValue importArgument = callFrame->argument(1);
     JSObject* importObject = importArgument.getObject();
-    if (UNLIKELY(!importArgument.isUndefined() && !importObject))
+    if (!importArgument.isUndefined() && !importObject) [[unlikely]]
         return JSValue::encode(JSPromise::rejectedPromise(globalObject, createTypeError(globalObject, "second argument to WebAssembly.instantiateStreaming must be undefined or an Object"_s, defaultSourceAppender, runtimeTypeForValue(importArgument))));
 
     ASSERT(globalObject->globalObjectMethodTable()->instantiateStreaming);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.cpp
@@ -79,7 +79,7 @@ std::optional<uint32_t> JSWebAssemblyTable::grow(JSGlobalObject* globalObject, u
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     uint64_t wasmValue = 0;
-    if (UNLIKELY(isExnref(m_table->wasmType()))) {
+    if (isExnref(m_table->wasmType())) [[unlikely]] {
         if (!defaultValue.isNull()) {
             throwTypeError(globalObject, scope, "Table.grow cannot handle exnref table"_s);
             return { };
@@ -98,7 +98,7 @@ JSValue JSWebAssemblyTable::get(JSGlobalObject* globalObject, uint32_t index)
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (UNLIKELY(isExnref(m_table->wasmType()))) {
+    if (isExnref(m_table->wasmType())) [[unlikely]] {
         throwTypeError(globalObject, scope, "Table.get cannot handle exnref table"_s);
         return { };
     }
@@ -111,7 +111,7 @@ void JSWebAssemblyTable::set(JSGlobalObject* globalObject, uint32_t index, JSVal
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (UNLIKELY(isExnref(m_table->wasmType()))) {
+    if (isExnref(m_table->wasmType())) [[unlikely]] {
         throwTypeError(globalObject, scope, "Table.set cannot handle exnref table"_s);
         return;
     }

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
@@ -58,7 +58,7 @@ static Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> handleBa
     emitThrowWasmToJSException(jit, GPRInfo::argumentGPR0, exceptionType);
 
     LinkBuffer linkBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::WasmThunk, JITCompilationCanFail);
-    if (UNLIKELY(linkBuffer.didFailToAllocate()))
+    if (linkBuffer.didFailToAllocate()) [[unlikely]]
         return makeUnexpected(BindingFailure::OutOfMemory);
 
     return FINALIZE_WASM_CODE(linkBuffer, WasmEntryPtrTag, nullptr, "WebAssembly->JavaScript throw exception due to invalid use of restricted type in import[%i]", importIndex);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionPrototype.cpp
@@ -82,7 +82,7 @@ ALWAYS_INLINE static JSWebAssemblyException* getException(JSGlobalObject* global
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (UNLIKELY(!thisValue.isCell())) {
+    if (!thisValue.isCell()) [[unlikely]] {
         throwVMError(globalObject, scope, createNotAnObjectError(globalObject, thisValue));
         return nullptr;
     }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp
@@ -299,7 +299,7 @@ JSWebAssemblyModule* WebAssemblyModuleConstructor::createModule(JSGlobalObject* 
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     auto result = Wasm::Module::validateSync(vm, WTFMove(buffer));
-    if (UNLIKELY(!result.has_value())) {
+    if (!result.has_value()) [[unlikely]] {
         throwException(globalObject, scope, createJSWebAssemblyCompileError(globalObject, vm, result.error()));
         return nullptr;
     }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -877,7 +877,7 @@ JSValue WebAssemblyModuleRecord::evaluate(JSGlobalObject* globalObject)
         return IterationStatus::Continue;
     });
 
-    if (UNLIKELY(exception))
+    if (exception) [[unlikely]]
         return exception.value();
 
     // Validation of all segment ranges comes before all Table and Memory initialization.
@@ -899,7 +899,7 @@ JSValue WebAssemblyModuleRecord::evaluate(JSGlobalObject* globalObject)
         return IterationStatus::Continue;
     });
 
-    if (UNLIKELY(exception))
+    if (exception) [[unlikely]]
         return exception.value();
 
     ASSERT(!exception);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTagPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTagPrototype.cpp
@@ -81,7 +81,7 @@ ALWAYS_INLINE static JSWebAssemblyTag* getTag(JSGlobalObject* globalObject, JSVa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (UNLIKELY(!thisValue.isCell())) {
+    if (!thisValue.isCell()) [[unlikely]] {
         throwVMError(globalObject, scope, createNotAnObjectError(globalObject, thisValue));
         return nullptr;
     }

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -1421,7 +1421,7 @@ public:
             while (backTrack->matchAmount < minimumMatchCount) {
                 // Try to do a match, and it it succeeds, add it to the list.
                 ParenthesesDisjunctionContext* context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
-                if (UNLIKELY(!context))
+                if (!context) [[unlikely]]
                     return JSRegExpResult::ErrorNoMemory;
                 fixedMatchResult = matchDisjunction(disjunctionBody, context->getDisjunctionContext());
                 if (fixedMatchResult == JSRegExpResult::Match)
@@ -1452,7 +1452,7 @@ public:
         case QuantifierType::Greedy: {
             while (backTrack->matchAmount < term.atom.quantityMaxCount) {
                 ParenthesesDisjunctionContext* context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
-                if (UNLIKELY(!context))
+                if (!context) [[unlikely]]
                     return JSRegExpResult::ErrorNoMemory;
                 JSRegExpResult result = matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext());
                 if (result == JSRegExpResult::Match)
@@ -1514,7 +1514,7 @@ public:
             while (backTrack->matchAmount < term.atom.quantityMaxCount) {
                 // Try to do a match, and it it succeeds, add it to the list.
                 context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
-                if (UNLIKELY(!context))
+                if (!context) [[unlikely]]
                     return JSRegExpResult::ErrorNoMemory;
                 result = matchDisjunction(disjunctionBody, context->getDisjunctionContext());
 
@@ -1548,7 +1548,7 @@ public:
             if (result == JSRegExpResult::Match) {
                 while (backTrack->matchAmount < term.atom.quantityMaxCount) {
                     ParenthesesDisjunctionContext* context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
-                    if (UNLIKELY(!context))
+                    if (!context) [[unlikely]]
                         return JSRegExpResult::ErrorNoMemory;
                     JSRegExpResult parenthesesResult = matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext());
                     if (parenthesesResult == JSRegExpResult::Match)
@@ -1595,7 +1595,7 @@ public:
             // If we've not reached the limit, try to add one more match.
             if (backTrack->matchAmount < term.atom.quantityMaxCount) {
                 ParenthesesDisjunctionContext* context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
-                if (UNLIKELY(!context))
+                if (!context) [[unlikely]]
                     return JSRegExpResult::ErrorNoMemory;
                 JSRegExpResult result = matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext());
                 if (result == JSRegExpResult::Match) {
@@ -1724,7 +1724,7 @@ public:
 
     JSRegExpResult matchDisjunction(ByteDisjunction* disjunction, DisjunctionContext* context, bool btrack = false)
     {
-        if (UNLIKELY(!isSafeToRecurse()))
+        if (!isSafeToRecurse()) [[unlikely]]
             return JSRegExpResult::ErrorNoMemory;
 
         if (!--remainingMatchCount) {
@@ -2210,7 +2210,7 @@ public:
         RELEASE_ASSERT(allocatorPool);
 
         DisjunctionContext* context = allocDisjunctionContext(pattern->m_body.get());
-        if (UNLIKELY(!context))
+        if (!context) [[unlikely]]
             return offsetNoMatch;
 
         dataLogLnIf(verbose, "  Interpret input: ", input, "\n  Matching");
@@ -2278,7 +2278,7 @@ public:
 
     std::unique_ptr<BytecodePattern> compile(BumpPointerAllocator* allocator, ConcurrentJSLock* lock, ErrorCode& errorCode)
     {
-        if (UNLIKELY(!isSafeToRecurse())) {
+        if (!isSafeToRecurse()) [[unlikely]] {
             errorCode = ErrorCode::TooManyDisjunctions;
             return nullptr;
         }
@@ -2666,7 +2666,7 @@ public:
 
     std::optional<ErrorCode> WARN_UNUSED_RETURN emitDisjunction(PatternDisjunction* disjunction, CheckedUint32 inputCountAlreadyChecked, unsigned parenthesesInputCountAlreadyChecked, MatchDirection matchDirection = Forward)
     {
-        if (UNLIKELY(!isSafeToRecurse()))
+        if (!isSafeToRecurse()) [[unlikely]]
             return ErrorCode::TooManyDisjunctions;
 
         for (unsigned alt = 0; alt < disjunction->m_alternatives.size(); ++alt) {

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -4473,7 +4473,7 @@ class YarrGenerator final : public YarrJITInfo {
         YarrOpCode alternativeNextOpCode = YarrOpCode::SimpleNestedAlternativeNext;
         YarrOpCode alternativeEndOpCode = YarrOpCode::SimpleNestedAlternativeEnd;
 
-        if (UNLIKELY(!isSafeToRecurse())) {
+        if (!isSafeToRecurse()) [[unlikely]] {
             m_failureReason = JITFailureReason::ParenthesisNestedTooDeep;
             return;
         }
@@ -4622,7 +4622,7 @@ class YarrGenerator final : public YarrJITInfo {
     // once, and will never backtrack back into the assertion.
     void opCompileParentheticalAssertion(Checked<unsigned> checkedOffset, PatternTerm* term)
     {
-        if (UNLIKELY(!isSafeToRecurse())) {
+        if (!isSafeToRecurse()) [[unlikely]] {
             m_failureReason = JITFailureReason::ParenthesisNestedTooDeep;
             return;
         }
@@ -4723,7 +4723,7 @@ class YarrGenerator final : public YarrJITInfo {
     // to return the failing result.
     void opCompileBody(PatternDisjunction* disjunction)
     {
-        if (UNLIKELY(!isSafeToRecurse())) {
+        if (!isSafeToRecurse()) [[unlikely]] {
             m_failureReason = JITFailureReason::ParenthesisNestedTooDeep;
             return;
         }

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1563,7 +1563,7 @@ public:
     // skip alternatives with m_startsWithBOL set true.
     PatternDisjunction* copyDisjunction(PatternDisjunction* disjunction, bool filterStartsWithBOL)
     {
-        if (UNLIKELY(!isSafeToRecurse())) {
+        if (!isSafeToRecurse()) [[unlikely]] {
             m_error = ErrorCode::PatternTooLarge;
             return nullptr;
         }
@@ -1601,7 +1601,7 @@ public:
     
     std::optional<PatternTerm> copyTerm(PatternTerm& term, bool filterStartsWithBOL)
     {
-        if (UNLIKELY(!isSafeToRecurse())) {
+        if (!isSafeToRecurse()) [[unlikely]] {
             m_error = ErrorCode::PatternTooLarge;
             return PatternTerm(term);
         }
@@ -1704,7 +1704,7 @@ public:
 
     ErrorCode setupAlternativeOffsets(PatternAlternative* alternative, unsigned currentCallFrameSize, unsigned initialInputPosition, unsigned& newCallFrameSize) WARN_UNUSED_RETURN
     {
-        if (UNLIKELY(!isSafeToRecurse()))
+        if (!isSafeToRecurse()) [[unlikely]]
             return ErrorCode::TooManyDisjunctions;
 
         ErrorCode error = ErrorCode::NoError;
@@ -1829,7 +1829,7 @@ public:
 
     ErrorCode setupDisjunctionOffsets(PatternDisjunction* disjunction, unsigned initialCallFrameSize, unsigned initialInputPosition, unsigned& callFrameSize)
     {
-        if (UNLIKELY(!isSafeToRecurse()))
+        if (!isSafeToRecurse()) [[unlikely]]
             return ErrorCode::TooManyDisjunctions;
 
         if ((disjunction != m_pattern.m_body) && (disjunction->m_alternatives.size() > 1))

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringContext.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringContext.cpp
@@ -211,7 +211,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsTestStringContextConstructor, (JSGlobalObject* lexica
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto* prototype = jsDynamicCast<JSTestStringContextPrototype*>(JSValue::decode(thisValue));
-    if (UNLIKELY(!prototype))
+    if (!prototype) [[unlikely]]
         return throwVMTypeError(lexicalGlobalObject, throwScope);
     return JSValue::encode(JSTestStringContext::getConstructor(vm, prototype->globalObject()));
 }

--- a/Source/WebCore/css/parser/CSSTokenizer.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizer.cpp
@@ -59,7 +59,7 @@ std::unique_ptr<CSSTokenizer> CSSTokenizer::tryCreate(const String& string)
     bool success = true;
     // We can't use makeUnique here because it does not have access to this private constructor.
     auto tokenizer = std::unique_ptr<CSSTokenizer>(new CSSTokenizer(string, nullptr, &success));
-    if (UNLIKELY(!success))
+    if (!success) [[unlikely]]
         return nullptr;
     return tokenizer;
 }
@@ -69,7 +69,7 @@ std::unique_ptr<CSSTokenizer> CSSTokenizer::tryCreate(const String& string, CSSP
     bool success = true;
     // We can't use makeUnique here because it does not have access to this private constructor.
     auto tokenizer = std::unique_ptr<CSSTokenizer>(new CSSTokenizer(string, &wrapper, &success));
-    if (UNLIKELY(!success))
+    if (!success) [[unlikely]]
         return nullptr;
     return tokenizer;
 }

--- a/Source/WebCore/dom/InternalObserverEvery.cpp
+++ b/Source/WebCore/dom/InternalObserverEvery.cpp
@@ -68,7 +68,7 @@ private:
             auto result = protectedCallback()->invokeRethrowingException(value, m_idx++);
 
             JSC::Exception* exception = scope.exception();
-            if (UNLIKELY(exception)) {
+            if (exception) [[unlikely]] {
                 scope.clearException();
                 auto value = exception->value();
                 protectedPromise()->reject<IDLAny>(value);

--- a/Source/WebCore/dom/InternalObserverFind.cpp
+++ b/Source/WebCore/dom/InternalObserverFind.cpp
@@ -69,7 +69,7 @@ private:
             auto result = protectedCallback()->invokeRethrowingException(value, m_idx++);
 
             JSC::Exception* exception = scope.exception();
-            if (UNLIKELY(exception)) {
+            if (exception) [[unlikely]] {
                 scope.clearException();
                 auto value = exception->value();
                 protectedPromise()->reject<IDLAny>(value);

--- a/Source/WebCore/dom/InternalObserverForEach.cpp
+++ b/Source/WebCore/dom/InternalObserverForEach.cpp
@@ -66,7 +66,7 @@ private:
             protectedCallback()->invokeRethrowingException(value, m_idx++);
 
             JSC::Exception* exception = scope.exception();
-            if (UNLIKELY(exception)) {
+            if (exception) [[unlikely]] {
                 scope.clearException();
                 auto value = exception->value();
                 protectedPromise()->reject<IDLAny>(value);

--- a/Source/WebCore/dom/InternalObserverInspect.cpp
+++ b/Source/WebCore/dom/InternalObserverInspect.cpp
@@ -75,7 +75,7 @@ public:
                 subscribe->invokeRethrowingException();
 
                 JSC::Exception* exception = scope.exception();
-                if (UNLIKELY(exception)) {
+                if (exception) [[unlikely]] {
                     scope.clearException();
                     subscriber.error(exception->value());
                     return { };
@@ -117,7 +117,7 @@ private:
             next->invokeRethrowingException(value);
 
             JSC::Exception* exception = scope.exception();
-            if (UNLIKELY(exception)) {
+            if (exception) [[unlikely]] {
                 scope.clearException();
                 protectedSubscriber()->error(exception->value());
                 return;
@@ -139,7 +139,7 @@ private:
             error->invokeRethrowingException(value);
 
             JSC::Exception* exception = scope.exception();
-            if (UNLIKELY(exception)) {
+            if (exception) [[unlikely]] {
                 scope.clearException();
                 protectedSubscriber()->error(exception->value());
                 return;
@@ -163,7 +163,7 @@ private:
             complete->invokeRethrowingException();
 
             JSC::Exception* exception = scope.exception();
-            if (UNLIKELY(exception)) {
+            if (exception) [[unlikely]] {
                 scope.clearException();
                 protectedSubscriber()->error(exception->value());
                 return;

--- a/Source/WebCore/dom/InternalObserverReduce.cpp
+++ b/Source/WebCore/dom/InternalObserverReduce.cpp
@@ -71,7 +71,7 @@ private:
         auto result = protectedCallback()->invokeRethrowingException(m_accumulator.getValue(), value, m_index++);
 
         JSC::Exception* exception = scope.exception();
-        if (UNLIKELY(exception)) {
+        if (exception) [[unlikely]] {
             scope.clearException();
             auto value = exception->value();
             protectedPromise()->reject<IDLAny>(value);

--- a/Source/WebCore/dom/InternalObserverSome.cpp
+++ b/Source/WebCore/dom/InternalObserverSome.cpp
@@ -69,7 +69,7 @@ private:
             auto result = protectedCallback()->invokeRethrowingException(value, m_idx++);
 
             JSC::Exception* exception = scope.exception();
-            if (UNLIKELY(exception)) {
+            if (exception) [[unlikely]] {
                 scope.clearException();
                 auto value = exception->value();
                 protectedPromise()->reject<IDLAny>(value);

--- a/Source/WebCore/dom/Microtasks.cpp
+++ b/Source/WebCore/dom/Microtasks.cpp
@@ -92,7 +92,7 @@ void MicrotaskQueue::runJSMicrotask(JSC::JSGlobalObject* globalObject, JSC::VM& 
         ++count;
     }
 
-    if (UNLIKELY(globalObject->hasDebugger())) {
+    if (globalObject->hasDebugger()) [[unlikely]] {
         JSC::DeferTerminationForAWhile deferTerminationForAWhile(vm);
         globalObject->debugger()->willRunMicrotask(globalObject, task.identifier());
         scope.clearException();
@@ -106,7 +106,7 @@ void MicrotaskQueue::runJSMicrotask(JSC::JSGlobalObject* globalObject, JSC::VM& 
         scope.clearExceptionExceptTermination();
     }
 
-    if (UNLIKELY(globalObject->hasDebugger())) {
+    if (globalObject->hasDebugger()) [[unlikely]] {
         JSC::DeferTerminationForAWhile deferTerminationForAWhile(vm);
         globalObject->debugger()->didRunMicrotask(globalObject, task.identifier());
         scope.clearException();


### PR DESCRIPTION
#### 535276bda0d5247cf3048b00be36a6503674aec6
<pre>
Further adopt C++20&apos;s [[likely]] / [[unlikely]] in JSC
<a href="https://bugs.webkit.org/show_bug.cgi?id=292493">https://bugs.webkit.org/show_bug.cgi?id=292493</a>

Reviewed by Yusuke Suzuki.

* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::argumentClampedIndexFromStartOrEnd):
(JSC::argumentUnclampedIndexFromStartOrEnd):
(JSC::fastJoin):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::createArrayIteratorObject):
(JSC::sortCompact):
(JSC::sortStableSort):
(JSC::sortCommit):
(JSC::sortImpl):
(JSC::fastIndexOf):
(JSC::concatAppendOne):
(JSC::concatAppendArray):
* Source/JavaScriptCore/runtime/DatePrototype.cpp:
(JSC::formateDateInstance):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::setNewValueFromTimeArgs):
(JSC::setNewValueFromDateArgs):
* Source/JavaScriptCore/runtime/FunctionConstructor.cpp:
(JSC::stringifyFunction):
(JSC::constructFunction):
(JSC::constructFunctionSkippingEvalEnabledCheck):
* Source/JavaScriptCore/runtime/FunctionExecutable.h:
* Source/JavaScriptCore/runtime/GenericArgumentsImplInlines.h:
(JSC::GenericArgumentsImpl&lt;Type&gt;::put):
(JSC::GenericArgumentsImpl&lt;Type&gt;::initModifiedArgumentsDescriptor):
* Source/JavaScriptCore/runtime/ImportMap.cpp:
(JSC::normalizeSpecifierKey):
(JSC::sortAndNormalizeSpecifierMap):
(JSC::ImportMap::parseImportMapString):
* Source/JavaScriptCore/runtime/IndexingHeaderInlines.h:
(JSC::IndexingHeader::preCapacity):
* Source/JavaScriptCore/runtime/InferredValue.h:
(JSC::InferredValue::notifyWrite):
(JSC::InferredValue::inflate):
* Source/JavaScriptCore/runtime/InternalFunction.cpp:
(JSC::InternalFunction::createSubclassStructure):
* Source/JavaScriptCore/runtime/IntlCollatorPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSC_DEFINE_CUSTOM_GETTER):
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::IntlDateTimeFormat::initializeDateTimeFormat):
* Source/JavaScriptCore/runtime/IntlDateTimeFormatPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSC_DEFINE_CUSTOM_GETTER):
* Source/JavaScriptCore/runtime/IntlDisplayNamesPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlDurationFormatPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlListFormatPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlLocalePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSC_DEFINE_CUSTOM_GETTER):
* Source/JavaScriptCore/runtime/IntlNumberFormatPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSC_DEFINE_CUSTOM_GETTER):
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::canonicalizeLocaleList):
* Source/JavaScriptCore/runtime/IntlObjectInlines.h:
(JSC::unwrapForLegacyIntlConstructor):
(JSC::intlGetOptionsObject):
* Source/JavaScriptCore/runtime/IntlPluralRules.cpp:
(JSC::IntlPluralRules::resolvedOptions const):
* Source/JavaScriptCore/runtime/IntlPluralRulesPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp:
(JSC::IntlRelativeTimeFormat::initializeRelativeTimeFormat):
(JSC::IntlRelativeTimeFormat::formatInternal const):
* Source/JavaScriptCore/runtime/IntlRelativeTimeFormatPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlSegmentIteratorPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlSegmenterPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlSegmentsPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IteratorOperations.cpp:
(JSC::iteratorClose):
* Source/JavaScriptCore/runtime/IteratorOperations.h:
(JSC::forEachInFastArray):
(JSC::forEachInIterationRecord):
(JSC::forEachInIterable):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::tryCreateUninitializedRestricted):
(JSC::JSArray::eagerlyInitializeButterfly):
(JSC::JSArray::put):
(JSC::JSArray::fastToReversed):
(JSC::JSArray::fastWith):
(JSC::JSArray::fastToSpliced):
(JSC::JSArray::fastSlice):
(JSC::JSArray::shiftCountWithAnyIndexingType):
(JSC::JSArray::unshiftCountWithAnyIndexingType):
(JSC::constructArrayNegativeIndexed):
(JSC::tryCloneArrayFromFast):
* Source/JavaScriptCore/runtime/JSArray.h:
(JSC::JSArray::tryCreate):
* Source/JavaScriptCore/runtime/JSArrayBufferConstructor.cpp:
(JSC::JSGenericArrayBufferConstructor&lt;sharingMode&gt;::constructImpl):
(JSC::constructArrayBufferWithSize):
* Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp:
(JSC::arrayBufferSpeciesConstructorSlow):
(JSC::arrayBufferCopyAndDetach):
* Source/JavaScriptCore/runtime/JSArrayBufferPrototypeInlines.h:
(JSC::arrayBufferSpeciesConstructor):
* Source/JavaScriptCore/runtime/JSArrayBufferView.h:
(JSC::JSArrayBufferView::byteOffset const):
(JSC::JSArrayBufferView::length const):
(JSC::JSArrayBufferView::byteLength const):
(JSC::JSArrayBufferView::isOutOfBounds const):
* Source/JavaScriptCore/runtime/JSArrayInlines.h:
(JSC::JSArray::pushInline):
* Source/JavaScriptCore/runtime/JSBigInt.cpp:
(JSC::JSBigInt::createWithLength):
(JSC::JSBigInt::absoluteDivWithDigitDivisor):
* Source/JavaScriptCore/runtime/JSBoundFunction.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSBoundFunction::create):
(JSC::JSBoundFunction::nameSlow):
* Source/JavaScriptCore/runtime/JSCJSValue.cpp:
(JSC::JSValue::putToPrimitive):
(JSC::JSValue::putToPrimitiveByIndex):
* Source/JavaScriptCore/runtime/JSCJSValueInlines.h:
(JSC::JSValue::getPropertySlot const):
(JSC::JSValue::getOwnPropertySlot const):
(JSC::JSValue::get const):
(JSC::JSValue::put):
(JSC::JSValue::putInline):
(JSC::JSValue::putByIndex):
* Source/JavaScriptCore/runtime/JSDataView.h:
(JSC::JSDataView::viewByteLength):
* Source/JavaScriptCore/runtime/JSDataViewPrototype.cpp:
(JSC::getData):
(JSC::setData):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSC_DEFINE_CUSTOM_GETTER):
* Source/JavaScriptCore/runtime/JSFunction.cpp:
(JSC::JSFunction::put):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h:
(JSC::constructGenericTypedArrayViewFromIterator):
(JSC::constructGenericTypedArrayViewWithArguments):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::setFromArrayLike):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::byteLength const):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::inBounds const):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::speciesConstruct):
(JSC::argumentClampedIndexFromStartOrEnd):
(JSC::genericTypedArrayViewProtoFuncSet):
(JSC::genericTypedArrayViewProtoFuncCopyWithin):
(JSC::genericTypedArrayViewProtoFuncIncludes):
(JSC::genericTypedArrayViewProtoFuncIndexOf):
(JSC::genericTypedArrayViewProtoFuncJoin):
(JSC::genericTypedArrayViewProtoFuncFill):
(JSC::genericTypedArrayViewProtoFuncLastIndexOf):
(JSC::genericTypedArrayViewProtoFuncForEach):
(JSC::genericTypedArrayViewProtoFuncFind):
(JSC::genericTypedArrayViewProtoFuncFindIndex):
(JSC::genericTypedArrayViewProtoFuncFindLast):
(JSC::genericTypedArrayViewProtoFuncFindLastIndex):
(JSC::genericTypedArrayViewProtoFuncEvery):
(JSC::genericTypedArrayViewProtoFuncSome):
(JSC::genericTypedArrayViewProtoFuncSortImpl):
(JSC::genericTypedArrayViewProtoFuncSort):
(JSC::genericTypedArrayViewProtoFuncToSorted):
(JSC::genericTypedArrayViewPrivateFuncFromFast):
(JSC::genericTypedArrayViewProtoFuncSlice):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::put):
(JSC::JSGlobalObject::createGlobalFunctionBinding):
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::encode):
(JSC::decode):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h:
(JSC::constructEmptyArray):
(JSC::constructArrayNegativeIndexed):
(JSC::tryCreateContiguousArrayWithPattern):
(JSC::JSGlobalObject::createGlobalVarBinding):
* Source/JavaScriptCore/runtime/JSImmutableButterfly.cpp:
(JSC::JSImmutableButterfly::createFromClonedArguments):
(JSC::createFromNonClonedArguments):
(JSC::JSImmutableButterfly::createFromString):
(JSC::JSImmutableButterfly::tryCreateFromArgList):
* Source/JavaScriptCore/runtime/JSImmutableButterfly.h:
(JSC::JSImmutableButterfly::tryCreate):
(JSC::JSImmutableButterfly::createFromArray):
* Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSLock.cpp:
(JSC::JSLock::didAcquireLock):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::runJSMicrotask):
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::Stringifier::appendStringifiedValue):
(JSC::Stringifier::Holder::appendNextProperty):
(JSC::bufferMode&gt;::append):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::calculatedClassName):
(JSC::JSObject::putInlineSlow):
(JSC::createArrayStorageButterflyImpl):
(JSC::JSObject::tryMakeWritableInt32Slow):
(JSC::JSObject::tryMakeWritableDoubleSlow):
(JSC::JSObject::tryMakeWritableContiguousSlow):
(JSC::JSObject::setPrototypeDirect):
(JSC::JSObject::hasProperty const):
(JSC::JSObject::hasInstance):
(JSC::JSObject::convertToUncacheableDictionary):
(JSC::JSObject::shiftButterflyAfterFlattening):
* Source/JavaScriptCore/runtime/JSObject.h:
(JSC::JSObject::putByIndexInline):
(JSC::JSObject::putDirectIndex):
(JSC::JSObject::butterflyTotalSize):
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::getPropertySlot):
(JSC::JSObject::prepareToPutDirectWithoutTransition):
(JSC::JSObject::putInlineForJSObject):
(JSC::JSObject::putDirectInternal):
(JSC::JSObject::deleteProperty):
(JSC::JSObject::get const):
* Source/JavaScriptCore/runtime/JSRemoteFunction.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSRemoteFunction::copyNameAndLength):
* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::jsMakeNontrivialString):
* Source/JavaScriptCore/runtime/JSStringJoiner.cpp:
(JSC::joinStrings):
(JSC::JSStringJoiner::joinImpl):
* Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp:
(JSC::isTypedArrayViewConstructor):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/KeyAtomStringCacheInlines.h:
(JSC::KeyAtomStringCache::make):
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::requires):
(JSC::reviverMode&gt;::parse):
* Source/JavaScriptCore/runtime/MapPrototype.cpp:
(JSC::getMap):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/MathObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ObjectConstructor.cpp:
(JSC::objectAssignGeneric):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::definePropertiesSlow):
(JSC::defineProperties):
(JSC::setIntegrityLevel):
(JSC::objectConstructorSeal):
(JSC::objectConstructorFreeze):
(JSC::ownPropertyKeys):
* Source/JavaScriptCore/runtime/ObjectInitializationScope.cpp:
(JSC::ObjectInitializationScope::verifyPropertiesAreInitialized):
* Source/JavaScriptCore/runtime/ObjectPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ParseInt.h:
(JSC::toStringView):
* Source/JavaScriptCore/runtime/ProxyObject.cpp:
(JSC::performProxyGet):
(JSC::ProxyObject::performInternalMethodGetOwnProperty):
(JSC::ProxyObject::performHasProperty):
(JSC::ProxyObject::getOwnPropertySlotCommon):
(JSC::ProxyObject::performPut):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::ProxyObject::performDelete):
(JSC::ProxyObject::performPreventExtensions):
(JSC::ProxyObject::performIsExtensible):
(JSC::ProxyObject::performDefineOwnProperty):
(JSC::ProxyObject::performGetOwnPropertyNames):
(JSC::ProxyObject::performSetPrototype):
(JSC::ProxyObject::performGetPrototype):
* Source/JavaScriptCore/runtime/ReflectObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/RegExpMatchesArray.cpp:
(JSC::createEmptyRegExpMatchesArray):
* Source/JavaScriptCore/runtime/RegExpMatchesArray.h:
(JSC::tryCreateUninitializedRegExpMatchesArray):
(JSC::createRegExpMatchesArray):
* Source/JavaScriptCore/runtime/RegExpObject.cpp:
(JSC::RegExpObject::put):
* Source/JavaScriptCore/runtime/RegExpObjectInlines.h:
(JSC::collectMatches):
(JSC::collectGlobalAtomMatches):
* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/RegExpSubstringGlobalAtomCache.cpp:
(JSC::RegExpSubstringGlobalAtomCache::collectMatches):
* Source/JavaScriptCore/runtime/RuntimeType.cpp:
(JSC::runtimeTypeForValue):
* Source/JavaScriptCore/runtime/ScopedArgumentsTable.cpp:
(JSC::ScopedArgumentsTable::tryCreate):
(JSC::ScopedArgumentsTable::tryClone):
(JSC::ScopedArgumentsTable::trySetLength):
(JSC::ScopedArgumentsTable::trySet):
* Source/JavaScriptCore/runtime/SetPrototype.cpp:
(JSC::getSet):
* Source/JavaScriptCore/runtime/ShadowRealmPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/SimpleTypedArrayController.cpp:
(JSC::SimpleTypedArrayController::JSArrayBufferOwner::isReachableFromOpaqueRoots):
* Source/JavaScriptCore/runtime/StringObject.cpp:
(JSC::StringObject::put):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::stringIndexOfImpl):
(JSC::toLocaleCase):
(JSC::trimString):
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::tryMakeReplacedString):
(JSC::stringReplaceStringString):
(JSC::removeAllUsingRegExpSearch):
(JSC::addToRegExpSearchCache):
(JSC::replaceAllWithCacheUsingRegExpSearchThreeArguments):
(JSC::replaceAllWithCacheUsingRegExpSearch):
(JSC::replaceAllWithStringUsingRegExpSearchNoBackreferences):
(JSC::replaceAllWithStringUsingRegExpSearch):
(JSC::replaceOneWithStringUsingRegExpSearch):
(JSC::replaceUsingRegExpSearch):
(JSC::replace):
* Source/JavaScriptCore/runtime/StringRecursionChecker.h:
(JSC::StringRecursionChecker::performCheck):
* Source/JavaScriptCore/runtime/SymbolTable.h:
(JSC::SymbolTableEntry::inflate):
* Source/JavaScriptCore/runtime/TemporalCalendarPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::didExhaustMicrotaskQueue):
(JSC::VM::drainMicrotasks):
(JSC::VM::executeEntryScopeServicesOnEntry):
(JSC::VM::executeEntryScopeServicesOnExit):
* Source/JavaScriptCore/runtime/VM.h:
(WTF::DefaultRefDerefTraits&lt;JSC::VM&gt;::refIfNotNull):
(WTF::DefaultRefDerefTraits&lt;JSC::VM&gt;::derefIfNotNull):
* Source/JavaScriptCore/runtime/WeakMapConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/WeakMapPrototype.cpp:
(JSC::getWeakMap):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/WeakObjectRefPrototype.cpp:
(JSC::getWeakRef):
* Source/JavaScriptCore/runtime/WeakSetPrototype.cpp:
(JSC::getWeakSet):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::endTopLevel):
(JSC::Wasm::BBQJITImpl::BBQJIT::willParseOpcode):
(JSC::Wasm::BBQJITImpl::BBQJIT::willParseExtendedOpcode):
(JSC::Wasm::BBQJITImpl::BBQJIT::finalize):
(JSC::Wasm::BBQJITImpl::BBQJIT::allocateWithHint):
(JSC::Wasm::BBQJITImpl::BBQJIT::loadIfNecessary):
(JSC::Wasm::BBQJITImpl::BBQJIT::bind):
(JSC::Wasm::BBQJITImpl::BBQJIT::unbind):
(JSC::Wasm::BBQJITImpl::BBQJIT::evictGPR):
(JSC::Wasm::BBQJITImpl::BBQJIT::evictFPR):
(JSC::Wasm::BBQJITImpl::BBQJIT::clobber):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
(JSC::Wasm::BBQJITImpl::BBQJIT::ScratchScope::bindGPRToScratch):
(JSC::Wasm::BBQJITImpl::BBQJIT::ScratchScope::bindFPRToScratch):
(JSC::Wasm::BBQJITImpl::BBQJIT::ScratchScope::unbindGPRFromScratch):
(JSC::Wasm::BBQJITImpl::BBQJIT::ScratchScope::unbindFPRFromScratch):
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::work):
(JSC::Wasm::BBQPlan::compileFunction):
* Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp:
(JSC::Wasm::ConstExprGenerator::createNewArray):
(JSC::Wasm::ConstExprGenerator::createNewStruct):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
* Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp:
(JSC::Wasm::IPIntPlan::compileFunction):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::compileFunction):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::atomicLoad):
(JSC::Wasm::OMGIRGenerator::atomicStore):
(JSC::Wasm::OMGIRGenerator::atomicBinaryRMW):
(JSC::Wasm::OMGIRGenerator::atomicCompareExchange):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::atomicLoad):
(JSC::Wasm::OMGIRGenerator::atomicStore):
(JSC::Wasm::OMGIRGenerator::atomicBinaryRMW):
(JSC::Wasm::OMGIRGenerator::atomicCompareExchange):
* Source/JavaScriptCore/wasm/WasmOMGPlan.cpp:
(JSC::Wasm::OMGPlan::work):
* Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp:
(JSC::Wasm::OSREntryPlan::work):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::arrayNew):
(JSC::Wasm::tryCopyElementsInReverse):
(JSC::Wasm::arrayNewFixed):
(JSC::Wasm::createArrayFromDataSegment):
(JSC::Wasm::arrayNewElem):
* Source/JavaScriptCore/wasm/WasmParser.h:
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseImport):
(JSC::Wasm::SectionParser::parseTable):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_SLOW_PATH_DECL):
* Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp:
(JSC::Wasm::StreamingCompiler::didComplete):
* Source/JavaScriptCore/wasm/WasmTable.cpp:
(JSC::Wasm::Table::grow):
* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
(JSC::Wasm::FunctionSignature::jsToWasmICEntrypoint const):
* Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp:
(JSC::JSWebAssembly::webAssemblyModuleValidateAsync):
(JSC::instantiate):
(JSC::compileAndInstantiate):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.cpp:
(JSC::JSWebAssemblyTable::grow):
(JSC::JSWebAssemblyTable::get):
(JSC::JSWebAssemblyTable::set):
* Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
(JSC::Wasm::handleBadImportTypeUse):
* Source/JavaScriptCore/wasm/js/WebAssemblyExceptionPrototype.cpp:
(JSC::getException):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp:
(JSC::WebAssemblyModuleConstructor::createModule):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::evaluate):
* Source/JavaScriptCore/wasm/js/WebAssemblyTagPrototype.cpp:
(JSC::getTag):
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::matchParentheses):
(JSC::Yarr::Interpreter::backtrackParentheses):
(JSC::Yarr::Interpreter::matchDisjunction):
(JSC::Yarr::ByteCompiler::compile):
(JSC::Yarr::ByteCompiler::emitDisjunction):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::copyDisjunction):
(JSC::Yarr::YarrPatternConstructor::copyTerm):
(JSC::Yarr::YarrPatternConstructor::setupDisjunctionOffsets):
* Source/WebCore/bindings/scripts/test/JS/JSTestStringContext.cpp:
(WebCore::JSC_DEFINE_CUSTOM_GETTER):
* Source/WebCore/css/parser/CSSTokenizer.cpp:
(WebCore::CSSTokenizer::tryCreate):
* Source/WebCore/dom/InternalObserverEvery.cpp:
* Source/WebCore/dom/InternalObserverFind.cpp:
* Source/WebCore/dom/InternalObserverForEach.cpp:
* Source/WebCore/dom/InternalObserverInspect.cpp:
* Source/WebCore/dom/InternalObserverReduce.cpp:
* Source/WebCore/dom/InternalObserverSome.cpp:
* Source/WebCore/dom/Microtasks.cpp:
(WebCore::MicrotaskQueue::runJSMicrotask):

Canonical link: <a href="https://commits.webkit.org/294480@main">https://commits.webkit.org/294480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd685fe25bd4b23e667ad1a0f7784b2ae6e9d459

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101991 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107150 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52625 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104031 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30166 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77646 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34647 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16988 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92089 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57982 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16815 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10114 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51984 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94663 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86660 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109523 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100601 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29124 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21456 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86619 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88293 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86198 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21926 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30976 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8694 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23322 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29052 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34347 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124226 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28863 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34507 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32186 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30422 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->