### PR TITLE
[JSC] Remove remaining LIKELY / UNLIKELY

### DIFF
--- a/Source/JavaScriptCore/KeywordLookupGenerator.py
+++ b/Source/JavaScriptCore/KeywordLookupGenerator.py
@@ -140,7 +140,7 @@ class Trie:
         str = makePadding(indent)
 
         if self.value != None:
-            print(str + "if (LIKELY(cannotBeIdentPartOrEscapeStart(code[%d]))) {" % (len(self.fullPrefix)))
+            print(str + "if (cannotBeIdentPartOrEscapeStart(code[%d])) [[likely]] {" % (len(self.fullPrefix)))
             print(str + "    internalShift<%d>();" % len(self.fullPrefix))
             print(str + "    if (shouldCreateIdentifier)")
             print(str + ("        data->ident = &m_vm.propertyNames->%sKeyword;" % self.fullPrefix))

--- a/Source/JavaScriptCore/assembler/LinkBuffer.h
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.h
@@ -417,9 +417,11 @@ private:
 };
 
 #define FINALIZE_CODE_IF(condition, linkBufferReference, resultPtrTag, simpleName, ...) \
-    (UNLIKELY((condition) || JSC::Options::logJIT()) \
-        ? (linkBufferReference).finalizeCodeWithDisassembly<resultPtrTag>((condition), simpleName, __VA_ARGS__) \
-        : (linkBufferReference).finalizeCodeWithoutDisassembly<resultPtrTag>(simpleName))
+    ([&]() { \
+        if ((condition) || JSC::Options::logJIT()) [[unlikely]] \
+            return (linkBufferReference).finalizeCodeWithDisassembly<resultPtrTag>((condition), simpleName, __VA_ARGS__); \
+        return (linkBufferReference).finalizeCodeWithoutDisassembly<resultPtrTag>(simpleName); \
+    }())
 
 #define FINALIZE_CODE_FOR(codeBlock, linkBufferReference, resultPtrTag, simpleName, ...)  \
     FINALIZE_CODE_IF((shouldDumpDisassemblyFor(codeBlock) || Options::asyncDisassembly()), linkBufferReference, resultPtrTag, simpleName, __VA_ARGS__)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -5661,12 +5661,14 @@ public:
             return;
         }
 
-        if (isRepresentableAs<int32_t>(imm.m_value) && LIKELY(imm.m_value != INT32_MIN))
-            m_assembler.leaq_mr(-imm.m_value, src, dest);
-        else {
-            move(src, dest);
-            sub64(imm, dest);
+        if (isRepresentableAs<int32_t>(imm.m_value)) {
+            if (imm.m_value != INT32_MIN) [[likely]] {
+                m_assembler.leaq_mr(-imm.m_value, src, dest);
+                return;
+            }
         }
+        move(src, dest);
+        sub64(imm, dest);
     }
 
     void sub64(TrustedImm32 imm, Address address)

--- a/Source/JavaScriptCore/bytecode/ArrayAllocationProfile.h
+++ b/Source/JavaScriptCore/bytecode/ArrayAllocationProfile.h
@@ -68,8 +68,10 @@ public:
         ASSERT(!isCompilationThread());
         JSArray* lastArray = m_storage.pointer();
         unsigned largestSeenVectorLength = current().vectorLength();
-        if (lastArray && (largestSeenVectorLength != BASE_CONTIGUOUS_VECTOR_LEN_MAX) && UNLIKELY(lastArray->getVectorLength() > largestSeenVectorLength))
-            updateProfile();
+        if (lastArray && (largestSeenVectorLength != BASE_CONTIGUOUS_VECTOR_LEN_MAX)) {
+            if (lastArray->getVectorLength() > largestSeenVectorLength) [[unlikely]]
+                updateProfile();
+        }
         return current().vectorLength();
     }
     

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -137,7 +137,7 @@ Plan::Plan(CodeBlock* passedCodeBlock, CodeBlock* profiledDFGCodeBlock,
         , m_profiledDFGCodeBlock(profiledDFGCodeBlock)
         , m_mustHandleValues(WTFMove(mustHandleValues))
         , m_osrEntryBytecodeIndex(osrEntryBytecodeIndex)
-        , m_compilation(UNLIKELY(m_vm->m_perBytecodeProfiler) ? adoptRef(new Profiler::Compilation(m_vm->m_perBytecodeProfiler->ensureBytecodesFor(m_codeBlock), profilerCompilationKindForMode(mode))) : nullptr)
+        , m_compilation(m_vm->m_perBytecodeProfiler ? adoptRef(new Profiler::Compilation(m_vm->m_perBytecodeProfiler->ensureBytecodesFor(m_codeBlock), profilerCompilationKindForMode(mode))) : nullptr)
         , m_inlineCallFrames(adoptRef(new InlineCallFrameSet()))
         , m_identifiers(m_codeBlock)
         , m_transitions(m_codeBlock)

--- a/Source/JavaScriptCore/heap/HeapInlines.h
+++ b/Source/JavaScriptCore/heap/HeapInlines.h
@@ -186,7 +186,7 @@ inline void Heap::decrementDeferralDepthAndGCIfNeeded()
     ASSERT(!Thread::mayBeGCThread() || m_worldIsStopped);
     m_deferralDepth--;
     
-    if (UNLIKELY(m_didDeferGCWork) || Options::forceDidDeferGCWork()) {
+    if (m_didDeferGCWork || Options::forceDidDeferGCWork()) [[unlikely]] {
         decrementDeferralDepthAndGCIfNeededSlow();
         
         // Here are the possible relationships between m_deferralDepth and m_didDeferGCWork.

--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -611,7 +611,11 @@ template <typename T>
 ALWAYS_INLINE bool Lexer<T>::atEnd() const
 {
     ASSERT(!m_current || m_code < m_codeEnd);
-    return UNLIKELY(UNLIKELY(!m_current) && m_code == m_codeEnd);
+    if (m_current) [[likely]]
+        return false;
+    if (m_code == m_codeEnd) [[unlikely]]
+        return true;
+    return false;
 }
 
 template <typename T>

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -1923,7 +1923,11 @@ private:
 
     ALWAYS_INLINE bool isPossiblyEscapedLet(const JSToken& token)
     {
-        return token.m_type == LET || UNLIKELY(token.m_type == ESCAPED_KEYWORD && *token.m_data.ident == m_vm.propertyNames->letKeyword);
+        if (token.m_type == LET)
+            return true;
+        if (token.m_type == ESCAPED_KEYWORD && *token.m_data.ident == m_vm.propertyNames->letKeyword) [[unlikely]]
+            return true;
+        return false;
     }
 
     bool isDisallowedIdentifierAwait(const JSToken& token)
@@ -1938,7 +1942,11 @@ private:
 
     ALWAYS_INLINE bool isPossiblyEscapedAwait(const JSToken& token)
     {
-        return token.m_type == AWAIT || UNLIKELY(token.m_type == ESCAPED_KEYWORD && *token.m_data.ident == m_vm.propertyNames->awaitKeyword);
+        if (token.m_type == AWAIT)
+            return true;
+        if (token.m_type == ESCAPED_KEYWORD && *token.m_data.ident == m_vm.propertyNames->awaitKeyword) [[unlikely]]
+            return true;
+        return false;
     }
 
     ALWAYS_INLINE bool canUseIdentifierAwait()
@@ -1958,7 +1966,11 @@ private:
 
     ALWAYS_INLINE bool isPossiblyEscapedYield(const JSToken& token)
     {
-        return token.m_type == YIELD || UNLIKELY(token.m_type == ESCAPED_KEYWORD && *token.m_data.ident == m_vm.propertyNames->yieldKeyword);
+        if (token.m_type == YIELD)
+            return true;
+        if (token.m_type == ESCAPED_KEYWORD && *token.m_data.ident == m_vm.propertyNames->yieldKeyword) [[unlikely]]
+            return true;
+        return false;
     }
 
     ALWAYS_INLINE bool canUseIdentifierYield()

--- a/Source/JavaScriptCore/parser/ParserArena.h
+++ b/Source/JavaScriptCore/parser/ParserArena.h
@@ -191,7 +191,7 @@ namespace JSC {
 
         IdentifierArena& identifierArena()
         {
-            if (UNLIKELY (!m_identifierArena))
+            if (!m_identifierArena) [[unlikely]]
                 m_identifierArena = makeUnique<IdentifierArena>();
             return *m_identifierArena;
         }

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.h
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.h
@@ -73,14 +73,15 @@ inline JSValue opEnumeratorGetByVal(JSGlobalObject* globalObject, JSValue baseVa
         RELEASE_AND_RETURN(scope, baseValue.get(globalObject, static_cast<unsigned>(index)));
     }
     case JSPropertyNameEnumerator::OwnStructureMode: {
-        if (LIKELY(baseValue.isCell()) && baseValue.asCell()->structureID() == enumerator->cachedStructureID()) {
-            // We'll only match the structure ID if the base is an object.
-            ASSERT(index < enumerator->endStructurePropertyIndex());
-            RELEASE_AND_RETURN(scope, baseValue.getObject()->getDirect(index < enumerator->cachedInlineCapacity() ? index : index - enumerator->cachedInlineCapacity() + firstOutOfLineOffset));
-        } else {
-            if (enumeratorMetadata)
-                *enumeratorMetadata |= static_cast<uint8_t>(JSPropertyNameEnumerator::HasSeenOwnStructureModeStructureMismatch);
+        if (baseValue.isCell()) [[likely]] {
+            if (baseValue.asCell()->structureID() == enumerator->cachedStructureID()) {
+                // We'll only match the structure ID if the base is an object.
+                ASSERT(index < enumerator->endStructurePropertyIndex());
+                RELEASE_AND_RETURN(scope, baseValue.getObject()->getDirect(index < enumerator->cachedInlineCapacity() ? index : index - enumerator->cachedInlineCapacity() + firstOutOfLineOffset));
+            }
         }
+        if (enumeratorMetadata)
+            *enumeratorMetadata |= static_cast<uint8_t>(JSPropertyNameEnumerator::HasSeenOwnStructureModeStructureMismatch);
         [[fallthrough]];
     }
 

--- a/Source/JavaScriptCore/runtime/IteratorOperations.cpp
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.cpp
@@ -98,7 +98,13 @@ void iteratorClose(JSGlobalObject* globalObject, JSValue iterator)
     }
 
     JSValue returnFunction = iterator.get(globalObject, vm.propertyNames->returnKeyword);
-    if (UNLIKELY(throwScope.exception()) || returnFunction.isUndefinedOrNull()) {
+    if (throwScope.exception()) [[unlikely]] {
+        if (exception)
+            throwException(globalObject, throwScope, exception);
+        return;
+    }
+
+    if (returnFunction.isUndefinedOrNull()) {
         if (exception)
             throwException(globalObject, throwScope, exception);
         return;

--- a/Source/JavaScriptCore/runtime/ObjectInitializationScope.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectInitializationScope.cpp
@@ -76,7 +76,9 @@ void ObjectInitializationScope::verifyPropertiesAreInitialized(JSObject* object)
     Structure* structure = object->structure();
     IndexingType indexingType = structure->indexingType();
     unsigned vectorLength = butterfly->vectorLength();
-    if (UNLIKELY(hasUndecided(indexingType)) || !hasIndexedProperties(indexingType)) {
+    if (hasUndecided(indexingType)) [[unlikely]] {
+        // Nothing to verify.
+    } else if (!hasIndexedProperties(indexingType)) {
         // Nothing to verify.
     } else if (!hasAnyArrayStorage(indexingType)) [[likely]] {
         auto data = butterfly->contiguous().data();


### PR DESCRIPTION
#### 213ac5a85b7133a15f3bd0c7f8c29fb3591caa27
<pre>
[JSC] Remove remaining LIKELY / UNLIKELY
<a href="https://bugs.webkit.org/show_bug.cgi?id=292517">https://bugs.webkit.org/show_bug.cgi?id=292517</a>
<a href="https://rdar.apple.com/150658311">rdar://150658311</a>

Reviewed by Chris Dumez.

Remove remaining LIKELY / UNLIKELY in JSC code.

* Source/JavaScriptCore/KeywordLookupGenerator.py:
(Trie.printSubTreeAsC):
* Source/JavaScriptCore/assembler/LinkBuffer.h:
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::sub64):
* Source/JavaScriptCore/bytecode/ArrayAllocationProfile.h:
(JSC::ArrayAllocationProfile::vectorLengthHint):
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::Plan):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::deprecatedReportExtraMemorySlowCase):
(JSC::Heap::extraMemorySize):
(JSC::Heap::reportExtraMemoryVisited):
* Source/JavaScriptCore/heap/HeapInlines.h:
(JSC::Heap::decrementDeferralDepthAndGCIfNeeded):
* Source/JavaScriptCore/parser/Lexer.cpp:
(JSC::Lexer&lt;T&gt;::atEnd const):
(JSC::Lexer&lt;CharacterType&gt;::parseUnicodeEscape):
(JSC::Lexer&lt;T&gt;::parseString):
(JSC::Lexer&lt;T&gt;::parseComplexEscape):
(JSC::Lexer&lt;T&gt;::parseStringSlowCase):
(JSC::Lexer&lt;T&gt;::parseTemplateLiteral):
(JSC::Lexer&lt;T&gt;::parseMultilineComment):
(JSC::Lexer&lt;CharacterType&gt;::parseCommentDirectiveValue):
(JSC::Lexer&lt;T&gt;::lexWithoutClearingLineTerminator):
(JSC::Lexer&lt;T&gt;::scanRegExp):
* Source/JavaScriptCore/parser/Parser.h:
(JSC::Parser::isPossiblyEscapedLet):
(JSC::Parser::isPossiblyEscapedAwait):
(JSC::Parser::isPossiblyEscapedYield):
* Source/JavaScriptCore/parser/ParserArena.h:
(JSC::ParserArena::identifierArena):
* Source/JavaScriptCore/runtime/CommonSlowPaths.h:
(JSC::CommonSlowPaths::opEnumeratorGetByVal):
* Source/JavaScriptCore/runtime/IteratorOperations.cpp:
(JSC::iteratorClose):
* Source/JavaScriptCore/runtime/ObjectInitializationScope.cpp:
(JSC::ObjectInitializationScope::verifyPropertiesAreInitialized):

Canonical link: <a href="https://commits.webkit.org/294497@main">https://commits.webkit.org/294497@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48da36685ec8af35db30244519b5090422f30c94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21758 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12074 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107249 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52725 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30265 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/77702 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34698 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92169 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58038 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/16900 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10194 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52084 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94762 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86739 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10267 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109624 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100700 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29223 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/21541 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86671 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29585 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88373 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/86253 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31054 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8773 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23447 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16589 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29151 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34446 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124325 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28962 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34522 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32285 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30521 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->