### PR TITLE
REGRESSION(294462@main): UI process may crash with 'NSInvalidArgumentException': -[WKPDFPageNumberIndicator canUseVisualEffectViewForBackdrop] :: unrecognized selector

### DIFF
--- a/Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm
+++ b/Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm
@@ -72,7 +72,11 @@ static constexpr Seconds indicatorMoveDuration { 0.3_s };
     self.layer.allowsGroupOpacity = NO;
     self.layer.allowsGroupBlending = NO;
 
-    if (self.canUseVisualEffectViewForBackdrop)
+    bool shouldUseVisualEffectViewForBackdrop = true;
+    if ([self respondsToSelector:@selector(canUseVisualEffectViewForBackdrop)])
+        shouldUseVisualEffectViewForBackdrop = self.canUseVisualEffectViewForBackdrop;
+
+    if (shouldUseVisualEffectViewForBackdrop)
         _backdropView = adoptNS([[UIVisualEffectView alloc] initWithEffect:[UIBlurEffect effectWithStyle:UIBlurEffectStyleLight]]);
     else {
         _backdropView = adoptNS([[UIView alloc] init]);


### PR DESCRIPTION
#### 3e090482f9ab6835ae897abb05bf801fdce5a8d6
<pre>
REGRESSION(294462@main): UI process may crash with &apos;NSInvalidArgumentException&apos;: -[WKPDFPageNumberIndicator canUseVisualEffectViewForBackdrop] :: unrecognized selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=292531">https://bugs.webkit.org/show_bug.cgi?id=292531</a>
<a href="https://rdar.apple.com/150637116">rdar://150637116</a>

Reviewed by David Kilzer.

Under certain configurations, the `canUserVisualEffectViewForBackdrop`
getter is not implemented, even though we still do have support for the
page number indicator at large. This results in the UI process crashing
with an `unrecognized selector` exception during indicator bring-up.

This patch mitigates said crash by ensuring there is a definition for
the property getter in question before calling into it. We default to
using an UIVisualEffectView for the indicator&apos;s backdrop in case the
getter is not implemented.

* Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm:
(-[WKPDFPageNumberIndicator initWithFrame:view:pageCount:]):

Canonical link: <a href="https://commits.webkit.org/294516@main">https://commits.webkit.org/294516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a800986fe84c0d3a9ab5b0c215556688d604db6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102114 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107273 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52749 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22090 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30288 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77721 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34711 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17093 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92189 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58056 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16921 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52107 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86762 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10287 "Found 60 new test failures: fast/css/aspect-ratio-min-height-replaced.html fast/shadow-dom/host-style-sharing.html fast/shapes/shape-outside-floats/shape-outside-floats-border-radius-margin-box-003.html fullscreen/full-screen-request-removed-with-raf.html http/tests/contentextensions/make-https.html http/tests/iframe-monitor/throttler.html http/tests/security/contentSecurityPolicy/user-style-sheet-font-crasher.py imported/w3c/web-platform-tests/editing/other/delete-in-child-of-html.tentative.html?designMode=on&method=forwarddelete imported/w3c/web-platform-tests/editing/other/typing-around-link-element-at-collapsed-selection.tentative.html?target=DesignMode&parent=b&child=i imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/security.pattern.fillStyle.sub.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109647 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86691 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29608 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88393 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86274 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31076 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8794 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23479 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16599 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29174 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34469 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28985 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32308 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30544 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->