### PR TITLE
Improve Swift implementation of some TextExtraction code

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -6063,15 +6063,6 @@ static Vector<Ref<API::TargetedElementInfo>> elementsFromWKElements(NSArray<_WKT
 
 @implementation WKWebView (WKTextExtraction)
 
-- (void)_requestTextExtractionForSwift:(WKTextExtractionRequest *)context
-{
-#if USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
-    [self _requestTextExtraction:context.rectInWebView completionHandler:makeBlockPtr([context = retainPtr(context)](WKTextExtractionItem *result) {
-        [context fulfill:result];
-    }).get()];
-#endif // USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
-}
-
 - (void)_requestTextExtraction:(CGRect)rectInWebView completionHandler:(void(^)(WKTextExtractionItem *))completionHandler
 {
 #if USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -137,7 +137,6 @@ class ViewGestureController;
 @class WKScrollGeometry;
 @class WKScrollView;
 @class WKTextExtractionItem;
-@class WKTextExtractionRequest;
 @class WKWebViewContentProviderRegistry;
 @class _WKFrameHandle;
 @class _WKWarningView;
@@ -580,11 +579,6 @@ RetainPtr<NSError> nsErrorFromExceptionDetails(const std::optional<WebCore::Exce
 @end
 #endif
 
-@interface WKWebView (WKTextExtraction)
-- (void)_requestTextExtractionForSwift:(WKTextExtractionRequest *)context;
-- (void)_requestTextExtraction:(CGRect)rect completionHandler:(void(^)(WKTextExtractionItem *))completionHandler;
-@end
-
 #endif // __cplusplus
 
 @interface WKWebView (NonCpp)
@@ -601,5 +595,7 @@ RetainPtr<NSError> nsErrorFromExceptionDetails(const std::optional<WebCore::Exce
 #endif
 
 - (void)_scrollToEdge:(_WKRectEdge)edge animated:(BOOL)animated;
+
+- (void)_requestTextExtraction:(CGRect)rect completionHandler:(void(^)(WKTextExtractionItem *))completionHandler;
 
 @end

--- a/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionItem.h
+++ b/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionItem.h
@@ -87,12 +87,6 @@ typedef NS_ENUM(NSInteger, WKTextExtractionContainer) {
 @property (nonatomic, readonly) NSString *altText;
 @end
 
-@interface WKTextExtractionRequest : NSObject
-- (instancetype)initWithRectInWebView:(CGRect)rectInWebView completionHandler:(void(^)(WKTextExtractionItem * _Nullable))completionHandler;
-- (void)fulfill:(WKTextExtractionItem *)result;
-@property (nonatomic, readonly) CGRect rectInWebView;
-@end
-
 NS_ASSUME_NONNULL_END
 
 #endif // USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))

--- a/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionItem.swift
+++ b/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionItem.swift
@@ -160,25 +160,4 @@ internal import WebKit_Internal
 #endif
 }
 
-@_objcImplementation extension WKTextExtractionRequest {
-    let rectInWebView: CGRect
-    @objc
-    private var completionHandler: ((WKTextExtractionItem?) -> Void)?
-
-    init(rectInWebView: CGRect, completionHandler: @escaping (WKTextExtractionItem?) -> Void) {
-        self.rectInWebView = rectInWebView
-        self.completionHandler = completionHandler
-    }
-
-    func fulfill(_ item: WKTextExtractionItem) {
-        guard let completionHandler = self.completionHandler else { return }
-        completionHandler(item)
-        self.completionHandler = nil
-    }
-
-#if compiler(<6.0)
-    @objc deinit { }
-#endif
-}
-
 #endif // USE_APPLE_INTERNAL_SDK || (!os(tvOS) && !os(watchOS))


### PR DESCRIPTION
#### 15a1935d15b9818253271e7809d303e74633d0f4
<pre>
Improve Swift implementation of some TextExtraction code
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Draft

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _requestTextExtractionForSwift:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionItem.h:
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionItem.swift:
(WKTextExtractionRequest.completionHandler): Deleted.
(WKTextExtractionRequest.fulfill(_:)): Deleted.
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift:
(WKWebView._intelligenceCollectContent(in:collector:)):
(WKWebView._intelligenceCollectRemoteContent(in:remoteContextWrapper:)):
(WKWebView._requestTextExtraction(in:completionHandler:)): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15a1935d15b9818253271e7809d303e74633d0f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102193 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21860 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107352 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52829 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30368 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77766 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/34763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17156 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92251 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58101 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16986 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52187 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86824 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10350 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109728 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29325 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21621 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86743 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29688 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88454 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86328 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31138 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8854 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23567 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29253 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34548 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29064 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32387 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->