### PR TITLE
Update compare-results to support MotionMark 1.3.1

### DIFF
--- a/Tools/Scripts/compare-results
+++ b/Tools/Scripts/compare-results
@@ -66,6 +66,7 @@ MotionMark1_1 = "MotionMark-1.1"
 MotionMark1_1_1 = "MotionMark-1.1.1"
 MotionMark1_2 = "MotionMark-1.2"
 MotionMark1_3 = "MotionMark-1.3"
+MotionMark1_3_1 = "MotionMark-1.3.1"
 RAMification = "RAMification"
 
 unitMarker = "__unit__"
@@ -199,6 +200,8 @@ def motionMarkBreakdown(jsonObject):
         name = "MotionMark-1.2"
     elif detectMotionMark1_3(jsonObject):
         name = "MotionMark-1.3"
+    elif detectMotionMark1_3_1(jsonObject):
+        name = "MotionMark-1.3.1"
 
     for test in breakdown._results[name]["tests"].keys():
         result[test] = breakdown._results[name]["tests"][test]["metrics"]["Score"][None]["current"]
@@ -564,8 +567,11 @@ def detectMotionMark1_2(payload):
 def detectMotionMark1_3(payload):
     return "MotionMark-1.3" in payload
 
+def detectMotionMark1_3_1(payload):
+    return "MotionMark-1.3.1" in payload
+
 def motionMarkResults(payload):
-    assert any(validMotionMarkDetector(payload) for validMotionMarkDetector in [detectMotionMark, detectMotionMark1_1, detectMotionMark1_1_1, detectMotionMark1_2, detectMotionMark1_3])
+    assert any(validMotionMarkDetector(payload) for validMotionMarkDetector in [detectMotionMark, detectMotionMark1_1, detectMotionMark1_1_1, detectMotionMark1_2, detectMotionMark1_3, detectMotionMark1_3_1])
     if detectMotionMark(payload):
         payload = payload["MotionMark"]
     elif detectMotionMark1_1(payload):
@@ -574,8 +580,10 @@ def motionMarkResults(payload):
         payload = payload["MotionMark-1.1.1"]
     elif detectMotionMark1_2(payload):
         payload = payload["MotionMark-1.2"]
-    else:
+    elif detectMotionMark1_3(payload):
         payload = payload["MotionMark-1.3"]
+    else:
+        payload = payload["MotionMark-1.3.1"]
     testNames = list(payload["tests"].keys())
     numTests = len(payload["tests"][testNames[0]]["metrics"]["Score"]["current"])
     results = []
@@ -620,12 +628,14 @@ def detectBenchmark(payload):
         return MotionMark1_2
     if detectMotionMark1_3(payload):
         return MotionMark1_3
+    if detectMotionMark1_3_1(payload):
+        return MotionMark1_3_1
     if detectRAMification(payload):
         return RAMification
     return None
 
 def biggerIsBetter(benchmarkType):
-    if benchmarkType in [JetStream2, JetStream3, Speedometer2, Speedometer3, MotionMark, MotionMark1_1, MotionMark1_1_1, MotionMark1_2, MotionMark1_3]:
+    if benchmarkType in [JetStream2, JetStream3, Speedometer2, Speedometer3, MotionMark, MotionMark1_1, MotionMark1_1_1, MotionMark1_2, MotionMark1_3, MotionMark1_3_1]:
         return True
     elif benchmarkType in [PLT5, CompetitivePLT, PLUM3, RAMification]:
         return False
@@ -763,7 +773,7 @@ def main():
 
         if args.csv:
             writeCSV(speedometer3Breakdown(a), speedometer3Breakdown(b), args.csv, args.sort)
-    elif any(typeA == validMotionMarkTest for validMotionMarkTest in [MotionMark, MotionMark1_1, MotionMark1_1_1, MotionMark1_2, MotionMark1_3]):
+    elif any(typeA == validMotionMarkTest for validMotionMarkTest in [MotionMark, MotionMark1_1, MotionMark1_1_1, MotionMark1_2, MotionMark1_3, MotionMark1_3_1]):
         if args.breakdown:
             dumpBreakdowns(motionMarkBreakdown(a), motionMarkBreakdown(b), args.sort)
 


### PR DESCRIPTION
#### adc84f53ac2e8a12fec130d25b0e7910d08ebaf9
<pre>
Update compare-results to support MotionMark 1.3.1
<a href="https://bugs.webkit.org/show_bug.cgi?id=292513">https://bugs.webkit.org/show_bug.cgi?id=292513</a>
<a href="https://rdar.apple.com/150642121">rdar://150642121</a>

Reviewed by Yusuke Suzuki.

Previously it only supported up to MotionMark 1.3.

* Tools/Scripts/compare-results:
(motionMarkBreakdown):
(detectMotionMark1_3):
(detectMotionMark1_3_1):
(motionMarkResults):
(detectBenchmark):
(biggerIsBetter):
(main):

Canonical link: <a href="https://commits.webkit.org/294525@main">https://commits.webkit.org/294525@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c925209dc542b0e4c636d12524eac8dce1ae7b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21739 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107230 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52705 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104111 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30246 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77685 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34685 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105078 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17054 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58021 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16882 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10176 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52065 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86721 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109605 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29204 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21523 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86657 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29566 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88355 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86239 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21953 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31037 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8755 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23416 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29132 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28943 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32266 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30502 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->