### PR TITLE
Leverage C++20's <bit> header functions in more places

### DIFF
--- a/Source/JavaScriptCore/runtime/PropertyTable.cpp
+++ b/Source/JavaScriptCore/runtime/PropertyTable.cpp
@@ -65,7 +65,7 @@ PropertyTable::PropertyTable(VM& vm, unsigned initialCapacity)
     , m_keyCount(0)
     , m_deletedCount(0)
 {
-    ASSERT(isPowerOf2(m_indexSize));
+    ASSERT(std::has_single_bit(m_indexSize));
     bool isCompact = tableCapacity() < UINT8_MAX;
     m_indexVector = allocateZeroedIndexVector(isCompact, m_indexSize);
     ASSERT(isCompact == this->isCompact());
@@ -79,7 +79,7 @@ PropertyTable::PropertyTable(VM& vm, const PropertyTable& other)
     , m_keyCount(other.m_keyCount)
     , m_deletedCount(other.m_deletedCount)
 {
-    ASSERT(isPowerOf2(m_indexSize));
+    ASSERT(std::has_single_bit(m_indexSize));
     ASSERT(isCompact() == other.isCompact());
     memcpy(std::bit_cast<void*>(m_indexVector & indexVectorMask), std::bit_cast<void*>(other.m_indexVector & indexVectorMask), dataSize(isCompact()));
 
@@ -102,7 +102,7 @@ PropertyTable::PropertyTable(VM& vm, unsigned initialCapacity, const PropertyTab
     , m_keyCount(0)
     , m_deletedCount(0)
 {
-    ASSERT(isPowerOf2(m_indexSize));
+    ASSERT(std::has_single_bit(m_indexSize));
     ASSERT(initialCapacity >= other.m_keyCount);
     bool isCompact = other.isCompact() && tableCapacity() < UINT8_MAX;
     m_indexVector = allocateZeroedIndexVector(isCompact, m_indexSize);

--- a/Source/JavaScriptCore/runtime/PropertyTable.h
+++ b/Source/JavaScriptCore/runtime/PropertyTable.h
@@ -24,6 +24,7 @@
 #include "PropertyOffset.h"
 #include "Structure.h"
 #include "WriteBarrier.h"
+#include <bit>
 #include <wtf/HashTable.h>
 #include <wtf/MathExtras.h>
 #include <wtf/StdLibExtras.h>
@@ -58,27 +59,6 @@ struct PropertyTableStats {
 JS_EXPORT_PRIVATE extern PropertyTableStats* propertyTableStats;
 
 #endif
-
-inline constexpr bool isPowerOf2(unsigned v)
-{
-    return hasOneBitSet(v);
-}
-
-inline constexpr unsigned nextPowerOf2(unsigned v)
-{
-    // Taken from http://www.cs.utk.edu/~vose/c-stuff/bithacks.html
-    // Devised by Sean Anderson, Sepember 14, 2001
-
-    v--;
-    v |= v >> 1;
-    v |= v >> 2;
-    v |= v >> 4;
-    v |= v >> 8;
-    v |= v >> 16;
-    v++;
-
-    return v;
-}
 
 // compact <-> non-compact PropertyTable
 // We need to maintain two things, one is PropertyOffset and one is unsigned index in index buffer of PropertyTable.
@@ -654,7 +634,7 @@ inline unsigned PropertyTable::sizeForCapacity(unsigned capacity)
 {
     if (capacity < MinimumTableSize / 2)
         return MinimumTableSize;
-    return nextPowerOf2(capacity + 1) * 2;
+    return std::bit_ceil(capacity + 1) * 2;
 }
 
 inline bool PropertyTable::canInsert(const ValueType& entry)

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -37,6 +37,7 @@
 #include "LengthFunctions.h"
 #include "TextureMapperFlags.h"
 #include "TextureMapperShaderProgram.h"
+#include <bit>
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Ref.h>
@@ -54,15 +55,6 @@
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TextureMapper);
-
-static size_t nextPowerOf2(size_t n)
-{
-    if (!n)
-        return 1;
-
-    const int totalBits = static_cast<int>(sizeof(size_t) * CHAR_BIT);
-    return static_cast<size_t>(1) << (totalBits - std::countl_zero(n - 1));
-}
 
 class TextureMapperGLData {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(TextureMapperGLData);
@@ -1532,7 +1524,7 @@ void TextureMapper::drawTextureExternalOES(GLuint texture, OptionSet<TextureMapp
 
 Ref<TextureMapperGPUBuffer> TextureMapper::acquireBufferFromPool(size_t size, TextureMapperGPUBuffer::Type type)
 {
-    size_t ceil = nextPowerOf2(size);
+    size_t ceil = std::bit_ceil(size);
     size_t floor = ceil >> 1; // half of ceil
     size_t mid = floor + (floor >> 1); // (1.5 times floor)
     size_t requestSize = (size <= mid) ? mid : ceil;

--- a/Source/WebKit/Shared/SharedStringHashStore.cpp
+++ b/Source/WebKit/Shared/SharedStringHashStore.cpp
@@ -37,26 +37,10 @@ using namespace WebCore;
 
 const unsigned sharedStringHashTableMaxLoad = 2;
 
-static unsigned nextPowerOf2(unsigned v)
-{
-    // Taken from http://www.cs.utk.edu/~vose/c-stuff/bithacks.html
-    // Devised by Sean Anderson, September 14, 2001
-
-    v--;
-    v |= v >> 1;
-    v |= v >> 2;
-    v |= v >> 4;
-    v |= v >> 8;
-    v |= v >> 16;
-    v++;
-
-    return v;
-}
-
 static unsigned tableLengthForKeyCount(unsigned keyCount)
 {
     // We want the table to be at least half empty.
-    unsigned tableLength = nextPowerOf2(keyCount * sharedStringHashTableMaxLoad);
+    unsigned tableLength = std::bit_ceil(keyCount * sharedStringHashTableMaxLoad);
 
     // Ensure that the table length is at least the size of a page.
     size_t minimumTableLength = pageSize() / sizeof(SharedStringHash);

--- a/Source/WebKit/Shared/SharedStringHashTableReadOnly.cpp
+++ b/Source/WebKit/Shared/SharedStringHashTableReadOnly.cpp
@@ -27,20 +27,12 @@
 #include "SharedStringHashTableReadOnly.h"
 
 #include <WebCore/SharedMemory.h>
+#include <bit>
 #include <wtf/StdLibExtras.h>
 
 namespace WebKit {
 
 using namespace WebCore;
-
-#if ASSERT_ENABLED
-static inline bool isPowerOf2(unsigned v)
-{
-    // Taken from http://www.cs.utk.edu/~vose/c-stuff/bithacks.html
-
-    return !(v & (v - 1)) && v;
-}
-#endif
 
 static inline unsigned doubleHash(unsigned key)
 {
@@ -63,7 +55,7 @@ void SharedStringHashTableReadOnly::setSharedMemory(RefPtr<SharedMemory>&& share
     if (m_sharedMemory) {
         ASSERT(!(m_sharedMemory->size() % sizeof(SharedStringHash)));
         m_table = spanReinterpretCast<SharedStringHash>(m_sharedMemory->mutableSpan());
-        ASSERT(isPowerOf2(m_table.size()));
+        ASSERT(std::has_single_bit(m_table.size()));
         m_tableSizeMask = m_table.size() - 1;
     } else {
         m_table = { };


### PR DESCRIPTION
#### d9dd5c05098caebda9ab2cd3d6aef07b4fae79df
<pre>
Leverage C++20&apos;s &lt;bit&gt; header functions in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=292509">https://bugs.webkit.org/show_bug.cgi?id=292509</a>

Reviewed by NOBODY (OOPS!).

* Source/JavaScriptCore/runtime/PropertyTable.cpp:
(JSC::PropertyTable::PropertyTable):
* Source/JavaScriptCore/runtime/PropertyTable.h:
(JSC::PropertyTable::sizeForCapacity):
(JSC::isPowerOf2): Deleted.
(JSC::nextPowerOf2): Deleted.
* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
(WebCore::TextureMapper::acquireBufferFromPool):
(WebCore::nextPowerOf2): Deleted.
* Source/WebKit/Shared/SharedStringHashStore.cpp:
(WebKit::tableLengthForKeyCount):
(WebKit::nextPowerOf2): Deleted.
* Source/WebKit/Shared/SharedStringHashTableReadOnly.cpp:
(WebKit::SharedStringHashTableReadOnly::setSharedMemory):
(WebKit::isPowerOf2): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9dd5c05098caebda9ab2cd3d6aef07b4fae79df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102037 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107196 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52671 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77662 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34667 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105044 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17025 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92125 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57998 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16852 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10150 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52030 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94709 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86692 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109569 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100647 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21489 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86634 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29532 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88329 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86213 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31008 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8729 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23369 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29098 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34393 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124272 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28909 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34517 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/cc-int-to-int-no-jit.js.default-wasm (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32232 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30468 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->