### PR TITLE
Drop remaining use of LIKELY() / UNLIKELY() in WebCore/

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -2524,7 +2524,7 @@ GUniquePtr<GstSDPMessage> GStreamerMediaEndpoint::completeSDPAnswer(const String
 
             auto value = StringView::fromLatin1(attribute->value);
             Vector<String> tokens = value.toStringWithoutCopying().split(' ');
-            if (UNLIKELY(tokens.size() < 2))
+            if (tokens.size() < 2) [[unlikely]]
                 continue;
 
             if (!sdpMediaHasRTPHeaderExtension(media, tokens[1]))

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -815,7 +815,7 @@ void SDPStringBuilder::appendAttribute(const GstSDPAttribute* attribute)
     auto value = String::fromUTF8(attribute->value);
     if (key == "extmap"_s) {
         auto tokens = value.split(' ');
-        if (UNLIKELY(tokens.size() < 2))
+        if (tokens.size() < 2) [[unlikely]]
             return;
         if (!GStreamerRegistryScanner::singleton().isRtpHeaderExtensionSupported(tokens[1]))
             return;
@@ -982,7 +982,7 @@ bool sdpMediaHasRTPHeaderExtension(const GstSDPMedia* media, const String& uri)
 
         auto value = String::fromUTF8(attribute->value);
         Vector<String> tokens = value.split(' ');
-        if (UNLIKELY(tokens.size() < 2))
+        if (tokens.size() < 2) [[unlikely]]
             continue;
 
         if (tokens[1] == uri)

--- a/Source/WebCore/Scripts/SettingsTemplates/Settings.cpp.erb
+++ b/Source/WebCore/Scripts/SettingsTemplates/Settings.cpp.erb
@@ -197,7 +197,7 @@ void Settings::disableFeaturesForLockdownMode()
 <%= @setting.parameterType %> Settings::<%= @setting.getterFunctionName %>() const
 {
 <%- if @setting.hasInspectorOverride? -%>
-    if (UNLIKELY(m_values.<%= @setting.name %>InspectorOverride)) {
+    if (m_values.<%= @setting.name %>InspectorOverride) [[unlikely]] {
         ASSERT(InspectorInstrumentation::hasFrontends());
         return m_values.<%= @setting.name %>InspectorOverride.value();
     }

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -136,8 +136,15 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
+static Node* nodeForRenderer(RenderObject& renderer)
+{
+    if (!renderer.isRenderView()) [[likely]]
+        return renderer.node();
+    return &renderer.document();
+}
+
 AccessibilityRenderObject::AccessibilityRenderObject(AXID axID, RenderObject& renderer)
-    : AccessibilityNodeObject(axID, LIKELY(!renderer.isRenderView()) ? renderer.node() : &renderer.document())
+    : AccessibilityNodeObject(axID, nodeForRenderer(renderer))
     , m_renderer(renderer)
 {
 #if ASSERT_ENABLED

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringContext.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringContext.cpp
@@ -236,7 +236,7 @@ static inline bool setJSTestStringContext_attributeWithStringContextTrustedHTMLS
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
     auto nativeValueConversionResult = convert<IDLStringContextTrustedHTMLAdaptor<IDLDOMString>>(lexicalGlobalObject, value, "TestStringContext attributeWithStringContextTrustedHTML"_s);
-    if (UNLIKELY(nativeValueConversionResult.hasException(throwScope)))
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
         return false;
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
         return impl.setAttributeWithStringContextTrustedHTML(nativeValueConversionResult.releaseReturnValue());
@@ -269,7 +269,7 @@ static inline bool setJSTestStringContext_attributeWithStringContextTrustedScrip
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
     auto nativeValueConversionResult = convert<IDLStringContextTrustedScriptAdaptor<IDLDOMString>>(lexicalGlobalObject, value, "TestStringContext attributeWithStringContextTrustedScript"_s);
-    if (UNLIKELY(nativeValueConversionResult.hasException(throwScope)))
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
         return false;
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
         return impl.setAttributeWithStringContextTrustedScript(nativeValueConversionResult.releaseReturnValue());
@@ -302,7 +302,7 @@ static inline bool setJSTestStringContext_attributeWithStringContextTrustedScrip
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
     auto nativeValueConversionResult = convert<IDLStringContextTrustedScriptURLAdaptor<IDLUSVString>>(lexicalGlobalObject, value, "TestStringContext attributeWithStringContextTrustedScriptURL"_s);
-    if (UNLIKELY(nativeValueConversionResult.hasException(throwScope)))
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
         return false;
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
         return impl.setAttributeWithStringContextTrustedScriptURL(nativeValueConversionResult.releaseReturnValue());
@@ -335,7 +335,7 @@ static inline bool setJSTestStringContext_attributeWithStringContextTrustedHTMLA
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
     auto nativeValueConversionResult = convert<IDLLegacyNullToEmptyStringStringContextTrustedHTMLAdaptor<IDLDOMString>>(lexicalGlobalObject, value, "TestStringContext attributeWithStringContextTrustedHTMLAndLegacyNullToEmptyString"_s);
-    if (UNLIKELY(nativeValueConversionResult.hasException(throwScope)))
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
         return false;
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
         return impl.setAttributeWithStringContextTrustedHTMLAndLegacyNullToEmptyString(nativeValueConversionResult.releaseReturnValue());
@@ -368,7 +368,7 @@ static inline bool setJSTestStringContext_attributeWithStringContextTrustedScrip
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
     auto nativeValueConversionResult = convert<IDLLegacyNullToEmptyStringStringContextTrustedScriptAdaptor<IDLDOMString>>(lexicalGlobalObject, value, "TestStringContext attributeWithStringContextTrustedScriptAndLegacyNullToEmptyString"_s);
-    if (UNLIKELY(nativeValueConversionResult.hasException(throwScope)))
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
         return false;
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
         return impl.setAttributeWithStringContextTrustedScriptAndLegacyNullToEmptyString(nativeValueConversionResult.releaseReturnValue());
@@ -401,7 +401,7 @@ static inline bool setJSTestStringContext_attributeWithStringContextTrustedScrip
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
     auto nativeValueConversionResult = convert<IDLLegacyNullToEmptyStringStringContextTrustedScriptURLAdaptor<IDLUSVString>>(lexicalGlobalObject, value, "TestStringContext attributeWithStringContextTrustedScriptURLAndLegacyNullToEmptyString"_s);
-    if (UNLIKELY(nativeValueConversionResult.hasException(throwScope)))
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
         return false;
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
         return impl.setAttributeWithStringContextTrustedScriptURLAndLegacyNullToEmptyString(nativeValueConversionResult.releaseReturnValue());
@@ -434,7 +434,7 @@ static inline bool setJSTestStringContext_reflectedAttributeWithStringContextTru
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
     auto nativeValueConversionResult = convert<IDLAtomStringStringContextTrustedHTMLAdaptor<IDLDOMString>>(lexicalGlobalObject, value, "TestStringContext reflectedAttributeWithStringContextTrustedHTML"_s);
-    if (UNLIKELY(nativeValueConversionResult.hasException(throwScope)))
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
         return false;
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
         return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedattributewithstringcontexttrustedhtmlAttr, nativeValueConversionResult.releaseReturnValue());
@@ -467,7 +467,7 @@ static inline bool setJSTestStringContext_reflectedAttributeWithStringContextTru
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
     auto nativeValueConversionResult = convert<IDLAtomStringStringContextTrustedScriptAdaptor<IDLDOMString>>(lexicalGlobalObject, value, "TestStringContext reflectedAttributeWithStringContextTrustedScript"_s);
-    if (UNLIKELY(nativeValueConversionResult.hasException(throwScope)))
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
         return false;
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
         return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedattributewithstringcontexttrustedscriptAttr, nativeValueConversionResult.releaseReturnValue());
@@ -500,7 +500,7 @@ static inline bool setJSTestStringContext_reflectedAttributeWithStringContextTru
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
     auto nativeValueConversionResult = convert<IDLAtomStringStringContextTrustedScriptURLAdaptor<IDLUSVString>>(lexicalGlobalObject, value, "TestStringContext reflectedAttributeWithStringContextTrustedScriptURL"_s);
-    if (UNLIKELY(nativeValueConversionResult.hasException(throwScope)))
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
         return false;
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
         return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedattributewithstringcontexttrustedscripturlAttr, nativeValueConversionResult.releaseReturnValue());
@@ -533,7 +533,7 @@ static inline bool setJSTestStringContext_reflectedUrlAttributeWithStringContext
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
     auto nativeValueConversionResult = convert<IDLAtomStringStringContextTrustedHTMLAdaptor<IDLDOMString>>(lexicalGlobalObject, value, "TestStringContext reflectedUrlAttributeWithStringContextTrustedHTML"_s);
-    if (UNLIKELY(nativeValueConversionResult.hasException(throwScope)))
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
         return false;
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
         return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedurlattributewithstringcontexttrustedhtmlAttr, nativeValueConversionResult.releaseReturnValue());
@@ -566,7 +566,7 @@ static inline bool setJSTestStringContext_reflectedUrlAttributeWithStringContext
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
     auto nativeValueConversionResult = convert<IDLAtomStringStringContextTrustedScriptAdaptor<IDLDOMString>>(lexicalGlobalObject, value, "TestStringContext reflectedUrlAttributeWithStringContextTrustedScript"_s);
-    if (UNLIKELY(nativeValueConversionResult.hasException(throwScope)))
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
         return false;
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
         return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedurlattributewithstringcontexttrustedscriptAttr, nativeValueConversionResult.releaseReturnValue());
@@ -599,7 +599,7 @@ static inline bool setJSTestStringContext_reflectedUrlAttributeWithStringContext
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
     auto nativeValueConversionResult = convert<IDLAtomStringStringContextTrustedScriptURLAdaptor<IDLUSVString>>(lexicalGlobalObject, value, "TestStringContext reflectedUrlAttributeWithStringContextTrustedScriptURL"_s);
-    if (UNLIKELY(nativeValueConversionResult.hasException(throwScope)))
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
         return false;
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
         return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedurlattributewithstringcontexttrustedscripturlAttr, nativeValueConversionResult.releaseReturnValue());
@@ -619,11 +619,11 @@ static inline JSC::EncodedJSValue jsTestStringContextPrototypeFunction_methodWit
     UNUSED_PARAM(throwScope);
     UNUSED_PARAM(callFrame);
     auto& impl = castedThis->wrapped();
-    if (UNLIKELY(callFrame->argumentCount() < 1))
+    if (callFrame->argumentCount() < 1) [[unlikely]]
         return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
     EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
     auto strConversionResult = convert<IDLStringContextTrustedHTMLAdaptor<IDLDOMString>>(*lexicalGlobalObject, argument0.value(), "TestStringContext methodWithStringContextTrustedHTML"_s);
-    if (UNLIKELY(strConversionResult.hasException(throwScope)))
+    if (strConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.methodWithStringContextTrustedHTML(strConversionResult.releaseReturnValue()); })));
 }
@@ -640,11 +640,11 @@ static inline JSC::EncodedJSValue jsTestStringContextPrototypeFunction_methodWit
     UNUSED_PARAM(throwScope);
     UNUSED_PARAM(callFrame);
     auto& impl = castedThis->wrapped();
-    if (UNLIKELY(callFrame->argumentCount() < 1))
+    if (callFrame->argumentCount() < 1) [[unlikely]]
         return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
     EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
     auto strConversionResult = convert<IDLStringContextTrustedScriptAdaptor<IDLDOMString>>(*lexicalGlobalObject, argument0.value(), "TestStringContext methodWithStringContextTrustedScript"_s);
-    if (UNLIKELY(strConversionResult.hasException(throwScope)))
+    if (strConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.methodWithStringContextTrustedScript(strConversionResult.releaseReturnValue()); })));
 }
@@ -661,11 +661,11 @@ static inline JSC::EncodedJSValue jsTestStringContextPrototypeFunction_methodWit
     UNUSED_PARAM(throwScope);
     UNUSED_PARAM(callFrame);
     auto& impl = castedThis->wrapped();
-    if (UNLIKELY(callFrame->argumentCount() < 1))
+    if (callFrame->argumentCount() < 1) [[unlikely]]
         return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
     EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
     auto strConversionResult = convert<IDLStringContextTrustedScriptURLAdaptor<IDLUSVString>>(*lexicalGlobalObject, argument0.value(), "TestStringContext methodWithStringContextTrustedScriptURL"_s);
-    if (UNLIKELY(strConversionResult.hasException(throwScope)))
+    if (strConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.methodWithStringContextTrustedScriptURL(strConversionResult.releaseReturnValue()); })));
 }
@@ -682,11 +682,11 @@ static inline JSC::EncodedJSValue jsTestStringContextPrototypeFunction_methodWit
     UNUSED_PARAM(throwScope);
     UNUSED_PARAM(callFrame);
     auto& impl = castedThis->wrapped();
-    if (UNLIKELY(callFrame->argumentCount() < 1))
+    if (callFrame->argumentCount() < 1) [[unlikely]]
         return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
     EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
     auto strConversionResult = convert<IDLLegacyNullToEmptyStringStringContextTrustedHTMLAdaptor<IDLDOMString>>(*lexicalGlobalObject, argument0.value(), "TestStringContext methodWithStringContextTrustedHTMLAndLegacyNullToEmptyString"_s);
-    if (UNLIKELY(strConversionResult.hasException(throwScope)))
+    if (strConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.methodWithStringContextTrustedHTMLAndLegacyNullToEmptyString(strConversionResult.releaseReturnValue()); })));
 }
@@ -703,11 +703,11 @@ static inline JSC::EncodedJSValue jsTestStringContextPrototypeFunction_methodWit
     UNUSED_PARAM(throwScope);
     UNUSED_PARAM(callFrame);
     auto& impl = castedThis->wrapped();
-    if (UNLIKELY(callFrame->argumentCount() < 1))
+    if (callFrame->argumentCount() < 1) [[unlikely]]
         return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
     EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
     auto strConversionResult = convert<IDLLegacyNullToEmptyStringStringContextTrustedScriptAdaptor<IDLDOMString>>(*lexicalGlobalObject, argument0.value(), "TestStringContext methodWithStringContextTrustedScriptAndLegacyNullToEmptyString"_s);
-    if (UNLIKELY(strConversionResult.hasException(throwScope)))
+    if (strConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.methodWithStringContextTrustedScriptAndLegacyNullToEmptyString(strConversionResult.releaseReturnValue()); })));
 }
@@ -724,11 +724,11 @@ static inline JSC::EncodedJSValue jsTestStringContextPrototypeFunction_methodWit
     UNUSED_PARAM(throwScope);
     UNUSED_PARAM(callFrame);
     auto& impl = castedThis->wrapped();
-    if (UNLIKELY(callFrame->argumentCount() < 1))
+    if (callFrame->argumentCount() < 1) [[unlikely]]
         return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
     EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
     auto strConversionResult = convert<IDLLegacyNullToEmptyStringStringContextTrustedScriptURLAdaptor<IDLUSVString>>(*lexicalGlobalObject, argument0.value(), "TestStringContext methodWithStringContextTrustedScriptURLAndLegacyNullToEmptyString"_s);
-    if (UNLIKELY(strConversionResult.hasException(throwScope)))
+    if (strConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.methodWithStringContextTrustedScriptURLAndLegacyNullToEmptyString(strConversionResult.releaseReturnValue()); })));
 }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2906,9 +2906,13 @@ void Element::updateEffectiveLangStateFromParent()
     }
 
     setEffectiveLangKnownToMatchDocumentElement(parent->effectiveLangKnownToMatchDocumentElement());
-    if (UNLIKELY(parent->hasRareData()) && !parent->elementRareData()->effectiveLang().isNull())
-        ensureElementRareData().setEffectiveLang(parent->elementRareData()->effectiveLang());
-    else if (hasRareData())
+    if (parent->hasRareData()) [[unlikely]] {
+        if (!parent->elementRareData()->effectiveLang().isNull()) {
+            ensureElementRareData().setEffectiveLang(parent->elementRareData()->effectiveLang());
+            return;
+        }
+    }
+    if (hasRareData())
         elementRareData()->setEffectiveLang(nullAtom());
 }
 
@@ -3075,7 +3079,13 @@ void Element::setEffectiveLangStateOnOldDocumentElement()
 
 bool Element::hasEffectiveLangState() const
 {
-    return effectiveLangKnownToMatchDocumentElement() || (UNLIKELY(hasRareData()) && !elementRareData()->effectiveLang().isNull());
+    if (effectiveLangKnownToMatchDocumentElement())
+        return true;
+
+    if (hasRareData()) [[unlikely]]
+        return !elementRareData()->effectiveLang().isNull();
+
+    return false;
 }
 
 void Element::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)

--- a/Source/WebCore/dom/EventContext.cpp
+++ b/Source/WebCore/dom/EventContext.cpp
@@ -74,7 +74,12 @@ void EventContext::handleLocalEvents(Event& event, EventInvokePhase phase) const
     }
 #endif
 
-    if (!m_node || UNLIKELY(m_type == Type::Window)) {
+    if (!m_node) {
+        protectedCurrentTarget()->fireEventListeners(event, phase);
+        return;
+    }
+
+    if (m_type == Type::Window) [[unlikely]] {
         protectedCurrentTarget()->fireEventListeners(event, phase);
         return;
     }

--- a/Source/WebCore/dom/make_names.pl
+++ b/Source/WebCore/dom/make_names.pl
@@ -1150,7 +1150,7 @@ sub printNodeNameHeaderFile
     print F "{\n";
     print F "    constexpr auto s_lastUniqueTagName = TagName::$lastUniqueTagEnumValue;\n";
     print F"\n";
-    print F "    if (LIKELY(enumToUnderlyingType(elementName) <= enumToUnderlyingType(s_lastUniqueTagName)))\n";
+    print F "    if (enumToUnderlyingType(elementName) <= enumToUnderlyingType(s_lastUniqueTagName)) [[likely]]\n";
     print F "        return static_cast<TagName>(elementName);\n";
     print F "\n";
     print F "    switch (elementName) {\n";
@@ -1175,10 +1175,10 @@ sub printNodeNameHeaderFile
         print F "        constexpr auto s_firstUnique${namespace}TagName = TagName::$firstUniqueTagEnumValueByNamespace{$namespace};\n";
         print F "        constexpr auto s_lastUnique${namespace}TagName = TagName::$lastUniqueTagEnumValueByNamespace{$namespace};\n";
         print F "\n";
-        print F "        if (UNLIKELY(tagName < s_firstUnique${namespace}TagName))\n";
+        print F "        if (tagName < s_firstUnique${namespace}TagName) [[unlikely]]\n";
         print F "            return ElementName::Unknown;\n";
         print F "\n";
-        print F "        if (LIKELY(tagName <= s_lastUnique${namespace}TagName))\n";
+        print F "        if (tagName <= s_lastUnique${namespace}TagName) [[likely]]\n";
         print F "            return static_cast<ElementName>(tagName);\n";
         print F "\n";
         my @tagKeysForNonUniqueTags = grep { elementCount($allElements{$_}{localName}) > 1 && $allElements{$_}{namespace} eq $namespace } sort byElementNameOrder keys %allElements;

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
@@ -380,7 +380,7 @@ static gboolean wpeViewWaylandRenderBuffer(WPEView* view, WPEBuffer* buffer, con
 
     auto* display = WPE_DISPLAY_WAYLAND(wpe_view_get_display(view));
     auto* wlCompositor = wpe_display_wayland_get_wl_compositor(display);
-    if (nDamageRects && LIKELY(wl_compositor_get_version(wlCompositor) >= 4)) {
+    if (nDamageRects && wl_compositor_get_version(wlCompositor) >= 4) [[likely]] {
         ASSERT(damageRects);
         for (unsigned i = 0; i < nDamageRects; ++i)
             wl_surface_damage_buffer(wlSurface, damageRects[i].x, damageRects[i].y, damageRects[i].width, damageRects[i].height);

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
@@ -415,7 +415,7 @@ EOF
 void ${className}::getPropertyNames(JSContextRef context, JSObjectRef thisObject, JSPropertyNameAccumulatorRef propertyNames)
 {
     RefPtr impl = to${implementationClassName}(context, thisObject);
-    if (UNLIKELY(!impl))
+    if (!impl) [[unlikely]]
         return;
 
     NSArray *propertyNameStrings = impl->${customGetPropertyNamesFunction}();
@@ -432,7 +432,7 @@ EOF
 bool ${className}::hasProperty(JSContextRef context, JSObjectRef thisObject, JSStringRef propertyName)
 {
     RefPtr impl = to${implementationClassName}(context, thisObject);
-    if (UNLIKELY(!impl))
+    if (!impl) [[unlikely]]
         return false;
 
     return impl->${customHasPropertyFunction}(toNSString(propertyName));
@@ -481,7 +481,7 @@ EOF
 
 {
     RefPtr impl = to${implementationClassName}(context, thisObject);
-    if (UNLIKELY(${functionEarlyReturnCondition}))
+    if (${functionEarlyReturnCondition}) [[unlikely]]
         return ${defaultEarlyReturnValue};
 
     RELEASE_LOG_DEBUG(Extensions, "Called function ${call} (%{public}lu %{public}s) in %{public}s world", argumentCount, argumentCount == 1 ? "argument" : "arguments", toDebugString(impl->contentWorldType()).utf8().data());
@@ -532,7 +532,7 @@ EOF
             if ($requiredArgumentCount) {
                 push(@contents, <<EOF);
     constexpr size_t requiredArgumentCount = ${requiredArgumentCount};
-    if (UNLIKELY(argumentCount < requiredArgumentCount)) {
+    if (argumentCount < requiredArgumentCount) [[unlikely]] {
         *exception = toJSError(context, @"${call}", nil, @"a required argument is missing");
         return ${defaultEarlyReturnValue};
     }
@@ -674,7 +674,7 @@ EOF
 
             if (!$hasSimpleOptionalArgumentHandling) {
                 push(@contents, "\n");
-                push(@contents, "    if (UNLIKELY($argumentIndexConditon)) {\n");
+                push(@contents, "    if ($argumentIndexConditon) [[unlikely]] {\n");
                 push(@contents, "        *exception = toJSError(context, @\"${call}\", nil, @\"an unknown argument was provided\");\n");
                 push(@contents, "        return ${defaultEarlyReturnValue};\n");
                 push(@contents, "    }\n");
@@ -731,7 +731,7 @@ EOF
 
             if ($needsPage || $needsPageIdentifier) {
                 push(@contents, "    RefPtr page = toWebPage(context);\n");
-                push(@contents, "    if (UNLIKELY(!page)) {\n");
+                push(@contents, "    if (!page) [[unlikely]] {\n");
                 push(@contents, "        RELEASE_LOG_ERROR(Extensions, \"Page could not be found for JSContextRef\");\n");
                 push(@contents, "        if (promiseResult)\n") if $returnsPromise;
                 push(@contents, "            promiseResult = toJSRejectedPromise(context, @\"${call}\", nil, @\"an unknown error occurred\");\n") if $returnsPromise;
@@ -741,7 +741,7 @@ EOF
 
             if ($needsFrame || $needsFrameIdentifier) {
                 push(@contents, "    RefPtr frame = toWebFrame(context);\n");
-                push(@contents, "    if (UNLIKELY(!frame)) {\n");
+                push(@contents, "    if (!frame) [[unlikely]] {\n");
                 push(@contents, "        RELEASE_LOG_ERROR(Extensions, \"Frame could not be found for JSContextRef\");\n");
                 push(@contents, "        if (promiseResult)\n") if $returnsPromise;
                 push(@contents, "            promiseResult = toJSRejectedPromise(context, @\"${call}\", nil, @\"an unknown error occurred\");\n") if $returnsPromise;
@@ -754,7 +754,7 @@ EOF
     NSString *exceptionString;
     JSValueRef result = ${returnExpression};
 
-    if (UNLIKELY(exceptionString)) {
+    if (exceptionString) [[unlikely]] {
         *exception = toJSError(context, @"${call}", nil, exceptionString);
         return ${defaultEarlyReturnValue};
     }
@@ -767,7 +767,7 @@ EOF
     NSString *exceptionString;
     ${functionCall};
 
-    if (UNLIKELY(exceptionString)) {
+    if (exceptionString) [[unlikely]] {
         *exception = toJSError(context, @"${call}", nil, exceptionString);
         return ${defaultEarlyReturnValue};
     }
@@ -788,7 +788,7 @@ EOF
 ${functionSignature}
 {
     RefPtr impl = to${implementationClassName}(context, thisObject);
-    if (UNLIKELY(${functionEarlyReturnCondition}))
+    if (${functionEarlyReturnCondition}) [[unlikely]]
         return JSValueMakeUndefined(context);
 
 EOF
@@ -891,7 +891,7 @@ EOF
 
             push(@contents, <<EOF);
     RefPtr impl = to${implementationClassName}(context, object);
-    if (UNLIKELY(${getterEarlyReturnCondition}))
+    if (${getterEarlyReturnCondition}) [[unlikely]]
         return JSValueMakeUndefined(context);
 
     RELEASE_LOG_DEBUG(Extensions, "Called getter ${call} in %{public}s world", toDebugString(impl->contentWorldType()).utf8().data());
@@ -900,7 +900,7 @@ EOF
             if ($needsPage || $needsPageIdentifier) {
                 push(@contents, "\n");
                 push(@contents, "    RefPtr page = toWebPage(context);\n");
-                push(@contents, "    if (UNLIKELY(!page)) {\n");
+                push(@contents, "    if (!page) [[unlikely]] {\n");
                 push(@contents, "        RELEASE_LOG_ERROR(Extensions, \"Page could not be found for JSContextRef\");\n");
                 push(@contents, "        return JSValueMakeUndefined(context);\n");
                 push(@contents, "    }\n");
@@ -909,7 +909,7 @@ EOF
             if ($needsFrame || $needsFrameIdentifier) {
                 push(@contents, "\n");
                 push(@contents, "    RefPtr frame = toWebFrame(context);\n");
-                push(@contents, "    if (UNLIKELY(!frame)) {\n");
+                push(@contents, "    if (!frame) [[unlikely]] {\n");
                 push(@contents, "        RELEASE_LOG_ERROR(Extensions, \"Frame could not be found for JSContextRef\");\n");
                 push(@contents, "        return JSValueMakeUndefined(context);\n");
                 push(@contents, "    }\n");
@@ -934,7 +934,7 @@ EOF
 
                 push(@contents, <<EOF);
     RefPtr impl = to${implementationClassName}(context, object);
-    if (UNLIKELY(${setterEarlyReturnCondition}))
+    if (${setterEarlyReturnCondition}) [[unlikely]]
         return false;
 
     RELEASE_LOG_DEBUG(Extensions, "Called setter ${call} in %{public}s world", toDebugString(impl->contentWorldType()).utf8().data());
@@ -952,7 +952,7 @@ EOF
                 if ($needsPage || $needsPageIdentifier) {
                     push(@contents, "\n");
                     push(@contents, "    RefPtr page = toWebPage(context);\n");
-                    push(@contents, "    if (UNLIKELY(!page)) {\n");
+                    push(@contents, "    if (!page) [[unlikely]] {\n");
                     push(@contents, "        RELEASE_LOG_ERROR(Extensions, \"Page could not be found for JSContextRef\");\n");
                     push(@contents, "        return false;\n");
                     push(@contents, "    }\n");
@@ -961,7 +961,7 @@ EOF
                 if ($needsFrame || $needsFrameIdentifier) {
                     push(@contents, "\n");
                     push(@contents, "    RefPtr frame = toWebFrame(context);\n");
-                    push(@contents, "    if (UNLIKELY(!frame)) {\n");
+                    push(@contents, "    if (!frame) [[unlikely]] {\n");
                     push(@contents, "        RELEASE_LOG_ERROR(Extensions, \"Frame could not be found for JSContextRef\");\n");
                     push(@contents, "        return false;\n");
                     push(@contents, "    }\n");
@@ -1101,7 +1101,7 @@ sub _installArgumentTypeExceptions
         $hasExceptions = 1;
 
         push(@$contents, <<EOF);
-${indentString}if (UNLIKELY(!($condition))) {
+${indentString}if (!($condition)) [[unlikely]] {
 ${indentString}    *exception = toJSError(context, @"${call}", @"${variableLabel}", @"a string is expected");
 ${indentString}    return ${result};
 ${indentString}}
@@ -1113,7 +1113,7 @@ EOF
         $hasExceptions = 1;
 
         push(@$contents, <<EOF);
-${indentString}if (UNLIKELY(!($condition))) {
+${indentString}if (!($condition)) [[unlikely]] {
 ${indentString}    *exception = toJSError(context, @"${call}", @"${variableLabel}", @"a number is expected");
 ${indentString}    return ${result};
 ${indentString}}
@@ -1125,7 +1125,7 @@ EOF
         $hasExceptions = 1;
 
         push(@$contents, <<EOF);
-${indentString}if (UNLIKELY(!($condition))) {
+${indentString}if (!($condition)) [[unlikely]] {
 ${indentString}    *exception = toJSError(context, @"${call}", @"${variableLabel}", @"a boolean is expected");
 ${indentString}    return ${result};
 ${indentString}}
@@ -1137,7 +1137,7 @@ EOF
         $hasExceptions = 1;
 
         push(@$contents, <<EOF);
-${indentString}if (UNLIKELY(!($condition))) {
+${indentString}if (!($condition)) [[unlikely]] {
 ${indentString}    *exception = toJSError(context, @"${call}", @"${variableLabel}", @"an object is expected");
 ${indentString}    return ${result};
 ${indentString}}
@@ -1149,7 +1149,7 @@ EOF
         $hasExceptions = 1;
 
         push(@$contents, <<EOF);
-${indentString}if (UNLIKELY(!($condition))) {
+${indentString}if (!($condition)) [[unlikely]] {
 ${indentString}    *exception = toJSError(context, @"${call}", @"${variableLabel}", @"an object is expected");
 ${indentString}    return ${result};
 ${indentString}}
@@ -1161,7 +1161,7 @@ EOF
         $hasExceptions = 1;
 
         push(@$contents, <<EOF);
-${indentString}if (UNLIKELY(!($condition))) {
+${indentString}if (!($condition)) [[unlikely]] {
 ${indentString}    *exception = toJSError(context, @"${call}", @"${variableLabel}", @"an array is expected");
 ${indentString}    return ${result};
 ${indentString}}
@@ -1173,7 +1173,7 @@ EOF
         $hasExceptions = 1;
 
         push(@$contents, <<EOF);
-${indentString}if (UNLIKELY(!($condition))) {
+${indentString}if (!($condition)) [[unlikely]] {
 ${indentString}    *exception = toJSError(context, @"${call}", @"${variableLabel}", @"a function is expected");
 ${indentString}    return ${result};
 ${indentString}}
@@ -1197,10 +1197,10 @@ sub _installAutomaticExceptions
 
         push(@$contents, <<EOF);
 
-    if (UNLIKELY(*exception))
+    if (*exception) [[unlikely]]
         return ${result};
 
-    if (UNLIKELY(!$variable)) {
+    if (!$variable) [[unlikely]] {
         *exception = toJSError(context, @"${call}", @"${variableLabel}", @"a JSON serializable value is expected");
         return ${result};
     }
@@ -1212,7 +1212,7 @@ EOF
 
         push(@$contents, <<EOF);
 
-    if (UNLIKELY(!$variable)) {
+    if (!$variable) [[unlikely]] {
         *exception = toJSError(context, @"${call}", @"${variableLabel}", @"a string is expected");
         return ${result};
     }
@@ -1224,7 +1224,7 @@ EOF
 
         push(@$contents, <<EOF);
 
-    if (UNLIKELY(!std::isfinite($variable))) {
+    if (!std::isfinite($variable)) [[unlikely]] {
         *exception = toJSError(context, @"${call}", @"${variableLabel}", @"a number is expected");
         return ${result};
     }
@@ -1236,7 +1236,7 @@ EOF
 
         push(@$contents, <<EOF);
 
-    if (UNLIKELY(!$variable)) {
+    if (!$variable) [[unlikely]] {
         *exception = toJSError(context, @"${call}", @"${variableLabel}", @"an object is expected");
         return ${result};
     }
@@ -1248,7 +1248,7 @@ EOF
 
         push(@$contents, <<EOF);
 
-    if (UNLIKELY($variable && !$variable.isObject)) {
+    if ($variable && !$variable.isObject) [[unlikely]] {
         *exception = toJSError(context, @"${call}", @"${variableLabel}", @"an object is expected");
         return ${result};
     }
@@ -1260,7 +1260,7 @@ EOF
 
         push(@$contents, <<EOF);
 
-    if (UNLIKELY(!$variable)) {
+    if (!$variable) [[unlikely]] {
         *exception = toJSError(context, @"${call}", @"${variableLabel}", @"an array is expected");
         return ${result};
     }
@@ -1279,7 +1279,7 @@ EOF
 
         push(@$contents, <<EOF);
 
-    if (UNLIKELY(${isEmptyCheck})) {
+    if (${isEmptyCheck}) [[unlikely]] {
         *exception = toJSError(context, @"${call}", @"${variableLabel}", @"it cannot be empty");
         return ${result};
     }
@@ -1294,7 +1294,7 @@ EOF
 
         push(@$contents, <<EOF);
 
-    if (UNLIKELY(${variable}.isFileURL)) {
+    if (${variable}.isFileURL) [[unlikely]] {
         *exception = toJSError(context, @"${call}", @"${variableLabel}", @"it cannot be a local file URL");
         return ${result};
     }
@@ -1306,7 +1306,7 @@ EOF
 
         push(@$contents, <<EOF);
 
-    if (UNLIKELY($variable && !JSObjectIsFunction(context, $variable))) {
+    if ($variable && !JSObjectIsFunction(context, $variable)) [[unlikely]] {
         *exception = toJSError(context, @"${call}", @"${variableLabel}", @"a function is expected");
         return ${result};
     }
@@ -1318,7 +1318,7 @@ EOF
 
         push(@$contents, <<EOF);
 
-    if (UNLIKELY(!$variable)) {
+    if (!$variable) [[unlikely]] {
         *exception = toJSError(context, @"${call}", @"${variableLabel}", @"a function is expected");
         return ${result};
     }
@@ -1682,7 +1682,7 @@ sub _dynamicAttributesImplementation
 void ${className}::getPropertyNames(JSContextRef context, JSObjectRef thisObject, JSPropertyNameAccumulatorRef propertyNames)
 {
     RefPtr impl = to${implementationClassName}(context, thisObject);
-    if (UNLIKELY(!impl))
+    if (!impl) [[unlikely]]
         return;
 
     RefPtr page = toWebPage(context);
@@ -1732,7 +1732,7 @@ EOF
 bool ${className}::hasProperty(JSContextRef context, JSObjectRef thisObject, JSStringRef propertyName)
 {
     RefPtr impl = to${implementationClassName}(context, thisObject);
-    if (UNLIKELY(!impl))
+    if (!impl) [[unlikely]]
         return false;
 
     RefPtr page = toWebPage(context);
@@ -1767,7 +1767,7 @@ EOF
 JSValueRef ${className}::getProperty(JSContextRef context, JSObjectRef thisObject, JSStringRef propertyName, JSValueRef* exception)
 {
     RefPtr impl = to${implementationClassName}(context, thisObject);
-    if (UNLIKELY(!impl))
+    if (!impl) [[unlikely]]
         return JSValueMakeUndefined(context);
 
     RefPtr page = toWebPage(context);

--- a/Source/bmalloc/bmalloc/BCompiler.h
+++ b/Source/bmalloc/bmalloc/BCompiler.h
@@ -75,26 +75,6 @@
 #endif
 #endif
 
-/* BLIKELY */
-
-#if !defined(BLIKELY) && BCOMPILER(GCC_COMPATIBLE)
-#define BLIKELY(x) __builtin_expect(!!(x), 1)
-#endif
-
-#if !defined(BLIKELY)
-#define BLIKELY(x) (x)
-#endif
-
-/* BUNLIKELY */
-
-#if !defined(BUNLIKELY) && BCOMPILER(GCC_COMPATIBLE)
-#define BUNLIKELY(x) __builtin_expect(!!(x), 0)
-#endif
-
-#if !defined(BUNLIKELY)
-#define BUNLIKELY(x) (x)
-#endif
-
 /* BUNUSED_TYPE_ALIAS */
 
 #if !defined(BUNUSED_TYPE_ALIAS) && BCOMPILER(GCC_COMPATIBLE)

--- a/Source/bmalloc/bmalloc/TZoneHeap.cpp
+++ b/Source/bmalloc/bmalloc/TZoneHeap.cpp
@@ -49,8 +49,8 @@ static_assert(sizeof(HeapRef) == sizeof(pas_heap_ref*));
 void* tzoneAllocateNonCompactSlow(size_t requestedSize, const TZoneSpecification& spec)
 {
     HeapRef heapRef = *spec.addressOfHeapRef;
-    if (BUNLIKELY(tzoneMallocFallback != TZoneMallocFallback::DoNotFallBack)) {
-        if (BUNLIKELY(tzoneMallocFallback == TZoneMallocFallback::Undecided)) {
+    if (tzoneMallocFallback != TZoneMallocFallback::DoNotFallBack) [[unlikely]] {
+        if (tzoneMallocFallback == TZoneMallocFallback::Undecided) [[unlikely]] {
             TZoneHeapManager::ensureSingleton();
             return tzoneAllocateNonCompactSlow(requestedSize, spec);
         }
@@ -60,7 +60,7 @@ void* tzoneAllocateNonCompactSlow(size_t requestedSize, const TZoneSpecification
     }
 
     // Handle TZoneMallocFallback::DoNotFallBack.
-    if (BUNLIKELY(requestedSize != spec.size))
+    if (requestedSize != spec.size) [[unlikely]]
         heapRef = tzoneHeapManager->heapRefForTZoneTypeDifferentSize(requestedSize, spec);
 
     if (!heapRef) {
@@ -73,8 +73,8 @@ void* tzoneAllocateNonCompactSlow(size_t requestedSize, const TZoneSpecification
 void* tzoneAllocateCompactSlow(size_t requestedSize, const TZoneSpecification& spec)
 {
     HeapRef heapRef = *spec.addressOfHeapRef;
-    if (BUNLIKELY(tzoneMallocFallback != TZoneMallocFallback::DoNotFallBack)) {
-        if (BUNLIKELY(tzoneMallocFallback == TZoneMallocFallback::Undecided)) {
+    if (tzoneMallocFallback != TZoneMallocFallback::DoNotFallBack) [[unlikely]] {
+        if (tzoneMallocFallback == TZoneMallocFallback::Undecided) [[unlikely]] {
             TZoneHeapManager::ensureSingleton();
             return tzoneAllocateCompactSlow(requestedSize, spec);
         }
@@ -84,7 +84,7 @@ void* tzoneAllocateCompactSlow(size_t requestedSize, const TZoneSpecification& s
     }
 
     // Handle TZoneMallocFallback::DoNotFallBack.
-    if (BUNLIKELY(requestedSize != spec.size))
+    if (requestedSize != spec.size) [[unlikely]]
         heapRef = tzoneHeapManager->heapRefForTZoneTypeDifferentSize(requestedSize, spec);
 
     if (!heapRef) {

--- a/Source/bmalloc/bmalloc/TZoneHeap.h
+++ b/Source/bmalloc/bmalloc/TZoneHeap.h
@@ -155,7 +155,7 @@ public: \
     \
     void* operator new(size_t size) \
     { \
-        if (BUNLIKELY(!s_heapRef || size != sizeof(_type))) \
+        if (!s_heapRef || size != sizeof(_type)) [[unlikely]] \
             BMUST_TAIL_CALL return operatorNewSlow(size); \
         BASSERT(::bmalloc::api::tzoneMallocFallback > TZoneMallocFallback::ForceDebugMalloc); \
         return ::bmalloc::api::tzoneAllocate ## _compactMode(s_heapRef); \

--- a/Source/bmalloc/bmalloc/TZoneHeapInlines.h
+++ b/Source/bmalloc/bmalloc/TZoneHeapInlines.h
@@ -56,7 +56,7 @@ public: \
         static HeapRef s_heapRef; \
         static const TZoneSpecification s_heapSpec = { &s_heapRef, sizeof(_type), SizeAndAlignment::encode<_type>() TZONE_SPEC_NAME_ARG(#_type) }; \
     \
-        if (BUNLIKELY(!s_heapRef || size != sizeof(_type))) \
+        if (!s_heapRef || size != sizeof(_type)) [[unlikely]] \
             return ::bmalloc::api::tzoneAllocate ## _compactMode ## Slow(size, s_heapSpec); \
         BASSERT(::bmalloc::api::tzoneMallocFallback > TZoneMallocFallback::ForceDebugMalloc); \
         return ::bmalloc::api::tzoneAllocate ## _compactMode(s_heapRef); \

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -915,20 +915,20 @@ class webkit_ipc_cpp_impl(object):
         self.in_exprs += [webkit_ipc_convert_expr(cpp_expr(webkit_ipc_types[a.type], a.name), a.type)]
         if a.type.type_name in named_object_types:
             if self.is_create:
-                self.pre_call_stmts += [f"if (UNLIKELY(!{a.name})) {{", f"    ASSERT_IS_TESTING_IPC();", f"    return;", f"}}"]
+                self.pre_call_stmts += [f"if (!{a.name}) [[unlikely]] {{", f"    ASSERT_IS_TESTING_IPC();", f"    return;", f"}}"]
             if self.is_delete:
                 self.pre_call_stmts += [
-                    f"if (UNLIKELY(!m_objectNames.isValidKey({a.name}))) {{",
+                    f"if (!m_objectNames.isValidKey({a.name})) [[unlikely]] {{",
                     f"    ASSERT_IS_TESTING_IPC();",
                     f"    return;",
                     f"}}",
-                    f"if (UNLIKELY(!{a.name}))",
+                    f"if (!{a.name}) [[unlikely]]",
                     f"    return;",
                     f"{a.name} = m_objectNames.take({a.name});"
                 ]
             else:
                 self.pre_call_stmts += [
-                    f"if (UNLIKELY(!m_objectNames.isValidKey({a.name}))) {{",
+                    f"if (!m_objectNames.isValidKey({a.name})) [[unlikely]] {{",
                     f"    ASSERT_IS_TESTING_IPC();",
                     f"    return;",
                     f"}}",
@@ -979,7 +979,7 @@ class webkit_ipc_cpp_impl(object):
             self.args.args += [cpp_arg(webkit_ipc_get_message_forwarder_type(ipc_return_type), "name")]
             return_value_expr = cpp_expr(return_type, f"auto result")
             self.return_value_expr = return_value_expr
-            self.pre_call_stmts += [f"if (UNLIKELY(!m_objectNames.isValidKey(name))) {{"]
+            self.pre_call_stmts += [f"if (!m_objectNames.isValidKey(name)) [[unlikely]] {{"]
             self.pre_call_stmts += [f"    ASSERT_IS_TESTING_IPC();"]
             self.pre_call_stmts += [f"    return;"]
             self.pre_call_stmts += [f"}}"]

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -5895,11 +5895,13 @@ class WebKitStyleTest(CppStyleTestBase):
             'if (othertrue == fontType)',
             '')
         self.assert_lint(
-            'if (LIKELY(foo == 0))',
-            '')
+            'if (foo == 0) [[likely]]',
+            'Tests for true/false, null/non-null, and zero/non-zero should all be done without equality comparisons.'
+            '  [readability/comparison_to_zero] [5]')
         self.assert_lint(
-            'if (UNLIKELY(foo == 0))',
-            '')
+            'if (foo == 0) [[unlikely]]',
+            'Tests for true/false, null/non-null, and zero/non-zero should all be done without equality comparisons.'
+            '  [readability/comparison_to_zero] [5]')
         self.assert_lint(
             'if ((a - b) == 0.5)',
             '')
@@ -5907,11 +5909,13 @@ class WebKitStyleTest(CppStyleTestBase):
             'if (0.5 == (a - b))',
             '')
         self.assert_lint(
-            'if (LIKELY(foo == NULL))',
-            'Use nullptr instead of NULL.  [readability/null] [5]')
+            'if (foo == NULL) [[likely]]',
+            ['Tests for true/false, null/non-null, and zero/non-zero should all be done without equality comparisons.  [readability/comparison_to_zero] [5]',
+                'Use nullptr instead of NULL.  [readability/null] [5]'])
         self.assert_lint(
-            'if (UNLIKELY(foo == NULL))',
-            'Use nullptr instead of NULL.  [readability/null] [5]')
+            'if (foo == NULL) [[unlikely]]',
+            ['Tests for true/false, null/non-null, and zero/non-zero should all be done without equality comparisons.  [readability/comparison_to_zero] [5]',
+                'Use nullptr instead of NULL.  [readability/null] [5]'])
 
     def test_directive_indentation(self):
         self.assert_lint(


### PR DESCRIPTION
#### 32027dd313a96fbe8f38c63fafcc63a71ca2c4e8
<pre>
Drop remaining use of LIKELY() / UNLIKELY() in WebCore/
<a href="https://bugs.webkit.org/show_bug.cgi?id=292545">https://bugs.webkit.org/show_bug.cgi?id=292545</a>

Reviewed by Per Arne Vollan.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::completeSDPAnswer):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::SDPStringBuilder::appendAttribute):
(WebCore::sdpMediaHasRTPHeaderExtension):
* Source/WebCore/Scripts/SettingsTemplates/Settings.cpp.erb:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::nodeForRenderer):
(WebCore::AccessibilityRenderObject::AccessibilityRenderObject):
* Source/WebCore/bindings/scripts/test/JS/JSTestStringContext.cpp:
(WebCore::setJSTestStringContext_attributeWithStringContextTrustedHTMLSetter):
(WebCore::setJSTestStringContext_attributeWithStringContextTrustedScriptSetter):
(WebCore::setJSTestStringContext_attributeWithStringContextTrustedScriptURLSetter):
(WebCore::setJSTestStringContext_attributeWithStringContextTrustedHTMLAndLegacyNullToEmptyStringSetter):
(WebCore::setJSTestStringContext_attributeWithStringContextTrustedScriptAndLegacyNullToEmptyStringSetter):
(WebCore::setJSTestStringContext_attributeWithStringContextTrustedScriptURLAndLegacyNullToEmptyStringSetter):
(WebCore::setJSTestStringContext_reflectedAttributeWithStringContextTrustedHTMLSetter):
(WebCore::setJSTestStringContext_reflectedAttributeWithStringContextTrustedScriptSetter):
(WebCore::setJSTestStringContext_reflectedAttributeWithStringContextTrustedScriptURLSetter):
(WebCore::setJSTestStringContext_reflectedUrlAttributeWithStringContextTrustedHTMLSetter):
(WebCore::setJSTestStringContext_reflectedUrlAttributeWithStringContextTrustedScriptSetter):
(WebCore::setJSTestStringContext_reflectedUrlAttributeWithStringContextTrustedScriptURLSetter):
(WebCore::jsTestStringContextPrototypeFunction_methodWithStringContextTrustedHTMLBody):
(WebCore::jsTestStringContextPrototypeFunction_methodWithStringContextTrustedScriptBody):
(WebCore::jsTestStringContextPrototypeFunction_methodWithStringContextTrustedScriptURLBody):
(WebCore::jsTestStringContextPrototypeFunction_methodWithStringContextTrustedHTMLAndLegacyNullToEmptyStringBody):
(WebCore::jsTestStringContextPrototypeFunction_methodWithStringContextTrustedScriptAndLegacyNullToEmptyStringBody):
(WebCore::jsTestStringContextPrototypeFunction_methodWithStringContextTrustedScriptURLAndLegacyNullToEmptyStringBody):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::updateEffectiveLangStateFromParent):
(WebCore::Element::hasEffectiveLangState const):
* Source/WebCore/dom/EventContext.cpp:
(WebCore::EventContext::handleLocalEvents const):
* Source/WebCore/dom/make_names.pl:
(printNodeNameHeaderFile):
* Source/WebGPU/WGSL/AttributeValidator.cpp:
(WGSL::AttributeValidator::visit):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:
(wpeViewWaylandRenderBuffer):
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm:
(_generateImplementationFile):
(_installArgumentTypeExceptions):
(_installAutomaticExceptions):
(_dynamicAttributesImplementation):
* Source/bmalloc/bmalloc/BCompiler.h:
* Source/bmalloc/bmalloc/TZoneHeap.cpp:
(bmalloc::api::tzoneAllocateNonCompactSlow):
(bmalloc::api::tzoneAllocateCompactSlow):
* Source/bmalloc/bmalloc/TZoneHeap.h:
* Source/bmalloc/bmalloc/TZoneHeapInlines.h:

Canonical link: <a href="https://commits.webkit.org/294522@main">https://commits.webkit.org/294522@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a198a62b5d5f0930dbed274459c8052f7bba71b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102162 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12145 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107321 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52798 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104201 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30337 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/77752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/34746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105168 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92225 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/58087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/101634 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16958 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10251 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/52156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/94833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86799 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10324 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109697 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100771 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21597 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86720 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29656 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88428 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86303 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21951 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31114 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8829 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/23536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29222 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34517 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124397 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29033 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34546 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32356 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30592 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->