### PR TITLE
[macOS][Writing Tools] Add support for top-level context menu items

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/NSMenuSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSMenuSPI.h
@@ -35,18 +35,6 @@ DECLARE_SYSTEM_HEADER
 
 #import <AppKit/NSMenu_Private.h>
 
-@interface NSMenuItem (Staging_129192954)
-
-+ (NSMenuItem *)standardWritingToolsMenuItem;
-
-@end
-
-#elif USE(APPLE_INTERNAL_SDK)
-
-WTF_EXTERN_C_BEGIN
-#import <AppKit/NSMenu_Private.h>
-WTF_EXTERN_C_END
-
 #else
 
 typedef NS_ENUM(NSInteger, NSMenuType) {

--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -1249,6 +1249,9 @@
 /* VP8/9 Codec Level & Profile (Codec Strings) */
 "Profile %d, Level %s" = "Profile %d, Level %s";
 
+/* Proofread context menu item */
+"Proofread" = "Proofread";
+
 /* Undo action name */
 "Raise Baseline (Undo action name)" = "Raise Baseline";
 
@@ -1281,6 +1284,9 @@
 
 /* Reset button in date input context menu */
 "Reset Button Date/Time Context Menu" = "Reset";
+
+/* Rewrite context menu item */
+"Rewrite" = "Rewrite";
 
 /* Right to Left context menu item */
 "Right to Left" = "Right to Left";
@@ -1369,6 +1375,9 @@
 /* Title for Show Text action button */
 "Show Text" = "Show Text";
 
+/* Writing Tools context menu item */
+"Show Writing Tools" = "Show Writing Tools";
+
 /* Single Page context menu item */
 "Single Page" = "Single Page";
 
@@ -1452,6 +1461,9 @@
 
 /* Accessibility announcement that the suggestions list became visible. The format argument is for the first option in the list. */
 "Suggestions list visible, %@" = "Suggestions list visible, %@";
+
+/* Summarize context menu item */
+"Summarize" = "Summarize";
 
 /* Undo action name */
 "Superscript (Undo action name)" = "Superscript";

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -651,7 +651,10 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
         break;
 
     case ContextMenuItemTagWritingTools:
-        // The Writing Tools context menu item action is handled in the client layer.
+    case ContextMenuItemTagProofread:
+    case ContextMenuItemTagRewrite:
+    case ContextMenuItemTagSummarize:
+        // Writing Tools context menu item actions are handled at the client layer.
         RELEASE_ASSERT_NOT_REACHED();
         break;
 
@@ -1194,6 +1197,11 @@ void ContextMenuController::populate()
                 appendItem(*separatorItem(), m_contextMenu.get());
                 ContextMenuItem writingToolsItem(ContextMenuItemType::Action, ContextMenuItemTagWritingTools, contextMenuItemTagWritingTools());
                 appendItem(writingToolsItem, m_contextMenu.get());
+#if ENABLE(TOP_LEVEL_WRITING_TOOLS_CONTEXT_MENU_ITEMS)
+                ContextMenuItem summarizeItem(ContextMenuItemType::Action, ContextMenuItemTagSummarize, contextMenuItemTagSummarize());
+                appendItem(summarizeItem, m_contextMenu.get());
+                appendItem(*separatorItem(), m_contextMenu.get());
+#endif
 #endif
 
                 ContextMenuItem SpeechMenuItem(ContextMenuItemType::Submenu, ContextMenuItemTagSpeechMenu, contextMenuItemTagSpeechMenu());
@@ -1351,6 +1359,22 @@ void ContextMenuController::populate()
             appendItem(*separatorItem(), m_contextMenu.get());
             ContextMenuItem writingToolsItem(ContextMenuItemType::Action, ContextMenuItemTagWritingTools, contextMenuItemTagWritingTools());
             appendItem(writingToolsItem, m_contextMenu.get());
+#if ENABLE(TOP_LEVEL_WRITING_TOOLS_CONTEXT_MENU_ITEMS)
+            bool editorHasText = [&] {
+                if (auto range = frame->editor().contextRangeForCandidateRequest())
+                    return !plainText(*range).isEmpty();
+
+                return false;
+            }();
+
+            if (editorHasText) {
+                ContextMenuItem proofreadItem(ContextMenuItemType::Action, ContextMenuItemTagProofread, contextMenuItemTagProofread());
+                appendItem(proofreadItem, m_contextMenu.get());
+                ContextMenuItem rewriteItem(ContextMenuItemType::Action, ContextMenuItemTagRewrite, contextMenuItemTagRewrite());
+                appendItem(rewriteItem, m_contextMenu.get());
+            }
+            appendItem(*separatorItem(), m_contextMenu.get());
+#endif
 #endif
 
 #if !PLATFORM(GTK)
@@ -1820,6 +1844,9 @@ void ContextMenuController::checkOrEnableIfNeeded(ContextMenuItem& item) const
         case ContextMenuItemTagLookUpImage:
         case ContextMenuItemTagTranslate:
         case ContextMenuItemTagWritingTools:
+        case ContextMenuItemTagProofread:
+        case ContextMenuItemTagRewrite:
+        case ContextMenuItemTagSummarize:
             break;
     }
 

--- a/Source/WebCore/platform/ContextMenuItem.cpp
+++ b/Source/WebCore/platform/ContextMenuItem.cpp
@@ -270,6 +270,9 @@ static bool isValidContextMenuAction(WebCore::ContextMenuAction action)
     case ContextMenuAction::ContextMenuItemTagLookUpImage:
     case ContextMenuAction::ContextMenuItemTagTranslate:
     case ContextMenuAction::ContextMenuItemTagWritingTools:
+    case ContextMenuAction::ContextMenuItemTagProofread:
+    case ContextMenuAction::ContextMenuItemTagRewrite:
+    case ContextMenuAction::ContextMenuItemTagSummarize:
     case ContextMenuAction::ContextMenuItemBaseCustomTag:
     case ContextMenuAction::ContextMenuItemLastCustomTag:
     case ContextMenuAction::ContextMenuItemBaseApplicationTag:

--- a/Source/WebCore/platform/ContextMenuItem.h
+++ b/Source/WebCore/platform/ContextMenuItem.h
@@ -165,7 +165,10 @@ enum ContextMenuAction {
     ContextMenuItemPDFTwoPagesContinuous,
     ContextMenuItemTagShowMediaStats,
     ContextMenuItemTagCopyLinkWithHighlight,
-    ContextMenuItemLastNonCustomTag = ContextMenuItemTagCopyLinkWithHighlight,
+    ContextMenuItemTagProofread,
+    ContextMenuItemTagRewrite,
+    ContextMenuItemTagSummarize,
+    ContextMenuItemLastNonCustomTag = ContextMenuItemTagSummarize,
     ContextMenuItemBaseCustomTag = 5000,
     ContextMenuItemLastCustomTag = 5999,
     ContextMenuItemBaseApplicationTag = 10000

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -506,7 +506,26 @@ String contextMenuItemTagTranslate(const String& selectedString)
 #if ENABLE(WRITING_TOOLS)
 String contextMenuItemTagWritingTools()
 {
+#if ENABLE(TOP_LEVEL_WRITING_TOOLS_CONTEXT_MENU_ITEMS)
+    return WEB_UI_STRING("Show Writing Tools", "Writing Tools context menu item");
+#else
     return WEB_UI_STRING("Writing Tools", "Writing Tools context menu item");
+#endif
+}
+
+String contextMenuItemTagProofread()
+{
+    return WEB_UI_STRING("Proofread", "Proofread context menu item");
+}
+
+String contextMenuItemTagRewrite()
+{
+    return WEB_UI_STRING("Rewrite", "Rewrite context menu item");
+}
+
+String contextMenuItemTagSummarize()
+{
+    return WEB_UI_STRING("Summarize", "Summarize context menu item");
 }
 #endif
 

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -179,6 +179,9 @@ namespace WebCore {
 #endif
 #if ENABLE(WRITING_TOOLS)
     String contextMenuItemTagWritingTools();
+    String contextMenuItemTagProofread();
+    String contextMenuItemTagRewrite();
+    String contextMenuItemTagSummarize();
 #endif
 #if ENABLE(UNIFIED_PDF)
     WEBCORE_EXPORT String contextMenuItemPDFOpenWithDefaultViewer(const String& appName);

--- a/Source/WebKit/Platform/mac/MenuUtilities.mm
+++ b/Source/WebKit/Platform/mac/MenuUtilities.mm
@@ -202,7 +202,13 @@ static NSString *symbolNameForAction(const WebCore::ContextMenuAction action, bo
     case WebCore::ContextMenuItemTagTransformationsMenu:
     case WebCore::ContextMenuItemTagWritingDirectionMenu:
     case WebCore::ContextMenuItemTagWritingTools:
-        return nil;
+        return @"apple.writing.tools";
+    case WebCore::ContextMenuItemTagProofread:
+        return @"text.magnifyingglass";
+    case WebCore::ContextMenuItemTagRewrite:
+        return @"pencil.arrow.trianglehead.clockwise";
+    case WebCore::ContextMenuItemTagSummarize:
+        return @"text.line.3.summary";
     case WebCore::ContextMenuItemPDFAutoSize:
         return @"sparkle.magnifyingglass";
     case WebCore::ContextMenuItemPDFActualSize:

--- a/Source/WebKit/Shared/API/c/WKContextMenuItemTypes.h
+++ b/Source/WebKit/Shared/API/c/WKContextMenuItemTypes.h
@@ -135,6 +135,9 @@ enum {
     kWKContextMenuItemTagCopyCroppedImage,
     kWKContextMenuItemTagWritingTools,
     kWKContextMenuItemTagCopyLinkWithHighlight,
+    kWKContextMenuItemTagProofread,
+    kWKContextMenuItemTagRewrite,
+    kWKContextMenuItemTagSummarize,
     kWKContextMenuItemBaseApplicationTag = 10000
 };
 typedef uint32_t WKContextMenuItemTag;

--- a/Source/WebKit/Shared/API/c/WKSharedAPICast.h
+++ b/Source/WebKit/Shared/API/c/WKSharedAPICast.h
@@ -603,6 +603,12 @@ inline WKContextMenuItemTag toAPI(WebCore::ContextMenuAction action)
         return kWKContextMenuItemTagTranslate;
     case WebCore::ContextMenuItemTagWritingTools:
         return kWKContextMenuItemTagWritingTools;
+    case WebCore::ContextMenuItemTagProofread:
+        return kWKContextMenuItemTagProofread;
+    case WebCore::ContextMenuItemTagRewrite:
+        return kWKContextMenuItemTagRewrite;
+    case WebCore::ContextMenuItemTagSummarize:
+        return kWKContextMenuItemTagSummarize;
     case WebCore::ContextMenuItemTagCopySubject:
         return kWKContextMenuItemTagCopyCroppedImage;
     default:
@@ -823,6 +829,12 @@ inline WebCore::ContextMenuAction toImpl(WKContextMenuItemTag tag)
         return WebCore::ContextMenuItemTagTranslate;
     case kWKContextMenuItemTagWritingTools:
         return WebCore::ContextMenuItemTagWritingTools;
+    case kWKContextMenuItemTagProofread:
+        return WebCore::ContextMenuItemTagProofread;
+    case kWKContextMenuItemTagRewrite:
+        return WebCore::ContextMenuItemTagRewrite;
+    case kWKContextMenuItemTagSummarize:
+        return WebCore::ContextMenuItemTagSummarize;
     case kWKContextMenuItemTagCopyCroppedImage:
         return WebCore::ContextMenuItemTagCopySubject;
     case kWKContextMenuItemTagOpenLinkInThisWindow:

--- a/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm
@@ -60,8 +60,16 @@ NSString * const _WKMenuItemIdentifierShareMenu = @"WKMenuItemIdentifierShareMen
 NSString * const _WKMenuItemIdentifierSpeechMenu = @"WKMenuItemIdentifierSpeechMenu";
 
 NSString * const _WKMenuItemIdentifierTranslate = @"WKMenuItemIdentifierTranslate";
-NSString * const _WKMenuItemIdentifierWritingTools = @"__NSTextViewContextSubmenuIdentifierWritingTools"; // AppKit creates this menu item.
 NSString * const _WKMenuItemIdentifierCopySubject = @"WKMenuItemIdentifierCopySubject";
+
+#if ENABLE(TOP_LEVEL_WRITING_TOOLS_CONTEXT_MENU_ITEMS)
+NSString * const _WKMenuItemIdentifierWritingTools = @"WKMenuItemIdentifierWritingTools";
+#else
+NSString * const _WKMenuItemIdentifierWritingTools = @"__NSTextViewContextSubmenuIdentifierWritingTools"; // AppKit creates this menu item.
+#endif
+NSString * const _WKMenuItemIdentifierProofread = @"WKMenuItemIdentifierProofread";
+NSString * const _WKMenuItemIdentifierRewrite = @"WKMenuItemIdentifierRewrite";
+NSString * const _WKMenuItemIdentifierSummarize = @"WKMenuItemIdentifierSummarize";
 
 NSString * const _WKMenuItemIdentifierSpellingMenu = @"WKMenuItemIdentifierSpellingMenu";
 NSString * const _WKMenuItemIdentifierShowSpellingPanel = @"WKMenuItemIdentifierShowSpellingPanel";

--- a/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h
@@ -61,8 +61,12 @@ WK_EXTERN NSString * const _WKMenuItemIdentifierAddHighlightToCurrentQuickNote W
 WK_EXTERN NSString * const _WKMenuItemIdentifierAddHighlightToNewQuickNote WK_API_AVAILABLE(macos(12.0), ios(15.0));
 
 WK_EXTERN NSString * const _WKMenuItemIdentifierTranslate WK_API_AVAILABLE(macos(12.0), ios(15.0));
-WK_EXTERN NSString * const _WKMenuItemIdentifierWritingTools WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
 WK_EXTERN NSString * const _WKMenuItemIdentifierCopySubject WK_API_AVAILABLE(macos(13.0), ios(16.0));
+
+WK_EXTERN NSString * const _WKMenuItemIdentifierWritingTools WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
+WK_EXTERN NSString * const _WKMenuItemIdentifierProofread WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+WK_EXTERN NSString * const _WKMenuItemIdentifierRewrite WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+WK_EXTERN NSString * const _WKMenuItemIdentifierSummarize WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 WK_EXTERN NSString * const _WKMenuItemIdentifierSpellingMenu WK_API_AVAILABLE(macos(13.0), ios(16.0));
 WK_EXTERN NSString * const _WKMenuItemIdentifierShowSpellingPanel WK_API_AVAILABLE(macos(13.0), ios(16.0));

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10244,6 +10244,15 @@ void WebPageProxy::contextMenuItemSelected(const WebContextMenuItemData& item, c
 #endif
         return;
 
+#if ENABLE(TOP_LEVEL_WRITING_TOOLS_CONTEXT_MENU_ITEMS)
+    case ContextMenuItemTagWritingTools:
+    case ContextMenuItemTagProofread:
+    case ContextMenuItemTagRewrite:
+    case ContextMenuItemTagSummarize:
+        handleContextMenuWritingTools(item);
+        return;
+#endif
+
     default:
         break;
     }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2416,6 +2416,7 @@ public:
 #endif
 #if ENABLE(CONTEXT_MENUS)
     bool canHandleContextMenuWritingTools() const;
+    void handleContextMenuWritingTools(const WebContextMenuItemData&);
     void handleContextMenuWritingTools(WebCore::WritingTools::RequestedTool);
 #endif
 #endif

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -68,6 +68,7 @@
 #import <WebCore/UserAgent.h>
 #import <WebCore/ValidationBubble.h>
 #import <mach-o/dyld.h>
+#import <pal/spi/cocoa/WritingToolsSPI.h>
 #import <pal/spi/mac/NSApplicationSPI.h>
 #import <pal/spi/mac/NSMenuSPI.h>
 #import <wtf/FileHandle.h>
@@ -963,6 +964,29 @@ bool WebPageProxy::shouldEnableWritingToolsRequestedTool(WebCore::WritingTools::
         return editorState.hasPostLayoutData() && !editorState.postLayoutData->paragraphContextForCandidateRequest.isEmpty();
 
     return true;
+}
+
+void WebPageProxy::handleContextMenuWritingTools(const WebContextMenuItemData& item)
+{
+    WTRequestedTool tool = WTRequestedToolIndex;
+    switch (item.action()) {
+    case ContextMenuItemTagWritingTools:
+        break;
+    case ContextMenuItemTagProofread:
+        tool = WTRequestedToolProofread;
+        break;
+    case ContextMenuItemTagRewrite:
+        tool = WTRequestedToolRewrite;
+        break;
+    case ContextMenuItemTagSummarize:
+        tool = WTRequestedToolTransformSummary;
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+        break;
+    }
+
+    handleContextMenuWritingTools(convertToWebRequestedTool(tool));
 }
 
 void WebPageProxy::handleContextMenuWritingTools(WebCore::WritingTools::RequestedTool tool)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -2676,12 +2676,17 @@ TEST(WritingTools, APIWithBehaviorNone)
     EXPECT_EQ([webView writingToolsBehaviorForTesting], CocoaWritingToolsBehaviorNone);
 
 #if PLATFORM(MAC)
-    [webView mouseDownAtPoint:NSMakePoint(10, 10) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
-    [webView mouseUpAtPoint:NSMakePoint(10, 10) withFlags:0 eventType:NSEventTypeRightMouseUp];
+    [webView rightClickAtPoint:NSMakePoint(10, [webView frame].size.height - 10)];
     TestWebKitAPI::Util::run(&gotProposedMenu);
 
-    NSMenuItem *writingToolsMenuItem = [proposedMenu itemWithIdentifier:_WKMenuItemIdentifierWritingTools];
-    EXPECT_NULL(writingToolsMenuItem);
+    RetainPtr writingToolsMenuItem = [proposedMenu itemWithIdentifier:_WKMenuItemIdentifierWritingTools];
+    EXPECT_NULL(writingToolsMenuItem.get());
+
+#if ENABLE(TOP_LEVEL_WRITING_TOOLS_CONTEXT_MENU_ITEMS)
+    EXPECT_NULL([proposedMenu itemWithIdentifier:_WKMenuItemIdentifierSummarize]);
+    EXPECT_NULL([proposedMenu itemWithIdentifier:_WKMenuItemIdentifierProofread]);
+    EXPECT_NULL([proposedMenu itemWithIdentifier:_WKMenuItemIdentifierRewrite]);
+#endif
 #endif
 }
 
@@ -2721,12 +2726,17 @@ TEST(WritingTools, APIWithBehaviorDefault)
     EXPECT_EQ([webView writingToolsBehaviorForTesting], CocoaWritingToolsBehaviorLimited);
 
 #if PLATFORM(MAC)
-    [webView mouseDownAtPoint:NSMakePoint(10, 10) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
-    [webView mouseUpAtPoint:NSMakePoint(10, 10) withFlags:0 eventType:NSEventTypeRightMouseUp];
+    [webView rightClickAtPoint:NSMakePoint(10, [webView frame].size.height - 10)];
     TestWebKitAPI::Util::run(&gotProposedMenu);
 
-    NSMenuItem *writingToolsMenuItem = [proposedMenu itemWithIdentifier:_WKMenuItemIdentifierWritingTools];
-    EXPECT_NOT_NULL(writingToolsMenuItem);
+    RetainPtr writingToolsMenuItem = [proposedMenu itemWithIdentifier:_WKMenuItemIdentifierWritingTools];
+    EXPECT_NOT_NULL(writingToolsMenuItem.get());
+
+#if ENABLE(TOP_LEVEL_WRITING_TOOLS_CONTEXT_MENU_ITEMS)
+    EXPECT_NULL([proposedMenu itemWithIdentifier:_WKMenuItemIdentifierSummarize]);
+    EXPECT_NOT_NULL([proposedMenu itemWithIdentifier:_WKMenuItemIdentifierProofread]);
+    EXPECT_NOT_NULL([proposedMenu itemWithIdentifier:_WKMenuItemIdentifierRewrite]);
+#endif
 #endif
 }
 
@@ -2766,12 +2776,17 @@ TEST(WritingTools, APIWithBehaviorComplete)
     EXPECT_EQ([webView writingToolsBehaviorForTesting], CocoaWritingToolsBehaviorComplete);
 
 #if PLATFORM(MAC)
-    [webView mouseDownAtPoint:NSMakePoint(10, 10) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
-    [webView mouseUpAtPoint:NSMakePoint(10, 10) withFlags:0 eventType:NSEventTypeRightMouseUp];
+    [webView rightClickAtPoint:NSMakePoint(10, [webView frame].size.height - 10)];
     TestWebKitAPI::Util::run(&gotProposedMenu);
 
     NSMenuItem *writingToolsMenuItem = [proposedMenu itemWithIdentifier:_WKMenuItemIdentifierWritingTools];
     EXPECT_NOT_NULL(writingToolsMenuItem);
+
+#if ENABLE(TOP_LEVEL_WRITING_TOOLS_CONTEXT_MENU_ITEMS)
+    EXPECT_NULL([proposedMenu itemWithIdentifier:_WKMenuItemIdentifierSummarize]);
+    EXPECT_NOT_NULL([proposedMenu itemWithIdentifier:_WKMenuItemIdentifierProofread]);
+    EXPECT_NOT_NULL([proposedMenu itemWithIdentifier:_WKMenuItemIdentifierRewrite]);
+#endif
 #endif
 }
 
@@ -3298,13 +3313,18 @@ TEST(WritingTools, ContextMenuItemsNonEditable)
 
     [webView focusDocumentBodyAndSelectAll];
 
-    [webView mouseDownAtPoint:NSMakePoint(10, 10) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
-    [webView mouseUpAtPoint:NSMakePoint(10, 10) withFlags:0 eventType:NSEventTypeRightMouseUp];
+    [webView rightClickAtPoint:NSMakePoint(10, [webView frame].size.height - 10)];
     TestWebKitAPI::Util::run(&gotProposedMenu);
 
     RetainPtr writingToolsMenuItem = [proposedMenu itemWithIdentifier:_WKMenuItemIdentifierWritingTools];
     EXPECT_NOT_NULL(writingToolsMenuItem.get());
 
+#if ENABLE(TOP_LEVEL_WRITING_TOOLS_CONTEXT_MENU_ITEMS)
+    EXPECT_NULL([writingToolsMenuItem submenu]);
+    EXPECT_NOT_NULL([proposedMenu itemWithIdentifier:_WKMenuItemIdentifierSummarize]);
+    EXPECT_NULL([proposedMenu itemWithIdentifier:_WKMenuItemIdentifierProofread]);
+    EXPECT_NULL([proposedMenu itemWithIdentifier:_WKMenuItemIdentifierRewrite]);
+#else
     RetainPtr<NSArray<NSMenuItem *>> items = [writingToolsMenuItem submenu].itemArray;
     EXPECT_GT([items count], 0U);
 
@@ -3314,6 +3334,7 @@ TEST(WritingTools, ContextMenuItemsNonEditable)
 
         EXPECT_EQ(subItem.enabled, subItem.tag != WTRequestedToolCompose);
     }
+#endif
 }
 
 TEST(WritingTools, ContextMenuItemsEditable)
@@ -3335,13 +3356,18 @@ TEST(WritingTools, ContextMenuItemsEditable)
 
     [webView focusDocumentBodyAndSelectAll];
 
-    [webView mouseDownAtPoint:NSMakePoint(10, 10) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
-    [webView mouseUpAtPoint:NSMakePoint(10, 10) withFlags:0 eventType:NSEventTypeRightMouseUp];
+    [webView rightClickAtPoint:NSMakePoint(10, [webView frame].size.height - 10)];
     TestWebKitAPI::Util::run(&gotProposedMenu);
 
     RetainPtr writingToolsMenuItem = [proposedMenu itemWithIdentifier:_WKMenuItemIdentifierWritingTools];
     EXPECT_NOT_NULL(writingToolsMenuItem.get());
 
+#if ENABLE(TOP_LEVEL_WRITING_TOOLS_CONTEXT_MENU_ITEMS)
+    EXPECT_NULL([writingToolsMenuItem submenu]);
+    EXPECT_NULL([proposedMenu itemWithIdentifier:_WKMenuItemIdentifierSummarize]);
+    EXPECT_NOT_NULL([proposedMenu itemWithIdentifier:_WKMenuItemIdentifierProofread]);
+    EXPECT_NOT_NULL([proposedMenu itemWithIdentifier:_WKMenuItemIdentifierRewrite]);
+#else
     RetainPtr<NSArray<NSMenuItem *>> items = [writingToolsMenuItem submenu].itemArray;
     EXPECT_GT([items count], 0U);
 
@@ -3351,6 +3377,7 @@ TEST(WritingTools, ContextMenuItemsEditable)
 
         EXPECT_TRUE(subItem.enabled);
     }
+#endif
 }
 
 TEST(WritingTools, ContextMenuItemsEditableEmpty)
@@ -3372,13 +3399,18 @@ TEST(WritingTools, ContextMenuItemsEditableEmpty)
 
     [webView focusDocumentBodyAndSelectAll];
 
-    [webView mouseDownAtPoint:NSMakePoint(10, 10) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
-    [webView mouseUpAtPoint:NSMakePoint(10, 10) withFlags:0 eventType:NSEventTypeRightMouseUp];
+    [webView rightClickAtPoint:NSMakePoint(10, [webView frame].size.height - 10)];
     TestWebKitAPI::Util::run(&gotProposedMenu);
 
     RetainPtr writingToolsMenuItem = [proposedMenu itemWithIdentifier:_WKMenuItemIdentifierWritingTools];
     EXPECT_NOT_NULL(writingToolsMenuItem.get());
 
+#if ENABLE(TOP_LEVEL_WRITING_TOOLS_CONTEXT_MENU_ITEMS)
+    EXPECT_NULL([writingToolsMenuItem submenu]);
+    EXPECT_NULL([proposedMenu itemWithIdentifier:_WKMenuItemIdentifierSummarize]);
+    EXPECT_NULL([proposedMenu itemWithIdentifier:_WKMenuItemIdentifierProofread]);
+    EXPECT_NULL([proposedMenu itemWithIdentifier:_WKMenuItemIdentifierRewrite]);
+#else
     RetainPtr<NSArray<NSMenuItem *>> items = [writingToolsMenuItem submenu].itemArray;
     EXPECT_GT([items count], 0U);
 
@@ -3388,6 +3420,7 @@ TEST(WritingTools, ContextMenuItemsEditableEmpty)
 
         EXPECT_EQ(subItem.enabled, subItem.tag == WTRequestedToolIndex || subItem.tag == WTRequestedToolCompose);
     }
+#endif
 }
 
 TEST(WritingTools, AppMenuNonEditable)


### PR DESCRIPTION
#### e51baa87492f4d1d2fdefc0b7ca765772252b671
<pre>
[macOS][Writing Tools] Add support for top-level context menu items
<a href="https://bugs.webkit.org/show_bug.cgi?id=292546">https://bugs.webkit.org/show_bug.cgi?id=292546</a>
<a href="https://rdar.apple.com/149953289">rdar://149953289</a>

Reviewed by Abrar Rahman Protyasha.

Add &quot;Summarize&quot;, &quot;Rewrite&quot;, and &quot;Proofread&quot; context menu items. Additionally,
the &quot;Writing Tools&quot; menu item is renamed to &quot;Show Writing Tools&quot;, and no longer
has a submenu.

Update tests and remove unnecessary staging code.

* Source/WebCore/PAL/pal/spi/mac/NSMenuSPI.h:

Remove staging code, and an `#elif` branch that is never compiled since its
condition is the same as the `#if`.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::contextMenuItemSelected):
(WebCore::ContextMenuController::populate):

&quot;Summarize&quot; is added for non-editable text. &quot;Rewrite&quot; and &quot;Proofread&quot; are added
for non-empty editable text.

(WebCore::ContextMenuController::checkOrEnableIfNeeded const):
* Source/WebCore/platform/ContextMenuItem.cpp:
(WebCore::isValidContextMenuAction):
* Source/WebCore/platform/ContextMenuItem.h:
* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::contextMenuItemTagWritingTools):
(WebCore::contextMenuItemTagProofread):
(WebCore::contextMenuItemTagRewrite):
(WebCore::contextMenuItemTagSummarize):
* Source/WebCore/platform/LocalizedStrings.h:
* Source/WebKit/Platform/mac/MenuUtilities.mm:
(WebKit::symbolNameForAction):
* Source/WebKit/Shared/API/c/WKContextMenuItemTypes.h:
* Source/WebKit/Shared/API/c/WKSharedAPICast.h:
(WebKit::toAPI):
(WebKit::toImpl):
* Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::contextMenuItemSelected):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::menuItemIdentifier):
(WebKit::WebContextMenuProxyMac::getContextMenuFromItems):
(WebKit::WebContextMenuProxyMac::getContextMenuItem):

Remove staging code.

* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::handleContextMenuWritingTools):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:

Update tests for the new behavior. Additionally, use a helper method to perform
the right click, and update the coordinates to right click over the element.

(TEST(WritingTools, APIWithBehaviorNone)):
(TEST(WritingTools, APIWithBehaviorDefault)):
(TEST(WritingTools, APIWithBehaviorComplete)):
(TEST(WritingTools, ContextMenuItemsNonEditable)):
(TEST(WritingTools, ContextMenuItemsEditable)):
(TEST(WritingTools, ContextMenuItemsEditableEmpty)):

Canonical link: <a href="https://commits.webkit.org/294541@main">https://commits.webkit.org/294541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9fee296ffae7a2d593567de9a5feaaf14362e95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102147 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107306 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52783 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104186 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30322 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77740 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34736 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17120 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92210 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58075 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16948 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10235 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52141 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86789 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109682 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29279 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21586 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86710 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29641 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88414 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86293 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31103 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8815 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23521 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16610 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29207 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34502 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29018 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32341 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30577 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->