### PR TITLE
Update WTF::roundUpToPowerOfTwo() to leverage C++20's std::bit_ceil

### DIFF
--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -214,7 +214,7 @@ private:
 
         bool malloc(size_t size, ptrdiff_t& result)
         {
-            size_t alignment = std::min(alignof(std::max_align_t), static_cast<size_t>(WTF::roundUpToPowerOfTwo(size)));
+            size_t alignment = std::min(alignof(std::max_align_t), static_cast<size_t>(roundUpToPowerOfTwo(size)));
             ptrdiff_t offset = roundUpToMultipleOf(alignment, m_offset);
             size = roundUpToMultipleOf(alignment, size);
             if (static_cast<size_t>(offset + size) > capacity())

--- a/Source/JavaScriptCore/runtime/PropertyTable.h
+++ b/Source/JavaScriptCore/runtime/PropertyTable.h
@@ -64,22 +64,6 @@ inline constexpr bool isPowerOf2(unsigned v)
     return hasOneBitSet(v);
 }
 
-inline constexpr unsigned nextPowerOf2(unsigned v)
-{
-    // Taken from http://www.cs.utk.edu/~vose/c-stuff/bithacks.html
-    // Devised by Sean Anderson, Sepember 14, 2001
-
-    v--;
-    v |= v >> 1;
-    v |= v >> 2;
-    v |= v >> 4;
-    v |= v >> 8;
-    v |= v >> 16;
-    v++;
-
-    return v;
-}
-
 // compact <-> non-compact PropertyTable
 // We need to maintain two things, one is PropertyOffset and one is unsigned index in index buffer of PropertyTable.
 // But both are typically small. It is possible that we can get optimized table if both are fit in uint8_t, that's
@@ -654,7 +638,7 @@ inline unsigned PropertyTable::sizeForCapacity(unsigned capacity)
 {
     if (capacity < MinimumTableSize / 2)
         return MinimumTableSize;
-    return nextPowerOf2(capacity + 1) * 2;
+    return roundUpToPowerOfTwo(capacity + 1) * 2;
 }
 
 inline bool PropertyTable::canInsert(const ValueType& entry)

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -590,7 +590,7 @@ public:
 
         ASSERT(outOfLineSize > initialOutOfLineCapacity);
         static_assert(outOfLineGrowthFactor == 2);
-        return WTF::roundUpToPowerOfTwo(outOfLineSize);
+        return roundUpToPowerOfTwo(outOfLineSize);
     }
     
     static unsigned outOfLineSize(PropertyOffset maxOffset)

--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -64,7 +64,7 @@ template<typename Visitor> constexpr decltype(auto) Table::visitDerived(Visitor&
 
 uint32_t Table::allocatedLength(uint32_t length)
 {
-    return WTF::roundUpToPowerOfTwo(length);
+    return roundUpToPowerOfTwo(length);
 }
 
 void Table::setLength(uint32_t length)

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -2319,7 +2319,7 @@ class YarrGenerator final : public YarrJITInfo {
                     ignoredCharsMask |= charMask << shiftAmount;
             }
 
-            auto numRealCharsToCheck = WTF::roundUpToPowerOfTwo(lastCharInLoad - firstCharInLoad + 1);
+            auto numRealCharsToCheck = roundUpToPowerOfTwo(lastCharInLoad - firstCharInLoad + 1);
 
 #if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
             if (m_useFirstNonBMPCharacterOptimization && numRealCharsToCheck > 1) {

--- a/Source/WTF/wtf/HashTable.h
+++ b/Source/WTF/wtf/HashTable.h
@@ -1222,7 +1222,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, ShouldValidateKey shouldValidateKey, typename Malloc>
     constexpr unsigned HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, shouldValidateKey, Malloc>::computeBestTableSize(unsigned keyCount)
     {
-        unsigned bestTableSize = WTF::roundUpToPowerOfTwo(keyCount);
+        unsigned bestTableSize = roundUpToPowerOfTwo(keyCount);
 
         if (HashTableSizePolicy::shouldExpand(keyCount, bestTableSize))
             bestTableSize *= 2;

--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <algorithm>
+#include <bit>
 #include <climits>
 #include <cmath>
 #include <float.h>
@@ -406,17 +407,9 @@ inline void doubleToInteger(double d, unsigned long long& value)
 
 namespace WTF {
 
-// From http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
-constexpr uint32_t roundUpToPowerOfTwo(uint32_t v)
+constexpr uint32_t roundUpToPowerOfTwo(auto v)
 {
-    v--;
-    v |= v >> 1;
-    v |= v >> 2;
-    v |= v >> 4;
-    v |= v >> 8;
-    v |= v >> 16;
-    v++;
-    return v;
+    return std::bit_ceil(v);
 }
 
 constexpr unsigned maskForSize(unsigned size)
@@ -788,5 +781,6 @@ using WTF::getMSBSet;
 using WTF::isNaNConstExpr;
 using WTF::fabsConstExpr;
 using WTF::reverseBits32;
+using WTF::roundUpToPowerOfTwo;
 using WTF::isIdentical;
 using WTF::isRepresentableAs;

--- a/Source/WTF/wtf/RobinHoodHashTable.h
+++ b/Source/WTF/wtf/RobinHoodHashTable.h
@@ -726,7 +726,7 @@ void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits,
 template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
 constexpr unsigned RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::computeBestTableSize(unsigned keyCount)
 {
-    unsigned bestTableSize = WTF::roundUpToPowerOfTwo(keyCount);
+    unsigned bestTableSize = roundUpToPowerOfTwo(keyCount);
 
     if (shouldExpand(keyCount, bestTableSize))
         bestTableSize *= 2;

--- a/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
+++ b/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
@@ -311,7 +311,7 @@ void CARingBuffer::fetchInternal(AudioBufferList* list, size_t nFrames, uint64_t
 
 std::unique_ptr<InProcessCARingBuffer> InProcessCARingBuffer::allocate(const WebCore::CAAudioStreamDescription& format, size_t frameCount)
 {
-    frameCount = WTF::roundUpToPowerOfTwo(frameCount);
+    frameCount = roundUpToPowerOfTwo(frameCount);
     auto bytesPerFrame = format.bytesPerFrame();
     auto numChannelStreams = format.numberOfChannelStreams();
 

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -145,7 +145,7 @@ void MediaSessionManagerCocoa::updateSessionState()
     else if (captureCount || audioMediaStreamTrackCount) {
         // In case of audio capture or audio MediaStreamTrack playing, we want to grab 20 ms chunks to limit the latency so that it is not noticeable by users
         // while having a large enough buffer so that the audio rendering remains stable, hence a computation based on sample rate.
-        bufferSize = WTF::roundUpToPowerOfTwo(sharedSession->sampleRate() / 50);
+        bufferSize = roundUpToPowerOfTwo<size_t>(sharedSession->sampleRate() / 50);
     } else if (m_supportedAudioHardwareBufferSizes && DeprecatedGlobalSettings::lowPowerVideoAudioBufferSizeEnabled())
         bufferSize = m_supportedAudioHardwareBufferSizes.nearest(kLowPowerVideoBufferSize);
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -38,6 +38,7 @@
 #include "TextureMapperFlags.h"
 #include "TextureMapperShaderProgram.h"
 #include <wtf/HashMap.h>
+#include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -54,15 +55,6 @@
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TextureMapper);
-
-static size_t nextPowerOf2(size_t n)
-{
-    if (!n)
-        return 1;
-
-    const int totalBits = static_cast<int>(sizeof(size_t) * CHAR_BIT);
-    return static_cast<size_t>(1) << (totalBits - std::countl_zero(n - 1));
-}
 
 class TextureMapperGLData {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(TextureMapperGLData);
@@ -1532,7 +1524,7 @@ void TextureMapper::drawTextureExternalOES(GLuint texture, OptionSet<TextureMapp
 
 Ref<TextureMapperGPUBuffer> TextureMapper::acquireBufferFromPool(size_t size, TextureMapperGPUBuffer::Type type)
 {
-    size_t ceil = nextPowerOf2(size);
+    size_t ceil = roundUpToPowerOfTwo(size);
     size_t floor = ceil >> 1; // half of ceil
     size_t mid = floor + (floor >> 1); // (1.5 times floor)
     size_t requestSize = (size <= mid) ? mid : ceil;

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
@@ -217,7 +217,7 @@ void MockRealtimeAudioSourceGStreamer::reconfigure()
     auto rate = sampleRate();
     size_t sampleCount = 2 * rate;
 
-    m_maximiumFrameCount = WTF::roundUpToPowerOfTwo(renderInterval().seconds() * sampleRate());
+    m_maximiumFrameCount = roundUpToPowerOfTwo<uint32_t>(renderInterval().seconds() * sampleRate());
     gst_audio_info_set_format(&info, GST_AUDIO_FORMAT_F32LE, rate, 1, nullptr);
     m_streamFormat = GStreamerAudioStreamDescription(info);
     m_caps = adoptGRef(gst_audio_info_to_caps(&info));

--- a/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
@@ -285,7 +285,7 @@ void MockAudioSharedInternalUnit::reconfigure()
     auto rate = sampleRate();
     ASSERT(rate);
 
-    m_maximiumFrameCount = WTF::roundUpToPowerOfTwo(renderInterval().seconds() * rate * 2);
+    m_maximiumFrameCount = roundUpToPowerOfTwo<size_t>(renderInterval().seconds() * rate * 2);
     ASSERT(m_maximiumFrameCount);
 
     m_audioBufferList = makeUnique<WebAudioBufferList>(m_streamFormat, m_maximiumFrameCount);

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -400,7 +400,7 @@ template <typename T>
 static T mergeAlignment(T previous, T next)
 {
     // https://gpuweb.github.io/gpuweb/#limit-class-alignment
-    return std::min(WTF::roundUpToPowerOfTwo(previous), WTF::roundUpToPowerOfTwo(next));
+    return std::min(roundUpToPowerOfTwo(previous), roundUpToPowerOfTwo(next));
 };
 
 static WGPULimits mergeLimits(const WGPULimits& previous, const WGPULimits& next)

--- a/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp
+++ b/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp
@@ -46,7 +46,7 @@ SharedCARingBufferBase::SharedCARingBufferBase(size_t bytesPerFrame, size_t fram
 
 std::unique_ptr<ConsumerSharedCARingBuffer> ConsumerSharedCARingBuffer::map(uint32_t bytesPerFrame, uint32_t numChannelStreams, ConsumerSharedCARingBuffer::Handle&& handle)
 {
-    auto frameCount = WTF::roundUpToPowerOfTwo(handle.frameCount);
+    auto frameCount = roundUpToPowerOfTwo(handle.frameCount);
 
     // Validate the parameters as they may be coming from an untrusted process.
     auto expectedStorageSize = computeSizeForBuffers(bytesPerFrame, frameCount, numChannelStreams) + sizeof(TimeBoundsBuffer);
@@ -71,7 +71,7 @@ std::unique_ptr<ConsumerSharedCARingBuffer> ConsumerSharedCARingBuffer::map(uint
 
 std::optional<ProducerSharedCARingBuffer::Pair> ProducerSharedCARingBuffer::allocate(const WebCore::CAAudioStreamDescription& format, size_t frameCount)
 {
-    frameCount = WTF::roundUpToPowerOfTwo(frameCount);
+    frameCount = roundUpToPowerOfTwo(frameCount);
     auto bytesPerFrame = format.bytesPerFrame();
     auto numChannelStreams = format.numberOfChannelStreams();
 

--- a/Source/WebKit/Shared/SharedStringHashStore.cpp
+++ b/Source/WebKit/Shared/SharedStringHashStore.cpp
@@ -28,6 +28,7 @@
 
 #include <algorithm>
 #include <ranges>
+#include <wtf/MathExtras.h>
 #include <wtf/PageBlock.h>
 #include <wtf/StdLibExtras.h>
 
@@ -35,28 +36,12 @@ namespace WebKit {
 
 using namespace WebCore;
 
-const unsigned sharedStringHashTableMaxLoad = 2;
-
-static unsigned nextPowerOf2(unsigned v)
-{
-    // Taken from http://www.cs.utk.edu/~vose/c-stuff/bithacks.html
-    // Devised by Sean Anderson, September 14, 2001
-
-    v--;
-    v |= v >> 1;
-    v |= v >> 2;
-    v |= v >> 4;
-    v |= v >> 8;
-    v |= v >> 16;
-    v++;
-
-    return v;
-}
+constexpr unsigned sharedStringHashTableMaxLoad = 2;
 
 static unsigned tableLengthForKeyCount(unsigned keyCount)
 {
     // We want the table to be at least half empty.
-    unsigned tableLength = nextPowerOf2(keyCount * sharedStringHashTableMaxLoad);
+    unsigned tableLength = roundUpToPowerOfTwo(keyCount * sharedStringHashTableMaxLoad);
 
     // Ensure that the table length is at least the size of a page.
     size_t minimumTableLength = pageSize() / sizeof(SharedStringHash);

--- a/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
@@ -466,9 +466,10 @@ TEST(WTF, clampInfinityToInteger)
 
 TEST(WTF, roundUpToPowerOfTwo)
 {
-    EXPECT_EQ(WTF::roundUpToPowerOfTwo(UINT32_MAX), 0U);
-    EXPECT_EQ(WTF::roundUpToPowerOfTwo(1U << 31), (1U << 31));
-    EXPECT_EQ(WTF::roundUpToPowerOfTwo((1U << 31) + 1), 0U);
+    EXPECT_EQ(roundUpToPowerOfTwo(1U), 1U);
+    EXPECT_EQ(roundUpToPowerOfTwo(4U), 4U);
+    EXPECT_EQ(roundUpToPowerOfTwo(120U), 128U);
+    EXPECT_EQ(roundUpToPowerOfTwo(1U << 31), (1U << 31));
 }
 
 TEST(WTF, clz)

--- a/Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashSet.cpp
@@ -52,7 +52,7 @@ struct RobinHoodHash : public DefaultHash<T> {
 
 static constexpr unsigned capacityForSize(unsigned size)
 {
-    unsigned capacity = WTF::roundUpToPowerOfTwo(size);
+    unsigned capacity = roundUpToPowerOfTwo(size);
     if (size * 100 >= capacity * 95)
         return capacity * 2;
     return capacity;


### PR DESCRIPTION
#### bd713cc1114e26f33b5b6e137c156dac8b8fceb7
<pre>
Update WTF::roundUpToPowerOfTwo() to leverage C++20&apos;s std::bit_ceil
<a href="https://bugs.webkit.org/show_bug.cgi?id=292551">https://bugs.webkit.org/show_bug.cgi?id=292551</a>

Reviewed by Ryosuke Niwa.

* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::Encoder::Page::malloc):
* Source/JavaScriptCore/runtime/PropertyTable.h:
(JSC::PropertyTable::sizeForCapacity):
(JSC::nextPowerOf2): Deleted.
* Source/JavaScriptCore/runtime/Structure.h:
(JSC::Structure::outOfLineCapacity):
* Source/JavaScriptCore/wasm/WasmTable.cpp:
(JSC::Wasm::Table::allocatedLength):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/WTF/wtf/HashTable.h:
(WTF::Malloc&gt;::computeBestTableSize):
* Source/WTF/wtf/MathExtras.h:
(WTF::roundUpToPowerOfTwo):
* Source/WTF/wtf/RobinHoodHashTable.h:
(WTF::Malloc&gt;::computeBestTableSize):
* Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp:
(WebCore::InProcessCARingBuffer::allocate):
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::updateSessionState):
* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
(WebCore::TextureMapper::acquireBufferFromPool):
(WebCore::nextPowerOf2): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp:
(WebCore::MockRealtimeAudioSourceGStreamer::reconfigure):
* Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm:
(WebCore::MockAudioSharedInternalUnit::reconfigure):
* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::mergeAlignment):
* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp:
(WebKit::ConsumerSharedCARingBuffer::map):
(WebKit::ProducerSharedCARingBuffer::allocate):
* Source/WebKit/Shared/SharedStringHashStore.cpp:
(WebKit::tableLengthForKeyCount):
(WebKit::nextPowerOf2): Deleted.
* Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp:
(TestWebKitAPI::TEST(WTF, roundUpToPowerOfTwo)):
* Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashSet.cpp:
(TestWebKitAPI::capacityForSize):

Canonical link: <a href="https://commits.webkit.org/294533@main">https://commits.webkit.org/294533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e89f142554003b57c7f4e0fb3289feaa3b566d5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12181 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107357 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52834 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22174 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30373 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/77775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/34765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92257 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/58110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16993 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10284 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52192 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/94869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/86828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10356 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109733 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100807 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29330 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21623 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29693 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88460 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/86343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21960 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31143 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8860 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/23572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29258 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34553 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124433 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29069 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34555 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32392 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30628 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->