### PR TITLE
[JSC] Move `log1p` from `FOR_EACH_ARITH_UNARY_OP_CUSTOM` to `FOR_EACH_ARITH_UNARY_OP_STD`

### DIFF
--- a/JSTests/microbenchmarks/math-log1p.js
+++ b/JSTests/microbenchmarks/math-log1p.js
@@ -1,0 +1,40 @@
+(function () {
+  var finiteResult = 0;
+  var posZeroResult = 0;
+  var negZeroResult = 0;
+  var infinityResult = 0;
+  var negInfinityResult = 0;
+  var nanResult = 0;
+  var values = [
+    0,
+    -0,
+    1,
+    -1 + Math.E,
+    -1,
+    -2,
+    Number.MAX_VALUE,
+    Number.MIN_VALUE,
+    Number.MAX_SAFE_INTEGER,
+    Number.MIN_SAFE_INTEGER,
+    Infinity,
+    -Infinity,
+    NaN
+  ];
+  for (var i = 0; i < testLoopCount; ++i) {
+    for (var j = 0; j < values.length; ++j) {
+      var output = Math.log1p(values[j]);
+      if (output !== output) nanResult++;
+      else if (output === Infinity) infinityResult++;
+      else if (output === -Infinity) negInfinityResult++;
+      else if (output === 0 && (1 / output) === Infinity) posZeroResult++;
+      else if (output === 0 && (1 / output) === -Infinity) negZeroResult++;
+      else finiteResult++;
+    }
+  }
+  if (finiteResult !== testLoopCount * 5) throw 'Error: bad finiteResult: ' + finiteResult;
+  if (posZeroResult !== testLoopCount * 1) throw 'Error: bad posZeroResult: ' + posZeroResult;
+  if (negZeroResult !== testLoopCount * 1) throw 'Error: bad negZeroResult: ' + negZeroResult;
+  if (negInfinityResult !== testLoopCount * 1) throw 'Error: bad infinityResult: ' + infinityResult;
+  if (negInfinityResult !== testLoopCount * 1) throw 'Error: bad negInfinityResult: ' + negInfinityResult;
+  if (nanResult !== testLoopCount * 4) throw 'Error: bad nanResult: ' + nanResult;
+})();

--- a/Source/JavaScriptCore/runtime/MathCommon.cpp
+++ b/Source/JavaScriptCore/runtime/MathCommon.cpp
@@ -486,25 +486,6 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(jsRound, double, (double value))
 
 namespace Math {
 
-static ALWAYS_INLINE double log1pDoubleImpl(double value)
-{
-    if (value == 0.0)
-        return value;
-    return std::log1p(value);
-}
-
-static ALWAYS_INLINE float log1pFloatImpl(float value)
-{
-    if (value == 0.0)
-        return value;
-    return std::log1p(value);
-}
-
-double log1p(double value)
-{
-    return log1pDoubleImpl(value);
-}
-
 #define JSC_DEFINE_VIA_STD(capitalizedName, lowerName) \
     JSC_DEFINE_NOEXCEPT_JIT_OPERATION(lowerName##Double, double, (double value)) \
     { \
@@ -516,18 +497,6 @@ double log1p(double value)
     }
 FOR_EACH_ARITH_UNARY_OP_STD(JSC_DEFINE_VIA_STD)
 #undef JSC_DEFINE_VIA_STD
-
-#define JSC_DEFINE_VIA_CUSTOM(capitalizedName, lowerName) \
-    JSC_DEFINE_NOEXCEPT_JIT_OPERATION(lowerName##Double, double, (double value)) \
-    { \
-        return lowerName##DoubleImpl(value); \
-    } \
-    JSC_DEFINE_NOEXCEPT_JIT_OPERATION(lowerName##Float, float, (float value)) \
-    { \
-        return lowerName##FloatImpl(value); \
-    }
-FOR_EACH_ARITH_UNARY_OP_CUSTOM(JSC_DEFINE_VIA_CUSTOM)
-#undef JSC_DEFINE_VIA_CUSTOM
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(truncDouble, double, (double value))
 {

--- a/Source/JavaScriptCore/runtime/MathCommon.h
+++ b/Source/JavaScriptCore/runtime/MathCommon.h
@@ -262,9 +262,6 @@ JSC_DECLARE_NOEXCEPT_JIT_OPERATION(jsRound, double, (double));
 namespace Math {
 
 // This macro defines a set of information about all known arith unary generic node.
-#define FOR_EACH_ARITH_UNARY_OP_CUSTOM(macro) \
-    macro(Log1p, log1p) \
-
 #define FOR_EACH_ARITH_UNARY_OP_STD(macro) \
     macro(Sin, sin) \
     macro(Sinh, sinh) \
@@ -284,10 +281,10 @@ namespace Math {
     macro(Cbrt, cbrt) \
     macro(Exp, exp) \
     macro(Expm1, expm1) \
+    macro(Log1p, log1p) \
 
 #define FOR_EACH_ARITH_UNARY_OP(macro) \
     FOR_EACH_ARITH_UNARY_OP_STD(macro) \
-    FOR_EACH_ARITH_UNARY_OP_CUSTOM(macro) \
 
 #define JSC_DEFINE_VIA_STD(capitalizedName, lowerName) \
     using std::lowerName; \
@@ -295,13 +292,6 @@ namespace Math {
     JSC_DECLARE_NOEXCEPT_JIT_OPERATION(lowerName##Float, float, (float));
 FOR_EACH_ARITH_UNARY_OP_STD(JSC_DEFINE_VIA_STD)
 #undef JSC_DEFINE_VIA_STD
-
-#define JSC_DEFINE_VIA_CUSTOM(capitalizedName, lowerName) \
-    JS_EXPORT_PRIVATE double lowerName(double); \
-    JSC_DECLARE_NOEXCEPT_JIT_OPERATION(lowerName##Double, double, (double)); \
-    JSC_DECLARE_NOEXCEPT_JIT_OPERATION(lowerName##Float, float, (float));
-FOR_EACH_ARITH_UNARY_OP_CUSTOM(JSC_DEFINE_VIA_CUSTOM)
-#undef JSC_DEFINE_VIA_CUSTOM
 
 template<typename FloatType>
 ALWAYS_INLINE FloatType fMax(FloatType a, FloatType b)


### PR DESCRIPTION
#### 80a7d8d4cd4f464f9c79298a16380065cb7ffa63
<pre>
[JSC] Move `log1p` from `FOR_EACH_ARITH_UNARY_OP_CUSTOM` to `FOR_EACH_ARITH_UNARY_OP_STD`
<a href="https://bugs.webkit.org/show_bug.cgi?id=292560">https://bugs.webkit.org/show_bug.cgi?id=292560</a>

Reviewed by Yusuke Suzuki.

Move log1p from FOR_EACH_ARITH_UNARY_OP_CUSTOM to FOR_EACH_ARITH_UNARY_OP_STD

* JSTests/microbenchmarks/math-log1p.js: Added.
* Source/JavaScriptCore/runtime/MathCommon.cpp:
(JSC::Math::log1pDoubleImpl): Deleted.
(JSC::Math::log1pFloatImpl): Deleted.
(JSC::Math::log1p): Deleted.
* Source/JavaScriptCore/runtime/MathCommon.h:

Canonical link: <a href="https://commits.webkit.org/294588@main">https://commits.webkit.org/294588@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81d6dfb9fd56135a6fa3d1164254bef5d4f55ad9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107418 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52894 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77808 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34795 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92310 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58146 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17041 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10338 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52252 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94929 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86870 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10408 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109793 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100867 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21663 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86789 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29754 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88513 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86377 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31189 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8905 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/23632 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16628 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29318 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34613 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124493 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29129 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34564 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32452 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30688 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->