### PR TITLE
[JSC] Remove `--useIteratorHelpers` flag

### DIFF
--- a/JSTests/stress/iterator-concat.js
+++ b/JSTests/stress/iterator-concat.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useIteratorHelpers=1", "--useIteratorSequencing=1")
+//@ requireOptions("--useIteratorSequencing=1")
 
 function shouldBe(actual, expected) {
     if (actual !== expected)

--- a/JSTests/stress/iterator-from.js
+++ b/JSTests/stress/iterator-from.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useIteratorHelpers=1")
-
 function assert(a, text) {
     if (!a)
         throw new Error(`Failed assertion: ${text}`);

--- a/JSTests/stress/iterator-prototype-chunks.js
+++ b/JSTests/stress/iterator-prototype-chunks.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useIteratorHelpers=1", "--useIteratorChunking=1")
+//@ requireOptions("--useIteratorChunking=1")
 
 function assert(a, text) {
     if (!a)

--- a/JSTests/stress/iterator-prototype-constructor-new.js
+++ b/JSTests/stress/iterator-prototype-constructor-new.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useIteratorHelpers=1")
-
 function assert(a, b) {
     if (a !== b)
         throw new Error("Expected: " + b + " but got: " + a);

--- a/JSTests/stress/iterator-prototype-constructor-setter.js
+++ b/JSTests/stress/iterator-prototype-constructor-setter.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useIteratorHelpers=1")
-
 function assert(a, b) {
     if (a !== b)
         throw new Error("Expected: " + b + " but got: " + a);

--- a/JSTests/stress/iterator-prototype-every.js
+++ b/JSTests/stress/iterator-prototype-every.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useIteratorHelpers=1")
-
 function assert(a, text) {
     if (!a)
         throw new Error(`Failed assertion: ${text}`);

--- a/JSTests/stress/iterator-prototype-find.js
+++ b/JSTests/stress/iterator-prototype-find.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useIteratorHelpers=1")
-
 function assert(a, text) {
     if (!a)
         throw new Error(`Failed assertion: ${text}`);

--- a/JSTests/stress/iterator-prototype-forEach.js
+++ b/JSTests/stress/iterator-prototype-forEach.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useIteratorHelpers=1")
-
 function assert(a, text) {
     if (!a)
         throw new Error(`Failed assertion: ${text}`);

--- a/JSTests/stress/iterator-prototype-map.js
+++ b/JSTests/stress/iterator-prototype-map.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useIteratorHelpers=1")
-
 function assert(x) {
     if (!x)
         throw new Error("Bad assertion!");

--- a/JSTests/stress/iterator-prototype-reduce.js
+++ b/JSTests/stress/iterator-prototype-reduce.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useIteratorHelpers=1")
-
 function assert(a, text) {
     if (!a)
         throw new Error(`Failed assertion: ${text}`);

--- a/JSTests/stress/iterator-prototype-some.js
+++ b/JSTests/stress/iterator-prototype-some.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useIteratorHelpers=1")
-
 function assert(a, text) {
     if (!a)
         throw new Error(`Failed assertion: ${text}`);

--- a/JSTests/stress/iterator-prototype-to-string-tag-basic-setter.js
+++ b/JSTests/stress/iterator-prototype-to-string-tag-basic-setter.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useIteratorHelpers=1")
-
 function assert(a, b) {
     if (a !== b)
         throw new Error("Expected: " + b + " but got: " + a);

--- a/JSTests/stress/iterator-prototype-toArray.js
+++ b/JSTests/stress/iterator-prototype-toArray.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useIteratorHelpers=1")
-
 function assert(a, text) {
     if (!a)
         throw new Error(`Failed assertion: ${text}`);

--- a/JSTests/stress/iterator-prototype-windows.js
+++ b/JSTests/stress/iterator-prototype-windows.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useIteratorHelpers=1", "--useIteratorChunking=1")
+//@ requireOptions("--useIteratorChunking=1")
 
 function assert(a, text) {
     if (!a)

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -3,7 +3,6 @@
 flags:
   SharedArrayBuffer: useSharedArrayBuffer
   Atomics: useSharedArrayBuffer
-  iterator-helpers: useIteratorHelpers
   Temporal: useTemporal
   ShadowRealm: useShadowRealm
   Math.sumPrecise: useMathSumPreciseMethod

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1135,12 +1135,11 @@ void JSGlobalObject::init(VM& vm)
         });
 
     m_iteratorPrototype.set(vm, this, JSIteratorPrototype::create(vm, this, JSIteratorPrototype::createStructure(vm, this, m_objectPrototype.get())));
-    if (Options::useIteratorHelpers()) {
-        m_iteratorStructure.set(vm, this, JSIterator::createStructure(vm, this, m_iteratorPrototype.get()));
 
-        m_iteratorHelperPrototype.set(vm, this, JSIteratorHelperPrototype::create(vm, this, JSIteratorHelperPrototype::createStructure(vm, this, m_iteratorPrototype.get())));
-        m_iteratorHelperStructure.set(vm, this, JSIteratorHelper::createStructure(vm, this, m_iteratorHelperPrototype.get()));
-    }
+    m_iteratorStructure.set(vm, this, JSIterator::createStructure(vm, this, m_iteratorPrototype.get()));
+
+    m_iteratorHelperPrototype.set(vm, this, JSIteratorHelperPrototype::create(vm, this, JSIteratorHelperPrototype::createStructure(vm, this, m_iteratorPrototype.get())));
+    m_iteratorHelperStructure.set(vm, this, JSIteratorHelper::createStructure(vm, this, m_iteratorHelperPrototype.get()));
 
     m_asyncIteratorPrototype.set(vm, this, AsyncIteratorPrototype::create(vm, this, AsyncIteratorPrototype::createStructure(vm, this, m_objectPrototype.get())));
 
@@ -1171,14 +1170,11 @@ void JSGlobalObject::init(VM& vm)
             init.set(JSRegExpStringIterator::createStructure(init.vm, init.owner, regExpStringIteratorPrototype));
     });
 
-    if (Options::useIteratorHelpers()) {
-        m_wrapForValidIteratorStructure.initLater(
-            [] (const Initializer<Structure>& init) {
-                auto* wrapForValidIteratorPrototype = WrapForValidIteratorPrototype::create(init.vm, init.owner, WrapForValidIteratorPrototype::createStructure(init.vm, init.owner, init.owner->m_iteratorPrototype.get()));
-                init.set(JSWrapForValidIterator::createStructure(init.vm, init.owner, wrapForValidIteratorPrototype));
-        });
-
-    }
+    m_wrapForValidIteratorStructure.initLater(
+        [] (const Initializer<Structure>& init) {
+            auto* wrapForValidIteratorPrototype = WrapForValidIteratorPrototype::create(init.vm, init.owner, WrapForValidIteratorPrototype::createStructure(init.vm, init.owner, init.owner->m_iteratorPrototype.get()));
+            init.set(JSWrapForValidIterator::createStructure(init.vm, init.owner, wrapForValidIteratorPrototype));
+    });
 
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::sentinelString)].set(vm, this, vm.smallStrings.sentinelString());
 
@@ -1311,12 +1307,10 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     putDirectWithoutTransition(vm, vm.propertyNames->Array, arrayConstructor, static_cast<unsigned>(PropertyAttribute::DontEnum));
     putDirectWithoutTransition(vm, vm.propertyNames->RegExp, regExpConstructor, static_cast<unsigned>(PropertyAttribute::DontEnum));
 
-    if (Options::useIteratorHelpers()) {
-        JSIteratorConstructor* iteratorConstructor = JSIteratorConstructor::create(vm, this, JSIteratorConstructor::createStructure(vm, this, m_functionPrototype.get()), m_iteratorPrototype.get());
-        m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::Iterator)].set(vm, this, iteratorConstructor);
-        m_iteratorConstructor.set(vm, this, iteratorConstructor);
-        putDirectWithoutTransition(vm, vm.propertyNames->Iterator, iteratorConstructor, static_cast<unsigned>(PropertyAttribute::DontEnum));
-    }
+    JSIteratorConstructor* iteratorConstructor = JSIteratorConstructor::create(vm, this, JSIteratorConstructor::createStructure(vm, this, m_functionPrototype.get()), m_iteratorPrototype.get());
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::Iterator)].set(vm, this, iteratorConstructor);
+    m_iteratorConstructor.set(vm, this, iteratorConstructor);
+    putDirectWithoutTransition(vm, vm.propertyNames->Iterator, iteratorConstructor, static_cast<unsigned>(PropertyAttribute::DontEnum));
 
     if (Options::useSharedArrayBuffer())
         putDirectWithoutTransition(vm, vm.propertyNames->SharedArrayBuffer, m_sharedArrayBufferStructure.constructor(this), static_cast<unsigned>(PropertyAttribute::DontEnum));
@@ -1571,16 +1565,14 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
         init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "regExpStringIteratorCreate"_s, regExpStringIteratorPrivateFuncCreate, ImplementationVisibility::Private));
     });
 
-    if (Options::useIteratorHelpers()) {
-        // WrapForValidIterator Helpers
-        m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::wrapForValidIteratorCreate)].initLater([](const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "wrapForValidIteratorCreate"_s, wrapForValidIteratorPrivateFuncCreate, ImplementationVisibility::Private));
-        });
+    // WrapForValidIterator Helpers
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::wrapForValidIteratorCreate)].initLater([](const Initializer<JSCell>& init) {
+        init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "wrapForValidIteratorCreate"_s, wrapForValidIteratorPrivateFuncCreate, ImplementationVisibility::Private));
+    });
 
-        m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::iteratorHelperCreate)].initLater([](const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "iteratorHelperCreate"_s, iteratorHelperPrivateFuncCreate, ImplementationVisibility::Private, IteratorHelperCreateIntrinsic));
-        });
-    }
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::iteratorHelperCreate)].initLater([](const Initializer<JSCell>& init) {
+        init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "iteratorHelperCreate"_s, iteratorHelperPrivateFuncCreate, ImplementationVisibility::Private, IteratorHelperCreateIntrinsic));
+    });
 
     // Global object and function helpers.
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isFinite)].initLater([] (const Initializer<JSCell>& init) {

--- a/Source/JavaScriptCore/runtime/JSIteratorConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorConstructor.cpp
@@ -57,7 +57,7 @@ void JSIteratorConstructor::finishCreation(VM& vm, JSGlobalObject* globalObject,
     putDirectWithoutTransition(vm, vm.propertyNames->prototype, iteratorPrototype, static_cast<unsigned>(PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->from, jsIteratorConstructorFromCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
 
-    if (Options::useIteratorHelpers() && Options::useIteratorSequencing())
+    if (Options::useIteratorSequencing())
         JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().concatPublicName(), jsIteratorConstructorConcatCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
 }
 

--- a/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
@@ -56,34 +56,32 @@ void JSIteratorPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     JSFunction* iteratorFunction = JSFunction::create(vm, globalObject, 0, "[Symbol.iterator]"_s, iteratorProtoFuncIterator, ImplementationVisibility::Public, IteratorIntrinsic);
     putDirectWithoutTransition(vm, vm.propertyNames->iteratorSymbol, iteratorFunction, static_cast<unsigned>(PropertyAttribute::DontEnum));
 
-    if (Options::useIteratorHelpers()) {
-        // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.constructor
-        putDirectCustomGetterSetterWithoutTransition(vm, vm.propertyNames->constructor, CustomGetterSetter::create(vm, iteratorProtoConstructorGetter, iteratorProtoConstructorSetter), static_cast<unsigned>(PropertyAttribute::DontEnum | PropertyAttribute::CustomAccessor));
-        // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype-@@tostringtag
-        putDirectCustomGetterSetterWithoutTransition(vm, vm.propertyNames->toStringTagSymbol, CustomGetterSetter::create(vm, iteratorProtoToStringTagGetter, iteratorProtoToStringTagSetter), static_cast<unsigned>(PropertyAttribute::DontEnum | PropertyAttribute::CustomAccessor));
-        // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.toarray
-        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->toArray, iteratorProtoFuncToArray, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Private);
-        // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.foreach
-        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->forEach, iteratorProtoFuncForEach, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Private);
-        // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.some
-        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().somePublicName(), jsIteratorPrototypeSomeCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-        // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.every
-        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().everyPublicName(), jsIteratorPrototypeEveryCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-        // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.find
-        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().findPublicName(), jsIteratorPrototypeFindCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-        // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.reduce
-        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().reducePublicName(), jsIteratorPrototypeReduceCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-        // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.map
-        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().mapPublicName(), jsIteratorPrototypeMapCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-        // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.filter
-        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().filterPublicName(), jsIteratorPrototypeFilterCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-        // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.take
-        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION("take"_s, jsIteratorPrototypeTakeCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-        // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.drop
-        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION("drop"_s, jsIteratorPrototypeDropCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-        // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.flatmap
-        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().flatMapPublicName(), jsIteratorPrototypeFlatMapCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-    }
+    // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.constructor
+    putDirectCustomGetterSetterWithoutTransition(vm, vm.propertyNames->constructor, CustomGetterSetter::create(vm, iteratorProtoConstructorGetter, iteratorProtoConstructorSetter), static_cast<unsigned>(PropertyAttribute::DontEnum | PropertyAttribute::CustomAccessor));
+    // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype-@@tostringtag
+    putDirectCustomGetterSetterWithoutTransition(vm, vm.propertyNames->toStringTagSymbol, CustomGetterSetter::create(vm, iteratorProtoToStringTagGetter, iteratorProtoToStringTagSetter), static_cast<unsigned>(PropertyAttribute::DontEnum | PropertyAttribute::CustomAccessor));
+    // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.toarray
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->toArray, iteratorProtoFuncToArray, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Private);
+    // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.foreach
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->forEach, iteratorProtoFuncForEach, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Private);
+    // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.some
+    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().somePublicName(), jsIteratorPrototypeSomeCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.every
+    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().everyPublicName(), jsIteratorPrototypeEveryCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.find
+    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().findPublicName(), jsIteratorPrototypeFindCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.reduce
+    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().reducePublicName(), jsIteratorPrototypeReduceCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.map
+    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().mapPublicName(), jsIteratorPrototypeMapCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.filter
+    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().filterPublicName(), jsIteratorPrototypeFilterCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.take
+    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION("take"_s, jsIteratorPrototypeTakeCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.drop
+    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION("drop"_s, jsIteratorPrototypeDropCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.flatmap
+    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().flatMapPublicName(), jsIteratorPrototypeFlatMapCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
 
     if (Options::useIteratorChunking()) {
         // https://tc39.es/proposal-iterator-chunking/#sec-iterator.prototype.chunks

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -634,7 +634,6 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, disallowMixedWasmExceptions, true, Restricted, "Disallow using both legacy and modern (try_table) wasm exception specs in the same module."_s) \
     v(Bool, useImportDefer, false, Normal, "Enable deferred module import."_s) \
     v(Bool, useIteratorChunking, false, Normal, "Expose the Iterator.prototype.chunks and Iterator.prototype.windows methods."_s) \
-    v(Bool, useIteratorHelpers, true, Normal, "Expose the Iterator Helpers."_s) \
     v(Bool, useIteratorSequencing, false, Normal, "Expose the Iterator.concat method."_s) \
     v(Bool, useJSONSourceTextAccess, true, Normal, "Expose JSON source text access feature."_s) \
     v(Bool, useMapGetOrInsert, false, Normal, "Expose the Map.prototype.getOrInsert family of methods."_s) \


### PR DESCRIPTION
#### 94489ff12ce643dbcb1c84249627a97bccea858b
<pre>
[JSC] Remove `--useIteratorHelpers` flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=292526">https://bugs.webkit.org/show_bug.cgi?id=292526</a>

Reviewed by Yusuke Suzuki.

Iterator Helpers Proposal[1] is now stage 4 and enabled by default in
JSC. So this patch removes `--useIteratorHelpers` flag.

* JSTests/stress/iterator-concat.js:
* JSTests/stress/iterator-from.js:
* JSTests/stress/iterator-prototype-chunks.js:
* JSTests/stress/iterator-prototype-constructor-new.js:
* JSTests/stress/iterator-prototype-constructor-setter.js:
* JSTests/stress/iterator-prototype-every.js:
* JSTests/stress/iterator-prototype-find.js:
* JSTests/stress/iterator-prototype-forEach.js:
* JSTests/stress/iterator-prototype-map.js:
* JSTests/stress/iterator-prototype-reduce.js:
* JSTests/stress/iterator-prototype-some.js:
* JSTests/stress/iterator-prototype-to-string-tag-basic-setter.js:
* JSTests/stress/iterator-prototype-toArray.js:
* JSTests/stress/iterator-prototype-windows.js:
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSIteratorConstructor.cpp:
(JSC::JSIteratorConstructor::finishCreation):
* Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp:
(JSC::JSIteratorPrototype::finishCreation):
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/294591@main">https://commits.webkit.org/294591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b7ea02a85a4cd3b6a7c9e53477f1a273db29cf1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102102 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12086 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107261 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52738 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30277 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77712 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34706 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17084 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92181 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58047 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16912 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10206 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52096 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94774 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86752 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109636 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100712 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29235 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21553 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86683 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29597 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88385 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86265 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21998 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31067 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8786 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23460 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29163 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34458 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124338 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28974 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34528 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32297 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30533 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->