### PR TITLE
Introduce ModelPlayerTransformState protocol that contains info about the model's bounds and transform

### DIFF
--- a/Source/WebCore/Modules/model-element/ModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.cpp
@@ -27,7 +27,9 @@
 #include "ModelPlayer.h"
 
 #include "Color.h"
+#include "FloatPoint3D.h"
 #include "ModelPlayerAnimationState.h"
+#include "ModelPlayerTransformState.h"
 #include "TransformationMatrix.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -42,6 +44,26 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ModelPlayer);
 ModelPlayer::~ModelPlayer() = default;
 
 std::optional<ModelPlayerAnimationState> ModelPlayer::currentAnimationState() const
+{
+    return std::nullopt;
+}
+
+std::optional<std::unique_ptr<ModelPlayerTransformState>> ModelPlayer::currentTransformState() const
+{
+    return std::nullopt;
+}
+
+std::optional<FloatPoint3D> ModelPlayer::boundingBoxCenter() const
+{
+    return std::nullopt;
+}
+
+std::optional<FloatPoint3D> ModelPlayer::boundingBoxExtents() const
+{
+    return std::nullopt;
+}
+
+std::optional<TransformationMatrix> ModelPlayer::entityTransform() const
 {
     return std::nullopt;
 }

--- a/Source/WebCore/Modules/model-element/ModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.h
@@ -44,8 +44,10 @@
 namespace WebCore {
 
 class Color;
+class FloatPoint3D;
 class Model;
 class ModelPlayerAnimationState;
+class ModelPlayerTransformState;
 class SharedBuffer;
 class TransformationMatrix;
 
@@ -59,11 +61,15 @@ public:
 #endif
 
     virtual std::optional<ModelPlayerAnimationState> currentAnimationState() const;
+    virtual std::optional<std::unique_ptr<ModelPlayerTransformState>> currentTransformState() const;
 
     virtual void load(Model&, LayoutSize) = 0;
     virtual void sizeDidChange(LayoutSize) = 0;
     virtual PlatformLayer* layer() = 0;
     virtual std::optional<LayerHostingContextIdentifier> layerHostingContextIdentifier() = 0;
+    virtual std::optional<FloatPoint3D> boundingBoxCenter() const;
+    virtual std::optional<FloatPoint3D> boundingBoxExtents() const;
+    virtual std::optional<TransformationMatrix> entityTransform() const;
     virtual void setEntityTransform(TransformationMatrix);
     virtual void enterFullscreen() = 0;
     virtual bool supportsMouseInteraction();

--- a/Source/WebCore/Modules/model-element/ModelPlayerTransformState.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayerTransformState.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StageModeOperations.h"
+
+namespace WebCore {
+
+class FloatPoint3D;
+class TransformationMatrix;
+
+class WEBCORE_EXPORT ModelPlayerTransformState {
+public:
+    virtual ~ModelPlayerTransformState() = default;
+
+    virtual std::optional<TransformationMatrix> entityTransform() const = 0;
+    virtual void setEntityTransform(TransformationMatrix) = 0;
+    virtual bool isEntityTransformSupported(const TransformationMatrix&) const = 0;
+
+#if ENABLE(MODEL_PROCESS)
+    virtual std::optional<FloatPoint3D> boundingBoxCenter() const = 0;
+    virtual std::optional<FloatPoint3D> boundingBoxExtents() const = 0;
+
+    virtual bool hasPortal() const = 0;
+    virtual void setHasPortal(bool) = 0;
+    virtual StageModeOperation stageMode() const = 0;
+    virtual void setStageMode(StageModeOperation) = 0;
+#endif
+};
+
+}

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -75,8 +75,6 @@ public:
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
-    static bool transformSupported(const simd_float4x4& transform);
-
     void invalidate();
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     template<typename T> void send(T&& message);

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -258,39 +258,6 @@ std::optional<SharedPreferencesForWebProcess> ModelProcessModelPlayerProxy::shar
     return std::nullopt;
 }
 
-static bool areSameSignAndAlmostEqual(float a, float b, float tolerance)
-{
-    if (a * b < 0)
-        return false;
-
-    float absA = std::abs(a);
-    float absB = std::abs(b);
-    return std::abs(absA - absB) < tolerance * std::min(absA, absB);
-}
-
-bool ModelProcessModelPlayerProxy::transformSupported(const simd_float4x4& transform)
-{
-    constexpr float tolerance = 1e-5f;
-
-    RESRT srt = REMakeSRTFromMatrix(transform);
-
-    // Scale must be uniform across all 3 axis
-    if (!areSameSignAndAlmostEqual(simd_reduce_max(srt.scale), simd_reduce_min(srt.scale), tolerance)) {
-        RELEASE_LOG_ERROR(ModelElement, "Rejecting non-uniform scaling %.05f %.05f %.05f", srt.scale[0], srt.scale[1], srt.scale[2]);
-        return false;
-    }
-
-    // Matrix must be a SRT (scale/rotation/translation) matrix - no shear.
-    // RESRT itself is already clean of shear, so we just need to see if the input is the same as the cleaned RESRT
-    simd_float4x4 noShearMatrix = RESRTMatrix(srt);
-    if (!simd_almost_equal_elements(transform, noShearMatrix, tolerance)) {
-        RELEASE_LOG_ERROR(ModelElement, "Rejecting shear matrix");
-        return false;
-    }
-
-    return true;
-}
-
 void ModelProcessModelPlayerProxy::invalidate()
 {
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy invalidated id=%" PRIu64, this, m_id.toUInt64());

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -718,6 +718,7 @@ WebProcess/Model/WebModelPlayerProvider.cpp
 WebProcess/Model/ModelProcessConnection.cpp
 WebProcess/Model/ModelProcessModelPlayer.cpp
 WebProcess/Model/ModelProcessModelPlayerManager.cpp
+WebProcess/Model/ModelProcessModelPlayerTransformState.cpp
 
 WebProcess/GPU/GPUProcessConnection.cpp
 WebProcess/GPU/RemoteSharedResourceCacheProxy.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1364,6 +1364,7 @@
 		523ADC8D2AFC2D2A00B352C3 /* AuthenticationServicesSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 523ADC8C2AFC2D0400B352C3 /* AuthenticationServicesSoftLink.mm */; };
 		5252A51927E048740094BEB9 /* VirtualHidConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 5252A51727E048740094BEB9 /* VirtualHidConnection.h */; };
 		5252A51A27E048740094BEB9 /* VirtualHidConnection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5252A51827E048740094BEB9 /* VirtualHidConnection.cpp */; };
+		52597BBC2DC41A3200CAAF01 /* ModelProcessModelPlayerTransformState.h in Headers */ = {isa = PBXBuildFile; fileRef = 52597BBA2DC4138600CAAF01 /* ModelProcessModelPlayerTransformState.h */; };
 		52688AB427D7CE40003577A2 /* _WKResidentKeyRequirement.h in Headers */ = {isa = PBXBuildFile; fileRef = 52688AB327D7CE40003577A2 /* _WKResidentKeyRequirement.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		526C5722284ADCBC00E08955 /* CtapCcidDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 526C5720284ADCBC00E08955 /* CtapCcidDriver.h */; };
 		526C5723284ADCBC00E08955 /* CtapCcidDriver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526C5721284ADCBC00E08955 /* CtapCcidDriver.cpp */; };
@@ -5984,6 +5985,8 @@
 		523ADC8C2AFC2D0400B352C3 /* AuthenticationServicesSoftLink.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AuthenticationServicesSoftLink.mm; sourceTree = "<group>"; };
 		5252A51727E048740094BEB9 /* VirtualHidConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VirtualHidConnection.h; sourceTree = "<group>"; };
 		5252A51827E048740094BEB9 /* VirtualHidConnection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = VirtualHidConnection.cpp; sourceTree = "<group>"; };
+		52597BBA2DC4138600CAAF01 /* ModelProcessModelPlayerTransformState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ModelProcessModelPlayerTransformState.h; sourceTree = "<group>"; };
+		52597BBB2DC4138600CAAF01 /* ModelProcessModelPlayerTransformState.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ModelProcessModelPlayerTransformState.cpp; sourceTree = "<group>"; };
 		52688AB327D7CE40003577A2 /* _WKResidentKeyRequirement.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKResidentKeyRequirement.h; sourceTree = "<group>"; };
 		526C5718284AD09500E08955 /* CcidConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CcidConnection.h; sourceTree = "<group>"; };
 		526C5719284AD09500E08955 /* CcidConnection.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = CcidConnection.mm; sourceTree = "<group>"; };
@@ -15330,6 +15333,8 @@
 				54BBB6092B80177C00BF1A8A /* ModelProcessModelPlayer.messages.in */,
 				54BBB5F72B7C3FE200BF1A8A /* ModelProcessModelPlayerManager.cpp */,
 				54BBB5F82B7C3FE200BF1A8A /* ModelProcessModelPlayerManager.h */,
+				52597BBB2DC4138600CAAF01 /* ModelProcessModelPlayerTransformState.cpp */,
+				52597BBA2DC4138600CAAF01 /* ModelProcessModelPlayerTransformState.h */,
 				BC2B411B2732F66E00A2D191 /* WebModelPlayerProvider.cpp */,
 				BC2B411A2732F66E00A2D191 /* WebModelPlayerProvider.h */,
 			);
@@ -17266,6 +17271,7 @@
 				57B8264C230603C100B72EB0 /* MockNfcService.h in Headers */,
 				EBA8D3B327A5E33F00CB7900 /* MockPushServiceConnection.h in Headers */,
 				7137BA8025F1542000914EE3 /* ModelElementController.h in Headers */,
+				52597BBC2DC41A3200CAAF01 /* ModelProcessModelPlayerTransformState.h in Headers */,
 				C0E3AA7C1209E83C00A49D01 /* Module.h in Headers */,
 				E539DFEB2A44A6A600769F09 /* MRUIKitSPI.h in Headers */,
 				2D50366B1BCDE17900E20BB3 /* NativeWebGestureEvent.h in Headers */,

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -77,12 +77,16 @@ private:
     // WebCore::ModelPlayer overrides.
     WebCore::ModelPlayerIdentifier identifier() const final { return m_id; }
     std::optional<WebCore::ModelPlayerAnimationState> currentAnimationState() const final;
+    std::optional<std::unique_ptr<WebCore::ModelPlayerTransformState>> currentTransformState() const final;
     void load(WebCore::Model&, WebCore::LayoutSize) final;
     void sizeDidChange(WebCore::LayoutSize) final;
     PlatformLayer* layer() final;
     void handleMouseDown(const WebCore::LayoutPoint&, MonotonicTime) final;
     void handleMouseMove(const WebCore::LayoutPoint&, MonotonicTime) final;
     void handleMouseUp(const WebCore::LayoutPoint&, MonotonicTime) final;
+    std::optional<WebCore::FloatPoint3D> boundingBoxCenter() const final;
+    std::optional<WebCore::FloatPoint3D> boundingBoxExtents() const final;
+    std::optional<WebCore::TransformationMatrix> entityTransform() const final;
     void setEntityTransform(WebCore::TransformationMatrix) final;
     bool supportsTransform(WebCore::TransformationMatrix) final;
     void enterFullscreen() final;
@@ -120,6 +124,9 @@ private:
 
     std::optional<WebCore::LayerHostingContextIdentifier> m_layerHostingContextIdentifier;
 
+    std::optional<WebCore::TransformationMatrix> m_entityTransform;
+    std::optional<WebCore::FloatPoint3D> m_boundingBoxCenter;
+    std::optional<WebCore::FloatPoint3D> m_boundingBoxExtents;
     bool m_hasPortal { true };
     WebCore::StageModeOperation m_stageModeOperation { WebCore::StageModeOperation::None };
     double m_requestedPlaybackRate { 1.0 };

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ModelProcessModelPlayerTransformState.h"
+
+#if ENABLE(MODEL_PROCESS)
+
+#include <CoreRE/CoreRE.h>
+#include <WebCore/FloatPoint3D.h>
+#include <WebCore/TransformationMatrix.h>
+
+namespace WebKit {
+
+std::unique_ptr<ModelProcessModelPlayerTransformState> ModelProcessModelPlayerTransformState::create(std::optional<WebCore::TransformationMatrix> entityTransform, std::optional<WebCore::FloatPoint3D> boundingBoxCenter, std::optional<WebCore::FloatPoint3D> boundingBoxExtents, bool hasPortal, WebCore::StageModeOperation stageModeOperation)
+{
+    return makeUnique<ModelProcessModelPlayerTransformState>(entityTransform, boundingBoxCenter, boundingBoxExtents, hasPortal, stageModeOperation);
+}
+
+ModelProcessModelPlayerTransformState::ModelProcessModelPlayerTransformState(std::optional<WebCore::TransformationMatrix> entityTransform, std::optional<WebCore::FloatPoint3D> boundingBoxCenter, std::optional<WebCore::FloatPoint3D> boundingBoxExtents, bool hasPortal, WebCore::StageModeOperation stageModeOperation)
+    : m_entityTransform(entityTransform)
+    , m_boundingBoxCenter(boundingBoxCenter)
+    , m_boundingBoxExtents(boundingBoxExtents)
+    , m_hasPortal(hasPortal)
+    , m_stageModeOperation(stageModeOperation)
+{
+}
+
+static bool areSameSignAndAlmostEqual(float a, float b, float tolerance)
+{
+    if (a * b < 0)
+        return false;
+
+    float absA = std::abs(a);
+    float absB = std::abs(b);
+    return std::abs(absA - absB) < tolerance * std::min(absA, absB);
+}
+
+bool ModelProcessModelPlayerTransformState::transformSupported(const WebCore::TransformationMatrix& transform)
+{
+    constexpr float tolerance = 1e-5f;
+
+    RESRT srt = REMakeSRTFromMatrix(transform);
+
+    // Scale must be uniform across all 3 axis
+    if (!areSameSignAndAlmostEqual(simd_reduce_max(srt.scale), simd_reduce_min(srt.scale), tolerance)) {
+        RELEASE_LOG_ERROR(ModelElement, "Rejecting non-uniform scaling %.05f %.05f %.05f", srt.scale[0], srt.scale[1], srt.scale[2]);
+        return false;
+    }
+
+    // Matrix must be a SRT (scale/rotation/translation) matrix - no shear.
+    // RESRT itself is already clean of shear, so we just need to see if the input is the same as the cleaned RESRT
+    simd_float4x4 noShearMatrix = RESRTMatrix(srt);
+    if (!simd_almost_equal_elements(transform, noShearMatrix, tolerance)) {
+        RELEASE_LOG_ERROR(ModelElement, "Rejecting shear matrix");
+        return false;
+    }
+
+    return true;
+}
+
+void ModelProcessModelPlayerTransformState::setEntityTransform(WebCore::TransformationMatrix entityTransform)
+{
+    ASSERT(m_stageModeOperation == WebCore::StageModeOperation::None);
+    if (transformSupported(entityTransform))
+        m_entityTransform = entityTransform;
+}
+
+bool ModelProcessModelPlayerTransformState::isEntityTransformSupported(const WebCore::TransformationMatrix& transform) const
+{
+    return transformSupported(transform);
+}
+
+void ModelProcessModelPlayerTransformState::setHasPortal(bool hasPortal)
+{
+    if (m_hasPortal == hasPortal)
+        return;
+
+    m_hasPortal = hasPortal;
+    // FIXME: Recalculate entity transform
+    // Invalidate m_entityTransform for now so the entityTransform can be recomputed on reload.
+    m_entityTransform = std::nullopt;
+}
+
+void ModelProcessModelPlayerTransformState::setStageMode(WebCore::StageModeOperation stageModeOperation)
+{
+    if (m_stageModeOperation == stageModeOperation)
+        return;
+
+    m_stageModeOperation = stageModeOperation;
+    // FIXME: recalculate entity transform
+    // Invalidate m_entityTransform for now so the entityTransform can be recomputed on reload.
+    m_entityTransform = std::nullopt;
+}
+
+}
+
+#endif

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(MODEL_PROCESS)
+
+#include <WebCore/ModelPlayerTransformState.h>
+
+namespace WebKit {
+
+class ModelProcessModelPlayerTransformState final : public WebCore::ModelPlayerTransformState {
+    WTF_MAKE_FAST_ALLOCATED;
+
+public:
+    static std::unique_ptr<ModelProcessModelPlayerTransformState> create(std::optional<WebCore::TransformationMatrix> entityTransform, std::optional<WebCore::FloatPoint3D> boundingBoxCenter, std::optional<WebCore::FloatPoint3D> boundingBoxExtents, bool hasPortal, WebCore::StageModeOperation);
+
+    ModelProcessModelPlayerTransformState(std::optional<WebCore::TransformationMatrix> entityTransform, std::optional<WebCore::FloatPoint3D> boundingBoxCenter, std::optional<WebCore::FloatPoint3D> boundingBoxExtents, bool hasPortal, WebCore::StageModeOperation);
+    virtual ~ModelProcessModelPlayerTransformState() = default;
+
+    static bool transformSupported(const WebCore::TransformationMatrix&);
+
+private:
+    // ModelPlayerTransformState overrides
+    std::optional<WebCore::TransformationMatrix> entityTransform() const final { return m_entityTransform; }
+    void setEntityTransform(WebCore::TransformationMatrix) final;
+    bool isEntityTransformSupported(const WebCore::TransformationMatrix&) const final;
+    std::optional<WebCore::FloatPoint3D> boundingBoxCenter() const final { return m_boundingBoxCenter; }
+    std::optional<WebCore::FloatPoint3D> boundingBoxExtents() const final { return m_boundingBoxExtents; }
+    bool hasPortal() const final { return m_hasPortal; }
+    void setHasPortal(bool) final;
+    WebCore::StageModeOperation stageMode() const final { return m_stageModeOperation; }
+    void setStageMode(WebCore::StageModeOperation) final;
+
+    std::optional<WebCore::TransformationMatrix> m_entityTransform;
+    std::optional<WebCore::FloatPoint3D> m_boundingBoxCenter;
+    std::optional<WebCore::FloatPoint3D> m_boundingBoxExtents;
+    bool m_hasPortal { true };
+    WebCore::StageModeOperation m_stageModeOperation { WebCore::StageModeOperation::None };
+};
+
+}
+
+#endif

--- a/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp
+++ b/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp
@@ -28,6 +28,7 @@
 
 #include "Logging.h"
 #include "MessageSenderInlines.h"
+#include "PluginView.h"
 #include "ViewGestureGeometryCollectorMessages.h"
 #include "WebFrame.h"
 #include "WebPage.h"


### PR DESCRIPTION
#### 37ba9b0bea2a73a54a97e2e88fec24ba6f93bc7b
<pre>
Introduce ModelPlayerTransformState protocol that contains info about the model&apos;s bounds and transform
<a href="https://bugs.webkit.org/show_bug.cgi?id=292506">https://bugs.webkit.org/show_bug.cgi?id=292506</a>
<a href="https://rdar.apple.com/150614639">rdar://150614639</a>

Reviewed by Mike Wyrzykowski.

Introduce ModelProcessModelPlayerTransformState that implements ModelPlayerTransformState.
The logic to determine whether a transform matrix is supported is moved from
ModelProcessModelPlayerProxy to there, so it can be used in
ModelProcessModelPlayerTransformState::isEntityTransformSupported() also.

Add a new method in ModelPlayer for getting the current transform state.
Implement this method in ModelProcessModelPlayer. This will be used in a
later patch for restoring the ModelPlayer state after reload.

* Source/WebCore/Modules/model-element/ModelPlayer.cpp:
(WebCore::ModelPlayer::currentTransformState const):
(WebCore::ModelPlayer::boundingBoxCenter const):
(WebCore::ModelPlayer::boundingBoxExtents const):
(WebCore::ModelPlayer::entityTransform const):
* Source/WebCore/Modules/model-element/ModelPlayer.h:
* Source/WebCore/Modules/model-element/ModelPlayerTransformState.h: Added.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::areSameSignAndAlmostEqual): Deleted.
(WebKit::ModelProcessModelPlayerProxy::transformSupported): Deleted.
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::didFinishLoading):
(WebKit::ModelProcessModelPlayer::didUpdateEntityTransform):
(WebKit::ModelProcessModelPlayer::currentTransformState const):
(WebKit::ModelProcessModelPlayer::boundingBoxCenter const):
(WebKit::ModelProcessModelPlayer::boundingBoxExtents const):
(WebKit::ModelProcessModelPlayer::entityTransform const):
(WebKit::ModelProcessModelPlayer::setEntityTransform):
(WebKit::ModelProcessModelPlayer::supportsTransform):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.cpp: Added.
(WebKit::ModelProcessModelPlayerTransformState::create):
(WebKit::ModelProcessModelPlayerTransformState::ModelProcessModelPlayerTransformState):
(WebKit::areSameSignAndAlmostEqual):
(WebKit::ModelProcessModelPlayerTransformState::transformSupported):
(WebKit::ModelProcessModelPlayerTransformState::setEntityTransform):
(WebKit::ModelProcessModelPlayerTransformState::isEntityTransformSupported const):
(WebKit::ModelProcessModelPlayerTransformState::setHasPortal):
(WebKit::ModelProcessModelPlayerTransformState::setStageMode):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.h: Added.
* Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp:

Canonical link: <a href="https://commits.webkit.org/294513@main">https://commits.webkit.org/294513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/832e05fff7770d83a392cce3ae31016e42bfe26c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107301 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52778 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104181 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30317 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/77737 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34732 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105148 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92207 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58072 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16943 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10232 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52136 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86784 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10305 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109677 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29274 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21581 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86708 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29636 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86291 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21947 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31097 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8812 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23516 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29202 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34497 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29013 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32336 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->