### PR TITLE
Refactor the model animation state tracking logic into another class

### DIFF
--- a/Source/WebCore/Modules/model-element/ModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.cpp
@@ -27,6 +27,7 @@
 #include "ModelPlayer.h"
 
 #include "Color.h"
+#include "ModelPlayerAnimationState.h"
 #include "TransformationMatrix.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -39,6 +40,11 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ModelPlayer);
 
 ModelPlayer::~ModelPlayer() = default;
+
+std::optional<ModelPlayerAnimationState> ModelPlayer::currentAnimationState() const
+{
+    return std::nullopt;
+}
 
 void ModelPlayer::setEntityTransform(TransformationMatrix)
 {

--- a/Source/WebCore/Modules/model-element/ModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.h
@@ -45,6 +45,7 @@ namespace WebCore {
 
 class Color;
 class Model;
+class ModelPlayerAnimationState;
 class SharedBuffer;
 class TransformationMatrix;
 
@@ -56,6 +57,8 @@ public:
 #if ENABLE(MODEL_PROCESS)
     virtual ModelPlayerIdentifier identifier() const = 0;
 #endif
+
+    virtual std::optional<ModelPlayerAnimationState> currentAnimationState() const;
 
     virtual void load(Model&, LayoutSize) = 0;
     virtual void sizeDidChange(LayoutSize) = 0;

--- a/Source/WebCore/Modules/model-element/ModelPlayerAnimationState.cpp
+++ b/Source/WebCore/Modules/model-element/ModelPlayerAnimationState.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ModelPlayerAnimationState.h"
+
+namespace WebCore {
+
+ModelPlayerAnimationState::ModelPlayerAnimationState(bool autoplay, bool loop, bool paused, Seconds duration, std::optional<double> effectivePlaybackRate, std::optional<Seconds> lastCachedCurrentTime, std::optional<MonotonicTime> lastCachedClockTimestamp)
+    : m_autoplay(autoplay)
+    , m_loop(loop)
+    , m_paused(paused)
+    , m_duration(duration)
+    , m_effectivePlaybackRate(effectivePlaybackRate)
+    , m_lastCachedCurrentTime(lastCachedCurrentTime)
+    , m_lastCachedClockTimestamp(lastCachedClockTimestamp)
+{
+}
+
+bool ModelPlayerAnimationState::autoplay() const
+{
+    return m_autoplay;
+}
+
+void ModelPlayerAnimationState::setAutoplay(bool autoplay)
+{
+    m_autoplay = autoplay;
+}
+
+bool ModelPlayerAnimationState::loop() const
+{
+    return m_loop;
+}
+
+void ModelPlayerAnimationState::setLoop(bool loop)
+{
+    m_loop = loop;
+}
+
+bool ModelPlayerAnimationState::paused() const
+{
+    return m_paused;
+}
+
+void ModelPlayerAnimationState::setPaused(bool paused)
+{
+    m_paused = paused;
+}
+
+Seconds ModelPlayerAnimationState::duration() const
+{
+    return m_duration;
+}
+
+void ModelPlayerAnimationState::setDuration(Seconds duration)
+{
+    m_duration = duration;
+}
+
+std::optional<double> ModelPlayerAnimationState::effectivePlaybackRate() const
+{
+    return m_effectivePlaybackRate;
+}
+
+void ModelPlayerAnimationState::setPlaybackRate(double playbackRate)
+{
+    // FIXME (280081): Support negative playback rate
+    m_effectivePlaybackRate = fmax(playbackRate, 0);
+}
+
+std::optional<Seconds> ModelPlayerAnimationState::lastCachedCurrentTime() const
+{
+    return m_lastCachedCurrentTime;
+}
+
+std::optional<MonotonicTime> ModelPlayerAnimationState::lastCachedClockTimestamp() const
+{
+    return m_lastCachedClockTimestamp;
+}
+
+Seconds ModelPlayerAnimationState::currentTime() const
+{
+    if (!m_duration || !m_lastCachedCurrentTime || !m_lastCachedClockTimestamp)
+        return 0_s;
+
+    Seconds lastCachedCurrentTime = *m_lastCachedCurrentTime;
+    if (m_paused)
+        return lastCachedCurrentTime;
+
+    // Approximate based on last cached animation time, clock timestamp, and playbackRate
+    MonotonicTime lastCachedTimestamp = *m_lastCachedClockTimestamp;
+    double playbackRate = m_effectivePlaybackRate ? *m_effectivePlaybackRate : 1.0;
+    Seconds timePassedSinceLastSync = MonotonicTime::now() - lastCachedTimestamp;
+    Seconds animationTimePassed = Seconds::fromMilliseconds(floor((timePassedSinceLastSync * playbackRate).milliseconds()));
+    Seconds estimatedCurrentTime = lastCachedCurrentTime + animationTimePassed;
+    if (estimatedCurrentTime > m_duration)
+        estimatedCurrentTime = m_loop ? estimatedCurrentTime % m_duration : m_duration;
+    return estimatedCurrentTime;
+}
+
+void ModelPlayerAnimationState::setCurrentTime(Seconds currentTime, MonotonicTime clockTimestamp)
+{
+    m_lastCachedCurrentTime = currentTime;
+    m_lastCachedClockTimestamp = clockTimestamp;
+}
+
+}

--- a/Source/WebCore/Modules/model-element/ModelPlayerAnimationState.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayerAnimationState.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/MonotonicTime.h>
+
+namespace WebCore {
+
+class WEBCORE_EXPORT ModelPlayerAnimationState {
+public:
+    ModelPlayerAnimationState() = default;
+    ModelPlayerAnimationState(const ModelPlayerAnimationState&) = default;
+    ModelPlayerAnimationState(ModelPlayerAnimationState&&) = default;
+    ModelPlayerAnimationState& operator=(ModelPlayerAnimationState&&) = default;
+    ModelPlayerAnimationState(bool autoplay, bool loop, bool paused, Seconds duration, std::optional<double> effectivePlaybackRate, std::optional<Seconds> lastCachedCurrentTime, std::optional<MonotonicTime> lastCachedClockTimestamp);
+
+    bool autoplay() const;
+    void setAutoplay(bool);
+    bool loop() const;
+    void setLoop(bool);
+    bool paused() const;
+    void setPaused(bool);
+    Seconds duration() const;
+    void setDuration(Seconds);
+    std::optional<double> effectivePlaybackRate() const;
+    void setPlaybackRate(double);
+    std::optional<Seconds> lastCachedCurrentTime() const;
+    std::optional<MonotonicTime> lastCachedClockTimestamp() const;
+
+    Seconds currentTime() const;
+    void setCurrentTime(Seconds, MonotonicTime clockTimestamp);
+
+private:
+    bool m_autoplay { false };
+    bool m_loop { false };
+    bool m_paused { true };
+    Seconds m_duration { 0_s };
+    std::optional<double> m_effectivePlaybackRate;
+    std::optional<Seconds> m_lastCachedCurrentTime;
+    std::optional<MonotonicTime> m_lastCachedClockTimestamp;
+};
+
+}

--- a/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
+++ b/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
@@ -29,6 +29,7 @@
 #include "HTMLIFrameElement.h"
 #include "HTMLNames.h"
 #include "HTMLPlugInElement.h"
+#include "NodeInlines.h"
 #include "RenderElement.h"
 #include "Settings.h"
 #include "ShadowRoot.h"

--- a/Source/WebCore/Modules/websockets/WebSocketExtensionParser.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketExtensionParser.cpp
@@ -51,7 +51,7 @@ bool WebSocketExtensionParser::parsedSuccessfully()
 static bool isSeparator(char character)
 {
     static constexpr auto separatorCharacters = "()<>@,;:\\\"/[]?={} \t"_span;
-    return contains(separatorCharacters, character);
+    return WTF::contains(separatorCharacters, character);
 }
 
 static bool isSpaceOrTab(LChar character)

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -294,6 +294,7 @@ Modules/mediastream/UserMediaRequest.cpp
 Modules/mediastream/VideoTrackGenerator.cpp
 Modules/model-element/HTMLModelElement.cpp
 Modules/model-element/ModelPlayer.cpp
+Modules/model-element/ModelPlayerAnimationState.cpp
 Modules/model-element/ModelPlayerClient.cpp
 Modules/model-element/ModelPlayerProvider.cpp
 Modules/model-element/dummy/DummyModelPlayer.cpp

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -31,6 +31,7 @@
 #import "WebPage.h"
 #import "WebPageProxyMessages.h"
 #import <WebCore/ModelPlayer.h>
+#import <WebCore/ModelPlayerAnimationState.h>
 #import <WebCore/ModelPlayerClient.h>
 #import <WebCore/ModelPlayerIdentifier.h>
 #import <WebCore/StageModeOperations.h>
@@ -75,6 +76,7 @@ private:
 
     // WebCore::ModelPlayer overrides.
     WebCore::ModelPlayerIdentifier identifier() const final { return m_id; }
+    std::optional<WebCore::ModelPlayerAnimationState> currentAnimationState() const final;
     void load(WebCore::Model&, WebCore::LayoutSize) final;
     void sizeDidChange(WebCore::LayoutSize) final;
     PlatformLayer* layer() final;
@@ -119,17 +121,11 @@ private:
     std::optional<WebCore::LayerHostingContextIdentifier> m_layerHostingContextIdentifier;
 
     bool m_hasPortal { true };
-    bool m_autoplay { false };
-    bool m_loop { false };
+    WebCore::StageModeOperation m_stageModeOperation { WebCore::StageModeOperation::None };
     double m_requestedPlaybackRate { 1.0 };
-    std::optional<double> m_effectivePlaybackRate;
-    Seconds m_duration { 0_s };
-    bool m_paused { true };
     std::optional<Seconds> m_pendingCurrentTime;
     std::optional<MonotonicTime> m_clockTimestampOfLastCurrentTimeSet;
-    std::optional<Seconds> m_lastCachedCurrentTime;
-    std::optional<MonotonicTime> m_lastCachedClockTimestamp;
-    WebCore::StageModeOperation m_stageModeOperation { WebCore::StageModeOperation::None };
+    WebCore::ModelPlayerAnimationState m_animationState;
 };
 
 }


### PR DESCRIPTION
#### 4c5b5ac8528c78a1eb89748a773b365b4a4d9899
<pre>
Refactor the model animation state tracking logic into another class
<a href="https://bugs.webkit.org/show_bug.cgi?id=292499">https://bugs.webkit.org/show_bug.cgi?id=292499</a>
<a href="https://rdar.apple.com/150608558">rdar://150608558</a>

Reviewed by Mike Wyrzykowski.

ModelPlayerAnimationState tracks all animation related properties
in the model player. It also has the logic to interpolate the
animation&apos;s current time based on the last cached current time along
with the clock timestamp. The code is copied from ModelProcessModelPlayer,
and ModelProcessModelPlayer has been updated to use ModelPlayerAnimationState.

Add a method in ModelPlayer for getting the current animation state.
This will be used in a later patch for restoring the ModelPlayer
state after reload.

* Source/WebCore/Modules/model-element/ModelPlayer.cpp:
(WebCore::ModelPlayer::currentAnimationState const):
* Source/WebCore/Modules/model-element/ModelPlayer.h:
* Source/WebCore/Modules/model-element/ModelPlayerAnimationState.cpp: Added.
(WebCore::ModelPlayerAnimationState::ModelPlayerAnimationState):
(WebCore::ModelPlayerAnimationState::autoplay const):
(WebCore::ModelPlayerAnimationState::setAutoplay):
(WebCore::ModelPlayerAnimationState::loop const):
(WebCore::ModelPlayerAnimationState::setLoop):
(WebCore::ModelPlayerAnimationState::paused const):
(WebCore::ModelPlayerAnimationState::setPaused):
(WebCore::ModelPlayerAnimationState::duration const):
(WebCore::ModelPlayerAnimationState::setDuration):
(WebCore::ModelPlayerAnimationState::effectivePlaybackRate const):
(WebCore::ModelPlayerAnimationState::setPlaybackRate):
(WebCore::ModelPlayerAnimationState::lastCachedCurrentTime const):
(WebCore::ModelPlayerAnimationState::lastCachedClockTimestamp const):
(WebCore::ModelPlayerAnimationState::currentTime const):
(WebCore::ModelPlayerAnimationState::setCurrentTime):
* Source/WebCore/Modules/model-element/ModelPlayerAnimationState.h: Added.
* Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp:
Fix compile error after adding ModelPlayerAnimationState.cpp to Sources.txt
* Source/WebCore/Modules/websockets/WebSocketExtensionParser.cpp:
(WebCore::isSeparator):
Ditto
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::didUpdateAnimationPlaybackState):
(WebKit::ModelProcessModelPlayer::currentAnimationState const):
(WebKit::ModelProcessModelPlayer::setAutoplay):
(WebKit::ModelProcessModelPlayer::setLoop):
(WebKit::ModelProcessModelPlayer::duration const):
(WebKit::ModelProcessModelPlayer::paused const):
(WebKit::ModelProcessModelPlayer::currentTime const):
(WebKit::ModelProcessModelPlayer::setCurrentTime):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:

Canonical link: <a href="https://commits.webkit.org/294509@main">https://commits.webkit.org/294509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46f08d4a4d23912270010739ad9d07efec2a9cbc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12003 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107178 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52653 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104059 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30194 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77654 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34659 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105026 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17011 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92114 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57990 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16838 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10139 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52012 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86678 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109551 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29152 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21473 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86628 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29513 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88318 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86207 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21943 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30998 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8719 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23351 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29080 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34375 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28891 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32214 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30450 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->