### PR TITLE
MediaCapabilitiesDecodingInfo supportedConfiguration should be renamed to configuration

### DIFF
--- a/LayoutTests/media/mediacapabilities/mock-decodingInfo-alphaChannel-expected.txt
+++ b/LayoutTests/media/mediacapabilities/mock-decodingInfo-alphaChannel-expected.txt
@@ -3,22 +3,22 @@ RUN(internals.settings.setMediaCapabilitiesExtensionsEnabled(true))
 RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs="mock-with-alpha"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 }});)
 Promise resolved OK
 EXPECTED (info.supported == 'true') OK
-EXPECTED (info.supportedConfiguration.video.alphaChannel == 'null') OK
+EXPECTED (info.configuration.video.alphaChannel == 'null') OK
 RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs="mock-with-alpha"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5, alphaChannel: false }});)
 Promise resolved OK
 EXPECTED (info.supported == 'true') OK
-EXPECTED (info.supportedConfiguration.video.alphaChannel == 'false') OK
+EXPECTED (info.configuration.video.alphaChannel == 'false') OK
 RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs="mock-with-alpha"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5, alphaChannel: true }});)
 Promise resolved OK
 EXPECTED (info.supported == 'true') OK
-EXPECTED (info.supportedConfiguration.video.alphaChannel == 'true') OK
+EXPECTED (info.configuration.video.alphaChannel == 'true') OK
 RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs="mock-without-alpha"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5, alphaChannel: false }});)
 Promise resolved OK
 EXPECTED (info.supported == 'true') OK
-EXPECTED (info.supportedConfiguration.video.alphaChannel == 'false') OK
+EXPECTED (info.configuration.video.alphaChannel == 'false') OK
 RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs="mock-without-alpha"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5, alphaChannel: true }});)
 Promise resolved OK
 EXPECTED (info.supported == 'false') OK
-EXPECTED (info.supportedConfiguration.video.alphaChannel == 'true') OK
+EXPECTED (info.configuration.video.alphaChannel == 'true') OK
 END OF TEST
 

--- a/LayoutTests/media/mediacapabilities/mock-decodingInfo-alphaChannel.html
+++ b/LayoutTests/media/mediacapabilities/mock-decodingInfo-alphaChannel.html
@@ -19,27 +19,27 @@
         run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs=\"mock-with-alpha\"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 }});");
         info = await shouldResolve(promise);
         testExpected('info.supported', true);
-        testExpected('info.supportedConfiguration.video.alphaChannel', null);
+        testExpected('info.configuration.video.alphaChannel', null);
 
         run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs=\"mock-with-alpha\"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5, alphaChannel: false }});");
         info = await shouldResolve(promise);
         testExpected('info.supported', true);
-        testExpected('info.supportedConfiguration.video.alphaChannel', false);
+        testExpected('info.configuration.video.alphaChannel', false);
 
         run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs=\"mock-with-alpha\"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5, alphaChannel: true }});");
         info = await shouldResolve(promise);
         testExpected('info.supported', true);
-        testExpected('info.supportedConfiguration.video.alphaChannel', true);
+        testExpected('info.configuration.video.alphaChannel', true);
 
         run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs=\"mock-without-alpha\"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5, alphaChannel: false }});");
         info = await shouldResolve(promise);
         testExpected('info.supported', true);
-        testExpected('info.supportedConfiguration.video.alphaChannel', false);
+        testExpected('info.configuration.video.alphaChannel', false);
 
         run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs=\"mock-without-alpha\"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5, alphaChannel: true }});");
         info = await shouldResolve(promise);
         testExpected('info.supported', false);
-        testExpected('info.supportedConfiguration.video.alphaChannel', true);
+        testExpected('info.configuration.video.alphaChannel', true);
 
 
         endTest();

--- a/LayoutTests/media/mediacapabilities/mock-decodingInfo-hdr-expected.txt
+++ b/LayoutTests/media/mediacapabilities/mock-decodingInfo-hdr-expected.txt
@@ -3,14 +3,14 @@ RUN(internals.settings.setMediaCapabilitiesExtensionsEnabled(true))
 RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs="mock-with-hdr"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 }});)
 Promise resolved OK
 EXPECTED (info.supported == 'true') OK
-EXPECTED (info.supportedConfiguration.video.colorGamut == 'null') OK
+EXPECTED (info.configuration.video.colorGamut == 'null') OK
 RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs="mock-with-hdr"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5, colorGamut: 'rec2020' }});)
 Promise resolved OK
 EXPECTED (info.supported == 'true') OK
-EXPECTED (info.supportedConfiguration.video.colorGamut == 'rec2020') OK
+EXPECTED (info.configuration.video.colorGamut == 'rec2020') OK
 RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs="mock"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5, colorGamut: 'rec2020' }});)
 Promise resolved OK
 EXPECTED (info.supported == 'false') OK
-EXPECTED (info.supportedConfiguration.video.colorGamut == 'rec2020') OK
+EXPECTED (info.configuration.video.colorGamut == 'rec2020') OK
 END OF TEST
 

--- a/LayoutTests/media/mediacapabilities/mock-decodingInfo-hdr.html
+++ b/LayoutTests/media/mediacapabilities/mock-decodingInfo-hdr.html
@@ -19,17 +19,17 @@
         run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs=\"mock-with-hdr\"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 }});");
         info = await shouldResolve(promise);
         testExpected('info.supported', true);
-        testExpected('info.supportedConfiguration.video.colorGamut', null);
+        testExpected('info.configuration.video.colorGamut', null);
 
         run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs=\"mock-with-hdr\"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5, colorGamut: 'rec2020' }});");
         info = await shouldResolve(promise);
         testExpected('info.supported', true);
-        testExpected('info.supportedConfiguration.video.colorGamut', 'rec2020');
+        testExpected('info.configuration.video.colorGamut', 'rec2020');
 
         run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs=\"mock\"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5, colorGamut: 'rec2020' }});");
         info = await shouldResolve(promise);
         testExpected('info.supported', false);
-        testExpected('info.supportedConfiguration.video.colorGamut', 'rec2020');
+        testExpected('info.configuration.video.colorGamut', 'rec2020');
 
         endTest();
     }

--- a/LayoutTests/media/mediacapabilities/mock-decodingInfo-spatialRendering-expected.txt
+++ b/LayoutTests/media/mediacapabilities/mock-decodingInfo-spatialRendering-expected.txt
@@ -3,18 +3,18 @@ RUN(internals.settings.setMediaCapabilitiesExtensionsEnabled(true))
 RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', audio: { contentType: 'audio/mp4; codecs="mp4a.40.2"', channels: '5.1', bitrate: 1000, samplerate: 44100 } });)
 Promise resolved OK
 EXPECTED (info.supported == 'true') OK
-EXPECTED (typeof info.supportedConfiguration.audio.spatialRendering == 'undefined') OK
+EXPECTED (typeof info.configuration.audio.spatialRendering == 'undefined') OK
 RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', audio: { contentType: 'audio/mp4; codecs="mp4a.40.2"', channels: '5.1', bitrate: 1000, samplerate: 44100, spatialRendering: true } });)
 Promise resolved OK
 EXPECTED (info.supported == 'true') OK
-EXPECTED (info.supportedConfiguration.audio.spatialRendering == 'true') OK
+EXPECTED (info.configuration.audio.spatialRendering == 'true') OK
 RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', audio: { contentType: 'audio/mp4; codecs="mp4a.40.2"', channels: '2', bitrate: 1000, samplerate: 44100, spatialRendering: true } });)
 Promise resolved OK
 EXPECTED (info.supported == 'false') OK
-EXPECTED (info.supportedConfiguration.audio.spatialRendering == 'true') OK
+EXPECTED (info.configuration.audio.spatialRendering == 'true') OK
 RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', audio: { contentType: 'audio/mp4; codecs="mp4a.40.2"', channels: '2', bitrate: 1000, samplerate: 44100, spatialRendering: false } });)
 Promise resolved OK
 EXPECTED (info.supported == 'true') OK
-EXPECTED (info.supportedConfiguration.audio.spatialRendering == 'false') OK
+EXPECTED (info.configuration.audio.spatialRendering == 'false') OK
 END OF TEST
 

--- a/LayoutTests/media/mediacapabilities/mock-decodingInfo-spatialRendering.html
+++ b/LayoutTests/media/mediacapabilities/mock-decodingInfo-spatialRendering.html
@@ -20,25 +20,25 @@
 
         info = await shouldResolve(promise);
         testExpected('info.supported', true);
-        testExpected('typeof info.supportedConfiguration.audio.spatialRendering', 'undefined');
+        testExpected('typeof info.configuration.audio.spatialRendering', 'undefined');
 
         run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', audio: { contentType: 'audio/mp4; codecs=\"mp4a.40.2\"', channels: '5.1', bitrate: 1000, samplerate: 44100, spatialRendering: true } });");
 
         info = await shouldResolve(promise);
         testExpected('info.supported', true);
-        testExpected('info.supportedConfiguration.audio.spatialRendering', true);
+        testExpected('info.configuration.audio.spatialRendering', true);
 
         run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', audio: { contentType: 'audio/mp4; codecs=\"mp4a.40.2\"', channels: '2', bitrate: 1000, samplerate: 44100, spatialRendering: true } });");
 
         info = await shouldResolve(promise);
         testExpected('info.supported', false);
-        testExpected('info.supportedConfiguration.audio.spatialRendering', true);
+        testExpected('info.configuration.audio.spatialRendering', true);
 
         run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', audio: { contentType: 'audio/mp4; codecs=\"mp4a.40.2\"', channels: '2', bitrate: 1000, samplerate: 44100, spatialRendering: false } });");
 
         info = await shouldResolve(promise);
         testExpected('info.supported', true);
-        testExpected('info.supportedConfiguration.audio.spatialRendering', false);
+        testExpected('info.configuration.audio.spatialRendering', false);
 
         endTest();
     }

--- a/LayoutTests/media/mediacapabilities/mock-decodingInfo-supportedConfiguration-expected.txt
+++ b/LayoutTests/media/mediacapabilities/mock-decodingInfo-supportedConfiguration-expected.txt
@@ -5,26 +5,26 @@ Promise resolved OK
 EXPECTED (info.supported == 'true') OK
 EXPECTED (info.smooth == 'true') OK
 EXPECTED (info.powerEfficient == 'true') OK
-EXPECTED (typeof info.supportedConfiguration != 'undefined') OK
-EXPECTED (info.supportedConfiguration.type == 'file') OK
-EXPECTED (info.supportedConfiguration.video.contentType == 'video/mp4; codecs="avc1"') OK
-EXPECTED (info.supportedConfiguration.video.height == '720') OK
-EXPECTED (info.supportedConfiguration.video.bitrate == '1000') OK
-EXPECTED (info.supportedConfiguration.video.width == '1280') OK
-EXPECTED (info.supportedConfiguration.video.framerate == '24.5') OK
-EXPECTED (typeof info.supportedConfiguration.unsupportedProperty == 'undefined') OK
+EXPECTED (typeof info.configuration != 'undefined') OK
+EXPECTED (info.configuration.type == 'file') OK
+EXPECTED (info.configuration.video.contentType == 'video/mp4; codecs="avc1"') OK
+EXPECTED (info.configuration.video.height == '720') OK
+EXPECTED (info.configuration.video.bitrate == '1000') OK
+EXPECTED (info.configuration.video.width == '1280') OK
+EXPECTED (info.configuration.video.framerate == '24.5') OK
+EXPECTED (typeof info.configuration.unsupportedProperty == 'undefined') OK
 RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', video: { contentType: 'video/mp4; codecs="avc1"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 }, unsupportedProperty: true });)
 Promise resolved OK
 EXPECTED (info.supported == 'false') OK
 EXPECTED (info.smooth == 'false') OK
 EXPECTED (info.powerEfficient == 'false') OK
-EXPECTED (typeof info.supportedConfiguration != 'undefined') OK
-EXPECTED (info.supportedConfiguration.type == 'media-source') OK
-EXPECTED (info.supportedConfiguration.video.contentType == 'video/mp4; codecs="avc1"') OK
-EXPECTED (info.supportedConfiguration.video.height == '720') OK
-EXPECTED (info.supportedConfiguration.video.bitrate == '1000') OK
-EXPECTED (info.supportedConfiguration.video.width == '1280') OK
-EXPECTED (info.supportedConfiguration.video.framerate == '24.5') OK
-EXPECTED (typeof info.supportedConfiguration.unsupportedProperty == 'undefined') OK
+EXPECTED (typeof info.configuration != 'undefined') OK
+EXPECTED (info.configuration.type == 'media-source') OK
+EXPECTED (info.configuration.video.contentType == 'video/mp4; codecs="avc1"') OK
+EXPECTED (info.configuration.video.height == '720') OK
+EXPECTED (info.configuration.video.bitrate == '1000') OK
+EXPECTED (info.configuration.video.width == '1280') OK
+EXPECTED (info.configuration.video.framerate == '24.5') OK
+EXPECTED (typeof info.configuration.unsupportedProperty == 'undefined') OK
 END OF TEST
 

--- a/LayoutTests/media/mediacapabilities/mock-decodingInfo-supportedConfiguration.html
+++ b/LayoutTests/media/mediacapabilities/mock-decodingInfo-supportedConfiguration.html
@@ -21,28 +21,28 @@
         testExpected('info.supported', true);
         testExpected('info.smooth', true);
         testExpected('info.powerEfficient', true);
-        testExpected('typeof info.supportedConfiguration', 'undefined', '!=');
-        testExpected('info.supportedConfiguration.type', 'file');
-        testExpected('info.supportedConfiguration.video.contentType', 'video/mp4; codecs="avc1"');
-        testExpected('info.supportedConfiguration.video.height', 720);
-        testExpected('info.supportedConfiguration.video.bitrate', 1000);
-        testExpected('info.supportedConfiguration.video.width', 1280);
-        testExpected('info.supportedConfiguration.video.framerate', 24.5);
-        testExpected('typeof info.supportedConfiguration.unsupportedProperty', 'undefined');
+        testExpected('typeof info.configuration', 'undefined', '!=');
+        testExpected('info.configuration.type', 'file');
+        testExpected('info.configuration.video.contentType', 'video/mp4; codecs="avc1"');
+        testExpected('info.configuration.video.height', 720);
+        testExpected('info.configuration.video.bitrate', 1000);
+        testExpected('info.configuration.video.width', 1280);
+        testExpected('info.configuration.video.framerate', 24.5);
+        testExpected('typeof info.configuration.unsupportedProperty', 'undefined');
 
         run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', video: { contentType: 'video/mp4; codecs=\"avc1\"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 }, unsupportedProperty: true });");
         info = await shouldResolve(promise);
         testExpected('info.supported', false);
         testExpected('info.smooth', false);
         testExpected('info.powerEfficient', false);
-        testExpected('typeof info.supportedConfiguration', 'undefined', '!=');
-        testExpected('info.supportedConfiguration.type', 'media-source');
-        testExpected('info.supportedConfiguration.video.contentType', 'video/mp4; codecs="avc1"');
-        testExpected('info.supportedConfiguration.video.height', 720);
-        testExpected('info.supportedConfiguration.video.bitrate', 1000);
-        testExpected('info.supportedConfiguration.video.width', 1280);
-        testExpected('info.supportedConfiguration.video.framerate', 24.5);
-        testExpected('typeof info.supportedConfiguration.unsupportedProperty', 'undefined');
+        testExpected('typeof info.configuration', 'undefined', '!=');
+        testExpected('info.configuration.type', 'media-source');
+        testExpected('info.configuration.video.contentType', 'video/mp4; codecs="avc1"');
+        testExpected('info.configuration.video.height', 720);
+        testExpected('info.configuration.video.bitrate', 1000);
+        testExpected('info.configuration.video.width', 1280);
+        testExpected('info.configuration.video.framerate', 24.5);
+        testExpected('typeof info.configuration.unsupportedProperty', 'undefined');
         endTest();
     }
     </script>

--- a/LayoutTests/platform/mac/media/mediacapabilities/hevc-decodingInfo-hdr-expected.txt
+++ b/LayoutTests/platform/mac/media/mediacapabilities/hevc-decodingInfo-hdr-expected.txt
@@ -2,14 +2,14 @@ RUN(internals.settings.setMediaCapabilitiesExtensionsEnabled(true))
 RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', video: { contentType: 'video/mp4; codecs="hvc1.2.4.H153.B0"', height: 720, bitrate: 800000, width: 1280, framerate: 24.5 }});)
 Promise resolved OK
 EXPECTED (info.supported == 'true') OK
-EXPECTED (info.supportedConfiguration.video.hdrMetadataType == 'null') OK
+EXPECTED (info.configuration.video.hdrMetadataType == 'null') OK
 RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', video: { contentType: 'video/mp4; codecs="hvc1.2.4.H153.B0"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5, hdrMetadataType: 'smpteSt2086', transferFunction: 'pq' }});)
 Promise resolved OK
 EXPECTED (info.supported == 'true') OK
-EXPECTED (info.supportedConfiguration.video.hdrMetadataType == 'smpteSt2086') OK
+EXPECTED (info.configuration.video.hdrMetadataType == 'smpteSt2086') OK
 RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', video: { contentType: 'video/mp4; codecs="avc1.640028"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5, hdrMetadataType: 'smpteSt2086', transferFunction: 'pq' }});)
 Promise resolved OK
 EXPECTED (info.supported == 'false') OK
-EXPECTED (info.supportedConfiguration.video.hdrMetadataType == 'smpteSt2086') OK
+EXPECTED (info.configuration.video.hdrMetadataType == 'smpteSt2086') OK
 END OF TEST
 

--- a/LayoutTests/platform/mac/media/mediacapabilities/hevc-decodingInfo-hdr.html
+++ b/LayoutTests/platform/mac/media/mediacapabilities/hevc-decodingInfo-hdr.html
@@ -18,17 +18,17 @@
         run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', video: { contentType: 'video/mp4; codecs=\"hvc1.2.4.H153.B0\"', height: 720, bitrate: 800000, width: 1280, framerate: 24.5 }});");
         info = await shouldResolve(promise);
         testExpected('info.supported', true);
-        testExpected('info.supportedConfiguration.video.hdrMetadataType', null);
+        testExpected('info.configuration.video.hdrMetadataType', null);
 
         run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', video: { contentType: 'video/mp4; codecs=\"hvc1.2.4.H153.B0\"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5, hdrMetadataType: 'smpteSt2086', transferFunction: 'pq' }});");
         info = await shouldResolve(promise);
         testExpected('info.supported', true);
-        testExpected('info.supportedConfiguration.video.hdrMetadataType', 'smpteSt2086');
+        testExpected('info.configuration.video.hdrMetadataType', 'smpteSt2086');
 
         run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', video: { contentType: 'video/mp4; codecs=\"avc1.640028\"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5, hdrMetadataType: 'smpteSt2086', transferFunction: 'pq' }});");
         info = await shouldResolve(promise);
         testExpected('info.supported', false);
-        testExpected('info.supportedConfiguration.video.hdrMetadataType', 'smpteSt2086');
+        testExpected('info.configuration.video.hdrMetadataType', 'smpteSt2086');
 
         endTest();
     }

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesDecodingInfo.idl
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesDecodingInfo.idl
@@ -27,5 +27,5 @@
     EnabledBySetting=MediaCapabilitiesEnabled,
     JSGenerateToJSObject,
 ] dictionary MediaCapabilitiesDecodingInfo : MediaCapabilitiesInfo {
-    [EnabledBySetting=MediaCapabilitiesExtensionsEnabled] MediaDecodingConfiguration supportedConfiguration;
+    [EnabledBySetting=MediaCapabilitiesExtensionsEnabled] MediaDecodingConfiguration configuration;
 };

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesEncodingInfo.idl
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesEncodingInfo.idl
@@ -27,5 +27,5 @@
     EnabledBySetting=MediaCapabilitiesEnabled,
     JSGenerateToJSObject,
 ] dictionary MediaCapabilitiesEncodingInfo : MediaCapabilitiesInfo {
-    [EnabledBySetting=MediaCapabilitiesExtensionsEnabled] MediaEncodingConfiguration supportedConfiguration;
+    [EnabledBySetting=MediaCapabilitiesExtensionsEnabled] MediaEncodingConfiguration configuration;
 };

--- a/Source/WebCore/platform/MediaCapabilitiesDecodingInfo.h
+++ b/Source/WebCore/platform/MediaCapabilitiesDecodingInfo.h
@@ -31,7 +31,7 @@
 namespace WebCore {
 
 struct MediaCapabilitiesDecodingInfo : MediaCapabilitiesInfo {
-    MediaDecodingConfiguration supportedConfiguration;
+    MediaDecodingConfiguration configuration;
 
     MediaCapabilitiesDecodingInfo isolatedCopy() const;
 
@@ -39,7 +39,7 @@ struct MediaCapabilitiesDecodingInfo : MediaCapabilitiesInfo {
 
 inline MediaCapabilitiesDecodingInfo MediaCapabilitiesDecodingInfo::isolatedCopy() const
 {
-    return { MediaCapabilitiesInfo::isolatedCopy(), supportedConfiguration.isolatedCopy() };
+    return { MediaCapabilitiesInfo::isolatedCopy(), configuration.isolatedCopy() };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/MediaCapabilitiesEncodingInfo.h
+++ b/Source/WebCore/platform/MediaCapabilitiesEncodingInfo.h
@@ -31,15 +31,14 @@
 namespace WebCore {
 
 struct MediaCapabilitiesEncodingInfo : MediaCapabilitiesInfo {
-    MediaEncodingConfiguration supportedConfiguration;
+    MediaEncodingConfiguration configuration;
 
     MediaCapabilitiesEncodingInfo isolatedCopy() const;
-
 };
 
 inline MediaCapabilitiesEncodingInfo MediaCapabilitiesEncodingInfo::isolatedCopy() const
 {
-    return { MediaCapabilitiesInfo::isolatedCopy(), supportedConfiguration.isolatedCopy() };
+    return { MediaCapabilitiesInfo::isolatedCopy(), configuration.isolatedCopy() };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gstreamer/MediaEngineConfigurationFactoryGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaEngineConfigurationFactoryGStreamer.cpp
@@ -60,7 +60,7 @@ void createMediaPlayerDecodingConfigurationGStreamer(MediaDecodingConfiguration&
     MediaCapabilitiesDecodingInfo info;
     info.supported = lookupResult.isSupported;
     info.powerEfficient = lookupResult.isUsingHardware;
-    info.supportedConfiguration = WTFMove(configuration);
+    info.configuration = WTFMove(configuration);
 
     callback(WTFMove(info));
 }
@@ -72,7 +72,7 @@ void createMediaPlayerEncodingConfigurationGStreamer(MediaEncodingConfiguration&
     MediaCapabilitiesEncodingInfo info;
     info.supported = lookupResult.isSupported;
     info.powerEfficient = lookupResult.isUsingHardware;
-    info.supportedConfiguration = WTFMove(configuration);
+    info.configuration = WTFMove(configuration);
 
     callback(WTFMove(info));
 }

--- a/Source/WebCore/platform/mediacapabilities/MediaCapabilitiesLogging.cpp
+++ b/Source/WebCore/platform/mediacapabilities/MediaCapabilitiesLogging.cpp
@@ -113,14 +113,14 @@ static Ref<JSON::Object> toJSONObject(const MediaCapabilitiesInfo& info)
 static Ref<JSON::Object> toJSONObject(const MediaCapabilitiesDecodingInfo& info)
 {
     auto object = toJSONObject(static_cast<const MediaCapabilitiesInfo&>(info));
-    object->setValue("supportedConfiguration"_s, toJSONObject(info.supportedConfiguration));
+    object->setValue("configuration"_s, toJSONObject(info.configuration));
     return object;
 }
 
 static Ref<JSON::Object> toJSONObject(const MediaCapabilitiesEncodingInfo& info)
 {
     auto object = toJSONObject(static_cast<const MediaCapabilitiesInfo&>(info));
-    object->setValue("supportedConfiguration"_s, toJSONObject(info.supportedConfiguration));
+    object->setValue("configuration"_s, toJSONObject(info.configuration));
     return object;
 }
 

--- a/Source/WebCore/platform/mediacapabilities/MediaEngineConfigurationFactory.cpp
+++ b/Source/WebCore/platform/mediacapabilities/MediaEngineConfigurationFactory.cpp
@@ -122,7 +122,7 @@ void MediaEngineConfigurationFactory::createDecodingConfiguration(MediaDecodingC
                 return;
             }
 
-            factoryCallback(factoryCallback, nextFactories.subspan(1), WTFMove(info.supportedConfiguration), WTFMove(callback));
+            factoryCallback(factoryCallback, nextFactories.subspan(1), WTFMove(info.configuration), WTFMove(callback));
         });
     };
     factoryCallback(factoryCallback, factories().span(), WTFMove(config), WTFMove(callback));
@@ -153,7 +153,7 @@ void MediaEngineConfigurationFactory::createEncodingConfiguration(MediaEncodingC
                 return;
             }
 
-            factoryCallback(factoryCallback, nextFactories.subspan(1), WTFMove(info.supportedConfiguration), WTFMove(callback));
+            factoryCallback(factoryCallback, nextFactories.subspan(1), WTFMove(info.configuration), WTFMove(callback));
         });
     };
     factoryCallback(factoryCallback, factories().span(), WTFMove(config), WTFMove(callback));

--- a/Source/WebCore/platform/mediastream/WebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/WebRTCProvider.cpp
@@ -206,14 +206,14 @@ void WebRTCProvider::createDecodingConfiguration(MediaDecodingConfiguration&& co
     MediaCapabilitiesDecodingInfo info { { }, WTFMove(configuration) };
 
 #if ENABLE(WEB_RTC)
-    if (info.supportedConfiguration.video) {
-        ContentType contentType { info.supportedConfiguration.video->contentType };
+    if (info.configuration.video) {
+        ContentType contentType { info.configuration.video->contentType };
         auto codec = codecCapability(contentType, videoDecodingCapabilities());
         if (!codec) {
             callback({ });
             return;
         }
-        if (auto infoOverride = videoDecodingCapabilitiesOverride(*info.supportedConfiguration.video)) {
+        if (auto infoOverride = videoDecodingCapabilitiesOverride(*info.configuration.video)) {
             if (!infoOverride->supported) {
                 callback({ });
                 return;
@@ -222,8 +222,8 @@ void WebRTCProvider::createDecodingConfiguration(MediaDecodingConfiguration&& co
             info.powerEfficient = infoOverride->powerEfficient;
         }
     }
-    if (info.supportedConfiguration.audio) {
-        ContentType contentType { info.supportedConfiguration.audio->contentType };
+    if (info.configuration.audio) {
+        ContentType contentType { info.configuration.audio->contentType };
         auto codec = codecCapability(contentType, audioDecodingCapabilities());
         if (!codec) {
             callback({ });
@@ -243,14 +243,14 @@ void WebRTCProvider::createEncodingConfiguration(MediaEncodingConfiguration&& co
     MediaCapabilitiesEncodingInfo info { { }, WTFMove(configuration) };
 
 #if ENABLE(WEB_RTC)
-    if (info.supportedConfiguration.video) {
-        ContentType contentType { info.supportedConfiguration.video->contentType };
+    if (info.configuration.video) {
+        ContentType contentType { info.configuration.video->contentType };
         auto codec = codecCapability(contentType, videoEncodingCapabilities());
         if (!codec) {
             callback({ });
             return;
         }
-        if (auto infoOverride = videoEncodingCapabilitiesOverride(*info.supportedConfiguration.video)) {
+        if (auto infoOverride = videoEncodingCapabilitiesOverride(*info.configuration.video)) {
             if (!infoOverride->supported) {
                 callback({ });
                 return;
@@ -259,8 +259,8 @@ void WebRTCProvider::createEncodingConfiguration(MediaEncodingConfiguration&& co
             info.powerEfficient = infoOverride->powerEfficient;
         }
     }
-    if (info.supportedConfiguration.audio) {
-        ContentType contentType { info.supportedConfiguration.audio->contentType };
+    if (info.configuration.audio) {
+        ContentType contentType { info.configuration.audio->contentType };
         auto codec = codecCapability(contentType, audioEncodingCapabilities());
         if (!codec) {
             callback({ });

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.cpp
@@ -110,7 +110,7 @@ void GStreamerWebRTCProvider::initializeVideoDecodingCapabilities()
 std::optional<MediaCapabilitiesDecodingInfo> GStreamerWebRTCProvider::videoDecodingCapabilitiesOverride(const VideoConfiguration& configuration)
 {
     MediaCapabilitiesDecodingInfo info;
-    info.supportedConfiguration.type = MediaDecodingType::WebRTC;
+    info.configuration.type = MediaDecodingType::WebRTC;
     ContentType contentType { configuration.contentType };
     auto containerType = contentType.containerType();
     if (equalLettersIgnoringASCIICase(containerType, "video/vp8"_s)) {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2413,11 +2413,11 @@ struct WebCore::MediaStreamRequest {
 };
 #endif
 struct WebCore::MediaCapabilitiesDecodingInfo : WebCore::MediaCapabilitiesInfo {
-    WebCore::MediaDecodingConfiguration supportedConfiguration;
+    WebCore::MediaDecodingConfiguration configuration;
 }
 
 struct WebCore::MediaCapabilitiesEncodingInfo : WebCore::MediaCapabilitiesInfo {
-    WebCore::MediaEncodingConfiguration supportedConfiguration;
+    WebCore::MediaEncodingConfiguration configuration;
 }
 
 header: <WebCore/VideoCodecType.h>


### PR DESCRIPTION
#### e5aba84835884d7436672f419012942d25479d70
<pre>
MediaCapabilitiesDecodingInfo supportedConfiguration should be renamed to configuration
<a href="https://rdar.apple.com/150680795">rdar://150680795</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292542">https://bugs.webkit.org/show_bug.cgi?id=292542</a>

Reviewed by Jean-Yves Avenard.

We update the WebIDL to match the spec (and Chrome).
We also update the C++ structures accordingly.
We do this for MediaCapabilitiesDecodingInfo and MediaCapabilitiesEncodingInfo.

* LayoutTests/media/mediacapabilities/mock-decodingInfo-alphaChannel-expected.txt:
* LayoutTests/media/mediacapabilities/mock-decodingInfo-alphaChannel.html:
* LayoutTests/media/mediacapabilities/mock-decodingInfo-hdr-expected.txt:
* LayoutTests/media/mediacapabilities/mock-decodingInfo-hdr.html:
* LayoutTests/media/mediacapabilities/mock-decodingInfo-spatialRendering-expected.txt:
* LayoutTests/media/mediacapabilities/mock-decodingInfo-spatialRendering.html:
* LayoutTests/media/mediacapabilities/mock-decodingInfo-supportedConfiguration-expected.txt:
* LayoutTests/media/mediacapabilities/mock-decodingInfo-supportedConfiguration.html:
* LayoutTests/platform/mac/media/mediacapabilities/hevc-decodingInfo-hdr-expected.txt:
* LayoutTests/platform/mac/media/mediacapabilities/hevc-decodingInfo-hdr.html:
* Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesDecodingInfo.idl:
* Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesEncodingInfo.idl:
* Source/WebCore/platform/MediaCapabilitiesDecodingInfo.h:
(WebCore::MediaCapabilitiesDecodingInfo::isolatedCopy const):
* Source/WebCore/platform/MediaCapabilitiesEncodingInfo.h:
(WebCore::MediaCapabilitiesEncodingInfo::isolatedCopy const):
* Source/WebCore/platform/graphics/gstreamer/MediaEngineConfigurationFactoryGStreamer.cpp:
(WebCore::createMediaPlayerDecodingConfigurationGStreamer):
(WebCore::createMediaPlayerEncodingConfigurationGStreamer):
* Source/WebCore/platform/mediacapabilities/MediaCapabilitiesLogging.cpp:
(WebCore::toJSONObject):
* Source/WebCore/platform/mediacapabilities/MediaEngineConfigurationFactory.cpp:
(WebCore::MediaEngineConfigurationFactory::createDecodingConfiguration):
(WebCore::MediaEngineConfigurationFactory::createEncodingConfiguration):
* Source/WebCore/platform/mediastream/WebRTCProvider.cpp:
(WebCore::WebRTCProvider::createDecodingConfiguration):
(WebCore::WebRTCProvider::createEncodingConfiguration):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.cpp:
(WebCore::GStreamerWebRTCProvider::videoDecodingCapabilitiesOverride):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/294895@main">https://commits.webkit.org/294895@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a37137faca283fd291b3ffa2f9a1fe2fcaa852a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108626 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54096 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105491 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31685 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78608 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93317 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58943 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18022 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/11363 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53453 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87818 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11423 "layout-tests (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111005 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30599 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22565 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87604 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30960 "Hash a37137fa for PR 44942 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89516 "layout-tests (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87245 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22209 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9831 "layout-tests (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24939 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30527 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35839 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30327 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33658 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31888 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->