### PR TITLE
WebRTC MediaCapabilitiesDecodingInfo.configuration should not be undefined if supported is false

### DIFF
--- a/LayoutTests/webrtc/vp9-tests.js
+++ b/LayoutTests/webrtc/vp9-tests.js
@@ -1,7 +1,11 @@
-let hasVP9 = false;
-test(() => {
+promise_test(async () => {
     if (window.internals)
         window.internals.setWebRTCVP9Support(false, false);
+
+    const videoConfiguration = { contentType: 'video/vp9', width: 800, height: 600, bitrate: 3000, framerate: 24 };
+    const results = await navigator.mediaCapabilities.encodingInfo({type: 'webrtc', video: videoConfiguration });
+    assert_false(results.supported, "decoder MC not supported");
+    assert_not_equals(results.configuration, undefined, "decoder MC configuration");
 
     let codecs = RTCRtpSender.getCapabilities("video").codecs;
     vp9Codecs = codecs.filter(codec => codec.mimeType === "video/VP9");
@@ -30,13 +34,17 @@ test(() => {
         assert_equals(vp9Codecs[0].sdpFmtpLine, "profile-id=0", "first codec");
         assert_equals(vp9Codecs[1].sdpFmtpLine, "profile-id=2", "second codec");
     }
-
-    hasVP9 = vp9Codecs.length > 0;
 }, "VP9 in sender getCapabilities");
 
-test(() => {
+promise_test(async () => {
     if (window.internals)
         window.internals.setWebRTCVP9Support(false, false);
+
+    const videoConfiguration = { contentType: 'video/vp9', width: 800, height: 600, bitrate: 3000, framerate: 24 };
+    const results = await navigator.mediaCapabilities.decodingInfo({type: 'webrtc', video: videoConfiguration });
+    assert_false(results.supported, "decoder MC not supported");
+    assert_not_equals(results.configuration, undefined, "decoder MC configuration");
+
 
     let codecs = RTCRtpReceiver.getCapabilities("video").codecs;
     vp9Codecs = codecs.filter(codec => codec.mimeType === "video/VP9");
@@ -59,97 +67,97 @@ test(() => {
     assert_equals(vp9Codecs[1].sdpFmtpLine, "profile-id=2", "second codec");
 }, "VP9 in receiver getCapabilities");
 
-if (hasVP9) {
-    promise_test(async () => {
-        let videoConfiguration = { contentType: 'video/vp9', width: 800, height: 600, bitrate: 3000, framerate: 24 };
-        let results = await navigator.mediaCapabilities.decodingInfo({type: 'webrtc', video: videoConfiguration });
-        assert_true(results.supported, "decoder supported 1");
-        assert_true(results.smooth, "decoder smooth 1");
+promise_test(async () => {
+    let videoConfiguration = { contentType: 'video/vp9', width: 800, height: 600, bitrate: 3000, framerate: 24 };
+    let results = await navigator.mediaCapabilities.decodingInfo({type: 'webrtc', video: videoConfiguration });
+    assert_true(results.supported, "decoder supported 1");
+    assert_true(results.smooth, "decoder smooth 1");
+    assert_not_equals(results.configuration, undefined);
 
-        videoConfiguration = { contentType: 'video/VP9', width: 800, height: 600, bitrate: 3000, framerate: 24 };
-        results = await navigator.mediaCapabilities.decodingInfo({type: 'webrtc', video: videoConfiguration });
-        assert_true(results.supported, "decoder supported 2");
-        assert_true(results.smooth, "decoder smooth 2");
-    }, "VP9 decoding in navigator.mediaCapabilities");
+    videoConfiguration = { contentType: 'video/VP9', width: 800, height: 600, bitrate: 3000, framerate: 24 };
+    results = await navigator.mediaCapabilities.decodingInfo({type: 'webrtc', video: videoConfiguration });
+    assert_true(results.supported, "decoder supported 2");
+    assert_not_equals(results.configuration, undefined);
+    assert_true(results.smooth, "decoder smooth 2");
+}, "VP9 decoding in navigator.mediaCapabilities");
 
-    promise_test(async () => {
-        let videoConfiguration = { contentType: 'video/vp9', width: 800, height: 600, bitrate: 3000, framerate: 24 };
-        let results = await navigator.mediaCapabilities.encodingInfo({type: 'webrtc', video: videoConfiguration });
-        assert_true(results.supported, "encoder supported 1");
-        assert_equals(results.powerEfficient, results.smooth, "encoder powerEfficient 1");
+promise_test(async () => {
+    let videoConfiguration = { contentType: 'video/vp9', width: 800, height: 600, bitrate: 3000, framerate: 24 };
+    let results = await navigator.mediaCapabilities.encodingInfo({type: 'webrtc', video: videoConfiguration });
+    assert_true(results.supported, "encoder supported 1");
+    assert_equals(results.powerEfficient, results.smooth, "encoder powerEfficient 1");
 
-        videoConfiguration = { contentType: 'video/VP9', width: 800, height: 600, bitrate: 3000, framerate: 24 };
-        results = await navigator.mediaCapabilities.encodingInfo({type: 'webrtc', video: videoConfiguration });
-        assert_true(results.supported, "encoder supported 2");
-        assert_equals(results.powerEfficient, results.smooth, "encoder powerEfficient 2");
-    }, "VP9 encoding in navigator.mediaCapabilities");
+    videoConfiguration = { contentType: 'video/VP9', width: 800, height: 600, bitrate: 3000, framerate: 24 };
+    results = await navigator.mediaCapabilities.encodingInfo({type: 'webrtc', video: videoConfiguration });
+    assert_true(results.supported, "encoder supported 2");
+    assert_equals(results.powerEfficient, results.smooth, "encoder powerEfficient 2");
+}, "VP9 encoding in navigator.mediaCapabilities");
 
-    promise_test(async (test) => {
-        const pc = new RTCPeerConnection();
-        pc.addTransceiver("video");
-        const description = await pc.createOffer();
-        pc.close();
-        assert_true(description.sdp.indexOf("VP9") !== -1, "VP9 codec is in the SDP");
-    }, "Verify VP9 activation")
+promise_test(async (test) => {
+    const pc = new RTCPeerConnection();
+    pc.addTransceiver("video");
+    const description = await pc.createOffer();
+    pc.close();
+    assert_true(description.sdp.indexOf("VP9") !== -1, "VP9 codec is in the SDP");
+}, "Verify VP9 activation")
 
-    var track;
-    var remoteTrack;
-    var receivingConnection;
-    promise_test((test) => {
-        return navigator.mediaDevices.getUserMedia({video: {width: 320, height: 240, facingMode: "environment"}}).then((localStream) => {
-            return new Promise((resolve, reject) => {
-                track = localStream.getVideoTracks()[0];
-
-                createConnections((firstConnection) => {
-                    firstConnection.addTrack(track, localStream);
-                }, (secondConnection) => {
-                    receivingConnection = secondConnection;
-                    secondConnection.ontrack = (trackEvent) => {
-                        remoteTrack = trackEvent.track;
-                        resolve(trackEvent.streams[0]);
-                    };
-                }, { observeOffer : (offer) => {
-                    offer.sdp = setCodec(offer.sdp, "VP9");
-                    return offer;
-                }
-                });
-                setTimeout(() => reject("Test timed out"), 5000);
-            });
-        }).then(async (remoteStream) => {
-            video.srcObject = remoteStream;
-            await video.play();
-
-            const frame = new VideoFrame(video);
-            test.add_cleanup(() => frame.close());
-            assert_equals(frame.colorSpace.primaries, "bt709", "primaries");
-            assert_equals(frame.colorSpace.transfer, "bt709", "transfer");
-            assert_equals(frame.colorSpace.matrix, "bt709", "matrix");
-        });
-    }, "Setting video exchange");
-
-    promise_test(() => {
-        if (receivingConnection.connectionState === "connected")
-            return Promise.resolve();
+var track;
+var remoteTrack;
+var receivingConnection;
+promise_test((test) => {
+    return navigator.mediaDevices.getUserMedia({video: {width: 320, height: 240, facingMode: "environment"}}).then((localStream) => {
         return new Promise((resolve, reject) => {
-            receivingConnection.onconnectionstatechange = () => {
-                if (receivingConnection.connectionState === "connected")
-                    resolve();
-            };
+            track = localStream.getVideoTracks()[0];
+
+            createConnections((firstConnection) => {
+                firstConnection.addTrack(track, localStream);
+            }, (secondConnection) => {
+                receivingConnection = secondConnection;
+                secondConnection.ontrack = (trackEvent) => {
+                    remoteTrack = trackEvent.track;
+                    resolve(trackEvent.streams[0]);
+                };
+            }, { observeOffer : (offer) => {
+                offer.sdp = setCodec(offer.sdp, "VP9");
+                return offer;
+            }
+            });
             setTimeout(() => reject("Test timed out"), 5000);
         });
-    }, "Ensuring connection state is connected");
+    }).then(async (remoteStream) => {
+        video.srcObject = remoteStream;
+        await video.play();
 
-    promise_test((test) => {
-        return checkVideoBlack(false, canvas1, video);
-    }, "Track is enabled, video should not be black");
+        const frame = new VideoFrame(video);
+        test.add_cleanup(() => frame.close());
+        assert_equals(frame.colorSpace.primaries, "bt709", "primaries");
+        assert_equals(frame.colorSpace.transfer, "bt709", "transfer");
+        assert_equals(frame.colorSpace.matrix, "bt709", "matrix");
+    });
+}, "Setting video exchange");
 
-    promise_test((test) => {
-        track.enabled = false;
-        return checkVideoBlack(true, canvas2, video);
-    }, "Track is disabled, video should be black");
+promise_test(() => {
+    if (receivingConnection.connectionState === "connected")
+        return Promise.resolve();
+    return new Promise((resolve, reject) => {
+        receivingConnection.onconnectionstatechange = () => {
+            if (receivingConnection.connectionState === "connected")
+                resolve();
+        };
+        setTimeout(() => reject("Test timed out"), 5000);
+    });
+}, "Ensuring connection state is connected");
 
-    promise_test((test) => {
-        track.enabled = true;
-        return checkVideoBlack(false, canvas2, video);
-    }, "Track is enabled, video should not be black 2");
-}
+promise_test((test) => {
+    return checkVideoBlack(false, canvas1, video);
+}, "Track is enabled, video should not be black");
+
+promise_test((test) => {
+    track.enabled = false;
+    return checkVideoBlack(true, canvas2, video);
+}, "Track is disabled, video should be black");
+
+promise_test((test) => {
+    track.enabled = true;
+    return checkVideoBlack(false, canvas2, video);
+}, "Track is enabled, video should not be black 2");

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesDecodingInfo.idl
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesDecodingInfo.idl
@@ -27,5 +27,5 @@
     EnabledBySetting=MediaCapabilitiesEnabled,
     JSGenerateToJSObject,
 ] dictionary MediaCapabilitiesDecodingInfo : MediaCapabilitiesInfo {
-    [EnabledBySetting=MediaCapabilitiesExtensionsEnabled] MediaDecodingConfiguration configuration;
+    [EnabledBySetting=MediaCapabilitiesExtensionsEnabled] required MediaDecodingConfiguration configuration;
 };

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesEncodingInfo.idl
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesEncodingInfo.idl
@@ -27,5 +27,5 @@
     EnabledBySetting=MediaCapabilitiesEnabled,
     JSGenerateToJSObject,
 ] dictionary MediaCapabilitiesEncodingInfo : MediaCapabilitiesInfo {
-    [EnabledBySetting=MediaCapabilitiesExtensionsEnabled] MediaEncodingConfiguration configuration;
+    [EnabledBySetting=MediaCapabilitiesExtensionsEnabled] required MediaEncodingConfiguration configuration;
 };

--- a/Source/WebCore/platform/mediastream/WebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/WebRTCProvider.cpp
@@ -210,12 +210,12 @@ void WebRTCProvider::createDecodingConfiguration(MediaDecodingConfiguration&& co
         ContentType contentType { info.configuration.video->contentType };
         auto codec = codecCapability(contentType, videoDecodingCapabilities());
         if (!codec) {
-            callback({ });
+            callback({ { }, WTFMove(info.configuration) });
             return;
         }
         if (auto infoOverride = videoDecodingCapabilitiesOverride(*info.configuration.video)) {
             if (!infoOverride->supported) {
-                callback({ });
+                callback({ { }, WTFMove(info.configuration) });
                 return;
             }
             info.smooth = infoOverride->smooth;
@@ -226,7 +226,7 @@ void WebRTCProvider::createDecodingConfiguration(MediaDecodingConfiguration&& co
         ContentType contentType { info.configuration.audio->contentType };
         auto codec = codecCapability(contentType, audioDecodingCapabilities());
         if (!codec) {
-            callback({ });
+            callback({ { }, WTFMove(info.configuration) });
             return;
         }
     }
@@ -247,12 +247,12 @@ void WebRTCProvider::createEncodingConfiguration(MediaEncodingConfiguration&& co
         ContentType contentType { info.configuration.video->contentType };
         auto codec = codecCapability(contentType, videoEncodingCapabilities());
         if (!codec) {
-            callback({ });
+            callback({ { }, WTFMove(info.configuration) });
             return;
         }
         if (auto infoOverride = videoEncodingCapabilitiesOverride(*info.configuration.video)) {
             if (!infoOverride->supported) {
-                callback({ });
+                callback({ { }, WTFMove(info.configuration) });
                 return;
             }
             info.smooth = infoOverride->smooth;
@@ -263,7 +263,7 @@ void WebRTCProvider::createEncodingConfiguration(MediaEncodingConfiguration&& co
         ContentType contentType { info.configuration.audio->contentType };
         auto codec = codecCapability(contentType, audioEncodingCapabilities());
         if (!codec) {
-            callback({ });
+            callback({ { }, WTFMove(info.configuration) });
             return;
         }
     }


### PR DESCRIPTION
#### 2f4c13b7dde46e6dd0df0a6e147e6147eed6768e
<pre>
WebRTC MediaCapabilitiesDecodingInfo.configuration should not be undefined if supported is false
<a href="https://rdar.apple.com/150680756">rdar://150680756</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292541">https://bugs.webkit.org/show_bug.cgi?id=292541</a>

Reviewed by Jean-Yves Avenard.

Make sure to return a non default configuration in the non supported WebRTC code path, as per specification.
We also update the dictionaries web idl to mark configuration as required to make it clear it should not be optional.

Covered by updated test.

* LayoutTests/webrtc/vp9-tests.js:
(promise_test.async if):
(promise_test):
(promise_test.async let):
(promise_test.async test):
(promise_test.then.async video):
(test): Deleted.
(hasVP9.promise_test.async let): Deleted.
(hasVP9.promise_test): Deleted.
(hasVP9.promise_test.async test): Deleted.
(hasVP9.promise_test.then.async video): Deleted.
* Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesDecodingInfo.idl:
* Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesEncodingInfo.idl:
* Source/WebCore/platform/mediastream/WebRTCProvider.cpp:
(WebCore::WebRTCProvider::createDecodingConfiguration):
(WebCore::WebRTCProvider::createEncodingConfiguration):

Canonical link: <a href="https://commits.webkit.org/294957@main">https://commits.webkit.org/294957@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92d7a2da052ba37566c42308471f50b52c31d8f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23299 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108792 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54263 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105656 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31849 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78736 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106622 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18350 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93472 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59071 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11519 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53617 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/87944 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11578 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111170 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30763 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22686 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87729 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89672 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87376 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22243 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32255 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9976 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25117 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30691 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/36003 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30491 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33822 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32052 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->