### PR TITLE
Add logging and Web Inspector support for spatial and projection metadata

### DIFF
--- a/Source/JavaScriptCore/inspector/protocol/DOM.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
@@ -237,7 +237,9 @@
                 { "name": "colorSpace", "$ref": "VideoColorSpace" },
                 { "name": "framerate", "type": "number", "description": "The nominal frame rate of video track in frames per second." },
                 { "name": "height", "type": "integer", "description": "The native height of the video track in CSS pixels" },
-                { "name": "width", "type": "integer", "description": "The native width of the video track in CSS pixels" }
+                { "name": "width", "type": "integer", "description": "The native width of the video track in CSS pixels" },
+                { "name": "spatialVideoMetadata", "$ref": "SpatialVideoMetadata", "optional": true },
+                { "name": "videoProjectionMetadata", "$ref": "VideoProjectionMetadata", "optional": true }
             ]
         },
         {
@@ -259,6 +261,32 @@
                 { "name": "displayCompositedVideoFrames", "type": "integer", "description": "The number of frames of the total which were composited by the display." },
                 { "name": "droppedVideoFrames", "type": "integer", "description": "The number of frames of the total which were dropped without being displayed." },
                 { "name": "totalVideoFrames", "type": "integer", "description": "The total number of frames enqueued for display by the media element." }
+            ]
+        },
+        {
+            "id": "SpatialVideoMetadata",
+            "type": "object",
+            "description": "A structure containing metadata describing spatial video properties.",
+            "properties": [
+                { "name": "width", "type": "number" },
+                { "name": "height", "type": "number" },
+                { "name": "horizontalFOVDegrees", "type": "number", "description": "The horizontal field-of-view measurement, in degrees" },
+                { "name": "baseline", "type": "number", "description": "The distance between the centers of the lenses in a camera system, in micrometers" },
+                { "name": "disparityAdjustment", "type": "number", "description": "The relative shift of the left and right eye images, as a percentage." }
+            ]
+        },
+        {
+            "id": "VideoProjectionMetadataKind",
+            "type": "string",
+            "enum": ["unknown", "equirectangular", "half-equirectangular", "equi-angular-cubemap", "parametric", "pyramid", "apple-immersive-video" ],
+            "description": "Video Projection Metadata Kind."
+        },
+        {
+            "id": "VideoProjectionMetadata",
+            "type": "object",
+            "description": "A structure containing metadata describing video projections.",
+            "properties": [
+                { "name": "kind", "$ref": "VideoProjectionMetadataKind", "description": "The kind of video projection." }
             ]
         },
         {

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -81,6 +81,7 @@ using SequesteredArenaMalloc = FastMalloc;
 namespace JSONImpl {
 class Array;
 class Object;
+class Value;
 template<typename> class ArrayOf;
 }
 

--- a/Source/WTF/wtf/JSONValues.cpp
+++ b/Source/WTF/wtf/JSONValues.cpp
@@ -545,6 +545,14 @@ RefPtr<Value> Value::parseJSON(StringView json)
     return result;
 }
 
+std::optional<Ref<Value>> Value::optionalParseJSON(StringView json)
+{
+    auto value = parseJSON(json);
+    if (value)
+        return value.releaseNonNull();
+    return std::nullopt;
+}
+
 String Value::toJSONString() const
 {
     StringBuilder result;

--- a/Source/WTF/wtf/JSONValues.h
+++ b/Source/WTF/wtf/JSONValues.h
@@ -108,6 +108,7 @@ public:
     RefPtr<Array> asArray();
 
     static RefPtr<Value> parseJSON(StringView);
+    static std::optional<Ref<Value>> optionalParseJSON(StringView);
 
     String toJSONString() const;
 

--- a/Source/WTF/wtf/Logger.h
+++ b/Source/WTF/wtf/Logger.h
@@ -430,6 +430,13 @@ template<> struct LogArgument<Logger::LogSiteIdentifier> {
 template<> struct LogArgument<const void*> {
     WTF_EXPORT_PRIVATE static String toString(const void*);
 };
+template<typename T>
+struct LogArgument<std::optional<T>> {
+    static String toString(const std::optional<T>& value)
+    {
+        return value ? LogArgument<T>::toString(value.value()) : "nullopt"_s;
+    }
+};
 
 #ifdef __OBJC__
 template<> struct LogArgument<id> {

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2281,6 +2281,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/VelocityData.h
     platform/graphics/VideoLayerManager.h
     platform/graphics/VideoPlaybackQualityMetrics.h
+    platform/graphics/VideoProjectionMetadata.h
     platform/graphics/VideoTarget.h
     platform/graphics/VideoTrackPrivate.h
     platform/graphics/VideoTrackPrivateClient.h

--- a/Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp
@@ -58,14 +58,6 @@ struct LogArgument<Vector<T>> {
     }
 };
 
-template<typename T>
-struct LogArgument<std::optional<T>> {
-    static String toString(const std::optional<T>& value)
-    {
-        return value ? "nullopt"_s : LogArgument<T>::toString(value.value());
-    }
-};
-
 }
 
 namespace WebCore {

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -2508,6 +2508,12 @@ void HTMLMediaElement::audioTrackLanguageChanged(AudioTrack& track)
         audioTracks->scheduleChangeEvent();
 }
 
+void HTMLMediaElement::audioTrackConfigurationChanged(AudioTrack& track)
+{
+    UNUSED_PARAM(track);
+    ALWAYS_LOG(LOGIDENTIFIER, ", "_s, MediaElementSession::descriptionForTrack(track));
+}
+
 void HTMLMediaElement::willRemoveAudioTrack(AudioTrack& track)
 {
     removeAudioTrack(track);
@@ -2577,6 +2583,12 @@ void HTMLMediaElement::videoTrackSelectedChanged(VideoTrack& track)
     if (RefPtr videoTracks = m_videoTracks; videoTracks && videoTracks->contains(track))
         videoTracks->scheduleChangeEvent();
     checkForAudioAndVideo();
+}
+
+void HTMLMediaElement::videoTrackConfigurationChanged(VideoTrack& track)
+{
+    UNUSED_PARAM(track);
+    ALWAYS_LOG(LOGIDENTIFIER, ", "_s, MediaElementSession::descriptionForTrack(track));
 }
 
 void HTMLMediaElement::videoTrackKindChanged(VideoTrack& track)
@@ -4989,6 +5001,7 @@ void HTMLMediaElement::addAudioTrack(Ref<AudioTrack>&& track)
     track->setLogger(protectedLogger(), logIdentifier());
 #endif
     track->addClient(*this);
+    ALWAYS_LOG(LOGIDENTIFIER, "id: "_s, track->id(), ", "_s, MediaElementSession::descriptionForTrack(track));
     ensureAudioTracks().append(WTFMove(track));
 }
 
@@ -5020,6 +5033,7 @@ void HTMLMediaElement::addVideoTrack(Ref<VideoTrack>&& track)
     track->setLogger(protectedLogger(), logIdentifier());
 #endif
     track->addClient(*this);
+    ALWAYS_LOG(LOGIDENTIFIER, "id: "_s, track->id(), ", "_s, MediaElementSession::descriptionForTrack(track));
     ensureVideoTracks().append(WTFMove(track));
 }
 
@@ -5028,6 +5042,7 @@ void HTMLMediaElement::removeAudioTrack(Ref<AudioTrack>&& track)
     if (!m_audioTracks || !m_audioTracks->contains(track))
         return;
     track->clearClient(*this);
+    ALWAYS_LOG(LOGIDENTIFIER, "id: "_s, track->id(), ", "_s, MediaElementSession::descriptionForTrack(track));
     m_audioTracks->remove(track.get());
 }
 
@@ -5065,6 +5080,7 @@ void HTMLMediaElement::removeVideoTrack(Ref<VideoTrack>&& track)
     if (!m_videoTracks || !m_videoTracks->contains(track))
         return;
     track->clearClient(*this);
+    ALWAYS_LOG(LOGIDENTIFIER, "id: "_s, track->id(), ", "_s, MediaElementSession::descriptionForTrack(track));
     RefPtr { m_videoTracks }->remove(track);
 }
 

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -448,6 +448,7 @@ public:
     void audioTrackKindChanged(AudioTrack&) final;
     void audioTrackLabelChanged(AudioTrack&) final;
     void audioTrackLanguageChanged(AudioTrack&) final;
+    void audioTrackConfigurationChanged(AudioTrack&) final;
     void willRemoveAudioTrack(AudioTrack&) final;
 
     // TextTrackClient
@@ -466,6 +467,7 @@ public:
     void videoTrackLabelChanged(VideoTrack&) final;
     void videoTrackLanguageChanged(VideoTrack&) final;
     void videoTrackSelectedChanged(VideoTrack&) final;
+    void videoTrackConfigurationChanged(VideoTrack&) final;
     void willRemoveVideoTrack(VideoTrack&) final;
 
     void setTextTrackRepresentataionBounds(const IntRect&);

--- a/Source/WebCore/html/MediaElementSession.h
+++ b/Source/WebCore/html/MediaElementSession.h
@@ -58,12 +58,14 @@ enum class MediaPlaybackDenialReason {
     InvalidState,
 };
 
+class AudioTrack;
 class Document;
 class HTMLMediaElement;
 class MediaMetadata;
 class MediaSession;
 class MediaElementSessionObserver;
 class SourceBuffer;
+class VideoTrack;
 
 struct MediaPositionState;
 
@@ -187,6 +189,8 @@ public:
     std::optional<MediaUsageInfo> mediaUsageInfo() const { return m_mediaUsageInfo; }
 
 #if !RELEASE_LOG_DISABLED
+    static String descriptionForTrack(const VideoTrack&);
+    static String descriptionForTrack(const AudioTrack&);
     String description() const final;
     ASCIILiteral logClassName() const final { return "MediaElementSession"_s; }
 #endif

--- a/Source/WebCore/html/track/AudioTrack.cpp
+++ b/Source/WebCore/html/track/AudioTrack.cpp
@@ -163,6 +163,9 @@ void AudioTrack::enabledChanged(bool enabled)
 void AudioTrack::configurationChanged(const PlatformAudioTrackConfiguration& configuration)
 {
     m_configuration->setState(configuration);
+    m_clients.forEach([this] (auto& client) {
+        client.audioTrackConfigurationChanged(*this);
+    });
 }
 
 void AudioTrack::idChanged(TrackID id)

--- a/Source/WebCore/html/track/VideoTrack.cpp
+++ b/Source/WebCore/html/track/VideoTrack.cpp
@@ -142,6 +142,9 @@ void VideoTrack::selectedChanged(bool selected)
 void VideoTrack::configurationChanged(const PlatformVideoTrackConfiguration& configuration)
 {
     m_configuration->setState(configuration);
+    m_clients.forEach([this] (auto& client) {
+        client.videoTrackConfigurationChanged(*this);
+    });
 }
 
 void VideoTrack::idChanged(TrackID id)

--- a/Source/WebCore/html/track/VideoTrackClient.h
+++ b/Source/WebCore/html/track/VideoTrackClient.h
@@ -50,6 +50,7 @@ public:
     virtual void videoTrackLabelChanged(VideoTrack&) { }
     virtual void videoTrackLanguageChanged(VideoTrack&) { }
     virtual void videoTrackSelectedChanged(VideoTrack&) { }
+    virtual void videoTrackConfigurationChanged(VideoTrack&) { }
     virtual void willRemoveVideoTrack(VideoTrack&) { }
 };
 

--- a/Source/WebCore/html/track/VideoTrackConfiguration.cpp
+++ b/Source/WebCore/html/track/VideoTrackConfiguration.cpp
@@ -35,6 +35,95 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(VideoTrackConfiguration);
 
+void VideoTrackConfiguration::setState(const VideoTrackConfigurationInit& state)
+{
+    if (m_state == state && m_colorSpace->state() == m_state.colorSpace)
+        return;
+
+    m_state = state;
+    m_colorSpace->setState(m_state.colorSpace);
+    notifyObservers();
+}
+
+void VideoTrackConfiguration::setCodec(String codec)
+{
+    if (m_state.codec == codec)
+        return;
+
+    m_state.codec = codec;
+    notifyObservers();
+}
+
+void VideoTrackConfiguration::setWidth(uint32_t width)
+{
+    if (m_state.width == width)
+        return;
+
+    m_state.width = width;
+    notifyObservers();
+}
+
+void VideoTrackConfiguration::setHeight(uint32_t height)
+{
+    if (m_state.height == height)
+        return;
+
+    m_state.height = height;
+    notifyObservers();
+}
+
+void VideoTrackConfiguration::setColorSpace(Ref<VideoColorSpace>&& colorSpace)
+{
+    if (m_colorSpace == colorSpace)
+        return;
+
+    m_colorSpace = WTFMove(colorSpace);
+    notifyObservers();
+}
+
+void VideoTrackConfiguration::setFramerate(double framerate)
+{
+    if (m_state.framerate == framerate)
+        return;
+
+    m_state.framerate = framerate;
+    notifyObservers();
+}
+
+void VideoTrackConfiguration::setBitrate(uint64_t bitrate)
+{
+    if (m_state.bitrate == bitrate)
+        return;
+
+    m_state.bitrate = bitrate;
+    notifyObservers();
+}
+
+void VideoTrackConfiguration::setSpatialVideoMetadata(std::optional<SpatialVideoMetadata> metadata)
+{
+    if (m_state.spatialVideoMetadata == metadata)
+        return;
+
+    m_state.spatialVideoMetadata = metadata;
+    notifyObservers();
+}
+
+void VideoTrackConfiguration::setVideoProjectionMetadata(std::optional<VideoProjectionMetadata> metadata)
+{
+    if (m_state.videoProjectionMetadata == metadata)
+        return;
+
+    m_state.videoProjectionMetadata = metadata;
+    notifyObservers();
+}
+
+void VideoTrackConfiguration::notifyObservers()
+{
+    m_observers.forEach([] (auto& observer) {
+        observer();
+    });
+}
+
 Ref<JSON::Object> VideoTrackConfiguration::toJSON() const
 {
     Ref json = JSON::Object::create();
@@ -45,7 +134,7 @@ Ref<JSON::Object> VideoTrackConfiguration::toJSON() const
     json->setDouble("framerate"_s, framerate());
     json->setInteger("bitrate"_s, bitrate());
     json->setBoolean("isSpatial"_s, !!spatialVideoMetadata());
-    json->setBoolean("isImmersive"_s, isImmersiveVideo());
+    json->setBoolean("isImmersive"_s, !!videoProjectionMetadata());
     return json;
 }
 

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -3168,6 +3168,28 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::setAllowEditingUserA
     return { };
 }
 
+static Inspector::Protocol::DOM::VideoProjectionMetadataKind videoProjectionMetadataKind(VideoProjectionMetadataKind kind)
+{
+    switch (kind) {
+    case VideoProjectionMetadataKind::Unknown:
+        return Inspector::Protocol::DOM::VideoProjectionMetadataKind::Unknown;
+    case VideoProjectionMetadataKind::Equirectangular:
+        return Inspector::Protocol::DOM::VideoProjectionMetadataKind::Equirectangular;
+    case VideoProjectionMetadataKind::HalfEquirectangular:
+        return Inspector::Protocol::DOM::VideoProjectionMetadataKind::HalfEquirectangular;
+    case VideoProjectionMetadataKind::EquiAngularCubemap:
+        return Inspector::Protocol::DOM::VideoProjectionMetadataKind::EquiAngularCubemap;
+    case VideoProjectionMetadataKind::Parametric:
+        return Inspector::Protocol::DOM::VideoProjectionMetadataKind::Parametric;
+    case VideoProjectionMetadataKind::Pyramid:
+        return Inspector::Protocol::DOM::VideoProjectionMetadataKind::Pyramid;
+    case VideoProjectionMetadataKind::AppleImmersiveVideo:
+        return Inspector::Protocol::DOM::VideoProjectionMetadataKind::AppleImmersiveVideo;
+    }
+    ASSERT_NOT_REACHED();
+    return Inspector::Protocol::DOM::VideoProjectionMetadataKind::Unknown;
+}
+
 Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::DOM::MediaStats>> InspectorDOMAgent::getMediaStats(Inspector::Protocol::DOM::NodeId nodeId)
 {
 #if ENABLE(VIDEO)
@@ -3231,6 +3253,22 @@ Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::DOM::MediaStats>> In
             .setHeight(configuration.height())
             .setWidth(configuration.width())
             .release();
+        if (auto metadata = configuration.spatialVideoMetadata()) {
+            auto metadataJSON = Inspector::Protocol::DOM::SpatialVideoMetadata::create()
+                .setWidth(metadata->size.width())
+                .setHeight(metadata->size.height())
+                .setHorizontalFOVDegrees(metadata->horizontalFOVDegrees)
+                .setBaseline(metadata->baseline)
+                .setDisparityAdjustment(metadata->disparityAdjustment)
+                .release();
+            videoJSON->setSpatialVideoMetadata(WTFMove(metadataJSON));
+        }
+        if (auto metadata = configuration.videoProjectionMetadata()) {
+            auto metadataJSON = Inspector::Protocol::DOM::VideoProjectionMetadata::create()
+                .setKind(videoProjectionMetadataKind(metadata->kind))
+                .release();
+            videoJSON->setVideoProjectionMetadata(WTFMove(metadataJSON));
+        }
         stats->setVideo(WTFMove(videoJSON));
     }
 

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -47,6 +47,7 @@ class TimeRanges;
 class PlaybackSessionModelClient;
 struct MediaSelectionOption;
 struct SpatialVideoMetadata;
+struct VideoProjectionMetadata;
 
 enum class AudioSessionSoundStageSize : uint8_t;
 
@@ -187,10 +188,10 @@ public:
     virtual void isInWindowFullscreenActiveChanged(bool) { }
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     virtual void supportsLinearMediaPlayerChanged(bool) { }
-    virtual void spatialVideoMetadataChanged(const std::optional<SpatialVideoMetadata>&) { };
-    virtual void isImmersiveVideoChanged(bool) { };
     virtual void didSetVideoReceiverEndpoint() { };
 #endif
+    virtual void spatialVideoMetadataChanged(const std::optional<SpatialVideoMetadata>&) { };
+    virtual void videoProjectionMetadataChanged(const std::optional<VideoProjectionMetadata>&) { };
     virtual void ensureControlsManager() { }
     virtual void modelDestroyed() { }
 };

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -30,11 +30,12 @@
 #include "EventListener.h"
 #include "HTMLMediaElementEnums.h"
 #include "PlaybackSessionModel.h"
-#if ENABLE(LINEAR_MEDIA_PLAYER)
 #include "SpatialVideoMetadata.h"
-#endif
+#include "VideoProjectionMetadata.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashSet.h>
+#include <wtf/Observer.h>
+#include <wtf/OptionSet.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
@@ -141,9 +142,18 @@ private:
     static const Vector<AtomString>& observedEventNames();
     const AtomString& eventNameAll();
 
+    double playbackStartedTime() const;
+    void updateMediaSelectionOptions();
+    void updateMediaSelectionIndices();
+    void maybeUpdateVideoMetadata();
+
+    void videoTrackConfigurationChanged();
+
 #if !RELEASE_LOG_DISABLED
     uint64_t logIdentifier() const final;
     const Logger* loggerPtr() const final;
+    ASCIILiteral logClassName() const { return "PlaybackSessionModelMediaElement"_s; }
+    WTFLogChannel& logChannel() const;
 #endif
 
     RefPtr<HTMLMediaElement> m_mediaElement;
@@ -152,15 +162,10 @@ private:
     Vector<RefPtr<TextTrack>> m_legibleTracksForMenu;
     Vector<RefPtr<AudioTrack>> m_audioTracksForMenu;
     AudioSessionSoundStageSize m_soundStageSize;
-#if ENABLE(LINEAR_MEDIA_PLAYER)
     std::optional<SpatialVideoMetadata> m_spatialVideoMetadata;
-    bool m_isImmersiveVideo { false };
-#endif
+    std::optional<VideoProjectionMetadata> m_videoProjectionMetadata;
 
-    double playbackStartedTime() const;
-    void updateMediaSelectionOptions();
-    void updateMediaSelectionIndices();
-    void maybeUpdateVideoMetadata();
+    Observer<void()> m_videoTrackConfigurationObserver;
 };
 
 }

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -52,6 +52,7 @@
 #include "SpatialVideoMetadata.h"
 #include "VideoFrame.h"
 #include "VideoFrameMetadata.h"
+#include "VideoProjectionMetadata.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <wtf/Identified.h>
 #include <wtf/Lock.h>
@@ -2190,6 +2191,33 @@ String convertSpatialVideoMetadataToString(const SpatialVideoMetadata& metadata)
         WTF::LogArgument<float>::toString(metadata.horizontalFOVDegrees),
         WTF::LogArgument<float>::toString(metadata.baseline),
         WTF::LogArgument<float>::toString(metadata.disparityAdjustment), '}');
+}
+
+String convertEnumerationToString(VideoProjectionMetadataKind kind)
+{
+    static const std::array<NeverDestroyed<String>, 7> values {
+        MAKE_STATIC_STRING_IMPL("Unknown"),
+        MAKE_STATIC_STRING_IMPL("Equirectangular"),
+        MAKE_STATIC_STRING_IMPL("HalfEquirectangular"),
+        MAKE_STATIC_STRING_IMPL("EquiAngularCubemap"),
+        MAKE_STATIC_STRING_IMPL("Parametric"),
+        MAKE_STATIC_STRING_IMPL("Pyramid"),
+        MAKE_STATIC_STRING_IMPL("AppleImmersiveVideo"),
+    };
+    static_assert(!static_cast<size_t>(VideoProjectionMetadataKind::Unknown), "VideoProjectionMetadataKind::Unknown is not 0 as expected");
+    static_assert(static_cast<size_t>(VideoProjectionMetadataKind::Equirectangular) == 1, "VideoProjectionMetadataKind::Equirectangular is not 1 as expected");
+    static_assert(static_cast<size_t>(VideoProjectionMetadataKind::HalfEquirectangular) == 2, "VideoProjectionMetadataKind::HalfEquirectangular is not 2 as expected");
+    static_assert(static_cast<size_t>(VideoProjectionMetadataKind::EquiAngularCubemap) == 3, "VideoProjectionMetadataKind::EquiAngularCubemap is not 3 as expected");
+    static_assert(static_cast<size_t>(VideoProjectionMetadataKind::Parametric) == 4, "VideoProjectionMetadataKind::Parametric is not 4 as expected");
+    static_assert(static_cast<size_t>(VideoProjectionMetadataKind::Pyramid) == 5, "VideoProjectionMetadataKind::Pyramid is not 5 as expected");
+    static_assert(static_cast<size_t>(VideoProjectionMetadataKind::AppleImmersiveVideo) == 6, "VideoProjectionMetadataKind::AppleImmersiveVideo is not 6 as expected");
+    ASSERT(static_cast<size_t>(kind) < std::size(values));
+    return values[static_cast<size_t>(kind)];
+}
+
+String convertVideoProjectionMetadataToString(const VideoProjectionMetadata& metadata)
+{
+    return makeString('{', convertEnumerationToString(metadata.kind), '}');
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/PlatformVideoTrackConfiguration.h
+++ b/Source/WebCore/platform/graphics/PlatformVideoTrackConfiguration.h
@@ -30,6 +30,7 @@
 #include "PlatformTrackConfiguration.h"
 #include "PlatformVideoColorSpace.h"
 #include "SpatialVideoMetadata.h"
+#include "VideoProjectionMetadata.h"
 #include <optional>
 
 namespace WebCore {
@@ -41,7 +42,7 @@ struct PlatformVideoTrackConfiguration : PlatformTrackConfiguration {
     double framerate { 0 };
     uint64_t bitrate { 0 };
     std::optional<SpatialVideoMetadata> spatialVideoMetadata;
-    bool isImmersiveVideo { false };
+    std::optional<VideoProjectionMetadata> videoProjectionMetadata;
 
     friend bool operator==(const PlatformVideoTrackConfiguration&, const PlatformVideoTrackConfiguration&) = default;
 };

--- a/Source/WebCore/platform/graphics/VideoProjectionMetadata.h
+++ b/Source/WebCore/platform/graphics/VideoProjectionMetadata.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,35 +25,45 @@
 
 #pragma once
 
-#if ENABLE(VIDEO)
-
-#include <wtf/WeakPtr.h>
+#include <wtf/JSONValues.h>
+#include <wtf/RefPtr.h>
 
 namespace WebCore {
-class AudioTrackClient;
-}
+
+enum class VideoProjectionMetadataKind : uint8_t {
+    Unknown,
+    Equirectangular,
+    HalfEquirectangular,
+    EquiAngularCubemap,
+    Parametric,
+    Pyramid,
+    AppleImmersiveVideo,
+};
+
+struct VideoProjectionMetadata {
+    using Kind = VideoProjectionMetadataKind;
+    Kind kind;
+
+    RefPtr<JSON::Value> parameters;
+
+    friend bool operator==(const VideoProjectionMetadata&, const VideoProjectionMetadata&) = default;
+};
+
+WEBCORE_EXPORT String convertVideoProjectionMetadataToString(const VideoProjectionMetadata&);
+WEBCORE_EXPORT String convertEnumerationToString(VideoProjectionMetadataKind);
+
+} // namespace WebCore
 
 namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::AudioTrackClient> : std::true_type { };
-}
 
-namespace WebCore {
+template<typename> struct LogArgument;
 
-class AudioTrack;
-
-class AudioTrackClient : public CanMakeWeakPtr<AudioTrackClient> {
-public:
-    virtual ~AudioTrackClient() = default;
-    virtual void audioTrackEnabledChanged(AudioTrack&) { }
-    virtual void audioTrackIdChanged(AudioTrack&) { }
-    virtual void audioTrackKindChanged(AudioTrack&) { }
-    virtual void audioTrackLabelChanged(AudioTrack&) { }
-    virtual void audioTrackLanguageChanged(AudioTrack&) { }
-    virtual void audioTrackConfigurationChanged(AudioTrack&) { }
-    virtual void willRemoveAudioTrack(AudioTrack&) { }
+template <>
+struct LogArgument<WebCore::VideoProjectionMetadata> {
+    static String toString(const WebCore::VideoProjectionMetadata& metadata)
+    {
+        return convertVideoProjectionMetadataToString(metadata);
+    }
 };
 
 }
-
-#endif

--- a/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
@@ -35,6 +35,7 @@
 #import "PlatformAudioTrackConfiguration.h"
 #import "PlatformVideoTrackConfiguration.h"
 #import "SharedBuffer.h"
+#import "VideoProjectionMetadata.h"
 #import <AVFoundation/AVAssetTrack.h>
 #import <AVFoundation/AVMediaSelectionGroup.h>
 #import <AVFoundation/AVMetadataItem.h>
@@ -102,12 +103,18 @@ void AVTrackPrivateAVFObjCImpl::initializeAssetTrack()
 
     [m_assetTrack loadValuesAsynchronouslyForKeys:assetTrackConfigurationKeyNames() completionHandler:[weakThis = WeakPtr(this)] () mutable {
         callOnMainThread([weakThis = WTFMove(weakThis)] {
-            if (weakThis && weakThis->m_audioTrackConfigurationObserver)
-                (*weakThis->m_audioTrackConfigurationObserver)();
-            if (weakThis && weakThis->m_videoTrackConfigurationObserver)
-                (*weakThis->m_videoTrackConfigurationObserver)();
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->initializationCompleted();
         });
     }];
+}
+
+void AVTrackPrivateAVFObjCImpl::initializationCompleted()
+{
+    if (m_audioTrackConfigurationObserver)
+        (*m_audioTrackConfigurationObserver)();
+    if (m_videoTrackConfigurationObserver)
+        (*m_videoTrackConfigurationObserver)();
 }
 
 bool AVTrackPrivateAVFObjCImpl::enabled() const
@@ -354,7 +361,7 @@ PlatformVideoTrackConfiguration AVTrackPrivateAVFObjCImpl::videoTrackConfigurati
         framerate(),
         bitrate(),
         spatialVideoMetadata(),
-        isImmersiveVideo(),
+        videoProjectionMetadata(),
     };
 }
 
@@ -455,18 +462,12 @@ uint64_t AVTrackPrivateAVFObjCImpl::bitrate() const
 
 std::optional<SpatialVideoMetadata> AVTrackPrivateAVFObjCImpl::spatialVideoMetadata() const
 {
-    auto metadata = videoMetadataFromFormatDescription(formatDescriptionFor(*this).get());
-    if (metadata && std::holds_alternative<SpatialVideoMetadata>(*metadata))
-        return std::get<SpatialVideoMetadata>(*metadata);
-    return { };
+    return spatialVideoMetadataFromFormatDescription(formatDescriptionFor(*this).get());
 }
 
-bool AVTrackPrivateAVFObjCImpl::isImmersiveVideo() const
+std::optional<VideoProjectionMetadata> AVTrackPrivateAVFObjCImpl::videoProjectionMetadata() const
 {
-    auto metadata = videoMetadataFromFormatDescription(formatDescriptionFor(*this).get());
-    if (metadata && std::holds_alternative<bool>(*metadata))
-        return std::get<bool>(*metadata);
-    return false;
+    return videoProjectionMetadataFromFormatDescription(formatDescriptionFor(*this).get());
 }
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/FormatDescriptionUtilities.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/FormatDescriptionUtilities.cpp
@@ -32,6 +32,8 @@
 #import "HEVCUtilities.h"
 #import "PlatformVideoColorSpace.h"
 #import "SharedBuffer.h"
+#import "SpatialVideoMetadata.h"
+#import "VideoProjectionMetadata.h"
 #import <wtf/cf/TypeCastsCF.h>
 
 #import <pal/cf/CoreMediaSoftLink.h>
@@ -205,7 +207,7 @@ String codecFromFormatDescription(CMFormatDescriptionRef formatDescription)
     return emptyString();
 }
 
-std::optional<VideoMetadata> videoMetadataFromFormatDescription(CMFormatDescriptionRef formatDescription)
+std::optional<SpatialVideoMetadata> spatialVideoMetadataFromFormatDescription(CMFormatDescriptionRef formatDescription)
 {
     if (!formatDescription)
         return { };
@@ -214,45 +216,88 @@ std::optional<VideoMetadata> videoMetadataFromFormatDescription(CMFormatDescript
     if (PAL::CMFormatDescriptionGetMediaType(formatDescription) != kCMMediaType_Video)
         return { };
 
-    auto checkForSpatialMetadata = [&]() -> std::optional<SpatialVideoMetadata> {
-        if (!PAL::canLoad_CoreMedia_kCMFormatDescriptionExtension_StereoCameraBaseline() || !PAL::canLoad_CoreMedia_kCMFormatDescriptionExtension_HorizontalDisparityAdjustment())
-            return { };
-        SInt32 value;
-        SpatialVideoMetadata metadata;
-        auto horizontalFieldOfView = dynamic_cf_cast<CFNumberRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, PAL::kCMFormatDescriptionExtension_HorizontalFieldOfView));
-        if (!horizontalFieldOfView)
-            return { };
-        CFNumberGetValue(horizontalFieldOfView, kCFNumberSInt32Type, &value);
-        metadata.horizontalFOVDegrees = value / 1000.0;
+    if (!PAL::canLoad_CoreMedia_kCMFormatDescriptionExtension_StereoCameraBaseline() || !PAL::canLoad_CoreMedia_kCMFormatDescriptionExtension_HorizontalDisparityAdjustment())
+        return { };
 
-        auto baselineField = dynamic_cf_cast<CFNumberRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, PAL::kCMFormatDescriptionExtension_StereoCameraBaseline));
-        if (!baselineField)
-            return { };
-        CFNumberGetValue(baselineField, kCFNumberSInt32Type, &value);
-        metadata.baseline = value;
+    auto horizontalFieldOfView = dynamic_cf_cast<CFNumberRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, PAL::kCMFormatDescriptionExtension_HorizontalFieldOfView));
+    if (!horizontalFieldOfView)
+        return { };
 
-        auto disparityAdjustmentField = dynamic_cf_cast<CFNumberRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, PAL::kCMFormatDescriptionExtension_HorizontalDisparityAdjustment));
-        if (!disparityAdjustmentField)
-            return { };
-        CFNumberGetValue(disparityAdjustmentField, kCFNumberSInt32Type, &value);
-        metadata.disparityAdjustment = value / 10000.0;
+    auto baselineField = dynamic_cf_cast<CFNumberRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, PAL::kCMFormatDescriptionExtension_StereoCameraBaseline));
+    if (!baselineField)
+        return { };
 
-        CMVideoDimensions dimensions = PAL::CMVideoFormatDescriptionGetDimensions(formatDescription);
-        metadata.size = { dimensions.width, dimensions.height };
-        return metadata;
-    };
-    if (auto spatialVideoMetadata = checkForSpatialMetadata())
-        return spatialVideoMetadata;
+    auto disparityAdjustmentField = dynamic_cf_cast<CFNumberRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, PAL::kCMFormatDescriptionExtension_HorizontalDisparityAdjustment));
+    if (!disparityAdjustmentField)
+        return { };
 
-    auto checkForImmersiveData = [&]() -> bool {
-        if (!PAL::canLoad_CoreMedia_kCMFormatDescriptionExtension_ProjectionKind() || !PAL::canLoad_CoreMedia_kCMFormatDescriptionProjectionKind_Equirectangular() || !PAL::canLoad_CoreMedia_kCMFormatDescriptionProjectionKind_HalfEquirectangular())
-            return false;
-        auto projectionKind = dynamic_cf_cast<CFStringRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, PAL::kCMFormatDescriptionExtension_ProjectionKind));
+    SInt32 value;
+    SpatialVideoMetadata metadata;
 
-        return projectionKind && (CFStringCompare(projectionKind, PAL::kCMFormatDescriptionProjectionKind_Equirectangular, 0) == kCFCompareEqualTo || CFStringCompare(projectionKind, PAL::kCMFormatDescriptionProjectionKind_HalfEquirectangular, 0) == kCFCompareEqualTo || (PAL::canLoad_CoreMedia_kCMFormatDescriptionProjectionKind_ParametricImmersive() && CFStringCompare(projectionKind, PAL::kCMFormatDescriptionProjectionKind_ParametricImmersive, 0) == kCFCompareEqualTo) || (PAL::canLoad_CoreMedia_kCMFormatDescriptionProjectionKind_AppleImmersiveVideo() && CFStringCompare(projectionKind, PAL::kCMFormatDescriptionProjectionKind_AppleImmersiveVideo, 0) == kCFCompareEqualTo));
-    };
-    if (auto isImmersive = checkForImmersiveData())
-        return isImmersive;
+    CFNumberGetValue(horizontalFieldOfView, kCFNumberSInt32Type, &value);
+    metadata.horizontalFOVDegrees = value / 1000.0;
+
+    CFNumberGetValue(baselineField, kCFNumberSInt32Type, &value);
+    metadata.baseline = value;
+
+    CFNumberGetValue(disparityAdjustmentField, kCFNumberSInt32Type, &value);
+    metadata.disparityAdjustment = value / 10000.0;
+
+    CMVideoDimensions dimensions = PAL::CMVideoFormatDescriptionGetDimensions(formatDescription);
+    metadata.size = { dimensions.width, dimensions.height };
+
+    return metadata;
+}
+
+static std::optional<VideoProjectionMetadataKind> toVideoProjectionMetadataKind(CFStringRef kind)
+{
+    if (!kind)
+        return { };
+
+    if (PAL::canLoad_CoreMedia_kCMFormatDescriptionProjectionKind_Equirectangular()
+        && CFStringCompare(kind, PAL::kCMFormatDescriptionProjectionKind_Equirectangular, 0) == kCFCompareEqualTo)
+        return VideoProjectionMetadata::Kind::Equirectangular;
+
+    if (PAL::canLoad_CoreMedia_kCMFormatDescriptionProjectionKind_HalfEquirectangular()
+        && CFStringCompare(kind, PAL::kCMFormatDescriptionProjectionKind_HalfEquirectangular, 0) == kCFCompareEqualTo)
+        return VideoProjectionMetadata::Kind::HalfEquirectangular;
+
+    if (PAL::canLoad_CoreMedia_kCMFormatDescriptionProjectionKind_ParametricImmersive()
+        && CFStringCompare(kind, PAL::kCMFormatDescriptionProjectionKind_ParametricImmersive, 0) == kCFCompareEqualTo)
+        return VideoProjectionMetadata::Kind::Parametric;
+
+    if (PAL::canLoad_CoreMedia_kCMFormatDescriptionProjectionKind_AppleImmersiveVideo()
+        && CFStringCompare(kind, PAL::kCMFormatDescriptionProjectionKind_AppleImmersiveVideo, 0) == kCFCompareEqualTo)
+        return VideoProjectionMetadata::Kind::AppleImmersiveVideo;
+
+    return { };
+}
+
+std::optional<VideoProjectionMetadata> videoProjectionMetadataFromFormatDescription(CMFormatDescriptionRef formatDescription)
+{
+    if (!formatDescription)
+        return { };
+
+    // Note: this assumes that the spatial metadata is in the first section of the format description.
+    if (PAL::CMFormatDescriptionGetMediaType(formatDescription) != kCMMediaType_Video)
+        return { };
+
+    if (!PAL::canLoad_CoreMedia_kCMFormatDescriptionExtension_ProjectionKind())
+        return { };
+
+    auto projectionKind = toVideoProjectionMetadataKind(dynamic_cf_cast<CFStringRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, PAL::kCMFormatDescriptionExtension_ProjectionKind)));
+    if (!projectionKind)
+        return { };
+
+    if (projectionKind == VideoProjectionMetadata::Kind::Equirectangular
+        || projectionKind == VideoProjectionMetadata::Kind::HalfEquirectangular
+        || projectionKind == VideoProjectionMetadata::Kind::AppleImmersiveVideo)
+        return VideoProjectionMetadata { *projectionKind, { } };
+
+    if (projectionKind == VideoProjectionMetadata::Kind::Parametric) {
+        // TODO: extract the camera lens parameters from the format description.
+        return VideoProjectionMetadata { *projectionKind, { } };
+    }
 
     return { };
 }

--- a/Source/WebCore/platform/graphics/avfoundation/FormatDescriptionUtilities.h
+++ b/Source/WebCore/platform/graphics/avfoundation/FormatDescriptionUtilities.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "SpatialVideoMetadata.h"
 #include <optional>
 #include <wtf/Forward.h>
 
@@ -35,11 +34,13 @@ namespace WebCore {
 
 class FloatSize;
 struct PlatformVideoColorSpace;
+struct SpatialVideoMetadata;
+struct VideoProjectionMetadata;
 
 FloatSize presentationSizeFromFormatDescription(CMFormatDescriptionRef);
 std::optional<PlatformVideoColorSpace> colorSpaceFromFormatDescription(CMFormatDescriptionRef);
 String codecFromFormatDescription(CMFormatDescriptionRef);
-using VideoMetadata = Variant<SpatialVideoMetadata, bool>;
-std::optional<VideoMetadata> videoMetadataFromFormatDescription(CMFormatDescriptionRef);
+std::optional<SpatialVideoMetadata> spatialVideoMetadataFromFormatDescription(CMFormatDescriptionRef);
+std::optional<VideoProjectionMetadata> videoProjectionMetadataFromFormatDescription(CMFormatDescriptionRef);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm
@@ -93,7 +93,7 @@ AVAssetTrack* MediaSelectionOptionAVFObjC::assetTrack() const
                 continue;
             if (!track.assetTrack)
                 continue;
-            if ([track.assetTrack mediaType] == [m_mediaSelectionOption mediaType] && [track.assetTrack isPlayable] == [m_mediaSelectionOption isPlayable])
+            if ([[track.assetTrack mediaType] isEqualToString:[m_mediaSelectionOption mediaType]] && [track.assetTrack isPlayable] == [m_mediaSelectionOption isPlayable])
                 return track.assetTrack;
         }
     }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.h
@@ -77,11 +77,11 @@ private:
     AudioTrackPrivateAVFObjC(AVPlayerItemTrack*);
     AudioTrackPrivateAVFObjC(AVAssetTrack*);
     AudioTrackPrivateAVFObjC(MediaSelectionOptionAVFObjC&);
-    AudioTrackPrivateAVFObjC(std::unique_ptr<AVTrackPrivateAVFObjCImpl>&&);
+    AudioTrackPrivateAVFObjC(Ref<AVTrackPrivateAVFObjCImpl>&&);
 
     void resetPropertiesFromTrack();
     void audioTrackConfigurationChanged();
-    std::unique_ptr<AVTrackPrivateAVFObjCImpl> m_impl;
+    const Ref<AVTrackPrivateAVFObjCImpl> m_impl;
 
     using AudioTrackConfigurationObserver = Observer<void()>;
     AudioTrackConfigurationObserver m_audioTrackConfigurationObserver;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.mm
@@ -36,21 +36,21 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioTrackPrivateAVFObjC);
 
 AudioTrackPrivateAVFObjC::AudioTrackPrivateAVFObjC(AVPlayerItemTrack* track)
-    : AudioTrackPrivateAVFObjC(makeUnique<AVTrackPrivateAVFObjCImpl>(track))
+    : AudioTrackPrivateAVFObjC(AVTrackPrivateAVFObjCImpl::create(track))
 {
 }
 
 AudioTrackPrivateAVFObjC::AudioTrackPrivateAVFObjC(AVAssetTrack* track)
-    : AudioTrackPrivateAVFObjC(makeUnique<AVTrackPrivateAVFObjCImpl>(track))
+    : AudioTrackPrivateAVFObjC(AVTrackPrivateAVFObjCImpl::create(track))
 {
 }
 
 AudioTrackPrivateAVFObjC::AudioTrackPrivateAVFObjC(MediaSelectionOptionAVFObjC& option)
-    : AudioTrackPrivateAVFObjC(makeUnique<AVTrackPrivateAVFObjCImpl>(option))
+    : AudioTrackPrivateAVFObjC(AVTrackPrivateAVFObjCImpl::create(option))
 {
 }
 
-AudioTrackPrivateAVFObjC::AudioTrackPrivateAVFObjC(std::unique_ptr<AVTrackPrivateAVFObjCImpl>&& impl)
+AudioTrackPrivateAVFObjC::AudioTrackPrivateAVFObjC(Ref<AVTrackPrivateAVFObjCImpl>&& impl)
     : m_impl(WTFMove(impl))
     , m_audioTrackConfigurationObserver([this] { audioTrackConfigurationChanged(); })
 {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioTrackPrivateMediaSourceAVFObjC);
 
 AudioTrackPrivateMediaSourceAVFObjC::AudioTrackPrivateMediaSourceAVFObjC(AVAssetTrack* track)
-    : m_impl(makeUnique<AVTrackPrivateAVFObjCImpl>(track))
+    : m_impl(AVTrackPrivateAVFObjCImpl::create(track))
 {
     resetPropertiesFromTrack();
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.h
@@ -57,7 +57,7 @@ private:
     
     void resetPropertiesFromTrack();
 
-    std::unique_ptr<AVTrackPrivateAVFObjCImpl> m_impl;
+    const Ref<AVTrackPrivateAVFObjCImpl> m_impl;
 };
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/TextTrackPrivateMediaSourceAVFObjC.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/TextTrackPrivateMediaSourceAVFObjC.cpp
@@ -38,7 +38,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(TextTrackPrivateMediaSourceAVFObjC);
 
 TextTrackPrivateMediaSourceAVFObjC::TextTrackPrivateMediaSourceAVFObjC(AVAssetTrack* track, CueFormat format)
     : InbandTextTrackPrivateAVF(0, format, [] { })
-    , m_impl(makeUniqueRef<AVTrackPrivateAVFObjCImpl>(track))
+    , m_impl(AVTrackPrivateAVFObjCImpl::create(track))
 {
     resetPropertiesFromTrack();
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/TextTrackPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/TextTrackPrivateMediaSourceAVFObjC.h
@@ -55,7 +55,7 @@ private:
 
     void resetPropertiesFromTrack();
 
-    UniqueRef<AVTrackPrivateAVFObjCImpl> m_impl;
+    const Ref<AVTrackPrivateAVFObjCImpl> m_impl;
 };
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp
@@ -38,21 +38,21 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(VideoTrackPrivateAVFObjC);
 
 VideoTrackPrivateAVFObjC::VideoTrackPrivateAVFObjC(AVPlayerItemTrack* track)
-    : VideoTrackPrivateAVFObjC(makeUnique<AVTrackPrivateAVFObjCImpl>(track))
+    : VideoTrackPrivateAVFObjC(AVTrackPrivateAVFObjCImpl::create(track))
 {
 }
 
 VideoTrackPrivateAVFObjC::VideoTrackPrivateAVFObjC(AVAssetTrack* track)
-    : VideoTrackPrivateAVFObjC(makeUnique<AVTrackPrivateAVFObjCImpl>(track))
+    : VideoTrackPrivateAVFObjC(AVTrackPrivateAVFObjCImpl::create(track))
 {
 }
 
 VideoTrackPrivateAVFObjC::VideoTrackPrivateAVFObjC(MediaSelectionOptionAVFObjC& option)
-    : VideoTrackPrivateAVFObjC(makeUnique<AVTrackPrivateAVFObjCImpl>(option))
+    : VideoTrackPrivateAVFObjC(AVTrackPrivateAVFObjCImpl::create(option))
 {
 }
 
-VideoTrackPrivateAVFObjC::VideoTrackPrivateAVFObjC(std::unique_ptr<AVTrackPrivateAVFObjCImpl>&& impl)
+VideoTrackPrivateAVFObjC::VideoTrackPrivateAVFObjC(Ref<AVTrackPrivateAVFObjCImpl>&& impl)
     : m_impl(WTFMove(impl))
     , m_videoTrackConfigurationObserver([this] { videoTrackConfigurationChanged(); })
 {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.h
@@ -75,11 +75,11 @@ private:
     explicit VideoTrackPrivateAVFObjC(AVPlayerItemTrack*);
     explicit VideoTrackPrivateAVFObjC(AVAssetTrack*);
     explicit VideoTrackPrivateAVFObjC(MediaSelectionOptionAVFObjC&);
-    explicit VideoTrackPrivateAVFObjC(std::unique_ptr<AVTrackPrivateAVFObjCImpl>&&);
+    explicit VideoTrackPrivateAVFObjC(Ref<AVTrackPrivateAVFObjCImpl>&&);
 
     void resetPropertiesFromTrack();
     void videoTrackConfigurationChanged();
-    std::unique_ptr<AVTrackPrivateAVFObjCImpl> m_impl;
+    const Ref<AVTrackPrivateAVFObjCImpl> m_impl;
 
     using VideoTrackConfigurationObserver = Observer<void()>;
     VideoTrackConfigurationObserver m_videoTrackConfigurationObserver;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.h
@@ -60,7 +60,7 @@ private:
     
     void resetPropertiesFromTrack();
 
-    std::unique_ptr<AVTrackPrivateAVFObjCImpl> m_impl;
+    const Ref<AVTrackPrivateAVFObjCImpl> m_impl;
 };
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm
@@ -38,7 +38,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(VideoTrackPrivateMediaSourceAVFObjC);
 
 VideoTrackPrivateMediaSourceAVFObjC::VideoTrackPrivateMediaSourceAVFObjC(AVAssetTrack* track)
-    : m_impl(makeUnique<AVTrackPrivateAVFObjCImpl>(track))
+    : m_impl(AVTrackPrivateAVFObjCImpl::create(track))
 {
     resetPropertiesFromTrack();
 }

--- a/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
@@ -55,7 +55,7 @@ public:
     PlaybackSessionModel* playbackSessionModel() const { return m_playbackSessionInterface->playbackSessionModel(); }
 
     void setSpatialVideoMetadata(const std::optional<SpatialVideoMetadata>&) { }
-    void setIsImmersiveVideo(bool) { }
+    void setVideoProjectionMetadata(const std::optional<VideoProjectionMetadata>&) { }
     void setVideoPresentationModel(VideoPresentationModel* model) { m_videoPresentationModel = model; }
     void setupFullscreen(const FloatRect&, const FloatSize&, UIView*, HTMLMediaElementEnums::VideoFullscreenMode, bool, bool, bool) { }
     void enterFullscreen() { }

--- a/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp
@@ -190,7 +190,7 @@ IGNORE_WARNINGS_BEGIN("c99-designator")
         .colorSpace = colorSpace(),
         .framerate = framerate(),
         .spatialVideoMetadata = { },
-        .isImmersiveVideo = false
+        .videoProjectionMetadata = { },
     };
 IGNORE_WARNINGS_END
     setConfiguration(WTFMove(configuration));

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -52,10 +52,14 @@ localizedStrings["%d redirect"] = "%d redirect";
 localizedStrings["%d redirects"] = "%d redirects";
 localizedStrings["%d resource"] = "%d resource";
 localizedStrings["%d resources"] = "%d resources";
+localizedStrings["%d%%"] = "%d%%";
+localizedStrings["%dmm"] = "%dmm";
 localizedStrings["%dpx"] = "%dpx";
 localizedStrings["%dpx\u00B2"] = "%dpx\u00B2";
+localizedStrings["%dx%d"] = "%dx%d";
 localizedStrings["%dx%d (%dfps)"] = "%dx%d (%dfps)";
 localizedStrings["%dx%d (%dx)"] = "%dx%d (%dx)";
+localizedStrings["%dº"] = "%dº";
 localizedStrings["%s (%s)"] = "%s (%s)";
 localizedStrings["%s (%s, %s)"] = "%s (%s, %s)";
 /* Label for case-insensitive match pattern of an event breakpoint. */
@@ -254,6 +258,8 @@ localizedStrings["Back (%s)"] = "Back (%s)";
 localizedStrings["Backtrace"] = "Backtrace";
 /* Label for navigation item that controls what badges are shown in the main DOM tree. */
 localizedStrings["Badges @ Elements Tab"] = "Badges";
+/* Title for Baseline in Media Sidebar */
+localizedStrings["Baseline @ Media Sidebar"] = "Baseline";
 localizedStrings["Basic"] = "Basic";
 /* Section title for basic font properties. */
 localizedStrings["Basic Properties @ Font Details Sidebar Section"] = "Basic Properties";
@@ -373,6 +379,7 @@ localizedStrings["Clear:"] = "Clear:";
 localizedStrings["Click Listener"] = "Click Listener";
 localizedStrings["Click to create a Local Override from this content"] = "Click to create a Local Override from this content";
 localizedStrings["Click to import a file and create a Local Override\nShift-click to create a Local Override from this content"] = "Click to import a file and create a Local Override\nShift-click to create a Local Override from this content";
+localizedStrings["Click to pretty print"] = "Click to pretty print";
 /* Title of text button that resets the gesture controls in the image resource content view. */
 localizedStrings["Click to reset @ Image Resource Content View Gesture Controls"] = "Click to reset";
 localizedStrings["Click to select a color."] = "Click to select a color.";
@@ -386,6 +393,7 @@ localizedStrings["Click to show blackboxed call frame @ Debugger Call Stack"] = 
 localizedStrings["Click to show blackboxed call frames @ Debugger Call Stack"] = "Click to show %d blackboxed call frames";
 /* Tooltip to show purpose of the CSS documentation button */
 localizedStrings["Click to show documentation @ CSS Documentation Button"] = "Click to show documentation";
+localizedStrings["Click to show original formatting"] = "Click to show original formatting";
 localizedStrings["Click to view variable value"] = "Click to view variable value";
 localizedStrings["Click to view variable value\nShift-click to replace variable with value"] = "Click to view variable value\nShift-click to replace variable with value";
 localizedStrings["Clickable"] = "Clickable";
@@ -591,6 +599,8 @@ localizedStrings["Disk Cache"] = "Disk Cache";
 localizedStrings["Dismiss"] = "Dismiss";
 /* Tooltip for the dismiss button in banner views. */
 localizedStrings["Dismiss @ Banner View"] = "Dismiss";
+/* Title for Disparity in Media Sidebar */
+localizedStrings["Disparity @ Media Sidebar"] = "Disparity";
 /* Label for a canvas that uses the Display P3 color space. */
 localizedStrings["Display P3 @ Color Space"] = "Display P3";
 localizedStrings["Displayed Columns"] = "Displayed Columns";
@@ -760,6 +770,8 @@ localizedStrings["Extension Style Sheets"] = "Extension Style Sheets";
 localizedStrings["Extensions"] = "Extensions";
 localizedStrings["Extra Scripts"] = "Extra Scripts";
 localizedStrings["Extra Style Sheets"] = "Extra Style Sheets";
+/* Title for FOV in Media Sidebar */
+localizedStrings["FOV @ Media Sidebar"] = "FOV";
 localizedStrings["Fade unexecuted code"] = "Fade unexecuted code";
 /* Title of icon indicating that the selected audit failed. */
 localizedStrings["Fail @ Audit Tab - Test Case"] = "Fail";
@@ -1221,7 +1233,7 @@ localizedStrings["Options"] = "Options";
 localizedStrings["Order Numbers @ Layout Panel Overlay Options"] = "Order Numbers";
 /* Property value for `font-variant-numeric: ordinal`. */
 localizedStrings["Ordinal Letter Forms @ Font Details Sidebar Property Value"] = "Ordinal Letter Forms";
-localizedStrings["Click to show original formatting"] = "Click to show original formatting";
+localizedStrings["Original formatting"] = "Original formatting";
 localizedStrings["Originally %s"] = "Originally %s";
 localizedStrings["Originator"] = "Originator";
 localizedStrings["Other"] = "Other";
@@ -1302,7 +1314,7 @@ localizedStrings["Press %s to start running the audit."] = "Press %s to start ru
 localizedStrings["Press %s to stop editing audits."] = "Press %s to stop editing audits.";
 localizedStrings["Press %s to stop running."] = "Press %s to stop running.";
 localizedStrings["Pressed"] = "Pressed";
-localizedStrings["Click to pretty print"] = "Click to pretty print";
+localizedStrings["Pretty print"] = "Pretty print";
 localizedStrings["Preview"] = "Preview";
 /* A submenu item of 'Add' to add DOM nodes before the selected DOM node */
 localizedStrings["Previous Sibling"] = "Previous Sibling";
@@ -1315,6 +1327,8 @@ localizedStrings["Probe Sample Recorded"] = "Probe Sample Recorded";
 localizedStrings["Probes"] = "Probes";
 localizedStrings["Processing Instruction"] = "Processing Instruction";
 localizedStrings["Program %d"] = "Program %d";
+/* Title for Projection row in Media Sidebar */
+localizedStrings["Projections @ Media Sidebar"] = "Projection";
 localizedStrings["Properties"] = "Properties";
 localizedStrings["Property"] = "Property";
 /* Property value for `font-variant-numeric: proportional-nums`. */
@@ -1594,6 +1608,8 @@ localizedStrings["Simplified Forms @ Font Details Sidebar Property Value"] = "Si
 localizedStrings["Size"] = "Size";
 /* Property title for `font-size`. */
 localizedStrings["Size @ Font Details Sidebar Property"] = "Size";
+/* Titel for Size row in Spatial Section of Media Sidebar */
+localizedStrings["Size @ Spatial Section @ Media Sidebar"] = "Size";
 localizedStrings["Size of current object plus all objects it keeps alive"] = "Size of current object plus all objects it keeps alive";
 localizedStrings["Sizes"] = "Sizes";
 /* Label for checkbox that controls whether the local override will actually perform a network request or skip it to immediately serve the response. */
@@ -1625,6 +1641,8 @@ localizedStrings["Sources Tab Name"] = "Sources";
 localizedStrings["Sources:"] = "Sources:";
 localizedStrings["Space"] = "Space";
 localizedStrings["Spaces"] = "Spaces";
+/* Title for Media Details section in Media Sidebar */
+localizedStrings["Spatial Details @ Media Sidebar"] = "Spatial Details";
 localizedStrings["Specially Exposed Data"] = "Specially Exposed Data";
 localizedStrings["Specificity: (%d, %d, %d)"] = "Specificity: (%d, %d, %d)";
 localizedStrings["Specificity: No value for selected element"] = "Specificity: No value for selected element";
@@ -2035,13 +2053,21 @@ localizedStrings["default prevented"] = "default prevented";
 /* Shown in the 'Type' column of the Network Table for document resources. */
 localizedStrings["document @ Network Tab Resource Type Column Value"] = "document";
 localizedStrings["ensuring that common debugging functions are available on every page via the Console"] = "ensuring that common debugging functions are available on every page via the Console";
+/* Value for 'equi-angular-cubemap' in the Media Sidebar */
+localizedStrings["equi-angular-cubemap @ Media Sidebar"] = "Equi Angular Cubemap";
+/* Value for 'equirectangular' in the Media Sidebar */
+localizedStrings["equirectangular @ Media Sidebar"] = "Equirectangular";
 /* Shown in the 'Type' column of the Network Table for resources loaded via the EventSource API. */
 localizedStrings["eventsource @ Network Tab Resource Type Column Value"] = "eventsource";
 /* Shown in the 'Type' column of the Network Table for resources loaded via the 'fetch' method. */
 localizedStrings["fetch @ Network Tab Resource Type Column Value"] = "fetch";
+/* Value for 'fisheye' in the Media Sidebar */
+localizedStrings["fisheye @ Media Sidebar"] = "Fisheye";
 /* Shown in the 'Type' column of the Network Table for font resources. */
 localizedStrings["font @ Network Tab Resource Type Column Value"] = "font";
 localizedStrings["for changes to take effect"] = "for changes to take effect";
+/* Value for 'half-equirectangular' in the Media Sidebar */
+localizedStrings["half-equirectangular @ Media Sidebar"] = "Half Equirectangular";
 /* Shown in the 'Type' column of the Network Table for image resources. */
 localizedStrings["image @ Network Tab Resource Type Column Value"] = "image";
 localizedStrings["invalid HAR"] = "invalid HAR";
@@ -2065,10 +2091,14 @@ localizedStrings["originally %s"] = "originally %s";
 /* Shown in the 'Type' column of the Network Table for resources that don't fall into any of the other known types/categories. */
 localizedStrings["other @ Network Tab Resource Type Column Value"] = "other";
 localizedStrings["overriding built-in functions to log call traces or add %s statements"] = "overriding built-in functions to log call traces or add %s statements";
+/* Value for 'parametric' in the Media Sidebar */
+localizedStrings["parametric @ Media Sidebar"] = "Parametric";
 /* Shown in the 'Type' column of the Network Table for resources loaded via '<a ping>' elements. */
 localizedStrings["ping @ Network Tab Resource Type Column Value"] = "ping";
 localizedStrings["popup"] = "popup";
 localizedStrings["popup, toggle"] = "popup, toggle";
+/* Value for 'pyramid' in the Media Sidebar */
+localizedStrings["pyramid @ Media Sidebar"] = "Pyramid";
 localizedStrings["requestAnimationFrame Fired"] = "requestAnimationFrame Fired";
 /* Label for a canvas that uses the sRGB color space. */
 localizedStrings["sRGB @ Color Space"] = "sRGB";
@@ -2086,6 +2116,8 @@ localizedStrings["too new to run in the inspected page @ Audit Tab"] = "too new 
 /* Warning text shown if the version number in the 'supports' input is too new. */
 localizedStrings["too new to run in this Web Inspector @ Audit Tab"] = "too new to run in this Web Inspector";
 localizedStrings["unknown %s \u0022%s\u0022"] = "unknown %s \u0022%s\u0022";
+/* Value for 'unknown' in the Media Sidebar */
+localizedStrings["unknown @ Media Sidebar"] = "Unknown";
 localizedStrings["unsupported %s"] = "unsupported %s";
 localizedStrings["unsupported HAR version"] = "unsupported HAR version";
 localizedStrings["unsupported version"] = "unsupported version";

--- a/Source/WebInspectorUI/UserInterface/Views/MediaDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/MediaDetailsSidebarPanel.js
@@ -50,8 +50,9 @@ WI.MediaDetailsSidebarPanel = class MediaDetailsSidebarPanel extends WI.DOMDetai
         this.#ui.primariesRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Color Primaries", "Color Primaries @ Media Sidebar", "Title for Color Primaries row in Media Sidebar"));
         this.#ui.matrixRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Matrix Coefficients", "Matrix Coefficients @ Media Sidebar", "Title for Matrix Coefficients row in Media Sidebar"));
         this.#ui.fullRangeRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Color Range", "Color Range @ Media Sidebar", "Title for Color Range row in Media Sidebar"));
+        this.#ui.projectionRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Projection", "Projections @ Media Sidebar", "Title for Projection row in Media Sidebar"));
 
-        let videoGroup = new WI.DetailsSectionGroup([this.#ui.videoCodecRow, this.#ui.primariesRow, this.#ui.transferRow, this.#ui.matrixRow, this.#ui.fullRangeRow]);
+        let videoGroup = new WI.DetailsSectionGroup([this.#ui.videoCodecRow, this.#ui.primariesRow, this.#ui.transferRow, this.#ui.matrixRow, this.#ui.fullRangeRow, this.#ui.projectionRow]);
         this.#ui.videoSection = new WI.DetailsSection("media-video-details", WI.UIString("Video Details", "Video Details @ Media Sidebar", "Title for Video Details section in Media Sidebar"), [videoGroup]);
         this.#ui.audioCodecRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Audio Codec", "Audio Codec @ Media Sidebar", "Title for Audio Codec row in Media Sidebar"));
         this.#ui.sampleRateRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Sample Rate", "Sample Rate @ Media Sidebar", "Title for Sample Rate row in Media Sidebar"));
@@ -59,6 +60,14 @@ WI.MediaDetailsSidebarPanel = class MediaDetailsSidebarPanel extends WI.DOMDetai
 
         let audioGroup = new WI.DetailsSectionGroup([this.#ui.audioCodecRow, this.#ui.sampleRateRow, this.#ui.channelsRow]);
         this.#ui.audioSection = new WI.DetailsSection("media-audio-details", WI.UIString("Audio Details", "Audio Details @ Media Sidebar", "Title for Audio Details section in Media Sidebar"), [audioGroup]);
+
+        this.#ui.spatialSizeRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Size", "Size @ Spatial Section @ Media Sidebar", "Titel for Size row in Spatial Section of Media Sidebar"));
+        this.#ui.fovRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("FOV", "FOV @ Media Sidebar", "Title for FOV in Media Sidebar"));
+        this.#ui.baselineRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Baseline", "Baseline @ Media Sidebar", "Title for Baseline in Media Sidebar"));
+        this.#ui.disparityRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Disparity", "Disparity @ Media Sidebar", "Title for Disparity in Media Sidebar"));
+
+        let spatialGroup = new WI.DetailsSectionGroup([this.#ui.spatialSizeRow, this.#ui.fovRow, this.#ui.baselineRow, this.#ui.disparityRow]);
+        this.#ui.spatialSection = new WI.DetailsSection("media-spatial-details", WI.UIString("Spatial Details", "Spatial Details @ Media Sidebar", "Title for Media Details section in Media Sidebar"), [spatialGroup]);
     }
 
     layout()
@@ -74,9 +83,14 @@ WI.MediaDetailsSidebarPanel = class MediaDetailsSidebarPanel extends WI.DOMDetai
         this.#ui.primariesRow.updateValue();
         this.#ui.matrixRow.updateValue();
         this.#ui.fullRangeRow.updateValue();
+        this.#ui.projectionRow.updateValue();
         this.#ui.audioCodecRow.updateValue();
         this.#ui.sampleRateRow.updateValue();
         this.#ui.channelsRow.updateValue();
+        this.#ui.spatialSizeRow.updateValue();
+        this.#ui.fovRow.updateValue();
+        this.#ui.baselineRow.updateValue();
+        this.#ui.disparityRow.updateValue();
     }
 
     // Protected
@@ -109,6 +123,7 @@ WI.MediaDetailsSidebarPanel = class MediaDetailsSidebarPanel extends WI.DOMDetai
         this.element.appendChild(this.#ui.generalSection.element);
         this.element.appendChild(this.#ui.videoSection.element);
         this.element.appendChild(this.#ui.audioSection.element);
+        this.element.appendChild(this.#ui.spatialSection.element);
     }
 
     // Private
@@ -162,11 +177,17 @@ WI.MediaDetailsSidebarPanel = class MediaDetailsSidebarPanel extends WI.DOMDetai
         primariesRow: null,
         matrixRow: null,
         fullRangeRow: null,
+        projectionRow: null,
         videoSection: null,
         audioCodecRow: null,
         sampleRateRow: null,
         channelsRow: null,
         audioSection: null,
+        spatialSection: null,
+        spatialSizeRow: null,
+        fovRow: null,
+        baselineRow: null,
+        disparityRow: null,
     };
 
     #updateTimer = null;
@@ -268,6 +289,22 @@ WI.MediaDetailsSidebarPanel = class MediaDetailsSidebarPanel extends WI.DOMDetai
         this.needsLayout();
     }
 
+    #localizedVideoProjectionMetadataKindString(projectionKind)
+    {
+        if (!projectionKind)
+            return "";
+
+        switch (projectionKind) {
+        case "unknown": return WI.UIString("Unknown", "unknown @ Media Sidebar", "Value for 'unknown' in the Media Sidebar")
+        case "equirectangular": return WI.UIString("Equirectangular", "equirectangular @ Media Sidebar", "Value for 'equirectangular' in the Media Sidebar")
+        case "half-equirectangular": return WI.UIString("Half Equirectangular", "half-equirectangular @ Media Sidebar", "Value for 'half-equirectangular' in the Media Sidebar")
+        case "equi-angular-cubemap": return WI.UIString("Equi Angular Cubemap", "equi-angular-cubemap @ Media Sidebar", "Value for 'equi-angular-cubemap' in the Media Sidebar")
+        case "parametric": return WI.UIString("Parametric", "parametric @ Media Sidebar", "Value for 'parametric' in the Media Sidebar")
+        case "pyramid": return WI.UIString("Pyramid", "pyramid @ Media Sidebar", "Value for 'pyramid' in the Media Sidebar")
+        case "apple-immersive-video": return WI.UIString("Apple Immersive Video", "apple-immersive-video @ Media Sidebar", "Value for 'immersive' in the Media Sidebar")
+        }
+    }
+
     #setVideo(video)
     {
         if (this.#values.video === video)
@@ -295,6 +332,13 @@ WI.MediaDetailsSidebarPanel = class MediaDetailsSidebarPanel extends WI.DOMDetai
             this.#ui.fullRangeRow.pendingValue = WI.UIString("Full range", "Full range @ Media Sidebar", "Value string for Full Range color in the Media Sidebar");
         else
             this.#ui.fullRangeRow.pendingValue = WI.UIString("Video range", "Video range @ Media Sidebar", "Value string for Video Range color in the Media Sidebar");
+        this.#ui.projectionRow.pendingValue = this.#localizedVideoProjectionMetadataKindString(video?.videoProjectionMetadata?.kind);
+        this.#ui.projectionRow.element.classList.toggle("hidden", !video?.videoProjectionMetadata);
+        this.#ui.spatialSizeRow.pendingValue = WI.UIString("%dx%d").format(video?.spatialVideoMetadata?.width ?? 0, video?.spatialVideoMetadata?.height ?? 0);
+        this.#ui.fovRow.pendingValue = WI.UIString("%dº").format(video?.spatialVideoMetadata?.horizontalFOVDegrees ?? 0);
+        this.#ui.baselineRow.pendingValue = WI.UIString("%dmm").format((video?.spatialVideoMetadata?.baseline ?? 0) / 1000);
+        this.#ui.disparityRow.pendingValue = WI.UIString("%d%%").format((video?.spatialVideoMetadata?.disparityAdjustment ?? 0) * 100);
+        this.#ui.spatialSection.element.classList.toggle("hidden", !video?.spatialVideoMetadata);
         this.needsLayout();
     }
 

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
@@ -61,7 +61,7 @@ public:
     void volumeChanged(double) final;
     void supportsLinearMediaPlayerChanged(bool) final;
     void spatialVideoMetadataChanged(const std::optional<WebCore::SpatialVideoMetadata>&) final;
-    void isImmersiveVideoChanged(bool) final;
+    void videoProjectionMetadataChanged(const std::optional<WebCore::VideoProjectionMetadata>&) final;
     void startObservingNowPlayingMetadata() final;
     void stopObservingNowPlayingMetadata() final;
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
@@ -37,6 +37,7 @@
 #import <WebCore/SharedBuffer.h>
 #import <WebCore/SpatialVideoMetadata.h>
 #import <WebCore/TimeRanges.h>
+#import <WebCore/VideoProjectionMetadata.h>
 #import <wtf/OSObjectPtr.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/WeakPtr.h>
@@ -387,9 +388,9 @@ void PlaybackSessionInterfaceLMK::spatialVideoMetadataChanged(const std::optiona
     [m_player setSpatialVideoMetadata:spatialVideoMetadata.get()];
 }
 
-void PlaybackSessionInterfaceLMK::isImmersiveVideoChanged(bool value)
+void PlaybackSessionInterfaceLMK::videoProjectionMetadataChanged(const std::optional<WebCore::VideoProjectionMetadata>& metadata)
 {
-    [m_player setIsImmersiveVideo:value];
+    [m_player setIsImmersiveVideo:!!metadata];
 }
 
 void PlaybackSessionInterfaceLMK::startObservingNowPlayingMetadata()

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -59,6 +59,11 @@ header: <wtf/text/AtomString.h>
     [Validator='WTF::UUID::isValid(*high, *low)'] uint64_t low();
 }
 
+header: <wtf/JSONValues.h>
+[RefCounted, CustomHeader, CreateUsing=optionalParseJSON] class WTF::JSONImpl::Value {
+    String toJSONString();
+}
+
 header: <wtf/ObjectIdentifier.h>
 template: class WebKit::WebURLSchemeHandler
 template: enum class WebCore::AXIDType

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5949,6 +5949,22 @@ struct WebCore::SpatialVideoMetadata {
     float disparityAdjustment;
 };
 
+enum class WebCore::VideoProjectionMetadataKind : uint8_t {
+    Unknown,
+    Equirectangular,
+    HalfEquirectangular,
+    EquiAngularCubemap,
+    Parametric,
+    Pyramid,
+    AppleImmersiveVideo,
+};
+
+header: <WebCore/VideoProjectionMetadata.h>
+struct WebCore::VideoProjectionMetadata {
+    WebCore::VideoProjectionMetadataKind kind;
+    RefPtr<WTF::JSONImpl::Value> parameters;
+};
+
 struct WebCore::PlatformTrackConfiguration {
     String codec;
 };
@@ -5966,7 +5982,7 @@ struct WebCore::PlatformVideoTrackConfiguration : WebCore::PlatformTrackConfigur
     double framerate;
     uint64_t bitrate;
     std::optional<WebCore::SpatialVideoMetadata> spatialVideoMetadata;
-    bool isImmersiveVideo;
+    std::optional<WebCore::VideoProjectionMetadata> videoProjectionMetadata;
 };
 
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -42,9 +42,8 @@
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
-#if ENABLE(LINEAR_MEDIA_PLAYER)
 #include <WebCore/SpatialVideoMetadata.h>
-#endif
+#include <WebCore/VideoProjectionMetadata.h>
 
 namespace WebKit {
 
@@ -100,9 +99,10 @@ public:
 #endif
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     void supportsLinearMediaPlayerChanged(bool);
-    void spatialVideoMetadataChanged(const std::optional<WebCore::SpatialVideoMetadata>&);
-    void isImmersiveVideoChanged(bool);
 #endif
+
+    void spatialVideoMetadataChanged(const std::optional<WebCore::SpatialVideoMetadata>&);
+    void videoProjectionMetadataChanged(const std::optional<WebCore::VideoProjectionMetadata>&);
 
     bool wirelessVideoPlaybackDisabled() const final { return m_wirelessVideoPlaybackDisabled; }
     const WebCore::VideoReceiverEndpoint& videoReceiverEndpoint() { return m_videoReceiverEndpoint; }
@@ -232,9 +232,9 @@ private:
     WebCore::AudioSessionSoundStageSize m_soundStageSize { 0 };
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     bool m_supportsLinearMediaPlayer { false };
-    std::optional<WebCore::SpatialVideoMetadata> m_spatialVideoMetadata;
-    bool m_isImmersiveVideo { false };
 #endif
+    std::optional<WebCore::SpatialVideoMetadata> m_spatialVideoMetadata;
+    std::optional<WebCore::VideoProjectionMetadata> m_videoProjectionMetadata;
 
 #if !RELEASE_LOG_DISABLED
     uint64_t m_logIdentifier { 0 };
@@ -310,9 +310,9 @@ private:
 #endif
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     void supportsLinearMediaPlayerChanged(PlaybackSessionContextIdentifier, bool);
-    void spatialVideoMetadataChanged(PlaybackSessionContextIdentifier, const std::optional<WebCore::SpatialVideoMetadata>&);
-    void isImmersiveVideoChanged(PlaybackSessionContextIdentifier, bool);
 #endif
+    void spatialVideoMetadataChanged(PlaybackSessionContextIdentifier, const std::optional<WebCore::SpatialVideoMetadata>&);
+    void videoProjectionMetadataChanged(PlaybackSessionContextIdentifier, const std::optional<WebCore::VideoProjectionMetadata>&);
 
     // Messages to PlaybackSessionManager
 #if HAVE(PIP_SKIP_PREROLL)

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
@@ -50,9 +50,9 @@ messages -> PlaybackSessionManagerProxy {
 #endif
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     SupportsLinearMediaPlayerChanged(WebCore::MediaPlayerClientIdentifier contextId, bool supportsLinearMediaPlayer)
-    SpatialVideoMetadataChanged(WebCore::MediaPlayerClientIdentifier contextId, struct std::optional<WebCore::SpatialVideoMetadata> metadata);
-    IsImmersiveVideoChanged(WebCore::MediaPlayerClientIdentifier contextId, bool value);
 #endif
+    SpatialVideoMetadataChanged(WebCore::MediaPlayerClientIdentifier contextId, struct std::optional<WebCore::SpatialVideoMetadata> metadata);
+    VideoProjectionMetadataChanged(WebCore::MediaPlayerClientIdentifier contextId, struct std::optional<WebCore::VideoProjectionMetadata> metadata);
     SetUpPlaybackControlsManagerWithID(WebCore::MediaPlayerClientIdentifier contextId, bool isVideo)
     ClearPlaybackControlsManager()
 

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -503,30 +503,29 @@ void PlaybackSessionModelContext::supportsLinearMediaPlayerChanged(bool supports
     if (RefPtr manager = m_manager.get())
         manager->updateVideoControlsManager(m_contextId);
 }
+#endif
 
 void PlaybackSessionModelContext::spatialVideoMetadataChanged(const std::optional<WebCore::SpatialVideoMetadata>& metadata)
 {
     if (m_spatialVideoMetadata == metadata)
         return;
-    if (metadata)
-        ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, *metadata);
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, metadata);
     m_spatialVideoMetadata = metadata;
 
     for (CheckedRef client : m_clients)
         client->spatialVideoMetadataChanged(m_spatialVideoMetadata);
 }
 
-void PlaybackSessionModelContext::isImmersiveVideoChanged(bool value)
+void PlaybackSessionModelContext::videoProjectionMetadataChanged(const std::optional<VideoProjectionMetadata>& metadata)
 {
-    if (m_isImmersiveVideo == value)
+    if (m_videoProjectionMetadata == metadata)
         return;
-    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, value);
-    m_isImmersiveVideo = value;
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, metadata);
+    m_videoProjectionMetadata = metadata;
 
     for (CheckedRef client : m_clients)
-        client->isImmersiveVideoChanged(m_isImmersiveVideo);
+        client->videoProjectionMetadataChanged(m_videoProjectionMetadata);
 }
-#endif
 
 void PlaybackSessionModelContext::invalidate()
 {
@@ -850,18 +849,17 @@ void PlaybackSessionManagerProxy::supportsLinearMediaPlayerChanged(PlaybackSessi
 {
     ensureModel(contextId)->supportsLinearMediaPlayerChanged(supportsLinearMediaPlayer);
 }
+#endif
 
 void PlaybackSessionManagerProxy::spatialVideoMetadataChanged(PlaybackSessionContextIdentifier contextId, const std::optional<WebCore::SpatialVideoMetadata>& metadata)
 {
     ensureModel(contextId)->spatialVideoMetadataChanged(metadata);
 }
 
-void PlaybackSessionManagerProxy::isImmersiveVideoChanged(PlaybackSessionContextIdentifier contextId, bool value)
+void PlaybackSessionManagerProxy::videoProjectionMetadataChanged(PlaybackSessionContextIdentifier contextId, const std::optional<WebCore::VideoProjectionMetadata>& metadata)
 {
-    ensureModel(contextId)->isImmersiveVideoChanged(value);
+    ensureModel(contextId)->videoProjectionMetadataChanged(metadata);
 }
-
-#endif
 
 void PlaybackSessionManagerProxy::handleControlledElementIDResponse(PlaybackSessionContextIdentifier contextId, String identifier) const
 {

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -103,10 +103,8 @@ private:
     void volumeChanged(double) final;
     void isPictureInPictureSupportedChanged(bool) final;
     void isInWindowFullscreenActiveChanged(bool) final;
-#if ENABLE(LINEAR_MEDIA_PLAYER)
     void spatialVideoMetadataChanged(const std::optional<WebCore::SpatialVideoMetadata>&) final;
-    void isImmersiveVideoChanged(bool) final;
-#endif
+    void videoProjectionMetadataChanged(const std::optional<WebCore::VideoProjectionMetadata>&) final;
 
     PlaybackSessionInterfaceContext(PlaybackSessionManager&, PlaybackSessionContextIdentifier);
 
@@ -188,7 +186,7 @@ private:
     void isPictureInPictureSupportedChanged(PlaybackSessionContextIdentifier, bool);
     void isInWindowFullscreenActiveChanged(PlaybackSessionContextIdentifier, bool);
     void spatialVideoMetadataChanged(PlaybackSessionContextIdentifier, const std::optional<WebCore::SpatialVideoMetadata>&);
-    void isImmersiveVideoChanged(PlaybackSessionContextIdentifier, bool);
+    void videoProjectionMetadataChanged(PlaybackSessionContextIdentifier, const std::optional<WebCore::VideoProjectionMetadata>&);
 #if HAVE(PIP_SKIP_PREROLL)
     void canSkipAdChanged(PlaybackSessionContextIdentifier, bool);
 #endif

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
@@ -171,19 +171,17 @@ void PlaybackSessionInterfaceContext::isInWindowFullscreenActiveChanged(bool isI
         manager->isInWindowFullscreenActiveChanged(m_contextId, isInWindow);
 }
 
-#if ENABLE(LINEAR_MEDIA_PLAYER)
 void PlaybackSessionInterfaceContext::spatialVideoMetadataChanged(const std::optional<WebCore::SpatialVideoMetadata>& metadata)
 {
     if (m_manager)
         m_manager->spatialVideoMetadataChanged(m_contextId, metadata);
 }
 
-void PlaybackSessionInterfaceContext::isImmersiveVideoChanged(bool value)
+void PlaybackSessionInterfaceContext::videoProjectionMetadataChanged(const std::optional<VideoProjectionMetadata>& value)
 {
     if (m_manager)
-        m_manager->isImmersiveVideoChanged(m_contextId, value);
+        m_manager->videoProjectionMetadataChanged(m_contextId, value);
 }
-#endif
 
 #pragma mark - PlaybackSessionManager
 
@@ -480,17 +478,15 @@ void PlaybackSessionManager::isInWindowFullscreenActiveChanged(PlaybackSessionCo
     m_page->send(Messages::PlaybackSessionManagerProxy::IsInWindowFullscreenActiveChanged(contextId, inWindow));
 }
 
-#if ENABLE(LINEAR_MEDIA_PLAYER)
 void PlaybackSessionManager::spatialVideoMetadataChanged(PlaybackSessionContextIdentifier contextId, const std::optional<WebCore::SpatialVideoMetadata>& metadata)
 {
     m_page->send(Messages::PlaybackSessionManagerProxy::SpatialVideoMetadataChanged(contextId, metadata));
 }
 
-void PlaybackSessionManager::isImmersiveVideoChanged(PlaybackSessionContextIdentifier contextId, bool value)
+void PlaybackSessionManager::videoProjectionMetadataChanged(PlaybackSessionContextIdentifier contextId, const std::optional<VideoProjectionMetadata>& value)
 {
-    m_page->send(Messages::PlaybackSessionManagerProxy::IsImmersiveVideoChanged(contextId, value));
+    m_page->send(Messages::PlaybackSessionManagerProxy::VideoProjectionMetadataChanged(contextId, value));
 }
-#endif
 
 #pragma mark Messages from PlaybackSessionManagerProxy:
 


### PR DESCRIPTION
#### 71b6d3a51a9e0df507c3ddb7cb63afe1914a709d
<pre>
Add logging and Web Inspector support for spatial and projection metadata
<a href="https://rdar.apple.com/150615061">rdar://150615061</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292507">https://bugs.webkit.org/show_bug.cgi?id=292507</a>

Reviewed by Jean-Yves Avenard.

Add an enumerated list of projection types, and pass that metadata as well
as spatialVideoMetadata through to the Web Inspector, as well as the UIProcess.

Drive-by fixes:
- Add a change observer to VideoTrackConfiguration to allow clients to be notified
  of changes to the configuration without requiring a Client superclass.
- Make AVTrackPrivateAVFObjCImpl reference-counted.
- Compare AVAssetTrack.mediaType and AVMediaSelectionOption.mediaType with -isEqualToString:
  rather than pointer equality.

* Source/JavaScriptCore/inspector/protocol/DOM.json:
* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/Logger.h:
(WTF::LogArgument&lt;std::optional&lt;T&gt;&gt;::toString):
* Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp:
(WTF::LogArgument&lt;std::optional&lt;T&gt;&gt;::toString): Deleted.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::audioTrackConfigurationChanged):
(WebCore::HTMLMediaElement::videoTrackConfigurationChanged):
(WebCore::HTMLMediaElement::addAudioTrack):
(WebCore::HTMLMediaElement::addVideoTrack):
(WebCore::HTMLMediaElement::removeAudioTrack):
(WebCore::HTMLMediaElement::removeVideoTrack):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::descriptionForTrack):
(WebCore::MediaElementSession::description const):
* Source/WebCore/html/MediaElementSession.h:
* Source/WebCore/html/track/AudioTrack.cpp:
(WebCore::AudioTrack::configurationChanged):
* Source/WebCore/html/track/AudioTrackClient.h:
(WebCore::AudioTrackClient::audioTrackConfigurationChanged):
* Source/WebCore/html/track/VideoTrack.cpp:
(WebCore::VideoTrack::configurationChanged):
* Source/WebCore/html/track/VideoTrackClient.h:
(WebCore::VideoTrackClient::videoTrackConfigurationChanged):
* Source/WebCore/html/track/VideoTrackConfiguration.cpp:
(WebCore::VideoTrackConfiguration::setState):
(WebCore::VideoTrackConfiguration::setCodec):
(WebCore::VideoTrackConfiguration::setWidth):
(WebCore::VideoTrackConfiguration::setHeight):
(WebCore::VideoTrackConfiguration::setColorSpace):
(WebCore::VideoTrackConfiguration::setFramerate):
(WebCore::VideoTrackConfiguration::setBitrate):
(WebCore::VideoTrackConfiguration::setSpatialVideoMetadata):
(WebCore::VideoTrackConfiguration::setVideoProjectionMetadata):
(WebCore::VideoTrackConfiguration::notifyObservers):
(WebCore::VideoTrackConfiguration::toJSON const):
* Source/WebCore/html/track/VideoTrackConfiguration.h:
(WebCore::VideoTrackConfiguration::videoProjectionMetadata const):
(WebCore::VideoTrackConfiguration::setState): Deleted.
(WebCore::VideoTrackConfiguration::setCodec): Deleted.
(WebCore::VideoTrackConfiguration::setWidth): Deleted.
(WebCore::VideoTrackConfiguration::setHeight): Deleted.
(WebCore::VideoTrackConfiguration::setColorSpace): Deleted.
(WebCore::VideoTrackConfiguration::setFramerate): Deleted.
(WebCore::VideoTrackConfiguration::setBitrate): Deleted.
(WebCore::VideoTrackConfiguration::setSpatialVideoMetadata): Deleted.
(WebCore::VideoTrackConfiguration::isImmersiveVideo const): Deleted.
(WebCore::VideoTrackConfiguration::setIsImmersiveVideo): Deleted.
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::videoProjectionMetadataKind):
(WebCore::InspectorDOMAgent::getMediaStats):
* Source/WebCore/platform/cocoa/PlaybackSessionModel.h:
(WebCore::PlaybackSessionModelClient::supportsLinearMediaPlayerChanged):
(WebCore::PlaybackSessionModelClient::spatialVideoMetadataChanged):
(WebCore::PlaybackSessionModelClient::videoProjectionMetadataChanged):
(WebCore::PlaybackSessionModelClient::isImmersiveVideoChanged): Deleted.
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm:
(WebCore::PlaybackSessionModelMediaElement::videoTrackConfigurationChanged):
(WebCore::PlaybackSessionModelMediaElement::maybeUpdateVideoMetadata):
(WebCore::PlaybackSessionModelMediaElement::seekableRanges const):
(WebCore::PlaybackSessionModelMediaElement::isInWindowFullscreenActive const):
(WebCore::PlaybackSessionModelMediaElement::logIdentifier const):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::convertEnumerationToString):
(WebCore::convertVideoProjectionMetadataToString):
* Source/WebCore/platform/graphics/PlatformVideoTrackConfiguration.h:
* Source/WebCore/platform/graphics/VideoProjectionMetadata.h: Copied from Source/WebCore/html/track/VideoTrackClient.h.
(WTF::LogArgument&lt;WebCore::VideoProjectionMetadata&gt;::toString):
* Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.h:
* Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm:
(WebCore::AVTrackPrivateAVFObjCImpl::initializeAssetTrack):
(WebCore::AVTrackPrivateAVFObjCImpl::initializationCompleted):
(WebCore::AVTrackPrivateAVFObjCImpl::readyState const):
(WebCore::AVTrackPrivateAVFObjCImpl::videoTrackConfiguration const):
(WebCore::AVTrackPrivateAVFObjCImpl::spatialVideoMetadata const):
(WebCore::AVTrackPrivateAVFObjCImpl::videoProjectionMetadata const):
(WebCore::AVTrackPrivateAVFObjCImpl::isImmersiveVideo const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/FormatDescriptionUtilities.cpp:
(WebCore::spatialVideoMetadataFromFormatDescription):
(WebCore::videoProjectionMetadataFromFormatDescription):
(WebCore::videoMetadataFromFormatDescription): Deleted.
* Source/WebCore/platform/graphics/avfoundation/FormatDescriptionUtilities.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.mm:
(WebCore::AudioTrackPrivateAVFObjC::AudioTrackPrivateAVFObjC):
(WebCore::AudioTrackPrivateAVFObjC::resetPropertiesFromTrack):
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.cpp:
(WebCore::AudioTrackPrivateMediaSourceAVFObjC::AudioTrackPrivateMediaSourceAVFObjC):
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/TextTrackPrivateMediaSourceAVFObjC.cpp:
(WebCore::m_impl):
* Source/WebCore/platform/graphics/avfoundation/objc/TextTrackPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp:
(WebCore::VideoTrackPrivateAVFObjC::VideoTrackPrivateAVFObjC):
(WebCore::VideoTrackPrivateAVFObjC::resetPropertiesFromTrack):
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm:
(WebCore::VideoTrackPrivateMediaSourceAVFObjC::VideoTrackPrivateMediaSourceAVFObjC):
* Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h:
* Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp:
(WebCore::VideoTrackPrivateWebM::updateConfiguration):
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Views/MediaDetailsSidebarPanel.js:
(WI.MediaDetailsSidebarPanel):
(WI.MediaDetailsSidebarPanel.prototype.layout):
(WI.MediaDetailsSidebarPanel.prototype.initialLayout):
(WI.MediaDetailsSidebarPanel.prototype.localizedVideoProjectionMetadataKindString):
(WI.MediaDetailsSidebarPanel.prototype.setVideo):
* Source/WebKit/Platform/IPC/ArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;JSON::Value&gt;::encode):
(IPC::ArgumentCoder&lt;JSON::Value&gt;::decode):
* Source/WebKit/Platform/IPC/ArgumentCoders.h:
* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h:
* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm:
(WebKit::PlaybackSessionInterfaceLMK::videoProjectionMetadataChanged):
(WebKit::PlaybackSessionInterfaceLMK::isImmersiveVideoChanged): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionModelContext::spatialVideoMetadataChanged):
(WebKit::PlaybackSessionModelContext::videoProjectionMetadataChanged):
(WebKit::PlaybackSessionManagerProxy::videoProjectionMetadataChanged):
(WebKit::PlaybackSessionModelContext::isImmersiveVideoChanged): Deleted.
(WebKit::PlaybackSessionManagerProxy::isImmersiveVideoChanged): Deleted.
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm:
(WebKit::PlaybackSessionInterfaceContext::videoProjectionMetadataChanged):
(WebKit::PlaybackSessionManager::videoProjectionMetadataChanged):
(WebKit::PlaybackSessionInterfaceContext::isImmersiveVideoChanged): Deleted.
(WebKit::PlaybackSessionManager::isImmersiveVideoChanged): Deleted.

Canonical link: <a href="https://commits.webkit.org/294733@main">https://commits.webkit.org/294733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4df94f916b75c47afa684f4408ac4392a5f6fb5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102882 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12876 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108048 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/53523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104921 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31057 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/78225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/53523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17716 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/92842 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/58559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/17557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10878 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52880 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/95557 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/87366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110423 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/101492 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22113 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87207 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30383 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89038 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/86826 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22100 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31674 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9388 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/24281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29946 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/35268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/125125 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/29754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34719 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33081 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/31316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->