### PR TITLE
REGRESSION(286329@main?): [ macOS wk2 Release x86_64 ] media/media-vp8-hiddenframes.html is a flaky failure.

### DIFF
--- a/LayoutTests/media/media-vp8-hiddenframes.html
+++ b/LayoutTests/media/media-vp8-hiddenframes.html
@@ -20,14 +20,8 @@
         let v = document.getElementsByTagName('video')[0];
         v.src = "content/test-vp8-hiddenframes.webm";
         await waitFor(v, 'loadedmetadata', true);
-        await waitForVideoFrame(v); // make sure the first frame got displayed before waiting for the last one.
-        // duration of the last frame.
-        v.currentTime = v.duration - 0.038;
-        let promise = new Promise(resolve => v.requestVideoFrameCallback(resolve));
+        v.currentTime = v.duration;
         await waitFor(v, 'seeked', true);
-        v.play();
-        await waitFor(v, 'ended', true);
-        await promise;
 
         if (window.testRunner)
             testRunner.notifyDone();

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1967,9 +1967,6 @@ webkit.org/b/284190 [ Sequoia+ ] http/tests/privateClickMeasurement/send-attribu
 webkit.org/b/284190 [ Sequoia+ ] imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window.html [ Failure ]
 webkit.org/b/284190 [ Sequoia+ ] imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/anonymous-iframe/cookie.tentative.https.window.html [ Failure ]
 
-# webkit.org/b/284186 [macOS Debug] media/media-vp8-hiddenframes.html is timing out (flaky in EWS)
-[ Debug ] media/media-vp8-hiddenframes.html [ Pass Timeout ]
-
 webkit.org/b/284492 [ Sequoia+ ] imported/w3c/web-platform-tests/fetch/api/cors/cors-cookies-redirect.any.html [ Failure ]
 webkit.org/b/284492 [ Sequoia+ ] imported/w3c/web-platform-tests/fetch/api/cors/cors-cookies-redirect.any.worker.html [ Failure ]
 
@@ -2144,8 +2141,6 @@ webkit.org/b/291119 [ Debug ] imported/w3c/web-platform-tests/html/semantics/emb
 webkit.org/b/291394 [ Debug ] imported/w3c/web-platform-tests/wasm/webapi/esm-integration/script-src-blocks-wasm.tentative.sub.html [ Pass Failure ]
 
 webkit.org/b/291710 [ Debug ] swipe/basic-cached-back-swipe.html [ Pass Timeout ]
-
-webkit.org/b/291861 [ Release x86_64 ] media/media-vp8-hiddenframes.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/291878 [ Sequoia ] http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleBias.html [ Failure ]
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -985,7 +985,7 @@ void MediaPlayerPrivateWebM::reenqueueMediaForTime(TrackBuffer& trackBuffer, Tra
 {
     if (needsFlush == NeedsFlush::Yes)
         flushTrack(trackId);
-    if (trackBuffer.reenqueueMediaForTime(time, timeFudgeFactor()))
+    if (trackBuffer.reenqueueMediaForTime(time, timeFudgeFactor(), m_loadFinished))
         provideMediaData(trackBuffer, trackId);
 }
 


### PR DESCRIPTION
#### 9e2d49b25af874b981621e73ed3556e6de0fca93
<pre>
REGRESSION(286329@main?): [ macOS wk2 Release x86_64 ] media/media-vp8-hiddenframes.html is a flaky failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=291861">https://bugs.webkit.org/show_bug.cgi?id=291861</a>
<a href="https://rdar.apple.com/149714451">rdar://149714451</a>

Reviewed by Jer Noble.

A fix was added in 288962@main to allow seeking to the end of the file.
The fix wasn&apos;t applied for the WebM player. We now allow seeking to the end
of the video if all content has been downloaded.

Updated test.
* LayoutTests/media/media-vp8-hiddenframes.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::reenqueueMediaForTime):

Canonical link: <a href="https://commits.webkit.org/294530@main">https://commits.webkit.org/294530@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a65f9bb423a88c886c01d216ae925aca6d3d4b96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102096 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107255 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52731 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104136 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22073 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30271 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77705 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34702 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17078 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92175 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58041 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16906 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10200 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52090 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86745 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10273 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109630 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29229 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21546 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86676 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29591 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88379 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86258 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21958 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31061 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8784 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23453 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29157 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34452 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28968 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32291 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30527 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->