### PR TITLE
Use sendWithAsyncReply for starting and requesting additional items for a drag session

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -530,12 +530,12 @@ void HTMLModelElement::renderingAbruptlyStopped()
         createModelPlayer();
 }
 
-bool HTMLModelElement::tryAnimateModelToFitPortal()
+void HTMLModelElement::tryAnimateModelToFitPortal(bool handledDrag, CompletionHandler<void(bool)>&& completionHandler)
 {
     if (hasPortal() && m_modelPlayer)
-        return m_modelPlayer->animateModelToFitPortal();
+        return m_modelPlayer->animateModelToFitPortal(WTFMove(completionHandler));
 
-    return false;
+    completionHandler(handledDrag);
 }
 #endif // ENABLE(MODEL_PROCESS)
 

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -162,7 +162,7 @@ public:
     WEBCORE_EXPORT void beginStageModeTransform(const TransformationMatrix&);
     WEBCORE_EXPORT void updateStageModeTransform(const TransformationMatrix&);
     WEBCORE_EXPORT void endStageModeInteraction();
-    WEBCORE_EXPORT bool tryAnimateModelToFitPortal();
+    WEBCORE_EXPORT void tryAnimateModelToFitPortal(bool handledDrag, CompletionHandler<void(bool)>&&);
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/Modules/model-element/ModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.cpp
@@ -163,9 +163,9 @@ void ModelPlayer::renderingAbruptlyStopped()
 {
 }
 
-bool ModelPlayer::animateModelToFitPortal()
+void ModelPlayer::animateModelToFitPortal(CompletionHandler<void(bool)>&& completionHandler)
 {
-    return false;
+    completionHandler(false);
 }
 #endif // ENABLE(MODEL_PROCESS)
 

--- a/Source/WebCore/Modules/model-element/ModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.h
@@ -111,7 +111,7 @@ public:
     virtual void updateStageModeTransform(const TransformationMatrix&);
     virtual void endStageModeInteraction();
     virtual void renderingAbruptlyStopped();
-    virtual bool animateModelToFitPortal();
+    virtual void animateModelToFitPortal(CompletionHandler<void(bool)>&&);
 #endif
 };
 

--- a/Source/WebCore/page/DragActions.h
+++ b/Source/WebCore/page/DragActions.h
@@ -94,10 +94,4 @@ enum class MayExtendDragSession : bool { No, Yes };
 enum class HasNonDefaultPasteboardData : bool { No, Yes };
 enum class DragHandlingMethod : uint8_t { None, EditPlainText, EditRichText, UploadFile, PageLoad, SetColor, NonDefault };
 
-enum class DragStartRequestResult : uint8_t {
-    Ended = 0,
-    Started,
-    Delayed
-};
-
 } // namespace WebCore

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -122,7 +122,6 @@ extern const int ImageDragHysteresis;
 extern const int TextDragHysteresis;
 extern const int ColorDragHystersis;
 extern const int GeneralDragHysteresis;
-enum class DragStartRequestResult : uint8_t;
 #endif
 
 #if ENABLE(IOS_GESTURE_EVENTS) || ENABLE(MAC_GESTURE_EVENTS)
@@ -367,7 +366,7 @@ public:
 #endif
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(DRAG_SUPPORT)
-    WEBCORE_EXPORT DragStartRequestResult tryToBeginDragAtPoint(const IntPoint& clientPosition, const IntPoint& globalPosition);
+    WEBCORE_EXPORT void tryToBeginDragAtPoint(const IntPoint& clientPosition, const IntPoint& globalPosition, CompletionHandler<void(bool)>&&);
 #endif
     
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -134,7 +134,7 @@ public:
     void updateStageModeTransform(const WebCore::TransformationMatrix&) final;
     void endStageModeInteraction() final;
     void stageModeInteractionDidUpdateModel();
-    bool animateModelToFitPortal() final;
+    void animateModelToFitPortal(CompletionHandler<void(bool)>&&) final;
 
     USING_CAN_MAKE_WEAKPTR(WebCore::REModelLoaderClient);
 

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
@@ -42,7 +42,7 @@ messages -> ModelProcessModelPlayerProxy {
     BeginStageModeTransform(WebCore::TransformationMatrix transform)
     UpdateStageModeTransform(WebCore::TransformationMatrix transform)
     EndStageModeInteraction()
-    AnimateModelToFitPortal()
+    AnimateModelToFitPortal() -> (bool success)
 }
 
 #endif

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -756,13 +756,10 @@ bool ModelProcessModelPlayerProxy::stageModeInteractionInProgress() const
     return [m_stageModeInteractionDriver stageModeInteractionInProgress];
 }
 
-bool ModelProcessModelPlayerProxy::animateModelToFitPortal()
+void ModelProcessModelPlayerProxy::animateModelToFitPortal(CompletionHandler<void(bool)>&& completionHandler)
 {
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=291289
-    send(Messages::ModelProcessModelPlayer::DidAnimateModelForDrag());
-
-    // Return value is unused
-    return true;
+    completionHandler(true);
 }
 
 void ModelProcessModelPlayerProxy::applyEnvironmentMapDataAndRelease()

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1018,7 +1018,6 @@ def headers_for_type(type, for_implementation_file=False):
         'WebCore::DragHandlingMethod': ['<WebCore/DragActions.h>'],
         'WebCore::DragOperation': ['<WebCore/DragActions.h>'],
         'WebCore::DragSourceAction': ['<WebCore/DragActions.h>'],
-        'WebCore::DragStartRequestResult': ['<WebCore/DragActions.h>'],
         'WebCore::DynamicRangeMode': ['<WebCore/PlatformScreen.h>'],
         'WebCore::ElementAnimationContext': ['<WebCore/ElementAnimationContext.h>'],
         'WebCore::ElementContext': ['<WebCore/ElementContext.h>'],

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -714,8 +714,6 @@ public:
 #endif
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(DRAG_SUPPORT)
-    virtual void didHandleDragStartRequest(bool started) = 0;
-    virtual void didHandleAdditionalDragItemsRequest(bool added) = 0;
     virtual void willReceiveEditDragSnapshot() = 0;
     virtual void didReceiveEditDragSnapshot(std::optional<WebCore::TextIndicatorData>) = 0;
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1177,10 +1177,8 @@ public:
     void shouldDismissKeyboardAfterTapAtPoint(WebCore::FloatPoint, CompletionHandler<void(bool)>&&);
 
 #if ENABLE(DRAG_SUPPORT)
-    void didHandleDragStartRequest(bool started);
-    void didHandleAdditionalDragItemsRequest(bool added);
-    void requestDragStart(const WebCore::IntPoint& clientPosition, const WebCore::IntPoint& globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask);
-    void requestAdditionalItemsForDragSession(const WebCore::IntPoint& clientPosition, const WebCore::IntPoint& globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask);
+    void requestDragStart(const WebCore::IntPoint& clientPosition, const WebCore::IntPoint& globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask, CompletionHandler<void(bool)>&&);
+    void requestAdditionalItemsForDragSession(const WebCore::IntPoint& clientPosition, const WebCore::IntPoint& globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask, CompletionHandler<void(bool)>&&);
     void insertDroppedImagePlaceholders(const Vector<WebCore::IntSize>&, CompletionHandler<void(const Vector<WebCore::IntRect>&, std::optional<WebCore::TextIndicatorData>)>&& reply);
     void willReceiveEditDragSnapshot();
     void didReceiveEditDragSnapshot(std::optional<WebCore::TextIndicatorData>);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -338,8 +338,6 @@ messages -> WebPageProxy {
 #endif
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(DRAG_SUPPORT)
-    DidHandleDragStartRequest(bool started)
-    DidHandleAdditionalDragItemsRequest(bool added)
     WillReceiveEditDragSnapshot()
     DidReceiveEditDragSnapshot(struct std::optional<WebCore::TextIndicatorData> textIndicator)
 #endif

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -300,8 +300,6 @@ private:
 
 #if ENABLE(DRAG_SUPPORT)
     void didPerformDragOperation(bool handled) override;
-    void didHandleDragStartRequest(bool started) override;
-    void didHandleAdditionalDragItemsRequest(bool added) override;
     void startDrag(const WebCore::DragItem&, WebCore::ShareableBitmap::Handle&& image) override;
     void willReceiveEditDragSnapshot() override;
     void didReceiveEditDragSnapshot(std::optional<WebCore::TextIndicatorData>) override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -1052,16 +1052,6 @@ void PageClientImpl::didPerformDragOperation(bool handled)
     [contentView() _didPerformDragOperation:handled];
 }
 
-void PageClientImpl::didHandleDragStartRequest(bool started)
-{
-    [contentView() _didHandleDragStartRequest:started];
-}
-
-void PageClientImpl::didHandleAdditionalDragItemsRequest(bool added)
-{
-    [contentView() _didHandleAdditionalDragItemsRequest:added];
-}
-
 void PageClientImpl::startDrag(const DragItem& item, ShareableBitmap::Handle&& image)
 {
     auto bitmap = ShareableBitmap::create(WTFMove(image));

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -11074,7 +11074,9 @@ static Vector<WebCore::IntSize> sizesOfPlaceholderElementsToInsertWhenDroppingIt
     }
 
     _dragDropInteractionState.dragSessionWillRequestAdditionalItem(completion);
-    _page->requestAdditionalItemsForDragSession(WebCore::roundedIntPoint(point), WebCore::roundedIntPoint(point), self._allowedDragSourceActions);
+    _page->requestAdditionalItemsForDragSession(WebCore::roundedIntPoint(point), WebCore::roundedIntPoint(point), self._allowedDragSourceActions, [weakSelf = WeakObjCPtr { self }] (bool handled) {
+        [weakSelf _didHandleAdditionalDragItemsRequest:handled];
+    });
 }
 
 - (void)_dragInteraction:(UIDragInteraction *)interaction prepareForSession:(id<UIDragSession>)session completion:(dispatch_block_t)completion
@@ -11098,7 +11100,9 @@ static Vector<WebCore::IntSize> sizesOfPlaceholderElementsToInsertWhenDroppingIt
 
         auto dragOrigin = [session locationInView:strongSelf.get()];
         strongSelf->_dragDropInteractionState.prepareForDragSession(session.get(), completion.get());
-        strongSelf->_page->requestDragStart(WebCore::roundedIntPoint(dragOrigin), WebCore::roundedIntPoint([strongSelf convertPoint:dragOrigin toView:[strongSelf window]]), [strongSelf _allowedDragSourceActions]);
+        strongSelf->_page->requestDragStart(WebCore::roundedIntPoint(dragOrigin), WebCore::roundedIntPoint([strongSelf convertPoint:dragOrigin toView:[strongSelf window]]), [strongSelf _allowedDragSourceActions], [weakSelf = WeakObjCPtr { strongSelf.get() }] (bool started) {
+            [weakSelf _didHandleDragStartRequest:started];
+        });
         RELEASE_LOG(DragAndDrop, "Drag session requested: %p at origin: {%.0f, %.0f}", session.get(), dragOrigin.x, dragOrigin.y);
     };
 

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1309,28 +1309,20 @@ void WebPageProxy::requestDocumentEditingContext(WebKit::DocumentEditingContextR
 
 #if ENABLE(DRAG_SUPPORT)
 
-void WebPageProxy::didHandleDragStartRequest(bool started)
+void WebPageProxy::requestDragStart(const WebCore::IntPoint& clientPosition, const WebCore::IntPoint& globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask, CompletionHandler<void(bool)>&& completionHandler)
 {
-    if (RefPtr pageClient = this->pageClient())
-        pageClient->didHandleDragStartRequest(started);
+    if (!hasRunningProcess())
+        return completionHandler(false);
+
+    m_legacyMainFrameProcess->sendWithAsyncReply(Messages::WebPage::RequestDragStart(clientPosition, globalPosition, allowedActionsMask), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
-void WebPageProxy::didHandleAdditionalDragItemsRequest(bool added)
-{
-    if (RefPtr pageClient = this->pageClient())
-        pageClient->didHandleAdditionalDragItemsRequest(added);
-}
-
-void WebPageProxy::requestDragStart(const WebCore::IntPoint& clientPosition, const WebCore::IntPoint& globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask)
+void WebPageProxy::requestAdditionalItemsForDragSession(const IntPoint& clientPosition, const IntPoint& globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask, CompletionHandler<void(bool)>&& completionHandler)
 {
     if (hasRunningProcess())
-        m_legacyMainFrameProcess->send(Messages::WebPage::RequestDragStart(clientPosition, globalPosition, allowedActionsMask), webPageIDInMainFrameProcess());
-}
+        return completionHandler(false);
 
-void WebPageProxy::requestAdditionalItemsForDragSession(const IntPoint& clientPosition, const IntPoint& globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask)
-{
-    if (hasRunningProcess())
-        m_legacyMainFrameProcess->send(Messages::WebPage::RequestAdditionalItemsForDragSession(clientPosition, globalPosition, allowedActionsMask), webPageIDInMainFrameProcess());
+    m_legacyMainFrameProcess->sendWithAsyncReply(Messages::WebPage::RequestAdditionalItemsForDragSession(clientPosition, globalPosition, allowedActionsMask), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::insertDroppedImagePlaceholders(const Vector<IntSize>& imageSizes, CompletionHandler<void(const Vector<IntRect>&, std::optional<WebCore::TextIndicatorData>)>&& completionHandler)

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -138,13 +138,6 @@ void ModelProcessModelPlayer::didFinishEnvironmentMapLoading(bool succeeded)
     m_client->didFinishEnvironmentMapLoading(succeeded);
 }
 
-void ModelProcessModelPlayer::didAnimateModelForDrag()
-{
-    RELEASE_ASSERT(modelProcessEnabled());
-
-    m_page->didAnimateModelForDrag();
-}
-
 // MARK: - WebCore::ModelPlayer
 
 std::optional<WebCore::ModelPlayerAnimationState> ModelProcessModelPlayer::currentAnimationState() const
@@ -399,10 +392,9 @@ void ModelProcessModelPlayer::renderingAbruptlyStopped()
         m_client->renderingAbruptlyStopped();
 }
 
-bool ModelProcessModelPlayer::animateModelToFitPortal()
+void ModelProcessModelPlayer::animateModelToFitPortal(CompletionHandler<void(bool)>&& completionHandler)
 {
-    send(Messages::ModelProcessModelPlayerProxy::AnimateModelToFitPortal());
-    return true;
+    sendWithAsyncReply(Messages::ModelProcessModelPlayerProxy::AnimateModelToFitPortal(), WTFMove(completionHandler));
 }
 
 }

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -73,7 +73,6 @@ private:
     void didUpdateEntityTransform(const WebCore::TransformationMatrix&);
     void didUpdateAnimationPlaybackState(bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp);
     void didFinishEnvironmentMapLoading(bool succeeded);
-    void didAnimateModelForDrag();
 
     // WebCore::ModelPlayer overrides.
     WebCore::ModelPlayerIdentifier identifier() const final { return m_id; }
@@ -118,7 +117,7 @@ private:
     void beginStageModeTransform(const WebCore::TransformationMatrix&) final;
     void updateStageModeTransform(const WebCore::TransformationMatrix&) final;
     void endStageModeInteraction() final;
-    bool animateModelToFitPortal() final;
+    void animateModelToFitPortal(CompletionHandler<void(bool)>&&) final;
 
     WebCore::ModelPlayerIdentifier m_id;
     WeakPtr<WebPage> m_page;

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in
@@ -34,7 +34,6 @@ messages -> ModelProcessModelPlayer {
     DidUpdateEntityTransform(WebCore::TransformationMatrix transform)
     DidUpdateAnimationPlaybackState(bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp)
     DidFinishEnvironmentMapLoading(bool succeeded)
-    DidAnimateModelForDrag()
 }
 
 #endif // ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5599,12 +5599,6 @@ void WebPage::stageModeSessionDidEnd(std::optional<ElementIdentifier> elementID)
     if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame()))
         localMainFrame->eventHandler().stageModeSessionDidEnd(elementID);
 }
-
-void WebPage::didAnimateModelForDrag()
-{
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=291284
-    send(Messages::WebPageProxy::DidHandleDragStartRequest(true));
-}
 #endif
 
 WebUndoStep* WebPage::webUndoStep(WebUndoStepID stepID)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1298,7 +1298,6 @@ public:
     void requestInteractiveModelElementAtPoint(WebCore::IntPoint clientPosition);
     void stageModeSessionDidUpdate(std::optional<WebCore::ElementIdentifier>, const WebCore::TransformationMatrix&);
     void stageModeSessionDidEnd(std::optional<WebCore::ElementIdentifier>);
-    void didAnimateModelForDrag();
 #endif
 
     void beginPrinting(WebCore::FrameIdentifier, const PrintInfo&);
@@ -2069,8 +2068,8 @@ private:
     void removeReasonsToDisallowLayoutViewportHeightExpansion(OptionSet<DisallowLayoutViewportHeightExpansionReason>);
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(DRAG_SUPPORT)
-    void requestDragStart(const WebCore::IntPoint& clientPosition, const WebCore::IntPoint& globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask);
-    void requestAdditionalItemsForDragSession(const WebCore::IntPoint& clientPosition, const WebCore::IntPoint& globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask);
+    void requestDragStart(const WebCore::IntPoint& clientPosition, const WebCore::IntPoint& globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask, CompletionHandler<void(bool)>&&);
+    void requestAdditionalItemsForDragSession(const WebCore::IntPoint& clientPosition, const WebCore::IntPoint& globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask, CompletionHandler<void(bool)>&&);
     void insertDroppedImagePlaceholders(const Vector<WebCore::IntSize>&, CompletionHandler<void(const Vector<WebCore::IntRect>&, std::optional<WebCore::TextIndicatorData>)>&& reply);
     void computeAndSendEditDragSnapshot();
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -369,8 +369,8 @@ messages -> WebPage WantsAsyncDispatchMessage {
 #endif
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(DRAG_SUPPORT)
-    RequestDragStart(WebCore::IntPoint clientPosition, WebCore::IntPoint globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask)
-    RequestAdditionalItemsForDragSession(WebCore::IntPoint clientPosition, WebCore::IntPoint globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask)
+    RequestDragStart(WebCore::IntPoint clientPosition, WebCore::IntPoint globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask) -> (bool started)
+    RequestAdditionalItemsForDragSession(WebCore::IntPoint clientPosition, WebCore::IntPoint globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask) -> (bool started)
     InsertDroppedImagePlaceholders(Vector<WebCore::IntSize> imageSize) -> (Vector<WebCore::IntRect> dropPreviewRects, struct std::optional<WebCore::TextIndicatorData> textIndicator)
     DidConcludeDrop()
 #endif


### PR DESCRIPTION
#### 243e10f98b11eb286da69baf032739f37014232c
<pre>
Use sendWithAsyncReply for starting and requesting additional items for a drag session
<a href="https://bugs.webkit.org/show_bug.cgi?id=292565">https://bugs.webkit.org/show_bug.cgi?id=292565</a>
<a href="https://rdar.apple.com/150717298">rdar://150717298</a>

Reviewed by Wenson Hsieh.

Use a CompletionHandler instead of DragStartRequestResult::Delayed.

* Source/WebCore/page/DragActions.h:
* Source/WebCore/page/EventHandler.h:
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::didHandleDragStartRequest): Deleted.
(WebKit::PageClientImpl::didHandleAdditionalDragItemsRequest): Deleted.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _dragInteraction:itemsForAddingToSession:withTouchAtPoint:completion:]):
(-[WKContentView _dragInteraction:prepareForSession:completion:]):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::requestDragStart):
(WebKit::WebPageProxy::requestAdditionalItemsForDragSession):
(WebKit::WebPageProxy::didHandleDragStartRequest): Deleted.
(WebKit::WebPageProxy::didHandleAdditionalDragItemsRequest): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::requestDragStart):
(WebKit::WebPage::requestAdditionalItemsForDragSession):

Canonical link: <a href="https://commits.webkit.org/294585@main">https://commits.webkit.org/294585@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1775b064803d61aa1478f1a16de3ca049a0110a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102389 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22058 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107550 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53025 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30564 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/77899 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34890 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17320 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92423 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58236 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/101863 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17156 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10451 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52383 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/86978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10522 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109925 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29521 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86879 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29885 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88619 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/86470 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31293 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9012 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/23763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16626 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29449 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/34751 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29260 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32583 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30819 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->