### PR TITLE
[GStreamer][WebRTC] Video rotation handling

### DIFF
--- a/LayoutTests/fast/mediastream/video-rotation2.html
+++ b/LayoutTests/fast/mediastream/video-rotation2.html
@@ -18,8 +18,6 @@
         <image id='image' style="z-index: 0; position: absolute; top: 0px; left: 0px; background-color:red; width:200px; height:400px"></image>
         <canvas id='canvas' style="z-index: 0; position: absolute; top: 0px; left: 0px; background-color:red; width:200px; height:400px"></canvas>
         <script>
-if (window.testRunner)
-    testRunner.setMockCameraOrientation(90);
 
 async function getSnapshotData()
 {
@@ -50,11 +48,13 @@ function isGreenPixel(data, i)
 }
 
 promise_test(async () => {
-    video.srcObject = await navigator.mediaDevices.getUserMedia({video: {width: 400, height: 200} });
-    await video.play();
-
     if (!window.testRunner)
         return;
+
+    video.srcObject = await navigator.mediaDevices.getUserMedia({video: {width: 400, height: 200} });
+    if (window.testRunner)
+        testRunner.setMockCameraOrientation(90);
+    await video.play();
 
     let data;
     let isOK = false;

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2242,17 +2242,11 @@ fast/mediastream/getUserMedia-video-rescaling.html [ Failure ]
 fast/mediastream/getUserMedia-frame-rate.html [ Failure ]
 fast/mediastream/get-user-media-constraints.html [ Failure ]
 fast/mediastream/get-user-media-ideal-constraints.html [ Failure ]
-fast/mediastream/video-rotation.html [ Skip ]
-webrtc/video-rotation-no-cvo.html [ Failure Timeout ]
-webrtc/video-rotation-black.html [ Crash Failure Pass Timeout ]
-
-fast/mediastream/video-rotation-clone.html [ Skip ]
 fast/mediastream/image-capture-grabFrame.html [ Failure ]
 
 # No AudioSession category handling in WPE/GTK ports.
 fast/mediastream/microphone-interruption-and-audio-session.html [ Skip ]
 
-webkit.org/b/261329 webrtc/video-clone-track.html [ Failure ]
 webrtc/clone-audio-track.html [ Pass Failure ]
 
 webkit.org/b/256758 fast/mediastream/captureStream/canvas3d.html [ Failure ]
@@ -2357,7 +2351,6 @@ webkit.org/b/252878 fast/mediastream/video-mediastream-restricted-invisible-auto
 webkit.org/b/252878 fast/mediastream/video-mediastream-restricted-invisible-autoplay-user-click.html [ Pass Timeout ]
 webkit.org/b/252878 http/tests/webrtc/video-mediastream-invisible-autoplay-detached.html [ Pass Timeout ]
 webkit.org/b/187064 webrtc/video-addTrack.html [ Failure Pass Timeout ]
-webkit.org/b/187064 webrtc/video-rotation.html [ Failure Timeout ]
 webkit.org/b/187064 webrtc/video-with-data-channel.html [ Failure ]
 webkit.org/b/177533 webrtc/video-interruption.html
 webkit.org/b/229346 webkit.org/b/235885 webrtc/multi-audio.html [ Timeout Pass Failure ]

--- a/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-answer-expected.txt
+++ b/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-answer-expected.txt
@@ -80,6 +80,7 @@ a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
 a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
 a=extmap:5 urn:ietf:params:rtp-hdrext:ntp-64
 a=extmap:6 http://www.webrtc.org/experiments/rtp-hdrext/color-space
+a=extmap:7 urn:3gpp:video-orientation
 ===
 
 PASS successfullyParsed is true

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/protocol/rtp-headerextensions-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/protocol/rtp-headerextensions-expected.txt
@@ -1,8 +1,0 @@
-
-PASS MID header extension is supported.
-PASS Audio level header extension is supported.
-FAIL Video orientation header extension is supported. assert_equals: expected 1 but got 0
-PASS Negotiates the subset of supported extensions offered
-PASS Supports header extensions with id=15
-PASS Supports two-byte header extensions
-

--- a/Source/WebCore/platform/SourcesGStreamer.txt
+++ b/Source/WebCore/platform/SourcesGStreamer.txt
@@ -139,6 +139,7 @@ platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
 platform/mediastream/gstreamer/GStreamerMockDevice.cpp
 platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp
 platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp
+platform/mediastream/gstreamer/GStreamerRTPVideoRotationHeaderExtension.cpp @no-unify
 platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
 platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
 platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp

--- a/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
@@ -87,7 +87,10 @@ static void webKitGLVideoSinkConstructed(GObject* object)
     GST_OBJECT_FLAG_SET(GST_OBJECT_CAST(sink), GST_ELEMENT_FLAG_SINK);
     gst_bin_set_suppressed_flags(GST_BIN_CAST(sink), static_cast<GstElementFlags>(GST_ELEMENT_FLAG_SOURCE | GST_ELEMENT_FLAG_SINK));
 
-    sink->priv->appSink = makeGStreamerElement("appsink"_s, "webkit-gl-video-appsink"_s);
+    static Atomic<uint64_t> sinkCounter = 0;
+    auto sinkName = makeString("webkit-gl-video-appsink-"_s, sinkCounter.exchangeAdd(1));
+    sink->priv->appSink = makeGStreamerElement("appsink"_s, sinkName);
+
     ASSERT(sink->priv->appSink);
     g_object_set(sink->priv->appSink.get(), "enable-last-sample", FALSE, "emit-signals", TRUE, "max-buffers", 1, nullptr);
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -91,6 +91,7 @@
 #endif
 
 #if USE(GSTREAMER_WEBRTC)
+#include "GStreamerRTPVideoRotationHeaderExtension.h"
 #include <gst/webrtc/webrtc-enumtypes.h>
 #endif
 
@@ -446,6 +447,10 @@ void registerWebKitGStreamerElements()
         gst_element_register(nullptr, "mediastreamsrc", GST_RANK_PRIMARY, WEBKIT_TYPE_MEDIA_STREAM_SRC);
 #endif
         registerInternalVideoEncoder();
+
+#if USE(GSTREAMER_WEBRTC)
+        gst_element_register(nullptr, "webkitrtpvideorotationheaderextension", GST_RANK_MARGINAL, WEBKIT_TYPE_GST_RTP_VIDEO_ROTATION_HEADER_EXTENSION);
+#endif
 
 #if ENABLE(MEDIA_SOURCE)
         gst_element_register(nullptr, "webkitmediasrc", GST_RANK_PRIMARY, WEBKIT_TYPE_MEDIA_SRC);

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -416,6 +416,7 @@ protected:
     mutable Lock m_sampleMutex;
     GRefPtr<GstSample> m_sample WTF_GUARDED_BY_LOCK(m_sampleMutex);
 
+    mutable IntSize m_videoSizeFromCaps;
     mutable FloatSize m_videoSize;
     bool m_isUsingFallbackVideoSink { false };
     bool m_canRenderingBeAccelerated { false };
@@ -485,6 +486,8 @@ private:
     void didEnd();
     void setPlaybackFlags(bool isMediaStream);
     void recalculateDurationIfNeeded() const; // It's called from other const methods.
+
+    ImageOrientation getVideoOrientation(const GstTagList*);
 
     GstElement* createVideoSink();
     GstElement* createAudioSink();

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.h
@@ -22,11 +22,18 @@
 #if ENABLE(VIDEO) && USE(GSTREAMER)
 
 #include "GRefPtrGStreamer.h"
+#include "VideoFrame.h"
 #include "VideoFrameMetadata.h"
 #include "VideoFrameTimeMetadata.h"
 
-WARN_UNUSED_RETURN GRefPtr<GstBuffer> webkitGstBufferSetVideoFrameTimeMetadata(GRefPtr<GstBuffer>&&, std::optional<WebCore::VideoFrameTimeMetadata>&&);
+// Modifies the buffer in-place.
+void webkitGstBufferAddVideoFrameMetadata(GstBuffer*, std::optional<WebCore::VideoFrameTimeMetadata>&&, WebCore::VideoFrame::Rotation, bool isMirrored);
+
+// Makes the buffer writable before modifying it.
+WARN_UNUSED_RETURN GRefPtr<GstBuffer> webkitGstBufferSetVideoFrameMetadata(GRefPtr<GstBuffer>&&, std::optional<WebCore::VideoFrameTimeMetadata>&&, WebCore::VideoFrame::Rotation = WebCore::VideoFrame::Rotation::None, bool isMirrored = false);
+
 void webkitGstTraceProcessingTimeForElement(GstElement*);
 WebCore::VideoFrameMetadata webkitGstBufferGetVideoFrameMetadata(GstBuffer*);
+std::pair<WebCore::VideoFrame::Rotation, bool> webkitGstBufferGetVideoRotation(GstBuffer*);
 
 #endif // ENABLE(VIDEO) && USE(GSTREAMER)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
@@ -208,7 +208,10 @@ GstElement* GStreamerCapturer::createSource()
         gst_pad_add_probe(srcPad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_PUSH | GST_PAD_PROBE_TYPE_BUFFER), [](GstPad*, GstPadProbeInfo* info, gpointer) -> GstPadProbeReturn {
             VideoFrameTimeMetadata metadata;
             metadata.captureTime = MonotonicTime::now().secondsSinceEpoch();
-            auto modifiedBuffer = webkitGstBufferSetVideoFrameTimeMetadata(GRefPtr(GST_PAD_PROBE_INFO_BUFFER(info)), metadata);
+            auto buffer = GST_PAD_PROBE_INFO_BUFFER(info);
+            auto [rotation, isMirrored] = webkitGstBufferGetVideoRotation(buffer);
+
+            auto modifiedBuffer = webkitGstBufferSetVideoFrameMetadata(GRefPtr(buffer), metadata, rotation, isMirrored);
             GST_PAD_PROBE_INFO_DATA(info) = modifiedBuffer.leakRef();
             return GST_PAD_PROBE_OK;
         }, nullptr, nullptr);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
@@ -306,10 +306,6 @@ void GStreamerIncomingTrackProcessor::installRtpBufferPadProbe(const GRefPtr<Gst
             if (!rtpBuffer) [[unlikely]]
                 return GST_PAD_PROBE_OK;
 
-            // Do not process further if this packet doesn't mark the end of a frame.
-            if (!gst_rtp_buffer_get_marker(rtpBuffer.mappedData()))
-                return GST_PAD_PROBE_OK;
-
             videoFrameTimeMetadata.rtpTimestamp = gst_rtp_buffer_get_timestamp(rtpBuffer.mappedData());
         }
 
@@ -318,7 +314,7 @@ void GStreamerIncomingTrackProcessor::installRtpBufferPadProbe(const GRefPtr<Gst
             videoFrameTimeMetadata.captureTime = Seconds::fromNanoseconds(gst_rtcp_ntp_to_unix(ntpTimestamp));
         }
 
-        auto modifiedBuffer = webkitGstBufferSetVideoFrameTimeMetadata(GRefPtr(buffer), WTFMove(videoFrameTimeMetadata));
+        auto modifiedBuffer = webkitGstBufferSetVideoFrameMetadata(GRefPtr(buffer), WTFMove(videoFrameTimeMetadata));
         GST_PAD_PROBE_INFO_DATA(info) = modifiedBuffer.leakRef();
         return GST_PAD_PROBE_OK;
     }, gst_caps_new_empty_simple("timestamp/x-ntp"), reinterpret_cast<GDestroyNotify>(gst_caps_unref));

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -513,6 +513,9 @@ public:
             m_configuredSize.setHeight(captureSize.height());
 
         auto videoRotation = videoFrame.rotation();
+        if (videoRotation == VideoFrameRotation::Left || videoRotation == VideoFrameRotation::Right)
+            m_configuredSize = m_configuredSize.transposedSize();
+
         bool videoMirrored = videoFrame.isMirrored();
         if (m_videoRotation != videoRotation || m_videoMirrored != videoMirrored) {
             m_videoRotation = videoRotation;
@@ -635,8 +638,8 @@ private:
 
         VideoFrameTimeMetadata metadata;
         metadata.captureTime = MonotonicTime::now().secondsSinceEpoch();
-        auto emptyBuffer = adoptGRef(gst_buffer_new_allocate(nullptr, GST_VIDEO_INFO_SIZE(&info), nullptr));
-        auto buffer = webkitGstBufferSetVideoFrameTimeMetadata(WTFMove(emptyBuffer), metadata);
+        auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, GST_VIDEO_INFO_SIZE(&info), nullptr));
+        webkitGstBufferAddVideoFrameMetadata(buffer.get(), WTFMove(metadata), m_videoRotation, m_videoMirrored);
         {
             GstMappedBuffer data(buffer, GST_MAP_WRITE);
             WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN; // GLib port

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPVideoRotationHeaderExtension.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPVideoRotationHeaderExtension.cpp
@@ -1,0 +1,129 @@
+/*
+ *  Copyright (C) 2025 Igalia S.L. All rights reserved.
+ *  Copyright (C) 2025 Metrological Group B.V.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "config.h"
+#include "GStreamerRTPVideoRotationHeaderExtension.h"
+
+#if USE(GSTREAMER_WEBRTC)
+
+#include "VideoFrameMetadataGStreamer.h"
+#include <gst/rtp/rtp.h>
+#include <wtf/PrintStream.h>
+#include <wtf/glib/WTFGType.h>
+
+using namespace WebCore;
+
+typedef struct _RTPVideoRotationHeaderExtensionPrivate {
+} RTPVideoRotationHeaderExtensionPrivate;
+
+typedef struct _RTPVideoRotationHeaderExtension {
+    GstRTPHeaderExtension parent;
+    RTPVideoRotationHeaderExtensionPrivate* priv;
+} RTPVideoRotationHeaderExtension;
+
+typedef struct _RTPVideoRotationHeaderExtensionClass {
+    GstRTPHeaderExtensionClass parentClass;
+} RTPVideoRotationHeaderExtensionClass;
+
+GST_DEBUG_CATEGORY_STATIC(extensionDebug);
+#define GST_CAT_DEFAULT extensionDebug
+
+WEBKIT_DEFINE_TYPE_WITH_CODE(RTPVideoRotationHeaderExtension, webkit_gst_rtp_video_rotation_header_extension, GST_TYPE_RTP_HEADER_EXTENSION, GST_DEBUG_CATEGORY_INIT(extensionDebug, "webkitrtpvideorotation", 0, "RTP Video Header Extension"))
+
+static GstRTPHeaderExtensionFlags extensionGetSupportedFlags(GstRTPHeaderExtension*)
+{
+    return static_cast<GstRTPHeaderExtensionFlags>(GST_RTP_HEADER_EXTENSION_ONE_BYTE | GST_RTP_HEADER_EXTENSION_TWO_BYTE);
+}
+
+static gsize extensionGetMaxSize(GstRTPHeaderExtension*, const GstBuffer*)
+{
+    return 1;
+}
+
+static gssize extensionWrite(GstRTPHeaderExtension* extension, const GstBuffer* inputBuffer, GstRTPHeaderExtensionFlags, GstBuffer*, guint8* data, gsize)
+{
+    auto [rotation, isMirrored] = webkitGstBufferGetVideoRotation(const_cast<GstBuffer*>(inputBuffer));
+    gssize written = 1;
+
+    switch (rotation) {
+    case VideoFrame::Rotation::None:
+        data[0] = 0x0;
+        break;
+    case VideoFrame::Rotation::Left:
+        data[0] = 0x1;
+        break;
+    case VideoFrame::Rotation::UpsideDown:
+        data[0] = 0x2;
+        break;
+    case VideoFrame::Rotation::Right:
+        data[0] = 0x3;
+        break;
+    }
+
+    if (isMirrored)
+        data[0] |= 1 << 3;
+
+    GST_TRACE_OBJECT(extension, "Wrote %" G_GSSIZE_FORMAT " bytes from video rotation %u (flipped: %s) to byte 0x%x", written, static_cast<unsigned>(rotation), WTF::boolForPrinting(isMirrored), data[0]);
+    return written;
+}
+
+static gboolean extensionRead(GstRTPHeaderExtension* extension, GstRTPHeaderExtensionFlags, const guint8* data, gsize, GstBuffer* buffer)
+{
+    VideoFrame::Rotation rotation = VideoFrame::Rotation::None;
+    uint8_t firstByte = data[0];
+
+    switch (firstByte & 0x7) {
+    case 0:
+        break;
+    case 1:
+        rotation = VideoFrame::Rotation::Left;
+        break;
+    case 2:
+        rotation = VideoFrame::Rotation::UpsideDown;
+        break;
+    case 3:
+        rotation = VideoFrame::Rotation::Right;
+        break;
+    default:
+        return FALSE;
+    }
+
+    bool isMirrored = (firstByte >> 3) & 0x1;
+    GST_TRACE_OBJECT(extension, "Read byte 0x%x to video rotation %u (flipped: %s)", firstByte, static_cast<unsigned>(rotation), boolForPrinting(isMirrored));
+    webkitGstBufferAddVideoFrameMetadata(buffer, { }, rotation, isMirrored);
+    return TRUE;
+}
+
+static void webkit_gst_rtp_video_rotation_header_extension_class_init(RTPVideoRotationHeaderExtensionClass* klass)
+{
+    auto rtpHeaderExtensionClass = GST_RTP_HEADER_EXTENSION_CLASS(klass);
+
+    rtpHeaderExtensionClass->get_supported_flags = extensionGetSupportedFlags;
+    rtpHeaderExtensionClass->get_max_size = extensionGetMaxSize;
+    rtpHeaderExtensionClass->write = extensionWrite;
+    rtpHeaderExtensionClass->read = extensionRead;
+
+    gst_element_class_set_static_metadata(GST_ELEMENT_CLASS(klass), "3GPP Orientation RTP Header Extension", GST_RTP_HDREXT_ELEMENT_CLASS,
+        "Read/write 3GPP Orientation from/to RTP packets", "Philippe Normand <philn@igalia.com>");
+    gst_rtp_header_extension_class_set_uri(rtpHeaderExtensionClass, "urn:3gpp:video-orientation");
+}
+
+#undef GST_CAT_DEFAULT
+
+#endif // USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPVideoRotationHeaderExtension.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPVideoRotationHeaderExtension.h
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (C) 2025 Igalia S.L. All rights reserved.
+ *  Copyright (C) 2025 Metrological Group B.V.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#pragma once
+
+#if USE(GSTREAMER_WEBRTC)
+
+#include <glib-object.h>
+
+GType webkit_gst_rtp_video_rotation_header_extension_get_type();
+#define WEBKIT_TYPE_GST_RTP_VIDEO_ROTATION_HEADER_EXTENSION webkit_gst_rtp_video_rotation_header_extension_get_type()
+
+#endif // USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
@@ -71,8 +71,9 @@ void GStreamerVideoCapturer::setSinkVideoFrameCallback(SinkVideoFrameCallback&& 
         if (GST_BUFFER_PTS_IS_VALID(buffer))
             presentationTime = fromGstClockTime(GST_BUFFER_PTS(buffer));
 
+        auto rotationFromMeta = webkitGstBufferGetVideoRotation(buffer);
         auto& size = capturer->size();
-        capturer->m_sinkVideoFrameCallback.second(VideoFrameGStreamer::create(WTFMove(sample), std::nullopt, size, presentationTime, VideoFrameGStreamer::Rotation::None, false, WTFMove(metadata)));
+        capturer->m_sinkVideoFrameCallback.second(VideoFrameGStreamer::create(WTFMove(sample), std::nullopt, size, presentationTime, rotationFromMeta.first, rotationFromMeta.second, WTFMove(metadata)));
         return GST_FLOW_OK;
     }), this);
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp
@@ -85,9 +85,6 @@ MockRealtimeVideoSourceGStreamer::~MockRealtimeVideoSourceGStreamer()
 
 void MockRealtimeVideoSourceGStreamer::startProducingData()
 {
-    if (deviceType() == CaptureDevice::DeviceType::Camera)
-        m_capturer->setSize(size());
-
     m_capturer->setFrameRate(frameRate());
     m_capturer->start();
     MockRealtimeVideoSource::startProducingData();

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp
@@ -100,8 +100,9 @@ void RealtimeIncomingVideoSourceGStreamer::dispatchSample(GRefPtr<GstSample>&& s
     }
 
     ensureSizeAndFramerate(GRefPtr<GstCaps>(caps));
+    auto [rotation, isMirrored] = webkitGstBufferGetVideoRotation(buffer);
 
-    videoFrameAvailable(VideoFrameGStreamer::create(WTFMove(sample), std::nullopt, intrinsicSize(), fromGstClockTime(GST_BUFFER_PTS(buffer))), { });
+    videoFrameAvailable(VideoFrameGStreamer::create(WTFMove(sample), std::nullopt, intrinsicSize(), fromGstClockTime(GST_BUFFER_PTS(buffer)), rotation, isMirrored), { });
 }
 
 const GstStructure* RealtimeIncomingVideoSourceGStreamer::stats()

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
@@ -68,7 +68,7 @@ public:
 
     void replaceTrack(RefPtr<MediaStreamTrackPrivate>&&);
 
-    virtual void teardown();
+    void teardown();
 
     virtual void dispatchBitrateRequest(uint32_t bitrate) = 0;
 
@@ -101,7 +101,6 @@ protected:
     std::optional<RealtimeMediaSourceSettings> m_initialSettings;
     GRefPtr<GstElement> m_bin;
     GRefPtr<GstElement> m_outgoingSource;
-    GRefPtr<GstElement> m_preProcessor;
     GRefPtr<GstElement> m_tee;
     GRefPtr<GstElement> m_rtpFunnel;
     GRefPtr<GstElement> m_rtpCapsfilter;
@@ -121,7 +120,6 @@ private:
 
     void stopOutgoingSource();
 
-    bool linkSource();
     virtual RTCRtpCapabilities rtpCapabilities() const = 0;
     void codecPreferencesChanged();
 

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h
@@ -37,8 +37,6 @@ public:
     WARN_UNUSED_RETURN GRefPtr<GstPad> outgoingSourcePad() const final;
     RefPtr<GStreamerRTPPacketizer> createPacketizer(RefPtr<UniqueSSRCGenerator>, const GstStructure*, GUniquePtr<GstStructure>&&) final;
 
-    void teardown() override;
-
     void dispatchBitrateRequest(uint32_t bitrate) final;
 
 protected:
@@ -48,7 +46,7 @@ protected:
     bool m_shouldApplyRotation { false };
 
 private:
-    void initializePreProcessor();
+    void initialize();
 
     RTCRtpCapabilities rtpCapabilities() const final;
 };

--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -301,6 +301,8 @@ _PATH_RULES_SPECIFIER = [
       os.path.join('Source', 'WebCore', 'platform', 'mediastream', 'gstreamer', 'GStreamerMockDevice.cpp'),
       os.path.join('Source', 'WebCore', 'platform', 'mediastream', 'gstreamer', 'GStreamerMockDeviceProvider.h'),
       os.path.join('Source', 'WebCore', 'platform', 'mediastream', 'gstreamer', 'GStreamerMockDeviceProvider.cpp'),
+      os.path.join('Source', 'WebCore', 'platform', 'mediastream', 'gstreamer', 'GStreamerRTPVideoRotationHeaderExtension.h'),
+      os.path.join('Source', 'WebCore', 'platform', 'mediastream', 'gstreamer', 'GStreamerRTPVideoRotationHeaderExtension.cpp'),
       os.path.join('Source', 'WebCore', 'platform', 'network', 'soup', 'ProxyResolverSoup.cpp'),
       os.path.join('Source', 'WebCore', 'platform', 'network', 'soup', 'ProxyResolverSoup.h'),
       os.path.join('Source', 'WebCore', 'platform', 'network', 'soup', 'WebKitAutoconfigProxyResolver.cpp'),


### PR DESCRIPTION
#### 2d8ffc935bc80c9c7d3630dd8a44abf8ebce16b4
<pre>
[GStreamer][WebRTC] Video rotation handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=292528">https://bugs.webkit.org/show_bug.cgi?id=292528</a>

Reviewed by Xabier Rodriguez-Calvar.

The video frames rotation and mirroring informations are now stored in the GstMeta attached to the
video buffers. When the RTP urn:3gpp:video-orientation header extension is negotiated through SDP
Offer/Answer, the metadata is added to RTP packets sent/received over the wire. The
MediaStreamSource element already had orientation tag handling, so as long as our video frames
contain the rotation and mirroring informations, they are translated to the corresponding GstTag and
propagated in our pipelines.

* LayoutTests/fast/mediastream/video-rotation2.html:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-answer-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/protocol/rtp-headerextensions-expected.txt: Removed.
* Source/WebCore/platform/SourcesGStreamer.txt:
* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
(webKitGLVideoSinkConstructed):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::registerWebKitGStreamerElements):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::getVideoOrientation):
(WebCore::MediaPlayerPrivateGStreamer::updateVideoOrientation):
(WebCore::MediaPlayerPrivateGStreamer::updateVideoSizeAndOrientationFromCaps):
(WebCore::getVideoOrientation): Deleted.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrameGStreamer::createFromPixelBuffer):
(WebCore::VideoFrameGStreamer::VideoFrameGStreamer):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp:
(videoFrameMetadataGetInfo):
(webkitGstBufferAddVideoFrameMetadata):
(webkitGstBufferSetVideoFrameMetadata):
(webkitGstBufferGetVideoRotation):
(webkitGstBufferSetVideoFrameTimeMetadata): Deleted.
* Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp:
(WebCore::GStreamerCapturer::createSource):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp:
(WebCore::GStreamerIncomingTrackProcessor::installRtpBufferPadProbe):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPVideoRotationHeaderExtension.cpp: Added.
(extensionGetSupportedFlags):
(extensionGetMaxSize):
(extensionWrite):
(extensionRead):
(webkit_gst_rtp_video_rotation_header_extension_class_init):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPVideoRotationHeaderExtension.h: Added.
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp:
(WebCore::GStreamerVideoCapturer::setSinkVideoFrameCallback):
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp:
(WebCore::MockRealtimeVideoSourceGStreamer::startProducingData):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp:
(WebCore::RealtimeIncomingVideoSourceGStreamer::dispatchSample):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::stopOutgoingSource):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::configurePacketizers):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::teardown):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::linkSource): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingVideoSourceGStreamer::RealtimeOutgoingVideoSourceGStreamer):
(WebCore::RealtimeOutgoingVideoSourceGStreamer::initialize):
(WebCore::RealtimeOutgoingVideoSourceGStreamer::initializePreProcessor): Deleted.
(WebCore::RealtimeOutgoingVideoSourceGStreamer::teardown): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h:
* Tools/Scripts/webkitpy/style/checker.py:

Canonical link: <a href="https://commits.webkit.org/294614@main">https://commits.webkit.org/294614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9438f5a5ad0f92ec60a2671c44afa575eae132ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12428 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107606 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53082 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104484 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30620 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/77940 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/34931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17367 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/92472 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58277 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/101919 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/17204 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10500 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52439 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/87021 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10571 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109981 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29577 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21809 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29941 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88668 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/86517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22011 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31341 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9060 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23822 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29505 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34808 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29316 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32639 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30875 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->