### PR TITLE
Correct serialization of CDATASection nodes in HTML

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/serializing-cdata-in-html-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/serializing-cdata-in-html-document-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Serializing CDATA in an HTML document
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/serializing-cdata-in-html-document.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/serializing-cdata-in-html-document.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>Serializing CDATA in an HTML document</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/parsing.html#serialising-html-fragments">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(t => {
+  const doc = new DOMParser().parseFromString('<svg xmlns="http://www.w3.org/2000/svg"><![CDATA[<img>]]></svg>', 'application/xml');
+  const el = document.adoptNode(doc.documentElement);
+  assert_equals(el.outerHTML, '<svg xmlns="http://www.w3.org/2000/svg">&lt;img&gt;</svg>');
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/w3c-import.log
@@ -17,5 +17,6 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/escaping.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/initial-linefeed-pre.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/outerHTML.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/serializing-cdata-in-html-document.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/serializing.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/template.html

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -164,36 +164,33 @@ static bool shouldSelfClose(const Element& element, SerializationSyntax syntax)
 }
 
 template<typename CharacterType>
-static inline void appendCharactersReplacingEntitiesInternal(StringBuilder& result, const String& source, unsigned offset, unsigned length, OptionSet<EntityMask> entityMask)
+static inline void appendCharactersReplacingEntitiesInternal(StringBuilder& result, const String& source, OptionSet<EntityMask> entityMask)
 {
-    auto text = source.span<CharacterType>().subspan(offset);
-
+    unsigned length = source.length();
     size_t positionAfterLastEntity = 0;
     for (size_t i = 0; i < length; ++i) {
-        CharacterType character = text[i];
+        CharacterType character = source[i];
         uint8_t substitution = character < std::size(entityMap) ? entityMap[character] : static_cast<uint8_t>(EntitySubstitutionIndex::Null);
         if (substitution != EntitySubstitutionIndex::Null) [[unlikely]] {
             if (entityMask.contains(*entitySubstitutionList[substitution].mask)) {
-                result.appendSubstring(source, offset + positionAfterLastEntity, i - positionAfterLastEntity);
+                result.appendSubstring(source, positionAfterLastEntity, i - positionAfterLastEntity);
                 result.append(entitySubstitutionList[substitution].characters);
                 positionAfterLastEntity = i + 1;
             }
         }
     }
-    result.appendSubstring(source, offset + positionAfterLastEntity, length - positionAfterLastEntity);
+    result.appendSubstring(source, positionAfterLastEntity, length - positionAfterLastEntity);
 }
 
-void MarkupAccumulator::appendCharactersReplacingEntities(StringBuilder& result, const String& source, unsigned offset, unsigned length, OptionSet<EntityMask> entityMask)
+void MarkupAccumulator::appendCharactersReplacingEntities(StringBuilder& result, const String& source, OptionSet<EntityMask> entityMask)
 {
-    ASSERT(offset + length <= source.length());
-
-    if (!length)
+    if (!source.length())
         return;
 
     if (source.is8Bit())
-        appendCharactersReplacingEntitiesInternal<LChar>(result, source, offset, length, entityMask);
+        appendCharactersReplacingEntitiesInternal<LChar>(result, source, entityMask);
     else
-        appendCharactersReplacingEntitiesInternal<UChar>(result, source, offset, length, entityMask);
+        appendCharactersReplacingEntitiesInternal<UChar>(result, source, entityMask);
 }
 
 MarkupAccumulator::MarkupAccumulator(Vector<Ref<Node>>* nodes, ResolveURLs resolveURLs, SerializationSyntax serializationSyntax, SerializeShadowRoots serializeShadowRoots, Vector<Ref<ShadowRoot>>&& explicitShadowRoots, const Vector<MarkupExclusionRule>& exclusionRules)
@@ -447,7 +444,7 @@ StringBuilder MarkupAccumulator::takeMarkup()
 
 void MarkupAccumulator::appendAttributeValue(StringBuilder& result, const String& attribute)
 {
-    appendCharactersReplacingEntities(result, attribute, 0, attribute.length(),
+    appendCharactersReplacingEntities(result, attribute,
         inXMLFragmentSerialization() ? EntityMaskInAttributeValue : EntityMaskInHTMLAttributeValue);
 }
 
@@ -552,7 +549,7 @@ OptionSet<EntityMask> MarkupAccumulator::entityMaskForText(const Text& text) con
 
 void MarkupAccumulator::appendText(StringBuilder& result, const Text& text)
 {
-    appendCharactersReplacingEntities(result, text.data(), 0, text.length(), entityMaskForText(text));
+    appendCharactersReplacingEntities(result, text.data(), entityMaskForText(text));
 }
 
 static void appendXMLDeclaration(StringBuilder& result, const Document& document)
@@ -845,8 +842,11 @@ void MarkupAccumulator::appendNonElementNode(StringBuilder& result, const Node& 
         ASSERT_NOT_REACHED();
         break;
     case Node::CDATA_SECTION_NODE:
-        // FIXME: CDATA content is not escaped, but XMLSerializer (and possibly other callers) should raise an exception if it includes "]]>".
-        result.append("<![CDATA["_s, uncheckedDowncast<CDATASection>(node).data(), "]]>"_s);
+        if (inXMLFragmentSerialization()) {
+            // FIXME: CDATA content is not escaped, but XMLSerializer (and possibly other callers) should raise an exception if it includes "]]>".
+            result.append("<![CDATA["_s, uncheckedDowncast<CDATASection>(node).data(), "]]>"_s);
+        } else
+            appendText(result, uncheckedDowncast<Text>(node));
         break;
     case Node::ATTRIBUTE_NODE:
         appendAttributeValue(result, uncheckedDowncast<Attr>(node).value());

--- a/Source/WebCore/editing/MarkupAccumulator.h
+++ b/Source/WebCore/editing/MarkupAccumulator.h
@@ -73,7 +73,7 @@ public:
 
     String serializeNodes(Node& targetNode, SerializedNodes);
 
-    static void appendCharactersReplacingEntities(StringBuilder&, const String&, unsigned, unsigned, OptionSet<EntityMask>);
+    static void appendCharactersReplacingEntities(StringBuilder&, const String&, OptionSet<EntityMask>);
     void enableURLReplacement(UncheckedKeyHashMap<String, String>&& replacementURLStrings, UncheckedKeyHashMap<Ref<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet);
 
 protected:

--- a/Source/WebCore/editing/TypingCommand.cpp
+++ b/Source/WebCore/editing/TypingCommand.cpp
@@ -438,7 +438,7 @@ RefPtr<DataTransfer> TypingCommand::inputEventDataTransfer() const
         return nullptr;
 
     StringBuilder htmlText;
-    MarkupAccumulator::appendCharactersReplacingEntities(htmlText, m_currentTextToInsert, 0, m_currentTextToInsert.length(), EntityMaskInHTMLPCDATA);
+    MarkupAccumulator::appendCharactersReplacingEntities(htmlText, m_currentTextToInsert, EntityMaskInHTMLPCDATA);
     return DataTransfer::createForInputEvent(m_currentTextToInsert, htmlText.toString());
 }
 

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -601,12 +601,12 @@ void StyledMarkupAccumulator::appendText(StringBuilder& out, const Text& text)
 
     if (!shouldAnnotate() || parentIsTextarea) {
         auto content = textContentRespectingRange(text);
-        appendCharactersReplacingEntities(out, content, 0, content.length(), entityMaskForText(text));
+        appendCharactersReplacingEntities(out, content, entityMaskForText(text));
     } else {
         const bool useRenderedText = !enclosingElementWithTag(firstPositionInNode(const_cast<Text*>(&text)), selectTag);
         String content = useRenderedText ? renderedTextRespectingRange(text) : textContentRespectingRange(text);
         StringBuilder buffer;
-        appendCharactersReplacingEntities(buffer, content, 0, content.length(), EntityMaskInPCDATA);
+        appendCharactersReplacingEntities(buffer, content, EntityMaskInPCDATA);
         out.append(convertHTMLTextToInterchangeFormat(buffer.toString(), &text));
     }
 
@@ -1446,7 +1446,7 @@ String urlToMarkup(const URL& url, const String& title)
 {
     StringBuilder markup;
     markup.append("<a href=\""_s, url.string(), "\">"_s);
-    MarkupAccumulator::appendCharactersReplacingEntities(markup, title, 0, title.length(), EntityMaskInPCDATA);
+    MarkupAccumulator::appendCharactersReplacingEntities(markup, title, EntityMaskInPCDATA);
     markup.append("</a>"_s);
     return markup.toString();
 }


### PR DESCRIPTION
#### d5fdea077b819db68f2cdff533392472ca0c8292
<pre>
Correct serialization of CDATASection nodes in HTML
<a href="https://bugs.webkit.org/show_bug.cgi?id=292529">https://bugs.webkit.org/show_bug.cgi?id=292529</a>

Reviewed by Ryosuke Niwa.

Import new upstream WPT test and address it:
<a href="https://github.com/web-platform-tests/wpt/commit/fe92d5e9ea136e2c97e75710af6189178faff5dd">https://github.com/web-platform-tests/wpt/commit/fe92d5e9ea136e2c97e75710af6189178faff5dd</a>

In addition to that this simplifies
MarkupAccumulator::appendCharactersReplacingEntities as its offset
argument is always 0 and its length argument is always the length of
its source argument.

Canonical link: <a href="https://commits.webkit.org/294547@main">https://commits.webkit.org/294547@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc13180d509ee225551d08cc5d524ce7fd82a93f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107266 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52742 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104146 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30281 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77716 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34708 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105113 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17088 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92185 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58051 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16916 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10210 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52100 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86757 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10283 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109640 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29239 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21557 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86685 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29601 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88389 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86268 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31071 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8790 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23465 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16612 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29167 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34462 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28978 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32301 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30537 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->