### PR TITLE
[Curl][WebDriver]: support acceptInsecureCerts capability

### DIFF
--- a/Source/WebCore/platform/network/curl/CurlStream.cpp
+++ b/Source/WebCore/platform/network/curl/CurlStream.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CurlStream);
 
-CurlStream::CurlStream(CurlStreamScheduler& scheduler, CurlStreamID streamID, URL&& url, ServerTrustEvaluation serverTrustEvaluation, LocalhostAlias localhostAlias)
+CurlStream::CurlStream(CurlStreamScheduler& scheduler, CurlStreamID streamID, bool ignoreTLSErrors, URL&& url, ServerTrustEvaluation serverTrustEvaluation, LocalhostAlias localhostAlias)
     : m_scheduler(scheduler)
     , m_streamID(streamID)
 {
@@ -52,6 +52,8 @@ CurlStream::CurlStream(CurlStreamScheduler& scheduler, CurlStreamID streamID, UR
         m_curlHandle->disableServerTrustEvaluation();
 
     m_curlHandle->enableConnectionOnly();
+    if (ignoreTLSErrors)
+        m_curlHandle->disableServerTrustEvaluation();
 
     auto errorCode = m_curlHandle->perform();
     if (errorCode != CURLE_OK) {

--- a/Source/WebCore/platform/network/curl/CurlStream.h
+++ b/Source/WebCore/platform/network/curl/CurlStream.h
@@ -56,12 +56,12 @@ public:
         virtual void didFail(CurlStreamID, CURLcode, CertificateInfo&&) = 0;
     };
 
-    static std::unique_ptr<CurlStream> create(CurlStreamScheduler& scheduler, CurlStreamID streamID, URL&& url, ServerTrustEvaluation serverTrustEvaluation, LocalhostAlias localhostAlias)
+    static std::unique_ptr<CurlStream> create(CurlStreamScheduler& scheduler, CurlStreamID streamID, bool ignoreTLSErrors, URL&& url, ServerTrustEvaluation serverTrustEvaluation, LocalhostAlias localhostAlias)
     {
-        return makeUnique<CurlStream>(scheduler, streamID, WTFMove(url), serverTrustEvaluation, localhostAlias);
+        return makeUnique<CurlStream>(scheduler, streamID, ignoreTLSErrors, WTFMove(url), serverTrustEvaluation, localhostAlias);
     }
 
-    CurlStream(CurlStreamScheduler&, CurlStreamID, URL&&, ServerTrustEvaluation, LocalhostAlias);
+    CurlStream(CurlStreamScheduler&, CurlStreamID, bool ignoreTLSErrors, URL&&, ServerTrustEvaluation, LocalhostAlias);
     virtual ~CurlStream();
 
     void send(UniqueArray<uint8_t>&&, size_t);

--- a/Source/WebCore/platform/network/curl/CurlStreamScheduler.cpp
+++ b/Source/WebCore/platform/network/curl/CurlStreamScheduler.cpp
@@ -43,7 +43,7 @@ CurlStreamScheduler::~CurlStreamScheduler()
     ASSERT(isMainThread());
 }
 
-CurlStreamID CurlStreamScheduler::createStream(const URL& url, CurlStream::Client& client, CurlStream::ServerTrustEvaluation serverTrustEvaluation, CurlStream::LocalhostAlias localhostAlias)
+CurlStreamID CurlStreamScheduler::createStream(const URL& url, bool ignoreTLSErrors, CurlStream::Client& client, CurlStream::ServerTrustEvaluation serverTrustEvaluation, CurlStream::LocalhostAlias localhostAlias)
 {
     ASSERT(isMainThread());
 
@@ -54,8 +54,8 @@ CurlStreamID CurlStreamScheduler::createStream(const URL& url, CurlStream::Clien
     auto streamID = m_currentStreamID;
     m_clientList.add(streamID, &client);
 
-    callOnWorkerThread([this, streamID, url = url.isolatedCopy(), serverTrustEvaluation, localhostAlias]() mutable {
-        m_streamList.add(streamID, CurlStream::create(*this, streamID, WTFMove(url), serverTrustEvaluation, localhostAlias));
+    callOnWorkerThread([this, streamID, ignoreTLSErrors, url = url.isolatedCopy(), serverTrustEvaluation, localhostAlias]() mutable {
+        m_streamList.add(streamID, CurlStream::create(*this, streamID, ignoreTLSErrors, WTFMove(url), serverTrustEvaluation, localhostAlias));
     });
 
     return streamID;

--- a/Source/WebCore/platform/network/curl/CurlStreamScheduler.h
+++ b/Source/WebCore/platform/network/curl/CurlStreamScheduler.h
@@ -39,7 +39,7 @@ public:
     CurlStreamScheduler();
     virtual ~CurlStreamScheduler();
 
-    WEBCORE_EXPORT CurlStreamID createStream(const URL&, CurlStream::Client&, CurlStream::ServerTrustEvaluation, CurlStream::LocalhostAlias);
+    WEBCORE_EXPORT CurlStreamID createStream(const URL&, bool ignoreTLSErrors, CurlStream::Client&, CurlStream::ServerTrustEvaluation, CurlStream::LocalhostAlias);
     WEBCORE_EXPORT void destroyStream(CurlStreamID);
     WEBCORE_EXPORT void send(CurlStreamID, UniqueArray<uint8_t>&&, size_t);
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -544,10 +544,13 @@ private:
 #endif
     
 #if USE(SOUP)
-    void setIgnoreTLSErrors(PAL::SessionID, bool);
     void userPreferredLanguagesChanged(const Vector<String>&);
     void setNetworkProxySettings(PAL::SessionID, WebCore::SoupNetworkProxySettings&&);
     void setPersistentCredentialStorageEnabled(PAL::SessionID, bool);
+#endif
+
+#if USE(SOUP) || USE(CURL)
+    void setIgnoreTLSErrors(PAL::SessionID, bool);
 #endif
 
 #if USE(CURL)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -32,9 +32,11 @@ messages -> NetworkProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
     SharedPreferencesForWebProcessDidChange(WebCore::ProcessIdentifier processIdentifier, struct WebKit::SharedPreferencesForWebProcess sharedPreferencesForWebProcess) -> ()
 
     AddAllowedFirstPartyForCookies(WebCore::ProcessIdentifier processIdentifier, WebCore::RegistrableDomain firstPartyForCookies, enum:bool WebKit::LoadedWebArchive loadedWebArchive) -> ()
+#if USE(SOUP) || USE(CURL)
+    SetIgnoreTLSErrors(PAL::SessionID sessionID, bool ignoreTLSErrors)
+#endif
 
 #if USE(SOUP)
-    SetIgnoreTLSErrors(PAL::SessionID sessionID, bool ignoreTLSErrors)
     UserPreferredLanguagesChanged(Vector<String> languages)
     SetNetworkProxySettings(PAL::SessionID sessionID, struct WebCore::SoupNetworkProxySettings settings)
     PrefetchDNS(String hostname)

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
@@ -71,9 +71,11 @@ struct NetworkSessionCreationParameters {
     String cookiePersistentStoragePath;
     SoupCookiePersistentStorageType cookiePersistentStorageType { SoupCookiePersistentStorageType::Text };
     bool persistentCredentialStorageEnabled { true };
-    bool ignoreTLSErrors { false };
     WebCore::SoupNetworkProxySettings proxySettings;
     WebCore::HTTPCookieAcceptPolicy cookieAcceptPolicy { WebCore::HTTPCookieAcceptPolicy::ExclusivelyFromMainDocumentDomain };
+#endif
+#if USE(SOUP) || USE(CURL)
+    bool ignoreTLSErrors { false };
 #endif
 #if USE(CURL)
     String cookiePersistentStorageFile;

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
@@ -45,9 +45,11 @@ enum class WebKit::AllowsCellularAccess : bool;
     String cookiePersistentStoragePath;
     WebKit::SoupCookiePersistentStorageType cookiePersistentStorageType;
     bool persistentCredentialStorageEnabled;
-    bool ignoreTLSErrors;
     WebCore::SoupNetworkProxySettings proxySettings;
     WebCore::HTTPCookieAcceptPolicy cookieAcceptPolicy;
+#endif
+#if USE(SOUP) || USE(CURL)
+    bool ignoreTLSErrors;
 #endif
 #if USE(CURL)
     String cookiePersistentStorageFile;

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -85,6 +85,8 @@ NetworkDataTaskCurl::NetworkDataTaskCurl(NetworkSession& session, NetworkDataTas
         m_curlRequest->setUserPass(m_initialCredential.user(), m_initialCredential.password());
         m_curlRequest->setAuthenticationScheme(ProtectionSpace::AuthenticationScheme::HTTPBasic);
     }
+    if (static_cast<const NetworkSessionCurl*>(networkSession())->ignoreTLSErrors())
+        m_curlRequest->disableServerTrustEvaluation();
 }
 
 NetworkDataTaskCurl::~NetworkDataTaskCurl()
@@ -410,6 +412,8 @@ void NetworkDataTaskCurl::willPerformHTTPRedirection()
             m_curlRequest->setUserPass(m_initialCredential.user(), m_initialCredential.password());
             m_curlRequest->setAuthenticationScheme(ProtectionSpace::AuthenticationScheme::HTTPBasic);
         }
+        if (static_cast<const NetworkSessionCurl*>(networkSession())->ignoreTLSErrors())
+            m_curlRequest->disableServerTrustEvaluation();
 
         if (m_state != State::Suspended) {
             m_state = State::Suspended;

--- a/Source/WebKit/NetworkProcess/curl/NetworkProcessCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkProcessCurl.cpp
@@ -69,4 +69,10 @@ void NetworkProcess::setNetworkProxySettings(PAL::SessionID sessionID, WebCore::
         ASSERT_NOT_REACHED();
 }
 
+void NetworkProcess::setIgnoreTLSErrors(PAL::SessionID sessionID, bool ignoreTLSErrors)
+{
+    if (auto* session = networkSession(sessionID))
+        static_cast<NetworkSessionCurl&>(*session).setIgnoreTLSErrors(ignoreTLSErrors);
+}
+
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp
@@ -68,7 +68,7 @@ void NetworkSessionCurl::clearAlternativeServices(WallTime)
 
 std::unique_ptr<WebSocketTask> NetworkSessionCurl::createWebSocketTask(WebPageProxyIdentifier webPageProxyID, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, NetworkSocketChannel& channel, const WebCore::ResourceRequest& request, const String& protocol, const WebCore::ClientOrigin& clientOrigin, bool, bool, OptionSet<WebCore::AdvancedPrivacyProtections>, StoredCredentialsPolicy)
 {
-    return makeUnique<WebSocketTask>(channel, webPageProxyID, request, protocol, clientOrigin);
+    return makeUnique<WebSocketTask>(channel, webPageProxyID, request, protocol, ignoreTLSErrors(), clientOrigin);
 }
 
 void NetworkSessionCurl::didReceiveChallenge(WebSocketTask& webSocketTask, WebCore::AuthenticationChallenge&& challenge, CompletionHandler<void(WebKit::AuthenticationChallengeDisposition, const WebCore::Credential&)>&& challengeCompletionHandler)

--- a/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.h
+++ b/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.h
@@ -46,8 +46,13 @@ public:
 
     void didReceiveChallenge(WebSocketTask&, WebCore::AuthenticationChallenge&&, CompletionHandler<void(WebKit::AuthenticationChallengeDisposition, const WebCore::Credential&)>&&);
 
+    void setIgnoreTLSErrors(bool ignore) { m_ignoreTLSErrors = ignore; }
+    bool ignoreTLSErrors() const { return m_ignoreTLSErrors; }
+
 private:
     std::unique_ptr<WebSocketTask> createWebSocketTask(WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, NetworkSocketChannel&, const WebCore::ResourceRequest&, const String& protocol, const WebCore::ClientOrigin&, bool, bool, OptionSet<WebCore::AdvancedPrivacyProtections>, WebCore::StoredCredentialsPolicy) final;
+
+    bool m_ignoreTLSErrors { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
@@ -39,11 +39,12 @@
 namespace WebKit {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSocketTask);
 
-WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, WebPageProxyIdentifier webProxyPageID, const WebCore::ResourceRequest& request, const String& protocol, const WebCore::ClientOrigin& clientOrigin)
+WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, WebPageProxyIdentifier webProxyPageID, const WebCore::ResourceRequest& request, const String& protocol, bool ignoreTLSErrors, const WebCore::ClientOrigin& clientOrigin)
     : m_channel(channel)
     , m_webProxyPageID(webProxyPageID)
     , m_request(request.isolatedCopy())
     , m_protocol(protocol)
+    , m_ignoreTLSErrors(ignoreTLSErrors)
     , m_scheduler(WebCore::CurlContext::singleton().streamScheduler())
 {
     // We use topOrigin in case of service worker websocket connections, for which pageID does not link to a real page.
@@ -55,7 +56,7 @@ WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, WebPageProxyIdentifi
     if (networkSession() && networkSession()->networkProcess().localhostAliasesForTesting().contains<StringViewHashTranslator>(m_request.url().host()))
         localhostAlias = WebCore::CurlStream::LocalhostAlias::Enable;
 
-    m_streamID = m_scheduler.createStream(request.url(), *this, WebCore::CurlStream::ServerTrustEvaluation::Enable, localhostAlias);
+    m_streamID = m_scheduler.createStream(request.url(), ignoreTLSErrors, *this, WebCore::CurlStream::ServerTrustEvaluation::Enable, localhostAlias);
     channel.didSendHandshakeRequest(WebCore::ResourceRequest(m_request));
 }
 
@@ -265,7 +266,7 @@ void WebSocketTask::tryServerTrustEvaluation(WebCore::AuthenticationChallenge&& 
             if (networkSession() && networkSession()->networkProcess().localhostAliasesForTesting().contains<StringViewHashTranslator>(m_request.url().host()))
                 localhostAlias = WebCore::CurlStream::LocalhostAlias::Enable;
 
-            m_streamID = m_scheduler.createStream(m_request.url(), *this, WebCore::CurlStream::ServerTrustEvaluation::Disable, localhostAlias);
+            m_streamID = m_scheduler.createStream(m_request.url(), m_ignoreTLSErrors, *this, WebCore::CurlStream::ServerTrustEvaluation::Disable, localhostAlias);
         } else
             didFail(WTFMove(errorReason));
     });

--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.h
+++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.h
@@ -55,7 +55,7 @@ class WebSocketTask : public CanMakeWeakPtr<WebSocketTask>, public CanMakeChecke
     WTF_MAKE_TZONE_ALLOCATED(WebSocketTask);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebSocketTask);
 public:
-    WebSocketTask(NetworkSocketChannel&, WebPageProxyIdentifier, const WebCore::ResourceRequest&, const String& protocol, const WebCore::ClientOrigin&);
+    WebSocketTask(NetworkSocketChannel&, WebPageProxyIdentifier, const WebCore::ResourceRequest&, const String& protocol,  bool ignoreTLSErrors, const WebCore::ClientOrigin&);
     virtual ~WebSocketTask();
 
     void sendString(std::span<const uint8_t>, CompletionHandler<void()>&&);
@@ -110,6 +110,7 @@ private:
     WebPageProxyIdentifier m_webProxyPageID;
     WebCore::ResourceRequest m_request;
     String m_protocol;
+    bool m_ignoreTLSErrors { false };
     WebCore::SecurityOriginData m_topOrigin;
 
     WebCore::CurlStreamScheduler& m_scheduler;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2231,6 +2231,9 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
     parameters.networkSessionParameters = WTFMove(networkSessionParameters);
     parameters.networkSessionParameters.resourceLoadStatisticsParameters.enabled = trackingPreventionEnabled();
     platformSetNetworkParameters(parameters);
+#if USE(SOUP) || USE(CURL)
+    parameters.networkSessionParameters.ignoreTLSErrors = m_ignoreTLSErrors;
+#endif
 #if PLATFORM(COCOA)
     parameters.networkSessionParameters.useNetworkLoader = useNetworkLoader();
 #endif
@@ -2258,6 +2261,17 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
     
     return parameters;
 }
+
+#if USE(SOUP) || USE(CURL)
+void WebsiteDataStore::setIgnoreTLSErrors(bool ignoreTLSErrors)
+{
+    if (m_ignoreTLSErrors == ignoreTLSErrors)
+        return;
+
+    m_ignoreTLSErrors = ignoreTLSErrors;
+    networkProcess().send(Messages::NetworkProcess::SetIgnoreTLSErrors(m_sessionID, m_ignoreTLSErrors), 0);
+}
+#endif
 
 #if HAVE(SEC_KEY_PROXY)
 void WebsiteDataStore::addSecKeyProxyStore(Ref<SecKeyProxyStore>&& store)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -318,11 +318,13 @@ public:
     const WebCore::CurlProxySettings& networkProxySettings() const { return m_proxySettings; }
 #endif
 
+#if USE(SOUP) || USE(CURL)
+    void setIgnoreTLSErrors(bool);
+#endif
+
 #if USE(SOUP)
     void setPersistentCredentialStorageEnabled(bool);
     bool persistentCredentialStorageEnabled() const { return m_persistentCredentialStorageEnabled && isPersistent(); }
-    void setIgnoreTLSErrors(bool);
-    bool ignoreTLSErrors() const { return m_ignoreTLSErrors; }
     void setNetworkProxySettings(WebCore::SoupNetworkProxySettings&&);
     const WebCore::SoupNetworkProxySettings& networkProxySettings() const { return m_networkProxySettings; }
     void setCookiePersistentStorage(const String&, SoupCookiePersistentStorageType);
@@ -616,9 +618,12 @@ private:
     WebCore::CurlProxySettings m_proxySettings;
 #endif
 
+#if USE(SOUP) || USE(CURL)
+    bool m_ignoreTLSErrors { false };
+#endif
+
 #if USE(SOUP)
     bool m_persistentCredentialStorageEnabled { true };
-    bool m_ignoreTLSErrors { true };
     WebCore::SoupNetworkProxySettings m_networkProxySettings;
     String m_cookiePersistentStoragePath;
     SoupCookiePersistentStorageType m_cookiePersistentStorageType { SoupCookiePersistentStorageType::SQLite };

--- a/Source/WebKit/UIProcess/WebsiteData/soup/WebsiteDataStoreSoup.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/soup/WebsiteDataStoreSoup.cpp
@@ -38,7 +38,6 @@ void WebsiteDataStore::platformSetNetworkParameters(WebsiteDataStoreParameters& 
 {
     auto& networkSessionParameters = parameters.networkSessionParameters;
     networkSessionParameters.persistentCredentialStorageEnabled = m_persistentCredentialStorageEnabled;
-    networkSessionParameters.ignoreTLSErrors = m_ignoreTLSErrors;
     networkSessionParameters.proxySettings = m_networkProxySettings;
     networkSessionParameters.cookiePersistentStoragePath = m_cookiePersistentStoragePath;
     networkSessionParameters.cookiePersistentStorageType = m_cookiePersistentStorageType;
@@ -55,15 +54,6 @@ void WebsiteDataStore::setPersistentCredentialStorageEnabled(bool enabled)
 
     m_persistentCredentialStorageEnabled = enabled;
     networkProcess().send(Messages::NetworkProcess::SetPersistentCredentialStorageEnabled(m_sessionID, m_persistentCredentialStorageEnabled), 0);
-}
-
-void WebsiteDataStore::setIgnoreTLSErrors(bool ignoreTLSErrors)
-{
-    if (m_ignoreTLSErrors == ignoreTLSErrors)
-        return;
-
-    m_ignoreTLSErrors = ignoreTLSErrors;
-    networkProcess().send(Messages::NetworkProcess::SetIgnoreTLSErrors(m_sessionID, m_ignoreTLSErrors), 0);
 }
 
 void WebsiteDataStore::setNetworkProxySettings(WebCore::SoupNetworkProxySettings&& settings)

--- a/Source/WebKit/UIProcess/win/AutomationClientWin.cpp
+++ b/Source/WebKit/UIProcess/win/AutomationClientWin.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(REMOTE_INSPECTOR)
 #include "AutomationSessionClientWin.h"
 #include "WebAutomationSession.h"
+#include "WebsiteDataStore.h"
 #include <wtf/RunLoop.h>
 
 namespace WebKit {
@@ -60,6 +61,12 @@ void AutomationClient::requestAutomationSession(const String& sessionIdentifier,
     session->setSessionIdentifier(sessionIdentifier);
     session->setClient(WTF::makeUnique<AutomationSessionClient>(sessionIdentifier, capabilities));
     m_processPool->setAutomationSession(WTFMove(session));
+
+    if (capabilities.acceptInsecureCertificates) {
+        WebsiteDataStore::forEachWebsiteDataStore([] (auto& dataStore) {
+            dataStore.setIgnoreTLSErrors(true);
+        });
+    }
 }
 
 void AutomationClient::closeAutomationSession()


### PR DESCRIPTION
#### f4806cbf080d00f4fad2d763db17ae0bfe8499f0
<pre>
[Curl][WebDriver]: support acceptInsecureCerts capability
<a href="https://bugs.webkit.org/show_bug.cgi?id=292564">https://bugs.webkit.org/show_bug.cgi?id=292564</a>

Reviewed by Michael Catanzaro and Don Olmstead.

The same logic as was used in libsoup is extended to Curl. The
flag is propagated down to the Curl implementation in the network
process.

* Source/WebCore/platform/network/curl/CurlStream.cpp:
(WebCore::CurlStream::CurlStream):
* Source/WebCore/platform/network/curl/CurlStream.h:
(WebCore::CurlStream::create):
* Source/WebCore/platform/network/curl/CurlStreamScheduler.cpp:
(WebCore::CurlStreamScheduler::createStream):
* Source/WebCore/platform/network/curl/CurlStreamScheduler.h:
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h:
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in:
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp:
(WebKit::NetworkDataTaskCurl::NetworkDataTaskCurl):
(WebKit::NetworkDataTaskCurl::willPerformHTTPRedirection):
* Source/WebKit/NetworkProcess/curl/NetworkProcessCurl.cpp:
(WebKit::NetworkProcess::setIgnoreTLSErrors):
* Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp:
(WebKit::NetworkSessionCurl::createWebSocketTask):
* Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.h:
* Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp:
(WebKit::WebSocketTask::WebSocketTask):
(WebKit::WebSocketTask::tryServerTrustEvaluation):
* Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::parameters):
(WebKit::WebsiteDataStore::setIgnoreTLSErrors):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
(WebKit::WebsiteDataStore::persistentCredentialStorageEnabled const):
(WebKit::WebsiteDataStore::ignoreTLSErrors const): Deleted.
* Source/WebKit/UIProcess/WebsiteData/soup/WebsiteDataStoreSoup.cpp:
(WebKit::WebsiteDataStore::platformSetNetworkParameters):
(WebKit::WebsiteDataStore::setIgnoreTLSErrors): Deleted.
* Source/WebKit/UIProcess/win/AutomationClientWin.cpp:
(WebKit::AutomationClient::requestAutomationSession):

Canonical link: <a href="https://commits.webkit.org/294594@main">https://commits.webkit.org/294594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/284b4665e46291cf30fe0809f094b0cf216e2323

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107547 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53022 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104425 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30561 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77898 "Failure limit exceed. At least found 444 new test failures: http/tests/IndexedDB/collect-IDB-objects.https.html http/tests/IndexedDB/storage-limit-1.https.html http/tests/IndexedDB/storage-limit-2.https.html http/tests/IndexedDB/storage-limit.https.html http/tests/blink/sendbeacon/beacon-cross-origin-UpgradeMixedContent.https.html http/tests/blink/sendbeacon/beacon-cross-origin.https.html http/tests/cache-storage/cache-clearing-all.https.html http/tests/cache-storage/cache-clearing-origin.https.html http/tests/cache-storage/cache-origins.https.html http/tests/cache-storage/cache-persistency.https.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34887 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105392 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17319 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92422 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58235 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17155 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10450 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52380 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86977 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109922 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29518 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/21762 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86881 "Failure limit exceed. At least found 430 new test failures: http/tests/IndexedDB/collect-IDB-objects.https.html http/tests/IndexedDB/storage-limit-1.https.html http/tests/IndexedDB/storage-limit-2.https.html http/tests/IndexedDB/storage-limit.https.html http/tests/blink/sendbeacon/beacon-cross-origin-UpgradeMixedContent.https.html http/tests/blink/sendbeacon/beacon-cross-origin.https.html http/tests/cache-storage/cache-clearing-all.https.html http/tests/cache-storage/cache-clearing-origin.https.html http/tests/cache-storage/cache-origins.https.html http/tests/cache-storage/cache-persistency.https.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29882 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88618 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86472 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22000 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31292 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9011 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23760 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29446 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34748 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29257 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32580 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30816 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->