### PR TITLE
Leverage C++20's std::bit_ceil()

### DIFF
--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -42,6 +42,7 @@
 #include "UnlinkedMetadataTableInlines.h"
 #include "UnlinkedModuleProgramCodeBlock.h"
 #include "UnlinkedProgramCodeBlock.h"
+#include <bit>
 #include <wtf/FileHandle.h>
 #include <wtf/MallocPtr.h>
 #include <wtf/MallocSpan.h>
@@ -214,7 +215,7 @@ private:
 
         bool malloc(size_t size, ptrdiff_t& result)
         {
-            size_t alignment = std::min(alignof(std::max_align_t), static_cast<size_t>(WTF::roundUpToPowerOfTwo(size)));
+            size_t alignment = std::min(alignof(std::max_align_t), static_cast<size_t>(std::bit_ceil(size)));
             ptrdiff_t offset = roundUpToMultipleOf(alignment, m_offset);
             size = roundUpToMultipleOf(alignment, size);
             if (static_cast<size_t>(offset + size) > capacity())

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -43,6 +43,7 @@
 #include "TypeInfoBlob.h"
 #include "Watchpoint.h"
 #include "WriteBarrierInlines.h"
+#include <bit>
 #include <wtf/Atomics.h>
 #include <wtf/CompactPointerTuple.h>
 #include <wtf/CompactPtr.h>
@@ -590,7 +591,7 @@ public:
 
         ASSERT(outOfLineSize > initialOutOfLineCapacity);
         static_assert(outOfLineGrowthFactor == 2);
-        return WTF::roundUpToPowerOfTwo(outOfLineSize);
+        return std::bit_ceil(outOfLineSize);
     }
     
     static unsigned outOfLineSize(PropertyOffset maxOffset)

--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -32,6 +32,7 @@
 #include "JSCJSValueInlines.h"
 #include "JSWebAssemblyInstance.h"
 #include "WasmTypeDefinitionInlines.h"
+#include <bit>
 #include <type_traits>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -64,7 +65,7 @@ template<typename Visitor> constexpr decltype(auto) Table::visitDerived(Visitor&
 
 uint32_t Table::allocatedLength(uint32_t length)
 {
-    return WTF::roundUpToPowerOfTwo(length);
+    return std::bit_ceil(length);
 }
 
 void Table::setLength(uint32_t length)

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -40,6 +40,7 @@
 #include "YarrDisassembler.h"
 #include "YarrJITRegisters.h"
 #include "YarrMatchingContextHolder.h"
+#include <bit>
 #include <wtf/ASCIICType.h>
 #include <wtf/BitVector.h>
 #include <wtf/HexNumber.h>
@@ -2319,7 +2320,7 @@ class YarrGenerator final : public YarrJITInfo {
                     ignoredCharsMask |= charMask << shiftAmount;
             }
 
-            auto numRealCharsToCheck = WTF::roundUpToPowerOfTwo(lastCharInLoad - firstCharInLoad + 1);
+            auto numRealCharsToCheck = std::bit_ceil(lastCharInLoad - firstCharInLoad + 1);
 
 #if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
             if (m_useFirstNonBMPCharacterOptimization && numRealCharsToCheck > 1) {

--- a/Source/WTF/wtf/HashTable.h
+++ b/Source/WTF/wtf/HashTable.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <atomic>
+#include <bit>
 #include <iterator>
 #include <mutex>
 #include <string.h>
@@ -345,7 +346,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
             constexpr unsigned maxCapacity = 1U << 31;
             UNUSED_PARAM(maxCapacity);
             ASSERT_UNDER_CONSTEXPR_CONTEXT(sizeArg <= maxCapacity);
-            uint32_t capacity = roundUpToPowerOfTwo(sizeArg);
+            uint32_t capacity = std::bit_ceil(sizeArg);
             ASSERT_UNDER_CONSTEXPR_CONTEXT(capacity <= maxCapacity);
             if (shouldExpand(sizeArg, capacity)) {
                 ASSERT_UNDER_CONSTEXPR_CONTEXT((static_cast<uint64_t>(capacity) * 2) <= maxCapacity);
@@ -1222,7 +1223,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, ShouldValidateKey shouldValidateKey, typename Malloc>
     constexpr unsigned HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, shouldValidateKey, Malloc>::computeBestTableSize(unsigned keyCount)
     {
-        unsigned bestTableSize = WTF::roundUpToPowerOfTwo(keyCount);
+        unsigned bestTableSize = std::bit_ceil(keyCount);
 
         if (HashTableSizePolicy::shouldExpand(keyCount, bestTableSize))
             bestTableSize *= 2;

--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <algorithm>
+#include <bit>
 #include <climits>
 #include <cmath>
 #include <float.h>
@@ -406,24 +407,11 @@ inline void doubleToInteger(double d, unsigned long long& value)
 
 namespace WTF {
 
-// From http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
-constexpr uint32_t roundUpToPowerOfTwo(uint32_t v)
-{
-    v--;
-    v |= v >> 1;
-    v |= v >> 2;
-    v |= v >> 4;
-    v |= v >> 8;
-    v |= v >> 16;
-    v++;
-    return v;
-}
-
 constexpr unsigned maskForSize(unsigned size)
 {
     if (!size)
         return 0;
-    return roundUpToPowerOfTwo(size) - 1;
+    return std::bit_ceil(size) - 1;
 }
 
 inline constexpr unsigned fastLog2(unsigned i)

--- a/Source/WTF/wtf/RobinHoodHashTable.h
+++ b/Source/WTF/wtf/RobinHoodHashTable.h
@@ -51,6 +51,7 @@
 
 #pragma once
 
+#include <bit>
 #include <wtf/AlignedStorage.h>
 #include <wtf/HashTable.h>
 #include <wtf/text/StringHash.h>
@@ -726,7 +727,7 @@ void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits,
 template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
 constexpr unsigned RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::computeBestTableSize(unsigned keyCount)
 {
-    unsigned bestTableSize = WTF::roundUpToPowerOfTwo(keyCount);
+    unsigned bestTableSize = std::bit_ceil(keyCount);
 
     if (shouldExpand(keyCount, bestTableSize))
         bestTableSize *= 2;

--- a/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
+++ b/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
@@ -34,6 +34,7 @@
 #include "VectorMath.h"
 #include <Accelerate/Accelerate.h>
 #include <CoreAudio/CoreAudioTypes.h>
+#include <bit>
 #include <wtf/MathExtras.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -311,7 +312,7 @@ void CARingBuffer::fetchInternal(AudioBufferList* list, size_t nFrames, uint64_t
 
 std::unique_ptr<InProcessCARingBuffer> InProcessCARingBuffer::allocate(const WebCore::CAAudioStreamDescription& format, size_t frameCount)
 {
-    frameCount = WTF::roundUpToPowerOfTwo(frameCount);
+    frameCount = std::bit_ceil(frameCount);
     auto bytesPerFrame = format.bytesPerFrame();
     auto numChannelStreams = format.numberOfChannelStreams();
 

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -40,6 +40,7 @@
 #import "PlatformStrategies.h"
 #import "SharedBuffer.h"
 #import "VP9UtilitiesCocoa.h"
+#import <bit>
 #import <pal/SessionID.h>
 #import <pal/spi/cocoa/AudioToolboxSPI.h>
 #import <wtf/BlockObjCExceptions.h>
@@ -145,7 +146,7 @@ void MediaSessionManagerCocoa::updateSessionState()
     else if (captureCount || audioMediaStreamTrackCount) {
         // In case of audio capture or audio MediaStreamTrack playing, we want to grab 20 ms chunks to limit the latency so that it is not noticeable by users
         // while having a large enough buffer so that the audio rendering remains stable, hence a computation based on sample rate.
-        bufferSize = WTF::roundUpToPowerOfTwo(sharedSession->sampleRate() / 50);
+        bufferSize = std::bit_ceil<size_t>(sharedSession->sampleRate() / 50);
     } else if (m_supportedAudioHardwareBufferSizes && DeprecatedGlobalSettings::lowPowerVideoAudioBufferSizeEnabled())
         bufferSize = m_supportedAudioHardwareBufferSizes.nearest(kLowPowerVideoBufferSize);
 

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
@@ -27,6 +27,7 @@
 
 #include "GStreamerCaptureDeviceManager.h"
 #include "MockRealtimeMediaSourceCenter.h"
+#include <bit>
 #include <gst/app/gstappsrc.h>
 #include <numbers>
 #include <wtf/IndexedRange.h>
@@ -217,7 +218,7 @@ void MockRealtimeAudioSourceGStreamer::reconfigure()
     auto rate = sampleRate();
     size_t sampleCount = 2 * rate;
 
-    m_maximiumFrameCount = WTF::roundUpToPowerOfTwo(renderInterval().seconds() * sampleRate());
+    m_maximiumFrameCount = std::bit_ceil<uint32_t>(renderInterval().seconds() * sampleRate());
     gst_audio_info_set_format(&info, GST_AUDIO_FORMAT_F32LE, rate, 1, nullptr);
     m_streamFormat = GStreamerAudioStreamDescription(info);
     m_caps = adoptGRef(gst_audio_info_to_caps(&info));

--- a/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
@@ -44,6 +44,7 @@
 #import <AVFoundation/AVAudioBuffer.h>
 #import <AudioToolbox/AudioConverter.h>
 #import <CoreAudio/CoreAudioTypes.h>
+#import <bit>
 #import <numbers>
 #import <wtf/IndexedRange.h>
 #import <wtf/RunLoop.h>
@@ -285,7 +286,7 @@ void MockAudioSharedInternalUnit::reconfigure()
     auto rate = sampleRate();
     ASSERT(rate);
 
-    m_maximiumFrameCount = WTF::roundUpToPowerOfTwo(renderInterval().seconds() * rate * 2);
+    m_maximiumFrameCount = std::bit_ceil<size_t>(renderInterval().seconds() * rate * 2);
     ASSERT(m_maximiumFrameCount);
 
     m_audioBufferList = makeUnique<WebAudioBufferList>(m_streamFormat, m_maximiumFrameCount);

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -27,6 +27,7 @@
 #import "HardwareCapabilities.h"
 
 #import <algorithm>
+#import <bit>
 #import <limits>
 #import <ranges>
 #import <sys/sysctl.h>
@@ -400,7 +401,7 @@ template <typename T>
 static T mergeAlignment(T previous, T next)
 {
     // https://gpuweb.github.io/gpuweb/#limit-class-alignment
-    return std::min(WTF::roundUpToPowerOfTwo(previous), WTF::roundUpToPowerOfTwo(next));
+    return std::min(std::bit_ceil(previous), std::bit_ceil(next));
 };
 
 static WGPULimits mergeLimits(const WGPULimits& previous, const WGPULimits& next)

--- a/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp
+++ b/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp
@@ -30,6 +30,7 @@
 
 #include "Logging.h"
 #include <WebCore/CARingBuffer.h>
+#include <bit>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
@@ -46,7 +47,7 @@ SharedCARingBufferBase::SharedCARingBufferBase(size_t bytesPerFrame, size_t fram
 
 std::unique_ptr<ConsumerSharedCARingBuffer> ConsumerSharedCARingBuffer::map(uint32_t bytesPerFrame, uint32_t numChannelStreams, ConsumerSharedCARingBuffer::Handle&& handle)
 {
-    auto frameCount = WTF::roundUpToPowerOfTwo(handle.frameCount);
+    auto frameCount = std::bit_ceil(handle.frameCount);
 
     // Validate the parameters as they may be coming from an untrusted process.
     auto expectedStorageSize = computeSizeForBuffers(bytesPerFrame, frameCount, numChannelStreams) + sizeof(TimeBoundsBuffer);
@@ -71,7 +72,7 @@ std::unique_ptr<ConsumerSharedCARingBuffer> ConsumerSharedCARingBuffer::map(uint
 
 std::optional<ProducerSharedCARingBuffer::Pair> ProducerSharedCARingBuffer::allocate(const WebCore::CAAudioStreamDescription& format, size_t frameCount)
 {
-    frameCount = WTF::roundUpToPowerOfTwo(frameCount);
+    frameCount = std::bit_ceil(frameCount);
     auto bytesPerFrame = format.bytesPerFrame();
     auto numChannelStreams = format.numberOfChannelStreams();
 

--- a/Source/bmalloc/bmalloc/Algorithm.h
+++ b/Source/bmalloc/bmalloc/Algorithm.h
@@ -288,17 +288,4 @@ constexpr unsigned getMSBSetConstexpr(T t)
     return bitSize - 1 - clzConstexpr(t);
 }
 
-// From http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
-constexpr uint32_t roundUpToPowerOfTwo(uint32_t v)
-{
-    v--;
-    v |= v >> 1;
-    v |= v >> 2;
-    v |= v >> 4;
-    v |= v >> 8;
-    v |= v >> 16;
-    v++;
-    return v;
-}
-
 } // namespace bmalloc

--- a/Source/bmalloc/bmalloc/ObjectTypeTable.cpp
+++ b/Source/bmalloc/bmalloc/ObjectTypeTable.cpp
@@ -26,6 +26,7 @@
 #include "ObjectTypeTable.h"
 
 #include "VMAllocate.h"
+#include <bit>
 
 #if !BUSE(LIBPAS)
 
@@ -83,7 +84,7 @@ void ObjectTypeTable::set(UniqueLockHolder&, Chunk* chunk, ObjectType objectType
         unsigned count = newEnd - newBegin;
         size_t size = vmSize(sizeof(Bits) + (roundUpToMultipleOf<size_t>(ObjectTypeTable::Bits::bitCountPerWord, count) / 8));
         RELEASE_BASSERT(size <= 0x80000000U); // Too large bitvector, out-of-memory.
-        size = roundUpToPowerOfTwo(size);
+        size = std::bit_ceil(size);
         newEnd = newBegin + ((size - sizeof(Bits)) / sizeof(ObjectTypeTable::Bits::WordType)) * ObjectTypeTable::Bits::bitCountPerWord;
         BASSERT(newEnd > newBegin);
         void* allocated = vmAllocate(size);

--- a/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
@@ -464,13 +464,6 @@ TEST(WTF, clampInfinityToInteger)
     EXPECT_EQ(10U, clampTo<unsigned>(-std::numeric_limits<float>::infinity(), 10, 20));
 }
 
-TEST(WTF, roundUpToPowerOfTwo)
-{
-    EXPECT_EQ(WTF::roundUpToPowerOfTwo(UINT32_MAX), 0U);
-    EXPECT_EQ(WTF::roundUpToPowerOfTwo(1U << 31), (1U << 31));
-    EXPECT_EQ(WTF::roundUpToPowerOfTwo((1U << 31) + 1), 0U);
-}
-
 TEST(WTF, clz)
 {
     EXPECT_EQ(WTF::clz<int32_t>(1), 31U);

--- a/Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashSet.cpp
@@ -30,6 +30,7 @@
 #include "MoveOnly.h"
 #include "RefLogger.h"
 #include "Test.h"
+#include <bit>
 #include <functional>
 #include <wtf/DataLog.h>
 #include <wtf/RefPtr.h>
@@ -52,7 +53,7 @@ struct RobinHoodHash : public DefaultHash<T> {
 
 static constexpr unsigned capacityForSize(unsigned size)
 {
-    unsigned capacity = WTF::roundUpToPowerOfTwo(size);
+    unsigned capacity = std::bit_ceil(size);
     if (size * 100 >= capacity * 95)
         return capacity * 2;
     return capacity;


### PR DESCRIPTION
#### b339a1470dffc31f78731b27629831241650454b
<pre>
Leverage C++20&apos;s std::bit_ceil()
<a href="https://bugs.webkit.org/show_bug.cgi?id=292508">https://bugs.webkit.org/show_bug.cgi?id=292508</a>

Reviewed by NOBODY (OOPS!).

Leverage C++20&apos;s std::bit_ceil() to round up to the next power of 2.

* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::Encoder::Page::malloc):
* Source/JavaScriptCore/runtime/Structure.h:
(JSC::Structure::outOfLineCapacity):
* Source/JavaScriptCore/wasm/WasmTable.cpp:
(JSC::Wasm::Table::allocatedLength):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/WTF/wtf/HashTable.h:
(WTF::HashTableCapacityForSize::capacityForSize):
(WTF::Malloc&gt;::computeBestTableSize):
* Source/WTF/wtf/MathExtras.h:
(WTF::maskForSize):
(WTF::roundUpToPowerOfTwo): Deleted.
* Source/WTF/wtf/RobinHoodHashTable.h:
(WTF::Malloc&gt;::computeBestTableSize):
* Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp:
(WebCore::InProcessCARingBuffer::allocate):
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::updateSessionState):
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp:
(WebCore::MockRealtimeAudioSourceGStreamer::reconfigure):
* Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm:
(WebCore::MockAudioSharedInternalUnit::reconfigure):
* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::mergeAlignment):
* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp:
(WebKit::ConsumerSharedCARingBuffer::map):
(WebKit::ProducerSharedCARingBuffer::allocate):
* Source/bmalloc/bmalloc/Algorithm.h:
(bmalloc::roundUpToPowerOfTwo): Deleted.
* Source/bmalloc/bmalloc/ObjectTypeTable.cpp:
(bmalloc::ObjectTypeTable::set):
* Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp:
(TestWebKitAPI::TEST(WTF, roundUpToPowerOfTwo)): Deleted.
* Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashSet.cpp:
(TestWebKitAPI::capacityForSize):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b339a1470dffc31f78731b27629831241650454b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102038 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107197 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52672 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104078 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77661 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34668 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92126 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57997 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16854 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10151 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52035 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94710 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86694 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109570 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100648 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86636 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29533 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88330 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86216 "Found 102 new API test failures: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/javascript-dialogs, /TestWebKit:WebKit.DOMWindowExtensionCrashOnReload, /TestWebKit:WebKit.PageLoadBasic, /TestWebKit:WebKit.NewFirstVisuallyNonEmptyLayoutFails, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /TestWebKit:WebKit.InjectedBundleBasic, /TestWebKit:WebKit.PreventEmptyUserAgent, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/select-all/non-editable ... (failure)") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31011 "Found 1 new test failure: resize-observer/contain-instrinsic-size-should-not-leak-nodes.html (failure)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8730 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23370 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29099 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34394 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124273 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28910 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34518 "Failed to compile JSC") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32233 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30469 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->