### PR TITLE
Further adopt C++20's [[likely]] / [[unlikely]] in JSC

### DIFF
--- a/Source/JavaScriptCore/runtime/JSArray.h
+++ b/Source/JavaScriptCore/runtime/JSArray.h
@@ -233,7 +233,7 @@ inline JSArray* JSArray::tryCreate(VM& vm, Structure* structure, unsigned initia
             || hasDouble(indexingType)
             || hasContiguous(indexingType));
 
-        if (UNLIKELY(vectorLengthHint > MAX_STORAGE_VECTOR_LENGTH))
+        if (vectorLengthHint > MAX_STORAGE_VECTOR_LENGTH) [[unlikely]]
             return nullptr;
 
         unsigned vectorLength = Butterfly::optimalContiguousVectorLength(structure, vectorLengthHint);
@@ -301,7 +301,7 @@ bool moveArrayElements(JSGlobalObject* globalObject, VM& vm, JSArray* target, un
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (LIKELY(!hasAnyArrayStorage(source->indexingType()) && !source->holesMustForwardToPrototype())) {
+    if (!hasAnyArrayStorage(source->indexingType()) && !source->holesMustForwardToPrototype()) [[likely]] {
         for (unsigned i = 0; i < sourceLength; ++i) {
             JSValue value = source->tryGetIndexQuickly(i);
             if constexpr (fillMode == ArrayFillMode::Empty) {

--- a/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
@@ -200,14 +200,14 @@ static EncodedJSValue arrayBufferSlice(JSGlobalObject* globalObject, JSValue arr
     auto speciesResult = speciesConstructArrayBuffer(globalObject, thisObject, newLength, mode);
     // We can only get an exception if we call some user function.
     EXCEPTION_ASSERT(!!scope.exception() == (speciesResult.first == SpeciesConstructResult::Exception));
-    if (UNLIKELY(speciesResult.first == SpeciesConstructResult::Exception))
+    if (speciesResult.first == SpeciesConstructResult::Exception) [[unlikely]]
         return { };
 
     // 23. If IsDetachedBuffer(O) is true, throw a TypeError exception.
     if (mode == ArrayBufferSharingMode::Default && thisObject->impl()->isDetached())
         return throwVMTypeError(globalObject, scope, "Receiver is detached"_s);
 
-    if (LIKELY(speciesResult.first == SpeciesConstructResult::FastPath)) {
+    if (speciesResult.first == SpeciesConstructResult::FastPath) [[likely]] {
         ASSERT(!thisObject->impl()->isDetached());
         RefPtr<ArrayBuffer> newBuffer;
         if (mode == ArrayBufferSharingMode::Default) {
@@ -280,13 +280,13 @@ JSC_DEFINE_HOST_FUNCTION(arrayBufferProtoFuncResize, (JSGlobalObject* globalObje
     if (!thisObject || (ArrayBufferSharingMode::Shared == thisObject->impl()->sharingMode()))
         return throwVMTypeError(globalObject, scope, "Receiver must be ArrayBuffer"_s);
 
-    if (UNLIKELY(!thisObject->impl()->isResizableOrGrowableShared()))
+    if (!thisObject->impl()->isResizableOrGrowableShared()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "ArrayBuffer is not resizable"_s);
 
     double newLength = callFrame->argument(0).toIntegerOrInfinity(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    if (UNLIKELY(thisObject->impl()->isDetached()))
+    if (thisObject->impl()->isDetached()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver is detached"_s);
 
     if (!std::isfinite(newLength) || newLength < 0)
@@ -311,7 +311,7 @@ static JSArrayBuffer* arrayBufferCopyAndDetach(JSGlobalObject* globalObject, JSA
     ASSERT(arrayBuffer->impl()->sharingMode() == ArrayBufferSharingMode::Default);
     bool isResizable = arrayBuffer->isResizableOrGrowableShared();
 
-    if (UNLIKELY(arrayBuffer->impl()->isDetached())) {
+    if (arrayBuffer->impl()->isDetached()) [[unlikely]] {
         throwVMTypeError(globalObject, scope, "Receiver is detached"_s);
         return nullptr;
     }
@@ -319,7 +319,7 @@ static JSArrayBuffer* arrayBufferCopyAndDetach(JSGlobalObject* globalObject, JSA
     if (!isResizable && newByteLength == arrayBuffer->impl()->byteLength()) {
         // We should just transfer!
         ArrayBufferContents contents;
-        if (UNLIKELY(!arrayBuffer->impl()->transferTo(vm, contents))) {
+        if (!arrayBuffer->impl()->transferTo(vm, contents)) [[unlikely]] {
             throwVMRangeError(globalObject, scope, "ArrayBuffer transfer failed"_s);
             return nullptr;
         }
@@ -328,13 +328,13 @@ static JSArrayBuffer* arrayBufferCopyAndDetach(JSGlobalObject* globalObject, JSA
     }
 
     if (mode == CopyAndDetachMode::PreserveResizability && isResizable) {
-        if (UNLIKELY(newByteLength > arrayBuffer->impl()->maxByteLength())) {
+        if (newByteLength > arrayBuffer->impl()->maxByteLength()) [[unlikely]] {
             throwVMRangeError(globalObject, scope, makeString("ArrayBuffer transfer failed with new byte length "_s, newByteLength));
             return nullptr;
         }
 
         ArrayBufferContents contents;
-        if (UNLIKELY(!arrayBuffer->impl()->transferTo(vm, contents))) {
+        if (!arrayBuffer->impl()->transferTo(vm, contents)) [[unlikely]] {
             throwVMRangeError(globalObject, scope, "ArrayBuffer transfer failed"_s);
             return nullptr;
         }
@@ -356,7 +356,7 @@ static JSArrayBuffer* arrayBufferCopyAndDetach(JSGlobalObject* globalObject, JSA
     memcpy(newBuffer->data(), arrayBuffer->impl()->data(), copyLength);
 
     ArrayBufferContents dummyContents;
-    if (UNLIKELY(!arrayBuffer->impl()->transferTo(vm, dummyContents))) {
+    if (!arrayBuffer->impl()->transferTo(vm, dummyContents)) [[unlikely]] {
         throwVMRangeError(globalObject, scope, "ArrayBuffer transfer failed"_s);
         return nullptr;
     }
@@ -376,7 +376,7 @@ static JSArrayBuffer* arrayBufferProtoFuncTransferImpl(JSGlobalObject* globalObj
     }
 
     // WebAssembly.Memory's buffer cannot be detached.
-    if (UNLIKELY(thisObject->impl()->isWasmMemory())) {
+    if (thisObject->impl()->isWasmMemory()) [[unlikely]] {
         throwVMTypeError(globalObject, scope, "Receiver cannot be detached because it is WebAssembly.Memory"_s);
         return nullptr;
     }

--- a/Source/JavaScriptCore/runtime/JSArrayBufferView.h
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferView.h
@@ -292,7 +292,7 @@ public:
             return byteOffsetRaw();
 
         IdempotentArrayBufferByteLengthGetter<std::memory_order_seq_cst> getter;
-        if (UNLIKELY(isArrayBufferViewOutOfBounds(const_cast<JSArrayBufferView*>(this), getter)))
+        if (isArrayBufferViewOutOfBounds(const_cast<JSArrayBufferView*>(this), getter)) [[unlikely]]
             return 0;
         return byteOffsetRaw();
     }
@@ -337,7 +337,7 @@ public:
         // https://tc39.es/proposal-resizablearraybuffer/#sec-isarraybufferviewoutofbounds
         if (isDetached()) [[unlikely]]
             return true;
-        if (LIKELY(!isResizableNonShared()))
+        if (!isResizableNonShared()) [[likely]]
             return false;
         IdempotentArrayBufferByteLengthGetter<std::memory_order_seq_cst> getter;
         return isArrayBufferViewOutOfBounds(const_cast<JSArrayBufferView*>(this), getter);

--- a/Source/JavaScriptCore/runtime/JSArrayBufferViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferViewInlines.h
@@ -123,10 +123,10 @@ bool isArrayBufferViewOutOfBounds(JSArrayBufferView* view, Getter& getter)
     //
     // This function should work with DataView too.
 
-    if (UNLIKELY(view->isDetached()))
+    if (view->isDetached()) [[unlikely]]
         return true;
 
-    if (LIKELY(!view->isResizableOrGrowableShared()))
+    if (!view->isResizableOrGrowableShared()) [[likely]]
         return false;
 
     ASSERT(hasArrayBuffer(view->mode()) && isResizableOrGrowableShared(view->mode()));
@@ -156,10 +156,10 @@ std::optional<size_t> integerIndexedObjectLength(JSArrayBufferView* typedArray, 
 {
     // https://tc39.es/proposal-resizablearraybuffer/#sec-integerindexedobjectlength
 
-    if (UNLIKELY(isIntegerIndexedObjectOutOfBounds(typedArray, getter)))
+    if (isIntegerIndexedObjectOutOfBounds(typedArray, getter)) [[unlikely]]
         return std::nullopt;
 
-    if (LIKELY(!typedArray->isAutoLength()))
+    if (!typedArray->isAutoLength()) [[likely]]
         return typedArray->lengthRaw();
 
     ASSERT(hasArrayBuffer(typedArray->mode()) && isResizableOrGrowableShared(typedArray->mode()));
@@ -179,7 +179,7 @@ size_t integerIndexedObjectByteLength(JSArrayBufferView* typedArray, Getter& get
     if (!length || !length.value())
         return 0;
 
-    if (LIKELY(!typedArray->isAutoLength()))
+    if (!typedArray->isAutoLength()) [[likely]]
         return typedArray->byteLengthRaw();
 
     return length.value() << logElementSize(typedArray->type());
@@ -191,13 +191,13 @@ inline JSArrayBufferView* validateTypedArray(JSGlobalObject* globalObject, JSArr
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (UNLIKELY(!isTypedView(typedArray->type()))) {
+    if (!isTypedView(typedArray->type())) [[unlikely]] {
         throwTypeError(globalObject, scope, "Argument needs to be a typed array."_s);
         return nullptr;
     }
 
     IdempotentArrayBufferByteLengthGetter<std::memory_order_seq_cst> getter;
-    if (UNLIKELY(isIntegerIndexedObjectOutOfBounds(typedArray, getter))) {
+    if (isIntegerIndexedObjectOutOfBounds(typedArray, getter)) [[unlikely]] {
         throwTypeError(globalObject, scope, typedArrayBufferHasBeenDetachedErrorMessage);
         return nullptr;
     }
@@ -209,13 +209,13 @@ inline JSArrayBufferView* validateTypedArray(JSGlobalObject* globalObject, JSVal
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (UNLIKELY(!typedArrayValue.isCell())) {
+    if (!typedArrayValue.isCell()) [[unlikely]] {
         throwTypeError(globalObject, scope, "Argument needs to be a typed array."_s);
         return nullptr;
     }
 
     JSCell* typedArrayCell = typedArrayValue.asCell();
-    if (UNLIKELY(!isTypedView(typedArrayCell->type()))) {
+    if (!isTypedView(typedArrayCell->type())) [[unlikely]] {
         throwTypeError(globalObject, scope, "Argument needs to be a typed array."_s);
         return nullptr;
     }

--- a/Source/JavaScriptCore/runtime/JSArrayInlines.h
+++ b/Source/JavaScriptCore/runtime/JSArrayInlines.h
@@ -79,9 +79,9 @@ inline IndexingType JSArray::mergeIndexingTypeForCopying(IndexingType other, boo
 ALWAYS_INLINE bool JSArray::holesMustForwardToPrototype() const
 {
     Structure* structure = this->structure();
-    if (LIKELY(type() == ArrayType)) {
+    if (type() == ArrayType) [[likely]] {
         JSGlobalObject* globalObject = structure->globalObject();
-        if (LIKELY(structure->hasMonoProto() && structure->storedPrototype() == globalObject->arrayPrototype() && globalObject->arrayPrototypeChainIsSane()))
+        if (structure->hasMonoProto() && structure->storedPrototype() == globalObject->arrayPrototype() && globalObject->arrayPrototypeChainIsSane()) [[likely]]
             return false;
     }
     return structure->holesMustForwardToPrototype(const_cast<JSArray*>(this));
@@ -152,7 +152,7 @@ ALWAYS_INLINE uint64_t toLength(JSGlobalObject* globalObject, JSObject* object)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (LIKELY(isJSArray(object)))
+    if (isJSArray(object)) [[likely]]
         return jsCast<JSArray*>(object)->length();
 
     switch (object->type()) {
@@ -306,7 +306,7 @@ ALWAYS_INLINE void JSArray::pushInline(JSGlobalObject* globalObject, JSValue val
         }
 
         // Pushing to an array of invalid length (2^31-1) stores the property, but throws a range error.
-        if (UNLIKELY(storage->length() > MAX_ARRAY_INDEX)) {
+        if (storage->length() > MAX_ARRAY_INDEX) [[unlikely]] {
             methodTable()->putByIndex(this, globalObject, storage->length(), value, true);
             // Per ES5.1 15.4.4.7 step 6 & 15.4.5.1 step 3.d.
             if (!scope.exception())

--- a/Source/JavaScriptCore/runtime/JSBigInt.cpp
+++ b/Source/JavaScriptCore/runtime/JSBigInt.cpp
@@ -110,7 +110,7 @@ JSBigInt* JSBigInt::tryCreateZero(VM& vm)
 
 inline JSBigInt* JSBigInt::createWithLength(JSGlobalObject* nullOrGlobalObjectForOOM, VM& vm, unsigned length)
 {
-    if (UNLIKELY(length > maxLength)) {
+    if (length > maxLength) [[unlikely]] {
         if (nullOrGlobalObjectForOOM) {
             auto scope = DECLARE_THROW_SCOPE(vm);
             throwOutOfMemoryError(nullOrGlobalObjectForOOM, scope, "BigInt generated from this operation is too big"_s);
@@ -148,7 +148,7 @@ inline JSBigInt* JSBigInt::createFrom(JSGlobalObject* nullOrGlobalObjectForOOM, 
         return createZero(nullOrGlobalObjectForOOM, vm);
 
     JSBigInt* bigInt = createWithLength(nullOrGlobalObjectForOOM, vm, 1);
-    if (UNLIKELY(!bigInt))
+    if (!bigInt) [[unlikely]]
         return nullptr;
 
     if (value < 0) {
@@ -2414,7 +2414,7 @@ JSBigInt* JSBigInt::rightTrim(JSGlobalObject* nullOrGlobalObjectForOOM, VM& vm)
 
     unsigned newLength = nonZeroIndex + 1;
     JSBigInt* trimmedBigInt = createWithLength(nullOrGlobalObjectForOOM, vm, newLength);
-    if (UNLIKELY(!trimmedBigInt))
+    if (!trimmedBigInt) [[unlikely]]
         return nullptr;
     std::copy_n(dataStorage(), newLength, trimmedBigInt->dataStorage());
 
@@ -2658,7 +2658,7 @@ JSValue JSBigInt::parseInt(JSGlobalObject* nullOrGlobalObjectForOOM, VM& vm, std
                 }
             }
             heapResult = allocateFor(nullOrGlobalObjectForOOM, vm, radix, initialLength);
-            if (UNLIKELY(!heapResult))
+            if (!heapResult) [[unlikely]]
                 return JSValue();
             heapResult->initialize(InitializationType::WithZero);
         }

--- a/Source/JavaScriptCore/runtime/JSBigInt.h
+++ b/Source/JavaScriptCore/runtime/JSBigInt.h
@@ -680,7 +680,7 @@ ALWAYS_INLINE JSBigInt::ComparisonResult invertBigIntCompareResult(JSBigInt::Com
 ALWAYS_INLINE JSValue tryConvertToBigInt32(JSBigInt* bigInt)
 {
 #if USE(BIGINT32)
-    if (UNLIKELY(!bigInt))
+    if (!bigInt) [[unlikely]]
         return JSValue();
 
     if (bigInt->length() <= 1) {

--- a/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
@@ -108,7 +108,7 @@ JSC_DEFINE_HOST_FUNCTION(boundFunctionConstruct, (JSGlobalObject* globalObject, 
 
     JSObject* targetFunction = boundFunction->targetFunction();
     auto constructData = JSC::getConstructData(targetFunction);
-    if (UNLIKELY(constructData.type == CallData::Type::None))
+    if (constructData.type == CallData::Type::None) [[unlikely]]
         return throwVMError(globalObject, scope, createNotAConstructorError(globalObject, boundFunction));
 
     MarkedArgumentBuffer args;
@@ -152,7 +152,7 @@ inline Structure* getBoundFunctionStructure(VM& vm, JSGlobalObject* globalObject
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSFunction* targetJSFunction = jsDynamicCast<JSFunction*>(targetFunction);
-    if (LIKELY(targetJSFunction && targetJSFunction->getPrototypeDirect() == globalObject->functionPrototype()))
+    if (targetJSFunction && targetJSFunction->getPrototypeDirect() == globalObject->functionPrototype()) [[likely]]
         return globalObject->boundFunctionStructure();
 
     JSValue prototype = targetFunction->getPrototype(vm, globalObject);

--- a/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
@@ -923,7 +923,7 @@ ALWAYS_INLINE std::optional<uint32_t> JSValue::toUInt32AfterToNumeric(JSGlobalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue result = toBigIntOrInt32(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
-    if (LIKELY(result.isInt32()))
+    if (result.isInt32()) [[likely]]
         return static_cast<uint32_t>(result.asInt32());
     return std::nullopt;
 }
@@ -1159,7 +1159,7 @@ ALWAYS_INLINE JSValue JSValue::get(JSGlobalObject* globalObject, unsigned proper
 
 ALWAYS_INLINE JSValue JSValue::get(JSGlobalObject* globalObject, uint64_t propertyName) const
 {
-    if (LIKELY(propertyName <= std::numeric_limits<unsigned>::max()))
+    if (propertyName <= std::numeric_limits<unsigned>::max()) [[likely]]
         return get(globalObject, static_cast<unsigned>(propertyName));
     return get(globalObject, Identifier::from(getVM(globalObject), static_cast<double>(propertyName)));
 }
@@ -1448,7 +1448,7 @@ ALWAYS_INLINE bool JSValue::requireObjectCoercible(JSGlobalObject* globalObject)
 ALWAYS_INLINE bool isThisValueAltered(const PutPropertySlot& slot, JSObject* baseObject)
 {
     JSValue thisValue = slot.thisValue();
-    if (LIKELY(thisValue == baseObject))
+    if (thisValue == baseObject) [[likely]]
         return false;
 
     if (!thisValue.isObject())

--- a/Source/JavaScriptCore/runtime/JSCast.h
+++ b/Source/JavaScriptCore/runtime/JSCast.h
@@ -255,7 +255,7 @@ template<typename To, typename From>
 To jsDynamicCast(From* from)
 {
     using Dispatcher = JSCastingHelpers::InheritsTraits<typename std::remove_cv<typename std::remove_pointer<To>::type>::type>;
-    if (LIKELY(Dispatcher::template inherits<>(from)))
+    if (Dispatcher::template inherits<>(from)) [[likely]]
         return static_cast<To>(from);
     return nullptr;
 }
@@ -263,7 +263,7 @@ To jsDynamicCast(From* from)
 template<typename To>
 To jsDynamicCast(JSValue from)
 {
-    if (UNLIKELY(!from.isCell()))
+    if (!from.isCell()) [[unlikely]]
         return nullptr;
     return jsDynamicCast<To>(from.asCell());
 }

--- a/Source/JavaScriptCore/runtime/JSCellInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCellInlines.h
@@ -408,7 +408,7 @@ inline TriState JSCell::pureToBoolean() const
 inline void JSCellLock::lock()
 {
     Atomic<IndexingType>* lock = std::bit_cast<Atomic<IndexingType>*>(&m_indexingTypeAndMisc);
-    if (UNLIKELY(!IndexingTypeLockAlgorithm::lockFast(*lock)))
+    if (!IndexingTypeLockAlgorithm::lockFast(*lock)) [[unlikely]]
         lockSlow();
 }
 
@@ -421,7 +421,7 @@ inline bool JSCellLock::tryLock()
 inline void JSCellLock::unlock()
 {
     Atomic<IndexingType>* lock = std::bit_cast<Atomic<IndexingType>*>(&m_indexingTypeAndMisc);
-    if (UNLIKELY(!IndexingTypeLockAlgorithm::unlockFast(*lock)))
+    if (!IndexingTypeLockAlgorithm::unlockFast(*lock)) [[unlikely]]
         unlockSlow();
 }
 
@@ -476,7 +476,7 @@ ALWAYS_INLINE JSString* JSCell::toStringInline(JSGlobalObject* globalObject) con
 ALWAYS_INLINE bool JSCell::putInline(JSGlobalObject* globalObject, PropertyName propertyName, JSValue value, PutPropertySlot& slot)
 {
     Structure* structure = this->structure();
-    if (LIKELY(!structure->typeInfo().overridesPut()))
+    if (!structure->typeInfo().overridesPut()) [[likely]]
         return JSObject::putInlineForJSObject(asObject(this), globalObject, propertyName, value, slot);
     return structure->methodTable()->put(this, globalObject, propertyName, value, slot);
 }

--- a/Source/JavaScriptCore/runtime/JSDateMath.cpp
+++ b/Source/JavaScriptCore/runtime/JSDateMath.cpp
@@ -227,7 +227,7 @@ LocalTimeOffset DateCache::DSTCache::localTimeOffset(DateCache& dateCache, int64
         millisecondsFromEpoch = newTime;
     }
 
-    if (UNLIKELY(m_epoch > UINT32_MAX)) {
+    if (m_epoch > UINT32_MAX) [[unlikely]] {
         dataLogLnIf(JSDateMathInternal::verbose, "reset DSTCache");
         reset();
     }

--- a/Source/JavaScriptCore/runtime/JSDateMath.h
+++ b/Source/JavaScriptCore/runtime/JSDateMath.h
@@ -99,7 +99,7 @@ public:
     void resetIfNecessary()
     {
 #if PLATFORM(COCOA)
-        if (LIKELY(!hasTimeZoneChange()))
+        if (!hasTimeZoneChange()) [[likely]]
             return;
         m_cachedTimezoneID = lastTimeZoneID;
 #endif

--- a/Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp
+++ b/Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp
@@ -123,7 +123,7 @@ void JSFinalizationRegistry::finalizeUnconditionally(VM& vm, CollectionScope)
         bool keyIsDead = !vm.heap.isMarked(bucket.key);
         DeadRegistrations* deadList = nullptr;
         auto getDeadList = [&] () -> DeadRegistrations& {
-            if (UNLIKELY(!deadList))
+            if (!deadList) [[unlikely]]
                 deadList = &m_deadRegistrations.add(bucket.key, DeadRegistrations()).iterator->value;
             return *deadList;
         };

--- a/Source/JavaScriptCore/runtime/JSFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSFunction.cpp
@@ -162,7 +162,7 @@ JSObject* JSFunction::prototypeForConstruction(VM& vm, JSGlobalObject* globalObj
     auto scope = DECLARE_CATCH_SCOPE(vm);
     JSValue prototype = get(globalObject, vm.propertyNames->prototype);
     scope.releaseAssertNoException();
-    if (LIKELY(prototype.isObject()))
+    if (prototype.isObject()) [[likely]]
         return asObject(prototype);
     if (isHostOrBuiltinFunction())
         return this->globalObject()->objectPrototype();

--- a/Source/JavaScriptCore/runtime/JSFunction.h
+++ b/Source/JavaScriptCore/runtime/JSFunction.h
@@ -131,7 +131,7 @@ public:
     FunctionRareData* ensureRareData(VM& vm)
     {
         uintptr_t executableOrRareData = m_executableOrRareData;
-        if (UNLIKELY(!(executableOrRareData & rareDataTag)))
+        if (!(executableOrRareData & rareDataTag)) [[unlikely]]
             return allocateRareData(vm);
         return std::bit_cast<FunctionRareData*>(executableOrRareData & ~rareDataTag);
     }

--- a/Source/JavaScriptCore/runtime/JSFunctionInlines.h
+++ b/Source/JavaScriptCore/runtime/JSFunctionInlines.h
@@ -164,7 +164,7 @@ template<typename... StringTypes>
 ALWAYS_INLINE String makeNameWithOutOfMemoryCheck(JSGlobalObject* globalObject, ThrowScope& throwScope, ASCIILiteral messagePrefix, StringTypes... strings)
 {
     String name = tryMakeString(strings...);
-    if (UNLIKELY(!name)) {
+    if (!name) [[unlikely]] {
         throwOutOfMemoryError(globalObject, throwScope, makeString(messagePrefix, "name is too long"_s));
         return String();
     }
@@ -258,7 +258,7 @@ inline FunctionRareData* JSFunction::ensureRareDataAndObjectAllocationProfile(JS
     FunctionRareData* rareData = this->rareData();
     if (!rareData)
         return allocateAndInitializeRareData(globalObject, inlineCapacity);
-    if (UNLIKELY(!rareData->isObjectAllocationProfileInitialized()))
+    if (!rareData->isObjectAllocationProfileInitialized()) [[unlikely]]
         return initializeRareData(globalObject, inlineCapacity);
     return rareData;
 }

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
@@ -89,7 +89,7 @@ inline JSObject* constructGenericTypedArrayViewFromIterator(JSGlobalObject* glob
     MarkedArgumentBuffer storage;
     forEachInIterable(*globalObject, iterable, iteratorMethod, [&] (VM&, JSGlobalObject&, JSValue value) {
         storage.append(value);
-        if (UNLIKELY(storage.hasOverflowed())) {
+        if (storage.hasOverflowed()) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
             return;
         }
@@ -131,12 +131,12 @@ inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* glo
         else {
             size_t byteLength = buffer->byteLength();
             if (buffer->isResizableOrGrowableShared()) {
-                if (UNLIKELY(offset > byteLength)) {
+                if (offset > byteLength) [[unlikely]] {
                     throwRangeError(globalObject, scope, "byteOffset exceeds source ArrayBuffer byteLength"_s);
                     return nullptr;
                 }
             } else {
-                if (UNLIKELY((byteLength - offset) % ViewClass::elementSize)) {
+                if ((byteLength - offset) % ViewClass::elementSize) [[unlikely]] {
                     throwRangeError(globalObject, scope, "ArrayBuffer length minus the byteOffset is not a multiple of the element size"_s);
                     return nullptr;
                 }
@@ -190,7 +190,7 @@ inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* glo
 
         // This getPropertySlot operation should not be observed by the Proxy.
         // So we use VMInquiry. And purge the opaque object cases (proxy and namespace object) by isTaintedByOpaqueObject() guard.
-        if (JSArray* array = jsDynamicCast<JSArray*>(object); LIKELY(array && isJSArray(array) && array->isIteratorProtocolFastAndNonObservable()))
+        if (JSArray* array = jsDynamicCast<JSArray*>(object); array && isJSArray(array) && array->isIteratorProtocolFastAndNonObservable()) [[likely]]
             length = array->length();
         else {
             PropertySlot lengthSlot(object, PropertySlot::InternalMethodType::VMInquiry, &vm);
@@ -274,7 +274,7 @@ ALWAYS_INLINE EncodedJSValue constructGenericTypedArrayViewImpl(JSGlobalObject* 
 
             if constexpr (ViewClass::TypedArrayStorageType == TypeDataView) {
                 RefPtr<ArrayBuffer> buffer = arrayBuffer->impl();
-                if (UNLIKELY(offset > buffer->byteLength())) {
+                if (offset > buffer->byteLength()) [[unlikely]] {
                     throwRangeError(globalObject, scope, "byteOffset exceeds source ArrayBuffer byteLength"_s);
                     RETURN_IF_EXCEPTION(scope, { });
                 }

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -385,7 +385,7 @@ void JSGenericTypedArrayView<Adaptor>::copyFromInt32ShapeArray(size_t offset, JS
     }
     for (size_t i = 0; i < length; ++i) {
         JSValue value = array->butterfly()->contiguous().at(array, static_cast<unsigned>(i + objectOffset)).get();
-        if (LIKELY(!!value))
+        if (!!value) [[likely]]
             setIndexQuicklyToNativeValue(offset + i, Adaptor::toNativeFromInt32(value.asInt32()));
         else
             setIndexQuicklyToNativeValue(offset + i, Adaptor::toNativeFromUndefined());
@@ -429,7 +429,7 @@ bool JSGenericTypedArrayView<Adaptor>::setFromArrayLike(JSGlobalObject* globalOb
     size_t safeLength = objectOffset <= safeUnadjustedLength ? safeUnadjustedLength - objectOffset : 0;
 
     if constexpr (TypedArrayStorageType != TypeBigInt64 && TypedArrayStorageType != TypeBigUint64) {
-        if (JSArray* array = jsDynamicCast<JSArray*>(object); LIKELY(array && isJSArray(array))) {
+        if (JSArray* array = jsDynamicCast<JSArray*>(object); array && isJSArray(array)) [[likely]] {
             if (safeLength == length && (safeLength + objectOffset) <= array->length() && array->isIteratorProtocolFastAndNonObservable()) {
                 IndexingType indexingType = array->indexingType() & IndexingShapeMask;
                 if (indexingType == Int32Shape) {
@@ -477,7 +477,7 @@ bool JSGenericTypedArrayView<Adaptor>::setFromArrayLike(JSGlobalObject* globalOb
         return false;
     }
 
-    if (JSArray* array = jsDynamicCast<JSArray*>(sourceValue); LIKELY(array && isJSArray(array)))
+    if (JSArray* array = jsDynamicCast<JSArray*>(sourceValue); array && isJSArray(array)) [[likely]]
         RELEASE_AND_RETURN(scope, setFromArrayLike(globalObject, offset, array, 0, array->length()));
 
     size_t targetLength = this->length();
@@ -887,7 +887,7 @@ template<typename Adaptor> inline auto JSGenericTypedArrayView<Adaptor>::sort() 
     auto originalSpan = typedSpan();
     auto array = originalSpan.data();
     if (isShared()) {
-        if (UNLIKELY(!forShared.tryGrow(length)))
+        if (!forShared.tryGrow(length)) [[unlikely]]
             return SortResult::OutOfMemory;
         WTF::copyElements(forShared.mutableSpan(), spanConstCast<const typename Adaptor::Type>(originalSpan.first(length)));
         array = forShared.data();

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp
@@ -56,7 +56,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeSetFromBase64, (JSGlobalObject* glob
     JSValue optionsValue = callFrame->argument(1);
     if (!optionsValue.isUndefined()) {
         JSObject* optionsObject = jsDynamicCast<JSObject*>(optionsValue);
-        if (UNLIKELY(!optionsValue.isObject()))
+        if (!optionsValue.isObject()) [[unlikely]]
             return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.setFromBase64 requires that options be an object"_s);
 
         JSValue alphabetValue = optionsObject->get(globalObject, vm.propertyNames->alphabet);
@@ -78,7 +78,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeSetFromBase64, (JSGlobalObject* glob
         RETURN_IF_EXCEPTION(scope, { });
         if (!lastChunkHandlingValue.isUndefined()) {
             JSString* lastChunkHandlingString = jsDynamicCast<JSString*>(lastChunkHandlingValue);
-            if (UNLIKELY(!lastChunkHandlingString))
+            if (!lastChunkHandlingString) [[unlikely]]
                 return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.setFromBase64 requires that lastChunkHandling be \"loose\", \"strict\", or \"stop-before-partial\""_s);
 
             auto lastChunkHandlingStringView = lastChunkHandlingString->view(globalObject);
@@ -102,7 +102,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeSetFromBase64, (JSGlobalObject* glob
 
     auto [shouldThrowError, readLength, writeLength] = fromBase64(view, std::span { uint8Array->typedVector(), uint8Array->length() }, alphabet, lastChunkHandling);
     ASSERT(readLength <= view.length());
-    if (UNLIKELY(shouldThrowError == WTF::FromBase64ShouldThrowError::Yes))
+    if (shouldThrowError == WTF::FromBase64ShouldThrowError::Yes) [[unlikely]]
         return JSValue::encode(throwSyntaxError(globalObject, scope, "Uint8Array.prototype.setFromBase64 requires a valid base64 string"_s));
 
     JSObject* resultObject = constructEmptyObject(globalObject);
@@ -128,7 +128,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeSetFromHex, (JSGlobalObject* globalO
     JSString* jsString = jsDynamicCast<JSString*>(callFrame->argument(0));
     if (!jsString) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.setFromHex requires a string"_s);
-    if (UNLIKELY(jsString->length() % 2))
+    if (jsString->length() % 2) [[unlikely]]
         return JSValue::encode(throwSyntaxError(globalObject, scope, "Uint8Array.prototype.setFromHex requires a string of even length"_s));
 
     auto gcOwnedData = jsString->view(globalObject);
@@ -169,7 +169,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeToBase64, (JSGlobalObject* globalObj
     JSValue optionsValue = callFrame->argument(0);
     if (!optionsValue.isUndefined()) {
         JSObject* optionsObject = jsDynamicCast<JSObject*>(optionsValue);
-        if (UNLIKELY(!optionsObject))
+        if (!optionsObject) [[unlikely]]
             return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.toBase64 requires that options be an object"_s);
 
         JSValue alphabetValue = optionsObject->get(globalObject, vm.propertyNames->alphabet);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -461,7 +461,7 @@ JSC_DEFINE_HOST_FUNCTION(dumpAndClearSamplingProfilerSamples, (JSGlobalObject* g
     }
 
     auto json = vm.takeSamplingProfilerSamplesAsJSON();
-    if (UNLIKELY(!json))
+    if (!json) [[unlikely]]
         return JSValue::encode(jsUndefined());
 
     auto jsonData = json->toJSONString();
@@ -1850,7 +1850,7 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
 
     initStaticGlobals(vm);
     
-    if (UNLIKELY(Options::useDollarVM()))
+    if (Options::useDollarVM()) [[unlikely]]
         exposeDollarVM(vm);
 
 #if ENABLE(WEBASSEMBLY)
@@ -1986,7 +1986,7 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
 
     fixupPrototypeChainWithObjectPrototype(vm);
 
-    if (UNLIKELY(Options::alwaysHaveABadTime()))
+    if (Options::alwaysHaveABadTime()) [[unlikely]]
         this->haveABadTime(vm);
 }
 
@@ -2061,7 +2061,7 @@ bool JSGlobalObject::canDeclareGlobalFunction(const Identifier& ident)
     PropertySlot slot(this, PropertySlot::InternalMethodType::GetOwnProperty);
     bool hasProperty = getOwnPropertySlot(this, this, ident, slot);
     scope.assertNoExceptionExceptTermination();
-    if (LIKELY(!hasProperty))
+    if (!hasProperty) [[likely]]
         return isStructureExtensible();
 
     bool isConfigurable = !(slot.attributes() & PropertyAttribute::DontDelete);

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -459,7 +459,7 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncEval, (JSGlobalObject* globalObject, CallFram
     JSValue x = callFrame->argument(0);
     String programSource;
     bool isTrusted = false;
-    if (LIKELY(x.isString())) {
+    if (x.isString()) [[likely]] {
         programSource = x.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
     } else if (Options::useTrustedTypes() && x.isObject()) {
@@ -496,7 +496,7 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncEval, (JSGlobalObject* globalObject, CallFram
         return JSValue::encode(jsUndefined());
     }
 
-    if (UNLIKELY(SourceProfiler::g_profilerHook)) {
+    if (SourceProfiler::g_profilerHook) [[unlikely]] {
         SourceOrigin sourceOrigin = callFrame->callerSourceOrigin(vm);
         SourceTaintedOrigin sourceTaintedOrigin = computeNewSourceTaintedOriginFromStack(vm, callFrame);
         auto source = makeSource(programSource, sourceOrigin, sourceTaintedOrigin);
@@ -936,7 +936,7 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncCopyDataProperties, (JSGlobalObject* globalOb
     }
 
     auto sourceStructure = source->structure();
-    if (LIKELY(canPerformFastPropertyEnumerationForCopyDataProperties(sourceStructure))) {
+    if (canPerformFastPropertyEnumerationForCopyDataProperties(sourceStructure)) [[likely]] {
         EnsureStillAliveScope sourceStructureScope(sourceStructure);
         Vector<UniquedStringImpl*, 8> properties; // sourceStructure ensures the lifetimes of these strings.
         MarkedArgumentBuffer values;
@@ -968,7 +968,7 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncCopyDataProperties, (JSGlobalObject* globalOb
         // excludedSet is no longer used.
         ensureStillAliveHere(unlinkedCodeBlock);
 
-        if (LIKELY(target->inherits<JSFinalObject>() && target->canPerformFastPutInlineExcludingProto() && target->isStructureExtensible()))
+        if (target->inherits<JSFinalObject>() && target->canPerformFastPutInlineExcludingProto() && target->isStructureExtensible()) [[likely]]
             target->putOwnDataPropertyBatching(vm, properties.data(), values.data(), properties.size());
         else {
             for (size_t i = 0; i < properties.size(); ++i)
@@ -1026,7 +1026,7 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncCloneObject, (JSGlobalObject* globalObject, C
     }
 
     Structure* sourceStructure = source->structure();
-    if (LIKELY(sourceStructure->canPerformFastPropertyEnumerationCommon())) {
+    if (sourceStructure->canPerformFastPropertyEnumerationCommon()) [[likely]] {
         if (auto* cloned = tryCreateObjectViaCloning(vm, globalObject, source))
             return JSValue::encode(cloned);
     }
@@ -1034,7 +1034,7 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncCloneObject, (JSGlobalObject* globalObject, C
     JSObject* target = constructEmptyObject(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    if (LIKELY(canPerformFastPropertyEnumerationForCopyDataProperties(sourceStructure))) {
+    if (canPerformFastPropertyEnumerationForCopyDataProperties(sourceStructure)) [[likely]] {
         EnsureStillAliveScope sourceStructureScope(sourceStructure);
         Vector<UniquedStringImpl*, 8> properties; // sourceStructure ensures the lifetimes of these strings.
         MarkedArgumentBuffer values;

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -334,7 +334,7 @@ ALWAYS_INLINE JSArray* tryCreateContiguousArrayWithPattern(JSGlobalObject* globa
 
     VM& vm = globalObject->vm();
     Structure* structure = globalObject->originalArrayStructureForIndexingType(ArrayWithContiguous);
-    if (UNLIKELY(!hasContiguous(structure->indexingType())))
+    if (!hasContiguous(structure->indexingType())) [[unlikely]]
         return nullptr;
 
     unsigned vectorLength = Butterfly::optimalContiguousVectorLength(structure, initialLength);
@@ -369,7 +369,7 @@ ALWAYS_INLINE JSArray* createPatternFilledArray(JSGlobalObject* globalObject, JS
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (JSArray* array = tryCreateContiguousArrayWithPattern(globalObject, pattern, count); LIKELY(array))
+    if (JSArray* array = tryCreateContiguousArrayWithPattern(globalObject, pattern, count); array) [[likely]]
         return array;
 
     JSArray* array = constructEmptyArray(globalObject, nullptr, count);
@@ -544,7 +544,7 @@ inline JSScope* JSGlobalObject::globalScope()
 // https://tc39.es/ecma262/#sec-candeclareglobalvar
 inline bool JSGlobalObject::canDeclareGlobalVar(const Identifier& ident)
 {
-    if (LIKELY(isStructureExtensible()))
+    if (isStructureExtensible()) [[likely]]
         return true;
 
     PropertySlot slot(this, PropertySlot::InternalMethodType::GetOwnProperty);

--- a/Source/JavaScriptCore/runtime/JSImmutableButterfly.h
+++ b/Source/JavaScriptCore/runtime/JSImmutableButterfly.h
@@ -53,7 +53,7 @@ public:
 
     ALWAYS_INLINE static JSImmutableButterfly* tryCreate(VM& vm, Structure* structure, unsigned length)
     {
-        if (UNLIKELY(length > IndexingHeader::maximumLength))
+        if (length > IndexingHeader::maximumLength) [[unlikely]]
             return nullptr;
 
         // Because of the above maximumLength requirement, allocationSize can never overflow.

--- a/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
@@ -140,7 +140,7 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncToArray, (JSGlobalObject* globalObject
     MarkedArgumentBuffer value;
     forEachInIteratorProtocol(globalObject, thisValue, [&value, &scope](VM&, JSGlobalObject* globalObject, JSValue nextItem) {
         value.append(nextItem);
-        if (UNLIKELY(value.hasOverflowed()))
+        if (value.hasOverflowed()) [[unlikely]]
             throwOutOfMemoryError(globalObject, scope);
     });
     RETURN_IF_EXCEPTION(scope, { });

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -43,15 +43,15 @@ void runJSMicrotask(JSGlobalObject* globalObject, MicrotaskIdentifier identifier
 
     auto scope = DECLARE_CATCH_SCOPE(vm);
 
-    if (UNLIKELY(!job.isObject()))
+    if (!job.isObject()) [[unlikely]]
         return;
 
     // If termination is issued, do not run microtasks. Otherwise, microtask should not care about exceptions.
-    if (UNLIKELY(!scope.clearExceptionExceptTermination()))
+    if (!scope.clearExceptionExceptTermination()) [[unlikely]]
         return;
 
     auto handlerCallData = JSC::getCallData(job);
-    if (UNLIKELY(!scope.clearExceptionExceptTermination()))
+    if (!scope.clearExceptionExceptTermination()) [[unlikely]]
         return;
     ASSERT(handlerCallData.type != CallData::Type::None);
 
@@ -68,7 +68,7 @@ void runJSMicrotask(JSGlobalObject* globalObject, MicrotaskIdentifier identifier
         scope.clearException();
     }
 
-    if (LIKELY(!vm.hasPendingTerminationException())) {
+    if (!vm.hasPendingTerminationException()) [[likely]] {
         profiledCall(globalObject, ProfilingReason::Microtask, job, handlerCallData, jsUndefined(), ArgList { std::bit_cast<EncodedJSValue*>(arguments.data()), count });
         scope.clearExceptionExceptTermination();
     }

--- a/Source/JavaScriptCore/runtime/JSModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleRecord.cpp
@@ -92,7 +92,7 @@ Synchronousness JSModuleRecord::link(JSGlobalObject* globalObject, JSValue scrip
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (UNLIKELY(SourceProfiler::g_profilerHook))
+    if (SourceProfiler::g_profilerHook) [[unlikely]]
         SourceProfiler::profile(SourceProfiler::Type::Module, sourceCode());
 
     ModuleProgramExecutable* executable = ModuleProgramExecutable::create(globalObject, sourceCode());
@@ -162,7 +162,7 @@ void JSModuleRecord::instantiateDeclarations(JSGlobalObject* globalObject, Modul
 
 #if CPU(ADDRESS64)
         // rdar://107531050: Speculative crash mitigation
-        if (UNLIKELY(importedModule == std::bit_cast<AbstractModuleRecord*>(encodedJSUndefined()))) {
+        if (importedModule == std::bit_cast<AbstractModuleRecord*>(encodedJSUndefined())) [[unlikely]] {
             RELEASE_ASSERT(vm.exceptionForInspection(), vm.traps().maybeNeedHandling(), vm.exceptionForInspection(), importedModule);
             RELEASE_ASSERT(vm.traps().maybeNeedHandling(), vm.traps().maybeNeedHandling(), vm.exceptionForInspection(), importedModule);
             if (!vm.exceptionForInspection() || !vm.traps().maybeNeedHandling()) {

--- a/Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h
+++ b/Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h
@@ -42,12 +42,12 @@ ALWAYS_INLINE Ref<AtomStringImpl> JSONAtomStringCache::makeIdentifier(std::span<
     if (characters.size() == 1) {
         if (firstCharacter <= maxSingleCharacterString)
             return vm().smallStrings.singleCharacterStringRep(firstCharacter);
-    } else if (UNLIKELY(characters.size() > maxStringLengthForCache))
+    } else if (characters.size() > maxStringLengthForCache) [[unlikely]]
         return AtomStringImpl::add(characters).releaseNonNull();
 
     auto lastCharacter = characters.back();
     auto& slot = cacheSlot(firstCharacter, lastCharacter, characters.size());
-    if (UNLIKELY(slot.m_length != characters.size() || !equal(slot.m_buffer, characters))) {
+    if (slot.m_length != characters.size() || !equal(slot.m_buffer, characters)) [[unlikely]] {
         auto result = AtomStringImpl::add(characters);
         slot.m_impl = result;
         slot.m_length = characters.size();
@@ -68,12 +68,12 @@ ALWAYS_INLINE AtomStringImpl* JSONAtomStringCache::existingIdentifier(std::span<
     if (characters.size() == 1) {
         if (firstCharacter <= maxSingleCharacterString)
             return vm().smallStrings.existingSingleCharacterStringRep(firstCharacter);
-    } else if (UNLIKELY(characters.size() > maxStringLengthForCache))
+    } else if (characters.size() > maxStringLengthForCache) [[unlikely]]
         return nullptr;
 
     auto lastCharacter = characters.back();
     auto& slot = cacheSlot(firstCharacter, lastCharacter, characters.size());
-    if (UNLIKELY(slot.m_length != characters.size() || !equal(slot.m_buffer, characters)))
+    if (slot.m_length != characters.size() || !equal(slot.m_buffer, characters)) [[unlikely]]
         return nullptr;
 
     return slot.m_impl.get();

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -303,11 +303,11 @@ String Stringifier::stringify(JSGlobalObject& globalObject, JSValue value, JSVal
     Holder root(Holder::RootHolder, object);
     auto stringifyResult = stringifier.appendStringifiedValue(result, value, root, emptyPropertyName);
     RETURN_IF_EXCEPTION(scope, { });
-    if (UNLIKELY(result.hasOverflowed())) {
+    if (result.hasOverflowed()) [[unlikely]] {
         throwOutOfMemoryError(&globalObject, scope);
         return { };
     }
-    if (UNLIKELY(stringifyResult != StringifySucceeded))
+    if (stringifyResult != StringifySucceeded) [[unlikely]]
         RELEASE_AND_RETURN(scope, { });
     RELEASE_AND_RETURN(scope, result.toString());
 }
@@ -452,7 +452,7 @@ Stringifier::StringifyResult Stringifier::appendStringifiedValue(StringBuilder& 
         }
     }
 
-    if (UNLIKELY(m_holderStack.size() >= maximumSideStackRecursion)) {
+    if (m_holderStack.size() >= maximumSideStackRecursion) [[unlikely]] {
         throwStackOverflowError(m_globalObject, scope);
         return StringifyFailed;
     }
@@ -532,7 +532,7 @@ bool Stringifier::Holder::appendNextProperty(Stringifier& stringifier, StringBui
         if (m_isArray) {
             uint64_t length = toLength(globalObject, m_object);
             RETURN_IF_EXCEPTION(scope, false);
-            if (UNLIKELY(length > std::numeric_limits<uint32_t>::max())) {
+            if (length > std::numeric_limits<uint32_t>::max()) [[unlikely]] {
                 throwOutOfMemoryError(globalObject, scope);
                 return false;
             }
@@ -964,10 +964,10 @@ bool FastStringifier<CharType, bufferMode>::hasRemainingCapacitySlow(unsigned si
         return true;
     } else {
         size_t newSize = std::max<size_t>(m_dynamicBuffer.size() * 2, m_dynamicBuffer.size() + size);
-        if (UNLIKELY(newSize > StringImpl::MaxLength))
+        if (newSize > StringImpl::MaxLength) [[unlikely]]
             return false;
 
-        if (UNLIKELY(!m_dynamicBuffer.tryGrow(newSize)))
+        if (!m_dynamicBuffer.tryGrow(newSize)) [[unlikely]]
             return false;
 
         m_capacity = m_dynamicBuffer.size();
@@ -1032,7 +1032,7 @@ inline bool FastStringifier<CharType, bufferMode>::mayHaveToJSON(JSObject& objec
 {
     if (auto function = object.structure()->cachedSpecialProperty(CachedSpecialPropertyKey::ToJSON))
         return !function.isUndefined();
-    if (UNLIKELY(object.noSideEffectMayHaveNonIndexProperty(m_vm, m_vm.propertyNames->toJSON))) {
+    if (object.noSideEffectMayHaveNonIndexProperty(m_vm, m_vm.propertyNames->toJSON)) [[unlikely]] {
         // Getting the property value so we can cache it could cause side effects; instead return true without caching anything.
         return true;
     }
@@ -1045,7 +1045,7 @@ inline bool FastStringifier<CharType, bufferMode>::mayHaveToJSON(JSObject& objec
 template<typename CharType, BufferMode bufferMode>
 inline void FastStringifier<CharType, bufferMode>::append(char a, char b, char c, char d)
 {
-    if (UNLIKELY(!hasRemainingCapacity(4))) {
+    if (!hasRemainingCapacity(4)) [[unlikely]] {
         recordBufferFull();
         return;
     }
@@ -1059,7 +1059,7 @@ inline void FastStringifier<CharType, bufferMode>::append(char a, char b, char c
 template<typename CharType, BufferMode bufferMode>
 inline void FastStringifier<CharType, bufferMode>::append(char a, char b, char c, char d, char e)
 {
-    if (UNLIKELY(!hasRemainingCapacity(5))) {
+    if (!hasRemainingCapacity(5)) [[unlikely]] {
         recordBufferFull();
         return;
     }
@@ -1117,10 +1117,10 @@ static ALWAYS_INLINE bool stringCopySameType(std::span<const CharType> span, Cha
 #endif
     for (auto character : span) {
         if constexpr (sizeof(CharType) != 1) {
-            if (UNLIKELY(U16_IS_SURROGATE(character)))
+            if (U16_IS_SURROGATE(character)) [[unlikely]]
                 return true;
         }
-        if (UNLIKELY(character <= 0xff && WTF::escapedFormsForJSON[character]))
+        if (character <= 0xff && WTF::escapedFormsForJSON[character]) [[unlikely]]
             return true;
         *cursor++ = character;
     }
@@ -1162,7 +1162,7 @@ static ALWAYS_INLINE bool stringCopyUpconvert(std::span<const LChar> span, UChar
     }
 #endif
     for (auto character : span) {
-        if (UNLIKELY(WTF::escapedFormsForJSON[character]))
+        if (WTF::escapedFormsForJSON[character]) [[unlikely]]
             return true;
         *cursor++ = character;
     }
@@ -1173,7 +1173,7 @@ template<typename CharType, BufferMode bufferMode>
 void FastStringifier<CharType, bufferMode>::append(JSValue value)
 {
     if constexpr (bufferMode == BufferMode::DynamicBuffer) {
-        if (UNLIKELY(std::bit_cast<uint8_t*>(currentStackPointer()) < m_stackLimit)) {
+        if (std::bit_cast<uint8_t*>(currentStackPointer()) < m_stackLimit) [[unlikely]] {
             recordFailure(FailureReason::StackOverflow, "stack overflow"_s);
             return;
         }
@@ -1197,7 +1197,7 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
     if (value.isInt32()) {
         auto number = value.asInt32();
         constexpr unsigned maxInt32StringLength = 11; // -INT32_MIN, "-2147483648".
-        if (UNLIKELY(!hasRemainingCapacity(maxInt32StringLength))) {
+        if (!hasRemainingCapacity(maxInt32StringLength)) [[unlikely]] {
             recordBufferFull();
             return;
         }
@@ -1223,7 +1223,7 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
             append('n', 'u', 'l', 'l');
             return;
         }
-        if (UNLIKELY(!hasRemainingCapacity(WTF::dragonbox::max_string_length<WTF::dragonbox::ieee754_binary64>()))) {
+        if (!hasRemainingCapacity(WTF::dragonbox::max_string_length<WTF::dragonbox::ieee754_binary64>())) [[unlikely]] {
             recordBufferFull();
             return;
         }
@@ -1249,44 +1249,44 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
     switch (cell.type()) {
     case StringType: {
         auto string = asString(&cell)->tryGetValue();
-        if (UNLIKELY(string.data.isNull())) {
+        if (string.data.isNull()) [[unlikely]] {
             recordFailure("String::tryGetValue"_s);
             return;
         }
 
         auto stringLength = string.data.length();
         if constexpr (sizeof(CharType) == 1) {
-            if (UNLIKELY(!string.data.is8Bit())) {
+            if (!string.data.is8Bit()) [[unlikely]] {
                 if constexpr (bufferMode == BufferMode::DynamicBuffer)
                     recordFailure(FailureReason::Unknown, "16-bit string"_s);
                 else
                     recordFailure(m_length < (m_capacity / 2) ? FailureReason::Found16BitEarly : FailureReason::Found16BitLate, "16-bit string"_s);
                 return;
             }
-            if (UNLIKELY(!hasRemainingCapacity(1 + stringLength + 1))) {
+            if (!hasRemainingCapacity(1 + stringLength + 1)) [[unlikely]] {
                 recordBufferFull();
                 return;
             }
             buffer()[m_length] = '"';
-            if (LIKELY(!stringCopySameType(string.data.span8(), buffer() + m_length + 1))) {
+            if (!stringCopySameType(string.data.span8(), buffer() + m_length + 1)) [[likely]] {
                 buffer()[m_length + 1 + stringLength] = '"';
                 m_length += 1 + stringLength + 1;
                 return;
             }
         } else {
-            if (UNLIKELY(!hasRemainingCapacity(1 + stringLength + 1))) {
+            if (!hasRemainingCapacity(1 + stringLength + 1)) [[unlikely]] {
                 recordBufferFull();
                 return;
             }
             buffer()[m_length] = '"';
             if (string.data.is8Bit()) {
-                if (LIKELY(!stringCopyUpconvert(string.data.span8(), buffer() + m_length + 1))) {
+                if (!stringCopyUpconvert(string.data.span8(), buffer() + m_length + 1)) [[likely]] {
                     buffer()[m_length + 1 + stringLength] = '"';
                     m_length += 1 + stringLength + 1;
                     return;
                 }
             } else {
-                if (LIKELY(!stringCopySameType(string.data.span16(), buffer() + m_length + 1))) {
+                if (!stringCopySameType(string.data.span16(), buffer() + m_length + 1)) [[likely]] {
                     buffer()[m_length + 1 + stringLength] = '"';
                     m_length += 1 + stringLength + 1;
                     return;
@@ -1294,7 +1294,7 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
             }
         }
 
-        if (UNLIKELY(!hasRemainingCapacity(1 + static_cast<size_t>(stringLength) * 6 + 1))) {
+        if (!hasRemainingCapacity(1 + static_cast<size_t>(stringLength) * 6 + 1)) [[unlikely]] {
             recordBufferFull();
             return;
         }
@@ -1314,21 +1314,21 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
     case ObjectType:
     case FinalObjectType: {
         auto& object = *asObject(&cell);
-        if (UNLIKELY(object.isCallable())) {
+        if (object.isCallable()) [[unlikely]] {
             recordFailure("callable object"_s);
             return;
         }
         auto& structure = *object.structure();
-        if (UNLIKELY(structure.hasPolyProto())) {
+        if (structure.hasPolyProto()) [[unlikely]] {
             recordFailure("hasPolyProto"_s);
             return;
         }
-        if (UNLIKELY(structure.storedPrototype() != m_globalObject.objectPrototype())) {
+        if (structure.storedPrototype() != m_globalObject.objectPrototype()) [[unlikely]] {
             recordFailure("non-standard object prototype"_s);
             return;
         }
         if (!m_checkedObjectPrototype) {
-            if (UNLIKELY(mayHaveToJSON(*m_globalObject.objectPrototype()))) {
+            if (mayHaveToJSON(*m_globalObject.objectPrototype())) [[unlikely]] {
                 recordFailure("object prototype may have toJSON"_s);
                 return;
             }
@@ -1339,7 +1339,7 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
             return;
         }
         buffer()[m_length++] = '{';
-        if (UNLIKELY(!structure.canPerformFastPropertyEnumeration())) {
+        if (!structure.canPerformFastPropertyEnumeration()) [[unlikely]] {
             recordFastPropertyEnumerationFailure(object);
             return;
         }
@@ -1347,19 +1347,19 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
             if (entry.attributes() & PropertyAttribute::DontEnum)
                 return true;
             auto& name = *entry.key();
-            if (UNLIKELY(name.isSymbol())) {
+            if (name.isSymbol()) [[unlikely]] {
                 recordFailure("symbol"_s);
                 return false;
             }
 
             // Right now, we do not support 16-bit name here since name in 16-bit is significantly more rare than 16-bit string.
-            if (UNLIKELY(!name.is8Bit())) {
+            if (!name.is8Bit()) [[unlikely]] {
                 recordFailure("16-bit property name"_s);
                 return false;
             }
             auto span = name.span8();
 
-            if (UNLIKELY(object.structure() != &structure)) {
+            if (object.structure() != &structure) [[unlikely]] {
                 ASSERT_NOT_REACHED();
                 recordFailure("unexpected structure transition"_s);
                 return false;
@@ -1369,7 +1369,7 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
                 return true;
 
             bool needComma = buffer()[m_length - 1] != '{';
-            if (UNLIKELY(!hasRemainingCapacity(needComma + 1 + span.size() + 2))) {
+            if (!hasRemainingCapacity(needComma + 1 + span.size() + 2)) [[unlikely]] {
                 recordBufferFull();
                 return false;
             }
@@ -1378,12 +1378,12 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
             buffer()[m_length] = '"';
 
             if constexpr (sizeof(CharType) == 2) {
-                if (UNLIKELY(stringCopyUpconvert(span, buffer() + m_length + 1))) {
+                if (stringCopyUpconvert(span, buffer() + m_length + 1)) [[unlikely]] {
                     recordFailure("property name character needs escaping"_s);
                     return false;
                 }
             } else {
-                if (UNLIKELY(stringCopySameType(span, buffer() + m_length + 1))) {
+                if (stringCopySameType(span, buffer() + m_length + 1)) [[unlikely]] {
                     recordFailure("property name character needs escaping"_s);
                     return false;
                 }
@@ -1395,7 +1395,7 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
             append(value);
             return !haveFailure();
         });
-        if (UNLIKELY(haveFailure()))
+        if (haveFailure()) [[unlikely]]
             return;
         if (!hasRemainingCapacity()) [[unlikely]] {
             recordBufferFull();
@@ -1408,16 +1408,16 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
     case ArrayType: {
         auto& array = *asArray(&cell);
         if (!m_checkedArrayPrototype) {
-            if (UNLIKELY(mayHaveToJSON(*m_globalObject.arrayPrototype()))) {
+            if (mayHaveToJSON(*m_globalObject.arrayPrototype())) [[unlikely]] {
                 recordFailure("array prototype may have toJSON"_s);
                 return;
             }
             m_checkedArrayPrototype = true;
         }
         auto& structure = *array.structure();
-        if (UNLIKELY(!m_globalObject.isOriginalArrayStructure(&structure))) {
+        if (!m_globalObject.isOriginalArrayStructure(&structure)) [[unlikely]] {
             structure.forEachProperty(m_vm, [&](const PropertyTableEntry& entry) -> bool {
-                if (UNLIKELY(entry.key() == m_vm.propertyNames->toJSON)) {
+                if (entry.key() == m_vm.propertyNames->toJSON) [[unlikely]] {
                     recordFailure("array has toJSON"_s);
                     return false;
                 }
@@ -1439,12 +1439,12 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
                 }
                 buffer()[m_length++] = ',';
             }
-            if (UNLIKELY(!array.canGetIndexQuickly(i))) {
+            if (!array.canGetIndexQuickly(i)) [[unlikely]] {
                 recordFailure("!canGetIndexQuickly"_s);
                 return;
             }
             append(array.getIndexQuickly(i));
-            if (UNLIKELY(haveFailure()))
+            if (haveFailure()) [[unlikely]]
                 return;
         }
         if (!hasRemainingCapacity()) [[unlikely]] {
@@ -1485,7 +1485,7 @@ static NEVER_INLINE String stringify(JSGlobalObject& globalObject, JSValue value
 {
     VM& vm = globalObject.vm();
     uint8_t* stackLimit = std::bit_cast<uint8_t*>(vm.softStackLimit());
-    if (LIKELY(std::bit_cast<uint8_t*>(currentStackPointer()) >= stackLimit)) {
+    if (std::bit_cast<uint8_t*>(currentStackPointer()) >= stackLimit) [[likely]] {
         std::optional<FailureReason> failureReason;
         failureReason = std::nullopt;
         if (String result = FastStringifier<LChar, BufferMode::StaticBuffer>::stringify(globalObject, value, replacer, space, failureReason); !result.isNull())
@@ -1602,7 +1602,7 @@ NEVER_INLINE JSValue Walker::walk(JSValue unfiltered)
                 ASSERT(isArray(m_globalObject, inValue));
                 EXCEPTION_ASSERT(!scope.exception());
 
-                if (UNLIKELY(markedStack.size() >= maximumSideStackRecursion))
+                if (markedStack.size() >= maximumSideStackRecursion) [[unlikely]]
                     return throwStackOverflowError(m_globalObject, scope);
 
                 JSObject* array = asObject(inValue);
@@ -1616,7 +1616,7 @@ NEVER_INLINE JSValue Walker::walk(JSValue unfiltered)
                 }
                 uint64_t length = toLength(m_globalObject, array);
                 RETURN_IF_EXCEPTION(scope, { });
-                if (UNLIKELY(length > std::numeric_limits<uint32_t>::max())) {
+                if (length > std::numeric_limits<uint32_t>::max()) [[unlikely]] {
                     throwOutOfMemoryError(m_globalObject, scope);
                     return { };
                 }
@@ -1688,7 +1688,7 @@ NEVER_INLINE JSValue Walker::walk(JSValue unfiltered)
             case ObjectStartState: {
                 ASSERT(inValue.isObject());
                 ASSERT(!isJSArray(inValue));
-                if (UNLIKELY(markedStack.size() >= maximumSideStackRecursion))
+                if (markedStack.size() >= maximumSideStackRecursion) [[unlikely]]
                     return throwStackOverflowError(m_globalObject, scope);
 
                 JSObject* object = asObject(inValue);
@@ -1758,7 +1758,7 @@ NEVER_INLINE JSValue Walker::walk(JSValue unfiltered)
                 else {
                     unsigned attributes;
                     PropertyOffset offset = object->getDirectOffset(vm, prop, attributes);
-                    if (LIKELY(offset != invalidOffset && attributes == static_cast<unsigned>(PropertyAttribute::None))) {
+                    if (offset != invalidOffset && attributes == static_cast<unsigned>(PropertyAttribute::None)) [[likely]] {
                         object->putDirectOffset(vm, offset, filteredValue);
                         object->structure()->didReplaceProperty(offset);
                     } else {
@@ -1950,19 +1950,19 @@ JSC_DEFINE_HOST_FUNCTION(jsonProtoFuncRawJSON, (JSGlobalObject* globalObject, Ca
 
     String string = jsString->value(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
-    if (UNLIKELY(string.isEmpty())) {
+    if (string.isEmpty()) [[unlikely]] {
         throwSyntaxError(globalObject, scope, "JSON.rawJSON cannot accept empty string"_s);
         return { };
     }
 
     UChar firstCharacter = string[0];
-    if (UNLIKELY(isJSONWhitespace(firstCharacter))) {
+    if (isJSONWhitespace(firstCharacter)) [[unlikely]] {
         throwSyntaxError(globalObject, scope, makeString("JSON.rawJSON cannot accept string starting with '"_s, firstCharacter, "'"_s));
         return { };
     }
 
     UChar lastCharacter = string[string.length() - 1];
-    if (UNLIKELY(isJSONWhitespace(lastCharacter))) {
+    if (isJSONWhitespace(lastCharacter)) [[unlikely]] {
         throwSyntaxError(globalObject, scope, makeString("JSON.rawJSON cannot accept string ending with '"_s, lastCharacter, "'"_s));
         return { };
     }

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -381,7 +381,7 @@ public:
     bool canGetIndexQuickly(uint64_t i) const
     {
         ASSERT(i <= maxSafeInteger());
-        if (LIKELY(i <= MAX_ARRAY_INDEX))
+        if (i <= MAX_ARRAY_INDEX) [[likely]]
             return canGetIndexQuickly(static_cast<uint32_t>(i));
         return false;
     }
@@ -450,7 +450,7 @@ public:
     JSValue tryGetIndexQuickly(uint64_t i) const
     {
         ASSERT(i <= maxSafeInteger());
-        if (LIKELY(i <= MAX_ARRAY_INDEX))
+        if (i <= MAX_ARRAY_INDEX) [[likely]]
             return tryGetIndexQuickly(static_cast<uint32_t>(i));
         return JSValue();
     }
@@ -985,9 +985,9 @@ public:
     // contiguous, array storage).
     ContiguousJSValues tryMakeWritableInt32(VM& vm)
     {
-        if (LIKELY(hasInt32(indexingType()) && !isCopyOnWrite(indexingMode())))
+        if (hasInt32(indexingType()) && !isCopyOnWrite(indexingMode())) [[likely]]
             return m_butterfly->contiguousInt32();
-            
+
         return tryMakeWritableInt32Slow(vm);
     }
         
@@ -997,9 +997,9 @@ public:
     // or array storage).
     ContiguousDoubles tryMakeWritableDouble(VM& vm)
     {
-        if (LIKELY(hasDouble(indexingType()) && !isCopyOnWrite(indexingMode())))
+        if (hasDouble(indexingType()) && !isCopyOnWrite(indexingMode())) [[likely]]
             return m_butterfly->contiguousDouble();
-            
+
         return tryMakeWritableDoubleSlow(vm);
     }
         
@@ -1007,9 +1007,9 @@ public:
     // indexing should be sparse or because we're having a bad time.
     ContiguousJSValues tryMakeWritableContiguous(VM& vm)
     {
-        if (LIKELY(hasContiguous(indexingType()) && !isCopyOnWrite(indexingMode())))
+        if (hasContiguous(indexingType()) && !isCopyOnWrite(indexingMode())) [[likely]]
             return m_butterfly->contiguous();
-            
+
         return tryMakeWritableContiguousSlow(vm);
     }
 
@@ -1019,7 +1019,7 @@ public:
     // already.
     ArrayStorage* ensureArrayStorage(VM& vm)
     {
-        if (LIKELY(hasAnyArrayStorage(indexingType())))
+        if (hasAnyArrayStorage(indexingType())) [[likely]]
             return m_butterfly->arrayStorage();
 
         return ensureArrayStorageSlow(vm);
@@ -1460,7 +1460,7 @@ inline JSValue JSObject::getPrototypeDirect() const
 
 inline JSValue JSObject::getPrototype(VM&, JSGlobalObject* globalObject)
 {
-    if (LIKELY(!structure()->typeInfo().overridesGetPrototype()))
+    if (!structure()->typeInfo().overridesGetPrototype()) [[likely]]
         return getPrototypeDirect();
     return methodTable()->getPrototype(this, globalObject);
 }
@@ -1578,7 +1578,7 @@ ALWAYS_INLINE bool JSObject::getPropertySlot(JSGlobalObject* globalObject, Prope
     VM& vm = getVM(globalObject);
     JSObject* object = this;
     while (true) {
-        if (UNLIKELY(TypeInfo::overridesGetOwnPropertySlot(object->inlineTypeFlags()))) {
+        if (TypeInfo::overridesGetOwnPropertySlot(object->inlineTypeFlags())) [[unlikely]] {
             // If propertyName is an index then we may have missed it (as this loop is using
             // getOwnNonIndexPropertySlot), so we cannot safely call the overridden getOwnPropertySlot
             // (lest we return a property from a prototype that is shadowed). Check now for an index,
@@ -1592,8 +1592,10 @@ ALWAYS_INLINE bool JSObject::getPropertySlot(JSGlobalObject* globalObject, Prope
         ASSERT(object->type() != ProxyObjectType);
         Structure* structure = object->structureID().decode();
 #if USE(JSVALUE64)
-        if (checkNullStructure && UNLIKELY(!structure))
-            CRASH_WITH_INFO(object->type(), object->structureID().bits());
+        if (checkNullStructure) {
+            if (!structure) [[unlikely]]
+                CRASH_WITH_INFO(object->type(), object->structureID().bits());
+        }
 #endif
         if (object->getOwnNonIndexPropertySlot(vm, structure, propertyName, slot))
             return true;
@@ -1683,7 +1685,7 @@ constexpr inline intptr_t offsetInButterfly(PropertyOffset offset)
 
 inline size_t JSObject::butterflyPreCapacity()
 {
-    if (UNLIKELY(hasIndexingHeader()))
+    if (hasIndexingHeader()) [[unlikely]]
         return butterfly()->indexingHeader()->preCapacity(structure());
     return 0;
 }

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -250,7 +250,7 @@ JSPromise* JSPromise::rejectWithCaughtException(JSGlobalObject* globalObject, Th
     VM& vm = globalObject->vm();
     Exception* exception = scope.exception();
     ASSERT(exception);
-    if (UNLIKELY(vm.isTerminationException(exception))) {
+    if (vm.isTerminationException(exception)) [[unlikely]] {
         scope.release();
         return this;
     }

--- a/Source/JavaScriptCore/runtime/JSPropertyNameEnumerator.cpp
+++ b/Source/JavaScriptCore/runtime/JSPropertyNameEnumerator.cpp
@@ -38,13 +38,13 @@ JSPropertyNameEnumerator* JSPropertyNameEnumerator::tryCreate(VM& vm, Structure*
 {
     unsigned propertyNamesSize = propertyNames.size();
     auto propertyNamesBufferSizeInBytes = CheckedUint32(propertyNamesSize) * sizeof(WriteBarrier<JSString>);
-    if (UNLIKELY(propertyNamesBufferSizeInBytes.hasOverflowed()))
+    if (propertyNamesBufferSizeInBytes.hasOverflowed()) [[unlikely]]
         return nullptr;
 
     WriteBarrier<JSString>* propertyNamesBuffer = nullptr;
     if (propertyNamesBufferSizeInBytes) {
         propertyNamesBuffer = static_cast<WriteBarrier<JSString>*>(vm.auxiliarySpace().allocate(vm, propertyNamesBufferSizeInBytes, nullptr, AllocationFailureMode::ReturnNull));
-        if (UNLIKELY(!propertyNamesBuffer))
+        if (!propertyNamesBuffer) [[unlikely]]
             return nullptr;
 
         for (unsigned i = 0; i < propertyNamesSize; ++i)
@@ -147,7 +147,7 @@ void getEnumerablePropertyNames(JSGlobalObject* globalObject, JSObject* base, Pr
         if (prototype.isNull())
             break;
 
-        if (UNLIKELY(++prototypeCount > JSObject::maximumPrototypeChainDepth)) {
+        if (++prototypeCount > JSObject::maximumPrototypeChainDepth) [[unlikely]] {
             throwStackOverflowError(globalObject, scope);
             return;
         }

--- a/Source/JavaScriptCore/runtime/JSPropertyNameEnumerator.h
+++ b/Source/JavaScriptCore/runtime/JSPropertyNameEnumerator.h
@@ -162,7 +162,7 @@ inline JSPropertyNameEnumerator* propertyNameEnumerator(JSGlobalObject* globalOb
         enumerator = vm.emptyPropertyNameEnumerator();
     else {
         enumerator = JSPropertyNameEnumerator::tryCreate(vm, structureAfterGettingPropertyNames, indexedLength, numberStructureProperties, WTFMove(propertyNames));
-        if (UNLIKELY(!enumerator)) {
+        if (!enumerator) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
             return nullptr;
         }

--- a/Source/JavaScriptCore/runtime/JSRawJSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSRawJSONObject.cpp
@@ -63,7 +63,7 @@ Structure* JSRawJSONObject::createStructure(VM& vm, JSGlobalObject* globalObject
 
 JSString* JSRawJSONObject::rawJSON(VM& vm)
 {
-    if (LIKELY(!structure()->didTransition()))
+    if (!structure()->didTransition()) [[likely]]
         return jsCast<JSString*>(getDirect(rawJSONObjectRawJSONPropertyOffset));
     return jsCast<JSString*>(getDirect(vm, vm.propertyNames->rawJSON));
 }

--- a/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
@@ -251,7 +251,7 @@ void JSRemoteFunction::finishCreation(JSGlobalObject* globalObject, VM& vm)
     copyNameAndLength(globalObject);
 
     auto* exception = scope.exception();
-    if (UNLIKELY(exception && !vm.isTerminationException(exception))) {
+    if (exception && !vm.isTerminationException(exception)) [[unlikely]] {
         scope.clearException();
         throwTypeError(globalObject, scope, "wrapping returned function throws an error"_s);
     }

--- a/Source/JavaScriptCore/runtime/JSScope.cpp
+++ b/Source/JavaScriptCore/runtime/JSScope.cpp
@@ -237,7 +237,7 @@ ALWAYS_INLINE JSObject* JSScope::resolve(JSGlobalObject* globalObject, JSScope* 
         // Global scope.
         if (++it == end) {
             JSScope* globalScopeExtension = scope->globalObject()->globalScopeExtension();
-            if (UNLIKELY(globalScopeExtension)) {
+            if (globalScopeExtension) [[unlikely]] {
                 bool hasProperty = object->hasProperty(globalObject, ident);
                 RETURN_IF_EXCEPTION(throwScope, nullptr);
                 if (hasProperty)

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -448,7 +448,7 @@ public:
 
         bool append(JSString* jsString)
         {
-            if (UNLIKELY(this->hasOverflowed()))
+            if (this->hasOverflowed()) [[unlikely]]
                 return false;
             if (!jsString->length())
                 return true;

--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -80,7 +80,7 @@ JSString* JSString::tryReplaceOneCharImpl(JSGlobalObject* globalObject, UChar se
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (UNLIKELY(std::bit_cast<uint8_t*>(currentStackPointer()) < stackLimit))
+    if (std::bit_cast<uint8_t*>(currentStackPointer()) < stackLimit) [[unlikely]]
         return nullptr; // Stack overflow
 
     if (this->isNonSubstringRope()) {
@@ -92,7 +92,7 @@ JSString* JSString::tryReplaceOneCharImpl(JSGlobalObject* globalObject, UChar se
         ASSERT(oldFiber0);
         JSString* newFiber0 = oldFiber0->tryReplaceOneCharImpl(globalObject, search, replacement, stackLimit, found);
         RETURN_IF_EXCEPTION(scope, nullptr);
-        if (UNLIKELY(!newFiber0))
+        if (!newFiber0) [[unlikely]]
             return nullptr;
         if (found)
             RELEASE_AND_RETURN(scope, jsString(globalObject, newFiber0, oldFiber1, oldFiber2));
@@ -100,7 +100,7 @@ JSString* JSString::tryReplaceOneCharImpl(JSGlobalObject* globalObject, UChar se
         if (oldFiber1) {
             JSString* newFiber1 = oldFiber1->tryReplaceOneCharImpl(globalObject, search, replacement, stackLimit, found);
             RETURN_IF_EXCEPTION(scope, nullptr);
-            if (UNLIKELY(!newFiber1))
+            if (!newFiber1) [[unlikely]]
                 return nullptr;
             if (found)
                 RELEASE_AND_RETURN(scope, jsString(globalObject, oldFiber0, newFiber1, oldFiber2));
@@ -109,7 +109,7 @@ JSString* JSString::tryReplaceOneCharImpl(JSGlobalObject* globalObject, UChar se
         if (oldFiber2) {
             JSString* newFiber2 = oldFiber2->tryReplaceOneCharImpl(globalObject, search, replacement, stackLimit, found);
             RETURN_IF_EXCEPTION(scope, nullptr);
-            if (UNLIKELY(!newFiber2))
+            if (!newFiber2) [[unlikely]]
                 return nullptr;
             if (found)
                 RELEASE_AND_RETURN(scope, jsString(globalObject, oldFiber0, oldFiber1, newFiber2));
@@ -312,7 +312,7 @@ inline void JSRopeString::resolveToBuffer(JSString* fiber0, JSString* fiber1, JS
                 unsigned offset = rope0->substringOffset();
                 view0.substring(offset, rope0Length).getCharacters(buffer);
             } else {
-                if (UNLIKELY(std::bit_cast<uint8_t*>(currentStackPointer()) < stackLimit))
+                if (std::bit_cast<uint8_t*>(currentStackPointer()) < stackLimit) [[unlikely]]
                     MUST_TAIL_CALL return JSRopeString::resolveToBufferSlow(fiber0, fiber1, fiber2, buffer, stackLimit);
                 resolveToBuffer(rope0->fiber0(), rope0->fiber1(), rope0->fiber2(), buffer.first(rope0Length), stackLimit);
             }
@@ -329,10 +329,10 @@ inline void JSRopeString::resolveToBuffer(JSString* fiber0, JSString* fiber1, JS
     }
 
     // 2 fibers.
-    if (LIKELY(fiber1)) {
+    if (fiber1) [[likely]] {
         if (fiber0->isRope()) {
             if (fiber1->isRope()) {
-                if (UNLIKELY(std::bit_cast<uint8_t*>(currentStackPointer()) < stackLimit))
+                if (std::bit_cast<uint8_t*>(currentStackPointer()) < stackLimit) [[unlikely]]
                     MUST_TAIL_CALL return JSRopeString::resolveToBufferSlow(fiber0, fiber1, fiber2, buffer, stackLimit);
 
                 auto* rope0 = static_cast<const JSRopeString*>(fiber0);

--- a/Source/JavaScriptCore/runtime/JSStringJoiner.cpp
+++ b/Source/JavaScriptCore/runtime/JSStringJoiner.cpp
@@ -238,7 +238,7 @@ JSValue JSStringJoiner::joinImpl(JSGlobalObject* globalObject)
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (UNLIKELY(m_hasOverflowed)) {
+    if (m_hasOverflowed) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return { };
     }
@@ -279,7 +279,7 @@ JSValue JSOnlyStringsJoiner::joinImpl(JSGlobalObject* globalObject, const WriteB
     CheckedInt32 separatorLength = m_separator.length();
     CheckedInt32 totalSeparatorsLength = separatorLength * (CheckedInt32(length) - 1);
     CheckedInt32 totalLength = totalSeparatorsLength + m_accumulatedStringsLength;
-    if (UNLIKELY(totalLength.hasOverflowed())) {
+    if (totalLength.hasOverflowed()) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return { };
     }

--- a/Source/JavaScriptCore/runtime/JSStringJoiner.h
+++ b/Source/JavaScriptCore/runtime/JSStringJoiner.h
@@ -79,7 +79,7 @@ inline void JSStringJoiner::reserveCapacity(JSGlobalObject* globalObject, size_t
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (UNLIKELY(!m_strings.tryReserveCapacity(count)))
+    if (!m_strings.tryReserveCapacity(count)) [[unlikely]]
         throwOutOfMemoryError(globalObject, scope);
 }
 
@@ -101,7 +101,7 @@ ALWAYS_INLINE void JSStringJoiner::append(JSString* jsString, StringViewWithUnde
     ++m_stringsCount;
     if (m_lastString == jsString) {
         auto& entry = m_strings.last();
-        if (LIKELY(entry.m_additional < UINT16_MAX)) {
+        if (entry.m_additional < UINT16_MAX) [[likely]] {
             ++entry.m_additional;
             m_accumulatedStringsLength += entry.m_view.view.length();
             return;

--- a/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp
@@ -175,7 +175,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewPrivateFuncLength, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue argument = callFrame->argument(0);
-    if (UNLIKELY(!argument.isCell() || !isTypedView(argument.asCell()->type())))
+    if (!argument.isCell() || !isTypedView(argument.asCell()->type())) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view"_s);
 
     JSArrayBufferView* thisObject = jsCast<JSArrayBufferView*>(argument);
@@ -190,7 +190,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewPrivateFuncContentType, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue argument = callFrame->argument(0);
-    if (UNLIKELY(!argument.isCell() || !isTypedView(argument.asCell()->type())))
+    if (!argument.isCell() || !isTypedView(argument.asCell()->type())) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view"_s);
     return JSValue::encode(jsNumber(static_cast<int32_t>(contentType(argument.asCell()->type()))));
 }
@@ -207,7 +207,7 @@ inline EncodedJSValue createTypedArrayIteratorObject(JSGlobalObject* globalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (UNLIKELY(!callFrame->thisValue().isCell() || !isTypedArrayType(callFrame->thisValue().asCell()->type())))
+    if (!callFrame->thisValue().isCell() || !isTypedArrayType(callFrame->thisValue().asCell()->type())) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view"_s);
 
     JSArrayBufferView* thisObject = jsCast<JSArrayBufferView*>(callFrame->thisValue());

--- a/Source/JavaScriptCore/runtime/LazyProperty.h
+++ b/Source/JavaScriptCore/runtime/LazyProperty.h
@@ -92,7 +92,7 @@ public:
 
     ElementType* getInitializedOnMainThread(const OwnerType* owner) const
     {
-        if (UNLIKELY(m_pointer & lazyTag)) {
+        if (m_pointer & lazyTag) [[unlikely]] {
             ASSERT(!isCompilationThread());
             FuncType func = *std::bit_cast<FuncType*>(m_pointer & ~(lazyTag | initializingTag));
             return func(Initializer(const_cast<OwnerType*>(owner), *const_cast<LazyProperty*>(this)));

--- a/Source/JavaScriptCore/runtime/MapConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/MapConstructor.cpp
@@ -93,7 +93,7 @@ JSC_DEFINE_HOST_FUNCTION(constructMap, (JSGlobalObject* globalObject, CallFrame*
         RETURN_IF_EXCEPTION(scope, { });
 
         adderFunctionCallData = JSC::getCallData(adderFunction);
-        if (UNLIKELY(adderFunctionCallData.type == CallData::Type::None))
+        if (adderFunctionCallData.type == CallData::Type::None) [[unlikely]]
             return throwVMTypeError(globalObject, scope, "'set' property of a Map should be callable."_s);
     }
 

--- a/Source/JavaScriptCore/runtime/MapPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/MapPrototype.cpp
@@ -119,8 +119,7 @@ ALWAYS_INLINE static JSMap* getMap(JSGlobalObject* globalObject, JSValue thisVal
         return nullptr;
     }
 
-    auto* map = jsDynamicCast<JSMap*>(thisValue.asCell());
-    if (LIKELY(map))
+    if (auto* map = jsDynamicCast<JSMap*>(thisValue.asCell())) [[likely]]
         return map;
     throwTypeError(globalObject, scope, "Map operation called on non-Map object"_s);
     return nullptr;

--- a/Source/JavaScriptCore/runtime/MegamorphicCache.h
+++ b/Source/JavaScriptCore/runtime/MegamorphicCache.h
@@ -276,7 +276,7 @@ public:
     void bumpEpoch()
     {
         ++m_epoch;
-        if (UNLIKELY(m_epoch == invalidEpoch))
+        if (m_epoch == invalidEpoch) [[unlikely]]
             clearEntries();
     }
 

--- a/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
@@ -72,7 +72,7 @@ void MicrotaskQueue::enqueue(QueuedTask&& task)
     auto microtaskIdentifier = task.identifier();
     m_queue.enqueue(WTFMove(task));
     if (globalObject) {
-        if (auto* debugger = globalObject->debugger(); UNLIKELY(debugger))
+        if (auto* debugger = globalObject->debugger(); debugger) [[unlikely]]
             debugger->didQueueMicrotask(globalObject, microtaskIdentifier);
     }
 }

--- a/Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h
@@ -35,20 +35,20 @@ inline void MicrotaskQueue::performMicrotaskCheckpoint(VM& vm, NOESCAPE const In
 {
     auto catchScope = DECLARE_CATCH_SCOPE(vm);
     while (!m_queue.isEmpty()) {
-        if (UNLIKELY(vm.executionForbidden())) {
+        if (vm.executionForbidden()) [[unlikely]] {
             clear();
             break;
         }
 
         auto task = m_queue.dequeue();
         auto result = functor(task);
-        if (UNLIKELY(!catchScope.clearExceptionExceptTermination())) {
+        if (!catchScope.clearExceptionExceptTermination()) [[unlikely]] {
             clear();
             break;
         }
 
         vm.callOnEachMicrotaskTick();
-        if (UNLIKELY(!catchScope.clearExceptionExceptTermination())) {
+        if (!catchScope.clearExceptionExceptTermination()) [[unlikely]] {
             clear();
             break;
         }

--- a/Source/JavaScriptCore/runtime/ObjectPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectPrototype.cpp
@@ -94,7 +94,7 @@ JSC_DEFINE_HOST_FUNCTION(objectProtoFuncValueOf, (JSGlobalObject* globalObject, 
 {
     JSValue thisValue = callFrame->thisValue().toThis(globalObject, ECMAMode::strict());
     JSObject* valueObj = thisValue.toObject(globalObject);
-    if (UNLIKELY(!valueObj))
+    if (!valueObj) [[unlikely]]
         return encodedJSValue();
     Integrity::auditStructureID(valueObj->structureID());
     return JSValue::encode(valueObj);

--- a/Source/JavaScriptCore/runtime/ObjectPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/ObjectPrototypeInlines.h
@@ -42,7 +42,7 @@ inline std::tuple<ASCIILiteral, JSString*> inferBuiltinTag(JSGlobalObject* globa
 
 #if PLATFORM(IOS) || PLATFORM(VISION)
     static bool needsOldBuiltinTag = isPokerBros();
-    if (UNLIKELY(needsOldBuiltinTag))
+    if (needsOldBuiltinTag) [[unlikely]]
         return std::tuple { object->className(), nullptr };
 #endif
 

--- a/Source/JavaScriptCore/runtime/Operations.cpp
+++ b/Source/JavaScriptCore/runtime/Operations.cpp
@@ -94,7 +94,7 @@ JSString* jsTypeStringForValueWithConcurrency(VM& vm, JSGlobalObject* globalObje
         // as null when doing comparisons.
         if (object->structure()->masqueradesAsUndefined(globalObject))
             return vm.smallStrings.undefinedString();
-        if (LIKELY(concurrency == Concurrency::MainThread)) {
+        if (concurrency == Concurrency::MainThread) [[likely]] {
             if (object->isCallable())
                 return vm.smallStrings.functionString();
             return vm.smallStrings.objectString();

--- a/Source/JavaScriptCore/runtime/Operations.h
+++ b/Source/JavaScriptCore/runtime/Operations.h
@@ -553,7 +553,7 @@ ALWAYS_INLINE JSValue jsAddNonNumber(JSGlobalObject* globalObject, JSValue v1, J
     auto scope = DECLARE_THROW_SCOPE(vm);
     ASSERT(!v1.isNumber() || !v2.isNumber());
 
-    if (LIKELY(v1.isString() && !v2.isObject())) {
+    if (v1.isString() && !v2.isObject()) [[likely]] {
         if (v2.isString())
             RELEASE_AND_RETURN(scope, jsString(globalObject, asString(v1), asString(v2)));
         String s2 = v2.toWTFString(globalObject);
@@ -807,7 +807,7 @@ ALWAYS_INLINE JSValue jsURShift(JSGlobalObject* globalObject, JSValue left, JSVa
     std::optional<uint32_t> rightUint32 = right.toUInt32AfterToNumeric(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    if (UNLIKELY(!leftUint32 || !rightUint32)) {
+    if (!leftUint32 || !rightUint32) [[unlikely]] {
         throwTypeError(globalObject, scope, "BigInt does not support >>> operator"_s);
         return { };
     }

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -727,7 +727,7 @@ static void disableAllSignalHandlerBasedOptions()
 
 void Options::executeDumpOptions()
 {
-    if (LIKELY(!Options::dumpOptions()))
+    if (!Options::dumpOptions()) [[likely]]
         return;
 
     DumpLevel level = static_cast<DumpLevel>(Options::dumpOptions());
@@ -1123,7 +1123,7 @@ void Options::finalize()
     // The following should only be done at the end after all options
     // have been initialized.
     assertOptionsAreCoherent();
-    if (UNLIKELY(Options::dumpOptions()))
+    if (Options::dumpOptions()) [[unlikely]]
         executeDumpOptions();
 
 #if USE(LIBPAS)

--- a/Source/JavaScriptCore/runtime/OrderedHashTableHelper.h
+++ b/Source/JavaScriptCore/runtime/OrderedHashTableHelper.h
@@ -232,13 +232,13 @@ public:
         ASSERT(!(capacity & (capacity - 1)));
 
         TableSize length = tableSize(capacity);
-        if (UNLIKELY(length > IndexingHeader::maximumLength)) {
+        if (length > IndexingHeader::maximumLength) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
             return nullptr;
         }
 
         Storage* storage = tryCreate(vm, length);
-        if (UNLIKELY(!storage)) {
+        if (!storage) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
             return nullptr;
         }
@@ -446,14 +446,14 @@ public:
         incrementAliveEntryCount(candidateRef);
 
         bool firstAliveEntry = result.normalizedKey.isEmpty();
-        if (UNLIKELY(firstAliveEntry)) {
+        if (firstAliveEntry) [[unlikely]] {
             result.normalizedKey = normalizeMapKey(key);
             result.hash = jsMapHash(globalObject, vm, result.normalizedKey);
             RETURN_IF_EXCEPTION(scope, void());
         }
 
         bool rehashed = &base != candidate;
-        if (UNLIKELY(rehashed || firstAliveEntry))
+        if (rehashed || firstAliveEntry) [[unlikely]]
             result.bucketIndex = bucketIndex(capacity, result.hash);
 
         addToChain(candidateRef, result.bucketIndex, newEntryKeyIndex);
@@ -461,7 +461,7 @@ public:
         if constexpr (Traits::hasValueData)
             setKeyOrValueData(vm, candidateRef, newEntryKeyIndex + 1, value);
 
-        if (UNLIKELY(rehashed))
+        if (rehashed) [[unlikely]]
             owner->m_storage.set(vm, owner, candidate);
     }
     ALWAYS_INLINE static void add(JSGlobalObject* globalObject, HashTable* owner, Storage& storage, JSValue key, JSValue value)

--- a/Source/JavaScriptCore/runtime/ProgramExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/ProgramExecutable.cpp
@@ -102,7 +102,7 @@ JSObject* ProgramExecutable::initializeGlobalProperties(VM& vm, JSGlobalObject* 
 
     JSValue nextPrototype = globalObject->getPrototypeDirect();
     while (nextPrototype && nextPrototype.isObject()) {
-        if (UNLIKELY(asObject(nextPrototype)->type() == ProxyObjectType))
+        if (asObject(nextPrototype)->type() == ProxyObjectType) [[unlikely]]
             return createTypeError(globalObject, "Proxy is not allowed in the global prototype chain."_s);
         nextPrototype = asObject(nextPrototype)->getPrototypeDirect();
     }
@@ -123,7 +123,7 @@ JSObject* ProgramExecutable::initializeGlobalProperties(VM& vm, JSGlobalObject* 
                 bool hasProperty = globalLexicalEnvironment->hasProperty(globalObject, entry.key.get());
                 throwScope.assertNoExceptionExceptTermination();
                 if (hasProperty) {
-                    if (UNLIKELY(entry.value.isConst() && !vm.globalConstRedeclarationShouldThrow() && !isInStrictContext())) {
+                    if (entry.value.isConst() && !vm.globalConstRedeclarationShouldThrow() && !isInStrictContext()) [[unlikely]] {
                         // We only allow "const" duplicate declarations under this setting.
                         // For example, we don't allow "let" variables to be overridden by "const" variables.
                         if (globalLexicalEnvironment->isConstVariable(entry.key.get()))
@@ -248,7 +248,7 @@ JSObject* ProgramExecutable::initializeGlobalProperties(VM& vm, JSGlobalObject* 
         SymbolTable* symbolTable = globalLexicalEnvironment->symbolTable();
         ConcurrentJSLocker locker(symbolTable->m_lock);
         for (auto& entry : lexicalDeclarations) {
-            if (UNLIKELY(entry.value.isConst() && !vm.globalConstRedeclarationShouldThrow() && !isInStrictContext())) {
+            if (entry.value.isConst() && !vm.globalConstRedeclarationShouldThrow() && !isInStrictContext()) [[unlikely]] {
                 if (symbolTable->contains(locker, entry.key.get()))
                     continue;
             }

--- a/Source/JavaScriptCore/runtime/PropertyNameArray.h
+++ b/Source/JavaScriptCore/runtime/PropertyNameArray.h
@@ -141,7 +141,7 @@ ALWAYS_INLINE bool PropertyNameArray::isUidMatchedToTypeMode(UniquedStringImpl* 
     if (identifier->isSymbol()) {
         if (!includeSymbolProperties())
             return false;
-        if (UNLIKELY(m_privateSymbolMode == PrivateSymbolMode::Include))
+        if (m_privateSymbolMode == PrivateSymbolMode::Include) [[unlikely]]
             return true;
         return !static_cast<SymbolImpl*>(identifier)->isPrivate();
     }

--- a/Source/JavaScriptCore/runtime/ReflectObject.cpp
+++ b/Source/JavaScriptCore/runtime/ReflectObject.cpp
@@ -116,7 +116,7 @@ JSC_DEFINE_HOST_FUNCTION(reflectObjectConstruct, (JSGlobalObject* globalObject, 
         return true;
     });
     RETURN_IF_EXCEPTION(scope, (arguments.overflowCheckNotNeeded(), encodedJSValue()));
-    if (UNLIKELY(arguments.hasOverflowed())) {
+    if (arguments.hasOverflowed()) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return encodedJSValue();
     }

--- a/Source/JavaScriptCore/runtime/RegExpCache.h
+++ b/Source/JavaScriptCore/runtime/RegExpCache.h
@@ -54,7 +54,7 @@ public:
 
     RegExp* ensureEmptyRegExp(VM& vm)
     {
-        if (LIKELY(m_emptyRegExp))
+        if (m_emptyRegExp) [[likely]]
             return m_emptyRegExp;
         return ensureEmptyRegExpSlow(vm);
     }

--- a/Source/JavaScriptCore/runtime/RegExpConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpConstructor.cpp
@@ -107,7 +107,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpConstructorEscape, (JSGlobalObject* globalObject,
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue value = callFrame->argument(0);
-    if (UNLIKELY(!value.isString()))
+    if (!value.isString()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "RegExp.escape requires a string"_s);
 
     auto string = asString(value)->value(globalObject);
@@ -320,7 +320,7 @@ static JSObject* regExpCreate(JSGlobalObject* globalObject, JSValue newTarget, J
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     RegExp* regExp = RegExp::create(vm, pattern, flags);
-    if (UNLIKELY(!regExp->isValid())) {
+    if (!regExp->isValid()) [[unlikely]] {
         throwException(globalObject, scope, regExp->errorToThrow(globalObject));
         return nullptr;
     }
@@ -360,7 +360,7 @@ JSObject* constructRegExp(JSGlobalObject* globalObject, const ArgList& args,  JS
             RETURN_IF_EXCEPTION(scope, nullptr);
 
             regExp = RegExp::create(vm, regExp->pattern(), flags);
-            if (UNLIKELY(!regExp->isValid())) {
+            if (!regExp->isValid()) [[unlikely]] {
                 throwException(globalObject, scope, regExp->errorToThrow(globalObject));
                 return nullptr;
             }

--- a/Source/JavaScriptCore/runtime/RegExpObject.h
+++ b/Source/JavaScriptCore/runtime/RegExpObject.h
@@ -76,7 +76,7 @@ public:
         VM& vm = getVM(globalObject);
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        if (LIKELY(lastIndexIsWritable())) {
+        if (lastIndexIsWritable()) [[likely]] {
             m_lastIndex.setWithoutWriteBarrier(jsNumber(lastIndex));
             return true;
         }
@@ -88,7 +88,7 @@ public:
         VM& vm = getVM(globalObject);
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        if (LIKELY(lastIndexIsWritable())) {
+        if (lastIndexIsWritable()) [[likely]] {
             m_lastIndex.set(vm, this, lastIndex);
             return true;
         }

--- a/Source/JavaScriptCore/runtime/RegExpObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/RegExpObjectInlines.h
@@ -44,7 +44,7 @@ ALWAYS_INLINE unsigned getRegExpObjectLastIndexAsUnsigned(JSGlobalObject* global
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue jsLastIndex = regExpObject->getLastIndex();
     unsigned lastIndex;
-    if (LIKELY(jsLastIndex.isUInt32())) {
+    if (jsLastIndex.isUInt32()) [[likely]] {
         lastIndex = jsLastIndex.asUInt32();
         if (lastIndex > input.length())
             return UINT_MAX;

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
@@ -103,13 +103,13 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncTest, (JSGlobalObject* globalObject, Cal
     JSString* str = callFrame->argument(0).toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    if (LIKELY(regExpTestWatchpointIsValid(vm, thisObject))) {
+    if (regExpTestWatchpointIsValid(vm, thisObject)) [[likely]] {
         auto* regExp = jsDynamicCast<RegExpObject*>(thisValue);
-        if (UNLIKELY(!regExp))
+        if (!regExp) [[unlikely]]
             return throwVMTypeError(globalObject, scope, "Builtin RegExp exec can only be called on a RegExp object"_s);
         auto strValue = str->value(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
-        if (LIKELY(!strValue->isNull() && regExp->getLastIndex().isNumber()))
+        if (!strValue->isNull() && regExp->getLastIndex().isNumber()) [[likely]]
             RELEASE_AND_RETURN(scope, JSValue::encode(jsBoolean(regExp->test(globalObject, str))));
     }
 
@@ -118,7 +118,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncTest, (JSGlobalObject* globalObject, Cal
     JSFunction* regExpBuiltinExec = globalObject->regExpProtoExecFunction();
 
     JSValue match;
-    if (UNLIKELY(regExpExec != regExpBuiltinExec && regExpExec.isCallable())) {
+    if (regExpExec != regExpBuiltinExec && regExpExec.isCallable()) [[unlikely]] {
         auto callData = JSC::getCallData(regExpExec);
         ASSERT(callData.type != CallData::Type::None);
         if (callData.type == CallData::Type::JS) [[likely]] {
@@ -179,7 +179,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncCompile, (JSGlobalObject* globalObject, 
 
     JSValue thisValue = callFrame->thisValue();
     auto* thisRegExp = jsDynamicCast<RegExpObject*>(thisValue);
-    if (UNLIKELY(!thisRegExp))
+    if (!thisRegExp) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
     if (thisRegExp->globalObject() != globalObject)

--- a/Source/JavaScriptCore/runtime/ResourceExhaustion.h
+++ b/Source/JavaScriptCore/runtime/ResourceExhaustion.h
@@ -33,7 +33,7 @@ enum ResourceExhaustionCode {
 };
 
 #define RELEASE_ASSERT_RESOURCE_AVAILABLE(assertion, resourceExhaustionCode, failureMessage) do { \
-        if (UNLIKELY(!(assertion))) \
+        if (!(assertion)) [[unlikely]] \
             handleResourceExhaustion(__FILE__, __LINE__, WTF_PRETTY_FUNCTION, #assertion, resourceExhaustionCode, #resourceExhaustionCode, failureMessage); \
     } while (false)
 

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -352,7 +352,7 @@ void SamplingProfiler::timerLoop()
         Seconds stackTraceProcessingTime = 0_s;
         {
             Locker locker { m_lock };
-            if (UNLIKELY(m_isShutDown))
+            if (m_isShutDown) [[unlikely]]
                 return;
 
             if (!m_isPaused && m_jscExecutionThread)

--- a/Source/JavaScriptCore/runtime/ScopedArguments.cpp
+++ b/Source/JavaScriptCore/runtime/ScopedArguments.cpp
@@ -147,7 +147,7 @@ void ScopedArguments::unmapArgument(JSGlobalObject* globalObject, uint32_t i)
     unsigned namedLength = m_table->length();
     if (i < namedLength) {
         auto* maybeCloned = m_table->trySet(vm, i, ScopeOffset());
-        if (UNLIKELY(!maybeCloned)) {
+        if (!maybeCloned) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
             return;
         }
@@ -169,10 +169,10 @@ bool ScopedArguments::isIteratorProtocolFastAndNonObservable()
     if (!globalObject->isArgumentsPrototypeIteratorProtocolFastAndNonObservable())
         return false;
 
-    if (UNLIKELY(m_overrodeThings))
+    if (m_overrodeThings) [[unlikely]]
         return false;
 
-    if (UNLIKELY(m_hasUnmappedArgument))
+    if (m_hasUnmappedArgument) [[unlikely]]
         return false;
 
     if (structure->didTransition())

--- a/Source/JavaScriptCore/runtime/ScopedArguments.h
+++ b/Source/JavaScriptCore/runtime/ScopedArguments.h
@@ -77,7 +77,7 @@ public:
     {
         VM& vm = getVM(globalObject);
         auto scope = DECLARE_THROW_SCOPE(vm);
-        if (UNLIKELY(m_overrodeThings)) {
+        if (m_overrodeThings) [[unlikely]] {
             auto value = get(globalObject, vm.propertyNames->length);
             RETURN_IF_EXCEPTION(scope, 0);
             RELEASE_AND_RETURN(scope, value.toUInt32(globalObject));

--- a/Source/JavaScriptCore/runtime/ScopedArgumentsTable.cpp
+++ b/Source/JavaScriptCore/runtime/ScopedArgumentsTable.cpp
@@ -66,7 +66,7 @@ ScopedArgumentsTable* ScopedArgumentsTable::tryCreate(VM& vm, uint32_t length)
 
     result->m_length = length;
     result->m_arguments = ArgumentsPtr::tryCreate(length);
-    if (UNLIKELY(!result->m_arguments))
+    if (!result->m_arguments) [[unlikely]]
         return nullptr;
     result->m_watchpointSets.fill(nullptr, length);
     return result;
@@ -85,9 +85,9 @@ ScopedArgumentsTable* ScopedArgumentsTable::tryClone(VM& vm)
 
 ScopedArgumentsTable* ScopedArgumentsTable::trySetLength(VM& vm, uint32_t newLength)
 {
-    if (LIKELY(!m_locked)) {
+    if (!m_locked) [[likely]] {
         ArgumentsPtr newArguments = ArgumentsPtr::tryCreate(newLength, newLength);
-        if (UNLIKELY(!newArguments))
+        if (!newArguments) [[unlikely]]
             return nullptr;
         for (unsigned i = std::min(m_length, newLength); i--;)
             newArguments.at(i) = this->at(i);
@@ -113,7 +113,7 @@ static_assert(std::is_trivially_destructible<ScopeOffset>::value);
 ScopedArgumentsTable* ScopedArgumentsTable::trySet(VM& vm, uint32_t i, ScopeOffset value)
 {
     ScopedArgumentsTable* result;
-    if (UNLIKELY(m_locked)) {
+    if (m_locked) [[unlikely]] {
         result = tryClone(vm);
         if (!result) [[unlikely]]
             return nullptr;

--- a/Source/JavaScriptCore/runtime/ScriptExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/ScriptExecutable.cpp
@@ -201,11 +201,11 @@ void ScriptExecutable::installCode(VM& vm, CodeBlock* genericCodeBlock, CodeType
         
         dataLogLnIf(Options::verboseOSR(), "Installing ", *genericCodeBlock);
         
-        if (UNLIKELY(vm.m_perBytecodeProfiler))
+        if (vm.m_perBytecodeProfiler) [[unlikely]]
             vm.m_perBytecodeProfiler->ensureBytecodesFor(genericCodeBlock);
         
         Debugger* debugger = genericCodeBlock->globalObject()->debugger();
-        if (UNLIKELY(debugger))
+        if (debugger) [[unlikely]]
             debugger->registerCodeBlock(genericCodeBlock);
     }
 
@@ -391,7 +391,7 @@ void ScriptExecutable::prepareForExecutionImpl(VM& vm, JSFunction* function, JSS
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     DeferGCForAWhile deferGC(vm);
 
-    if (UNLIKELY(vm.getAndClearFailNextNewCodeBlock())) {
+    if (vm.getAndClearFailNextNewCodeBlock()) [[unlikely]] {
         JSGlobalObject* globalObject = scope->globalObject();
         throwException(globalObject, throwScope, createError(globalObject, "Forced Failure"_s));
         return;

--- a/Source/JavaScriptCore/runtime/SetConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/SetConstructor.cpp
@@ -88,7 +88,7 @@ JSC_DEFINE_HOST_FUNCTION(constructSet, (JSGlobalObject* globalObject, CallFrame*
         RETURN_IF_EXCEPTION(scope, { });
 
         adderFunctionCallData = JSC::getCallData(adderFunction);
-        if (UNLIKELY(adderFunctionCallData.type == CallData::Type::None))
+        if (adderFunctionCallData.type == CallData::Type::None) [[unlikely]]
             return throwVMTypeError(globalObject, scope, "'add' property of a Set should be callable."_s);
     }
 

--- a/Source/JavaScriptCore/runtime/SetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SetPrototype.cpp
@@ -109,8 +109,7 @@ ALWAYS_INLINE static JSSet* getSet(JSGlobalObject* globalObject, JSValue thisVal
         throwVMError(globalObject, scope, createNotAnObjectError(globalObject, thisValue));
         return nullptr;
     }
-    auto* set = jsDynamicCast<JSSet*>(thisValue.asCell());
-    if (LIKELY(set))
+    if (auto* set = jsDynamicCast<JSSet*>(thisValue.asCell())) [[likely]]
         return set;
     throwTypeError(globalObject, scope, "Set operation called on non-Set object"_s);
     return nullptr;

--- a/Source/JavaScriptCore/runtime/SmallStrings.cpp
+++ b/Source/JavaScriptCore/runtime/SmallStrings.cpp
@@ -116,7 +116,7 @@ SmallStrings::~SmallStrings() = default;
 
 Ref<AtomStringImpl> SmallStrings::singleCharacterStringRep(unsigned char character)
 {
-    if (LIKELY(m_isInitialized))
+    if (m_isInitialized) [[likely]]
         return *static_cast<AtomStringImpl*>(const_cast<StringImpl*>(m_singleCharacterStrings[character]->tryGetValueImpl()));
     std::array<const LChar, 1> string = { static_cast<LChar>(character) };
     return AtomStringImpl::add(string).releaseNonNull();
@@ -124,7 +124,7 @@ Ref<AtomStringImpl> SmallStrings::singleCharacterStringRep(unsigned char charact
 
 AtomStringImpl* SmallStrings::existingSingleCharacterStringRep(unsigned char character)
 {
-    if (UNLIKELY(!m_isInitialized))
+    if (!m_isInitialized) [[unlikely]]
         return nullptr;
     return static_cast<AtomStringImpl*>(const_cast<StringImpl*>(m_singleCharacterStrings[character]->tryGetValueImpl()));
 }

--- a/Source/JavaScriptCore/runtime/SparseArrayValueMap.cpp
+++ b/Source/JavaScriptCore/runtime/SparseArrayValueMap.cpp
@@ -149,7 +149,7 @@ void SparseArrayEntry::get(JSObject* thisObject, PropertySlot& slot) const
     JSValue value = Base::get();
     ASSERT(value);
 
-    if (LIKELY(!value.isGetterSetter())) {
+    if (!value.isGetterSetter()) [[likely]] {
         slot.setValue(thisObject, m_attributes, value);
         return;
     }

--- a/Source/JavaScriptCore/runtime/StableSort.h
+++ b/Source/JavaScriptCore/runtime/StableSort.h
@@ -35,7 +35,7 @@ namespace JSC {
 
 static ALWAYS_INLINE bool coerceComparatorResultToBoolean(JSGlobalObject* globalObject, JSValue comparatorResult)
 {
-    if (LIKELY(comparatorResult.isInt32()))
+    if (comparatorResult.isInt32()) [[likely]]
         return comparatorResult.asInt32() < 0;
 
     // See https://bugs.webkit.org/show_bug.cgi?id=47825 on boolean special-casing

--- a/Source/JavaScriptCore/runtime/StringConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/StringConstructor.cpp
@@ -82,7 +82,7 @@ JSC_DEFINE_HOST_FUNCTION(stringFromCharCode, (JSGlobalObject* globalObject, Call
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     unsigned length = callFrame->argumentCount();
-    if (LIKELY(length == 1)) {
+    if (length == 1) [[likely]] {
         scope.release();
         UChar code = callFrame->uncheckedArgument(0).toUInt32(globalObject);
         // Not checking for an exception here is ok because jsSingleCharacterString will just fetch an unused string if there's an exception.
@@ -94,7 +94,7 @@ JSC_DEFINE_HOST_FUNCTION(stringFromCharCode, (JSGlobalObject* globalObject, Call
     for (unsigned i = 0; i < length; ++i) {
         UChar character = static_cast<UChar>(callFrame->uncheckedArgument(i).toUInt32(globalObject));
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
-        if (UNLIKELY(!isLatin1(character))) {
+        if (!isLatin1(character)) [[unlikely]] {
             std::span<UChar> buf16Bit;
             auto impl16Bit = StringImpl::createUninitialized(length, buf16Bit);
             StringImpl::copyCharacters(buf16Bit, buf8Bit.first(i));

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -270,7 +270,7 @@ NEVER_INLINE void substituteBackreferencesSlow(StringBuilder& result, StringView
 inline void substituteBackreferencesInline(StringBuilder& result, const String& replacement, StringView source, const int* ovector, RegExp* reg)
 {
     size_t i = replacement.find('$');
-    if (UNLIKELY(i != notFound))
+    if (i != notFound) [[unlikely]]
         return substituteBackreferencesSlow(result, replacement, source, ovector, reg, i);
 
     result.append(replacement);
@@ -689,7 +689,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSplitFast, (JSGlobalObject* globalObject
         RELEASE_AND_RETURN(scope, JSValue::encode(constructArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), result)));
     }
 
-    if (LIKELY(limit == 0xFFFFFFFFu && !globalObject->isHavingABadTime())) {
+    if (limit == 0xFFFFFFFFu && !globalObject->isHavingABadTime()) [[likely]] {
         if (auto* immutableButterfly = vm.stringSplitCache.get(input, separator)) {
             Structure* arrayStructure = globalObject->originalArrayStructureForIndexingType(CopyOnWriteArrayWithContiguous);
             return JSValue::encode(JSArray::createWithButterfly(vm, nullptr, arrayStructure, immutableButterfly->toButterfly()));
@@ -705,7 +705,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSplitFast, (JSGlobalObject* globalObject
             return constructEmptyArray(globalObject, nullptr);
 
         unsigned resultSize = result.size();
-        if (LIKELY(limit == 0xFFFFFFFFu && !globalObject->isHavingABadTime() && resultSize < MIN_SPARSE_ARRAY_INDEX)) {
+        if (limit == 0xFFFFFFFFu && !globalObject->isHavingABadTime() && resultSize < MIN_SPARSE_ARRAY_INDEX) [[likely]] {
             bool makeAtomStringsArray = resultSize < atomStringsArrayLimit;
             Structure* immutableButterflyStructure = makeAtomStringsArray ? vm.immutableButterflyOnlyAtomStringsStructure.get() : vm.immutableButterflyStructure(CopyOnWriteArrayWithContiguous);
 
@@ -774,7 +774,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSplitFast, (JSGlobalObject* globalObject
         // Zero limt/input length handled in steps 9/11 respectively, above.
         ASSERT(resultSize);
 
-        if (LIKELY(limit == 0xFFFFFFFFu && !globalObject->isHavingABadTime() && resultSize < MIN_SPARSE_ARRAY_INDEX)) {
+        if (limit == 0xFFFFFFFFu && !globalObject->isHavingABadTime() && resultSize < MIN_SPARSE_ARRAY_INDEX) [[likely]] {
             bool makeAtomStringsArray = resultSize < atomStringsArrayLimit;
             Structure* immutableButterflyStructure = makeAtomStringsArray ? vm.immutableButterflyOnlyAtomStringsStructure.get() : vm.immutableButterflyStructure(CopyOnWriteArrayWithContiguous);
 
@@ -914,7 +914,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSubstring, (JSGlobalObject* globalObject
     JSValue a0 = callFrame->argument(0);
     JSValue a1 = callFrame->argument(1);
 
-    if (LIKELY(a0.isInt32() && (a1.isUndefined() || a1.isInt32())))
+    if (a0.isInt32() && (a1.isUndefined() || a1.isInt32())) [[likely]]
         RELEASE_AND_RETURN(scope, JSValue::encode(stringSubstring(globalObject, jsString, a0.asInt32(), a1.isUndefined() ? std::nullopt : std::optional<int32_t>(a1.asInt32()))));
 
     int len = jsString->length();
@@ -963,7 +963,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncToLowerCase, (JSGlobalObject* globalObje
         auto view = sVal->view(globalObject);
         auto scanQuickly = [&](auto span) ALWAYS_INLINE_LAMBDA {
             for (auto character : span) {
-                if (UNLIKELY(!isASCII(character) || isASCIIUpper(character)))
+                if (!isASCII(character) || isASCIIUpper(character)) [[unlikely]]
                     return false;
             }
             return true;
@@ -999,7 +999,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncToUpperCase, (JSGlobalObject* globalObje
         auto view = sVal->view(globalObject);
         auto scanQuickly = [&](auto span) ALWAYS_INLINE_LAMBDA {
             for (auto character : span) {
-                if (UNLIKELY(!isASCII(character) || isASCIILower(character)))
+                if (!isASCII(character) || isASCIILower(character)) [[unlikely]]
                     return false;
             }
             return true;
@@ -1595,7 +1595,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncAt, (JSGlobalObject* globalObject, CallF
     RETURN_IF_EXCEPTION(scope, { });
     uint32_t length = view->length();
     JSValue argument0 = callFrame->argument(0);
-    if (LIKELY(argument0.isInt32())) {
+    if (argument0.isInt32()) [[likely]] {
         int32_t i = argument0.asInt32();
         int64_t k = i < 0 ? static_cast<int64_t>(length) + i : i;
         if (k < length && k >= 0)

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -848,7 +848,7 @@ public:
     
     void startWatchingInternalPropertiesIfNecessary(VM& vm)
     {
-        if (LIKELY(didWatchInternalProperties()))
+        if (didWatchInternalProperties()) [[likely]]
             return;
         startWatchingInternalProperties(vm);
     }

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -126,7 +126,7 @@ inline bool Structure::holesMustForwardToPrototype(JSObject* base) const
     ASSERT(base->structure() == this);
     if (typeInfo().type() == ArrayType) {
         JSGlobalObject* globalObject = this->globalObject();
-        if (LIKELY(globalObject->isOriginalArrayStructure(const_cast<Structure*>(this)) && globalObject->arrayPrototypeChainIsSane()))
+        if (globalObject->isOriginalArrayStructure(const_cast<Structure*>(this)) && globalObject->arrayPrototypeChainIsSane()) [[likely]]
             return false;
     }
 
@@ -392,7 +392,7 @@ inline bool Structure::isValid(JSGlobalObject* globalObject, StructureChain* cac
 
 inline void Structure::didReplaceProperty(PropertyOffset offset)
 {
-    if (LIKELY(!isWatchingReplacement()))
+    if (!isWatchingReplacement()) [[likely]]
         return;
     didReplacePropertySlow(offset);
 }

--- a/Source/JavaScriptCore/runtime/SymbolTable.cpp
+++ b/Source/JavaScriptCore/runtime/SymbolTable.cpp
@@ -111,7 +111,7 @@ DEFINE_VISIT_CHILDREN(SymbolTable);
 
 const SymbolTable::LocalToEntryVec& SymbolTable::localToEntry(const ConcurrentJSLocker&)
 {
-    if (UNLIKELY(!m_localToEntry)) {
+    if (!m_localToEntry) [[unlikely]] {
         unsigned size = 0;
         for (auto& entry : m_map) {
             VarOffset offset = entry.value.varOffset();

--- a/Source/JavaScriptCore/runtime/SymbolTable.h
+++ b/Source/JavaScriptCore/runtime/SymbolTable.h
@@ -196,7 +196,7 @@ public:
     
     SymbolTableEntry& operator=(const SymbolTableEntry& other)
     {
-        if (UNLIKELY(other.isFat()))
+        if (other.isFat()) [[unlikely]]
             return copySlow(other);
         freeFatEntry();
         m_bits = other.m_bits;
@@ -391,7 +391,7 @@ private:
     
     void freeFatEntry()
     {
-        if (LIKELY(!isFat()))
+        if (!isFat()) [[likely]]
             return;
         freeFatEntrySlow();
     }
@@ -666,7 +666,7 @@ public:
     
     bool trySetArgumentsLength(VM& vm, uint32_t length)
     {
-        if (UNLIKELY(!m_arguments)) {
+        if (!m_arguments) [[unlikely]] {
             ScopedArgumentsTable* table = ScopedArgumentsTable::tryCreate(vm, length);
             if (!table) [[unlikely]]
                 return false;
@@ -779,7 +779,7 @@ private:
     ~SymbolTable();
     SymbolTableRareData& ensureRareData()
     {
-        if (LIKELY(m_rareData))
+        if (m_rareData) [[likely]]
             return *m_rareData;
         return ensureRareDataSlow();
     }

--- a/Source/JavaScriptCore/runtime/TemporalDuration.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.cpp
@@ -601,7 +601,7 @@ static void appendInteger(JSGlobalObject* globalObject, StringBuilder& builder, 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     double absValue = std::abs(value);
-    if (LIKELY(absValue <= maxSafeInteger())) {
+    if (absValue <= maxSafeInteger()) [[likely]] {
         builder.append(absValue);
         return;
     }
@@ -680,7 +680,7 @@ String TemporalDuration::toString(JSGlobalObject* globalObject, const ISO8601::D
         // Although we must be able to display Number values beyond MAX_SAFE_INTEGER, it does not seem reasonable
         // to require that calculations be performed outside of double space purely to support a case like
         // `Temporal.Duration.from({ microseconds: Number.MAX_VALUE, nanoseconds: Number.MAX_VALUE }).toString()`.
-        if (UNLIKELY(!std::isfinite(balancedSeconds))) {
+        if (!std::isfinite(balancedSeconds)) [[unlikely]] {
             throwRangeError(globalObject, scope, "Cannot display infinite seconds!"_s);
             return { };
         }

--- a/Source/JavaScriptCore/runtime/ThrowScope.cpp
+++ b/Source/JavaScriptCore/runtime/ThrowScope.cpp
@@ -93,7 +93,7 @@ void ThrowScope::simulateThrow()
     m_vm.m_simulatedThrowPointLocation = m_location;
     m_vm.m_simulatedThrowPointRecursionDepth = m_recursionDepth;
     m_vm.m_needExceptionCheck = true;
-    if (UNLIKELY(Options::dumpSimulatedThrows()))
+    if (Options::dumpSimulatedThrows()) [[unlikely]]
         m_vm.m_nativeStackTraceOfLastSimulatedThrow = StackTrace::captureStackTrace(Options::unexpectedExceptionStackTraceLimit());
 }
 

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -540,21 +540,21 @@ public:
 
     JSCell* orderedHashTableDeletedValue()
     {
-        if (LIKELY(m_orderedHashTableDeletedValue))
+        if (m_orderedHashTableDeletedValue) [[likely]]
             return m_orderedHashTableDeletedValue.get();
         return orderedHashTableDeletedValueSlow();
     }
 
     JSCell* orderedHashTableSentinel()
     {
-        if (LIKELY(m_orderedHashTableSentinel))
+        if (m_orderedHashTableSentinel) [[likely]]
             return m_orderedHashTableSentinel.get();
         return orderedHashTableSentinelSlow();
     }
 
     JSPropertyNameEnumerator* emptyPropertyNameEnumerator()
     {
-        if (LIKELY(m_emptyPropertyNameEnumerator))
+        if (m_emptyPropertyNameEnumerator) [[likely]]
             return m_emptyPropertyNameEnumerator.get();
         return emptyPropertyNameEnumeratorSlow();
     }

--- a/Source/JavaScriptCore/runtime/VMEntryScope.cpp
+++ b/Source/JavaScriptCore/runtime/VMEntryScope.cpp
@@ -42,7 +42,7 @@ void VMEntryScope::setUpSlow()
     m_vm.entryScope = this;
 
     auto& thread = Thread::currentSingleton();
-    if (UNLIKELY(!thread.isJSThread())) {
+    if (!thread.isJSThread()) [[unlikely]] {
         Thread::registerJSThread(thread);
 
         if (Wasm::isSupported())
@@ -52,7 +52,7 @@ void VMEntryScope::setUpSlow()
 #endif
     }
 
-    if (UNLIKELY(m_vm.hasAnyEntryScopeServiceRequest() || m_vm.hasTimeZoneChange()))
+    if (m_vm.hasAnyEntryScopeServiceRequest() || m_vm.hasTimeZoneChange()) [[unlikely]]
         m_vm.executeEntryScopeServicesOnEntry();
 }
 
@@ -62,7 +62,7 @@ void VMEntryScope::tearDownSlow()
 
     m_vm.entryScope = nullptr;
 
-    if (UNLIKELY(m_vm.hasAnyEntryScopeServiceRequest()))
+    if (m_vm.hasAnyEntryScopeServiceRequest()) [[unlikely]]
         m_vm.executeEntryScopeServicesOnExit();
 }
 

--- a/Source/JavaScriptCore/runtime/VMInlines.h
+++ b/Source/JavaScriptCore/runtime/VMInlines.h
@@ -72,7 +72,7 @@ bool VM::isSafeToRecurseSoft() const
 template<typename Func>
 void VM::logEvent(CodeBlock* codeBlock, const char* summary, const Func& func)
 {
-    if (LIKELY(!m_perBytecodeProfiler))
+    if (!m_perBytecodeProfiler) [[likely]]
         return;
     
     m_perBytecodeProfiler->logEvent(codeBlock, summary, func());
@@ -81,9 +81,9 @@ void VM::logEvent(CodeBlock* codeBlock, const char* summary, const Func& func)
 inline CallFrame* VM::topJSCallFrame() const
 {
     CallFrame* frame = topCallFrame;
-    if (UNLIKELY(!frame))
+    if (!frame) [[unlikely]]
         return frame;
-    if (LIKELY(!frame->isNativeCalleeFrame() && !frame->isPartiallyInitializedFrame()))
+    if (!frame->isNativeCalleeFrame() && !frame->isPartiallyInitializedFrame()) [[likely]]
         return frame;
     EntryFrame* entryFrame = topEntryFrame;
     do {
@@ -102,7 +102,7 @@ inline void VM::setFuzzerAgent(std::unique_ptr<FuzzerAgent>&& fuzzerAgent)
 template<typename Func>
 inline void VM::forEachDebugger(const Func& callback)
 {
-    if (LIKELY(m_debuggers.isEmpty()))
+    if (m_debuggers.isEmpty()) [[likely]]
         return;
 
     for (auto* debugger = m_debuggers.head(); debugger; debugger = debugger->next())

--- a/Source/JavaScriptCore/runtime/VMTraps.cpp
+++ b/Source/JavaScriptCore/runtime/VMTraps.cpp
@@ -438,7 +438,7 @@ void VMTraps::handleTraps(VMTraps::BitField mask)
 
         case NeedWatchdogCheck:
             ASSERT(vm.watchdog());
-            if (LIKELY(!vm.watchdog()->isActive() || !vm.watchdog()->shouldTerminate(vm.entryScope->globalObject())))
+            if (!vm.watchdog()->isActive() || !vm.watchdog()->shouldTerminate(vm.entryScope->globalObject())) [[likely]]
                 continue;
             vm.setHasTerminationRequest();
             [[fallthrough]];

--- a/Source/JavaScriptCore/runtime/VMTraps.h
+++ b/Source/JavaScriptCore/runtime/VMTraps.h
@@ -199,7 +199,7 @@ public:
     ALWAYS_INLINE bool needHandling(BitField mask) const
     {
         auto maskedValue = m_trapBits.loadRelaxed() & (mask | DeferTrapHandling);
-        if (UNLIKELY(maskedValue))
+        if (maskedValue) [[unlikely]]
             return (maskedValue & NeedExceptionHandling) || !(maskedValue & DeferTrapHandling);
         return false;
     }

--- a/Source/JavaScriptCore/runtime/VMTrapsInlines.h
+++ b/Source/JavaScriptCore/runtime/VMTrapsInlines.h
@@ -38,7 +38,7 @@ inline void VMTraps::deferTermination(DeferAction deferAction)
 {
     auto originalCount = m_deferTerminationCount++;
     ASSERT(m_deferTerminationCount < UINT_MAX);
-    if (UNLIKELY(originalCount == 0 && vm().exception()))
+    if (!originalCount && vm().exception()) [[unlikely]]
         deferTerminationSlow(deferAction);
 }
 
@@ -46,7 +46,7 @@ inline void VMTraps::undoDeferTermination(DeferAction deferAction)
 {
     ASSERT(m_deferTerminationCount > 0);
     ASSERT(!m_suspendedTerminationException || vm().hasTerminationRequest());
-    if (UNLIKELY(--m_deferTerminationCount == 0 && vm().hasTerminationRequest()))
+    if (!--m_deferTerminationCount && vm().hasTerminationRequest()) [[unlikely]]
         undoDeferTerminationSlow(deferAction);
 }
 

--- a/Source/JavaScriptCore/runtime/WeakMapPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/WeakMapPrototype.cpp
@@ -72,8 +72,7 @@ ALWAYS_INLINE static JSWeakMap* getWeakMap(JSGlobalObject* globalObject, JSValue
         return nullptr;
     }
 
-    auto* map = jsDynamicCast<JSWeakMap*>(asObject(value));
-    if (LIKELY(map))
+    if (auto* map = jsDynamicCast<JSWeakMap*>(asObject(value))) [[likely]]
         return map;
 
     throwTypeError(globalObject, scope, "Called WeakMap function on a non-WeakMap object"_s);

--- a/Source/JavaScriptCore/runtime/WeakObjectRefConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/WeakObjectRefConstructor.cpp
@@ -62,7 +62,7 @@ JSC_DEFINE_HOST_FUNCTION(constructWeakRef, (JSGlobalObject* globalObject, CallFr
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue target = callFrame->argument(0);
-    if (UNLIKELY(!canBeHeldWeakly(target)))
+    if (!canBeHeldWeakly(target)) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "First argument to WeakRef should be an object or a non-registered symbol"_s);
 
     JSObject* newTarget = asObject(callFrame->newTarget());

--- a/Source/JavaScriptCore/runtime/WeakObjectRefPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/WeakObjectRefPrototype.cpp
@@ -56,8 +56,7 @@ ALWAYS_INLINE static JSWeakObjectRef* getWeakRef(JSGlobalObject* globalObject, J
         return nullptr;
     }
 
-    auto* ref = jsDynamicCast<JSWeakObjectRef*>(asObject(value));
-    if (LIKELY(ref))
+    if (auto* ref = jsDynamicCast<JSWeakObjectRef*>(asObject(value))) [[likely]]
         return ref;
 
     throwTypeError(globalObject, scope, "Called WeakRef function on a non-WeakRef object"_s);

--- a/Source/JavaScriptCore/runtime/WeakSetConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/WeakSetConstructor.cpp
@@ -83,7 +83,7 @@ JSC_DEFINE_HOST_FUNCTION(constructWeakSet, (JSGlobalObject* globalObject, CallFr
     scope.release();
     forEachInIterable(globalObject, iterable, [&](VM&, JSGlobalObject* globalObject, JSValue nextValue) {
         if (canPerformFastAdd) {
-            if (UNLIKELY(!canBeHeldWeakly(nextValue))) {
+            if (!canBeHeldWeakly(nextValue)) [[unlikely]] {
                 throwTypeError(asObject(adderFunction)->globalObject(), scope, WeakSetInvalidValueError);
                 return;
             }

--- a/Source/JavaScriptCore/runtime/WeakSetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/WeakSetPrototype.cpp
@@ -62,8 +62,7 @@ ALWAYS_INLINE static JSWeakSet* getWeakSet(JSGlobalObject* globalObject, JSValue
         return nullptr;
     }
 
-    auto* set = jsDynamicCast<JSWeakSet*>(asObject(value));
-    if (LIKELY(set))
+    if (auto* set = jsDynamicCast<JSWeakSet*>(asObject(value))) [[likely]]
         return set;
 
     throwTypeError(globalObject, scope, "Called WeakSet function on a non-WeakSet object"_s);

--- a/Source/JavaScriptCore/tools/CompilerTimingScope.cpp
+++ b/Source/JavaScriptCore/tools/CompilerTimingScope.cpp
@@ -88,13 +88,13 @@ CompilerTimingScope::CompilerTimingScope(ASCIILiteral compilerName, ASCIILiteral
     : m_compilerName(compilerName)
     , m_name(name)
 {
-    if (UNLIKELY(Options::logPhaseTimes() || Options::reportTotalPhaseTimes()))
+    if (Options::logPhaseTimes() || Options::reportTotalPhaseTimes()) [[unlikely]]
         m_before = MonotonicTime::now();
 }
 
 CompilerTimingScope::~CompilerTimingScope()
 {
-    if (UNLIKELY(Options::logPhaseTimes() || Options::reportTotalPhaseTimes())) {
+    if (Options::logPhaseTimes() || Options::reportTotalPhaseTimes()) [[unlikely]] {
         Seconds duration = MonotonicTime::now() - m_before;
         auto total = compilerTimingScopeState().addToTotal(m_compilerName, m_name, duration);
         if (Options::logPhaseTimes()) {

--- a/Source/JavaScriptCore/tools/HeapVerifier.cpp
+++ b/Source/JavaScriptCore/tools/HeapVerifier.cpp
@@ -327,7 +327,7 @@ bool HeapVerifier::validateJSCell(VM* expectedVM, JSCell* cell, CellProfile* pro
         }
         
         CodeBlock* codeBlock = jsDynamicCast<CodeBlock*>(cell);
-        if (UNLIKELY(codeBlock)) {
+        if (codeBlock) [[unlikely]] {
             bool success = true;
             codeBlock->forEachValueProfile([&](auto& valueProfile, bool) {
                 for (unsigned i = 0; i < std::remove_reference_t<decltype(valueProfile)>::totalNumberOfBuckets; ++i) {

--- a/Source/JavaScriptCore/tools/Integrity.h
+++ b/Source/JavaScriptCore/tools/Integrity.h
@@ -186,7 +186,7 @@ template<typename T> ALWAYS_INLINE T audit(T value) { return value; }
     } while (false)
 
 #define IA_ASSERT_WITH_ACTION(assertion, action, ...) do { \
-        if (UNLIKELY(!(assertion))) { \
+        if (!(assertion)) [[unlikely]] { \
             IA_LOG(assertion, __VA_ARGS__); \
             WTFReportBacktraceWithPrefixAndPrintStream(Integrity::logFile(), "    "); \
             action; \
@@ -206,7 +206,7 @@ template<typename T> ALWAYS_INLINE T audit(T value) { return value; }
     } while (false)
 
 #define IA_ASSERT_WITH_ACTION(assertion, action, ...) do { \
-        if (UNLIKELY(!(assertion))) { \
+        if (!(assertion)) [[unlikely]] { \
             IA_LOG(assertion, __VA_ARGS__); \
             WTFReportBacktraceWithPrefixAndPrintStream(Integrity::logFile(), "    "); \
             action; \

--- a/Source/JavaScriptCore/tools/IntegrityInlines.h
+++ b/Source/JavaScriptCore/tools/IntegrityInlines.h
@@ -54,7 +54,7 @@ ALWAYS_INLINE bool Random::shouldAudit(VM& vm)
     uint64_t newTriggerBits = m_triggerBits;
     bool shouldAudit = newTriggerBits & 1;
     newTriggerBits = newTriggerBits >> 1;
-    if (LIKELY(!shouldAudit)) {
+    if (!shouldAudit) [[likely]] {
         m_triggerBits = newTriggerBits;
         return false;
     }
@@ -78,13 +78,13 @@ ALWAYS_INLINE void auditCell(VM& vm, JSValue value)
 
 ALWAYS_INLINE void auditCellMinimally(VM& vm, JSCell* cell)
 {
-    if (UNLIKELY(Gigacage::contains(cell)))
+    if (Gigacage::contains(cell)) [[unlikely]]
         auditCellMinimallySlow(vm, cell);
 }
 
 ALWAYS_INLINE void auditCellRandomly(VM& vm, JSCell* cell)
 {
-    if (UNLIKELY(vm.integrityRandom().shouldAudit(vm)))
+    if (vm.integrityRandom().shouldAudit(vm)) [[unlikely]]
         auditCellFully(vm, cell);
 }
 
@@ -117,7 +117,7 @@ JS_EXPORT_PRIVATE VM* doAuditSlow(VM*);
 
 ALWAYS_INLINE VM* doAudit(VM* vm)
 {
-    if (UNLIKELY(!VMInspector::isValidVM(vm)))
+    if (!VMInspector::isValidVM(vm)) [[unlikely]]
         return doAuditSlow(vm);
     return vm;
 }

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -3137,7 +3137,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateProxy, (JSGlobalObject* globalObject, Cal
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
     JSGlobalObject* target = jsDynamicCast<JSGlobalObject*>(callFrame->argument(0));
-    if (UNLIKELY(!target))
+    if (!target) [[unlikely]]
         return JSValue::encode(jsUndefined());
     Structure* structure = JSGlobalProxy::createStructure(vm, target, target->getPrototypeDirect());
     return JSValue::encode(JSGlobalProxy::create(vm, structure, target));
@@ -3375,7 +3375,7 @@ JSC_DEFINE_HOST_FUNCTION(functionSetImpureGetterDelegate, (JSGlobalObject* globa
     if (!delegate.isObject())
         return JSValue::encode(jsUndefined());
     ImpureGetter* impureGetter = jsDynamicCast<ImpureGetter*>(asObject(base.asCell()));
-    if (UNLIKELY(!impureGetter)) {
+    if (!impureGetter) [[unlikely]] {
         throwTypeError(globalObject, scope, "argument is not an ImpureGetter"_s);
         return encodedJSValue();
     }
@@ -3491,7 +3491,7 @@ JSC_DEFINE_HOST_FUNCTION(functionGetHiddenValue, (JSGlobalObject* globalObject, 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     SimpleObject* simpleObject = jsDynamicCast<SimpleObject*>(callFrame->argument(0));
-    if (UNLIKELY(!simpleObject)) {
+    if (!simpleObject) [[unlikely]] {
         throwTypeError(globalObject, scope, "Invalid use of getHiddenValue test function"_s);
         return encodedJSValue();
     }
@@ -3506,7 +3506,7 @@ JSC_DEFINE_HOST_FUNCTION(functionSetHiddenValue, (JSGlobalObject* globalObject, 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     SimpleObject* simpleObject = jsDynamicCast<SimpleObject*>(callFrame->argument(0));
-    if (UNLIKELY(!simpleObject)) {
+    if (!simpleObject) [[unlikely]] {
         throwTypeError(globalObject, scope, "Invalid use of setHiddenValue test function"_s);
         return encodedJSValue();
     }
@@ -3766,7 +3766,7 @@ JSC_DEFINE_HOST_FUNCTION(functionLoadGetterFromGetterSetter, (JSGlobalObject* gl
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     GetterSetter* getterSetter = jsDynamicCast<GetterSetter*>(callFrame->argument(0));
-    if (UNLIKELY(!getterSetter)) {
+    if (!getterSetter) [[unlikely]] {
         throwTypeError(globalObject, scope, "Invalid use of loadGetterFromGetterSetter test function: argument is not a GetterSetter"_s);
         return encodedJSValue();
     }

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -707,7 +707,7 @@ BBQJIT::BBQJIT(CCallHelpers& jit, const TypeDefinition& signature, BBQCallee& ca
     if ((Options::verboseBBQJITAllocation()))
         dataLogLn("BBQ\tUsing GPR set: ", m_gprSet, "\n   \tFPR set: ", m_fprSet);
 
-    if (UNLIKELY(shouldDumpDisassemblyFor(CompilationMode::BBQMode))) {
+    if (shouldDumpDisassemblyFor(CompilationMode::BBQMode)) [[unlikely]] {
         m_disassembler = makeUnique<BBQDisassembler>();
         m_disassembler->setStartOfCode(m_jit.label());
     }
@@ -796,7 +796,7 @@ Value BBQJIT::addConstant(Type type, uint64_t value)
         return Value::none();
     }
 
-    if (UNLIKELY(Options::disableBBQConsts())) {
+    if (Options::disableBBQConsts()) [[unlikely]] {
         Value stackResult = topValue(type.kind);
         emitStoreConst(result, canonicalSlot(stackResult));
         result = stackResult;
@@ -1202,7 +1202,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addDataDrop(unsigned dataSegmentIndex)
 
 PartialResult WARN_UNUSED_RETURN BBQJIT::atomicLoad(ExtAtomicOpType loadOp, Type valueType, ExpressionType pointer, ExpressionType& result, uint32_t uoffset)
 {
-    if (UNLIKELY(sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(loadOp)))) {
+    if (sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(loadOp))) [[unlikely]] {
         // FIXME: Same issue as in AirIRGenerator::load(): https://bugs.webkit.org/show_bug.cgi?id=166435
         emitThrowException(ExceptionType::OutOfBoundsMemoryAccess);
         consume(pointer);
@@ -1218,7 +1218,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::atomicLoad(ExtAtomicOpType loadOp, Type
 PartialResult WARN_UNUSED_RETURN BBQJIT::atomicStore(ExtAtomicOpType storeOp, Type valueType, ExpressionType pointer, ExpressionType value, uint32_t uoffset)
 {
     Location valueLocation = locationOf(value);
-    if (UNLIKELY(sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(storeOp)))) {
+    if (sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(storeOp))) [[unlikely]] {
         // FIXME: Same issue as in AirIRGenerator::load(): https://bugs.webkit.org/show_bug.cgi?id=166435
         emitThrowException(ExceptionType::OutOfBoundsMemoryAccess);
         consume(pointer);
@@ -1234,7 +1234,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::atomicStore(ExtAtomicOpType storeOp, Ty
 PartialResult WARN_UNUSED_RETURN BBQJIT::atomicBinaryRMW(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t uoffset)
 {
     Location valueLocation = locationOf(value);
-    if (UNLIKELY(sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(op)))) {
+    if (sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(op))) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
         // as a runtime exception. However, this may change: https://bugs.webkit.org/show_bug.cgi?id=166435
         emitThrowException(ExceptionType::OutOfBoundsMemoryAccess);
@@ -1252,7 +1252,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::atomicBinaryRMW(ExtAtomicOpType op, Typ
 PartialResult WARN_UNUSED_RETURN BBQJIT::atomicCompareExchange(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint32_t uoffset)
 {
     Location valueLocation = locationOf(value);
-    if (UNLIKELY(sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(op)))) {
+    if (sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(op))) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
         // as a runtime exception. However, this may change: https://bugs.webkit.org/show_bug.cgi?id=166435
         emitThrowException(ExceptionType::OutOfBoundsMemoryAccess);
@@ -2983,7 +2983,7 @@ void BBQJIT::emitEntryTierUpCheck()
 // Control flow
 ControlData WARN_UNUSED_RETURN BBQJIT::addTopLevel(BlockSignature signature)
 {
-    if (UNLIKELY(Options::verboseBBQJITInstructions())) {
+    if (Options::verboseBBQJITInstructions()) [[unlikely]] {
         auto nameSection = m_info.nameSection;
         std::pair<const Name*, RefPtr<NameSection>> name = nameSection->get(m_functionIndex);
         dataLog("BBQ\tFunction ");

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -848,9 +848,9 @@ private:
     }
 
 #define RESULT(...) Result { __VA_ARGS__ }
-#define LOG_INSTRUCTION(...) do { if (UNLIKELY(Options::verboseBBQJITInstructions())) { logInstruction(__VA_ARGS__); } } while (false)
-#define LOG_INDENT() do { if (UNLIKELY(Options::verboseBBQJITInstructions())) { m_loggingIndent += 2; } } while (false);
-#define LOG_DEDENT() do { if (UNLIKELY(Options::verboseBBQJITInstructions())) { m_loggingIndent -= 2; } } while (false);
+#define LOG_INSTRUCTION(...) do { if (Options::verboseBBQJITInstructions()) [[unlikely]] { logInstruction(__VA_ARGS__); } } while (false)
+#define LOG_INDENT() do { if (Options::verboseBBQJITInstructions()) [[unlikely]] { m_loggingIndent += 2; } } while (false);
+#define LOG_DEDENT() do { if (Options::verboseBBQJITInstructions()) [[unlikely]] { m_loggingIndent -= 2; } } while (false);
 
 public:
     // FIXME: Support fused branch compare on 32-bit platforms.

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp
@@ -400,7 +400,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::setGlobal(uint32_t index, Value value)
 
 PartialResult WARN_UNUSED_RETURN BBQJIT::load(LoadOpType loadOp, Value pointer, Value& result, uint32_t uoffset)
 {
-    if (UNLIKELY(sumOverflows<uint32_t>(uoffset, sizeOfLoadOp(loadOp)))) {
+    if (sumOverflows<uint32_t>(uoffset, sizeOfLoadOp(loadOp))) [[unlikely]] {
         // FIXME: Same issue as in AirIRGenerator::load(): https://bugs.webkit.org/show_bug.cgi?id=166435
         emitThrowException(ExceptionType::OutOfBoundsMemoryAccess);
         consume(pointer);
@@ -501,7 +501,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::load(LoadOpType loadOp, Value pointer, 
 PartialResult WARN_UNUSED_RETURN BBQJIT::store(StoreOpType storeOp, Value pointer, Value value, uint32_t uoffset)
 {
     Location valueLocation = locationOf(value);
-    if (UNLIKELY(sumOverflows<uint32_t>(uoffset, sizeOfStoreOp(storeOp)))) {
+    if (sumOverflows<uint32_t>(uoffset, sizeOfStoreOp(storeOp))) [[unlikely]] {
         // FIXME: Same issue as in AirIRGenerator::load(): https://bugs.webkit.org/show_bug.cgi?id=166435
         emitThrowException(ExceptionType::OutOfBoundsMemoryAccess);
         consume(pointer);

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -346,7 +346,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::setGlobal(uint32_t index, Value value)
 
 PartialResult WARN_UNUSED_RETURN BBQJIT::load(LoadOpType loadOp, Value pointer, Value& result, uint32_t uoffset)
 {
-    if (UNLIKELY(sumOverflows<uint32_t>(uoffset, sizeOfLoadOp(loadOp)))) {
+    if (sumOverflows<uint32_t>(uoffset, sizeOfLoadOp(loadOp))) [[unlikely]] {
         // FIXME: Same issue as in AirIRGenerator::load(): https://bugs.webkit.org/show_bug.cgi?id=166435
         emitThrowException(ExceptionType::OutOfBoundsMemoryAccess);
         consume(pointer);
@@ -442,7 +442,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::load(LoadOpType loadOp, Value pointer, 
 PartialResult WARN_UNUSED_RETURN BBQJIT::store(StoreOpType storeOp, Value pointer, Value value, uint32_t uoffset)
 {
     Location valueLocation = locationOf(value);
-    if (UNLIKELY(sumOverflows<uint32_t>(uoffset, sizeOfStoreOp(storeOp)))) {
+    if (sumOverflows<uint32_t>(uoffset, sizeOfStoreOp(storeOp))) [[unlikely]] {
         // FIXME: Same issue as in AirIRGenerator::load(): https://bugs.webkit.org/show_bug.cgi?id=166435
         emitThrowException(ExceptionType::OutOfBoundsMemoryAccess);
         consume(pointer);
@@ -2378,7 +2378,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI64Add(Value lhs, Value rhs, Value& 
             m_jit.add64(lhsLocation.asGPR(), rhsLocation.asGPR(), resultLocation.asGPR());
         ),
         BLOCK(
-            if (LIKELY(isRepresentableAs<int32_t>(ImmHelpers::imm(lhs, rhs).asI64())))
+            if (isRepresentableAs<int32_t>(ImmHelpers::imm(lhs, rhs).asI64())) [[likely]]
                 m_jit.add64(TrustedImm32(ImmHelpers::imm(lhs, rhs).asI64()), ImmHelpers::regLocation(lhsLocation, rhsLocation).asGPR(), resultLocation.asGPR());
             else {
                 m_jit.move(ImmHelpers::regLocation(lhsLocation, rhsLocation).asGPR(), resultLocation.asGPR());

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -74,7 +74,7 @@ FunctionAllowlist& BBQPlan::ensureGlobalBBQAllowlist()
 
 bool BBQPlan::dumpDisassembly(CompilationContext& context, LinkBuffer& linkBuffer, FunctionCodeIndex functionIndex, const TypeDefinition& signature, FunctionSpaceIndex functionIndexSpace)
 {
-    if (UNLIKELY(shouldDumpDisassemblyFor(CompilationMode::BBQMode))) {
+    if (shouldDumpDisassemblyFor(CompilationMode::BBQMode)) [[unlikely]] {
         dataLogF("Generated BBQ code for WebAssembly BBQ function[%zu] %s name %s\n", functionIndex.rawIndex(), signature.toString().ascii().data(), makeString(IndexOrName(functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace))).ascii().data());
         if (context.bbqDisassembler)
             context.bbqDisassembler->dump(linkBuffer);

--- a/Source/JavaScriptCore/wasm/WasmBinding.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBinding.cpp
@@ -80,7 +80,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToWasm(unsi
     jit.farJump(scratch, WasmEntryPtrTag);
 
     LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::WasmThunk, JITCompilationCanFail);
-    if (UNLIKELY(patchBuffer.didFailToAllocate()))
+    if (patchBuffer.didFailToAllocate()) [[unlikely]]
         return makeUnexpected(BindingFailure::OutOfMemory);
 
     return FINALIZE_WASM_CODE(patchBuffer, WasmEntryPtrTag, nullptr, "WebAssembly->WebAssembly import[%i]", importIndex);

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -230,7 +230,7 @@ void CalleeGroup::releaseBBQCallee(const AbstractLocker&, FunctionCodeIndex func
     // We could have triggered a tier up from a BBQCallee has MemoryMode::BoundsChecking
     // but is currently running a MemoryMode::Signaling memory. In that case there may
     // be nothing to release.
-    if (LIKELY(!m_bbqCallees.isEmpty())) {
+    if (!m_bbqCallees.isEmpty()) [[likely]] {
         if (RefPtr bbqCallee = m_bbqCallees[functionIndex].convertToWeak()) {
             bbqCallee->reportToVMsForDestruction();
             return;

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
@@ -236,7 +236,7 @@ void EntryPlan::compileFunctions()
     }
 
     if (!areWasmToWasmStubsCompiled) {
-        if (UNLIKELY(!generateWasmToWasmStubs())) {
+        if (!generateWasmToWasmStubs()) [[unlikely]] {
             Locker locker { m_lock };
             fail(makeString("Out of executable memory at stub generation"_s));
             return;
@@ -244,7 +244,7 @@ void EntryPlan::compileFunctions()
     }
 
     if (!areWasmToJSStubsCompiled) {
-        if (UNLIKELY(!generateWasmToJSStubs())) {
+        if (!generateWasmToJSStubs()) [[unlikely]] {
             Locker locker { m_lock };
             fail(makeString("Out of executable memory at stub generation"_s));
             return;
@@ -285,14 +285,14 @@ bool EntryPlan::completeSyncIfPossible()
 void EntryPlan::generateStubsIfNecessary()
 {
     if (!std::exchange(m_areWasmToWasmStubsCompiled, true)) {
-        if (UNLIKELY(!generateWasmToWasmStubs())) {
+        if (!generateWasmToWasmStubs()) [[unlikely]] {
             fail(makeString("Out of executable memory at stub generation"_s));
             return;
         }
     }
 
     if (!std::exchange(m_areWasmToJSStubsCompiled, true)) {
-        if (UNLIKELY(!generateWasmToJSStubs())) {
+        if (!generateWasmToJSStubs()) [[unlikely]] {
             fail(makeString("Out of executable memory at stub generation"_s));
             return;
         }
@@ -312,7 +312,7 @@ bool EntryPlan::generateWasmToWasmStubs()
 #if ENABLE(JIT)
         if (Options::useWasmJIT()) {
             auto binding = wasmToWasm(importFunctionIndex);
-            if (UNLIKELY(!binding))
+            if (!binding) [[unlikely]]
                 return false;
             m_wasmToWasmExitStubs[importFunctionIndex++] = binding.value();
         }
@@ -340,7 +340,7 @@ bool EntryPlan::generateWasmToJSStubs()
         Wasm::TypeIndex typeIndex = m_moduleInformation->importFunctionTypeIndices.at(importIndex);
         if (Options::useWasmJIT()) {
             auto binding = wasmToJS(typeIndex, importIndex);
-            if (UNLIKELY(!binding))
+            if (!binding) [[unlikely]]
                 return false;
             m_wasmToJSExitStubs[importIndex] = binding.value();
         }

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.h
@@ -122,7 +122,7 @@ protected:
     template<typename T>
     bool tryReserveCapacity(Vector<T>& vector, size_t size, ASCIILiteral what)
     {
-        if (UNLIKELY(!vector.tryReserveCapacity(size))) {
+        if (!vector.tryReserveCapacity(size)) [[unlikely]] {
             Locker locker { m_lock };
             fail(WTF::makeString("Failed allocating enough space for "_s, size, what));
             return false;

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -308,7 +308,7 @@ private:
     NEVER_INLINE UnexpectedResult WARN_UNUSED_RETURN validationFail(const Args&... args) const
     {
         using namespace FailureHelper; // See ADL comment in WasmParser.h.
-        if (UNLIKELY(ASSERT_ENABLED && Options::crashOnFailedWasmValidate()))
+        if (ASSERT_ENABLED && Options::crashOnFailedWasmValidate())
             WTFBreakpointTrap();
 
         StringPrintStream out;
@@ -461,7 +461,7 @@ auto FunctionParser<Context>::parse() -> Result
         totalNumberOfLocals += numberOfLocals;
         WASM_PARSER_FAIL_IF(totalNumberOfLocals > maxFunctionLocals, "Function's number of locals is too big "_s, totalNumberOfLocals, " maximum "_s, maxFunctionLocals);
         WASM_PARSER_FAIL_IF(!parseValueType(m_info, typeOfLocal), "can't get Function local's type in group "_s, i);
-        if (UNLIKELY(!isDefaultableType(typeOfLocal)))
+        if (!isDefaultableType(typeOfLocal)) [[unlikely]]
             totalNonDefaultableLocals++;
 
         if (typeOfLocal.isV128()) {
@@ -520,7 +520,7 @@ auto FunctionParser<Context>::parseBody() -> PartialResult
 
         m_currentOpcode = static_cast<OpType>(op);
 #if ENABLE(WEBASSEMBLY_OMGJIT)
-        if (UNLIKELY(Options::dumpWasmOpcodeStatistics()))
+        if (Options::dumpWasmOpcodeStatistics()) [[unlikely]]
             WasmOpcodeCounter::singleton().increment(m_currentOpcode);
 #endif
 
@@ -1854,10 +1854,10 @@ ALWAYS_INLINE auto FunctionParser<Context>::parseNestedBlocksEagerly(bool& shoul
         BlockSignature inlineSignature;
 
         // Only attempt to parse the most optimistic case of a single non-ref or void return signature.
-        if (LIKELY(peekInt7(kindByte) && isValidTypeKind(kindByte))) {
+        if (peekInt7(kindByte) && isValidTypeKind(kindByte)) [[likely]] {
             TypeKind typeKind = static_cast<TypeKind>(kindByte);
             Type type = { typeKind, TypeDefinition::invalidIndex };
-            if (UNLIKELY(!(type.isVoid() || isValueType(type))))
+            if (!(type.isVoid() || isValueType(type))) [[unlikely]]
                 return { };
             inlineSignature = { m_typeInformation.thunkFor(type), nullptr };
             m_offset++;
@@ -2847,7 +2847,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
         ExtAtomicOpType op = static_cast<ExtAtomicOpType>(m_currentExtOp);
 #if ENABLE(WEBASSEMBLY_OMGJIT)
-        if (UNLIKELY(Options::dumpWasmOpcodeStatistics()))
+        if (Options::dumpWasmOpcodeStatistics()) [[unlikely]]
             WasmOpcodeCounter::singleton().increment(op);
 #endif
 
@@ -3628,12 +3628,12 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         String errorMessage;
         targets.appendUsingFunctor(numberOfTargets, [&](size_t i) -> ControlType* {
             uint32_t target;
-            if (UNLIKELY(!parseVarUInt32(target))) {
+            if (!parseVarUInt32(target)) [[unlikely]] {
                 if (errorMessage.isNull())
                     errorMessage = WTF::makeString("can't get "_s, i, "th target for br_table"_s);
                 return nullptr;
             }
-            if (UNLIKELY(target >= m_controlStack.size())) {
+            if (target >= m_controlStack.size()) [[unlikely]] {
                 if (errorMessage.isNull())
                     errorMessage = WTF::makeString("br_table's "_s, i, "th target "_s, target, " exceeds control stack size "_s, m_controlStack.size());
                 return nullptr;
@@ -3746,7 +3746,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         constexpr bool isReachable = true;
 
         ExtSIMDOpType op = static_cast<ExtSIMDOpType>(m_currentExtOp);
-        if (UNLIKELY(Options::dumpWasmOpcodeStatistics()))
+        if (Options::dumpWasmOpcodeStatistics()) [[unlikely]]
             WasmOpcodeCounter::singleton().increment(op);
 
         switch (op) {
@@ -4128,7 +4128,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
 
         ExtGCOpType op = static_cast<ExtGCOpType>(m_currentExtOp);
 #if ENABLE(WEBASSEMBLY_OMGJIT)
-        if (UNLIKELY(Options::dumpWasmOpcodeStatistics()))
+        if (Options::dumpWasmOpcodeStatistics()) [[unlikely]]
             WasmOpcodeCounter::singleton().increment(op);
 #endif
 

--- a/Source/JavaScriptCore/wasm/WasmGlobal.cpp
+++ b/Source/JavaScriptCore/wasm/WasmGlobal.cpp
@@ -62,7 +62,7 @@ JSValue Global::get(JSGlobalObject* globalObject) const
     case TypeKind::Funcref:
     case TypeKind::Ref:
     case TypeKind::RefNull: {
-        if (UNLIKELY(isExnref(m_type))) {
+        if (isExnref(m_type)) [[unlikely]] {
             throwException(globalObject, throwScope, createJSWebAssemblyRuntimeError(globalObject, vm, "Cannot get value of exnref global"_s));
             return { };
         }

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -147,7 +147,7 @@ static inline Wasm::JITCallee* jitCompileAndSetHeuristics(Wasm::IPIntCallee* cal
         if (Wasm::BBQPlan::ensureGlobalBBQAllowlist().containsWasmFunction(functionIndex)) {
             auto plan = Wasm::BBQPlan::create(instance->vm(), const_cast<Wasm::ModuleInformation&>(instance->module().moduleInformation()), functionIndex, callee->hasExceptionHandlers(), Ref(*instance->calleeGroup()), Wasm::Plan::dontFinalize());
             Wasm::ensureWorklist().enqueue(plan.get());
-            if (UNLIKELY(!Options::useConcurrentJIT() || !Options::useWasmIPInt()))
+            if (!Options::useConcurrentJIT() || !Options::useWasmIPInt()) [[unlikely]]
                 plan->waitForCompletion();
             else
                 tierUpCounter.optimizeAfterWarmUp();
@@ -226,7 +226,7 @@ WASM_IPINT_EXTERN_CPP_DECL(simd_go_straight_to_bbq, CallFrame* cfr)
     dataLogLnIf(Options::verboseOSR(), *callee, ": Entered simd_go_straight_to_bbq_osr with tierUpCounter = ", callee->tierUpCounter());
 
     auto result = jitCompileSIMDFunction(callee, instance);
-    if (LIKELY(result.has_value()))
+    if (result.has_value()) [[likely]]
         WASM_RETURN_TWO(result.value()->entrypoint().taggedPtr(), nullptr);
 
     switch (result.error()) {
@@ -709,7 +709,7 @@ WASM_IPINT_EXTERN_CPP_DECL(array_new_fixed, Wasm::TypeIndex type, uint32_t size,
 WASM_IPINT_EXTERN_CPP_DECL(array_new_data, IPInt::ArrayNewDataMetadata* metadata, uint32_t offset, uint32_t size)
 {
     EncodedJSValue result = Wasm::arrayNewData(instance, static_cast<uint32_t>(metadata->typeIndex), metadata->dataSegmentIndex, size, offset);
-    if (UNLIKELY(JSValue::decode(result).isNull()))
+    if (JSValue::decode(result).isNull()) [[unlikely]]
         IPINT_THROW(Wasm::ExceptionType::BadArrayNewInitData);
 
     IPINT_RETURN(result);
@@ -718,7 +718,7 @@ WASM_IPINT_EXTERN_CPP_DECL(array_new_data, IPInt::ArrayNewDataMetadata* metadata
 WASM_IPINT_EXTERN_CPP_DECL(array_new_elem, IPInt::ArrayNewElemMetadata* metadata, uint32_t offset, uint32_t size)
 {
     EncodedJSValue result = Wasm::arrayNewElem(instance, static_cast<uint32_t>(metadata->typeIndex), metadata->elemSegmentIndex, size, offset);
-    if (UNLIKELY(JSValue::decode(result).isNull()))
+    if (JSValue::decode(result).isNull()) [[unlikely]]
         IPINT_THROW(Wasm::ExceptionType::BadArrayNewInitElem);
 
     IPINT_RETURN(result);

--- a/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -460,10 +460,10 @@ private:
 
     ExpressionType jsNullConstant()
     {
-        if (UNLIKELY(!m_jsNullConstant.isValid())) {
+        if (!m_jsNullConstant.isValid()) [[unlikely]] {
             m_jsNullConstant = VirtualRegister(FirstConstantRegisterIndex + m_codeBlock->m_constants.size());
             m_codeBlock->m_constants.append(JSValue::encode(jsNull()));
-            if (UNLIKELY(Options::dumpGeneratedWasmBytecodes()))
+            if (Options::dumpGeneratedWasmBytecodes()) [[unlikely]]
                 m_codeBlock->m_constantTypes.append(Types::Externref);
         }
         return m_jsNullConstant;
@@ -471,10 +471,10 @@ private:
 
     ExpressionType zeroConstant()
     {
-        if (UNLIKELY(!m_zeroConstant.isValid())) {
+        if (!m_zeroConstant.isValid()) [[unlikely]] {
             m_zeroConstant = VirtualRegister(FirstConstantRegisterIndex + m_codeBlock->m_constants.size());
             m_codeBlock->m_constants.append(0);
-            if (UNLIKELY(Options::dumpGeneratedWasmBytecodes()))
+            if (Options::dumpGeneratedWasmBytecodes()) [[unlikely]]
                 m_codeBlock->m_constantTypes.append(Types::I32);
         }
         return m_zeroConstant;
@@ -1026,7 +1026,7 @@ auto LLIntGenerator::addConstantWithoutPush(Type type, int64_t value) -> Express
     if (!result.isNewEntry)
         return result.iterator->value;
     m_codeBlock->m_constants.append(value);
-    if (UNLIKELY(Options::dumpGeneratedWasmBytecodes()))
+    if (Options::dumpGeneratedWasmBytecodes()) [[unlikely]]
         m_codeBlock->m_constantTypes.append(type);
     return source;
 }

--- a/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
@@ -129,7 +129,7 @@ void LLIntPlan::compileFunction(FunctionCodeIndex functionIndex)
     }
 
     m_wasmInternalFunctions[functionIndex] = WTFMove(*parseAndCompileResult);
-    if (UNLIKELY(Options::dumpGeneratedWasmBytecodes()))
+    if (Options::dumpGeneratedWasmBytecodes()) [[unlikely]]
         BytecodeDumper::dumpBlock(m_wasmInternalFunctions[functionIndex].get(), m_moduleInformation, WTF::dataFile());
 
     LLIntCallee* llintCallee = nullptr;

--- a/Source/JavaScriptCore/wasm/WasmMemory.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemory.cpp
@@ -208,7 +208,7 @@ RefPtr<Memory> Memory::tryCreate(VM& vm, PageCount initial, PageCount maximum, M
     if (desiredMemoryMode == MemoryMode::Signaling)
         return nullptr;
 
-    if (UNLIKELY(Options::crashIfWasmCantFastMemory()))
+    if (Options::crashIfWasmCantFastMemory()) [[unlikely]]
         webAssemblyCouldntGetFastMemory();
 
     switch (sharingMode) {

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -2349,7 +2349,7 @@ auto OMGIRGenerator::load(LoadOpType op, ExpressionType pointerVar, ExpressionTy
     Value* pointer = get(pointerVar);
     ASSERT(pointer->type() == Int32);
 
-    if (UNLIKELY(sumOverflows<uint32_t>(offset, sizeOfLoadOp(op)))) {
+    if (sumOverflows<uint32_t>(offset, sizeOfLoadOp(op))) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
         // as a runtime exception. However, this may change: https://bugs.webkit.org/show_bug.cgi?id=166435
         B3::PatchpointValue* throwException = m_currentBlock->appendNew<B3::PatchpointValue>(m_proc, B3::Void, origin());
@@ -2450,7 +2450,7 @@ auto OMGIRGenerator::store(StoreOpType op, ExpressionType pointerVar, Expression
     Value* value = get(valueVar);
     ASSERT(pointer->type() == Int32);
 
-    if (UNLIKELY(sumOverflows<uint32_t>(offset, sizeOfStoreOp(op)))) {
+    if (sumOverflows<uint32_t>(offset, sizeOfStoreOp(op))) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
         // as a runtime exception. However, this may change: https://bugs.webkit.org/show_bug.cgi?id=166435
         B3::PatchpointValue* throwException = m_currentBlock->appendNew<B3::PatchpointValue>(m_proc, B3::Void, origin());

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -2689,7 +2689,7 @@ auto OMGIRGenerator::load(LoadOpType op, ExpressionType pointerVar, ExpressionTy
     Value* pointer = get(pointerVar);
     ASSERT(pointer->type() == Int32);
 
-    if (UNLIKELY(sumOverflows<uint32_t>(offset, sizeOfLoadOp(op)))) {
+    if (sumOverflows<uint32_t>(offset, sizeOfLoadOp(op))) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
         // as a runtime exception. However, this may change: https://bugs.webkit.org/show_bug.cgi?id=166435
         B3::PatchpointValue* throwException = append<B3::PatchpointValue>(m_proc, B3::Void, origin());
@@ -2789,7 +2789,7 @@ auto OMGIRGenerator::store(StoreOpType op, ExpressionType pointerVar, Expression
     Value* value = get(valueVar);
     ASSERT(pointer->type() == Int32);
 
-    if (UNLIKELY(sumOverflows<uint32_t>(offset, sizeOfStoreOp(op)))) {
+    if (sumOverflows<uint32_t>(offset, sizeOfStoreOp(op))) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
         // as a runtime exception. However, this may change: https://bugs.webkit.org/show_bug.cgi?id=166435
         B3::PatchpointValue* throwException = append<B3::PatchpointValue>(m_proc, B3::Void, origin());

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -78,7 +78,7 @@ FunctionAllowlist& OMGPlan::ensureGlobalOMGAllowlist()
 void OMGPlan::dumpDisassembly(CompilationContext& context, LinkBuffer& linkBuffer, FunctionCodeIndex functionIndex, const TypeDefinition& signature, FunctionSpaceIndex functionIndexSpace)
 {
     dataLogLnIf(context.procedure->shouldDumpIR() || shouldDumpDisassemblyFor(CompilationMode::OMGMode), "Generated OMG code for WebAssembly OMG function[", functionIndex, "] ", signature.toString().ascii().data(), " name ", makeString(IndexOrName(functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace))).ascii().data());
-    if (UNLIKELY(shouldDumpDisassemblyFor(CompilationMode::OMGMode))) {
+    if (shouldDumpDisassemblyFor(CompilationMode::OMGMode)) [[unlikely]] {
         ScopedPrintStream out;
         UncheckedKeyHashSet<B3::Value*> printedValues;
         auto* disassembler = context.procedure->code().disassembler();

--- a/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
@@ -68,7 +68,7 @@ void OSREntryPlan::dumpDisassembly(CompilationContext& context, LinkBuffer& link
 {
     CompilationMode targetCompilationMode = CompilationMode::OMGForOSREntryMode;
     dataLogLnIf(context.procedure->shouldDumpIR() || shouldDumpDisassemblyFor(targetCompilationMode), "Generated OMG code for WebAssembly OMGforOSREntry function[", functionIndex, "] ", signature.toString().ascii().data(), " name ", makeString(IndexOrName(functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace))).ascii().data());
-    if (UNLIKELY(shouldDumpDisassemblyFor(targetCompilationMode))) {
+    if (shouldDumpDisassemblyFor(targetCompilationMode)) [[unlikely]] {
         auto* disassembler = context.procedure->code().disassembler();
 
         const char* b3Prefix = "b3    ";

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -96,7 +96,7 @@ JSC_DEFINE_JIT_OPERATION(operationJSToWasmEntryWrapperBuildFrame, JSEntrypointCa
     const FunctionSignature& functionSignature = *signature.as<FunctionSignature>();
     CallInformation wasmFrameConvention = wasmCallingConvention().callInformationFor(signature, CallRole::Caller);
 
-    if (UNLIKELY(functionSignature.argumentsOrResultsIncludeV128() || functionSignature.argumentsOrResultsIncludeExnref())) {
+    if (functionSignature.argumentsOrResultsIncludeV128() || functionSignature.argumentsOrResultsIncludeExnref()) [[unlikely]] {
         throwVMTypeError(globalObject, scope, Wasm::errorMessageForExceptionType(Wasm::ExceptionType::TypeErrorInvalidValueUse));
         OPERATION_RETURN(scope, callee);
     }
@@ -313,7 +313,7 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, bool, (void* sp,
     const auto& wasmCC = wasmCallingConvention().callInformationFor(typeDefinition, CallRole::Caller);
     const auto& jsCC = jsCallingConvention().callInformationFor(typeDefinition, CallRole::Callee);
 
-    if (UNLIKELY(signature.argumentsOrResultsIncludeV128() || signature.argumentsOrResultsIncludeExnref()))
+    if (signature.argumentsOrResultsIncludeV128() || signature.argumentsOrResultsIncludeExnref()) [[unlikely]]
         OPERATION_RETURN(scope, false);
 
     for (unsigned argNum = 0; argNum < argCount; ++argNum) {
@@ -565,7 +565,7 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, void, (void* 
                     // operationConvertToAnyref
                     JSValue value = JSValue::decode(std::bit_cast<EncodedJSValue>(returned));
                     value = Wasm::internalizeExternref(value);
-                    if (UNLIKELY(!Wasm::TypeInformation::castReference(value, returnType.isNullable(), returnType.index))) {
+                    if (!Wasm::TypeInformation::castReference(value, returnType.isNullable(), returnType.index)) [[unlikely]] {
                         throwTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
                         OPERATION_RETURN(scope);
                     }
@@ -699,7 +699,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmToJSExitIterateResults, bool, (JS
                     }
                 } else {
                     value = Wasm::internalizeExternref(value);
-                    if (UNLIKELY(!Wasm::TypeInformation::castReference(value, returnType.isNullable(), returnType.index))) {
+                    if (!Wasm::TypeInformation::castReference(value, returnType.isNullable(), returnType.index)) [[unlikely]] {
                         throwTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
                         return true;
                     }
@@ -768,7 +768,7 @@ static void triggerOMGReplacementCompile(TierUpCount& tierUp, OMGCallee* replace
         // We need to compile the code.
         Ref<Plan> plan = adoptRef(*new OMGPlan(instance->vm(), Ref<Wasm::Module>(instance->module()), functionIndex, hasExceptionHandlers, calleeGroup.mode(), Plan::dontFinalize()));
         ensureWorklist().enqueue(plan.copyRef());
-        if (UNLIKELY(!Options::useConcurrentJIT()))
+        if (!Options::useConcurrentJIT()) [[unlikely]]
             plan->waitForCompletion();
         else
             tierUp.setOptimizationThresholdBasedOnCompilationResult(functionIndex, CompilationDeferred);
@@ -1015,7 +1015,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmTriggerOSREntryNow, void, (Probe:
             return true;
         uintptr_t stackExtent = stackPointer - callee->stackCheckSize();
         uintptr_t stackLimit = reinterpret_cast<uintptr_t>(instance->softStackLimit());
-        if (UNLIKELY(stackExtent >= stackPointer || stackExtent <= stackLimit)) {
+        if (stackExtent >= stackPointer || stackExtent <= stackLimit) [[unlikely]] {
             dataLogLnIf(Options::verboseOSR(), "\tSkipping OMG loop tier up due to stack check; ", RawHex(stackPointer), " -> ", RawHex(stackExtent), " is past soft limit ", RawHex(stackLimit));
             return false;
         }
@@ -1188,7 +1188,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmTriggerOSREntryNow, void, (Probe:
         dataLogLnIf(Options::verboseOSR(), "\ttriggerOMGOSR for ", functionIndex);
         Ref<Plan> plan = adoptRef(*new OSREntryPlan(instance->vm(), Ref<Wasm::Module>(instance->module()), Ref<Wasm::BBQCallee>(callee), functionIndex, callee.hasExceptionHandlers(), loopIndex, calleeGroup.mode(), Plan::dontFinalize()));
         ensureWorklist().enqueue(plan.copyRef());
-        if (UNLIKELY(!Options::useConcurrentJIT()))
+        if (!Options::useConcurrentJIT()) [[unlikely]]
             plan->waitForCompletion();
         else
             tierUp.setOptimizationThresholdBasedOnCompilationResult(functionIndex, CompilationDeferred);
@@ -1377,7 +1377,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationConvertToAnyref, EncodedJSValue, (JSW
 
     JSValue value = JSValue::decode(v);
     value = Wasm::internalizeExternref(value);
-    if (UNLIKELY(!Wasm::TypeInformation::castReference(value, resultType.isNullable(), resultType.index))) {
+    if (!Wasm::TypeInformation::castReference(value, resultType.isNullable(), resultType.index)) [[unlikely]] {
         throwTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
         return { };
     }
@@ -1472,7 +1472,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationIterateResults, bool, (JSWebAssemblyI
                     }
                 } else {
                     value = Wasm::internalizeExternref(value);
-                    if (UNLIKELY(!Wasm::TypeInformation::castReference(value, returnType.isNullable(), returnType.index))) {
+                    if (!Wasm::TypeInformation::castReference(value, returnType.isNullable(), returnType.index)) [[unlikely]] {
                         throwTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
                         return true;
                     }

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -58,7 +58,7 @@ JSWebAssemblyArray* tryFillArray(JSWebAssemblyInstance* instance, WebAssemblyGCS
     VM& vm = instance->vm();
 
     auto* array = JSWebAssemblyArray::tryCreate(vm, structure, size);
-    if (LIKELY(array))
+    if (array) [[likely]]
         array->fill(vm, 0, static_cast<T>(value), size);
     return array;
 }
@@ -215,13 +215,13 @@ inline EncodedJSValue arrayNewData(JSWebAssemblyInstance* instance, uint32_t typ
     size_t elementSize = fieldType.type.elementSize();
 
     // Check for overflow when determining array length in bytes
-    if (UNLIKELY(productOverflows<uint32_t>(elementSize, arraySize)))
+    if (productOverflows<uint32_t>(elementSize, arraySize)) [[unlikely]]
         return JSValue::encode(jsNull());
 
     uint32_t arrayLengthInBytes = arraySize * elementSize;
 
     // Check for offset + arrayLengthInBytes overflow
-    if (UNLIKELY(sumOverflows<uint32_t>(offset, arrayLengthInBytes)))
+    if (sumOverflows<uint32_t>(offset, arrayLengthInBytes)) [[unlikely]]
         return JSValue::encode(jsNull());
 
     // Finally, allocate the array from the `values` vector
@@ -270,7 +270,7 @@ inline EncodedJSValue arrayNewElem(JSWebAssemblyInstance* instance, uint32_t typ
     auto element = instance->elementAt(elemSegmentIndex);
     size_t segmentLength = element ? element->length() : 0U;
     auto calculatedArrayEnd = CheckedUint32 { offset } + arraySize;
-    if (UNLIKELY(calculatedArrayEnd.hasOverflowed() || calculatedArrayEnd > segmentLength))
+    if (calculatedArrayEnd.hasOverflowed() || calculatedArrayEnd > segmentLength) [[unlikely]]
         return JSValue::encode(jsNull());
 
     VM& vm = instance->vm();

--- a/Source/JavaScriptCore/wasm/WasmParser.h
+++ b/Source/JavaScriptCore/wasm/WasmParser.h
@@ -118,7 +118,7 @@ protected:
 
 #define WASM_FAIL_IF_HELPER_FAILS(helper) do {                      \
         auto helperResult = helper;                                 \
-        if (UNLIKELY(!helperResult))                                \
+        if (!helperResult) [[unlikely]]                             \
             return makeUnexpected(WTFMove(helperResult.error()));   \
     } while (0)
 

--- a/Source/JavaScriptCore/wasm/WasmPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmPlan.cpp
@@ -140,7 +140,7 @@ CString Plan::signpostMessage(CompilationMode compilationMode, uint32_t function
 
 void Plan::beginCompilerSignpost(CompilationMode compilationMode, uint32_t functionIndexSpace) const
 {
-    if (UNLIKELY(Options::useCompilerSignpost())) {
+    if (Options::useCompilerSignpost()) [[unlikely]] {
         auto message = signpostMessage(compilationMode, functionIndexSpace);
         WTFBeginSignpost(this, JSCJITCompiler, "%" PUBLIC_LOG_STRING, message.data() ? message.data() : "(nullptr)");
     }
@@ -153,7 +153,7 @@ void Plan::beginCompilerSignpost(const Callee& callee) const
 
 void Plan::endCompilerSignpost(CompilationMode compilationMode, uint32_t functionIndexSpace) const
 {
-    if (UNLIKELY(Options::useCompilerSignpost())) {
+    if (Options::useCompilerSignpost()) [[unlikely]] {
         auto message = signpostMessage(compilationMode, functionIndexSpace);
         WTFEndSignpost(this, JSCJITCompiler, "%" PUBLIC_LOG_STRING, message.data() ? message.data() : "(nullptr)");
     }

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -301,7 +301,7 @@ auto SectionParser::parseTableHelper(bool isImport) -> PartialResult
     std::optional<uint32_t> maximum;
     bool isShared = false;
     PartialResult limits = parseResizableLimits(initial, maximum, isShared, LimitsType::Table);
-    if (UNLIKELY(!limits))
+    if (!limits) [[unlikely]]
         return makeUnexpected(WTFMove(limits.error()));
     WASM_PARSER_FAIL_IF(initial > maxTableEntries, "Table's initial page count of "_s, initial, " is too big, maximum "_s, maxTableEntries);
 
@@ -359,7 +359,7 @@ auto SectionParser::parseMemoryHelper(bool isImport) -> PartialResult
         uint32_t initial;
         std::optional<uint32_t> maximum;
         PartialResult limits = parseResizableLimits(initial, maximum, isShared, LimitsType::Memory);
-        if (UNLIKELY(!limits))
+        if (!limits) [[unlikely]]
             return makeUnexpected(WTFMove(limits.error()));
         ASSERT(!maximum || *maximum >= initial);
         WASM_PARSER_FAIL_IF(!PageCount::isValid(initial), "Memory's initial page count of "_s, initial, " is invalid"_s);

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.h
@@ -56,7 +56,7 @@ private:
     NEVER_INLINE UnexpectedResult WARN_UNUSED_RETURN fail(Args... args) const
     {
         using namespace FailureHelper; // See ADL comment in namespace above.
-        if (UNLIKELY(ASSERT_ENABLED && Options::crashOnFailedWasmValidate()))
+        if (ASSERT_ENABLED && Options::crashOnFailedWasmValidate()) [[unlikely]]
             CRASH();
 
         return UnexpectedResult(makeString("WebAssembly.Module doesn't parse at byte "_s, String::number(m_offset + m_offsetInSource), ": "_s, makeString(args)...));

--- a/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
@@ -49,7 +49,7 @@ static constexpr bool verbose = false;
 #define WASM_STREAMING_PARSER_FAIL_IF_HELPER_FAILS(helper) \
     do { \
         auto helperResult = helper; \
-        if (UNLIKELY(!helperResult)) { \
+        if (!helperResult) [[unlikely]] { \
             m_errorMessage = helperResult.error(); \
             return State::FatalError; \
         } \
@@ -299,12 +299,12 @@ auto StreamingParser::addBytes(std::span<const uint8_t> bytes, IsEndOfStream isE
         return m_state;
 
     m_totalSize += bytes.size();
-    if (UNLIKELY(m_totalSize.hasOverflowed() || m_totalSize > maxModuleSize)) {
+    if (m_totalSize.hasOverflowed() || m_totalSize > maxModuleSize) [[unlikely]] {
         m_state = fail("module size is too large, maximum "_s, maxModuleSize);
         return m_state;
     }
 
-    if (UNLIKELY(Options::useEagerWasmModuleHashing()))
+    if (Options::useEagerWasmModuleHashing()) [[unlikely]]
         m_hasher.addBytes(bytes);
 
     size_t offsetInBytes = 0;
@@ -439,14 +439,14 @@ auto StreamingParser::finalize() -> State
         }
 
         if (m_info->numberOfDataSegments) {
-            if (UNLIKELY(m_info->data.size() != m_info->numberOfDataSegments.value())) {
+            if (m_info->data.size() != m_info->numberOfDataSegments.value()) [[unlikely]] {
                 m_state = fail("Data section's count "_s, m_info->data.size(), " is different from Data Count section's count "_s, m_info->numberOfDataSegments.value());
                 break;
             }
         }
 
         if (m_remaining.isEmpty()) {
-            if (UNLIKELY(Options::useEagerWasmModuleHashing()))
+            if (Options::useEagerWasmModuleHashing()) [[unlikely]]
                 m_info->nameSection->setHash(m_hasher.computeHexDigest());
 
             m_state = State::Finished;

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -826,7 +826,7 @@ public:
     Ref<const TypeDefinition> replacePlaceholders(TypeIndex) const;
     ALWAYS_INLINE const TypeDefinition& unroll() const
     {
-        if (UNLIKELY(is<Projection>()))
+        if (is<Projection>()) [[unlikely]]
             return unrollSlow();
         ASSERT(refCount() > 1); // TypeInformation registry + owner(s).
         return *this;

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -478,7 +478,7 @@ static RegisterAtOffsetList usedCalleeSaveRegisters(const Wasm::FunctionSignatur
 
 CodePtr<JSEntryPtrTag> FunctionSignature::jsToWasmICEntrypoint() const
 {
-    if (LIKELY(m_jsToWasmICCallee)) {
+    if (m_jsToWasmICCallee) [[likely]] {
         ASSERT(m_jsToWasmICCallee->jsEntrypoint());
         return m_jsToWasmICCallee->jsEntrypoint();
     }
@@ -501,7 +501,7 @@ CodePtr<JSEntryPtrTag> FunctionSignature::jsToWasmICEntrypoint() const
 
     const Wasm::WasmCallingConvention& wasmCC = Wasm::wasmCallingConvention();
     Wasm::CallInformation wasmCallInfo = wasmCC.callInformationFor(*this);
-    if (UNLIKELY(argumentsOrResultsIncludeV128() || argumentsOrResultsIncludeExnref()))
+    if (argumentsOrResultsIncludeV128() || argumentsOrResultsIncludeExnref()) [[unlikely]]
         return nullptr;
     Wasm::CallInformation jsCallInfo = Wasm::jsCallingConvention().callInformationFor(*this, Wasm::CallRole::Callee);
     RegisterAtOffsetList savedResultRegisters = wasmCallInfo.computeResultsOffsetList();

--- a/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
@@ -213,7 +213,7 @@ static void instantiate(VM& vm, JSGlobalObject* globalObject, JSPromise* promise
             }
             case Resolve::WithModuleRecord: {
                 auto* moduleRecord = instance->moduleRecord();
-                if (UNLIKELY(Options::dumpModuleRecord()))
+                if (Options::dumpModuleRecord()) [[unlikely]]
                     moduleRecord->dump();
                 promise->resolve(globalObject, moduleRecord);
                 break;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp
@@ -57,7 +57,7 @@ JSWebAssemblyArray* JSWebAssemblyArray::tryCreate(VM& vm, WebAssemblyGCStructure
 {
     Wasm::FieldType fieldType = elementType(structure);
     std::optional<unsigned> allocationSize = allocationSizeInBytes(fieldType, size);
-    if (UNLIKELY(!allocationSize))
+    if (!allocationSize) [[unlikely]]
         return nullptr;
 
     auto* array = new (NotNull, allocateCell<JSWebAssemblyArray>(vm, allocationSize.value())) JSWebAssemblyArray(vm, structure, size);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
@@ -94,7 +94,7 @@ public:
     static std::optional<unsigned> allocationSizeInBytes(Wasm::FieldType fieldType, unsigned size)
     {
         unsigned elementSize = fieldType.type.elementSize();
-        if (UNLIKELY(productOverflows<uint32_t>(elementSize, size) || elementSize * size > Wasm::maxArraySizeInBytes))
+        if (productOverflows<uint32_t>(elementSize, size) || elementSize * size > Wasm::maxArraySizeInBytes) [[unlikely]]
             return std::nullopt;
         return sizeof(JSWebAssemblyArray) + size * elementSize + static_cast<size_t>(needsAlignmentCheck(fieldType.type) * v128AlignmentShift);
     }

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
@@ -94,7 +94,7 @@ ALWAYS_INLINE std::span<const uint8_t> getWasmBufferFromValue(JSGlobalObject* gl
             RETURN_IF_EXCEPTION(throwScope, { });
         } else {
             IdempotentArrayBufferByteLengthGetter<std::memory_order_relaxed> getter;
-            if (UNLIKELY(!jsCast<JSDataView*>(arrayBufferView)->viewByteLength(getter))) {
+            if (!jsCast<JSDataView*>(arrayBufferView)->viewByteLength(getter)) [[unlikely]] {
                 throwTypeError(globalObject, throwScope, typedArrayBufferHasBeenDetachedErrorMessage);
                 return { };
             }

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -666,7 +666,7 @@ bool JSWebAssemblyInstance::evaluateConstantExpression(uint64_t index, Type expe
 {
     const auto& constantExpression = m_module->moduleInformation().constantExpressions[index];
     auto evalResult = evaluateExtendedConstExpr(constantExpression, this, m_module->moduleInformation(), expectedType);
-    if (UNLIKELY(!evalResult.has_value()))
+    if (!evalResult.has_value()) [[unlikely]]
         return false;
 
     result = evalResult.value();

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
@@ -52,7 +52,7 @@ JSWebAssemblyStruct* JSWebAssemblyStruct::tryCreate(VM& vm, WebAssemblyGCStructu
 {
     auto* structType = structure->typeDefinition().as<Wasm::StructType>();
     auto* cell = tryAllocateCell<JSWebAssemblyStruct>(vm, TrailingArrayType::allocationSize(structType->instancePayloadSize()));
-    if (UNLIKELY(!cell))
+    if (!cell) [[unlikely]]
         return nullptr;
 
     auto* structValue = new (NotNull, cell) JSWebAssemblyStruct(vm, structure);

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
@@ -103,7 +103,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(TypeIn
     // https://webassembly.github.io/spec/js-api/index.html#exported-function-exotic-objects
     // If parameters or results contain v128, throw a TypeError.
     // Note: the above error is thrown each time the [[Call]] method is invoked.
-    if (UNLIKELY(signature.argumentsOrResultsIncludeV128() || signature.argumentsOrResultsIncludeExnref()))
+    if (signature.argumentsOrResultsIncludeV128() || signature.argumentsOrResultsIncludeExnref()) [[unlikely]]
         return handleBadImportTypeUse(jit, importIndex, ExceptionType::TypeErrorInvalidValueUse);
 
     // Here we assume that the JS calling convention saves at least all the wasm callee saved. We therefore don't need to save and restore more registers since the wasm callee already took care of this.
@@ -502,7 +502,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(TypeIn
     }
 
     LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::WasmThunk, JITCompilationCanFail);
-    if (UNLIKELY(patchBuffer.didFailToAllocate()))
+    if (patchBuffer.didFailToAllocate()) [[unlikely]]
         return makeUnexpected(BindingFailure::OutOfMemory);
 
     return FINALIZE_WASM_CODE(patchBuffer, WasmEntryPtrTag, nullptr, "WebAssembly->JavaScript import[%i] %s", importIndex, signature.toString().ascii().data());

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp
@@ -54,7 +54,7 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyException, (JSGlobalObject* globa
     if (!tag)
         return throwVMTypeError(globalObject, scope, "WebAssembly.Exception constructor expects the first argument to be a WebAssembly.Tag"_s);
 
-    if (UNLIKELY(&tag->tag() == &Wasm::Tag::jsExceptionTag()))
+    if (&tag->tag() == &Wasm::Tag::jsExceptionTag()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "WebAssembly.Exception constructor does not accept WebAssembly.JSTag"_s);
 
     const auto& tagFunctionType = tag->type();
@@ -62,7 +62,7 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyException, (JSGlobalObject* globa
     values.ensureCapacity(tagFunctionType.argumentCount());
     forEachInIterable(globalObject, tagParameters, [&] (VM&, JSGlobalObject*, JSValue nextValue) {
         values.append(nextValue);
-        if (UNLIKELY(values.hasOverflowed()))
+        if (values.hasOverflowed()) [[unlikely]]
             throwOutOfMemoryError(globalObject, scope);
     });
     RETURN_IF_EXCEPTION(scope, { });
@@ -74,7 +74,7 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyException, (JSGlobalObject* globa
     FixedVector<uint64_t> payload(values.size());
     for (unsigned i = 0; i < values.size(); ++i) {
         auto type = tagFunctionType.argumentType(i);
-        if (UNLIKELY(type.kind == Wasm::TypeKind::V128 || isExnref(type)))
+        if (type.kind == Wasm::TypeKind::V128 || isExnref(type)) [[unlikely]]
             return throwVMTypeError(globalObject, scope, "WebAssembly.Exception constructor expects payload includes neither v128 nor exnref."_s);
         payload[i] = toWebAssemblyValue(globalObject, type, values.at(i));
         RETURN_IF_EXCEPTION(scope, { });

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionPrototype.cpp
@@ -87,7 +87,7 @@ ALWAYS_INLINE static JSWebAssemblyException* getException(JSGlobalObject* global
         return nullptr;
     }
     auto* tag = jsDynamicCast<JSWebAssemblyException*>(thisValue.asCell());
-    if (LIKELY(tag))
+    if (tag) [[likely]]
         return tag;
     throwTypeError(globalObject, scope, "WebAssembly.Exception operation called on non-Exception object"_s);
     return nullptr;
@@ -105,20 +105,20 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyExceptionProtoFuncGetArg, (JSGlobalObject* g
     JSWebAssemblyException* jsException = getException(globalObject, callFrame->thisValue());
     RETURN_IF_EXCEPTION(throwScope, { });
 
-    if (UNLIKELY(callFrame->argumentCount() < 2))
+    if (callFrame->argumentCount() < 2) [[unlikely]]
         return JSValue::encode(throwException(globalObject, throwScope, createNotEnoughArgumentsError(globalObject)));
 
     JSWebAssemblyTag* tag = jsDynamicCast<JSWebAssemblyTag*>(callFrame->argument(0));
-    if (UNLIKELY(!tag))
+    if (!tag) [[unlikely]]
         return throwVMTypeError(globalObject, throwScope, formatMessage("First argument must be a WebAssembly.Tag"_s));
 
     uint32_t index = toNonWrappingUint32(globalObject, callFrame->argument(1), ErrorType::RangeError);
     RETURN_IF_EXCEPTION(throwScope, { });
 
-    if (UNLIKELY(jsException->tag() != tag->tag()))
+    if (jsException->tag() != tag->tag()) [[unlikely]]
         return throwVMTypeError(globalObject, throwScope, formatMessage("First argument does not match the exception tag"_s));
 
-    if (UNLIKELY(index >= tag->tag().parameterCount()))
+    if (index >= tag->tag().parameterCount()) [[unlikely]]
         return throwVMRangeError(globalObject, throwScope, formatMessage("Index out of range"_s));
 
     RELEASE_AND_RETURN(throwScope, JSValue::encode(jsException->getArg(globalObject, index)));
@@ -132,7 +132,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyExceptionProtoFuncIs, (JSGlobalObject* globa
     JSWebAssemblyException* jsException = getException(globalObject, callFrame->thisValue());
     RETURN_IF_EXCEPTION(throwScope, { });
 
-    if (UNLIKELY(callFrame->argumentCount() < 1))
+    if (callFrame->argumentCount() < 1) [[unlikely]]
         return JSValue::encode(throwException(globalObject, throwScope, createNotEnoughArgumentsError(globalObject)));
 
     JSWebAssemblyTag* tag = jsDynamicCast<JSWebAssemblyTag*>(callFrame->argument(0));

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalPrototype.cpp
@@ -109,7 +109,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyGlobalProtoSetterFuncValue, (JSGlobalObject*
     VM& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    if (UNLIKELY(callFrame->argumentCount() < 1))
+    if (callFrame->argumentCount() < 1) [[unlikely]]
         return JSValue::encode(throwException(globalObject, throwScope, createNotEnoughArgumentsError(globalObject)));
 
     JSWebAssemblyGlobal* global = getGlobal(globalObject, vm, callFrame->thisValue());

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp
@@ -106,7 +106,7 @@ JSWebAssemblyMemory* WebAssemblyMemoryConstructor::createMemoryFromDescriptor(JS
     // Even though Options::useSharedArrayBuffer() is false, we can create SharedArrayBuffer through wasm shared memory.
     // But we cannot send SharedArrayBuffer to the other workers, so it is not effective.
     MemorySharingMode sharingMode = MemorySharingMode::Default;
-    if (LIKELY(Options::useWasmFaultSignalHandler())) {
+    if (Options::useWasmFaultSignalHandler()) [[likely]] {
         JSValue sharedValue = memoryDescriptor->get(globalObject, Identifier::fromString(vm, "shared"_s));
         RETURN_IF_EXCEPTION(throwScope, { });
         bool shared = sharedValue.toBoolean(globalObject);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp
@@ -72,7 +72,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyModuleCustomSections, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    if (UNLIKELY(callFrame->argumentCount() < 2))
+    if (callFrame->argumentCount() < 2) [[unlikely]]
         return JSValue::encode(throwException(globalObject, throwScope, createNotEnoughArgumentsError(globalObject)));
 
     JSWebAssemblyModule* module = jsDynamicCast<JSWebAssemblyModule*>(callFrame->uncheckedArgument(0));

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -778,7 +778,7 @@ JSValue WebAssemblyModuleRecord::evaluateConstantExpression(JSGlobalObject* glob
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto evalResult = Wasm::evaluateExtendedConstExpr(constantExpression, m_instance.get(), info, expectedType);
-    if (UNLIKELY(!evalResult.has_value()))
+    if (!evalResult.has_value()) [[unlikely]]
         return JSValue(throwException(globalObject, scope, createJSWebAssemblyRuntimeError(globalObject, vm, makeString("couldn't evaluate constant expression: "_s, evalResult.error()))));
 
     result = evalResult.value();
@@ -868,7 +868,7 @@ JSValue WebAssemblyModuleRecord::evaluate(JSGlobalObject* globalObject)
     // Validation of all element ranges comes before all Table and Memory initialization.
     forEachActiveElement([&](const Wasm::Element& element, uint32_t tableIndex, uint32_t elementIndex) {
         int64_t lastWrittenIndex = static_cast<int64_t>(elementIndex) + static_cast<int64_t>(element.initTypes.size()) - 1;
-        if (UNLIKELY(lastWrittenIndex >= m_instance->table(tableIndex)->length())) {
+        if (lastWrittenIndex >= m_instance->table(tableIndex)->length()) [[unlikely]] {
             exception = JSValue(throwException(globalObject, scope, createJSWebAssemblyRuntimeError(globalObject, vm, "Element is trying to set an out of bounds table index"_s)));
             return IterationStatus::Done;
         }
@@ -882,11 +882,11 @@ JSValue WebAssemblyModuleRecord::evaluate(JSGlobalObject* globalObject)
 
     // Validation of all segment ranges comes before all Table and Memory initialization.
     forEachActiveDataSegment([&](uint8_t* memory, uint64_t sizeInBytes, const Wasm::Segment::Ptr& segment, uint32_t offset) {
-        if (UNLIKELY(sizeInBytes < segment->sizeInBytes)) {
+        if (sizeInBytes < segment->sizeInBytes) [[unlikely]] {
             exception = dataSegmentFail(globalObject, vm, scope, sizeInBytes, segment->sizeInBytes, offset, ", segment is too big"_s);
             return IterationStatus::Done;
         }
-        if (UNLIKELY(offset > sizeInBytes - segment->sizeInBytes)) {
+        if (offset > sizeInBytes - segment->sizeInBytes) [[unlikely]] {
             exception = dataSegmentFail(globalObject, vm, scope, sizeInBytes, segment->sizeInBytes, offset, ", segment writes outside of memory"_s);
             return IterationStatus::Done;
         }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTagPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTagPrototype.cpp
@@ -86,7 +86,7 @@ ALWAYS_INLINE static JSWebAssemblyTag* getTag(JSGlobalObject* globalObject, JSVa
         return nullptr;
     }
     auto* tag = jsDynamicCast<JSWebAssemblyTag*>(thisValue.asCell());
-    if (LIKELY(tag))
+    if (tag) [[likely]]
         return tag;
     throwTypeError(globalObject, scope, "WebAssembly.Tag operation called on non-Tag object"_s);
     return nullptr;
@@ -111,7 +111,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyTagProtoFuncType, (JSGlobalObject* globalObj
         argList.append(valueString);
     }
 
-    if (UNLIKELY(argList.hasOverflowed())) {
+    if (argList.hasOverflowed()) [[unlikely]] {
         throwOutOfMemoryError(globalObject, throwScope);
         return encodedJSValue();
     }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp
@@ -51,7 +51,7 @@ WebAssemblyWrapperFunction* WebAssemblyWrapperFunction::create(VM& vm, JSGlobalO
     String name = emptyString();
     const auto& signature = Wasm::TypeInformation::getFunctionSignature(typeIndex);
     NativeExecutable* executable = nullptr;
-    if (UNLIKELY(signature.argumentsOrResultsIncludeV128() || signature.argumentsOrResultsIncludeExnref()))
+    if (signature.argumentsOrResultsIncludeV128() || signature.argumentsOrResultsIncludeExnref()) [[unlikely]]
         executable = vm.getHostFunction(callWebAssemblyWrapperFunctionIncludingInvalidValues, ImplementationVisibility::Public, NoIntrinsic, callHostFunctionAsConstructor, nullptr, name);
     else
         executable = vm.getHostFunction(callWebAssemblyWrapperFunction, ImplementationVisibility::Public, NoIntrinsic, callHostFunctionAsConstructor, nullptr, name);

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -136,7 +136,7 @@ public:
     {
         size_t size = DisjunctionContext::allocationSize(disjunction->m_frameSize);
         auto* newAllocatorPool = allocatorPool->ensureCapacity(size);
-        if (UNLIKELY(!newAllocatorPool))
+        if (!newAllocatorPool) [[unlikely]]
             return nullptr;
         allocatorPool = newAllocatorPool;
         return new (allocatorPool->alloc(size)) DisjunctionContext();
@@ -254,7 +254,7 @@ public:
 
         size_t size = Checked<size_t>(ParenthesesDisjunctionContext::allocationSize(numNestedSubpatterns, numDuplicateNamedGroups)) + DisjunctionContext::allocationSize(disjunction->m_frameSize);
         auto* newAllocatorPool = allocatorPool->ensureCapacity(size);
-        if (UNLIKELY(!newAllocatorPool))
+        if (!newAllocatorPool) [[unlikely]]
             return nullptr;
         allocatorPool = newAllocatorPool;
         return new (allocatorPool->alloc(size)) ParenthesesDisjunctionContext(pattern, output, term, numDuplicateNamedGroups, duplicateNamedCaptureGroups);

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -4572,7 +4572,7 @@ class YarrGenerator final : public YarrJITInfo {
                 Checked<unsigned, RecordOverflow> checkedOffsetResult(checkedOffset);
                 checkedOffsetResult += lastOp.m_checkAdjust;
 
-                if (UNLIKELY(checkedOffsetResult.hasOverflowed())) {
+                if (checkedOffsetResult.hasOverflowed()) [[unlikely]] {
                     m_failureReason = JITFailureReason::OffsetTooLarge;
                     return;
                 }
@@ -5257,7 +5257,7 @@ public:
             return;
         }
 
-        if (UNLIKELY(Options::dumpDisassembly() || Options::dumpRegExpDisassembly()))
+        if (Options::dumpDisassembly() || Options::dumpRegExpDisassembly()) [[unlikely]]
             m_disassembler = makeUnique<YarrDisassembler>(this);
 
         if (m_disassembler)
@@ -5426,7 +5426,7 @@ public:
         RELEASE_ASSERT(!m_containsNestedSubpatterns);
 #endif
 
-        if (UNLIKELY(Options::dumpDisassembly() || Options::dumpRegExpDisassembly()))
+        if (Options::dumpDisassembly() || Options::dumpRegExpDisassembly()) [[unlikely]]
             m_disassembler = makeUnique<YarrDisassembler>(this);
 
         if (m_disassembler)
@@ -5964,7 +5964,7 @@ void jitCompile(YarrPattern& pattern, StringView patternString, CharSize charSiz
     YarrGenerator<YarrJITDefaultRegisters>(masm, vm, &codeBlock, jitRegisters, pattern, patternString, charSize, mode, sampleString).compile(codeBlock);
 
     if (auto failureReason = codeBlock.failureReason()) {
-        if (UNLIKELY(Options::dumpCompiledRegExpPatterns())) {
+        if (Options::dumpCompiledRegExpPatterns()) [[unlikely]] {
             pattern.dumpPatternString(WTF::dataFile(), patternString);
             dataLog(" : ");
             dumpCompileFailure(*failureReason);

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -2500,7 +2500,7 @@ ErrorCode YarrPattern::compile(StringView patternString)
 
     constructor.extractSpecificPattern();
 
-    if (UNLIKELY(Options::dumpCompiledRegExpPatterns()))
+    if (Options::dumpCompiledRegExpPatterns()) [[unlikely]]
         dumpPattern(patternString);
 
     return ErrorCode::NoError;


### PR DESCRIPTION
#### 5e3cb59618f7fa2062a03fb28bd0bff4327f1002
<pre>
Further adopt C++20&apos;s [[likely]] / [[unlikely]] in JSC
<a href="https://bugs.webkit.org/show_bug.cgi?id=292505">https://bugs.webkit.org/show_bug.cgi?id=292505</a>

Reviewed by Sosuke Suzuki.

* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::fastIncludes):
(JSC::JSArray::fastToSpliced):
(JSC::JSArray::appendMemcpy):
(JSC::JSArray::fastSlice):
(JSC::JSArray::shiftCountWithAnyIndexingType):
(JSC::JSArray::unshiftCountWithAnyIndexingType):
(JSC::tryCloneArrayFromFast):
* Source/JavaScriptCore/runtime/JSArray.h:
(JSC::JSArray::tryCreate):
(JSC::moveArrayElements):
* Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp:
(JSC::arrayBufferSlice):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::arrayBufferCopyAndDetach):
(JSC::arrayBufferProtoFuncTransferImpl):
* Source/JavaScriptCore/runtime/JSArrayBufferView.h:
(JSC::JSArrayBufferView::byteOffset const):
(JSC::JSArrayBufferView::isOutOfBounds const):
* Source/JavaScriptCore/runtime/JSArrayBufferViewInlines.h:
(JSC::isArrayBufferViewOutOfBounds):
(JSC::integerIndexedObjectLength):
(JSC::integerIndexedObjectByteLength):
(JSC::validateTypedArray):
* Source/JavaScriptCore/runtime/JSArrayInlines.h:
(JSC::JSArray::holesMustForwardToPrototype const):
(JSC::toLength):
(JSC::JSArray::pushInline):
* Source/JavaScriptCore/runtime/JSBigInt.cpp:
(JSC::JSBigInt::createWithLength):
(JSC::JSBigInt::createFrom):
(JSC::JSBigInt::rightTrim):
(JSC::JSBigInt::parseInt):
* Source/JavaScriptCore/runtime/JSBigInt.h:
(JSC::tryConvertToBigInt32):
* Source/JavaScriptCore/runtime/JSBoundFunction.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::getBoundFunctionStructure):
* Source/JavaScriptCore/runtime/JSCJSValueInlines.h:
(JSC::JSValue::toUInt32AfterToNumeric const):
(JSC::JSValue::get const):
(JSC::isThisValueAltered):
* Source/JavaScriptCore/runtime/JSCast.h:
(JSC::jsDynamicCast):
* Source/JavaScriptCore/runtime/JSCellInlines.h:
(JSC::JSCellLock::lock):
(JSC::JSCellLock::unlock):
(JSC::JSCell::putInline):
* Source/JavaScriptCore/runtime/JSDateMath.cpp:
(JSC::DateCache::DSTCache::localTimeOffset):
* Source/JavaScriptCore/runtime/JSDateMath.h:
(JSC::DateCache::resetIfNecessary):
* Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp:
(JSC::JSFinalizationRegistry::finalizeUnconditionally):
* Source/JavaScriptCore/runtime/JSFunction.cpp:
(JSC::JSFunction::prototypeForConstruction):
* Source/JavaScriptCore/runtime/JSFunction.h:
(JSC::JSFunction::ensureRareData):
* Source/JavaScriptCore/runtime/JSFunctionInlines.h:
(JSC::makeNameWithOutOfMemoryCheck):
(JSC::JSFunction::ensureRareDataAndObjectAllocationProfile):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::decodeHexImpl):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h:
(JSC::constructGenericTypedArrayViewFromIterator):
(JSC::constructGenericTypedArrayViewWithArguments):
(JSC::constructGenericTypedArrayViewImpl):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::copyFromInt32ShapeArray):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::setFromArrayLike):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::sort):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::speciesConstruct):
(JSC::typedArrayViewForEachImpl):
(JSC::genericTypedArrayViewProtoFuncSet):
(JSC::genericTypedArrayViewProtoFuncSortImpl):
(JSC::genericTypedArrayViewProtoFuncSlice):
(JSC::genericTypedArrayViewProtoFuncSubarray):
(JSC::validateIntegerIndex):
(JSC::genericTypedArrayViewProtoFuncWith):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSGlobalObject::init):
(JSC::JSGlobalObject::canDeclareGlobalFunction):
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h:
(JSC::tryCreateContiguousArrayWithPattern):
(JSC::createPatternFilledArray):
(JSC::JSGlobalObject::canDeclareGlobalVar):
* Source/JavaScriptCore/runtime/JSImmutableButterfly.h:
(JSC::JSImmutableButterfly::tryCreate):
* Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::runJSMicrotask):
* Source/JavaScriptCore/runtime/JSModuleRecord.cpp:
(JSC::JSModuleRecord::link):
(JSC::JSModuleRecord::instantiateDeclarations):
* Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h:
(JSC::JSONAtomStringCache::makeIdentifier):
(JSC::JSONAtomStringCache::existingIdentifier):
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::Stringifier::stringify):
(JSC::Stringifier::appendStringifiedValue):
(JSC::Stringifier::Holder::appendNextProperty):
(JSC::bufferMode&gt;::hasRemainingCapacitySlow):
(JSC::bufferMode&gt;::mayHaveToJSON const):
(JSC::bufferMode&gt;::append):
(JSC::stringCopySameType):
(JSC::stringCopyUpconvert):
(JSC::stringify):
(JSC::Walker::walk):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::calculatedClassName):
(JSC::JSObject::putInlineSlow):
(JSC::JSObject::definePropertyOnReceiver):
(JSC::JSObject::notifyPresenceOfIndexedAccessors):
(JSC::JSObject::ensureArrayStorageSlow):
(JSC::JSObject::setPrototypeDirect):
(JSC::JSObject::setPrototypeWithCycleCheck):
(JSC::JSObject::deleteProperty):
(JSC::JSObject::getPropertyNames):
(JSC::JSObject::toString const):
(JSC::JSObject::putByIndexBeyondVectorLengthWithArrayStorage):
(JSC::JSObject::putByIndexBeyondVectorLength):
(JSC::JSObject::putDirectIndexBeyondVectorLengthWithArrayStorage):
(JSC::JSObject::putDirectIndexSlowOrBeyondVectorLength):
(JSC::JSObject::increaseVectorLength):
(JSC::JSObject::putOwnDataPropertyBatching):
* Source/JavaScriptCore/runtime/JSObject.h:
(JSC::JSObject::canGetIndexQuickly const):
(JSC::JSObject::tryGetIndexQuickly const):
(JSC::JSObject::tryMakeWritableInt32):
(JSC::JSObject::tryMakeWritableDouble):
(JSC::JSObject::tryMakeWritableContiguous):
(JSC::JSObject::ensureArrayStorage):
(JSC::JSObject::getPrototype):
(JSC::JSObject::getPropertySlot):
(JSC::JSObject::butterflyPreCapacity):
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::canPerformFastPutInline):
(JSC::JSObject::getPropertySlot):
(JSC::JSObject::getNonIndexPropertySlot):
(JSC::JSObject::getOwnPropertySlotInline):
(JSC::JSObject::getIfPropertyExists):
(JSC::JSObject::noSideEffectMayHaveNonIndexProperty):
(JSC::JSObject::putInlineForJSObject):
(JSC::JSObject::hasOwnProperty const):
(JSC::JSObject::putDirectInternal):
(JSC::JSObject::didBecomePrototype):
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::rejectWithCaughtException):
* Source/JavaScriptCore/runtime/JSPropertyNameEnumerator.cpp:
(JSC::JSPropertyNameEnumerator::tryCreate):
(JSC::getEnumerablePropertyNames):
* Source/JavaScriptCore/runtime/JSPropertyNameEnumerator.h:
(JSC::propertyNameEnumerator):
* Source/JavaScriptCore/runtime/JSRawJSONObject.cpp:
(JSC::JSRawJSONObject::rawJSON):
* Source/JavaScriptCore/runtime/JSRemoteFunction.cpp:
(JSC::JSRemoteFunction::finishCreation):
* Source/JavaScriptCore/runtime/JSScope.cpp:
(JSC::JSScope::resolve):
* Source/JavaScriptCore/runtime/JSString.h:
* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::JSString::tryReplaceOneCharImpl):
(JSC::JSRopeString::resolveToBuffer):
* Source/JavaScriptCore/runtime/JSStringJoiner.cpp:
(JSC::JSStringJoiner::joinImpl):
(JSC::JSOnlyStringsJoiner::joinImpl):
* Source/JavaScriptCore/runtime/JSStringJoiner.h:
(JSC::JSStringJoiner::reserveCapacity):
(JSC::JSStringJoiner::append):
* Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::createTypedArrayIteratorObject):
* Source/JavaScriptCore/runtime/LazyProperty.h:
(JSC::LazyProperty::getInitializedOnMainThread const):
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::reviverMode&gt;::Lexer::lex):
(JSC::reviverMode&gt;::Lexer::lexString):
(JSC::requires):
(JSC::reviverMode&gt;::parse):
* Source/JavaScriptCore/runtime/MapConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/MapPrototype.cpp:
(JSC::getMap):
* Source/JavaScriptCore/runtime/MegamorphicCache.h:
(JSC::MegamorphicCache::bumpEpoch):
* Source/JavaScriptCore/runtime/MicrotaskQueue.cpp:
(JSC::MicrotaskQueue::enqueue):
* Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h:
(JSC::MicrotaskQueue::performMicrotaskCheckpoint):
* Source/JavaScriptCore/runtime/ObjectConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::toPropertyDescriptor):
(JSC::defineProperties):
(JSC::ownPropertyKeys):
* Source/JavaScriptCore/runtime/ObjectPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ObjectPrototypeInlines.h:
* Source/JavaScriptCore/runtime/Operations.cpp:
(JSC::jsTypeStringForValueWithConcurrency):
* Source/JavaScriptCore/runtime/Operations.h:
(JSC::jsAddNonNumber):
(JSC::jsURShift):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::executeDumpOptions):
(JSC::Options::finalize):
* Source/JavaScriptCore/runtime/OrderedHashTableHelper.h:
(JSC::OrderedHashTableHelper::tryCreate):
(JSC::OrderedHashTableHelper::addImpl):
* Source/JavaScriptCore/runtime/ProgramExecutable.cpp:
(JSC::ProgramExecutable::initializeGlobalProperties):
* Source/JavaScriptCore/runtime/PropertyNameArray.h:
(JSC::PropertyNameArray::isUidMatchedToTypeMode):
* Source/JavaScriptCore/runtime/ReflectObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/RegExpCache.h:
* Source/JavaScriptCore/runtime/RegExpConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::regExpCreate):
(JSC::constructRegExp):
* Source/JavaScriptCore/runtime/RegExpObject.h:
* Source/JavaScriptCore/runtime/RegExpObjectInlines.h:
(JSC::getRegExpObjectLastIndexAsUnsigned):
* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ResourceExhaustion.h:
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::SamplingProfiler::timerLoop):
* Source/JavaScriptCore/runtime/ScopedArguments.cpp:
(JSC::ScopedArguments::unmapArgument):
(JSC::ScopedArguments::isIteratorProtocolFastAndNonObservable):
* Source/JavaScriptCore/runtime/ScopedArguments.h:
* Source/JavaScriptCore/runtime/ScopedArgumentsTable.cpp:
(JSC::ScopedArgumentsTable::tryCreate):
(JSC::ScopedArgumentsTable::trySetLength):
(JSC::ScopedArgumentsTable::trySet):
* Source/JavaScriptCore/runtime/ScriptExecutable.cpp:
(JSC::ScriptExecutable::installCode):
(JSC::ScriptExecutable::prepareForExecutionImpl):
* Source/JavaScriptCore/runtime/SetConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/SetPrototype.cpp:
(JSC::getSet):
* Source/JavaScriptCore/runtime/SmallStrings.cpp:
(JSC::SmallStrings::singleCharacterStringRep):
(JSC::SmallStrings::existingSingleCharacterStringRep):
* Source/JavaScriptCore/runtime/SparseArrayValueMap.cpp:
(JSC::SparseArrayEntry::get const):
* Source/JavaScriptCore/runtime/StableSort.h:
(JSC::coerceComparatorResultToBoolean):
* Source/JavaScriptCore/runtime/StringConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::substituteBackreferencesInline):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::tryMakeReplacedString):
(JSC::stringReplaceAllStringString):
(JSC::replaceUsingStringSearch):
(JSC::removeAllUsingRegExpSearch):
(JSC::replaceAllWithCacheUsingRegExpSearchThreeArguments):
(JSC::replaceAllWithCacheUsingRegExpSearch):
(JSC::replaceOneWithStringUsingRegExpSearch):
(JSC::replace):
* Source/JavaScriptCore/runtime/Structure.h:
(JSC::Structure::startWatchingInternalPropertiesIfNecessary):
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::Structure::holesMustForwardToPrototype const):
(JSC::Structure::didReplaceProperty):
* Source/JavaScriptCore/runtime/SymbolTable.cpp:
(JSC::SymbolTable::localToEntry):
* Source/JavaScriptCore/runtime/SymbolTable.h:
(JSC::SymbolTableEntry::operator=):
(JSC::SymbolTableEntry::freeFatEntry):
* Source/JavaScriptCore/runtime/TemporalDuration.cpp:
(JSC::appendInteger):
(JSC::TemporalDuration::toString):
* Source/JavaScriptCore/runtime/ThrowScope.cpp:
(JSC::ThrowScope::simulateThrow):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
(JSC::VM::~VM):
(JSC::VM::hasExceptionsAfterHandlingTraps):
(JSC::VM::throwException):
(JSC::logSanitizeStack):
(JSC::VM::drainMicrotasks):
(JSC::VM::verifyExceptionCheckNeedIsSatisfied):
(JSC::VM::executeEntryScopeServicesOnEntry):
(JSC::VM::executeEntryScopeServicesOnExit):
* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::orderedHashTableDeletedValue):
(JSC::VM::orderedHashTableSentinel):
(JSC::VM::emptyPropertyNameEnumerator):
* Source/JavaScriptCore/runtime/VMEntryScope.cpp:
(JSC::VMEntryScope::setUpSlow):
(JSC::VMEntryScope::tearDownSlow):
* Source/JavaScriptCore/runtime/VMInlines.h:
(JSC::VM::logEvent):
(JSC::VM::topJSCallFrame const):
(JSC::VM::forEachDebugger):
* Source/JavaScriptCore/runtime/VMTraps.cpp:
(JSC::VMTraps::handleTraps):
* Source/JavaScriptCore/runtime/VMTraps.h:
(JSC::VMTraps::needHandling const):
* Source/JavaScriptCore/runtime/VMTrapsInlines.h:
(JSC::VMTraps::deferTermination):
(JSC::VMTraps::undoDeferTermination):
* Source/JavaScriptCore/runtime/WeakMapPrototype.cpp:
(JSC::getWeakMap):
* Source/JavaScriptCore/runtime/WeakObjectRefConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/WeakObjectRefPrototype.cpp:
(JSC::getWeakRef):
* Source/JavaScriptCore/runtime/WeakSetConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/WeakSetPrototype.cpp:
(JSC::getWeakSet):
* Source/JavaScriptCore/tools/CompilerTimingScope.cpp:
(JSC::CompilerTimingScope::CompilerTimingScope):
(JSC::CompilerTimingScope::~CompilerTimingScope):
* Source/JavaScriptCore/tools/HeapVerifier.cpp:
(JSC::HeapVerifier::validateJSCell):
* Source/JavaScriptCore/tools/Integrity.h:
* Source/JavaScriptCore/tools/IntegrityInlines.h:
(JSC::Integrity::Random::shouldAudit):
(JSC::Integrity::auditCellMinimally):
(JSC::Integrity::auditCellRandomly):
(JSC::Integrity::doAudit):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::BBQJIT):
(JSC::Wasm::BBQJITImpl::BBQJIT::addConstant):
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicLoad):
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicStore):
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicBinaryRMW):
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicCompareExchange):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTopLevel):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::load):
(JSC::Wasm::BBQJITImpl::BBQJIT::store):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::load):
(JSC::Wasm::BBQJITImpl::BBQJIT::store):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Add):
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::dumpDisassembly):
* Source/JavaScriptCore/wasm/WasmBinding.cpp:
(JSC::Wasm::wasmToWasm):
* Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp:
(JSC::Wasm::CalleeGroup::releaseBBQCallee):
* Source/JavaScriptCore/wasm/WasmEntryPlan.cpp:
(JSC::Wasm::EntryPlan::compileFunctions):
(JSC::Wasm::EntryPlan::generateStubsIfNecessary):
(JSC::Wasm::EntryPlan::generateWasmToWasmStubs):
(JSC::Wasm::EntryPlan::generateWasmToJSStubs):
* Source/JavaScriptCore/wasm/WasmEntryPlan.h:
(JSC::Wasm::EntryPlan::tryReserveCapacity):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser::validationFail const):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parse):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseBody):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseNestedBlocksEagerly):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseUnreachableExpression):
* Source/JavaScriptCore/wasm/WasmGlobal.cpp:
(JSC::Wasm::Global::get const):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::jitCompileAndSetHeuristics):
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::jsNullConstant):
(JSC::Wasm::LLIntGenerator::zeroConstant):
(JSC::Wasm::LLIntGenerator::addConstantWithoutPush):
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::compileFunction):
* Source/JavaScriptCore/wasm/WasmMemory.cpp:
(JSC::Wasm::Memory::tryCreate):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::load):
(JSC::Wasm::OMGIRGenerator::store):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::load):
(JSC::Wasm::OMGIRGenerator::store):
* Source/JavaScriptCore/wasm/WasmOMGPlan.cpp:
(JSC::Wasm::OMGPlan::dumpDisassembly):
* Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp:
(JSC::Wasm::OSREntryPlan::dumpDisassembly):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
(JSC::Wasm::triggerOMGReplacementCompile):
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::tryFillArray):
(JSC::Wasm::arrayNewData):
(JSC::Wasm::arrayNewElem):
* Source/JavaScriptCore/wasm/WasmParser.h:
* Source/JavaScriptCore/wasm/WasmPlan.cpp:
(JSC::Wasm::Plan::beginCompilerSignpost const):
(JSC::Wasm::Plan::endCompilerSignpost const):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseTableHelper):
(JSC::Wasm::SectionParser::parseMemoryHelper):
* Source/JavaScriptCore/wasm/WasmSectionParser.h:
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::jitCompileAndSetHeuristics):
(JSC::LLInt::WASM_SLOW_PATH_DECL):
* Source/JavaScriptCore/wasm/WasmStreamingParser.cpp:
(JSC::Wasm::StreamingParser::addBytes):
(JSC::Wasm::StreamingParser::finalize):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::TypeDefinition::unroll const):
* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
(JSC::Wasm::FunctionSignature::jsToWasmICEntrypoint const):
* Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp:
(JSC::instantiate):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp:
(JSC::JSWebAssemblyArray::tryCreate):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h:
(JSC::getWasmBufferFromValue):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::evaluateConstantExpression):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp:
(JSC::JSWebAssemblyStruct::tryCreate):
* Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
(JSC::Wasm::wasmToJS):
* Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyExceptionPrototype.cpp:
(JSC::getException):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyGlobalPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp:
(JSC::WebAssemblyMemoryConstructor::createMemoryFromDescriptor):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::evaluateConstantExpression):
(JSC::WebAssemblyModuleRecord::evaluate):
* Source/JavaScriptCore/wasm/js/WebAssemblyTagPrototype.cpp:
(JSC::getTag):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp:
(JSC::WebAssemblyWrapperFunction::create):
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::allocDisjunctionContext):
(JSC::Yarr::Interpreter::allocParenthesesDisjunctionContext):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::jitCompile):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPattern::compile):

Canonical link: <a href="https://commits.webkit.org/294484@main">https://commits.webkit.org/294484@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98e117e84023e62b446fbf7f7adbbe625431a66a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11999 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107174 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52649 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104055 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30190 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/77658 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34658 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105022 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57994 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16835 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10135 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52008 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94687 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86675 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10208 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109547 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100625 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29148 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21472 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86630 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29509 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88314 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86209 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21928 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30997 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8715 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23346 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29076 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34371 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124250 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28887 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34512 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32210 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30446 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->