### PR TITLE
MediaCapabilitiesDecodingInfo does not need to define constructors

### DIFF
--- a/Source/WebCore/platform/MediaCapabilitiesDecodingInfo.h
+++ b/Source/WebCore/platform/MediaCapabilitiesDecodingInfo.h
@@ -31,20 +31,6 @@
 namespace WebCore {
 
 struct MediaCapabilitiesDecodingInfo : MediaCapabilitiesInfo {
-    // FIXME(C++17): remove the following constructors once all compilers support extended
-    // aggregate initialization:
-    // <http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0017r1.html>
-    MediaCapabilitiesDecodingInfo() = default;
-    MediaCapabilitiesDecodingInfo(MediaDecodingConfiguration&& supportedConfiguration)
-        : MediaCapabilitiesDecodingInfo({ }, WTFMove(supportedConfiguration))
-    {
-    }
-    MediaCapabilitiesDecodingInfo(MediaCapabilitiesInfo&& info, MediaDecodingConfiguration&& supportedConfiguration)
-        : MediaCapabilitiesInfo(WTFMove(info))
-        , supportedConfiguration(WTFMove(supportedConfiguration))
-    {
-    }
-
     MediaDecodingConfiguration supportedConfiguration;
 
     MediaCapabilitiesDecodingInfo isolatedCopy() const;

--- a/Source/WebCore/platform/MediaCapabilitiesEncodingInfo.h
+++ b/Source/WebCore/platform/MediaCapabilitiesEncodingInfo.h
@@ -31,20 +31,6 @@
 namespace WebCore {
 
 struct MediaCapabilitiesEncodingInfo : MediaCapabilitiesInfo {
-    // FIXME(C++17): remove the following constructors once all compilers support extended
-    // aggregate initialization:
-    // <http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0017r1.html>
-    MediaCapabilitiesEncodingInfo() = default;
-    MediaCapabilitiesEncodingInfo(MediaEncodingConfiguration&& supportedConfiguration)
-        : MediaCapabilitiesEncodingInfo({ }, WTFMove(supportedConfiguration))
-    {
-    }
-    MediaCapabilitiesEncodingInfo(MediaCapabilitiesInfo&& info, MediaEncodingConfiguration&& supportedConfiguration)
-        : MediaCapabilitiesInfo(WTFMove(info))
-        , supportedConfiguration(WTFMove(supportedConfiguration))
-    {
-    }
-
     MediaEncodingConfiguration supportedConfiguration;
 
     MediaCapabilitiesEncodingInfo isolatedCopy() const;

--- a/Source/WebCore/platform/mediastream/WebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/WebRTCProvider.cpp
@@ -203,7 +203,7 @@ void WebRTCProvider::createDecodingConfiguration(MediaDecodingConfiguration&& co
     ASSERT(configuration.type == MediaDecodingType::WebRTC);
 
     // FIXME: Validate additional parameters, in particular mime type parameters.
-    MediaCapabilitiesDecodingInfo info { WTFMove(configuration) };
+    MediaCapabilitiesDecodingInfo info { { }, WTFMove(configuration) };
 
 #if ENABLE(WEB_RTC)
     if (info.supportedConfiguration.video) {
@@ -240,7 +240,7 @@ void WebRTCProvider::createEncodingConfiguration(MediaEncodingConfiguration&& co
     ASSERT(configuration.type == MediaEncodingType::WebRTC);
 
     // FIXME: Validate additional parameters, in particular mime type parameters.
-    MediaCapabilitiesEncodingInfo info { WTFMove(configuration) };
+    MediaCapabilitiesEncodingInfo info { { }, WTFMove(configuration) };
 
 #if ENABLE(WEB_RTC)
     if (info.supportedConfiguration.video) {

--- a/Source/WebCore/platform/mock/MediaEngineConfigurationFactoryMock.cpp
+++ b/Source/WebCore/platform/mock/MediaEngineConfigurationFactoryMock.cpp
@@ -153,8 +153,7 @@ static bool canPowerEfficientlyEncodeMedia(const MediaEncodingConfiguration& con
 void MediaEngineConfigurationFactoryMock::createDecodingConfiguration(MediaDecodingConfiguration&& configuration, DecodingConfigurationCallback&& callback)
 {
     if (!canDecodeMedia(configuration)) {
-        MediaCapabilitiesDecodingInfo info { WTFMove(configuration) };
-        callback(WTFMove(info));
+        callback({ { }, WTFMove(configuration) });
         return;
     }
     callback({{ true, canSmoothlyDecodeMedia(configuration), canPowerEfficientlyDecodeMedia(configuration) }, WTFMove(configuration)});
@@ -163,7 +162,7 @@ void MediaEngineConfigurationFactoryMock::createDecodingConfiguration(MediaDecod
 void MediaEngineConfigurationFactoryMock::createEncodingConfiguration(MediaEncodingConfiguration&& configuration, EncodingConfigurationCallback&& callback)
 {
     if (!canEncodeMedia(configuration)) {
-        callback({{ }, WTFMove(configuration) });
+        callback({ { }, WTFMove(configuration) });
         return;
     }
     callback({{ true, canSmoothlyEncodeMedia(configuration), canPowerEfficientlyEncodeMedia(configuration) }, WTFMove(configuration)});


### PR DESCRIPTION
#### 7d17e997434f299e9c7b8433fd420006b1124dc6
<pre>
MediaCapabilitiesDecodingInfo does not need to define constructors
<a href="https://rdar.apple.com/150680673">rdar://150680673</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292540">https://bugs.webkit.org/show_bug.cgi?id=292540</a>

Reviewed by Eric Carlson.

Remove explicit constructors as compilers should now support aggregate initialization for derived structs.
Update call sites accordingly.

* Source/WebCore/platform/MediaCapabilitiesDecodingInfo.h:
(WebCore::MediaCapabilitiesDecodingInfo::MediaCapabilitiesDecodingInfo): Deleted.
(): Deleted.
* Source/WebCore/platform/MediaCapabilitiesEncodingInfo.h:
(WebCore::MediaCapabilitiesEncodingInfo::MediaCapabilitiesEncodingInfo): Deleted.
(): Deleted.
* Source/WebCore/platform/mediastream/WebRTCProvider.cpp:
(WebCore::WebRTCProvider::createDecodingConfiguration):
(WebCore::WebRTCProvider::createEncodingConfiguration):
* Source/WebCore/platform/mock/MediaEngineConfigurationFactoryMock.cpp:
(WebCore::MediaEngineConfigurationFactoryMock::createDecodingConfiguration):
(WebCore::MediaEngineConfigurationFactoryMock::createEncodingConfiguration):

Canonical link: <a href="https://commits.webkit.org/294550@main">https://commits.webkit.org/294550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fed95ed46c55d62ca61e089033c6d06f5b8fba8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12114 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107290 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52767 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104170 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77729 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34723 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105137 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92204 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58064 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16934 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10229 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52124 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86775 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109664 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21576 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86698 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29625 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88408 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86281 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21971 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31089 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8809 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23505 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29191 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34486 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29002 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32325 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30561 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->