### PR TITLE
[WPE] WPE Platform: add clipboard implementation for wayland

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt
@@ -4,6 +4,7 @@ configure_file(wpe-platform-wayland.pc.in ${CMAKE_BINARY_DIR}/wpe-platform-wayla
 configure_file(wpe-platform-wayland-uninstalled.pc.in ${CMAKE_BINARY_DIR}/wpe-platform-wayland-${WPE_API_VERSION}-uninstalled.pc @ONLY)
 
 set(WPEPlatformWayland_SOURCES
+    ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEClipboardWayland.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV1.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV3.cpp
@@ -25,6 +26,7 @@ set(WPEPlatformWayland_SOURCES
 
 set(WPEPlatformWayland_INSTALLED_HEADERS
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/wpe-wayland.h
+    ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEClipboardWayland.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEDisplayWayland.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEScreenWayland.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEToplevelWayland.h
@@ -38,11 +40,13 @@ set(WPEPlatformWayland_PRIVATE_INCLUDE_DIRECTORIES
 )
 
 set(WPEPlatformWayland_SYSTEM_INCLUDE_DIRECTORIES
+    ${GIO_UNIX_INCLUDE_DIRS}
     ${WAYLAND_INCLUDE_DIRS}
     ${WPEPlatform_SYSTEM_INCLUDE_DIRECTORIES}
 )
 
 set(WPEPlatformWayland_LIBRARIES
+    ${GIO_UNIX_LIBRARIES}
     ${WAYLAND_LIBRARIES}
     ${WPEPlatform_LIBRARIES}
 )

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEClipboardWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEClipboardWayland.cpp
@@ -1,0 +1,263 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEClipboardWayland.h"
+
+#include "WPEClipboardWaylandPrivate.h"
+#include "WPEDisplayWaylandPrivate.h"
+#include <gio/gunixinputstream.h>
+#include <gio/gunixoutputstream.h>
+#include <glib-unix.h>
+#include <wayland-client.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GWeakPtr.h>
+#include <wtf/glib/WTFGType.h>
+
+/**
+ * WPEClipboardWayland:
+ *
+ */
+struct _WPEClipboardWaylandPrivate {
+    struct wl_data_device* wlDataDevice;
+    struct wl_data_offer* offer;
+    struct wl_data_source* source;
+    GRefPtr<GPtrArray> formats;
+};
+WEBKIT_DEFINE_FINAL_TYPE(WPEClipboardWayland, wpe_clipboard_wayland, WPE_TYPE_CLIPBOARD, WPEClipboard)
+
+static const struct wl_data_source_listener wlDataSourceListener = {
+    // target
+    [](void*, wl_data_source*, const char* /*mimeType*/) {
+
+    },
+    // send
+    [](void* data, wl_data_source* source, const char* mimeType, int32_t fd) {
+        auto* priv = WPE_CLIPBOARD_WAYLAND(data)->priv;
+        if (priv->source != source) {
+            close(fd);
+            return;
+        }
+
+        auto* content = wpe_clipboard_get_content(WPE_CLIPBOARD(data));
+        if (!content) {
+            close(fd);
+            return;
+        }
+
+        GRefPtr<GOutputStream> stream = adoptGRef(g_unix_output_stream_new(fd, TRUE));
+        wpe_clipboard_content_serialize(content, mimeType, stream.get());
+    },
+    // cancelled
+    [](void* data, wl_data_source* source) {
+        auto* priv = WPE_CLIPBOARD_WAYLAND(data)->priv;
+        if (priv->source != source)
+            return;
+
+        g_clear_pointer(&priv->offer, wl_data_offer_destroy);
+        g_clear_pointer(&priv->source, wl_data_source_destroy);
+        priv->formats = nullptr;
+
+        auto* clipboard = WPE_CLIPBOARD(data);
+        WPE_CLIPBOARD_GET_CLASS(clipboard)->changed(clipboard, nullptr, FALSE, nullptr);
+    },
+    // dnd_drop_performed
+    [](void*, wl_data_source*) {
+    },
+    // dnd_finished
+    [](void*, wl_data_source*) {
+    },
+    // action
+    [](void*, wl_data_source*, uint32_t /*dndAction*/) {
+    }
+};
+
+static const struct wl_data_offer_listener  wlDataOfferListener = {
+    // offer
+    [](void* data, wl_data_offer* offer, const char* mimeType) {
+        auto* priv = WPE_CLIPBOARD_WAYLAND(data)->priv;
+        if (priv->offer != offer)
+            return;
+
+        const auto* format = g_intern_string(mimeType);
+        if (!g_ptr_array_find(priv->formats.get(), format, nullptr))
+            g_ptr_array_add(priv->formats.get(), static_cast<gpointer>(const_cast<char*>(format)));
+    },
+    // source_actions
+    [](void*, wl_data_offer*, uint32_t /*sourceActions*/) {
+    },
+    // action
+    [](void*, wl_data_offer*, uint32_t /*dndAction*/) {
+    }
+};
+
+static const struct wl_data_device_listener wlDataDeviceListener = {
+    // data_offer
+    [](void* data, wl_data_device*, wl_data_offer* offer) {
+        auto* priv = WPE_CLIPBOARD_WAYLAND(data)->priv;
+        g_clear_pointer(&priv->offer, wl_data_offer_destroy);
+        priv->offer = offer;
+        wl_data_offer_add_listener(priv->offer, &wlDataOfferListener, data);
+
+        priv->formats = adoptGRef(g_ptr_array_new());
+    },
+    // enter
+    [](void*, wl_data_device*, uint32_t /*serial*/, wl_surface*, wl_fixed_t /*x*/, wl_fixed_t /*y*/, wl_data_offer*) {
+    },
+    // leave
+    [](void*, wl_data_device*) {
+    },
+    // motion
+    [](void*, wl_data_device*, uint32_t /*time*/, wl_fixed_t /*x*/, wl_fixed_t /*y*/) {
+    },
+    // drop
+    [](void*, wl_data_device*) {
+    },
+    // selection
+    [](void* data, wl_data_device*, wl_data_offer* offer) {
+        auto* priv = WPE_CLIPBOARD_WAYLAND(data)->priv;
+        GRefPtr<GPtrArray> formats;
+        if (offer) {
+            if (priv->offer == offer) {
+                g_ptr_array_add(priv->formats.get(), nullptr);
+                formats = std::exchange(priv->formats, nullptr);
+            } else {
+                g_clear_pointer(&priv->offer, wl_data_offer_destroy);
+                priv->formats = nullptr;
+            }
+        }
+
+        if (priv->source)
+            return;
+
+        auto* clipboard = WPE_CLIPBOARD(data);
+        WPE_CLIPBOARD_GET_CLASS(clipboard)->changed(clipboard, formats.get(), FALSE, nullptr);
+    }
+};
+
+static void wpeClipboardWaylandConstructed(GObject *object)
+{
+    G_OBJECT_CLASS(wpe_clipboard_wayland_parent_class)->constructed(object);
+
+    auto* clipboard = WPE_CLIPBOARD(object);
+    auto* display = WPE_DISPLAY_WAYLAND(wpe_clipboard_get_display(clipboard));
+    auto* seat = wpeDisplayWaylandGetSeat(display);
+    ASSERT(seat);
+    auto* wlDataDeviceManager = wpeDisplayWaylandGetDataDeviceManager(display);
+    ASSERT(wlDataDeviceManager);
+    auto* priv = WPE_CLIPBOARD_WAYLAND(clipboard)->priv;
+    priv->wlDataDevice = wl_data_device_manager_get_data_device(wlDataDeviceManager, seat->seat());
+    wl_data_device_add_listener(priv->wlDataDevice, &wlDataDeviceListener, clipboard);
+}
+
+static void wpeClipboardWaylandDispose(GObject* object)
+{
+    wpeClipboardWaylandInvalidate(WPE_CLIPBOARD_WAYLAND(object));
+
+    G_OBJECT_CLASS(wpe_clipboard_wayland_parent_class)->dispose(object);
+}
+
+static GBytes* wpeClipboardWaylandRead(WPEClipboard* clipboard, const char* format)
+{
+    auto* priv = WPE_CLIPBOARD_WAYLAND(clipboard)->priv;
+    if (!priv->offer)
+        return nullptr;
+
+    int pipeFD[2];
+    if (!g_unix_open_pipe(pipeFD, O_CLOEXEC, nullptr))
+        return nullptr;
+
+    wl_data_offer_receive(priv->offer, format, pipeFD[1]);
+    close(pipeFD[1]);
+
+    auto* display = WPE_DISPLAY_WAYLAND(wpe_clipboard_get_display(clipboard));
+    wl_display_roundtrip(wpe_display_wayland_get_wl_display(display));
+
+    GRefPtr<GInputStream> inStream = adoptGRef(g_unix_input_stream_new(pipeFD[0], TRUE));
+    GRefPtr<GOutputStream> outStream = adoptGRef(g_memory_output_stream_new_resizable());
+    auto result = g_output_stream_splice(outStream.get(), inStream.get(), static_cast<GOutputStreamSpliceFlags>(G_OUTPUT_STREAM_SPLICE_CLOSE_SOURCE | G_OUTPUT_STREAM_SPLICE_CLOSE_TARGET), nullptr, nullptr);
+    if (result == -1)
+        return nullptr;
+
+    return g_memory_output_stream_steal_as_bytes(G_MEMORY_OUTPUT_STREAM(outStream.get()));
+}
+
+static void wpeClipboardWaylandChanged(WPEClipboard* clipboard, GPtrArray* formats, gboolean isLocal, WPEClipboardContent* content)
+{
+    if (isLocal) {
+        auto* priv = WPE_CLIPBOARD_WAYLAND(clipboard)->priv;
+        g_clear_pointer(&priv->offer, wl_data_offer_destroy);
+        g_clear_pointer(&priv->source, wl_data_source_destroy);
+        priv->formats = nullptr;
+
+        auto* display = WPE_DISPLAY_WAYLAND(wpe_clipboard_get_display(clipboard));
+        auto* wlDataDeviceManager = wpeDisplayWaylandGetDataDeviceManager(display);
+        ASSERT(wlDataDeviceManager);
+        priv->source = wl_data_device_manager_create_data_source(wlDataDeviceManager);
+        wl_data_source_add_listener(priv->source, &wlDataSourceListener, clipboard);
+
+        if (formats) {
+            for (unsigned i = 0; formats->pdata[i]; ++i)
+                wl_data_source_offer(priv->source, static_cast<const char*>(formats->pdata[i]));
+        }
+
+        auto* seat = wpeDisplayWaylandGetSeat(display);
+        wl_data_device_set_selection(priv->wlDataDevice, priv->source, seat->keyboardSerial());
+    }
+
+    WPE_CLIPBOARD_CLASS(wpe_clipboard_wayland_parent_class)->changed(clipboard, formats, isLocal, content);
+}
+
+static void wpe_clipboard_wayland_class_init(WPEClipboardWaylandClass* clipboardWaylandClass)
+{
+    GObjectClass* objectClass = G_OBJECT_CLASS(clipboardWaylandClass);
+    objectClass->constructed = wpeClipboardWaylandConstructed;
+    objectClass->dispose = wpeClipboardWaylandDispose;
+
+    WPEClipboardClass* clipboardClass = WPE_CLIPBOARD_CLASS(clipboardWaylandClass);
+    clipboardClass->read = wpeClipboardWaylandRead;
+    clipboardClass->changed = wpeClipboardWaylandChanged;
+}
+
+void wpeClipboardWaylandInvalidate(WPEClipboardWayland* clipboard)
+{
+    auto* priv = clipboard->priv;
+    g_clear_pointer(&priv->offer, wl_data_offer_destroy);
+    g_clear_pointer(&priv->source, wl_data_source_destroy);
+    g_clear_pointer(&priv->wlDataDevice, wl_data_device_destroy);
+}
+
+/**
+ * wpe_clipboard_wayland_new:
+ * @display: a #WPEDisplayWayland
+ *
+ * Create a new #WPEClipboardWayland
+ *
+ * Returns: (transfer full): a #WPEClipboard
+ */
+WPEClipboard* wpe_clipboard_wayland_new(WPEDisplayWayland* display)
+{
+    return WPE_CLIPBOARD(g_object_new(WPE_TYPE_CLIPBOARD_WAYLAND, "display", display, nullptr));
+}

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEClipboardWayland.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEClipboardWayland.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2025 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,17 +22,25 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef __WPE_WAYLAND_H__
-#define __WPE_WAYLAND_H__
 
-#define __WPE_WAYLAND_H_INSIDE__
+#ifndef WPEClipboardWayland_h
+#define WPEClipboardWayland_h
 
-#include <wpe/wayland/WPEClipboardWayland.h>
+#if !defined(__WPE_WAYLAND_H_INSIDE__) && !defined(BUILDING_WEBKIT)
+#error "Only <wpe/wayland/wpe-wayland.h> can be included directly."
+#endif
+
+#include <glib-object.h>
+#include <wpe/wpe-platform.h>
 #include <wpe/wayland/WPEDisplayWayland.h>
-#include <wpe/wayland/WPEScreenWayland.h>
-#include <wpe/wayland/WPEToplevelWayland.h>
-#include <wpe/wayland/WPEViewWayland.h>
 
-#undef __WPE_WAYLAND_H_INSIDE__
+G_BEGIN_DECLS
 
-#endif /* __WPE_PLATFORM_H__ */
+#define WPE_TYPE_CLIPBOARD_WAYLAND (wpe_clipboard_wayland_get_type())
+WPE_API G_DECLARE_FINAL_TYPE (WPEClipboardWayland, wpe_clipboard_wayland, WPE, CLIPBOARD_WAYLAND, WPEClipboard)
+
+WPE_API WPEClipboard *wpe_clipboard_wayland_new (WPEDisplayWayland *display);
+
+G_END_DECLS
+
+#endif /* WPEClipboardWayland_h */

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEClipboardWaylandPrivate.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEClipboardWaylandPrivate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2025 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,17 +22,9 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef __WPE_WAYLAND_H__
-#define __WPE_WAYLAND_H__
 
-#define __WPE_WAYLAND_H_INSIDE__
+#pragma once
 
-#include <wpe/wayland/WPEClipboardWayland.h>
-#include <wpe/wayland/WPEDisplayWayland.h>
-#include <wpe/wayland/WPEScreenWayland.h>
-#include <wpe/wayland/WPEToplevelWayland.h>
-#include <wpe/wayland/WPEViewWayland.h>
+#include "WPEClipboardWayland.h"
 
-#undef __WPE_WAYLAND_H_INSIDE__
-
-#endif /* __WPE_PLATFORM_H__ */
+void wpeClipboardWaylandInvalidate(WPEClipboardWayland*);

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWaylandPrivate.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWaylandPrivate.h
@@ -33,6 +33,7 @@
 struct xdg_wm_base* wpeDisplayWaylandGetXDGWMBase(WPEDisplayWayland*);
 WPE::WaylandSeat* wpeDisplayWaylandGetSeat(WPEDisplayWayland*);
 WPE::WaylandCursor* wpeDisplayWaylandGetCursor(WPEDisplayWayland*);
+struct wl_data_device_manager* wpeDisplayWaylandGetDataDeviceManager(WPEDisplayWayland*);
 WPEScreen* wpeDisplayWaylandFindScreen(WPEDisplayWayland*, struct wl_output*);
 struct zwp_linux_dmabuf_v1* wpeDisplayWaylandGetLinuxDMABuf(WPEDisplayWayland*);
 struct zwp_linux_explicit_synchronization_v1* wpeDisplayWaylandGetLinuxExplicitSync(WPEDisplayWayland*);

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp
@@ -294,7 +294,7 @@ const struct wl_keyboard_listener WaylandSeat::s_keyboardListener = {
         wpe_keymap_xkb_update(WPE_KEYMAP_XKB(seat.m_keymap.get()), format, fd, size);
     },
     // enter
-    [](void* data, struct wl_keyboard*, uint32_t /*serial*/, struct wl_surface* surface, struct wl_array*)
+    [](void* data, struct wl_keyboard*, uint32_t serial, struct wl_surface* surface, struct wl_array*)
     {
         if (!surface)
             return;
@@ -309,6 +309,7 @@ const struct wl_keyboard_listener WaylandSeat::s_keyboardListener = {
         auto& seat = *static_cast<WaylandSeat*>(data);
         seat.m_keyboard.toplevel.reset(toplevelWayland);
         seat.m_keyboard.repeat.key = 0;
+        seat.m_keyboard.serial = serial;
 
         if (GRefPtr<WPEView> view = wpeToplevelWaylandGetVisibleFocusedView(toplevelWayland))
             wpe_view_focus_in(view.get());
@@ -329,6 +330,7 @@ const struct wl_keyboard_listener WaylandSeat::s_keyboardListener = {
         seat.m_keyboard.toplevel = nullptr;
         seat.m_keyboard.repeat.key = 0;
         seat.m_keyboard.repeat.deadline = { };
+        seat.m_keyboard.serial = 0;
 
         if (view)
             wpe_view_focus_out(view.get());

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.h
@@ -48,6 +48,7 @@ public:
     WPEKeymap* keymap() const { return m_keymap.get(); }
     uint32_t pointerModifiers() const { return m_pointer.modifiers; }
     std::pair<double, double> pointerCoords() const { return std::pair<double, double>(m_pointer.x, m_pointer.y); }
+    uint32_t keyboardSerial() const { return m_keyboard.serial; }
     WPEAvailableInputDevices availableInputDevices() const;
 
     void startListening();
@@ -100,6 +101,7 @@ private:
         GWeakPtr<WPEToplevelWayland> toplevel;
         uint32_t modifiers { 0 };
         uint32_t time { 0 };
+        uint32_t serial { 0 };
 
         struct {
             std::optional<int32_t> rate;


### PR DESCRIPTION
#### 5aba2bfb3e6ef2b6b5d58e8d2971dc0185041d77
<pre>
[WPE] WPE Platform: add clipboard implementation for wayland
<a href="https://bugs.webkit.org/show_bug.cgi?id=292532">https://bugs.webkit.org/show_bug.cgi?id=292532</a>

Reviewed by Patrick Griffis.

Implement WPEClipboard on wayland platform.

* Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEClipboardWayland.cpp: Added.
(wpeClipboardWaylandDispose):
(wpeClipboardWaylandRead):
(wpeClipboardWaylandChanged):
(wpe_clipboard_wayland_class_init):
(wpeClipboardWaylandInvalidate):
(wpe_clipboard_wayland_new):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEClipboardWayland.h: Copied from Source/WebKit/WPEPlatform/wpe/wayland/wpe-wayland.h.
* Source/WebKit/WPEPlatform/wpe/wayland/WPEClipboardWaylandPrivate.h: Copied from Source/WebKit/WPEPlatform/wpe/wayland/wpe-wayland.h.
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp:
(wpeDisplayWaylandDispose):
(wpeDisplayWaylandSetup):
(wpeDisplayWaylandGetClipboard):
(wpeDisplayWaylandGetDataDeviceManager):
(wpe_display_wayland_class_init):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWaylandPrivate.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.h:
(WPE::WaylandSeat::keyboardSerial const):
* Source/WebKit/WPEPlatform/wpe/wayland/wpe-wayland.h:

Canonical link: <a href="https://commits.webkit.org/294551@main">https://commits.webkit.org/294551@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c1dcdc2eec1edddeb1785e0568bcb17a11dd144

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107277 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52753 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30292 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77724 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34717 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92194 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58059 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16929 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52111 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86770 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10292 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109651 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29250 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21569 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86694 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29612 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88398 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86277 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31084 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8799 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23494 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16614 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29178 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34473 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28989 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32312 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30548 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->