### PR TITLE
Apply dynamic-range-limit to HDR WebGPU canvas

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit-constrained-disabled-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit-constrained-disabled-expected.txt
@@ -1,0 +1,4 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit-constrained-disabled.html
+++ b/LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit-constrained-disabled.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SupportHDRDisplayEnabled=true CSSConstrainedDynamicRangeLimitEnabled=false ] -->
+<html id="html">
+<body>
+<script src='../../resources/js-test-pre.js'></script>
+<canvas id="canvasd"></canvas>
+<canvas id="canvasn" style="dynamic-range-limit: no-limit"></canvas>
+<canvas id="canvasc" style="dynamic-range-limit: constrained"></canvas>
+<canvas id="canvass" style="dynamic-range-limit: standard"></canvas>
+<script>
+var canvasd;
+var canvasn;
+var canvasc;
+var canvass;
+var canvas2;
+
+const quiet = true; // So that the non-failure output is the same if dynamic-range-limit is not supported.
+
+function verifyCanvas(expectations)
+{
+    shouldBe(expectations.canvas + '.style["dynamic-range-limit"]', expectations.limit, quiet);
+    shouldBe('getComputedStyle(' + expectations.canvas + ')["dynamic-range-limit"]', expectations.computed, quiet);
+    shouldBe('internals.getContextEffectiveDynamicRangeLimitValue(' + expectations.canvas + ')', expectations.value, quiet);
+}
+
+if (!window.internals) {
+    failTest('This test requires window.internals.');
+} else if (CSS.supports("dynamic-range-limit", "standard") && CSS.supports("dynamic-range-limit", "no-limit")) {
+    shouldBe('CSS.supports("dynamic-range-limit", "constrained")', 'false', quiet);
+
+    canvasd = document.getElementById("canvasd");
+    canvasn = document.getElementById("canvasn");
+    canvasc = document.getElementById("canvasc");
+    canvass = document.getElementById("canvass");
+
+    const contextd = canvasd.getContext("webgpu");
+    const contextn = canvasn.getContext("webgpu");
+    const contextc = canvasc.getContext("webgpu");
+    const contexts = canvass.getContext("webgpu");
+
+    verifyCanvas({canvas: 'canvasd', limit: '""', computed: '"no-limit"', value: '1.0'});
+    verifyCanvas({canvas: 'canvasn', limit: '"no-limit"', computed: '"no-limit"', value: '1.0'});
+    verifyCanvas({canvas: 'canvasc', limit: '""', computed: '"no-limit"', value: '1.0'});
+    verifyCanvas({canvas: 'canvass', limit: '"standard"', computed: '"standard"', value: '0.0'});
+
+    canvas2 = document.createElement("canvas");
+    canvasn.append(canvas2);
+    const context2 = canvas2.getContext("webgpu");
+    verifyCanvas({canvas: 'canvas2', limit: '""', computed: '"no-limit"', value: '1.0'});
+}
+</script>
+<script src='../../resources/js-test-post.js'></script>
+</body>
+</html>

--- a/LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit-expected.txt
@@ -1,0 +1,4 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit.html
+++ b/LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SupportHDRDisplayEnabled=true CSSConstrainedDynamicRangeLimitEnabled=true ] -->
+<html id="html">
+<body>
+<script src='../../resources/js-test-pre.js'></script>
+<canvas id="canvasd"></canvas>
+<canvas id="canvasn" style="dynamic-range-limit: no-limit"></canvas>
+<canvas id="canvasc" style="dynamic-range-limit: constrained"></canvas>
+<canvas id="canvass" style="dynamic-range-limit: standard"></canvas>
+<script>
+var canvasd;
+var canvasn;
+var canvasc;
+var canvass;
+var canvas2;
+
+const quiet = true; // So that the non-failure output is the same if dynamic-range-limit is not supported.
+
+function verifyCanvas(expectations)
+{
+    shouldBe(expectations.canvas + '.style["dynamic-range-limit"]', expectations.limit, quiet);
+    shouldBe('getComputedStyle(' + expectations.canvas + ')["dynamic-range-limit"]', expectations.computed, quiet);
+    shouldBe('internals.getContextEffectiveDynamicRangeLimitValue(' + expectations.canvas + ')', expectations.value, quiet);
+}
+
+if (!window.internals) {
+    failTest('This test requires window.internals.');
+} else if (CSS.supports("dynamic-range-limit", "standard") && CSS.supports("dynamic-range-limit", "no-limit")) {
+    shouldBe('CSS.supports("dynamic-range-limit", "constrained")', 'true', quiet);
+
+    canvasd = document.getElementById("canvasd");
+    canvasn = document.getElementById("canvasn");
+    canvasc = document.getElementById("canvasc");
+    canvass = document.getElementById("canvass");
+
+    const contextd = canvasd.getContext("webgpu");
+    const contextn = canvasn.getContext("webgpu");
+    const contextc = canvasc.getContext("webgpu");
+    const contexts = canvass.getContext("webgpu");
+
+    verifyCanvas({canvas: 'canvasd', limit: '""', computed: '"no-limit"', value: '1.0'});
+    verifyCanvas({canvas: 'canvasn', limit: '"no-limit"', computed: '"no-limit"', value: '1.0'});
+    verifyCanvas({canvas: 'canvasc', limit: '"constrained"', computed: '"constrained"', value: '0.5'});
+    verifyCanvas({canvas: 'canvass', limit: '"standard"', computed: '"standard"', value: '0.0'});
+
+    canvas2 = document.createElement("canvas");
+    canvasn.append(canvas2);
+    const context2 = canvas2.getContext("webgpu");
+    verifyCanvas({canvas: 'canvas2', limit: '""', computed: '"no-limit"', value: '1.0'});
+}
+</script>
+<script src='../../resources/js-test-post.js'></script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -542,6 +542,9 @@ GPUCanvasContext* HTMLCanvasElement::createContextWebGPU(const String& type, GPU
     if (m_context) {
         // Need to make sure a RenderLayer and compositing layer get created for the Canvas.
         invalidateStyleAndLayerComposition();
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+        m_context->setDynamicRangeLimit(m_dynamicRangeLimit);
+#endif // ENABLE(PIXEL_FORMAT_RGBA16F)
     }
 
     return downcast<GPUCanvasContext>(m_context.get());
@@ -1011,6 +1014,25 @@ void HTMLCanvasElement::prepareForDisplay()
     if (m_context)
         m_context->prepareForDisplay();
     notifyObserversCanvasDisplayBufferPrepared();
+}
+
+void HTMLCanvasElement::dynamicRangeLimitDidChange(PlatformDynamicRangeLimit dynamicRangeLimit)
+{
+    if (m_dynamicRangeLimit == dynamicRangeLimit)
+        return;
+
+    m_dynamicRangeLimit = dynamicRangeLimit;
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    if (m_context)
+        m_context->setDynamicRangeLimit(dynamicRangeLimit);
+#endif // ENABLE(PIXEL_FORMAT_RGBA16F)
+}
+
+std::optional<double> HTMLCanvasElement::getContextEffectiveDynamicRangeLimitValue() const
+{
+    if (m_context)
+        return m_context->getEffectiveDynamicRangeLimitValue();
+    return std::nullopt;
 }
 
 bool HTMLCanvasElement::isControlledByOffscreen() const

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -33,6 +33,7 @@
 #include "FloatRect.h"
 #include "GraphicsTypes.h"
 #include "HTMLElement.h"
+#include "PlatformDynamicRangeLimit.h"
 #include <memory>
 #include <wtf/Forward.h>
 
@@ -134,6 +135,8 @@ public:
 
     bool needsPreparationForDisplay();
     void prepareForDisplay();
+    void dynamicRangeLimitDidChange(PlatformDynamicRangeLimit);
+    WEBCORE_EXPORT std::optional<double> getContextEffectiveDynamicRangeLimitValue() const;
 
     void setIsSnapshotting(bool isSnapshotting) { m_isSnapshotting = isSnapshotting; }
     bool isSnapshotting() const { return m_isSnapshotting; }
@@ -190,6 +193,7 @@ private:
     bool m_isSnapshotting { false };
 
     std::unique_ptr<CanvasRenderingContext> m_context;
+    PlatformDynamicRangeLimit m_dynamicRangeLimit { PlatformDynamicRangeLimit::initialValue() };
     mutable RefPtr<Image> m_copiedImage; // FIXME: This is temporary for platforms that have to copy the image buffer to render (and for CSSCanvasValue).
 };
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -122,7 +122,9 @@ public:
 
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
     bool isHDR() const { return pixelFormat() == ImageBufferPixelFormat::RGBA16F; }
+    virtual void setDynamicRangeLimit(PlatformDynamicRangeLimit) { };
 #endif
+    virtual std::optional<double> getEffectiveDynamicRangeLimitValue() const { return std::nullopt; };
 
     void setIsInPreparationForDisplayOrFlush(bool flag) { m_isInPreparationForDisplayOrFlush = flag; }
     bool isInPreparationForDisplayOrFlush() const { return m_isInPreparationForDisplayOrFlush; }

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -76,6 +76,11 @@ public:
     ExceptionOr<RefPtr<GPUTexture>> getCurrentTexture() override;
     RefPtr<ImageBuffer> transferToImageBuffer() override;
 
+#if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
+    void setDynamicRangeLimit(PlatformDynamicRangeLimit) override;
+    std::optional<double> getEffectiveDynamicRangeLimitValue() const override;
+#endif
+
 private:
     explicit GPUCanvasContextCocoa(CanvasBase&, Ref<GPUCompositorIntegration>&&, Ref<GPUPresentationContext>&&, Document*);
 
@@ -89,7 +94,12 @@ private:
     CanvasType htmlOrOffscreenCanvas() const;
     ExceptionOr<void> configure(GPUCanvasConfiguration&&, bool);
     void present(uint32_t frameIndex);
-    void updateContentsHeadroom(float);
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    float computeContentsHeadroom();
+    void updateContentsHeadroom();
+    void updateScreenHeadroom(float, bool suppressEDR);
+    void updateScreenHeadroomFromScreenProperties();
+#endif // HAVE(SUPPORT_HDR_DISPLAY)
 
     struct Configuration {
         Ref<GPUDevice> device;
@@ -111,9 +121,13 @@ private:
 
     GPUIntegerCoordinate m_width { 0 };
     GPUIntegerCoordinate m_height { 0 };
-    float m_contentsHeadroom { 0.f };
+#if HAVE(SUPPORT_HDR_DISPLAY)
     using ScreenPropertiesChangedObserver = Observer<void(PlatformDisplayID)>;
     std::optional<ScreenPropertiesChangedObserver> m_screenPropertiesChangedObserver;
+    PlatformDynamicRangeLimit m_dynamicRangeLimit { PlatformDynamicRangeLimit::initialValue() };
+    float m_currentEDRHeadroom { 1 };
+    bool m_suppressEDR { false };
+#endif // HAVE(SUPPORT_HDR_DISPLAY)
     bool m_compositingResultsNeedsUpdating { false };
 };
 

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -170,15 +170,12 @@ GPUCanvasContextCocoa::GPUCanvasContextCocoa(CanvasBase& canvas, Ref<GPUComposit
     , m_presentationContext(WTFMove(presentationContext))
     , m_width(getCanvasWidth(htmlOrOffscreenCanvas()))
     , m_height(getCanvasHeight(htmlOrOffscreenCanvas()))
-    , m_screenPropertiesChangedObserver([this](auto displayID) {
 #if HAVE(SUPPORT_HDR_DISPLAY)
+    , m_screenPropertiesChangedObserver([this](PlatformDisplayID displayID) {
         if (auto* screenData = WebCore::screenData(displayID))
-            updateContentsHeadroom(screenData->currentEDRHeadroom);
-#else
-        UNUSED_PARAM(displayID);
-        UNUSED_PARAM(this);
-#endif
+            updateScreenHeadroom(screenData->currentEDRHeadroom, screenData->suppressEDR);
     })
+#endif // HAVE(SUPPORT_HDR_DISPLAY)
 {
 #if HAVE(SUPPORT_HDR_DISPLAY)
     if (document)
@@ -190,14 +187,92 @@ GPUCanvasContextCocoa::GPUCanvasContextCocoa(CanvasBase& canvas, Ref<GPUComposit
 #endif
 }
 
-void GPUCanvasContextCocoa::updateContentsHeadroom(float headroom)
+#if HAVE(SUPPORT_HDR_DISPLAY)
+template <float limitLow, float limitHigh>
+static float interpolateHeadroom(float headroomForLow, float headroomForHigh, float limit)
 {
-    if (m_contentsHeadroom == headroom)
+    static_assert(limitLow < limitHigh);
+    if (headroomForHigh <= headroomForLow)
+        return headroomForHigh;
+    return std::lerp(headroomForLow, headroomForHigh, (limit - limitLow) / (limitHigh - limitLow));
+}
+
+float GPUCanvasContextCocoa::computeContentsHeadroom()
+{
+    if (m_currentEDRHeadroom <= 1.f)
+        return m_currentEDRHeadroom;
+
+    if (m_dynamicRangeLimit == PlatformDynamicRangeLimit::noLimit())
+        return m_currentEDRHeadroom;
+
+    constexpr auto forcedStandardHeadroom = 1.0000001f;
+
+    if (m_dynamicRangeLimit == PlatformDynamicRangeLimit::standard())
+        return forcedStandardHeadroom;
+
+    auto limitValue = m_dynamicRangeLimit.value();
+
+    if (m_suppressEDR) {
+        if (limitValue >= PlatformDynamicRangeLimit::constrained().value())
+            return m_currentEDRHeadroom;
+        return interpolateHeadroom<PlatformDynamicRangeLimit::standard().value(), PlatformDynamicRangeLimit::constrained().value()>(forcedStandardHeadroom, m_currentEDRHeadroom, limitValue);
+    }
+
+    constexpr auto maxConstrainedHeadroom = 1.6f;
+    auto suppressedHeadroom = std::min(maxConstrainedHeadroom, m_currentEDRHeadroom);
+    if (limitValue <= PlatformDynamicRangeLimit::constrained().value())
+        return interpolateHeadroom<PlatformDynamicRangeLimit::standard().value(), PlatformDynamicRangeLimit::constrained().value()>(forcedStandardHeadroom, suppressedHeadroom, limitValue);
+    return interpolateHeadroom<PlatformDynamicRangeLimit::constrained().value(), PlatformDynamicRangeLimit::noLimit().value()>(suppressedHeadroom, m_currentEDRHeadroom, limitValue);
+}
+
+void GPUCanvasContextCocoa::updateContentsHeadroom()
+{
+    m_compositorIntegration->updateContentsHeadroom(computeContentsHeadroom());
+}
+
+void GPUCanvasContextCocoa::updateScreenHeadroom(float currentEDRHeadroom, bool suppressEDR)
+{
+    if (m_suppressEDR == suppressEDR && m_currentEDRHeadroom == currentEDRHeadroom)
         return;
 
-    m_contentsHeadroom = headroom;
-    m_compositorIntegration->updateContentsHeadroom(headroom);
+    m_currentEDRHeadroom = currentEDRHeadroom;
+    m_suppressEDR = suppressEDR;
+    updateContentsHeadroom();
 }
+
+void GPUCanvasContextCocoa::updateScreenHeadroomFromScreenProperties()
+{
+    m_currentEDRHeadroom = 1.f;
+    m_suppressEDR = false;
+    for (const auto& screenData : WebCore::getScreenProperties().screenDataMap.values()) {
+        m_currentEDRHeadroom = std::max(m_currentEDRHeadroom, screenData.currentEDRHeadroom);
+        m_suppressEDR |= screenData.suppressEDR;
+    }
+    updateContentsHeadroom();
+}
+
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+void GPUCanvasContextCocoa::setDynamicRangeLimit(PlatformDynamicRangeLimit dynamicRangeLimit)
+{
+    if (m_dynamicRangeLimit == dynamicRangeLimit)
+        return;
+
+    m_dynamicRangeLimit = dynamicRangeLimit;
+
+    if (!m_screenPropertiesChangedObserver || m_currentEDRHeadroom < 1.f)
+        return updateScreenHeadroomFromScreenProperties();
+
+    updateContentsHeadroom();
+}
+
+std::optional<double> GPUCanvasContextCocoa::getEffectiveDynamicRangeLimitValue() const
+{
+    auto limitValue = m_dynamicRangeLimit.value();
+    auto suppressValue = m_suppressEDR ? PlatformDynamicRangeLimit::constrained().value() : PlatformDynamicRangeLimit::noLimit().value();
+    return std::min(limitValue, suppressValue);
+}
+#endif // ENABLE(PIXEL_FORMAT_RGBA16F)
+#endif // HAVE(SUPPORT_HDR_DISPLAY)
 
 void GPUCanvasContextCocoa::reshape()
 {
@@ -234,12 +309,8 @@ RefPtr<ImageBuffer> GPUCanvasContextCocoa::surfaceBufferToImageBuffer(SurfaceBuf
 
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=294654 - OffscreenCanvas may not reflect the display the OffscreenCanvas is displayed on during background / resume
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    if (!m_screenPropertiesChangedObserver) {
-        float maxHeadroom = 1.f;
-        for (auto& screenData : WebCore::getScreenProperties().screenDataMap.values())
-            maxHeadroom = std::max(maxHeadroom, screenData.maxEDRHeadroom);
-        updateContentsHeadroom(maxHeadroom);
-    }
+    if (!m_screenPropertiesChangedObserver)
+        updateScreenHeadroomFromScreenProperties();
 #endif
 
     auto frameCount = m_configuration->frameCount;
@@ -350,7 +421,10 @@ ExceptionOr<void> GPUCanvasContextCocoa::configure(GPUCanvasConfiguration&& conf
     m_layerContentsDisplayDelegate->setContentsFormat(textureFormat != WebGPU::TextureFormat::Rgba16float ? ContentsFormat::RGBA8 : ContentsFormat::RGBA16F);
 #endif
 
-    m_contentsHeadroom = 0.f;
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    m_currentEDRHeadroom = 0.f;
+    m_suppressEDR = false;
+#endif // HAVE(SUPPORT_HDR_DISPLAY)
     auto renderBuffers = m_compositorIntegration->recreateRenderBuffers(m_width, m_height, toWebCoreColorSpace(configuration.colorSpace, configuration.toneMapping), configuration.alphaMode == GPUCanvasAlphaMode::Premultiplied ? WebCore::AlphaPremultiplication::Premultiplied : WebCore::AlphaPremultiplication::Unpremultiplied, textureFormat, configuration.device->backing());
     // FIXME: This ASSERT() is wrong. It's totally possible for the IPC to the GPU process to timeout if the GPUP is busy, and return nothing here.
     ASSERT(!renderBuffers.isEmpty());

--- a/Source/WebCore/rendering/RenderHTMLCanvas.cpp
+++ b/Source/WebCore/rendering/RenderHTMLCanvas.cpp
@@ -120,4 +120,12 @@ void RenderHTMLCanvas::canvasSizeChanged()
     setNeedsLayoutIfNeededAfterIntrinsicSizeChange();
 }
 
+void RenderHTMLCanvas::styleDidChange(StyleDifference difference, const RenderStyle* oldStyle)
+{
+    RenderReplaced::styleDidChange(difference, oldStyle);
+
+    if (!oldStyle || style().dynamicRangeLimit() != oldStyle->dynamicRangeLimit())
+        canvasElement().dynamicRangeLimitDidChange(style().dynamicRangeLimit().toPlatformDynamicRangeLimit());
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderHTMLCanvas.h
+++ b/Source/WebCore/rendering/RenderHTMLCanvas.h
@@ -48,6 +48,7 @@ private:
     ASCIILiteral renderName() const override { return "RenderHTMLCanvas"_s; }
     void paintReplaced(PaintInfo&, const LayoutPoint&) override;
     void intrinsicSizeChanged() override { canvasSizeChanged(); }
+    void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1222,6 +1222,11 @@ bool RenderStyle::changeRequiresLayerRepaint(const RenderStyle& other, OptionSet
             return true;
     }
 
+    if (m_rareInheritedData.ptr() != other.m_rareInheritedData.ptr()
+        && m_rareInheritedData->dynamicRangeLimit != other.m_rareInheritedData->dynamicRangeLimit) {
+        return true;
+    }
+
 #if HAVE(CORE_MATERIAL)
     if (m_rareInheritedData.ptr() != other.m_rareInheritedData.ptr()
         && m_rareInheritedData->usedAppleVisualEffectForSubtree != other.m_rareInheritedData->usedAppleVisualEffectForSubtree) {

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4683,6 +4683,14 @@ double Internals::effectiveDynamicRangeLimitValue(const HTMLMediaElement& media)
 
 #endif
 
+ExceptionOr<double> Internals::getContextEffectiveDynamicRangeLimitValue(const HTMLCanvasElement& canvas)
+{
+    auto value = canvas.getContextEffectiveDynamicRangeLimitValue();
+    if (value.has_value())
+        return *value;
+    return Exception { ExceptionCode::InvalidStateError };
+}
+
 ExceptionOr<void> Internals::setPageShouldSuppressHDR(bool shouldSuppressHDR)
 {
     Document* document = contextDocument();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -818,6 +818,7 @@ public:
 
     double effectiveDynamicRangeLimitValue(const HTMLMediaElement&);
 #endif
+    ExceptionOr<double> getContextEffectiveDynamicRangeLimitValue(const HTMLCanvasElement&);
 
     ExceptionOr<void> setPageShouldSuppressHDR(bool);
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -979,6 +979,7 @@ enum ContentsFormat {
     [Conditional=VIDEO] undefined enableGStreamerHolePunching(HTMLVideoElement element);
 
     [Conditional=VIDEO] double effectiveDynamicRangeLimitValue(HTMLMediaElement media);
+    double getContextEffectiveDynamicRangeLimitValue(HTMLCanvasElement canvas);
     undefined setPageShouldSuppressHDR(boolean shouldSuppressHDR);
 
     undefined setIsPlayingToBluetoothOverride(optional boolean? isPlaying = null);

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -1261,13 +1261,10 @@ void WebProcessPool::screenPropertiesChanged()
 #if HAVE(SUPPORT_HDR_DISPLAY)
     if (m_suppressEDR) {
         for (auto& properties : screenProperties.screenDataMap.values()) {
-            constexpr auto maxStudioDisplayHeadroom = 2.f;
-            constexpr auto threeQuartersStudioDisplayHeadroom = 1.5f;
-            constexpr auto halfMaxHeadroomMultiplier = 0.5f;
-            auto maxHeadroom = std::clamp(properties.maxEDRHeadroom * halfMaxHeadroomMultiplier, std::min(properties.maxEDRHeadroom, threeQuartersStudioDisplayHeadroom), maxStudioDisplayHeadroom);
-            properties.currentEDRHeadroom = maxHeadroom;
-            properties.maxEDRHeadroom = maxHeadroom;
-            properties.suppressEDR = m_suppressEDR;
+            constexpr auto maxSuppressedHeadroom = 1.6f;
+            auto suppressedHeadroom = std::min(maxSuppressedHeadroom, properties.currentEDRHeadroom);
+            properties.currentEDRHeadroom = suppressedHeadroom;
+            properties.suppressEDR = true;
         }
     }
 #endif


### PR DESCRIPTION
#### 959ddfba001700372b372d86ca7ef0b30574c604
<pre>
Apply dynamic-range-limit to HDR WebGPU canvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=294831">https://bugs.webkit.org/show_bug.cgi?id=294831</a>
<a href="https://rdar.apple.com/148558614">rdar://148558614</a>

Reviewed by Mike Wyrzykowski.

Handle both dynamic-range-limit and suppress-HDR, to apply whichever
constrains the most.

* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::createContextWebGPU):
(WebCore::HTMLCanvasElement::dynamicRangeLimitDidChange):
Stores the current dynamic-range-limit, and sets the effective limit
(which accounts for the suppress-HDR state) in the rendering context.

(WebCore::HTMLCanvasElement::getContextEffectiveDynamicRangeLimitValue const):
For testing.

* Source/WebCore/html/canvas/CanvasRenderingContext.h:
(WebCore::CanvasRenderingContext::setDynamicRangeLimit):
Default dynamic-range-limit handler, does nothing.

(WebCore::CanvasRenderingContext::getEffectiveDynamicRangeLimitValue const):
For testing.

* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::GPUCanvasContextCocoa):
Observer now also passes suppressHDR to updateScreenHeadroom().

(WebCore::interpolateHeadroom):
(WebCore::GPUCanvasContextCocoa::computeContentsHeadroom):
Computes the headroom based on the screen headroom (which may already
be suppressed), and the dynamic-range-limit.

(WebCore::GPUCanvasContextCocoa::updateContentsHeadroom):
Computes the headroom and updates the compositorIntegration with it.

(WebCore::GPUCanvasContextCocoa::updateScreenHeadroom):
Called by observer, stores current headroom and suppressHDR, and
calls updateContentsHeadroom.

(WebCore::GPUCanvasContextCocoa::updateScreenHeadroomFromScreenProperties):
Fetches suppressHDR and current headroom from all screen properties, and
calls updateContentsHeadroom.

(WebCore::GPUCanvasContextCocoa::setDynamicRangeLimit):
WebGPU dynamic-range-limit handler, stores the new limits and:
- If there&apos;s no current screen data, calls
  updateScreenHeadroomFromScreenProperties, because dynamic-range-limit
  needs the current headroom and suppres-HDR flag to work,
- Otherwise just calls updateContentsHeadroom.

(WebCore::GPUCanvasContextCocoa::getEffectiveDynamicRangeLimitValue const):
For testing, combines dynamic-range-limit with suppress-HDR.

(WebCore::GPUCanvasContextCocoa::surfaceBufferToImageBuffer):
Refactored into updateScreenHeadroomFromScreenProperties.

(WebCore::GPUCanvasContextCocoa::configure):
Resets both current headroom and suppressHDR.

* Source/WebCore/rendering/RenderHTMLCanvas.h:
* Source/WebCore/rendering/RenderHTMLCanvas.cpp:
(WebCore::RenderHTMLCanvas::styleDidChange):
Catches dynamic-range-limit changes and notifies element.

* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::changeRequiresLayerRepaint const):
Ensures that dynamic-range-limit changes repaint the element, as its
effective colors may change.

* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::getContextEffectiveDynamicRangeLimitValue):
For testing: `internals.getContextEffectiveDynamicRangeLimitValue(canvas)`.

* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::screenPropertiesChanged):
Reworked suppress-headroom computation: Always 1.6, or current headroom
if lower.

* LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit-constrained-disabled-expected.txt: Added.
* LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit-constrained-disabled.html: Added.
* LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit-expected.txt: Added.
* LayoutTests/http/tests/webgpu/webgpu/web_platform/canvas/dynamic-range-limit.html: Added.

Canonical link: <a href="https://commits.webkit.org/297105@main">https://commits.webkit.org/297105@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b5de0fab9485b576c16114b0a5a061279a05c00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110542 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30201 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116568 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60809 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112505 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38789 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84061 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113490 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24653 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99537 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64502 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24014 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17677 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60363 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94036 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17736 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119358 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37582 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27900 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93027 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37956 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95808 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92850 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23661 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37856 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15597 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/33555 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37477 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42948 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37140 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40479 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38848 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->