### PR TITLE
[WebGPU] Override which is not populated fails metal compilation, it should fail prior to attempting compilation

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_292562-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_292562-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: Pass
+

--- a/LayoutTests/fast/webgpu/regression/repro_292562.html
+++ b/LayoutTests/fast/webgpu/regression/repro_292562.html
@@ -1,0 +1,105 @@
+<style>
+    :root {
+        background: #102030e0; color: #99ddbbcc; font-size: 15px;
+    }
+</style>
+<script id="shared">
+    const log = console.log;
+    
+</script>
+<script>
+    globalThis.testRunner?.waitUntilDone();
+    
+    async function window0() {
+        let promise0 = navigator.gpu.requestAdapter(
+        {
+        });
+        let adapter0 = await promise0;
+        let device0 = await adapter0.requestDevice();
+        // START
+        
+        let canvas0 = document.createElement(
+        'canvas'
+        );
+        let shaderModule2 = device0.createShaderModule(
+        {
+            code: ` 
+  @id(13668) override override7: f32;
+  
+  @group(0) @binding(0) var<storage, read_write> buffer13: array<array<array<array<f32, 23>, 8>, 1>>;
+ 
+ struct FragmentOutput0 {
+    @location(0) location_0: vec4f,
+ }
+ 
+ @fragment fn fragment0() -> FragmentOutput0 {   
+    var out: FragmentOutput0;
+   
+    return out;   _ = override7;     
+ }
+  
+ @vertex fn vertex4() -> @builtin(position) vec4f {
+   var out: vec4f;
+   return out;
+ }
+ 
+ `,
+        }
+        );
+        
+        
+        let veryExplicitBindGroupLayout3 = device0.createBindGroupLayout(
+        {
+            entries: [     {
+                binding: 0,       visibility: GPUShaderStage.FRAGMENT,       buffer: {
+                    type: 'storage', hasDynamicOffset: false
+                },
+            }
+            ,   ],
+        }
+        );
+        
+        let pipelineLayout3 = device0.createPipelineLayout(
+        {
+            bindGroupLayouts: [veryExplicitBindGroupLayout3],
+        }
+        );
+        
+        let pipeline33 = device0.createRenderPipeline(
+        {
+            layout: pipelineLayout3,   fragment: {
+                module: shaderModule2,   targets: [{
+                    format: 'r32float', writeMask: GPUColorWrite.GREEN}
+                ], }
+            ,   vertex: {
+                module: shaderModule2, }
+            ,
+        }
+        );
+        
+        
+        // END
+        await device0.queue.onSubmittedWorkDone();
+        console.debug('Pass');
+        globalThis.testRunner?.dumpAsText();
+        globalThis.testRunner?.notifyDone();
+    }
+    onload = async () => {
+        try {
+            let workers = [
+            ];
+            let promises = [ window0() ];
+        } catch (
+        e
+        ) {
+            if (
+            e instanceof GPUPipelineError
+            ) {
+                if (
+                e.name === 'OperationError'
+                ) {
+      }
+    }
+  }
+};
+</script>


### PR DESCRIPTION
#### 40cb3d324dffbe20afd096b68d1c384e9981177c
<pre>
[WebGPU] Override which is not populated fails metal compilation, it should fail prior to attempting compilation
<a href="https://bugs.webkit.org/show_bug.cgi?id=292562">https://bugs.webkit.org/show_bug.cgi?id=292562</a>
<a href="https://rdar.apple.com/150550066">rdar://150550066</a>

Reviewed by Tadeu Zagallo.

There isn&apos;t any functional difference here, but a shader which uses a non-populated
override expession would fail Metal compilation whereas we would expect to never
fail Metal compilation (and error earlier).

Generate the error earlier as expected.

* LayoutTests/fast/webgpu/regression/repro_292562-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_292562.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::createLibrary):

Canonical link: <a href="https://commits.webkit.org/294795@main">https://commits.webkit.org/294795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d599b691b01ac55dbf255e199ec0309418a3edb4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21858 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107350 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52827 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30366 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77762 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34760 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105197 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58097 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16985 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10276 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52185 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86823 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10348 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109726 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21620 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86739 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29686 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88452 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86324 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22141 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31136 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8852 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23565 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29251 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34546 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29062 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32385 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30621 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->