### PR TITLE
Improving Decoding Capability accuracy on Media Capability API

### DIFF
--- a/LayoutTests/webrtc/media-capabilities-webrtc-expected.txt
+++ b/LayoutTests/webrtc/media-capabilities-webrtc-expected.txt
@@ -1,0 +1,4 @@
+
+PASS HEVC baseline with HDR is not supported
+PASS VP9 profile 3 is not supported
+

--- a/LayoutTests/webrtc/media-capabilities-webrtc.html
+++ b/LayoutTests/webrtc/media-capabilities-webrtc.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <script>
+async function validateDecodingCapabilities(test, videoConfiguration)
+{
+    const results = await navigator.mediaCapabilities.decodingInfo({type: 'webrtc', video: videoConfiguration });
+    assert_not_equals(results.configuration, undefined, "decoder MC configuration");
+    return results.supported && results.powerEfficient;
+}
+
+promise_test(async (test) => {
+    const videoConfiguration = { contentType: 'video/h265', hdrMetadataType: "smpteSt2094-10", width: 800, height: 600, bitrate: 3000, framerate: 24 };
+    assert_false(await validateDecodingCapabilities(test, videoConfiguration), "decoder MC not supported");
+}, "HEVC baseline with HDR is not supported");
+
+promise_test(async (test) => {
+    const videoConfiguration = { contentType: 'video/vp9;profile-id=3', width: 800, height: 600, bitrate: 3000, framerate: 24 };
+    assert_false(await validateDecodingCapabilities(test, videoConfiguration), "decoder MC not supported");
+}, "VP9 profile 3 is not supported");
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/platform/graphics/AV1Utilities.cpp
+++ b/Source/WebCore/platform/graphics/AV1Utilities.cpp
@@ -180,15 +180,6 @@ template<> bool isValidEnum<WebCore::AV1ConfigurationMatrixCoefficients>(std::un
 
 namespace WebCore {
 
-template<typename E>
-std::optional<E> parseEnumFromStringView(StringView stringView)
-{
-    auto value = parseInteger<std::underlying_type_t<E>>(stringView);
-    if (!value || !isValidEnum<E>(*value))
-        return std::nullopt;
-    return static_cast<E>(*value);
-}
-
 std::optional<AV1CodecConfigurationRecord> parseAV1CodecParameters(StringView codecView)
 {
     // Ref: https://aomediacodec.github.io/av1-isobmff/#codecsparam

--- a/Source/WebCore/platform/graphics/AV1Utilities.h
+++ b/Source/WebCore/platform/graphics/AV1Utilities.h
@@ -177,4 +177,13 @@ WEBCORE_EXPORT bool validateAV1PerLevelConstraints(const AV1CodecConfigurationRe
 
 std::optional<AV1CodecConfigurationRecord> parseAV1DecoderConfigurationRecord(const SharedBuffer&);
 
+template<typename E>
+std::optional<E> parseEnumFromStringView(StringView stringView)
+{
+    auto value = parseInteger<std::underlying_type_t<E>>(stringView);
+    if (!value || !isValidEnum<E>(*value))
+        return std::nullopt;
+    return static_cast<E>(*value);
+}
+
 }

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -1178,9 +1178,10 @@ Vector<RTCRtpCapabilities::HeaderExtensionCapability> GStreamerRegistryScanner::
 
 GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::isRtpPacketizerSupported(const String& encoding)
 {
-    static UncheckedKeyHashMap<String, ASCIILiteral> mapping = { { "h264"_s, "video/x-h264"_s }, { "vp8"_s, "video/x-vp8"_s },
-        { "vp9"_s, "video/x-vp9"_s }, { "av1"_s, "video/x-av1"_s }, { "h265"_s, "video/x-h265"_s }, { "opus"_s, "audio/x-opus"_s },
-        { "g722"_s, "audio/G722"_s }, { "pcma"_s, "audio/x-alaw"_s }, { "pcmu"_s, "audio/x-mulaw"_s } };
+    static UncheckedKeyHashMap<String, ASCIILiteral> mapping = {
+        { "h264"_s, "video/x-h264"_s }, { "vp8"_s, "video/x-vp8"_s }, { "vp9"_s, "video/x-vp9"_s }, { "av1"_s, "video/x-av1"_s }, { "h265"_s, "video/x-h265"_s },
+        { "avc1"_s, "video/x-h264"_s }, { "vp08"_s, "video/x-vp8"_s }, { "vp09"_s, "video/x-vp9"_s }, { "av01"_s, "video/x-av1"_s }, { "hvc1"_s, "video/x-h265"_s },
+        { "opus"_s, "audio/x-opus"_s }, { "g722"_s, "audio/G722"_s }, { "pcma"_s, "audio/x-alaw"_s }, { "pcmu"_s, "audio/x-mulaw"_s } };
     auto gstCapsName = mapping.getOptional(encoding);
     if (!gstCapsName) {
         GST_WARNING("Unhandled RTP encoding-name: %s", encoding.ascii().data());

--- a/Source/WebCore/platform/mediastream/WebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/WebRTCProvider.cpp
@@ -26,15 +26,20 @@
 #include "config.h"
 #include "WebRTCProvider.h"
 
+#include "AV1Utilities.h"
 #include "ContentType.h"
+#include "HEVCUtilities.h"
 #include "MediaCapabilitiesDecodingInfo.h"
 #include "MediaCapabilitiesEncodingInfo.h"
 #include "MediaDecodingConfiguration.h"
 #include "MediaEncodingConfiguration.h"
+#include "MediaEngineConfigurationFactory.h"
+#include "VP9Utilities.h"
 
 #include <wtf/Function.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/MakeString.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
 namespace WebCore {
@@ -198,6 +203,131 @@ bool WebRTCProvider::isH264EncoderSmooth(const VideoConfiguration&)
     return true;
 }
 
+static String contentTypeFromRTPVideoMimeType(const String& mimeType)
+{
+    ContentType contentType { mimeType };
+    auto containerType = contentType.containerType();
+    if (equalLettersIgnoringASCIICase(containerType, "video/h264"_s)) {
+        // https://datatracker.ietf.org/doc/html/rfc6184#section-8.1
+        auto profileLevelId = contentType.parameter("profile-level-id"_s);
+        if (profileLevelId.isEmpty())
+            profileLevelId = "42001f"_s;
+        return makeString("video/mp4;codecs=avc1."_s, profileLevelId);
+    }
+
+    if (equalLettersIgnoringASCIICase(containerType, "video/h265"_s)) {
+        // https://datatracker.ietf.org/doc/html/rfc7798#section-7.1
+        HEVCParameters parameters;
+        auto profileSpace = contentType.parameter("profile-space"_s);
+        if (!profileSpace.isEmpty()) {
+            auto result = parseInteger<uint16_t>(profileSpace);
+            if (!result || result > 3)
+                return { };
+            parameters.generalProfileSpace = *result;
+        }
+
+        auto profileId = contentType.parameter("profile-id"_s);
+        if (!profileId.isEmpty()) {
+            auto result = parseInteger<uint16_t>(profileId);
+            if (!result)
+                return { };
+            parameters.generalProfileIDC = *result;
+        } else
+            parameters.generalProfileIDC = 1;
+
+        auto profileCompatibilityIndicator = contentType.parameter("profile-compatibility-indicator"_s);
+        if (!profileCompatibilityIndicator.isEmpty()) {
+            auto compatibilityFlags = parseInteger<uint32_t>(profileCompatibilityIndicator, 16);
+            if (!compatibilityFlags)
+                return { };
+            parameters.generalProfileCompatibilityFlags = reverseBits32(*compatibilityFlags);
+        } else
+            parameters.generalProfileCompatibilityFlags = 1 << parameters.generalProfileIDC;
+
+        auto tierFlag = contentType.parameter("tier-flag"_s);
+        if (tierFlag.isEmpty() || tierFlag == "0"_s)
+            parameters.generalTierFlag = 0;
+        else if (tierFlag == "1"_s)
+            parameters.generalTierFlag = 1;
+        else
+            return { };
+
+        auto levelId = contentType.parameter("level-id"_s);
+        if (!levelId.isEmpty()) {
+            auto result = parseInteger<uint16_t>(levelId);
+            if (!result)
+                return { };
+            parameters.generalLevelIDC = *result;
+        } else
+            parameters.generalLevelIDC = 93;
+
+        return makeString("video/mp4;codecs="_s, createHEVCCodecParametersString(parameters));
+    }
+
+    if (equalLettersIgnoringASCIICase(containerType, "video/vp9"_s)) {
+        // https://www.rfc-editor.org/rfc/rfc9628.html#payloadFormatParameters
+        VPCodecConfigurationRecord parameters;
+        parameters.codecName = "vp09"_s;
+
+        auto profileId = contentType.parameter("profile-id"_s);
+        if (!profileId.isEmpty()) {
+            auto result = parseInteger<uint8_t>(profileId);
+            if (!result || *result > 3)
+                return { };
+            parameters.profile = *result;
+        }
+
+        // We use level 5 as the default.
+        parameters.level = VPConfigurationLevel::Level_5;
+
+        parameters.bitDepth = parameters.profile < 2 ? 8 : 10;
+
+        return makeString("video/mp4;codecs="_s, createVPCodecParametersString(parameters));
+    }
+
+    if (equalLettersIgnoringASCIICase(containerType, "video/av1"_s)) {
+        // https://www.iana.org/assignments/media-types/video/AV1
+        AV1CodecConfigurationRecord parameters;
+        parameters.codecName = "av01"_s;
+
+        auto profile = contentType.parameter("profile"_s);
+        if (!profile.isEmpty()) {
+            auto result = parseEnumFromStringView<AV1ConfigurationProfile>(profile);
+            if (!result)
+                return { };
+            parameters.profile = *result;
+        }
+
+        auto levelIdx = contentType.parameter("level-idx"_s);
+        if (!levelIdx.isEmpty()) {
+            auto result = parseEnumFromStringView<AV1ConfigurationLevel>(levelIdx);
+            if (!result)
+                return { };
+            parameters.level = *result;
+        } else
+            parameters.level = AV1ConfigurationLevel::Level_3_1;
+
+        auto tier = contentType.parameter("tier"_s);
+        if (!tier.isEmpty()) {
+            if (tier == "M"_s)
+                parameters.tier = AV1ConfigurationTier::Main;
+            else if (tier == "H"_s)
+                parameters.tier = AV1ConfigurationTier::High;
+            else
+                return { };
+        }
+
+        parameters.bitDepth = parameters.profile < AV1ConfigurationProfile::Professional ? 8 : 10;
+
+        return makeString("video/mp4;codecs="_s, createAV1CodecParametersString(parameters));
+    }
+
+    if (equalLettersIgnoringASCIICase(containerType, "video/vp8"_s))
+        return "video/webm;codecs=vp08.00.50.08"_s;
+
+    return { };
+}
+
 void WebRTCProvider::createDecodingConfiguration(MediaDecodingConfiguration&& configuration, DecodingConfigurationCallback&& callback)
 {
     ASSERT(configuration.type == MediaDecodingType::WebRTC);
@@ -231,6 +361,24 @@ void WebRTCProvider::createDecodingConfiguration(MediaDecodingConfiguration&& co
         }
     }
 #endif
+    // For power efficient decoders, we use the regular media engine MC code path which has more fine grained checks.
+    if (info.powerEfficient && info.configuration.video) {
+        auto videoConfiguration = info.configuration;
+        videoConfiguration.audio = { };
+        videoConfiguration.video->contentType = contentTypeFromRTPVideoMimeType(info.configuration.video->contentType);
+        videoConfiguration.type = MediaDecodingType::MediaSource;
+
+        MediaEngineConfigurationFactory::createDecodingConfiguration(WTFMove(videoConfiguration), [info = WTFMove(info), callback = WTFMove(callback)](auto&& result) mutable {
+            info.supported = result.supported;
+            info.smooth = result.smooth;
+            info.powerEfficient = result.powerEfficient;
+            if (!info.supported)
+                info.configuration = { };
+            callback(WTFMove(info));
+        });
+        return;
+    }
+
     info.supported = true;
     callback(WTFMove(info));
 }

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
@@ -528,13 +528,14 @@ std::optional<MediaCapabilitiesDecodingInfo> LibWebRTCProvider::videoDecodingCap
         }
         info.powerEfficient = decodingInfo ? decodingInfo->powerEfficient : isSupportingVP9HardwareDecoder();
         info.smooth = decodingInfo ? decodingInfo->smooth : isVPSoftwareDecoderSmooth(configuration);
-    } else if (equalLettersIgnoringASCIICase(containerType, "video/h264"_s)) {
-        // FIXME: Provide more granular H.264 decoder information.
-        info.powerEfficient = info.smooth = isH264EncoderSmooth(configuration);
-    } else if (equalLettersIgnoringASCIICase(containerType, "video/h265"_s))
+    } else if (equalLettersIgnoringASCIICase(containerType, "video/h264"_s))
         info.powerEfficient = info.smooth = true;
-    else if (equalLettersIgnoringASCIICase(containerType, "video/av1"_s))
+    else if (equalLettersIgnoringASCIICase(containerType, "video/h265"_s))
+        info.powerEfficient = info.smooth = true;
+    else if (equalLettersIgnoringASCIICase(containerType, "video/av1"_s)) {
+        // FIXME: Set value to true if AV1 is only enabled when HW decoder support is enabled.
         info.powerEfficient = false;
+    }
 
     info.supported = true;
     return { info };


### PR DESCRIPTION
#### 044bcbf0c269e999b8bcda26e7de11041e057c0d
<pre>
Improving Decoding Capability accuracy on Media Capability API
<a href="https://rdar.apple.com/150685443">rdar://150685443</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292468">https://bugs.webkit.org/show_bug.cgi?id=292468</a>

Reviewed by Jean-Yves Avenard.

The regular streaming media capabilities code path is doing finer grained checks on things like HDR.
We reuse that code path for WebRTC video decoding media capabilities by first checking whether the video decoder
is supported by WebRTC and is power efficient.
If so, we make another call to validate that the same video configuration would be supported for MSE.
We then reuse these results.

The reason we do this two step approach is that, HW support be the same for WebRTC and regular video streaming.
But SW support may be different (VP8 support for instance).

We update GStreamerRegistryScanner::isRtpPacketizerSupported to add missing FourCC based codec names (vp08, vp09, avc1....).

* LayoutTests/webrtc/media-capabilities-webrtc-expected.txt: Added.
* LayoutTests/webrtc/media-capabilities-webrtc.html: Added.
* Source/WebCore/platform/graphics/AV1Utilities.cpp:
(WebCore::parseEnumFromStringView): Deleted.
* Source/WebCore/platform/graphics/AV1Utilities.h:
(WebCore::parseEnumFromStringView):
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::isRtpPacketizerSupported):
* Source/WebCore/platform/mediastream/WebRTCProvider.cpp:
(WebCore::contentTypeFromRTPVideoMimeType):
(WebCore::WebRTCProvider::createDecodingConfiguration):
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp:
(WebCore::LibWebRTCProvider::videoDecodingCapabilitiesOverride):

Canonical link: <a href="https://commits.webkit.org/295001@main">https://commits.webkit.org/295001@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2885ba77ee869a9f20b21c75d80ac623000f783a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103791 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108983 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54443 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105831 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23844 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32039 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78853 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18506 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93631 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59187 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11680 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53819 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11737 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111371 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30947 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87855 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31309 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89832 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87509 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22275 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32398 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10120 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25304 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30875 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36178 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30669 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34004 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32230 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->