### PR TITLE
[WPE] Implement PlatformWebView::focus() on new API

### DIFF
--- a/Tools/WebKitTestRunner/libwpe/PlatformWebViewClient.h
+++ b/Tools/WebKitTestRunner/libwpe/PlatformWebViewClient.h
@@ -40,6 +40,7 @@ public:
 
     virtual void addToWindow() = 0;
     virtual void removeFromWindow() = 0;
+    virtual void focus() { }
 
     virtual PlatformImage snapshot() = 0;
 

--- a/Tools/WebKitTestRunner/libwpe/PlatformWebViewLibWPE.cpp
+++ b/Tools/WebKitTestRunner/libwpe/PlatformWebViewLibWPE.cpp
@@ -70,6 +70,7 @@ WKPageRef PlatformWebView::page()
 
 void PlatformWebView::focus()
 {
+    m_window->focus();
 }
 
 WKRect PlatformWebView::windowFrame()

--- a/Tools/WebKitTestRunner/wpe/PlatformWebViewClientWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/PlatformWebViewClientWPE.cpp
@@ -68,6 +68,11 @@ void PlatformWebViewClientWPE::removeFromWindow()
     // FIXME: implement.
 }
 
+void PlatformWebViewClientWPE::focus()
+{
+    wpe_view_focus_in(WKViewGetView(m_view));
+}
+
 PlatformImage PlatformWebViewClientWPE::snapshot()
 {
     while (g_main_context_pending(nullptr))

--- a/Tools/WebKitTestRunner/wpe/PlatformWebViewClientWPE.h
+++ b/Tools/WebKitTestRunner/wpe/PlatformWebViewClientWPE.h
@@ -47,6 +47,8 @@ private:
     void addToWindow() override;
     void removeFromWindow() override;
 
+    void focus() override;
+
     PlatformImage snapshot() override;
 
     GRefPtr<WPEDisplay> m_display;


### PR DESCRIPTION
#### 9cce51c1323029068629df2b875ee317264d5ad9
<pre>
[WPE] Implement PlatformWebView::focus() on new API
<a href="https://bugs.webkit.org/show_bug.cgi?id=292537">https://bugs.webkit.org/show_bug.cgi?id=292537</a>

Reviewed by Nikolas Zimmermann.

* Tools/WebKitTestRunner/libwpe/PlatformWebViewClient.h:
(WTR::PlatformWebViewClient::focus):
* Tools/WebKitTestRunner/libwpe/PlatformWebViewLibWPE.cpp:
(WTR::PlatformWebView::focus):
* Tools/WebKitTestRunner/wpe/PlatformWebViewClientWPE.cpp:
(WTR::PlatformWebViewClientWPE::focus):
* Tools/WebKitTestRunner/wpe/PlatformWebViewClientWPE.h:

Canonical link: <a href="https://commits.webkit.org/294552@main">https://commits.webkit.org/294552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7fadffa2b30b47c614cee7122bd81547ac8bc84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21791 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107283 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52759 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104163 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30298 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77727 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34721 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105130 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17102 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92200 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58062 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16930 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10225 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52117 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86771 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10298 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109657 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29256 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21571 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86697 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29618 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88404 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86280 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31085 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8805 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23498 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16615 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29184 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28995 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32318 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30554 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->