### PR TITLE
Use C++ [[fallthrough]]

### DIFF
--- a/Source/JavaScriptCore/API/glib/JSCValue.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCValue.cpp
@@ -881,7 +881,7 @@ static JSValueRef jsObjectCall(JSGlobalContextRef jsContext, JSObjectRef functio
         return JSObjectCallAsConstructor(jsContext, function, arguments.size(), arguments.data(), exception);
     case JSC::JSCCallbackFunction::Type::Method:
         ASSERT(thisObject);
-        FALLTHROUGH;
+        [[fallthrough]];
     case JSC::JSCCallbackFunction::Type::Function:
         return JSObjectCallAsFunction(jsContext, function, thisObject, arguments.size(), arguments.data(), exception);
     }

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -8565,7 +8565,7 @@ public:
             return;
         case SIMDLane::i8x16:
             vectorReplaceLane(SIMDLane::i8x16, TrustedImm32(1), src, dest);
-            FALLTHROUGH;
+            [[fallthrough]];
         case SIMDLane::i16x8:
             m_assembler.vpshuflw_i8rr(0, dest, dest);
             m_assembler.vpunpcklqdq_rrr(dest, dest, dest);
@@ -8593,7 +8593,7 @@ public:
             return;
         case SIMDLane::i8x16:
             vectorReplaceLane(SIMDLane::i8x16, TrustedImm32(1), src, dest);
-            FALLTHROUGH;
+            [[fallthrough]];
         case SIMDLane::i16x8:
             m_assembler.pshuflw_i8rr(0, dest, dest);
             m_assembler.punpcklqdq_rr(dest, dest);

--- a/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
@@ -236,7 +236,7 @@ private:
             // XXX: be smarter and resolve to the low Tmp
             if (value->type().kind() == Int32)
                 return false;
-            FALLTHROUGH;
+            [[fallthrough]];
         case Identity:
         case Opaque:
             return true;

--- a/Source/JavaScriptCore/b3/B3StackmapSpecial.cpp
+++ b/Source/JavaScriptCore/b3/B3StackmapSpecial.cpp
@@ -103,7 +103,7 @@ void StackmapSpecial::forEachArgImpl(
                 role = Arg::LateColdUse;
                 break;
             }
-            FALLTHROUGH;
+            [[fallthrough]];
         case SameAsRep:
             switch (child.rep().kind()) {
             case ValueRep::WarmAny:
@@ -301,7 +301,7 @@ ValueRep StackmapSpecial::repForArg(Air::Code& code, const Arg& arg)
         break;
     case Arg::ExtendedOffsetAddr:
         ASSERT(arg.base() == Tmp(GPRInfo::callFrameRegister));
-        FALLTHROUGH;
+        [[fallthrough]];
     case Arg::Addr:
         if (arg.base() == Tmp(GPRInfo::callFrameRegister))
             return ValueRep::stack(arg.offset());

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -644,10 +644,10 @@ private:
             break;
         case Three:
             std::bit_cast<Value**>(std::bit_cast<char*>(this) + offset)[2] = valueToClone.childrenArray()[2];
-            FALLTHROUGH;
+            [[fallthrough]];
         case Two:
             std::bit_cast<Value**>(std::bit_cast<char*>(this) + offset)[1] = valueToClone.childrenArray()[1];
-            FALLTHROUGH;
+            [[fallthrough]];
         case One:
             std::bit_cast<Value**>(std::bit_cast<char*>(this) + offset)[0] = valueToClone.childrenArray()[0];
             break;

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -5400,7 +5400,7 @@ void FunctionNode::emitBytecode(BytecodeGenerator& generator, RegisterID*)
         }
 
         generator.emitLabel(generatorBodyLabel.get());
-        FALLTHROUGH;
+        [[fallthrough]];
     }
 
     case SourceParseMode::AsyncArrowFunctionBodyMode:

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3329,7 +3329,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             setConstant(node, childConst);
             break;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     }
     case ToPropertyKey: {
         if (!(forNode(node->child1()).m_type & ~(SpecString | SpecSymbol))) {
@@ -5104,7 +5104,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         case Array::ArrayStorage: {
             if (mode.isInBounds())
                 break;
-            FALLTHROUGH;
+            [[fallthrough]];
         }
         default: {
             clobberWorld();
@@ -5137,7 +5137,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             case Array::ArrayStorage: {
                 if (arrayMode.isInBounds())
                     break;
-                FALLTHROUGH;
+                [[fallthrough]];
             }
             default: {
                 clobberWorld();

--- a/Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp
@@ -481,7 +481,7 @@ private:
                 case GetByOffset:
                     if (node->child2()->op() == CreateClonedArguments && node->storageAccessData().offset == clonedArgumentsLengthPropertyOffset)
                         break;
-                    FALLTHROUGH;
+                    [[fallthrough]];
                 default:
                     m_graph.doToChildren(node, [&] (Edge edge) { return escape(edge, node); });
                     break;

--- a/Source/JavaScriptCore/dfg/DFGArithMode.h
+++ b/Source/JavaScriptCore/dfg/DFGArithMode.h
@@ -73,7 +73,7 @@ inline bool doesOverflow(Arith::Mode mode)
     case Arith::NotSet:
         ASSERT_NOT_REACHED();
 #if !ASSERT_ENABLED
-        FALLTHROUGH;
+        [[fallthrough]];
 #endif
     case Arith::Unchecked:
     case Arith::CheckOverflow:

--- a/Source/JavaScriptCore/dfg/DFGArrayMode.h
+++ b/Source/JavaScriptCore/dfg/DFGArrayMode.h
@@ -614,7 +614,7 @@ private:
         case Array::Array:
             if (hasInt32(shape) || hasDouble(shape) || hasContiguous(shape))
                 return asArrayModesIgnoringTypedArrays(shape | IsArray) | asArrayModesIgnoringTypedArrays(shape | IsArray | CopyOnWrite);
-            FALLTHROUGH;
+            [[fallthrough]];
         case Array::OriginalNonCopyOnWriteArray:
             return asArrayModesIgnoringTypedArrays(shape | IsArray);
         case Array::PossiblyArray:

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -2599,7 +2599,7 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
 
             addToGraph(CheckArray, OpInfo(mode.asWord()), get(virtualRegisterForArgumentIncludingThis(0, registerOffset)));
             addToGraph(CheckDetached, get(virtualRegisterForArgumentIncludingThis(0, registerOffset)));
-            FALLTHROUGH;
+            [[fallthrough]];
         }
 
         case ArrayEntriesIntrinsic:
@@ -3897,21 +3897,21 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             switch (intrinsic) {
             case DataViewGetInt8:
                 isSigned = true;
-                FALLTHROUGH;
+                [[fallthrough]];
             case DataViewGetUint8:
                 byteSize = 1;
                 break;
 
             case DataViewGetInt16:
                 isSigned = true;
-                FALLTHROUGH;
+                [[fallthrough]];
             case DataViewGetUint16:
                 byteSize = 2;
                 break;
 
             case DataViewGetInt32:
                 isSigned = true;
-                FALLTHROUGH;
+                [[fallthrough]];
             case DataViewGetUint32:
                 byteSize = 4;
                 break;
@@ -3997,21 +3997,21 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             switch (intrinsic) {
             case DataViewSetInt8:
                 isSigned = true;
-                FALLTHROUGH;
+                [[fallthrough]];
             case DataViewSetUint8:
                 byteSize = 1;
                 break;
 
             case DataViewSetInt16:
                 isSigned = true;
-                FALLTHROUGH;
+                [[fallthrough]];
             case DataViewSetUint16:
                 byteSize = 2;
                 break;
 
             case DataViewSetInt32:
                 isSigned = true;
-                FALLTHROUGH;
+                [[fallthrough]];
             case DataViewSetUint32:
                 byteSize = 4;
                 break;

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -222,7 +222,7 @@ private:
                     break;
                 node->convertCheckStructureOrEmptyToCheckStructure();
                 changed = true;
-                FALLTHROUGH;
+                [[fallthrough]];
             }
             case CheckStructure:
             case ArrayifyToStructure: {
@@ -387,7 +387,7 @@ private:
                 // CheckArrayOrEmpty can be removed when arrayMode meets the requirement. In that case, CellUse's
                 // check just remains, and it works as CheckArrayOrEmpty without ArrayMode checking.
                 ASSERT(typeFilterFor(node->child1().useKind()) & SpecEmpty);
-                FALLTHROUGH;
+                [[fallthrough]];
             }
 
             case CheckArray:
@@ -1267,7 +1267,7 @@ private:
                         edge.setUseKind(KnownStringUse);
                     });
                 changed = true;
-                FALLTHROUGH;
+                [[fallthrough]];
             }
 
             case MakeRope:

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -641,7 +641,7 @@ bool doesGC(Graph& graph, Node* node)
         switch (node->switchData()->kind) {
         case SwitchCell:
             ASSERT(graph.m_plan.isFTL());
-            FALLTHROUGH;
+            [[fallthrough]];
         case SwitchImm:
             return false;
         case SwitchChar:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1114,7 +1114,7 @@ private:
             fixEdge<KnownInt32Use>(m_graph.varArgChild(node, 3));
             fixEdge<KnownInt32Use>(m_graph.varArgChild(node, 4));
             fixEdge<KnownCellUse>(m_graph.varArgChild(node, 5));
-            FALLTHROUGH;
+            [[fallthrough]];
         }
 
         case GetByVal:
@@ -1854,7 +1854,7 @@ private:
                 node->setResult(NodeResultDouble);
                 return;
             }
-            FALLTHROUGH;
+            [[fallthrough]];
         }
         case ToPropertyKey: {
             if (node->child1()->shouldSpeculateString()) {

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -278,7 +278,7 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
             break;
         if (node->isBinaryUseKind(OtherUse) || node->isSymmetricBinaryUseKind(OtherUse, UntypedUse))
             break;
-        FALLTHROUGH;
+        [[fallthrough]];
     case CompareEq:
     case CompareLess:
     case CompareLessEq:

--- a/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
@@ -777,7 +777,7 @@ void OSRExit::compileExit(CCallHelpers& jit, VM& vm, const OSRExit& exit, const 
             spooler.storeGPR(operand.virtualRegister().offset() * sizeof(CPURegister));
             break;
 #else
-            FALLTHROUGH;
+            [[fallthrough]];
 #endif
         }
         case DisplacedInJSStack:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -4930,7 +4930,7 @@ void SpeculativeJIT::compilePutByVal(Node* node)
     }
     case Array::Int32: {
         speculateInt32(child3);
-        FALLTHROUGH;
+        [[fallthrough]];
     }
     case Array::Contiguous: {
         compileContiguousPutByVal(node);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -1197,7 +1197,7 @@ GPRReg SpeculativeJIT::fillSpeculateInt32Internal(Edge edge, DataFormat& returnF
         // Fill as JSValue, and fall through.
         info.fillJSValue(m_stream, gpr, DataFormatJSInt32);
         m_gprs.unlock(gpr);
-        FALLTHROUGH;
+        [[fallthrough]];
     }
 
     case DataFormatJS: {
@@ -1215,7 +1215,7 @@ GPRReg SpeculativeJIT::fillSpeculateInt32Internal(Edge edge, DataFormat& returnF
         }
         // else fall through & handle as DataFormatJSInt32.
         m_gprs.unlock(gpr);
-        FALLTHROUGH;
+        [[fallthrough]];
     }
 
     case DataFormatJSInt32: {
@@ -1658,7 +1658,7 @@ GPRReg SpeculativeJIT::fillSpeculateBigInt32(Edge edge)
 
         info.fillJSValue(m_stream, gpr, DataFormatJS);
         m_gprs.unlock(gpr);
-        FALLTHROUGH;
+        [[fallthrough]];
     }
 
     case DataFormatJS: {
@@ -7423,7 +7423,7 @@ void SpeculativeJIT::compilePutByVal(Node* node)
     }
     case Array::Int32: {
         speculateInt32(child3);
-        FALLTHROUGH;
+        [[fallthrough]];
     }
     case Array::Contiguous: {
         compileContiguousPutByVal(node);

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.cpp
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.cpp
@@ -57,7 +57,7 @@ bool RemoteInspectionTarget::allowsInspectionByPolicy() const
         static bool allowInternalSecurityPolicies = os_variant_allows_internal_security_policies("com.apple.WebInspector");
         if (allowInternalSecurityPolicies && !RemoteInspector::singleton().isSimulatingCustomerInstall())
             return true;
-        FALLTHROUGH;
+        [[fallthrough]];
 #endif
     case Inspectable::NoIgnoringInternalPolicies:
         return false;

--- a/Source/JavaScriptCore/interpreter/CallFrame.cpp
+++ b/Source/JavaScriptCore/interpreter/CallFrame.cpp
@@ -204,7 +204,7 @@ SourceOrigin CallFrame::callerSourceOrigin(VM& vm)
             // instead of the source origin of the forEach function.
             if (static_cast<FunctionExecutable*>(visitor->codeBlock()->ownerExecutable())->isBuiltinFunction())
                 return IterationStatus::Continue;
-            FALLTHROUGH;
+            [[fallthrough]];
 
         case StackVisitor::Frame::CodeType::Eval:
         case StackVisitor::Frame::CodeType::Module:

--- a/Source/JavaScriptCore/jit/CallFrameShuffler64.cpp
+++ b/Source/JavaScriptCore/jit/CallFrameShuffler64.cpp
@@ -49,7 +49,7 @@ DataFormat CallFrameShuffler::emitStore(
     case UnboxedInt52InGPR:
         m_jit.rshift64(MacroAssembler::TrustedImm32(JSValue::int52ShiftAmount),
             cachedRecovery.recovery().gpr());
-        FALLTHROUGH;
+        [[fallthrough]];
     case UnboxedStrictInt52InGPR:
         m_jit.storePtr(cachedRecovery.recovery().gpr(), address);
         return DataFormatStrictInt52;
@@ -110,7 +110,7 @@ void CallFrameShuffler::emitBox(CachedRecovery& cachedRecovery)
                 ValueRecovery::inGPR(cachedRecovery.recovery().gpr(), DataFormatStrictInt52));
             if (verbose)
                 dataLog(" into ", cachedRecovery.recovery(), "\n");
-            FALLTHROUGH;
+            [[fallthrough]];
         case DataFormatStrictInt52: {
             if (verbose)
                 dataLog("   * Boxing ", cachedRecovery.recovery());

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -1671,7 +1671,7 @@ static void directPutByVal(JSGlobalObject* globalObject, JSObject* baseObject, J
         case ALL_ARRAY_STORAGE_INDEXING_TYPES:
             if (index < baseObject->butterfly()->vectorLength())
                 break;
-            FALLTHROUGH;
+            [[fallthrough]];
         default:
             if (arrayProfile)
                 arrayProfile->setOutOfBounds();

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -2753,7 +2753,7 @@ extern "C" UGPRPair SYSV_ABI llint_slow_path_checkpoint_osr_exit_from_inlined_ca
             }
             hasInstanceOrPrototype = constructor.get(globalObject, vm.propertyNames->prototype);
             RETURN_IF_EXCEPTION(throwScope, { });
-            FALLTHROUGH;
+            [[fallthrough]];
         }
         case OpInstanceof::instanceof:
             bool result = JSObject::defaultHasInstance(globalObject, value, hasInstanceOrPrototype);

--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -2433,7 +2433,7 @@ start:
                 token = tokenTypeForIntegerLikeToken(tokenData->doubleValue);
             }
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     case CharacterNumber:
         if (token != INTEGER && token != DOUBLE) [[likely]] {
             auto parseNumberResult = parseDecimal();
@@ -2520,7 +2520,7 @@ start:
                 break;
             }
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     }
     case CharacterNonLatin1IdentifierStart: {
         if constexpr (ASSERT_ENABLED) {
@@ -2528,7 +2528,7 @@ start:
             U16_GET(m_code, 0, 0, m_codeEnd - m_code, codePoint);
             ASSERT(isIdentStart(codePoint));
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     }
     case CharacterBackSlash:
         parseIdent:

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -477,7 +477,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseModuleSo
             }
 
             // This is `import("...")` call or `import.meta` meta property case.
-            FALLTHROUGH;
+            [[fallthrough]];
         }
 
         default: {
@@ -688,7 +688,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseSingleFu
             statement = parseAsyncFunctionDeclaration(context, functionStart, ExportType::NotExported, DeclarationDefaultContext::Standard, functionConstructorParametersEndPosition);
             break;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     default:
         failDueToUnexpectedToken();
     }
@@ -752,7 +752,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseStatementList
     case ESCAPED_KEYWORD:
         if (!matchAllowedEscapedContextualKeyword()) [[unlikely]]
             failDueToUnexpectedToken();
-        FALLTHROUGH;
+        [[fallthrough]];
     case IDENT:
         if (*m_token.m_data.ident == m_vm.propertyNames->async && !m_token.m_data.escaped) [[unlikely]] {
             // Eagerly parse as AsyncFunctionDeclaration. This is the uncommon case,
@@ -766,7 +766,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseStatementList
             }
             restoreSavePoint(context, savePoint);
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     case AWAIT:
     case YIELD: {
         if (currentScope()->isStaticBlock()) [[unlikely]] {
@@ -2056,7 +2056,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseStatement(Tre
     case ESCAPED_KEYWORD:
         if (!matchAllowedEscapedContextualKeyword()) [[unlikely]]
             failDueToUnexpectedToken();
-        FALLTHROUGH;
+        [[fallthrough]];
     case LET:
     case IDENT:
     case AWAIT:
@@ -2071,7 +2071,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseStatement(Tre
         if (directiveLiteralLength)
             *directiveLiteralLength = m_token.m_location.endOffset - m_token.m_location.startOffset;
         nonTrivialExpressionCount = m_parserState.nonTrivialExpressionCount;
-        FALLTHROUGH;
+        [[fallthrough]];
     default:
         TreeStatement exprStatement = parseExpressionStatement(context);
         if (directive && nonTrivialExpressionCount != m_parserState.nonTrivialExpressionCount)
@@ -3078,7 +3078,7 @@ parseMethod:
                     goto parseMethod;
                 }
             }
-            FALLTHROUGH;
+            [[fallthrough]];
         case AWAIT: {
             ident = m_token.m_data.ident;
             bool escaped = m_token.m_data.escaped;
@@ -4034,7 +4034,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseExportDeclara
                 result = parseAsyncFunctionDeclaration(context, functionStart, ExportType::Exported);
                 break;
             }
-            FALLTHROUGH;
+            [[fallthrough]];
         default:
             failWithMessage("Expected either a declaration or a variable statement");
         }
@@ -4497,11 +4497,11 @@ parseProperty:
                 goto parseProperty;
             }
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     case YIELD:
     case AWAIT:
         wasIdent = true;
-        FALLTHROUGH;
+        [[fallthrough]];
     case STRING: {
 namedProperty:
         const Identifier* ident = m_token.m_data.ident;
@@ -5148,7 +5148,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parsePrimaryExpre
     case ESCAPED_KEYWORD:
         if (matchAllowedEscapedContextualKeyword()) [[likely]]
             goto identifierExpression;
-        FALLTHROUGH;
+        [[fallthrough]];
     default:
         failDueToUnexpectedToken();
     }

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.h
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.h
@@ -81,7 +81,7 @@ inline JSValue opEnumeratorGetByVal(JSGlobalObject* globalObject, JSValue baseVa
             if (enumeratorMetadata)
                 *enumeratorMetadata |= static_cast<uint8_t>(JSPropertyNameEnumerator::HasSeenOwnStructureModeStructureMismatch);
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     }
 
     case JSPropertyNameEnumerator::GenericMode: {

--- a/Source/JavaScriptCore/runtime/CommonSlowPathsInlines.h
+++ b/Source/JavaScriptCore/runtime/CommonSlowPathsInlines.h
@@ -53,7 +53,7 @@ inline void tryCachePutToScopeGlobal(
             metadata.m_getPutInfo = GetPutInfo(metadata.m_getPutInfo.resolveMode(), newResolveType, metadata.m_getPutInfo.initializationMode(), metadata.m_getPutInfo.ecmaMode());
             break;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     }
     case GlobalProperty:
     case GlobalPropertyWithVarInjectionChecks: {
@@ -115,7 +115,7 @@ inline void tryCacheGetFromScopeGlobal(
             metadata.m_getPutInfo = GetPutInfo(metadata.m_getPutInfo.resolveMode(), newResolveType, metadata.m_getPutInfo.initializationMode(), metadata.m_getPutInfo.ecmaMode());
             break;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     }
     case GlobalProperty:
     case GlobalPropertyWithVarInjectionChecks: {
@@ -223,7 +223,7 @@ inline void opEnumeratorPutByVal(JSGlobalObject* globalObject, JSValue baseValue
         }
         if (enumeratorMetadata)
             *enumeratorMetadata |= static_cast<uint8_t>(JSPropertyNameEnumerator::HasSeenOwnStructureModeStructureMismatch);
-        FALLTHROUGH;
+        [[fallthrough]];
     }
 
     case JSPropertyNameEnumerator::GenericMode: {

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -674,7 +674,7 @@ static std::optional<Variant<Vector<LChar>, int64_t>> parseTimeZoneAnnotation(St
                 }
             }
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     }
     default: {
         // TZLeadingChar :

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -1108,7 +1108,7 @@ bool JSArray::setLength(JSGlobalObject* globalObject, unsigned newLength, bool t
             return true;
         convertFromCopyOnWrite(vm);
         butterfly = this->butterfly();
-        FALLTHROUGH;
+        [[fallthrough]];
 
     case ArrayWithUndecided:
     case ArrayWithInt32:

--- a/Source/JavaScriptCore/runtime/JSArrayInlines.h
+++ b/Source/JavaScriptCore/runtime/JSArrayInlines.h
@@ -182,7 +182,7 @@ ALWAYS_INLINE void JSArray::pushInline(JSGlobalObject* globalObject, JSValue val
     switch (indexingMode()) {
     case ArrayClass: {
         createInitialUndecided(vm, 0);
-        FALLTHROUGH;
+        [[fallthrough]];
     }
 
     case ArrayWithUndecided: {
@@ -290,7 +290,7 @@ ALWAYS_INLINE void JSArray::pushInline(JSGlobalObject* globalObject, JSValue val
             }
             return;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     }
 
     case ArrayWithArrayStorage: {

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -1625,7 +1625,7 @@ NEVER_INLINE JSValue Walker::walk(JSValue unfiltered)
                 indexStack.append(0);
             }
             arrayStartVisitMember:
-            FALLTHROUGH;
+            [[fallthrough]];
             case ArrayStartVisitMember: {
                 JSObject* array = asObject(markedStack.last());
                 uint32_t index = indexStack.last();
@@ -1670,7 +1670,7 @@ NEVER_INLINE JSValue Walker::walk(JSValue unfiltered)
                     outValue = inValue;
                     outValueRange = inValueRange;
                 }
-                FALLTHROUGH;
+                [[fallthrough]];
             }
             case ArrayEndVisitMember: {
                 JSObject* array = asObject(markedStack.last());
@@ -1706,7 +1706,7 @@ NEVER_INLINE JSValue Walker::walk(JSValue unfiltered)
                 RETURN_IF_EXCEPTION(scope, { });
             }
             objectStartVisitMember:
-            FALLTHROUGH;
+            [[fallthrough]];
             case ObjectStartVisitMember: {
                 JSObject* object = jsCast<JSObject*>(markedStack.last());
                 uint32_t index = indexStack.last();
@@ -1746,7 +1746,7 @@ NEVER_INLINE JSValue Walker::walk(JSValue unfiltered)
                     outValue = inValue;
                     outValueRange = inValueRange;
                 }
-                FALLTHROUGH;
+                [[fallthrough]];
             }
             case ObjectEndVisitMember: {
                 JSObject* object = jsCast<JSObject*>(markedStack.last());

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -1034,7 +1034,7 @@ bool JSObject::putByIndex(JSCell* cell, JSGlobalObject* globalObject, unsigned p
             thisObject->convertInt32ForValue(vm, value);
             return putByIndex(cell, globalObject, propertyName, value, shouldThrow);
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     }
         
     case ALL_CONTIGUOUS_INDEXING_TYPES: {
@@ -2399,7 +2399,7 @@ bool JSObject::deletePropertyByIndex(JSCell* cell, JSGlobalObject* globalObject,
         if (i >= butterfly->vectorLength())
             return true;
         thisObject->convertFromCopyOnWrite(vm);
-        FALLTHROUGH;
+        [[fallthrough]];
     }
 
     case ALL_WRITABLE_INT32_INDEXING_TYPES:
@@ -2416,7 +2416,7 @@ bool JSObject::deletePropertyByIndex(JSCell* cell, JSGlobalObject* globalObject,
         if (i >= butterfly->vectorLength())
             return true;
         thisObject->convertFromCopyOnWrite(vm);
-        FALLTHROUGH;
+        [[fallthrough]];
     }
 
     case ALL_WRITABLE_DOUBLE_INDEXING_TYPES: {
@@ -3364,7 +3364,7 @@ bool JSObject::putByIndexBeyondVectorLength(JSGlobalObject* globalObject, unsign
             if (result)
                 return putResult;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     }
 
     case NonArrayWithArrayStorage:

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -493,7 +493,7 @@ public:
                 convertInt32ToDoubleOrContiguousWhilePerformingSetIndex(vm, i, v);
                 return true;
             }
-            FALLTHROUGH;
+            [[fallthrough]];
         }
         case ALL_WRITABLE_CONTIGUOUS_INDEXING_TYPES: {
             if (i >= butterfly->vectorLength())
@@ -550,7 +550,7 @@ public:
                 convertInt32ToDoubleOrContiguousWhilePerformingSetIndex(vm, i, v);
                 return;
             }
-            FALLTHROUGH;
+            [[fallthrough]];
         }
         case ALL_CONTIGUOUS_INDEXING_TYPES: {
             ASSERT(i < butterfly->vectorLength());
@@ -610,7 +610,7 @@ public:
                 convertInt32ToDoubleOrContiguousWhilePerformingSetIndex(vm, i, v);
                 break;
             }
-            FALLTHROUGH;
+            [[fallthrough]];
         }
         case ALL_CONTIGUOUS_INDEXING_TYPES: {
             ASSERT(i < butterfly->publicLength());
@@ -664,7 +664,7 @@ public:
             ASSERT(i < butterfly->publicLength());
             ASSERT(i < butterfly->vectorLength());
             RELEASE_ASSERT(v.isInt32());
-            FALLTHROUGH;
+            [[fallthrough]];
         }
         case ALL_CONTIGUOUS_INDEXING_TYPES: {
             ASSERT(i < butterfly->publicLength());

--- a/Source/JavaScriptCore/runtime/JSPropertyNameEnumerator.cpp
+++ b/Source/JavaScriptCore/runtime/JSPropertyNameEnumerator.cpp
@@ -170,7 +170,7 @@ JSString* JSPropertyNameEnumerator::computeNext(JSGlobalObject* globalObject, JS
     case InitMode: {
         mode = IndexedMode;
         index = 0;
-        FALLTHROUGH;
+        [[fallthrough]];
     }
 
     case JSPropertyNameEnumerator::IndexedMode: {
@@ -188,7 +188,7 @@ JSString* JSPropertyNameEnumerator::computeNext(JSGlobalObject* globalObject, JS
 
         mode = OwnStructureMode;
         index = 0;
-        FALLTHROUGH;
+        [[fallthrough]];
     }
 
     case JSPropertyNameEnumerator::OwnStructureMode:

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -1536,7 +1536,7 @@ JSValue LiteralParser<CharType, reviverMode>::parse(VM& vm, ParserState initialS
             }
         }
         doParseArrayStartExpression:
-        FALLTHROUGH;
+        [[fallthrough]];
         case DoParseArrayStartExpression: {
             TokenType lastToken = m_lexer.currentToken()->type;
             if (m_lexer.next() == TokRBracket) {

--- a/Source/JavaScriptCore/runtime/VMTraps.cpp
+++ b/Source/JavaScriptCore/runtime/VMTraps.cpp
@@ -441,7 +441,7 @@ void VMTraps::handleTraps(VMTraps::BitField mask)
             if (LIKELY(!vm.watchdog()->isActive() || !vm.watchdog()->shouldTerminate(vm.entryScope->globalObject())))
                 continue;
             vm.setHasTerminationRequest();
-            FALLTHROUGH;
+            [[fallthrough]];
 
         case NeedTermination:
             ASSERT(vm.hasTerminationRequest());

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -3080,7 +3080,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
     case TailCall:
         WASM_PARSER_FAIL_IF(!Options::useWasmTailCalls(), "wasm tail calls are not enabled"_s);
-        FALLTHROUGH;
+        [[fallthrough]];
     case Call: {
         FunctionSpaceIndex functionIndex;
         WASM_FAIL_IF_HELPER_FAILS(parseFunctionIndex(functionIndex));
@@ -3142,7 +3142,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
     case TailCallIndirect:
         WASM_PARSER_FAIL_IF(!Options::useWasmTailCalls(), "wasm tail calls are not enabled"_s);
-        FALLTHROUGH;
+        [[fallthrough]];
     case CallIndirect: {
         uint32_t signatureIndex;
         uint32_t tableIndex;
@@ -3211,7 +3211,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
     case TailCallRef:
         WASM_PARSER_FAIL_IF(!Options::useWasmTailCalls(), "wasm tail calls are not enabled"_s);
-        FALLTHROUGH;
+        [[fallthrough]];
     case CallRef: {
         uint32_t typeIndex;
         WASM_PARSER_FAIL_IF(!parseVarUInt32(typeIndex), "can't get call_ref's signature index"_s);
@@ -3921,7 +3921,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
 
     case TailCallIndirect:
         WASM_PARSER_FAIL_IF(!Options::useWasmTailCalls(), "wasm tail calls are not enabled"_s);
-        FALLTHROUGH;
+        [[fallthrough]];
     case CallIndirect: {
         uint32_t unused;
         uint32_t unused2;
@@ -3932,7 +3932,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
 
     case TailCallRef:
         WASM_PARSER_FAIL_IF(!Options::useWasmTailCalls(), "wasm tail calls are not enabled"_s);
-        FALLTHROUGH;
+        [[fallthrough]];
     case CallRef: {
         uint32_t unused;
         WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't call_ref's signature index in unreachable context"_s);
@@ -3984,7 +3984,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
 
     case TailCall:
         WASM_PARSER_FAIL_IF(!Options::useWasmTailCalls(), "wasm tail calls are not enabled"_s);
-        FALLTHROUGH;
+        [[fallthrough]];
     case Call: {
         FunctionSpaceIndex functionIndex;
         WASM_FAIL_IF_HELPER_FAILS(parseFunctionIndex(functionIndex));
@@ -4097,7 +4097,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
     case TableSet: {
         unsigned tableIndex;
         WASM_PARSER_FAIL_IF(!parseVarUInt32(tableIndex), "can't parse table index"_s);
-        FALLTHROUGH;
+        [[fallthrough]];
     }
     case RefIsNull:
     case RefNull: {

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -2416,7 +2416,7 @@ inline void OMGIRGenerator::emitStoreOp(StoreOpType op, Value* pointer, Value* v
     switch (op) {
     case StoreOpType::I64Store8:
         value = m_currentBlock->appendNew<Value>(m_proc, Trunc, origin(), value);
-        FALLTHROUGH;
+        [[fallthrough]];
 
     case StoreOpType::I32Store8:
         m_currentBlock->appendNew<MemoryValue>(m_proc, memoryKind(Store8), origin(), value, pointer, offset);
@@ -2424,7 +2424,7 @@ inline void OMGIRGenerator::emitStoreOp(StoreOpType op, Value* pointer, Value* v
 
     case StoreOpType::I64Store16:
         value = m_currentBlock->appendNew<Value>(m_proc, Trunc, origin(), value);
-        FALLTHROUGH;
+        [[fallthrough]];
 
     case StoreOpType::I32Store16:
         m_currentBlock->appendNew<MemoryValue>(m_proc, memoryKind(Store16), origin(), value, pointer, offset);
@@ -2432,7 +2432,7 @@ inline void OMGIRGenerator::emitStoreOp(StoreOpType op, Value* pointer, Value* v
 
     case StoreOpType::I64Store32:
         value = m_currentBlock->appendNew<Value>(m_proc, Trunc, origin(), value);
-        FALLTHROUGH;
+        [[fallthrough]];
 
     case StoreOpType::I64Store:
     case StoreOpType::I32Store:

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -2755,7 +2755,7 @@ inline void OMGIRGenerator::emitStoreOp(StoreOpType op, Value* pointer, Value* v
     switch (op) {
     case StoreOpType::I64Store8:
         value = append<Value>(m_proc, Trunc, origin(), value);
-        FALLTHROUGH;
+        [[fallthrough]];
 
     case StoreOpType::I32Store8:
         append<MemoryValue>(heapWasmMemory(), m_proc, memoryKind(Store8), origin(), value, pointer, offset);
@@ -2763,7 +2763,7 @@ inline void OMGIRGenerator::emitStoreOp(StoreOpType op, Value* pointer, Value* v
 
     case StoreOpType::I64Store16:
         value = append<Value>(m_proc, Trunc, origin(), value);
-        FALLTHROUGH;
+        [[fallthrough]];
 
     case StoreOpType::I32Store16:
         append<MemoryValue>(heapWasmMemory(), m_proc, memoryKind(Store16), origin(), value, pointer, offset);
@@ -2771,7 +2771,7 @@ inline void OMGIRGenerator::emitStoreOp(StoreOpType op, Value* pointer, Value* v
 
     case StoreOpType::I64Store32:
         value = append<Value>(m_proc, Trunc, origin(), value);
-        FALLTHROUGH;
+        [[fallthrough]];
 
     case StoreOpType::I64Store:
     case StoreOpType::I32Store:

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -59,7 +59,7 @@ static void marshallJSResult(CCallHelpers& jit, const FunctionSignature& signatu
             break;
         case TypeKind::F32:
             jit.convertFloatToDouble(src.fpr(), src.fpr());
-            FALLTHROUGH;
+            [[fallthrough]];
         case TypeKind::F64: {
             jit.moveTrustedValue(jsNumber(PNaN), dst);
             auto isNaN = jit.branchIfNaN(src.fpr());

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -993,7 +993,7 @@ public:
         switch (term.atom.quantityType) {
         case QuantifierType::NonGreedy:
             backTrack->matchAmount = 0;
-            FALLTHROUGH;
+            [[fallthrough]];
 
         case QuantifierType::FixedCount:
             backTrack->begin = input.getPos();
@@ -1235,7 +1235,7 @@ public:
             return true;
         case QuantifierType::NonGreedy:
             ASSERT(backTrack->begin != notFound);
-            FALLTHROUGH;
+            [[fallthrough]];
         case QuantifierType::FixedCount:
             break;
         }
@@ -1256,7 +1256,7 @@ public:
                 context->term -= term.atom.parenthesesWidth;
                 return false;
             }
-            FALLTHROUGH;
+            [[fallthrough]];
         case QuantifierType::NonGreedy:
             if (backTrack->begin == notFound) {
                 backTrack->begin = input.getPos();
@@ -1273,7 +1273,7 @@ public:
                 context->term -= term.atom.parenthesesWidth;
                 return true;
             }
-            FALLTHROUGH;
+            [[fallthrough]];
         case QuantifierType::FixedCount:
             break;
         }
@@ -1874,7 +1874,7 @@ public:
         case ByteTerm::Type::PatternCasedCharacterNonGreedy:
             // Case insensitive matching of unicode characters is handled as Type::CharacterClass.
             ASSERT(!isEitherUnicodeCompilation() || U_IS_BMP(currentTerm().atom.patternCharacter));
-            FALLTHROUGH;
+            [[fallthrough]];
         case ByteTerm::Type::PatternCharacterNonGreedy: {
             DUMP_CURR_CHAR();
             BackTrackInfoPatternCharacter* backTrack = reinterpret_cast<BackTrackInfoPatternCharacter*>(context->frame + currentTerm().frameLocation);

--- a/Source/JavaScriptCore/yarr/YarrParser.h
+++ b/Source/JavaScriptCore/yarr/YarrParser.h
@@ -266,7 +266,7 @@ private:
                     return;
                 }
                 // Otherwise just fall through - cached character so treat this as CharacterClassConstructionState::Empty.
-                FALLTHROUGH;
+                [[fallthrough]];
 
             case CharacterClassConstructionState::Empty:
                 m_character = ch;
@@ -315,7 +315,7 @@ private:
             case CharacterClassConstructionState::CachedCharacter:
                 // Flush the currently cached character, then fall through.
                 m_delegate.atomCharacterClassAtom(m_character);
-                FALLTHROUGH;
+                [[fallthrough]];
             case CharacterClassConstructionState::Empty:
             case CharacterClassConstructionState::AfterCharacterClass:
                 m_delegate.atomCharacterClassBuiltIn(classID, invert);
@@ -333,7 +333,7 @@ private:
             case CharacterClassConstructionState::CachedCharacterHyphen:
                 m_delegate.atomCharacterClassAtom(m_character);
                 m_delegate.atomCharacterClassAtom('-');
-                FALLTHROUGH;
+                [[fallthrough]];
             case CharacterClassConstructionState::AfterCharacterClassHyphen:
                 if (m_isUnicode) {
                     m_errorCode = ErrorCode::CharacterClassRangeInvalid;
@@ -612,13 +612,13 @@ private:
                     return;
                 }
                 // Otherwise just fall through - cached character so treat this as ClassSetConstructionState::Empty.
-                FALLTHROUGH;
+                [[fallthrough]];
 
             case ClassSetConstructionState::AfterSetRange:
                 switchFromDefaultOpToUnionOpIfNeeded();
 
                 // Continue processing the current character.
-                FALLTHROUGH;
+                [[fallthrough]];
 
             case ClassSetConstructionState::Empty:
             case ClassSetConstructionState::AfterSetOperator:
@@ -706,13 +706,13 @@ private:
 
                 // Yes, we really want to fall through to the AfterSetRange case to switch from Default to Union op
                 // and then handle the built in class by falling through again.
-                FALLTHROUGH;
+                [[fallthrough]];
 
             case ClassSetConstructionState::AfterSetRange:
                 switchFromDefaultOpToUnionOpIfNeeded();
 
                 // Continue processing the current character.
-                FALLTHROUGH;
+                [[fallthrough]];
 
             case ClassSetConstructionState::Empty:
             case ClassSetConstructionState::AfterCharacterClass:
@@ -731,7 +731,7 @@ private:
             case ClassSetConstructionState::CachedCharacterHyphen:
                 m_delegate.atomCharacterClassAtom(m_character);
                 m_delegate.atomCharacterClassAtom('-');
-                FALLTHROUGH;
+                [[fallthrough]];
             case ClassSetConstructionState::AfterCharacterClassHyphen:
                 m_errorCode = ErrorCode::CharacterClassRangeInvalid;
                 return;
@@ -1823,7 +1823,7 @@ private:
 
                 restoreState(state);
                 // if we did not find a complete quantifer, fall through to the default case.
-                FALLTHROUGH;
+                [[fallthrough]];
             }
 
             default:

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -2738,7 +2738,7 @@ void PatternTerm::dump(PrintStream& out, YarrPattern* thisPattern, unsigned nest
         else
             out.print("non-captured ");
 
-        FALLTHROUGH;
+        [[fallthrough]];
     case Type::ParentheticalAssertion:
         if (m_matchDirection) {
             if (type == Type::ParenthesesSubpattern)

--- a/Source/WTF/wtf/ParkingLot.cpp
+++ b/Source/WTF/wtf/ParkingLot.cpp
@@ -164,7 +164,7 @@ public:
                 break;
             case DequeueResult::RemoveAndStop:
                 shouldContinue = false;
-                FALLTHROUGH;
+                [[fallthrough]];
             case DequeueResult::RemoveAndContinue:
                 if (verbose)
                     dataLogForCurrentThread(": dequeueing ", RawPointer(current.get()), " from ", RawPointer(this), "\n");

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -813,28 +813,28 @@ void URLParser::copyURLPartsUntil(const URL& base, URLPart part, const CodePoint
     switch (part) {
     case URLPart::QueryEnd:
         m_url.m_queryEnd = base.m_queryEnd;
-        FALLTHROUGH;
+        [[fallthrough]];
     case URLPart::PathEnd:
         m_url.m_pathEnd = base.m_pathEnd;
-        FALLTHROUGH;
+        [[fallthrough]];
     case URLPart::PathAfterLastSlash:
         m_url.m_pathAfterLastSlash = base.m_pathAfterLastSlash;
-        FALLTHROUGH;
+        [[fallthrough]];
     case URLPart::PortEnd:
         m_url.m_portLength = base.m_portLength;
-        FALLTHROUGH;
+        [[fallthrough]];
     case URLPart::HostEnd:
         m_url.m_hostEnd = base.m_hostEnd;
-        FALLTHROUGH;
+        [[fallthrough]];
     case URLPart::PasswordEnd:
         m_url.m_passwordEnd = base.m_passwordEnd;
-        FALLTHROUGH;
+        [[fallthrough]];
     case URLPart::UserEnd:
         m_url.m_userEnd = base.m_userEnd;
-        FALLTHROUGH;
+        [[fallthrough]];
     case URLPart::UserStart:
         m_url.m_userStart = base.m_userStart;
-        FALLTHROUGH;
+        [[fallthrough]];
     case URLPart::SchemeEnd:
         m_url.m_isValid = base.m_isValid;
         m_url.m_protocolIsInHTTPFamily = base.m_protocolIsInHTTPFamily;
@@ -849,7 +849,7 @@ void URLParser::copyURLPartsUntil(const URL& base, URLPart part, const CodePoint
         return;
     case Scheme::File:
         m_urlIsFile = true;
-        FALLTHROUGH;
+        [[fallthrough]];
     case Scheme::FTP:
     case Scheme::HTTP:
     case Scheme::HTTPS:
@@ -1240,7 +1240,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
                 case Scheme::HTTP:
                 case Scheme::HTTPS:
                     m_url.m_protocolIsInHTTPFamily = true;
-                    FALLTHROUGH;
+                    [[fallthrough]];
                 case Scheme::FTP:
                     m_urlIsSpecial = true;
                     if (base.protocolIs(urlScheme))
@@ -1515,7 +1515,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
             switch (*c) {
             case '\\':
                 syntaxViolation(c);
-                FALLTHROUGH;
+                [[fallthrough]];
             case '/':
                 appendToASCIIBuffer('/');
                 state = State::FileSlash;
@@ -2029,7 +2029,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
         LOG_FINAL_STATE("PathStart");
         RELEASE_ASSERT_NOT_REACHED();
     case State::FilePathStart:
-        FALLTHROUGH;
+        [[fallthrough]];
     case State::Path:
         LOG_FINAL_STATE("Path");
         m_url.m_pathEnd = currentPosition(c);

--- a/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
@@ -484,7 +484,7 @@ String TextCodecCJK::iso2022JPDecode(std::span<const uint8_t> bytes, bool flush,
             break;
         case ISO2022JPDecoderState::TrailByte:
             m_iso2022JPDecoderState = ISO2022JPDecoderState::LeadByte;
-            FALLTHROUGH;
+            [[fallthrough]];
         case ISO2022JPDecoderState::EscapeStart:
             sawError = true;
             result.append(replacementCharacter);

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -5020,7 +5020,7 @@ void AXObjectCache::updateIsolatedTree(const Vector<std::pair<Ref<AccessibilityO
         case AXNotification::LanguageChanged:
         case AXNotification::RowCountChanged:
             updateNode(notification.first);
-            FALLTHROUGH;
+            [[fallthrough]];
         case AXNotification::RowCollapsed:
         case AXNotification::RowExpanded:
             updateChildren(notification.first);

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1915,7 +1915,7 @@ bool AccessibilityObject::dependsOnTextUnderElement() const
         // Native popup buttons should not use their descendant's text as a title. That value is retrieved through stringValue().
         if (hasTagName(selectTag))
             break;
-        FALLTHROUGH;
+        [[fallthrough]];
     case AccessibilityRole::Summary:
     case AccessibilityRole::Button:
     case AccessibilityRole::ToggleButton:

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -944,7 +944,7 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
     case AccessibilityRole::Group:
         if ([self isSVGGroupElement])
             return true;
-        FALLTHROUGH;
+        [[fallthrough]];
     case AccessibilityRole::Application:
     case AccessibilityRole::ApplicationAlert:
     case AccessibilityRole::ApplicationAlertDialog:

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -2788,7 +2788,7 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
                 lengthStack.append(length);
             }
             arrayStartVisitIndexedMember:
-            FALLTHROUGH;
+            [[fallthrough]];
             case ArrayStartVisitIndexedMember: {
                 JSObject* array = inputObjectStack.last();
                 uint32_t index = indexStack.last();
@@ -2861,7 +2861,7 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
                     return SerializationReturnCode::ExistingExceptionError;
             }
             startVisitNamedMember:
-            FALLTHROUGH;
+            [[fallthrough]];
             case ObjectStartVisitNamedMember: {
                 JSObject* object = inputObjectStack.last();
                 uint32_t index = indexStack.last();
@@ -2894,7 +2894,7 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
                 }
                 if (terminalCode != SerializationReturnCode::SuccessfullyCompleted)
                     return terminalCode;
-                FALLTHROUGH;
+                [[fallthrough]];
             }
             case ObjectEndVisitNamedMember: {
                 if (scope.exception()) [[unlikely]]
@@ -5552,7 +5552,7 @@ DeserializationResult CloneDeserializer::deserialize()
             outputObjectStack.append(outArray);
         }
         arrayStartVisitIndexedMember:
-        FALLTHROUGH;
+        [[fallthrough]];
         case ArrayStartVisitIndexedMember: {
             uint32_t index;
             if (!read(index)) {
@@ -5643,7 +5643,7 @@ DeserializationResult CloneDeserializer::deserialize()
             outputObjectStack.append(outObject);
         }
         startVisitNamedMember:
-        FALLTHROUGH;
+        [[fallthrough]];
         case ObjectStartVisitNamedMember: {
             switch (startVisitNamedMember<ObjectEndVisitNamedMember>(outputObjectStack, propertyNameStack, stateStack, outValue)) {
             case VisitNamedMemberResult::Error:

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -2331,7 +2331,7 @@ static Ref<CSSValue> valueForTextEmphasisStyle(const RenderStyle& style)
     case TextEmphasisMark::Auto:
         ASSERT_NOT_REACHED();
 #if !ASSERT_ENABLED
-        FALLTHROUGH;
+        [[fallthrough]];
 #endif
     case TextEmphasisMark::Dot:
     case TextEmphasisMark::Circle:

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -383,7 +383,7 @@ bool CSSParser::consumeRuleList(CSSParserTokenRange range, RuleList ruleListType
                 range.consume();
                 continue;
             }
-            FALLTHROUGH;
+            [[fallthrough]];
         default:
             rule = consumeQualifiedRule(range, allowedRules);
             break;

--- a/Source/WebCore/css/parser/CSSParserToken.cpp
+++ b/Source/WebCore/css/parser/CSSParserToken.cpp
@@ -578,7 +578,7 @@ bool CSSParserToken::operator==(const CSSParserToken& other) const
     case HashToken:
         if (m_hashTokenType != other.m_hashTokenType)
             return false;
-        FALLTHROUGH;
+        [[fallthrough]];
     case IdentToken:
     case FunctionToken:
     case StringToken:
@@ -591,7 +591,7 @@ bool CSSParserToken::operator==(const CSSParserToken& other) const
                 return false;
             return m_numericSign == other.m_numericSign && m_numericValue == other.m_numericValue && m_numericValueType == other.m_numericValueType;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     case NumberToken:
     case PercentageToken:
         return originalText() == other.originalText();

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -1074,7 +1074,7 @@ CSSSelector::Match CSSSelectorParser::consumeAttributeMatch(CSSParserTokenRange&
     case DelimiterToken:
         if (token.delimiter() == '=')
             return CSSSelector::Match::Exact;
-        FALLTHROUGH;
+        [[fallthrough]];
     default:
         m_failedParsing = true;
         return CSSSelector::Match::Exact;

--- a/Source/WebCore/css/parser/SizesCalcParser.cpp
+++ b/Source/WebCore/css/parser/SizesCalcParser.cpp
@@ -140,7 +140,7 @@ bool SizesCalcParser::calcToReversePolishNotation(CSSParserTokenRange range)
             if (!equalLettersIgnoringASCIICase(token.value(), "calc"_s))
                 return false;
             // "calc(" is the same as "("
-            FALLTHROUGH;
+            [[fallthrough]];
         case LeftParenthesisToken:
             // If the token is a left parenthesis, then push it onto the stack.
             stack.append(token);

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1507,13 +1507,13 @@ static FunctionType constructFragmentsInternal(const CSSSelector* rootSelector, 
         case CSSSelector::Match::List:
             if (selector->value().find(isASCIIWhitespace<UChar>) != notFound)
                 return FunctionType::CannotMatchAnything;
-            FALLTHROUGH;
+            [[fallthrough]];
         case CSSSelector::Match::Begin:
         case CSSSelector::Match::End:
         case CSSSelector::Match::Contain:
             if (selector->value().isEmpty())
                 return FunctionType::CannotMatchAnything;
-            FALLTHROUGH;
+            [[fallthrough]];
         case CSSSelector::Match::Exact:
         case CSSSelector::Match::Hyphen:
             fragment->onlyMatchesLinksInQuirksMode = false;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1636,7 +1636,7 @@ ExceptionOr<Ref<Node>> Document::importNode(Node& nodeToImport, Variant<bool, Im
     case Node::DOCUMENT_FRAGMENT_NODE:
         if (nodeToImport.isShadowRoot())
             break;
-        FALLTHROUGH;
+        [[fallthrough]];
     case Node::ELEMENT_NODE:
     case Node::TEXT_NODE:
     case Node::CDATA_SECTION_NODE:
@@ -2033,7 +2033,7 @@ void Document::setReadyState(ReadyState readyState)
                 eventTiming->domComplete = now;
             WTFEmitSignpost(this, NavigationAndPaintTiming, "domComplete");
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     case ReadyState::Interactive:
         if (!m_eventTiming.domInteractive) {
             auto now = MonotonicTime::now();

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1767,7 +1767,7 @@ static void appendTextContent(const Node* node, bool convertBRsToNewlines, bool&
             content.append('\n');
             break;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     case Node::DOCUMENT_FRAGMENT_NODE:
         isNullString = false;
         for (RefPtr child = node->firstChild(); child; child = child->nextSibling()) {

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -854,7 +854,7 @@ ScriptExecutionContext::HasResourceAccess ScriptExecutionContext::canAccessResou
     case ResourceType::StorageManager:
         if (isOriginEquivalentToLocal(*origin))
             return HasResourceAccess::No;
-        FALLTHROUGH;
+        [[fallthrough]];
     case ResourceType::SessionStorage:
         if (m_storageBlockingPolicy == StorageBlockingPolicy::BlockAll)
             return HasResourceAccess::No;

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -625,7 +625,7 @@ ALWAYS_INLINE void SelectorDataList::execute(ContainerNode& rootNode, OutputType
     case CompiledSingleWithRootFilter:
         CompiledSingleWithRootFilterCase:
         searchRootNode = &filterRootById(*searchRootNode, *m_selectors.first().selector);
-        FALLTHROUGH;
+        [[fallthrough]];
     case CompiledSingle:
         {
         CompiledSingleCase:
@@ -647,14 +647,14 @@ ALWAYS_INLINE void SelectorDataList::execute(ContainerNode& rootNode, OutputType
     case CompiledSingle:
         ASSERT_NOT_REACHED();
 #if !ASSERT_ENABLED
-        FALLTHROUGH;
+        [[fallthrough]];
 #endif
 #endif // ENABLE(CSS_SELECTOR_JIT)
 
     case SingleSelectorWithRootFilter:
         SingleSelectorWithRootFilterCase:
         searchRootNode = &filterRootById(*searchRootNode, *m_selectors.first().selector);
-        FALLTHROUGH;
+        [[fallthrough]];
     case SingleSelector:
         SingleSelectorCase:
         executeSingleSelectorData(rootNode, *searchRootNode, m_selectors.first(), output);
@@ -682,7 +682,7 @@ ALWAYS_INLINE void SelectorDataList::execute(ContainerNode& rootNode, OutputType
         goto CompiledMultipleSelectorMatch;
         }
 #else
-        FALLTHROUGH;
+        [[fallthrough]];
 #endif // ENABLE(CSS_SELECTOR_JIT)
     case CompiledMultipleSelectorMatch:
 #if ENABLE(CSS_SELECTOR_JIT)
@@ -690,7 +690,7 @@ ALWAYS_INLINE void SelectorDataList::execute(ContainerNode& rootNode, OutputType
         executeCompiledSingleMultiSelectorData(*searchRootNode, output);
         break;
 #else
-        FALLTHROUGH;
+        [[fallthrough]];
 #endif // ENABLE(CSS_SELECTOR_JIT)
     case MultipleSelectorMatch:
 #if ENABLE(CSS_SELECTOR_JIT)

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -183,7 +183,7 @@ Element* editableRootForPosition(const Position& position, EditableType editable
     case HasEditableAXRole:
         if (CheckedPtr cache = node->document().existingAXObjectCache())
             return const_cast<Element*>(cache->rootAXEditableElement(node.get()));
-        FALLTHROUGH;
+        [[fallthrough]];
     case ContentIsEditable:
         return node->rootEditableElement();
     }

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -463,7 +463,7 @@ static Ref<DataTransfer> createDataTransferForClipboardEvent(Document& document,
             pasteboard->writeString(plainTextType, plainText);
             return DataTransfer::createForCopyAndPaste(document, DataTransfer::StoreMode::Readonly, WTFMove(pasteboard));
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     case ClipboardEventKind::Paste:
     case ClipboardEventKind::PasteAsQuotation:
     case ClipboardEventKind::PasteFont:

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -532,7 +532,7 @@ OptionSet<EntityMask> MarkupAccumulator::entityMaskForText(const Text& text) con
         case HTML::noscript:
             if (!isScriptEnabled(*element))
                 break;
-            FALLTHROUGH;
+            [[fallthrough]];
         case HTML::iframe:
         case HTML::noembed:
         case HTML::noframes:

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -223,7 +223,7 @@ void HTMLElement::collectPresentationalHintsForAttribute(const QualifiedName& na
             break;
         case ContentEditableType::PlaintextOnly:
             userModifyValue = CSSValueReadWritePlaintextOnly;
-            FALLTHROUGH;
+            [[fallthrough]];
         case ContentEditableType::True:
             addPropertyToPresentationalHintStyle(style, CSSPropertyOverflowWrap, CSSValueBreakWord);
             addPropertyToPresentationalHintStyle(style, CSSPropertyWebkitNbspMode, CSSValueSpace);

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -150,7 +150,7 @@ void HTMLIFrameElement::attributeChanged(const QualifiedName& name, const AtomSt
         break;
     case AttributeNames::srcdocAttr:
     case AttributeNames::srcAttr:
-        FALLTHROUGH;
+        [[fallthrough]];
     default:
         HTMLFrameElementBase::attributeChanged(name, oldValue, newValue, attributeModificationReason);
         break;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1026,7 +1026,7 @@ void HTMLMediaElement::attributeChanged(const QualifiedName& name, const AtomStr
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     case AttributeNames::webkitwirelessvideoplaybackdisabledAttr:
         mediaSession().setWirelessVideoPlaybackDisabled(newValue != nullAtom());
-        FALLTHROUGH;
+        [[fallthrough]];
     case AttributeNames::disableremoteplaybackAttr:
     case AttributeNames::webkitairplayAttr:
         isWirelessPlaybackTargetDisabledChanged();

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -2806,7 +2806,7 @@ WebGLAny WebGL2RenderingContext::getFramebufferAttachmentParameter(GCGLenum targ
     case GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER:
         if (!isTexture)
             break;
-        FALLTHROUGH;
+        [[fallthrough]];
     case GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_RED_SIZE:
     case GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_GREEN_SIZE:
     case GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_BLUE_SIZE:
@@ -2906,7 +2906,7 @@ void WebGL2RenderingContext::renderbufferStorageImpl(GCGLenum target, GCGLsizei 
             synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "for integer formats, samples > 0 is not allowed"_s);
             return;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     case GraphicsContextGL::R8:
     case GraphicsContextGL::RG8:
     case GraphicsContextGL::RGB8:

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -1933,7 +1933,7 @@ WebGLAny WebGLRenderingContextBase::getParameter(GCGLenum pname)
     case GraphicsContextGL::GREEN_BITS:
         return getIntParameter(pname);
     case GraphicsContextGL::IMPLEMENTATION_COLOR_READ_FORMAT:
-        FALLTHROUGH;
+        [[fallthrough]];
     case GraphicsContextGL::IMPLEMENTATION_COLOR_READ_TYPE: {
         int value = getIntParameter(pname);
         if (!value) {
@@ -2253,7 +2253,7 @@ WebGLAny WebGLRenderingContextBase::getRenderbufferParameter(GCGLenum target, GC
             synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getRenderbufferParameter"_s, "invalid parameter name"_s);
             return nullptr;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     case GraphicsContextGL::RENDERBUFFER_WIDTH:
     case GraphicsContextGL::RENDERBUFFER_HEIGHT:
     case GraphicsContextGL::RENDERBUFFER_RED_SIZE:
@@ -3775,7 +3775,7 @@ bool WebGLRenderingContextBase::validateTypeAndArrayBufferType(ASCIILiteral func
             break;
         }
         ASSERT(functionType == ArrayBufferViewFunctionType::ReadPixels);
-        FALLTHROUGH;
+        [[fallthrough]];
     default:
         synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid type"_s);
         return false;
@@ -4191,7 +4191,7 @@ void WebGLRenderingContextBase::texParameter(GCGLenum target, GCGLenum pname, GC
             synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "texParameter"_s, "invalid parameter name"_s);
             return;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     case GraphicsContextGL::TEXTURE_WRAP_S:
     case GraphicsContextGL::TEXTURE_WRAP_T:
         if ((paramf == GraphicsContextGL::MIRROR_CLAMP_TO_EDGE_EXT) || (parami == GraphicsContextGL::MIRROR_CLAMP_TO_EDGE_EXT)) {

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -817,7 +817,7 @@ void HTMLTreeBuilder::processStartTagForInBody(AtomHTMLToken&& token)
         parseError(token);
         // Apparently we're not supposed to ask.
         token.setTagName(TagName::img);
-        FALLTHROUGH;
+        [[fallthrough]];
     case TagName::area:
     case TagName::br:
     case TagName::img:
@@ -1108,7 +1108,7 @@ void HTMLTreeBuilder::processStartTag(AtomHTMLToken&& token)
     case InsertionMode::Initial:
         defaultForInitial();
         ASSERT(m_insertionMode == InsertionMode::BeforeHTML);
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::BeforeHTML:
         if (token.tagName() == TagName::html) {
             m_tree.insertHTMLHtmlStartTagBeforeHTML(WTFMove(token));
@@ -1117,7 +1117,7 @@ void HTMLTreeBuilder::processStartTag(AtomHTMLToken&& token)
         }
         defaultForBeforeHTML();
         ASSERT(m_insertionMode == InsertionMode::BeforeHead);
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::BeforeHead:
         if (token.tagName() == TagName::html) {
             processHtmlStartTagForInBody(WTFMove(token));
@@ -1130,13 +1130,13 @@ void HTMLTreeBuilder::processStartTag(AtomHTMLToken&& token)
         }
         defaultForBeforeHead();
         ASSERT(m_insertionMode == InsertionMode::InHead);
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::InHead:
         if (processStartTagForInHead(WTFMove(token)))
             return;
         defaultForInHead();
         ASSERT(m_insertionMode == InsertionMode::AfterHead);
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::AfterHead:
         switch (token.tagName()) {
         case TagName::html:
@@ -1175,7 +1175,7 @@ void HTMLTreeBuilder::processStartTag(AtomHTMLToken&& token)
         }
         defaultForAfterHead();
         ASSERT(m_insertionMode == InsertionMode::InBody);
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::InBody:
         processStartTagForInBody(WTFMove(token));
         break;
@@ -1400,7 +1400,7 @@ void HTMLTreeBuilder::processStartTag(AtomHTMLToken&& token)
         default:
             break;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::InSelect:
         switch (token.tagName()) {
         case TagName::html:
@@ -2127,7 +2127,7 @@ void HTMLTreeBuilder::processEndTag(AtomHTMLToken&& token)
     case InsertionMode::Initial:
         defaultForInitial();
         ASSERT(m_insertionMode == InsertionMode::BeforeHTML);
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::BeforeHTML:
         switch (token.tagName()) {
         case TagName::head:
@@ -2141,7 +2141,7 @@ void HTMLTreeBuilder::processEndTag(AtomHTMLToken&& token)
         }
         defaultForBeforeHTML();
         ASSERT(m_insertionMode == InsertionMode::BeforeHead);
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::BeforeHead:
         switch (token.tagName()) {
         case TagName::head:
@@ -2155,7 +2155,7 @@ void HTMLTreeBuilder::processEndTag(AtomHTMLToken&& token)
         }
         defaultForBeforeHead();
         ASSERT(m_insertionMode == InsertionMode::InHead);
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::InHead:
         // FIXME: This case should be broken out into processEndTagForInHead,
         // because other end tag cases now refer to it ("process the token for using the rules of the "in head" insertion mode").
@@ -2178,7 +2178,7 @@ void HTMLTreeBuilder::processEndTag(AtomHTMLToken&& token)
         }
         defaultForInHead();
         ASSERT(m_insertionMode == InsertionMode::AfterHead);
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::AfterHead:
         switch (token.tagName()) {
         case TagName::body:
@@ -2191,7 +2191,7 @@ void HTMLTreeBuilder::processEndTag(AtomHTMLToken&& token)
         }
         defaultForAfterHead();
         ASSERT(m_insertionMode == InsertionMode::InBody);
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::InBody:
         processEndTagForInBody(WTFMove(token));
         break;
@@ -2266,7 +2266,7 @@ void HTMLTreeBuilder::processEndTag(AtomHTMLToken&& token)
             m_insertionMode = InsertionMode::AfterAfterBody;
             return;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::AfterAfterBody:
         ASSERT(m_insertionMode == InsertionMode::AfterBody || m_insertionMode == InsertionMode::AfterAfterBody);
         parseError(token);
@@ -2329,7 +2329,7 @@ void HTMLTreeBuilder::processEndTag(AtomHTMLToken&& token)
             m_insertionMode = InsertionMode::AfterAfterFrameset;
             return;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::AfterAfterFrameset:
         ASSERT(m_insertionMode == InsertionMode::AfterFrameset || m_insertionMode == InsertionMode::AfterAfterFrameset);
         parseError(token);
@@ -2354,7 +2354,7 @@ void HTMLTreeBuilder::processEndTag(AtomHTMLToken&& token)
         default:
             break;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::InSelect:
         ASSERT(m_insertionMode == InsertionMode::InSelect || m_insertionMode == InsertionMode::InSelectInTable);
         switch (token.tagName()) {
@@ -2586,34 +2586,34 @@ ReprocessBuffer:
             return;
         defaultForInitial();
         ASSERT(m_insertionMode == InsertionMode::BeforeHTML);
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::BeforeHTML:
         buffer.skipLeadingWhitespace();
         if (buffer.isEmpty())
             return;
         defaultForBeforeHTML();
         ASSERT(m_insertionMode == InsertionMode::BeforeHead);
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::BeforeHead:
         buffer.skipLeadingWhitespace();
         if (buffer.isEmpty())
             return;
         defaultForBeforeHead();
         ASSERT(m_insertionMode == InsertionMode::InHead);
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::InHead: {
         if (consumeAndInsertWhitespace(buffer))
             return;
         defaultForInHead();
         ASSERT(m_insertionMode == InsertionMode::AfterHead);
-        FALLTHROUGH;
+        [[fallthrough]];
     }
     case InsertionMode::AfterHead: {
         if (consumeAndInsertWhitespace(buffer))
             return;
         defaultForAfterHead();
         ASSERT(m_insertionMode == InsertionMode::InBody);
-        FALLTHROUGH;
+        [[fallthrough]];
     }
     case InsertionMode::InBody:
     case InsertionMode::InCaption:
@@ -2639,7 +2639,7 @@ ReprocessBuffer:
             processCharacterBufferForInBody(buffer);
             break;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::InTableText:
         buffer.giveRemainingTo(m_pendingTableCharacters);
         break;
@@ -2721,23 +2721,23 @@ void HTMLTreeBuilder::processEndOfFile(AtomHTMLToken&& token)
     case InsertionMode::Initial:
         defaultForInitial();
         ASSERT(m_insertionMode == InsertionMode::BeforeHTML);
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::BeforeHTML:
         defaultForBeforeHTML();
         ASSERT(m_insertionMode == InsertionMode::BeforeHead);
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::BeforeHead:
         defaultForBeforeHead();
         ASSERT(m_insertionMode == InsertionMode::InHead);
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::InHead:
         defaultForInHead();
         ASSERT(m_insertionMode == InsertionMode::AfterHead);
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::AfterHead:
         defaultForAfterHead();
         ASSERT(m_insertionMode == InsertionMode::InBody);
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::InBody:
     case InsertionMode::InCell:
     case InsertionMode::InCaption:
@@ -2765,7 +2765,7 @@ void HTMLTreeBuilder::processEndOfFile(AtomHTMLToken&& token)
         }
         ASSERT(m_tree.currentElementName() == HTML::colgroup || m_tree.currentElementName() == HTML::template_);
         processColgroupEndTagForInColumnGroup();
-        FALLTHROUGH;
+        [[fallthrough]];
     case InsertionMode::InFrameset:
     case InsertionMode::InTable:
     case InsertionMode::InTableBody:
@@ -3001,7 +3001,7 @@ void HTMLTreeBuilder::processTokenInForeignContent(AtomHTMLToken&& token)
         case TagName::font:
             if (!(hasAttribute(token, colorAttr) || hasAttribute(token, faceAttr) || hasAttribute(token, sizeAttr)))
                 break;
-            FALLTHROUGH;
+            [[fallthrough]];
         case TagName::b:
         case TagName::big:
         case TagName::blockquote:

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -1974,7 +1974,7 @@ Ref<Inspector::Protocol::DOM::Node> InspectorDOMAgent::buildObjectForNode(Node* 
     case Node::PROCESSING_INSTRUCTION_NODE:
         nodeName = node->nodeName();
         localName = node->localName();
-        FALLTHROUGH;
+        [[fallthrough]];
     case Node::TEXT_NODE:
     case Node::COMMENT_NODE:
     case Node::CDATA_SECTION_NODE:

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -265,14 +265,14 @@ InlineLayoutUnit InlineFormattingUtils::horizontalAlignmentOffset(const RenderSt
     case TextAlignMode::WebKitLeft:
         if (!isLeftToRightDirection)
             return horizontalAvailableSpace;
-        FALLTHROUGH;
+        [[fallthrough]];
     case TextAlignMode::Start:
         return { };
     case TextAlignMode::Right:
     case TextAlignMode::WebKitRight:
         if (!isLeftToRightDirection)
             return { };
-        FALLTHROUGH;
+        [[fallthrough]];
     case TextAlignMode::End:
         return horizontalAvailableSpace;
     case TextAlignMode::Center:

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -925,7 +925,7 @@ bool LineBuilder::shouldTryToPlaceFloatBox(const Box& floatBox, LayoutUnit float
         ASSERT(m_suspendedFloats.isEmpty());
         if (!isLineConstrainedByFloat())
             return true;
-        FALLTHROUGH;
+        [[fallthrough]];
     case MayOverConstrainLine::No: {
         auto lineIsConsideredEmpty = !m_line.hasContent() && !isLineConstrainedByFloat();
         if (lineIsConsideredEmpty)

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1184,7 +1184,7 @@ void DocumentLoader::continueAfterContentPolicy(PolicyAction policy)
     case PolicyAction::LoadWillContinueInAnotherProcess:
         ASSERT_NOT_REACHED();
 #if !ASSERT_ENABLED
-        FALLTHROUGH;
+        [[fallthrough]];
 #endif
     case PolicyAction::Ignore:
         if (RefPtr mainResourceLoader = this->mainResourceLoader())

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -217,7 +217,7 @@ static std::unique_ptr<LinkPreloadResourceClient> createLinkPreloadResourceClien
 #endif
     case CachedResource::Type::MediaResource:
         ASSERT_UNUSED(document, document.settings().mediaPreloadingEnabled());
-        FALLTHROUGH;
+        [[fallthrough]];
     case CachedResource::Type::RawResource:
         return makeUnique<LinkPreloadRawResourceClient>(loader, downcast<CachedRawResource>(resource));
     case CachedResource::Type::MainResource:

--- a/Source/WebCore/loader/PolicyChecker.cpp
+++ b/Source/WebCore/loader/PolicyChecker.cpp
@@ -248,7 +248,7 @@ void PolicyChecker::checkNavigationPolicy(ResourceRequest&& request, const Resou
                 frameLoader->client().startDownload(request, suggestedFilename, fromDownloadAttribute);
             } else if (RefPtr document = frame->document())
                 document->addConsoleMessage(MessageSource::Security, MessageLevel::Error, "Not allowed to download due to sandboxing"_s);
-            FALLTHROUGH;
+            [[fallthrough]];
         case PolicyAction::Ignore:
             POLICYCHECKER_RELEASE_LOG("checkNavigationPolicy: ignoring because policyAction from dispatchDecidePolicyForNavigationAction is Ignore");
             return function({ }, nullptr, NavigationPolicyDecision::IgnoreLoad);
@@ -350,7 +350,7 @@ void PolicyChecker::checkNewWindowPolicy(NavigationAction&& navigationAction, Re
                 frame->protectedLoader()->client().startDownload(request);
             else if (RefPtr document = frame->document())
                 document->addConsoleMessage(MessageSource::Security, MessageLevel::Error, "Not allowed to download due to sandboxing"_s);
-            FALLTHROUGH;
+            [[fallthrough]];
         case PolicyAction::Ignore:
             function({ }, nullptr, { }, { }, ShouldContinuePolicyCheck::No);
             return;

--- a/Source/WebCore/loader/ResourceLoadInfo.cpp
+++ b/Source/WebCore/loader/ResourceLoadInfo.cpp
@@ -74,7 +74,7 @@ OptionSet<ResourceType> toResourceType(CachedResource::Type type, ResourceReques
         if (requester == ResourceRequestRequester::XHR
             || requester == ResourceRequestRequester::Fetch)
             return { ResourceType::Fetch };
-        FALLTHROUGH;
+        [[fallthrough]];
     case CachedResource::Type::Beacon:
     case CachedResource::Type::Ping:
     case CachedResource::Type::Icon:

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1284,7 +1284,7 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
     case Reload:
         if (mayAddToMemoryCache == MayAddToMemoryCache::Yes)
             memoryCache->remove(*resource);
-        FALLTHROUGH;
+        [[fallthrough]];
     case Load:
         if (resource && mayAddToMemoryCache == MayAddToMemoryCache::Yes)
             memoryCache->remove(*resource);

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -325,7 +325,7 @@ void EventSource::parseEventStream()
                 break;
             case '\r':
                 m_discardTrailingNewline = true;
-                FALLTHROUGH;
+                [[fallthrough]];
             case '\n':
                 lineLength = i - position;
                 break;

--- a/Source/WebCore/page/mac/EventHandlerMac.mm
+++ b/Source/WebCore/page/mac/EventHandlerMac.mm
@@ -404,7 +404,7 @@ bool EventHandler::passSubframeEventToSubframe(MouseEventWithHitTestResults& eve
         if (subframe.page()->dragController().didInitiateDrag())
             return false;
 #endif
-        FALLTHROUGH;
+        [[fallthrough]];
     case NSEventTypeMouseMoved:
         // Since we're passing in currentNSEvent() here, we can call
         // handleMouseMoveEvent() directly, since the save/restore of

--- a/Source/WebCore/platform/DateComponents.cpp
+++ b/Source/WebCore/platform/DateComponents.cpp
@@ -748,7 +748,7 @@ String DateComponents::toStringForTime(SecondFormat format) const
     default:
         ASSERT_NOT_REACHED();
 #if !ASSERT_ENABLED
-        FALLTHROUGH; // To None.
+        [[fallthrough]]; // To None.
 #endif
     case SecondFormat::None:
         return makeString(pad('0', 2, m_hour), ':', pad('0', 2, m_minute));

--- a/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
@@ -313,12 +313,12 @@ Ref<InbandGenericCue> InbandTextTrackPrivateAVF::processCueAttributes(CFAttribut
         switch (cueData->align()) {
         case GenericCueData::Alignment::None:
             // By default, VTT cues alignment align as "start"
-            FALLTHROUGH;
+            [[fallthrough]];
         case GenericCueData::Alignment::Middle:
             // AVFoundation generates "middle" alignment cues for single line cues
             // and cues multi-line cues with lines of equal length, so just treat
             // "middle" alignment the same as "start"
-            FALLTHROUGH;
+            [[fallthrough]];
         case GenericCueData::Alignment::Start:
             cueData->setPositionAlign(GenericCueData::Alignment::Start);
             cueData->setPosition(cueData->position() - cueData->size() / 2);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1007,13 +1007,13 @@ void MediaPlayerPrivateMediaSourceAVFObjC::ensureLayerOrVideoRenderer(MediaPlaye
     switch (acceleratedVideoMode()) {
     case AcceleratedVideoMode::Layer:
         destroyVideoRenderer();
-        FALLTHROUGH;
+        [[fallthrough]];
     case AcceleratedVideoMode::StagedLayer:
         ensureLayer();
         break;
     case AcceleratedVideoMode::VideoRenderer:
         destroyLayer();
-        FALLTHROUGH;
+        [[fallthrough]];
     case AcceleratedVideoMode::StagedVideoRenderer:
         ensureVideoRenderer();
         break;
@@ -1035,14 +1035,14 @@ void MediaPlayerPrivateMediaSourceAVFObjC::ensureLayerOrVideoRenderer(MediaPlaye
     switch (acceleratedVideoMode()) {
     case AcceleratedVideoMode::Layer:
         needsRenderingModeChanged = MediaPlayerEnums::NeedsRenderingModeChanged::Yes;
-        FALLTHROUGH;
+        [[fallthrough]];
     case AcceleratedVideoMode::VideoRenderer:
         if (mediaSourcePrivate)
             mediaSourcePrivate->setVideoRenderer(renderer.get());
         break;
     case AcceleratedVideoMode::StagedLayer:
         needsRenderingModeChanged = MediaPlayerEnums::NeedsRenderingModeChanged::Yes;
-        FALLTHROUGH;
+        [[fallthrough]];
     case AcceleratedVideoMode::StagedVideoRenderer:
         if (mediaSourcePrivate)
             mediaSourcePrivate->stageVideoRenderer(renderer.get());

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1687,13 +1687,13 @@ void MediaPlayerPrivateWebM::ensureLayerOrVideoRenderer(MediaPlayerEnums::NeedsR
     switch (acceleratedVideoMode()) {
     case AcceleratedVideoMode::Layer:
         destroyVideoRenderer();
-        FALLTHROUGH;
+        [[fallthrough]];
     case AcceleratedVideoMode::StagedLayer:
         ensureLayer();
         break;
     case AcceleratedVideoMode::VideoRenderer:
         destroyLayer();
-        FALLTHROUGH;
+        [[fallthrough]];
     case AcceleratedVideoMode::StagedVideoRenderer:
         ensureVideoRenderer();
         break;
@@ -1717,13 +1717,13 @@ void MediaPlayerPrivateWebM::ensureLayerOrVideoRenderer(MediaPlayerEnums::NeedsR
 #else
         needsRenderingModeChanged = MediaPlayerEnums::NeedsRenderingModeChanged::Yes;
 #endif
-        FALLTHROUGH;
+        [[fallthrough]];
     case AcceleratedVideoMode::VideoRenderer:
         setVideoRenderer(renderer.get());
         break;
     case AcceleratedVideoMode::StagedLayer:
         needsRenderingModeChanged = MediaPlayerEnums::NeedsRenderingModeChanged::Yes;
-        FALLTHROUGH;
+        [[fallthrough]];
     case AcceleratedVideoMode::StagedVideoRenderer:
         stageVideoRenderer(renderer.get());
         break;

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -980,7 +980,7 @@ unsigned long long MediaPlayerPrivateGStreamer::totalBytes() const
             gst_iterator_resync(iter);
             break;
         case GST_ITERATOR_ERROR:
-            FALLTHROUGH;
+            [[fallthrough]];
         case GST_ITERATOR_DONE:
             done = true;
             break;
@@ -2772,7 +2772,7 @@ void MediaPlayerPrivateGStreamer::updateStates()
             m_networkState = MediaPlayer::NetworkState::Empty;
             break;
         case GST_STATE_PAUSED:
-            FALLTHROUGH;
+            [[fallthrough]];
         case GST_STATE_PLAYING: {
             bool isLooping = player && player->isLooping();
             if (m_wasBuffering) {

--- a/Source/WebCore/platform/graphics/gstreamer/VideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoSinkGStreamer.cpp
@@ -252,7 +252,7 @@ static gboolean webkitVideoSinkEvent(GstBaseSink* baseSink, GstEvent* event)
 
         GST_DEBUG_OBJECT(sink, "Flush-start, releasing m_sample");
     }
-        FALLTHROUGH;
+        [[fallthrough]];
     default:
         return GST_BASE_SINK_CLASS(webkit_video_sink_parent_class)->event(baseSink, event);
     }

--- a/Source/WebCore/platform/graphics/win/FullScreenController.cpp
+++ b/Source/WebCore/platform/graphics/win/FullScreenController.cpp
@@ -96,7 +96,7 @@ LRESULT FullScreenController::Private::fullscreenClientWndProc(HWND hwnd, UINT m
             m_controller->exitFullScreen();
             break;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     default:
         lResult = ::DefWindowProc(hwnd, msg, wParam, lParam);
     }

--- a/Source/WebCore/platform/graphics/win/SystemFontDatabaseWin.cpp
+++ b/Source/WebCore/platform/graphics/win/SystemFontDatabaseWin.cpp
@@ -71,7 +71,7 @@ auto SystemFontDatabase::platformSystemFontShorthandInfo(FontShorthand fontShort
     case FontShorthand::WebkitMiniControl: // Just map to small.
     case FontShorthand::WebkitControl: // Just map to small.
         shouldUseDefaultControlFontPixelSize = true;
-        FALLTHROUGH;
+        [[fallthrough]];
     default: { // Everything else uses the stock GUI font.
         HGDIOBJ hGDI = ::GetStockObject(DEFAULT_GUI_FONT);
         if (!hGDI)

--- a/Source/WebCore/platform/gtk/ScrollbarThemeGtk.cpp
+++ b/Source/WebCore/platform/gtk/ScrollbarThemeGtk.cpp
@@ -117,7 +117,7 @@ static GtkStateFlags scrollbarPartStateFlags(Scrollbar& scrollbar, ScrollbarPart
             stateFlags |= GTK_STATE_FLAG_INSENSITIVE;
             break;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     default:
         if (scrollbar.hoveredPart() == part)
             stateFlags |= GTK_STATE_FLAG_PRELIGHT;

--- a/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
@@ -409,7 +409,7 @@ public:
                 m_info.src->bytes_in_buffer = 0;
                 return true;
             }
-            FALLTHROUGH;
+            [[fallthrough]];
 
         case JPEG_START_DECOMPRESS:
             // Set parameters for decompression.
@@ -427,7 +427,7 @@ public:
 
             // If this is a progressive JPEG ...
             m_state = (m_info.buffered_image) ? JPEG_DECOMPRESS_PROGRESSIVE : JPEG_DECOMPRESS_SEQUENTIAL;
-            FALLTHROUGH;
+            [[fallthrough]];
 
         case JPEG_DECOMPRESS_SEQUENTIAL:
             if (m_state == JPEG_DECOMPRESS_SEQUENTIAL) {
@@ -439,7 +439,7 @@ public:
                 ASSERT(m_info.output_scanline == m_info.output_height);
                 m_state = JPEG_DONE;
             }
-            FALLTHROUGH;
+            [[fallthrough]];
 
         case JPEG_DECOMPRESS_PROGRESSIVE:
             if (m_state == JPEG_DECOMPRESS_PROGRESSIVE) {
@@ -493,7 +493,7 @@ public:
 
                 m_state = JPEG_DONE;
             }
-            FALLTHROUGH;
+            [[fallthrough]];
 
         case JPEG_DONE:
             // Finish decompression.

--- a/Source/WebCore/platform/image-decoders/webp/WEBPImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/webp/WEBPImageDecoder.cpp
@@ -209,7 +209,7 @@ void WEBPImageDecoder::decodeFrame(size_t frameIndex, WebPDemuxer* demuxer)
             buffer.setDecodingStatus(DecodingStatus::Partial);
             break;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     default:
         setFailed();
     }

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
@@ -76,7 +76,7 @@ CaptureSourceOrError DisplayCaptureSourceCocoa::create(const CaptureDevice& devi
             return makeUniqueRefWithoutRefCountedCheck<ReplayKitCaptureSource>(source);
         }, device, WTFMove(hashSalts), constraints, pageIdentifier);
 #elif HAVE(SCREEN_CAPTURE_KIT)
-        FALLTHROUGH;
+        [[fallthrough]];
 #else
         ASSERT_NOT_REACHED();
         return { };

--- a/Source/WebCore/platform/network/NetworkStorageSession.cpp
+++ b/Source/WebCore/platform/network/NetworkStorageSession.cpp
@@ -209,7 +209,7 @@ ThirdPartyCookieBlockingDecision NetworkStorageSession::thirdPartyCookieBlocking
     case ThirdPartyCookieBlockingMode::AllOnSitesWithoutUserInteraction:
         if (!hasHadUserInteractionAsFirstParty(firstPartyDomain))
             return decideThirdPartyCookieBlocking(false);
-        FALLTHROUGH;
+        [[fallthrough]];
     case ThirdPartyCookieBlockingMode::OnlyAccordingToPerDomainPolicy:
         return decideThirdPartyCookieBlocking(!shouldBlockThirdPartyCookies(resourceDomain));
     }

--- a/Source/WebCore/platform/network/curl/CurlMultipartHandle.cpp
+++ b/Source/WebCore/platform/network/curl/CurlMultipartHandle.cpp
@@ -122,7 +122,7 @@ bool CurlMultipartHandle::processContent()
 {
     switch (m_state) {
     case State::FindBoundaryStart:
-        FALLTHROUGH;
+        [[fallthrough]];
     case State::InBody: {
         auto result = findBoundary();
         if (result.isSyntaxError) {

--- a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
+++ b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
@@ -353,7 +353,7 @@ void NetworkStorageSession::setCookieAcceptPolicy(HTTPCookieAcceptPolicy policy)
         soupPolicy = SOUP_COOKIE_JAR_ACCEPT_GRANDFATHERED_THIRD_PARTY;
         break;
 #else
-        FALLTHROUGH;
+        [[fallthrough]];
 #endif
     case HTTPCookieAcceptPolicy::ExclusivelyFromMainDocumentDomain:
         soupPolicy = SOUP_COOKIE_JAR_ACCEPT_NO_THIRD_PARTY;

--- a/Source/WebCore/platform/text/BidiResolver.h
+++ b/Source/WebCore/platform/text/BidiResolver.h
@@ -502,7 +502,7 @@ inline void BidiResolverBase<Iterator, Run, DerivedClass>::updateStatusLastFromC
         // ignore these
         break;
     case U_EUROPEAN_NUMBER:
-        FALLTHROUGH;
+        [[fallthrough]];
     default:
         m_status.last = dirCurrent;
     }
@@ -698,7 +698,7 @@ void BidiResolverBase<Iterator, Run, DerivedClass>::createBidiRunsForLine(const 
                 case U_EUROPEAN_NUMBER:
                 case U_ARABIC_NUMBER:
                     appendRun();
-                    FALLTHROUGH;
+                    [[fallthrough]];
                 case U_RIGHT_TO_LEFT:
                 case U_RIGHT_TO_LEFT_ARABIC:
                     break;
@@ -751,7 +751,7 @@ void BidiResolverBase<Iterator, Run, DerivedClass>::createBidiRunsForLine(const 
                     case U_COMMON_NUMBER_SEPARATOR:
                         if (m_status.eor == U_EUROPEAN_NUMBER)
                             break;
-                        FALLTHROUGH;
+                        [[fallthrough]];
                     case U_EUROPEAN_NUMBER_TERMINATOR:
                     case U_BOUNDARY_NEUTRAL:
                     case U_BLOCK_SEPARATOR:
@@ -799,7 +799,7 @@ void BidiResolverBase<Iterator, Run, DerivedClass>::createBidiRunsForLine(const 
                     m_direction = U_LEFT_TO_RIGHT;
                 break;
             }
-            FALLTHROUGH;
+            [[fallthrough]];
         case U_ARABIC_NUMBER:
             dirCurrent = U_ARABIC_NUMBER;
             switch (m_status.last) {
@@ -818,7 +818,7 @@ void BidiResolverBase<Iterator, Run, DerivedClass>::createBidiRunsForLine(const 
                 case U_COMMON_NUMBER_SEPARATOR:
                     if (m_status.eor == U_ARABIC_NUMBER)
                         break;
-                    FALLTHROUGH;
+                    [[fallthrough]];
                 case U_EUROPEAN_NUMBER_SEPARATOR:
                 case U_EUROPEAN_NUMBER_TERMINATOR:
                 case U_BOUNDARY_NEUTRAL:

--- a/Source/WebCore/platform/text/TextFlags.cpp
+++ b/Source/WebCore/platform/text/TextFlags.cpp
@@ -217,13 +217,13 @@ FeaturesMap computeFeatureSettingsFromVariants(const FontVariantSettings& varian
         break;
     case FontVariantCaps::AllSmall:
         features.set(fontFeatureTag("c2sc"), 1);
-        FALLTHROUGH;
+        [[fallthrough]];
     case FontVariantCaps::Small:
         features.set(fontFeatureTag("smcp"), 1);
         break;
     case FontVariantCaps::AllPetite:
         features.set(fontFeatureTag("c2pc"), 1);
-        FALLTHROUGH;
+        [[fallthrough]];
     case FontVariantCaps::Petite:
         features.set(fontFeatureTag("pcap"), 1);
         break;

--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -325,10 +325,10 @@ float AutoTableLayout::calcEffectiveLogicalWidth()
                     // legacy behaviour anyway. mozilla doesn't do this so I decided we don't neither.
                     break;
                 }
-                FALLTHROUGH;
+                [[fallthrough]];
             case LengthType::Auto:
                 haveAuto = true;
-                FALLTHROUGH;
+                [[fallthrough]];
             default:
                 // If the column is a percentage width, do not let the spanning cell overwrite the
                 // width value.  This caused a mis-rendering on amazon.com.

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -783,7 +783,7 @@ LayoutSize BackgroundPainter::calculateFillTileSize(const RenderBoxModelObject& 
         // If the image has neither an intrinsic width nor an intrinsic height, its size is determined as for ‘contain’.
         type = FillSizeType::Contain;
     }
-    FALLTHROUGH;
+    [[fallthrough]];
     case FillSizeType::Contain:
     case FillSizeType::Cover: {
         // Scale computation needs higher precision than what LayoutUnit can offer.

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -1240,7 +1240,7 @@ void BorderPainter::drawLineForBoxSide(GraphicsContext& graphicsContext, const D
     case BorderStyle::Inset:
     case BorderStyle::Outset:
         color = calculateBorderStyleColor(borderStyle, side, color);
-        FALLTHROUGH;
+        [[fallthrough]];
     case BorderStyle::Solid: {
         StrokeStyle oldStrokeStyle = graphicsContext.strokeStyle();
         ASSERT(x2 >= x1);

--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -306,7 +306,7 @@ Vector<MarkedText> MarkedText::collectForDocumentMarkers(const RenderText& rende
             if (!shouldPaintMarker)
                 break;
 
-            BFALLTHROUGH;
+            [[fallthrough]];
         }
 #endif
         case DocumentMarkerType::DictationAlternatives:

--- a/Source/WebCore/rendering/PointerEventsHitRules.cpp
+++ b/Source/WebCore/rendering/PointerEventsHitRules.cpp
@@ -40,7 +40,7 @@ PointerEventsHitRules::PointerEventsHitRules(HitTestingTargetType hitTestingTarg
             case PointerEvents::Auto: // "auto" is like "visiblePainted" when in SVG content
                 requireFill = true;
                 requireStroke = true;
-                FALLTHROUGH;
+                [[fallthrough]];
             case PointerEvents::Visible:
                 requireVisible = true;
                 canHitFill = true;
@@ -57,7 +57,7 @@ PointerEventsHitRules::PointerEventsHitRules(HitTestingTargetType hitTestingTarg
             case PointerEvents::Painted:
                 requireFill = true;
                 requireStroke = true;
-                FALLTHROUGH;
+                [[fallthrough]];
             case PointerEvents::All:
                 canHitFill = true;
                 canHitStroke = true;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -917,7 +917,7 @@ void RenderLayerBacking::updateVideoGravity(const RenderStyle& style)
     case ObjectFit::None:
     case ObjectFit::ScaleDown:
         // FIXME: Add support for "None" and "ScaleDown" with video gravity modes
-        FALLTHROUGH;
+        [[fallthrough]];
     case ObjectFit::Fill:
         videoGravity = MediaPlayerVideoGravity::Resize;
         break;
@@ -2625,7 +2625,7 @@ bool RenderLayerBacking::updateViewportConstrainedSublayers(ViewportConstrainedS
         break;
     case ClippingAndAnchor:
         needsClippingLayer = true;
-        FALLTHROUGH;
+        [[fallthrough]];
     case Anchor:
         needsAnchorLayer = true;
         break;

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -617,7 +617,7 @@ bool RenderLayerModelObject::pointInSVGClippingArea(const FloatPoint& point) con
                     referenceBox.setSize(*viewportSize);
                 break;
             }
-            FALLTHROUGH;
+            [[fallthrough]];
         case CSSBoxType::ContentBox:
         case CSSBoxType::FillBox:
         case CSSBoxType::PaddingBox:

--- a/Source/WebCore/rendering/RenderQuote.cpp
+++ b/Source/WebCore/rendering/RenderQuote.cpp
@@ -469,7 +469,7 @@ String RenderQuote::computeText() const
         return emptyString();
     case QuoteType::OpenQuote:
         isOpenQuote = true;
-        FALLTHROUGH;
+        [[fallthrough]];
     case QuoteType::CloseQuote:
         if (const auto* quotes = style().quotes())
             return isOpenQuote ? quotes->openQuote(m_depth).impl() : quotes->closeQuote(m_depth).impl();

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -530,7 +530,7 @@ LayoutRect RenderReplaced::replacedContentRect(const LayoutSize& intrinsicSize) 
         finalRect.setSize(finalRect.size().fitToAspectRatio(intrinsicSize, objectFit == ObjectFit::Cover ? AspectRatioFitGrow : AspectRatioFitShrink));
         if (objectFit != ObjectFit::ScaleDown || finalRect.width() <= intrinsicSize.width())
             break;
-        FALLTHROUGH;
+        [[fallthrough]];
     case ObjectFit::None:
         finalRect.setSize(intrinsicSize);
         break;

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -218,7 +218,7 @@ void RenderTable::willInsertTableSection(RenderTableSection& child, RenderObject
             m_foot = child;
             break;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     case DisplayType::TableRowGroup:
         resetSectionPointerIfNotBefore(m_firstBody, beforeChild);
         if (!m_firstBody)

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -706,7 +706,7 @@ Color RenderThemeMac::systemColor(CSSValueID cssValueID, OptionSet<StyleColorOpt
 
         case CSSValueBackground:
             // Use platform-independent value returned by base class.
-            FALLTHROUGH;
+            [[fallthrough]];
 
         default:
             return RenderTheme::systemColor(cssValueID, options);

--- a/Source/WebCore/rendering/style/WillChangeData.h
+++ b/Source/WebCore/rendering/style/WillChangeData.h
@@ -103,7 +103,7 @@ private:
             case Feature::Property:
                 ASSERT(willChangeProperty != CSSPropertyInvalid);
                 m_cssPropertyID = willChangeProperty;
-                FALLTHROUGH;
+                [[fallthrough]];
             case Feature::ScrollPosition:
             case Feature::Contents:
                 m_feature = willChange;

--- a/Source/WebCore/rendering/svg/SVGMarkerData.h
+++ b/Source/WebCore/rendering/svg/SVGMarkerData.h
@@ -140,7 +140,7 @@ private:
             break;
         case PathElement::Type::MoveToPoint:
             m_subpathStart = points[0];
-            FALLTHROUGH;
+            [[fallthrough]];
         case PathElement::Type::AddLineToPoint:
             updateInslope(points[0]);
             m_origin = points[0];

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -388,7 +388,7 @@ inline FloatRect clipPathReferenceBox(const RenderElement& renderer, CSSBoxType 
                 referenceBox.setSize(*viewportSize);
             break;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     case CSSBoxType::ContentBox:
     case CSSBoxType::FillBox:
     case CSSBoxType::PaddingBox:

--- a/Source/WebCore/style/StylePendingResources.cpp
+++ b/Source/WebCore/style/StylePendingResources.cpp
@@ -59,7 +59,7 @@ static void loadPendingImage(Document& document, const StyleImage* styleImage, c
         switch (loadPolicy) {
         case LoadPolicy::Anonymous:
             options.storedCredentialsPolicy = StoredCredentialsPolicy::DoNotUse;
-            FALLTHROUGH;
+            [[fallthrough]];
         case LoadPolicy::CORS:
             options.mode = FetchOptions::Mode::Cors;
             options.credentials = FetchOptions::Credentials::SameOrigin;

--- a/Source/WebCore/svg/SVGFEDropShadowElement.cpp
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.cpp
@@ -99,7 +99,7 @@ void SVGFEDropShadowElement::svgAttributeChanged(const QualifiedName& attrName)
             markFilterEffectForRebuild();
             return;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     }
     case AttributeNames::dxAttr:
     case AttributeNames::dyAttr: {

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
@@ -102,7 +102,7 @@ void SVGFEGaussianBlurElement::svgAttributeChanged(const QualifiedName& attrName
             markFilterEffectForRebuild();
             return;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     }
     case AttributeNames::edgeModeAttr: {
         InstanceInvalidationGuard guard(*this);

--- a/Source/WebCore/svg/SVGPathParser.cpp
+++ b/Source/WebCore/svg/SVGPathParser.cpp
@@ -313,28 +313,28 @@ bool SVGPathParser::parsePathData(bool checkForInitialMoveTo)
         switch (command) {
         case SVGPathSegType::MoveToRel:
             m_mode = RelativeCoordinates;
-            FALLTHROUGH;
+            [[fallthrough]];
         case SVGPathSegType::MoveToAbs:
             if (!parseMoveToSegment())
                 return false;
             break;
         case SVGPathSegType::LineToRel:
             m_mode = RelativeCoordinates;
-            FALLTHROUGH;
+            [[fallthrough]];
         case SVGPathSegType::LineToAbs:
             if (!parseLineToSegment())
                 return false;
             break;
         case SVGPathSegType::LineToHorizontalRel:
             m_mode = RelativeCoordinates;
-            FALLTHROUGH;
+            [[fallthrough]];
         case SVGPathSegType::LineToHorizontalAbs:
             if (!parseLineToHorizontalSegment())
                 return false;
             break;
         case SVGPathSegType::LineToVerticalRel:
             m_mode = RelativeCoordinates;
-            FALLTHROUGH;
+            [[fallthrough]];
         case SVGPathSegType::LineToVerticalAbs:
             if (!parseLineToVerticalSegment())
                 return false;
@@ -344,35 +344,35 @@ bool SVGPathParser::parsePathData(bool checkForInitialMoveTo)
             break;
         case SVGPathSegType::CurveToCubicRel:
             m_mode = RelativeCoordinates;
-            FALLTHROUGH;
+            [[fallthrough]];
         case SVGPathSegType::CurveToCubicAbs:
             if (!parseCurveToCubicSegment())
                 return false;
             break;
         case SVGPathSegType::CurveToCubicSmoothRel:
             m_mode = RelativeCoordinates;
-            FALLTHROUGH;
+            [[fallthrough]];
         case SVGPathSegType::CurveToCubicSmoothAbs:
             if (!parseCurveToCubicSmoothSegment())
                 return false;
             break;
         case SVGPathSegType::CurveToQuadraticRel:
             m_mode = RelativeCoordinates;
-            FALLTHROUGH;
+            [[fallthrough]];
         case SVGPathSegType::CurveToQuadraticAbs:
             if (!parseCurveToQuadraticSegment())
                 return false;
             break;
         case SVGPathSegType::CurveToQuadraticSmoothRel:
             m_mode = RelativeCoordinates;
-            FALLTHROUGH;
+            [[fallthrough]];
         case SVGPathSegType::CurveToQuadraticSmoothAbs:
             if (!parseCurveToQuadraticSmoothSegment())
                 return false;
             break;
         case SVGPathSegType::ArcRel:
             m_mode = RelativeCoordinates;
-            FALLTHROUGH;
+            [[fallthrough]];
         case SVGPathSegType::ArcAbs:
             if (!parseArcToSegment())
                 return false;

--- a/Source/WebCore/svg/SVGTransformDistance.cpp
+++ b/Source/WebCore/svg/SVGTransformDistance.cpp
@@ -58,7 +58,7 @@ SVGTransformDistance::SVGTransformDistance(const SVGTransformValue& fromSVGTrans
     case SVGTransformValue::SVG_TRANSFORM_MATRIX:
         ASSERT_NOT_REACHED();
 #if !ASSERT_ENABLED
-        FALLTHROUGH;
+        [[fallthrough]];
 #endif
     case SVGTransformValue::SVG_TRANSFORM_UNKNOWN:
         break;
@@ -93,7 +93,7 @@ SVGTransformDistance SVGTransformDistance::scaledDistance(float scaleFactor) con
     case SVGTransformValue::SVG_TRANSFORM_MATRIX:
         ASSERT_NOT_REACHED();
 #if !ASSERT_ENABLED
-        FALLTHROUGH;
+        [[fallthrough]];
 #endif
     case SVGTransformValue::SVG_TRANSFORM_UNKNOWN:
         return SVGTransformDistance();
@@ -126,7 +126,7 @@ SVGTransformValue SVGTransformDistance::addSVGTransforms(const SVGTransformValue
     case SVGTransformValue::SVG_TRANSFORM_MATRIX:
         ASSERT_NOT_REACHED();
 #if !ASSERT_ENABLED
-        FALLTHROUGH;
+        [[fallthrough]];
 #endif
     case SVGTransformValue::SVG_TRANSFORM_UNKNOWN:
         return { };
@@ -168,7 +168,7 @@ SVGTransformValue SVGTransformDistance::addToSVGTransform(const SVGTransformValu
     case SVGTransformValue::SVG_TRANSFORM_MATRIX:
         ASSERT_NOT_REACHED();
 #if !ASSERT_ENABLED
-        FALLTHROUGH;
+        [[fallthrough]];
 #endif
     case SVGTransformValue::SVG_TRANSFORM_UNKNOWN:
         return { };
@@ -207,7 +207,7 @@ float SVGTransformDistance::distance() const
     case SVGTransformValue::SVG_TRANSFORM_MATRIX:
         ASSERT_NOT_REACHED();
 #if !ASSERT_ENABLED
-        FALLTHROUGH;
+        [[fallthrough]];
 #endif
     case SVGTransformValue::SVG_TRANSFORM_UNKNOWN:
         return 0;

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -1031,7 +1031,7 @@ Ref<TextResourceDecoder> XMLHttpRequest::createDecoder() const
             decoder->useLenientXMLDecoding();
             return decoder;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     case ResponseType::Text:
     case ResponseType::Json: {
         auto decoder = TextResourceDecoder::create("text/plain"_s, "UTF-8"_s);

--- a/Source/WebDriver/Session.cpp
+++ b/Source/WebDriver/Session.cpp
@@ -2895,7 +2895,7 @@ void Session::performActions(Vector<Vector<Action>>&& actionsByTick, Function<vo
                         state->setObject("location"_s, WTFMove(location));
                         if (action.origin->type == PointerOrigin::Type::Element)
                             state->setString("nodeHandle"_s, action.origin->elementID.value());
-                        FALLTHROUGH;
+                        [[fallthrough]];
                     }
                     case Action::Subtype::Pause:
                         if (action.duration)
@@ -2970,7 +2970,7 @@ void Session::performActions(Vector<Vector<Action>>&& actionsByTick, Function<vo
 
                         if (action.origin->type == PointerOrigin::Type::Element)
                             state->setString("nodeHandle"_s, action.origin->elementID.value());
-                        FALLTHROUGH;
+                        [[fallthrough]];
                     }
                     case Action::Subtype::Pause:
                         if (action.duration)

--- a/Source/WebDriver/glib/WebDriverServiceGLib.cpp
+++ b/Source/WebDriver/glib/WebDriverServiceGLib.cpp
@@ -42,14 +42,14 @@ static bool parseVersion(const String& version, uint64_t& major, uint64_t& minor
             return false;
         micro = *parsedMicro;
     }
-        FALLTHROUGH;
+        [[fallthrough]];
     case 2: {
         auto parsedMinor = parseIntegerAllowingTrailingJunk<uint64_t>(tokens[1]);
         if (!parsedMinor)
             return false;
         minor = *parsedMinor;
     }
-        FALLTHROUGH;
+        [[fallthrough]];
     case 1: {
         auto parsedMajor = parseIntegerAllowingTrailingJunk<uint64_t>(tokens[0]);
         if (!parsedMajor)

--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -84,7 +84,7 @@ Vector<Token> Lexer<T>::lex()
         switch (token.type) {
         case TokenType::GtGtEq:
             tokens.append(makeToken(TokenType::Placeholder));
-            FALLTHROUGH;
+            [[fallthrough]];
         case TokenType::GtGt:
         case TokenType::GtEq:
         case TokenType::MinusMinus:

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -238,7 +238,7 @@ static MTLPixelFormat metalPixelFormat(CVPixelBufferRef pixelBuffer, size_t plan
         return MTLPixelFormatRGBA8Unorm;
     case kCVPixelFormatType_64ARGB:     /* 64 bit ARGB, 16-bit big-endian samples */
         swizzle = MTLTextureSwizzleChannelsMake(MTLTextureSwizzleGreen, MTLTextureSwizzleZero, MTLTextureSwizzleZero, MTLTextureSwizzleZero);
-        FALLTHROUGH;
+        [[fallthrough]];
     case kCVPixelFormatType_64RGBALE:     /* 64 bit RGBA, 16-bit little-endian full-range (0-65535) samples */
         return MTLPixelFormatRGBA16Unorm;
 

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
@@ -2770,7 +2770,7 @@ bool ResourceLoadStatisticsStore::shouldRemoveAllButCookiesFor(const DomainData&
     OperatingDatesWindow window { };
     switch (firstPartyWebsiteDataRemovalMode()) {
     case FirstPartyWebsiteDataRemovalMode::AllButCookies:
-        FALLTHROUGH;
+        [[fallthrough]];
     case FirstPartyWebsiteDataRemovalMode::None:
         window = resourceStatistic.dataRemovalFrequency == DataRemovalFrequency::Short ? OperatingDatesWindow::Short : OperatingDatesWindow::Long;
         break;

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -435,7 +435,7 @@ void NetworkLoadChecker::checkCORSRequest(ResourceRequest&& request, ValidationH
             checkCORSRequestWithPreflight(WTFMove(request), WTFMove(handler));
             return;
         }
-        FALLTHROUGH;
+        [[fallthrough]];
     case PreflightPolicy::Prevent:
         updateRequestForAccessControl(request, *origin(), m_storedCredentialsPolicy);
         handler(WTFMove(request));

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -475,7 +475,7 @@ void Cache::retrieve(const WebCore::ResourceRequest& request, std::optional<Glob
             UNUSED_PARAM(allowPrivacyProxy);
             UNUSED_PARAM(advancedPrivacyProtections);
 #endif
-            FALLTHROUGH;
+            [[fallthrough]];
         }
         case UseDecision::Use:
             break;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -125,7 +125,7 @@ static NSURLSessionResponseDisposition toNSURLSessionResponseDisposition(WebCore
     case WebCore::PolicyAction::LoadWillContinueInAnotherProcess:
         ASSERT_NOT_REACHED();
 #if !ASSERT_ENABLED
-        FALLTHROUGH;
+        [[fallthrough]];
 #endif
     case WebCore::PolicyAction::Ignore:
         return NSURLSessionResponseCancel;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -480,13 +480,13 @@ WallTime NetworkStorageManager::lastModificationTimeForOrigin(const WebCore::Cli
         auto idbStoragePath = IDBStorageManager::idbStorageOriginDirectory(m_customIDBStoragePath, origin);
         auto idbStorageModificationTime = valueOrDefault(FileSystem::fileModificationTime(idbStoragePath));
         lastModificationTime = std::max(idbStorageModificationTime, lastModificationTime);
-        FALLTHROUGH;
+        [[fallthrough]];
     }
     case UnifiedOriginStorageLevel::Basic: {
         auto cacheStoragePath = CacheStorageManager::cacheStorageOriginDirectory(m_customCacheStoragePath, origin);
         auto cacheStorageModificationTime = valueOrDefault(FileSystem::fileModificationTime(cacheStoragePath));
         lastModificationTime = std::max(cacheStorageModificationTime, lastModificationTime);
-        FALLTHROUGH;
+        [[fallthrough]];
     }
     case UnifiedOriginStorageLevel::Standard: {
         auto originFile = originFilePath(manager.path());

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
@@ -72,7 +72,7 @@ static void didReceiveServerTrustChallenge(Ref<NetworkConnectionToWebProcess>&& 
                 return;
             }
         }
-        FALLTHROUGH;
+        [[fallthrough]];
         case AuthenticationChallengeDisposition::RejectProtectionSpaceAndContinue:
         case AuthenticationChallengeDisposition::PerformDefaultHandling: {
             OSStatus status = SecTrustEvaluateAsyncWithError(secTrust.get(), dispatch_get_main_queue(), makeBlockPtr([completion = completion](SecTrustRef trustRef, bool result, CFErrorRef error) {

--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
@@ -307,7 +307,7 @@ static void encodeInvocationArguments(WKRemoteObjectEncoder *encoder, NSInvocati
                 encodeToObjectStream(encoder, @(value.height));
                 break;
             }
-            FALLTHROUGH;
+            [[fallthrough]];
 
         default:
             [NSException raise:NSInvalidArgumentException format:@"Unsupported invocation argument type '%.*s'", static_cast<int>(type.size()), type.data()];
@@ -988,7 +988,7 @@ static void decodeInvocationArguments(WKRemoteObjectDecoder *decoder, NSInvocati
                 [invocation setArgument:&value atIndex:i];
                 break;
             }
-            FALLTHROUGH;
+            [[fallthrough]];
 
         default:
             [NSException raise:NSInvalidArgumentException format:@"Unsupported invocation argument type '%.*s' for argument %zu", static_cast<int>(type.size()), type.data(), (unsigned long)i];

--- a/Source/WebKit/UIProcess/API/C/WKAPICast.h
+++ b/Source/WebKit/UIProcess/API/C/WKAPICast.h
@@ -242,7 +242,7 @@ inline WKProcessTerminationReason toAPI(ProcessTerminationReason reason)
     case ProcessTerminationReason::NavigationSwap:
         // We probably shouldn't bother coming up with a new C-API type for process-swapping.
         // "Requested by client" seems like the best match for existing types.
-        FALLTHROUGH;
+        [[fallthrough]];
     case ProcessTerminationReason::RequestedByClient:
         return kWKProcessTerminationReasonRequestedByClient;
     case ProcessTerminationReason::ExceededProcessCountLimit:

--- a/Source/WebKit/UIProcess/API/gtk/WebKitScriptDialogImpl.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitScriptDialogImpl.cpp
@@ -315,7 +315,7 @@ GtkWidget* webkitScriptDialogImplNew(WebKitScriptDialog* scriptDialog, const cha
         gtk_entry_set_activates_default(GTK_ENTRY(dialog->priv->entry), TRUE);
         gtk_widget_show(dialog->priv->entry);
 
-        FALLTHROUGH;
+        [[fallthrough]];
     case WEBKIT_SCRIPT_DIALOG_CONFIRM: {
         gtk_label_set_text(GTK_LABEL(dialog->priv->title), title);
 

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -1325,7 +1325,7 @@ static void webkitWebViewBaseHandleMouseEvent(WebKitWebViewBase* webViewBase, Gd
 
         clickCount = priv->clickCounter.currentClickCountForGdkButtonEvent(event);
     }
-        FALLTHROUGH;
+        [[fallthrough]];
     case GDK_BUTTON_RELEASE:
         gtk_widget_grab_focus(GTK_WIDGET(webViewBase));
         break;
@@ -1890,7 +1890,7 @@ static gboolean webkitWebViewBaseTouchEvent(GtkWidget* widget, GdkEventTouch* ev
         break;
     }
     case GDK_TOUCH_CANCEL:
-        FALLTHROUGH;
+        [[fallthrough]];
     case GDK_TOUCH_END:
         ASSERT(priv->touchEvents.contains(sequence));
         priv->touchEvents.remove(sequence);

--- a/Source/WebKit/UIProcess/API/libwpe/TouchGestureController.cpp
+++ b/Source/WebKit/UIProcess/API/libwpe/TouchGestureController.cpp
@@ -75,7 +75,7 @@ TouchGestureController::EventVariant TouchGestureController::handleEvent(const s
 
             // Over threshold, bump the gestured event and directly fall through to handling it.
             m_gesturedEvent = GesturedEvent::Axis;
-            FALLTHROUGH;
+            [[fallthrough]];
         }
         case GesturedEvent::ContextMenu:
             break;
@@ -144,7 +144,7 @@ TouchGestureController::EventVariant TouchGestureController::handleEvent(const s
                 return generatedEvent;
             }
 
-            FALLTHROUGH;
+            [[fallthrough]];
         }
         case GesturedEvent::ContextMenu:
         {

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
@@ -321,7 +321,7 @@ gboolean ViewPlatform::handleEvent(WPEEvent* event)
         break;
     case WPE_EVENT_POINTER_DOWN:
         m_inputMethodFilter.cancelComposition();
-        FALLTHROUGH;
+        [[fallthrough]];
     case WPE_EVENT_POINTER_UP:
     case WPE_EVENT_POINTER_MOVE:
     case WPE_EVENT_POINTER_ENTER:

--- a/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp
+++ b/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp
@@ -50,7 +50,7 @@ SimulatedInputSourceState SimulatedInputSourceState::emptyStateForSourceType(Sim
         break;
     case SimulatedInputSourceType::Wheel:
         result.scrollDelta = WebCore::IntSize();
-        FALLTHROUGH;
+        [[fallthrough]];
     case SimulatedInputSourceType::Mouse:
     case SimulatedInputSourceType::Touch:
     case SimulatedInputSourceType::Pen:

--- a/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
+++ b/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
@@ -561,7 +561,7 @@ static unsigned short keyCodeForVirtualKey(VirtualKey key)
     case VirtualKey::NumberPadSeparator:
         // The 'Separator' key is only present on a few international keyboards.
         // It is usually mapped to the same character as Decimal ('.' or ',').
-        FALLTHROUGH;
+        [[fallthrough]];
     case VirtualKey::NumberPadDecimal:
         return kVK_ANSI_KeypadDecimal;
         // FIXME: this might be locale-dependent. See the above comment.

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -1247,7 +1247,7 @@ static _WKProcessTerminationReason wkProcessTerminationReason(ProcessTermination
     case ProcessTerminationReason::IdleExit:
         // We probably shouldn't bother coming up with a new API type for process-swapping.
         // "Requested by client" seems like the best match for existing types.
-        FALLTHROUGH;
+        [[fallthrough]];
     case ProcessTerminationReason::RequestedByClient:
         return _WKProcessTerminationReasonRequestedByClient;
     case ProcessTerminationReason::ExceededProcessCountLimit:

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -12169,7 +12169,7 @@ void WebPageProxy::willStartCapture(UserMediaPermissionRequestProxy& request, Co
         break;
     case WebCore::MediaStreamRequest::Type::DisplayMediaWithAudio:
         m_mutedCaptureKindsDesiredByWebApp.remove(WebCore::MediaProducerMediaCaptureKind::SystemAudio);
-        FALLTHROUGH;
+        [[fallthrough]];
     case WebCore::MediaStreamRequest::Type::DisplayMedia:
         m_mutedCaptureKindsDesiredByWebApp.remove(WebCore::MediaProducerMediaCaptureKind::Display);
         break;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -732,7 +732,7 @@ private:
     case ProcessAccessType::Launch:
         networkProcess();
         ASSERT(m_networkProcess);
-        FALLTHROUGH;
+        [[fallthrough]];
     case ProcessAccessType::OnlyIfLaunched:
         if (RefPtr networkProcess = m_networkProcess) {
             networkProcess->fetchWebsiteData(m_sessionID, dataTypes, fetchOptions, [callbackAggregator](WebsiteData websiteData) {

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -3428,7 +3428,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         switch (ignoreTapGestureReason(_singleTapGestureRecognizer.get())) {
         case WebKit::IgnoreTapGestureReason::ToggleEditMenu:
             _page->clearSelectionAfterTappingSelectionHighlightIfNeeded(point);
-            FALLTHROUGH;
+            [[fallthrough]];
         case WebKit::IgnoreTapGestureReason::DeferToScrollView:
             return NO;
         case WebKit::IgnoreTapGestureReason::None:

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
@@ -209,12 +209,12 @@ NSString *toNSString(JSContextRef context, JSValueRef value, NullStringPolicy nu
     case NullStringPolicy::NullAndUndefinedAsNullString:
         if (JSValueIsUndefined(context, value))
             return nil;
-        FALLTHROUGH;
+        [[fallthrough]];
 
     case NullStringPolicy::NullAsNullString:
         if (JSValueIsNull(context, value))
             return nil;
-        FALLTHROUGH;
+        [[fallthrough]];
 
     case NullStringPolicy::NoNullString:
         // Don't try to convert other objects into strings.
@@ -283,7 +283,7 @@ JSValueRef toJSValueRef(JSContextRef context, NSString *string, NullOrEmptyStrin
     case NullOrEmptyString::NullStringAsNull:
         if (!string)
             return JSValueMakeNull(context);
-        FALLTHROUGH;
+        [[fallthrough]];
 
     case NullOrEmptyString::NullStringAsEmptyString:
         return JSValueMakeString(context, toJSString(string).get());

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
@@ -610,7 +610,7 @@ AffineTransform PDFDocumentLayout::toPageTransform(const PageGeometry& pageGeome
     AffineTransform matrix;
     switch (pageGeometry.rotation) {
     default:
-        FALLTHROUGH;
+        [[fallthrough]];
     case 0:
         matrix = AffineTransform::makeTranslation(FloatSize { pageGeometry.cropBox.x(), pageGeometry.cropBox.y() });
         break;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -748,7 +748,7 @@ T UnifiedPDFPlugin::convertDown(CoordinateSpace sourceSpace, CoordinateSpace des
             return mappedValue;
 
         mappedValue.moveBy(WebCore::FloatPoint { m_scrollOffset });
-        FALLTHROUGH;
+        [[fallthrough]];
 
     case CoordinateSpace::ScrolledContents:
         if (destinationSpace == CoordinateSpace::ScrolledContents)
@@ -758,14 +758,14 @@ T UnifiedPDFPlugin::convertDown(CoordinateSpace sourceSpace, CoordinateSpace des
             mappedValue.scale(1 / m_scaleFactor);
             mappedValue.move(-centeringOffset());
         }
-        FALLTHROUGH;
+        [[fallthrough]];
 
     case CoordinateSpace::Contents:
         if (destinationSpace == CoordinateSpace::Contents)
             return mappedValue;
 
         mappedValue.scale(1 / m_documentLayout.scale());
-        FALLTHROUGH;
+        [[fallthrough]];
 
     case CoordinateSpace::PDFDocumentLayout:
         if (destinationSpace == CoordinateSpace::PDFDocumentLayout)
@@ -774,7 +774,7 @@ T UnifiedPDFPlugin::convertDown(CoordinateSpace sourceSpace, CoordinateSpace des
         ASSERT(pageIndex);
         ASSERT(*pageIndex < m_documentLayout.pageCount());
         mappedValue = m_documentLayout.documentToPDFPage(mappedValue, *pageIndex);
-        FALLTHROUGH;
+        [[fallthrough]];
 
     case CoordinateSpace::PDFPage:
         if (destinationSpace == CoordinateSpace::PDFPage)
@@ -799,14 +799,14 @@ T UnifiedPDFPlugin::convertUp(CoordinateSpace sourceSpace, CoordinateSpace desti
         ASSERT(pageIndex);
         ASSERT(*pageIndex < m_documentLayout.pageCount());
         mappedValue = m_documentLayout.pdfPageToDocument(mappedValue, *pageIndex);
-        FALLTHROUGH;
+        [[fallthrough]];
 
     case CoordinateSpace::PDFDocumentLayout:
         if (destinationSpace == CoordinateSpace::PDFDocumentLayout)
             return mappedValue;
 
         mappedValue.scale(m_documentLayout.scale());
-        FALLTHROUGH;
+        [[fallthrough]];
 
     case CoordinateSpace::Contents:
         if (destinationSpace == CoordinateSpace::Contents)
@@ -814,7 +814,7 @@ T UnifiedPDFPlugin::convertUp(CoordinateSpace sourceSpace, CoordinateSpace desti
 
         mappedValue.move(centeringOffset());
         mappedValue.scale(m_scaleFactor);
-        FALLTHROUGH;
+        [[fallthrough]];
 
     case CoordinateSpace::ScrolledContents:
         if (destinationSpace == CoordinateSpace::ScrolledContents)
@@ -822,7 +822,7 @@ T UnifiedPDFPlugin::convertUp(CoordinateSpace sourceSpace, CoordinateSpace desti
 
         if (!shouldSizeToFitContent())
             mappedValue.moveBy(-WebCore::FloatPoint { m_scrollOffset });
-        FALLTHROUGH;
+        [[fallthrough]];
 
     case CoordinateSpace::Plugin:
         if (destinationSpace == CoordinateSpace::Plugin)

--- a/Source/WebKitLegacy/mac/History/BinaryPropertyList.cpp
+++ b/Source/WebKitLegacy/mac/History/BinaryPropertyList.cpp
@@ -745,26 +745,26 @@ void BinaryPropertyListSerializer::appendObjectReference(ObjectReference referen
 #ifdef __LP64__
     case 8:
         appendByte(reference >> 56);
-        FALLTHROUGH;
+        [[fallthrough]];
     case 7:
         appendByte(reference >> 48);
-        FALLTHROUGH;
+        [[fallthrough]];
     case 6:
         appendByte(reference >> 40);
-        FALLTHROUGH;
+        [[fallthrough]];
     case 5:
         appendByte(reference >> 32);
-        FALLTHROUGH;
+        [[fallthrough]];
 #endif
     case 4:
         appendByte(reference >> 24);
-        FALLTHROUGH;
+        [[fallthrough]];
     case 3:
         appendByte(reference >> 16);
-        FALLTHROUGH;
+        [[fallthrough]];
     case 2:
         appendByte(reference >> 8);
-        FALLTHROUGH;
+        [[fallthrough]];
     case 1:
         appendByte(reference);
     }
@@ -781,26 +781,26 @@ void BinaryPropertyListSerializer::startObject()
 #ifdef __LP64__
     case 8:
         offsetTableEntry[-8] = offset >> 56;
-        FALLTHROUGH;
+        [[fallthrough]];
     case 7:
         offsetTableEntry[-7] = offset >> 48;
-        FALLTHROUGH;
+        [[fallthrough]];
     case 6:
         offsetTableEntry[-6] = offset >> 40;
-        FALLTHROUGH;
+        [[fallthrough]];
     case 5:
         offsetTableEntry[-5] = offset >> 32;
-        FALLTHROUGH;
+        [[fallthrough]];
 #endif
     case 4:
         offsetTableEntry[-4] = offset >> 24;
-        FALLTHROUGH;
+        [[fallthrough]];
     case 3:
         offsetTableEntry[-3] = offset >> 16;
-        FALLTHROUGH;
+        [[fallthrough]];
     case 2:
         offsetTableEntry[-2] = offset >> 8;
-        FALLTHROUGH;
+        [[fallthrough]];
     case 1:
         offsetTableEntry[-1] = offset;
     }
@@ -812,26 +812,26 @@ void BinaryPropertyListSerializer::addAggregateObjectReference(ObjectReference r
 #ifdef __LP64__
     case 8:
         m_buffer[--m_currentAggregateBufferByteIndex] = reference >> 56;
-        FALLTHROUGH;
+        [[fallthrough]];
     case 7:
         m_buffer[--m_currentAggregateBufferByteIndex] = reference >> 48;
-        FALLTHROUGH;
+        [[fallthrough]];
     case 6:
         m_buffer[--m_currentAggregateBufferByteIndex] = reference >> 40;
-        FALLTHROUGH;
+        [[fallthrough]];
     case 5:
         m_buffer[--m_currentAggregateBufferByteIndex] = reference >> 32;
-        FALLTHROUGH;
+        [[fallthrough]];
 #endif
     case 4:
         m_buffer[--m_currentAggregateBufferByteIndex] = reference >> 24;
-        FALLTHROUGH;
+        [[fallthrough]];
     case 3:
         m_buffer[--m_currentAggregateBufferByteIndex] = reference >> 16;
-        FALLTHROUGH;
+        [[fallthrough]];
     case 2:
         m_buffer[--m_currentAggregateBufferByteIndex] = reference >> 8;
-        FALLTHROUGH;
+        [[fallthrough]];
     case 1:
         m_buffer[--m_currentAggregateBufferByteIndex] = reference;
     }

--- a/Source/bmalloc/bmalloc/BCompiler.h
+++ b/Source/bmalloc/bmalloc/BCompiler.h
@@ -75,24 +75,6 @@
 #endif
 #endif
 
-/* BFALLTHROUGH */
-
-#if !defined(BFALLTHROUGH) && defined(__cplusplus) && defined(__has_cpp_attribute)
-
-#if __has_cpp_attribute(fallthrough)
-#define BFALLTHROUGH [[fallthrough]]
-#elif __has_cpp_attribute(clang::fallthrough)
-#define BFALLTHROUGH [[clang::fallthrough]]
-#elif __has_cpp_attribute(gnu::fallthrough)
-#define BFALLTHROUGH [[gnu::fallthrough]]
-#endif
-
-#endif // !defined(BFALLTHROUGH) && defined(__cplusplus) && defined(__has_cpp_attribute)
-
-#if !defined(BFALLTHROUGH)
-#define BFALLTHROUGH
-#endif
-
 /* BLIKELY */
 
 #if !defined(BLIKELY) && BCOMPILER(GCC_COMPATIBLE)

--- a/Source/bmalloc/bmalloc/IsoHeapImplInlines.h
+++ b/Source/bmalloc/bmalloc/IsoHeapImplInlines.h
@@ -271,7 +271,7 @@ AllocationMode IsoHeapImpl<Config>::updateAllocationMode()
             //     }
             if (m_numberOfAllocationsFromSharedInOneCycle <= IsoPage<Config>::numObjects)
                 return AllocationMode::Shared;
-            BFALLTHROUGH;
+            [[fallthrough]];
 
         case AllocationMode::Fast: {
             // The allocation pattern may change. We should check the allocation rate and decide which mode is more appropriate.

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
@@ -88,7 +88,7 @@ static RetainPtr<nw_protocol_definition_t> proxyDefinition(HTTPServer::Protocol 
                 }
                 case State::DidRequestCredentials:
                     EXPECT_TRUE(strnstr(byteCast<char>(buffer), "Proxy-Authorization: Basic dGVzdHVzZXI6dGVzdHBhc3N3b3Jk\r\n", bufferLength));
-                    FALLTHROUGH;
+                    [[fallthrough]];
                 case State::WillNotRequestCredentials: {
                     const char* negotiationResponse = ""
                         "HTTP/1.1 200 Connection Established\r\n"


### PR DESCRIPTION
#### fb045b8a4a2a7c16bda06b610270178a0d458eb9
<pre>
Use C++ [[fallthrough]]
<a href="https://bugs.webkit.org/show_bug.cgi?id=292497">https://bugs.webkit.org/show_bug.cgi?id=292497</a>
<a href="https://rdar.apple.com/150607884">rdar://150607884</a>

Reviewed by Chris Dumez.

Use C++ [[fallthrough]] attribute instead of FALLTHROUGH.

* Source/JavaScriptCore/API/glib/JSCValue.cpp:
(jsObjectCall):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::vectorSplatAVX):
(JSC::MacroAssemblerX86_64::vectorSplat):
* Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp:
* Source/JavaScriptCore/b3/B3StackmapSpecial.cpp:
(JSC::B3::StackmapSpecial::forEachArgImpl):
(JSC::B3::StackmapSpecial::repForArg):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::FunctionNode::emitBytecode):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGArithMode.h:
(JSC::DFG::doesOverflow):
* Source/JavaScriptCore/dfg/DFGArrayMode.h:
(JSC::DFG::ArrayMode::arrayModesWithIndexingShapes const):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGMayExit.cpp:
* Source/JavaScriptCore/dfg/DFGOSRExit.cpp:
(JSC::DFG::OSRExit::compileExit):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compilePutByVal):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::fillSpeculateInt32Internal):
(JSC::DFG::SpeculativeJIT::fillSpeculateBigInt32):
(JSC::DFG::SpeculativeJIT::compilePutByVal):
* Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.cpp:
(Inspector::RemoteInspectionTarget::allowsInspectionByPolicy const):
* Source/JavaScriptCore/interpreter/CallFrame.cpp:
(JSC::CallFrame::callerSourceOrigin):
* Source/JavaScriptCore/jit/CallFrameShuffler64.cpp:
(JSC::CallFrameShuffler::emitStore):
(JSC::CallFrameShuffler::emitBox):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::directPutByVal):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::llint_slow_path_checkpoint_osr_exit_from_inlined_call):
* Source/JavaScriptCore/parser/Lexer.cpp:
(JSC::Lexer&lt;T&gt;::lexWithoutClearingLineTerminator):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseModuleSourceElements):
(JSC::Parser&lt;LexerType&gt;::parseSingleFunction):
(JSC::Parser&lt;LexerType&gt;::parseStatementListItem):
(JSC::Parser&lt;LexerType&gt;::parseStatement):
(JSC::Parser&lt;LexerType&gt;::parseClass):
(JSC::Parser&lt;LexerType&gt;::parseExportDeclaration):
(JSC::Parser&lt;LexerType&gt;::parseProperty):
(JSC::Parser&lt;LexerType&gt;::parsePrimaryExpression):
* Source/JavaScriptCore/runtime/CommonSlowPaths.h:
(JSC::CommonSlowPaths::opEnumeratorGetByVal):
* Source/JavaScriptCore/runtime/CommonSlowPathsInlines.h:
(JSC::CommonSlowPaths::tryCachePutToScopeGlobal):
(JSC::CommonSlowPaths::tryCacheGetFromScopeGlobal):
(JSC::CommonSlowPaths::opEnumeratorPutByVal):
* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::parseTimeZoneAnnotation):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::setLength):
* Source/JavaScriptCore/runtime/JSArrayInlines.h:
(JSC::JSArray::pushInline):
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::Walker::walk):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::putByIndex):
(JSC::JSObject::deletePropertyByIndex):
(JSC::JSObject::putByIndexBeyondVectorLength):
* Source/JavaScriptCore/runtime/JSObject.h:
(JSC::JSObject::trySetIndexQuickly):
(JSC::JSObject::setIndexQuickly):
(JSC::JSObject::initializeIndex):
(JSC::JSObject::initializeIndexWithoutBarrier):
* Source/JavaScriptCore/runtime/JSPropertyNameEnumerator.cpp:
(JSC::JSPropertyNameEnumerator::computeNext):
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::reviverMode&gt;::parse):
* Source/JavaScriptCore/runtime/VMTraps.cpp:
(JSC::VMTraps::handleTraps):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseUnreachableExpression):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::emitStoreOp):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::emitStoreOp):
* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
(JSC::Wasm::marshallJSResult):
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::matchBackReference):
(JSC::Yarr::Interpreter::backtrackParenthesesOnceBegin):
(JSC::Yarr::Interpreter::backtrackParenthesesOnceEnd):
(JSC::Yarr::Interpreter::matchDisjunction):
* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::Parser::CharacterClassParserDelegate::atomPatternCharacter):
(JSC::Yarr::Parser::CharacterClassParserDelegate::atomBuiltInCharacterClass):
(JSC::Yarr::Parser::ClassSetParserDelegate::atomPatternCharacter):
(JSC::Yarr::Parser::ClassSetParserDelegate::atomBuiltInCharacterClass):
(JSC::Yarr::Parser::parseTokens):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::PatternTerm::dump):
* Source/WTF/wtf/ParkingLot.cpp:
* Source/WTF/wtf/URLParser.cpp:
(WTF::URLParser::copyURLPartsUntil):
(WTF::URLParser::parse):
* Source/WebCore/PAL/pal/text/TextCodecCJK.cpp:
(PAL::TextCodecCJK::iso2022JPDecode):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::updateIsolatedTree):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::dependsOnTextUnderElement const):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper determineIsAccessibilityElement]):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::serialize):
(WebCore::CloneDeserializer::deserialize):
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::valueForTextEmphasisStyle):
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::consumeRuleList):
* Source/WebCore/css/parser/CSSParserToken.cpp:
(WebCore::CSSParserToken::operator== const):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumeAttributeMatch):
* Source/WebCore/css/parser/SizesCalcParser.cpp:
(WebCore::SizesCalcParser::calcToReversePolishNotation):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::constructFragmentsInternal):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::importNode):
(WebCore::Document::setReadyState):
* Source/WebCore/dom/Node.cpp:
(WebCore::appendTextContent):
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::canAccessResource const):
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::SelectorDataList::execute const):
* Source/WebCore/editing/Editing.cpp:
(WebCore::editableRootForPosition):
* Source/WebCore/editing/Editor.cpp:
(WebCore::createDataTransferForClipboardEvent):
* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::MarkupAccumulator::entityMaskForText const):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::collectPresentationalHintsForAttribute):
* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::HTMLIFrameElement::attributeChanged):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::attributeChanged):
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::getFramebufferAttachmentParameter):
(WebCore::WebGL2RenderingContext::renderbufferStorageImpl):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::getParameter):
(WebCore::WebGLRenderingContextBase::getRenderbufferParameter):
(WebCore::WebGLRenderingContextBase::validateTypeAndArrayBufferType):
(WebCore::WebGLRenderingContextBase::texParameter):
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::processStartTagForInBody):
(WebCore::HTMLTreeBuilder::processStartTag):
(WebCore::HTMLTreeBuilder::processEndTag):
(WebCore::HTMLTreeBuilder::processCharacterBuffer):
(WebCore::HTMLTreeBuilder::processEndOfFile):
(WebCore::HTMLTreeBuilder::processTokenInForeignContent):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::buildObjectForNode):
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
(WebCore::Layout::InlineFormattingUtils::horizontalAlignmentOffset):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::LineBuilder::shouldTryToPlaceFloatBox const):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::continueAfterContentPolicy):
* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::createLinkPreloadResourceClient):
* Source/WebCore/loader/PolicyChecker.cpp:
(WebCore::PolicyChecker::checkNavigationPolicy):
(WebCore::PolicyChecker::checkNewWindowPolicy):
* Source/WebCore/loader/ResourceLoadInfo.cpp:
(WebCore::ContentExtensions::toResourceType):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
* Source/WebCore/page/EventSource.cpp:
(WebCore::EventSource::parseEventStream):
* Source/WebCore/page/mac/EventHandlerMac.mm:
(WebCore::EventHandler::passSubframeEventToSubframe):
* Source/WebCore/platform/DateComponents.cpp:
(WebCore::DateComponents::toStringForTime const):
* Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp:
(WebCore::InbandTextTrackPrivateAVF::processCueAttributes):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureLayerOrVideoRenderer):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::ensureLayerOrVideoRenderer):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::totalBytes const):
(WebCore::MediaPlayerPrivateGStreamer::updateStates):
* Source/WebCore/platform/graphics/gstreamer/VideoSinkGStreamer.cpp:
(webkitVideoSinkEvent):
* Source/WebCore/platform/graphics/win/FullScreenController.cpp:
(WebCore::FullScreenController::Private::fullscreenClientWndProc):
* Source/WebCore/platform/graphics/win/SystemFontDatabaseWin.cpp:
(WebCore::SystemFontDatabase::platformSystemFontShorthandInfo):
* Source/WebCore/platform/gtk/ScrollbarThemeGtk.cpp:
(WebCore::scrollbarPartStateFlags):
* Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp:
(WebCore::JPEGImageReader::decode):
* Source/WebCore/platform/image-decoders/webp/WEBPImageDecoder.cpp:
(WebCore::WEBPImageDecoder::decodeFrame):
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp:
(WebCore::DisplayCaptureSourceCocoa::create):
* Source/WebCore/platform/network/NetworkStorageSession.cpp:
(WebCore::NetworkStorageSession::thirdPartyCookieBlockingDecisionForRequest const):
* Source/WebCore/platform/network/curl/CurlMultipartHandle.cpp:
(WebCore::CurlMultipartHandle::processContent):
* Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp:
(WebCore::NetworkStorageSession::setCookieAcceptPolicy):
* Source/WebCore/platform/text/BidiResolver.h:
(WebCore::DerivedClass&gt;::updateStatusLastFromCurrentDirection):
(WebCore::DerivedClass&gt;::createBidiRunsForLine):
* Source/WebCore/platform/text/TextFlags.cpp:
(WebCore::computeFeatureSettingsFromVariants):
* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::calcEffectiveLogicalWidth):
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::calculateFillTileSize):
* Source/WebCore/rendering/BorderPainter.cpp:
(WebCore::BorderPainter::drawLineForBoxSide):
* Source/WebCore/rendering/MarkedText.cpp:
(WebCore::MarkedText::collectForDocumentMarkers):
* Source/WebCore/rendering/PointerEventsHitRules.cpp:
(WebCore::PointerEventsHitRules::PointerEventsHitRules):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateVideoGravity):
(WebCore::RenderLayerBacking::updateViewportConstrainedSublayers):
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::pointInSVGClippingArea const):
* Source/WebCore/rendering/RenderQuote.cpp:
(WebCore::RenderQuote::computeText const):
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::paint):
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::willInsertTableSection):
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::RenderThemeMac::systemColor const):
* Source/WebCore/rendering/style/WillChangeData.h:
(WebCore::WillChangeData::AnimatableFeature::AnimatableFeature):
* Source/WebCore/rendering/svg/SVGMarkerData.h:
(WebCore::SVGMarkerData::updateMarkerDataForPathElement):
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::clipPathReferenceBox):
* Source/WebCore/style/StylePendingResources.cpp:
(WebCore::Style::loadPendingImage):
* Source/WebCore/svg/SVGFEDropShadowElement.cpp:
(WebCore::SVGFEDropShadowElement::svgAttributeChanged):
* Source/WebCore/svg/SVGFEGaussianBlurElement.cpp:
(WebCore::SVGFEGaussianBlurElement::svgAttributeChanged):
* Source/WebCore/svg/SVGPathParser.cpp:
(WebCore::SVGPathParser::parsePathData):
* Source/WebCore/svg/SVGTransformDistance.cpp:
(WebCore::SVGTransformDistance::SVGTransformDistance):
(WebCore::SVGTransformDistance::scaledDistance const):
(WebCore::SVGTransformDistance::addSVGTransforms):
(WebCore::SVGTransformDistance::addToSVGTransform const):
(WebCore::SVGTransformDistance::distance const):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::createDecoder const):
* Source/WebDriver/Session.cpp:
(WebDriver::Session::performActions):
* Source/WebDriver/glib/WebDriverServiceGLib.cpp:
(WebDriver::parseVersion):
* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::lex):
* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::metalPixelFormat):
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::ResourceLoadStatisticsStore::shouldRemoveAllButCookiesFor):
* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::checkCORSRequest):
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::retrieve):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(toNSURLSessionResponseDisposition):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::lastModificationTimeForOrigin const):
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::didReceiveServerTrustChallenge):
* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm:
(encodeInvocationArguments):
(decodeInvocationArguments):
* Source/WebKit/UIProcess/API/C/WKAPICast.h:
(WebKit::toAPI):
* Source/WebKit/UIProcess/API/gtk/WebKitScriptDialogImpl.cpp:
(webkitScriptDialogImplNew):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseHandleMouseEvent):
(webkitWebViewBaseTouchEvent):
* Source/WebKit/UIProcess/API/libwpe/TouchGestureController.cpp:
(WebKit::TouchGestureController::handleEvent):
* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp:
(WKWPE::ViewPlatform::handleEvent):
* Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp:
(WebKit::SimulatedInputSourceState::emptyStateForSourceType):
* Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm:
(WebKit::keyCodeForVirtualKey):
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::wkProcessTerminationReason):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::willStartCapture):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::fetchDataAndApply):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView gestureRecognizerShouldBegin:]):
* Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm:
(WebKit::toNSString):
(WebKit::toJSValueRef):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::toPageTransform const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
(WebKit::UnifiedPDFPlugin::convertDown const):
(WebKit::UnifiedPDFPlugin::convertUp const):
* Source/WebKitLegacy/mac/History/BinaryPropertyList.cpp:
(BinaryPropertyListSerializer::appendObjectReference):
(BinaryPropertyListSerializer::startObject):
(BinaryPropertyListSerializer::addAggregateObjectReference):
* Source/bmalloc/bmalloc/BCompiler.h:
* Source/bmalloc/bmalloc/IsoHeapImplInlines.h:
(bmalloc::IsoHeapImpl&lt;Config&gt;::updateAllocationMode):
* Tools/TestWebKitAPI/cocoa/HTTPServer.mm:
(TestWebKitAPI::proxyDefinition):

Canonical link: <a href="https://commits.webkit.org/294481@main">https://commits.webkit.org/294481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34af1c4d5a43c376a764f3a71bcd2f4501bef2a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101995 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107154 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52629 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104035 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30170 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77645 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34648 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16994 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92094 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57981 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16821 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10119 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51988 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94667 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86662 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10192 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109527 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100605 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29128 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21458 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86617 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29489 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88298 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86196 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30979 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8699 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23326 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16584 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29056 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34351 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124230 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28867 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34506 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32190 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30426 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->