### PR TITLE
Move EventTarget::ref/deref to EventTargetInlines.h

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp
@@ -31,6 +31,7 @@
 #include "Document.h"
 #include "EventLoop.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "Logging.h"
 #include "Page.h"
 #include "SecurityOriginData.h"

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -84,8 +84,8 @@ class EventTarget : public ScriptWrappable, public CanMakeWeakPtrWithBitField<Ev
 public:
     static Ref<EventTarget> create(ScriptExecutionContext&);
 
-    inline void ref(); // Defined in Node.h.
-    inline void deref(); // Defined in Node.h.
+    inline void ref(); // Defined in EventTargetInlines.h.
+    inline void deref(); // Defined in EventTargetInlines.h.
 
     virtual enum EventTargetInterfaceType eventTargetInterface() const = 0;
     virtual ScriptExecutionContext* scriptExecutionContext() const = 0;

--- a/Source/WebCore/dom/EventTargetInlines.h
+++ b/Source/WebCore/dom/EventTargetInlines.h
@@ -32,8 +32,27 @@
 #pragma once
 
 #include "EventTarget.h"
+#include "Node.h"
 
 namespace WebCore {
+
+inline void EventTarget::ref()
+{
+    auto* node = dynamicDowncast<Node>(*this);
+    if (node) [[likely]]
+        node->ref();
+    else
+        refEventTarget();
+}
+
+inline void EventTarget::deref()
+{
+    auto* node = dynamicDowncast<Node>(*this);
+    if (node) [[likely]]
+        node->deref();
+    else
+        derefEventTarget();
+}
 
 inline bool EventTarget::hasEventListeners() const
 {

--- a/Source/WebCore/dom/FocusEvent.cpp
+++ b/Source/WebCore/dom/FocusEvent.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "FocusEvent.h"
 
+#include "EventTargetInlines.h"
 #include "Node.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -54,5 +55,7 @@ FocusEvent::FocusEvent(const AtomString& type, const Init& initializer)
     , m_relatedTarget(initializer.relatedTarget)
 {
 }
+
+FocusEvent::~FocusEvent() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/dom/FocusEvent.h
+++ b/Source/WebCore/dom/FocusEvent.h
@@ -46,6 +46,8 @@ public:
         return adoptRef(*new FocusEvent);
     }
 
+    ~FocusEvent();
+
     struct Init : UIEventInit {
         RefPtr<EventTarget> relatedTarget;
     };

--- a/Source/WebCore/dom/MouseEvent.cpp
+++ b/Source/WebCore/dom/MouseEvent.cpp
@@ -213,4 +213,9 @@ RefPtr<Node> MouseEvent::fromElement() const
     return dynamicDowncast<Node>(WTFMove(target));
 }
 
+void MouseEvent::setRelatedTarget(RefPtr<EventTarget>&& relatedTarget)
+{
+    m_relatedTarget = WTFMove(relatedTarget);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/dom/MouseEvent.h
+++ b/Source/WebCore/dom/MouseEvent.h
@@ -111,7 +111,7 @@ protected:
 private:
     bool isMouseEvent() const final;
 
-    void setRelatedTarget(RefPtr<EventTarget>&& relatedTarget) final { m_relatedTarget = WTFMove(relatedTarget); }
+    void setRelatedTarget(RefPtr<EventTarget>&&) final;
 
     int16_t m_button { enumToUnderlyingType(MouseButton::Left) };
     unsigned short m_buttons { 0 };

--- a/Source/WebCore/dom/MouseEventInit.h
+++ b/Source/WebCore/dom/MouseEventInit.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "EventTargetInlines.h"
 #include "MouseRelatedEvent.h"
 
 namespace WebCore {

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -887,24 +887,6 @@ ALWAYS_INLINE void Node::setStyleFlag(NodeStyleFlag flag)
     setStyleBitfields(bitfields);
 }
 
-inline void EventTarget::ref()
-{
-    auto* node = dynamicDowncast<Node>(*this);
-    if (node) [[likely]]
-        node->ref();
-    else
-        refEventTarget();
-}
-
-inline void EventTarget::deref()
-{
-    auto* node = dynamicDowncast<Node>(*this);
-    if (node) [[likely]]
-        node->deref();
-    else
-        derefEventTarget();
-}
-
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const Node&);
 
 inline void collectChildNodes(Node&, NodeVector&);

--- a/Source/WebCore/dom/Touch.cpp
+++ b/Source/WebCore/dom/Touch.cpp
@@ -29,6 +29,7 @@
 
 #include "Touch.h"
 
+#include "EventTargetInlines.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
@@ -96,6 +97,8 @@ Touch::Touch(EventTarget* target, int identifier, int clientX, int clientY, int 
     , m_absoluteLocation(absoluteLocation)
 {
 }
+
+Touch::~Touch() = default;
 
 Ref<Touch> Touch::cloneWithNewTarget(EventTarget* eventTarget) const
 {

--- a/Source/WebCore/dom/Touch.h
+++ b/Source/WebCore/dom/Touch.h
@@ -48,6 +48,8 @@ public:
                 screenY, pageX, pageY, radiusX, radiusY, rotationAngle, force));
     }
 
+    ~Touch();
+
     EventTarget* target() const { return m_target.get(); }
     int identifier() const { return m_identifier; }
     int clientX() const { return m_clientX; }

--- a/Source/WebCore/dom/WheelEvent.cpp
+++ b/Source/WebCore/dom/WheelEvent.cpp
@@ -26,6 +26,7 @@
 
 #include "DataTransfer.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "MouseEventTypes.h"
 #include "Node.h"
 #include <wtf/MathExtras.h>

--- a/Source/WebCore/dom/ios/PointerEventIOS.cpp
+++ b/Source/WebCore/dom/ios/PointerEventIOS.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY)
 
 #import "EventNames.h"
+#import "EventTargetInlines.h"
 #import "MouseEventTypes.h"
 
 namespace WebCore {

--- a/Source/WebCore/editing/AlternativeTextController.cpp
+++ b/Source/WebCore/editing/AlternativeTextController.cpp
@@ -37,6 +37,7 @@
 #include "EditorClient.h"
 #include "Element.h"
 #include "EventLoop.h"
+#include "EventTargetInlines.h"
 #include "FloatQuad.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"

--- a/Source/WebCore/html/HTMLSlotElement.cpp
+++ b/Source/WebCore/html/HTMLSlotElement.cpp
@@ -29,6 +29,7 @@
 #include "AXObjectCache.h"
 #include "ElementInlines.h"
 #include "Event.h"
+#include "EventTargetInlines.h"
 #include "EventNames.h"
 #include "HTMLNames.h"
 #include "InspectorInstrumentation.h"

--- a/Source/WebCore/html/HTMLSummaryElement.cpp
+++ b/Source/WebCore/html/HTMLSummaryElement.cpp
@@ -23,6 +23,7 @@
 
 #include "ElementInlines.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "HTMLDetailsElement.h"
 #include "HTMLFormControlElement.h"
 #include "HTMLSlotElement.h"

--- a/Source/WebCore/inspector/InspectorController.cpp
+++ b/Source/WebCore/inspector/InspectorController.cpp
@@ -35,6 +35,7 @@
 #include "CommandLineAPIHost.h"
 #include "CommonVM.h"
 #include "DOMWrapperWorld.h"
+#include "EventTargetInlines.h"
 #include "GraphicsContext.h"
 #include "InspectorAnimationAgent.h"
 #include "InspectorCPUProfilerAgent.h"

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -40,6 +40,7 @@
 #include "DOMCSSNamespace.h"
 #include "DOMTokenList.h"
 #include "ElementInlines.h"
+#include "EventTargetInlines.h"
 #include "FloatLine.h"
 #include "FloatPoint.h"
 #include "FloatRoundedRect.h"

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -31,6 +31,7 @@
 #include "Element.h"
 #include "ElementInlines.h"
 #include "EventRegion.h"
+#include "EventTargetInlines.h"
 #include "FloatQuad.h"
 #include "FrameSelection.h"
 #include "GraphicsContext.h"


### PR DESCRIPTION
#### 9fc517fc7ffb7942d59e98c4bd7e4000d1f4f4dd
<pre>
Move EventTarget::ref/deref to EventTargetInlines.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=292502">https://bugs.webkit.org/show_bug.cgi?id=292502</a>

Reviewed by Chris Dumez.

Moved EventTarget::ref/deref from Node.h to EventTargetInlines.h.

* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp:
* Source/WebCore/dom/EventTarget.h:
* Source/WebCore/dom/EventTargetInlines.h:
(WebCore::EventTarget::ref):
(WebCore::EventTarget::deref):
* Source/WebCore/dom/FocusEvent.cpp:
* Source/WebCore/dom/FocusEvent.h:
* Source/WebCore/dom/MouseEvent.cpp:
(WebCore::MouseEvent::setRelatedTarget):
* Source/WebCore/dom/MouseEvent.h:
* Source/WebCore/dom/MouseEventInit.h:
* Source/WebCore/dom/Node.h:
(WebCore::EventTarget::ref): Deleted.
(WebCore::EventTarget::deref): Deleted.
* Source/WebCore/dom/Touch.cpp:
* Source/WebCore/dom/Touch.h:
* Source/WebCore/dom/WheelEvent.cpp:
* Source/WebCore/dom/ios/PointerEventIOS.cpp:
* Source/WebCore/editing/AlternativeTextController.cpp:
* Source/WebCore/html/HTMLSlotElement.cpp:
* Source/WebCore/html/HTMLSummaryElement.cpp:
* Source/WebCore/inspector/InspectorController.cpp:
* Source/WebCore/inspector/InspectorOverlay.cpp:
* Source/WebCore/rendering/RenderBlock.cpp:

Canonical link: <a href="https://commits.webkit.org/294500@main">https://commits.webkit.org/294500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75ddc9beb177559cba68a24ef33f4bb1ae98a30e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102042 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21710 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12026 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107201 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52676 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104082 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30217 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77667 "Found 11 new test failures: imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-self/worklet-animation.https.html imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_name_equals_in_value.https.window.html imported/w3c/web-platform-tests/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-003.html imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-item-margin-auto-columns-rows-001.html imported/w3c/web-platform-tests/css/cssom-view/cssom-getBoundingClientRect-001.html imported/w3c/web-platform-tests/editing/other/typing-around-link-element-at-non-collapsed-selection.tentative.html?target=ContentEditable imported/w3c/web-platform-tests/html/canvas/element/pixel-manipulation/2d.imageData.object.ctor.basics.html imported/w3c/web-platform-tests/media-source/mediasource-closed.html imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/worker-classic-data.meta/unset/fetch.https.html imported/w3c/web-platform-tests/wasm/jsapi/idlharness.any.worker.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34670 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17030 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92130 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58003 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16858 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10155 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52036 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86697 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10228 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109576 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29175 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21494 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86637 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29537 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88334 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86223 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31015 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8734 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23374 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16592 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29103 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34398 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28914 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32237 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30473 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->