### PR TITLE
Reduce header includes in SVGElement.h

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1267,6 +1267,7 @@ svg/SVGCursorElement.cpp
 svg/SVGCursorElement.h
 svg/SVGElement.cpp
 svg/SVGElement.h
+svg/SVGElementInlines.h
 svg/SVGEllipseElement.h
 svg/SVGFEBlendElement.h
 svg/SVGFEColorMatrixElement.cpp

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -77,7 +77,7 @@
 #include "RenderTextControl.h"
 #include "RenderTreeUpdater.h"
 #include "RenderView.h"
-#include "SVGElement.h"
+#include "SVGElementInlines.h"
 #include "ScopedEventQueue.h"
 #include "ScriptDisallowedScope.h"
 #include "Settings.h"

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp
@@ -148,7 +148,7 @@ AffineTransform RenderSVGResourceMarker::markerTransformation(const FloatPoint& 
     // The 'referencePoint()' coordinate maps to SVGs refX/refY, given in coordinates relative to the viewport established by the marker
     auto mappedOrigin = m_supplementalLayerTransform.mapPoint(referencePoint());
 
-    if (markerUnits() == SVGMarkerUnitsStrokeWidth)
+    if (markerUnits() == SVGMarkerUnitsType::StrokeWidth)
         transform.scaleNonUniform(strokeWidth, strokeWidth);
 
     transform.translate(-mappedOrigin);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.cpp
@@ -94,7 +94,7 @@ std::optional<float> LegacyRenderSVGResourceMarker::angle() const
 
 AffineTransform LegacyRenderSVGResourceMarker::markerTransformation(const FloatPoint& origin, float autoAngle, float strokeWidth) const
 {
-    bool useStrokeWidth = markerElement().markerUnits() == SVGMarkerUnitsStrokeWidth;
+    bool useStrokeWidth = markerElement().markerUnits() == SVGMarkerUnitsType::StrokeWidth;
 
     AffineTransform transform;
     transform.translate(origin);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.h
@@ -27,6 +27,8 @@ class AffineTransform;
 class RenderObject;
 class SVGMarkerElement;
 
+enum class SVGMarkerUnitsType : uint8_t;
+
 class LegacyRenderSVGResourceMarker final : public LegacyRenderSVGResourceContainer {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(LegacyRenderSVGResourceMarker);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGResourceMarker);

--- a/Source/WebCore/svg/SVGAnimationElement.h
+++ b/Source/WebCore/svg/SVGAnimationElement.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "SVGAttributeAnimator.h"
 #include "SVGSMILElement.h"
 #include "SVGTests.h"
 #include "UnitBezier.h"

--- a/Source/WebCore/svg/SVGCircleElement.cpp
+++ b/Source/WebCore/svg/SVGCircleElement.cpp
@@ -27,6 +27,7 @@
 #include "NodeName.h"
 #include "RenderSVGEllipse.h"
 #include "SVGElementInlines.h"
+#include "SVGParsingError.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -64,7 +65,7 @@ SVGAnimatedProperty* SVGCircleElement::propertyForAttribute(const QualifiedName&
 
 void SVGCircleElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGParsingError parseError = NoError;
+    auto parseError = SVGParsingError::None;
 
     switch (name.nodeName()) {
     case AttributeNames::cxAttr:

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
@@ -23,7 +23,9 @@
 
 #include "FEComponentTransfer.h"
 #include "NodeName.h"
+#include "SVGAnimatedPropertyImpl.h"
 #include "SVGElement.h"
+#include "SVGNumberList.h"
 #include <wtf/SortedArrayMap.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/svg/SVGCursorElement.cpp
+++ b/Source/WebCore/svg/SVGCursorElement.cpp
@@ -25,6 +25,7 @@
 #include "Document.h"
 #include "NodeInlines.h"
 #include "SVGNames.h"
+#include "SVGParsingError.h"
 #include "SVGStringList.h"
 #include "StyleCursorImage.h"
 #include <wtf/NeverDestroyed.h>
@@ -61,7 +62,7 @@ SVGCursorElement::~SVGCursorElement()
 
 void SVGCursorElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGParsingError parseError = NoError;
+    auto parseError = SVGParsingError::None;
 
     if (name == SVGNames::xAttr)
         Ref { m_x }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));

--- a/Source/WebCore/svg/SVGDescElement.cpp
+++ b/Source/WebCore/svg/SVGDescElement.cpp
@@ -22,6 +22,7 @@
 #include "SVGDescElement.h"
 
 #include "SVGNames.h"
+#include "SVGPropertyOwnerRegistry.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -22,30 +22,45 @@
 
 #pragma once
 
-#include "SVGAnimatedPropertyImpl.h"
-#include "SVGLocatable.h"
 #include "SVGNames.h"
-#include "SVGParsingError.h"
-#include "SVGPropertyOwnerRegistry.h"
+#include "SVGPropertyOwner.h"
 #include "SVGRenderStyleDefs.h"
 #include "StyledElement.h"
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
 class AffineTransform;
 class Document;
+class SVGAnimatedProperty;
+class SVGAnimatedString;
+class SVGAttributeAnimator;
+class SVGConditionalProcessingAttributes;
 class SVGDocumentExtensions;
 class SVGElementRareData;
 class SVGPropertyAnimatorFactory;
+class SVGPropertyRegistry;
 class SVGResourceElementClient;
 class SVGSVGElement;
+class SVGTransformList;
 class SVGUseElement;
 class Settings;
 class Timer;
+
+enum class AnimationMode : uint8_t;
+enum class CTMScope : bool;
+enum class CalcMode : uint8_t;
+enum class SVGParsingError : uint8_t;
+
+template<typename PropertyType>
+class SVGAnimatedPrimitiveProperty;
+
+template<typename OwnerType, typename... BaseTypes>
+class SVGPropertyOwnerRegistry;
 
 class SVGElement : public StyledElement, public SVGPropertyOwner {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(SVGElement);
@@ -63,7 +78,7 @@ public:
     virtual bool needsPendingResourceHandling() const { return true; }
     bool instanceUpdatesBlocked() const;
     void setInstanceUpdatesBlocked(bool);
-    virtual AffineTransform localCoordinateSpaceTransform(SVGLocatable::CTMScope) const;
+    virtual AffineTransform localCoordinateSpaceTransform(CTMScope) const;
 
     bool hasPendingResources() const { return hasEventTargetFlag(EventTargetFlag::HasPendingResources); }
     void setHasPendingResources() { setEventTargetFlag(EventTargetFlag::HasPendingResources, true); }
@@ -139,7 +154,7 @@ public:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGElement>;
     const SVGPropertyRegistry& propertyRegistry() const { return m_propertyRegistry.get(); }
-    void detachAllProperties() { propertyRegistry().detachAllProperties(); }
+    inline void detachAllProperties(); // Defined in SVGElementInlines.h
 
     bool isAnimatedPropertyAttribute(const QualifiedName&) const;
     bool isAnimatedAttribute(const QualifiedName&) const;
@@ -162,7 +177,7 @@ public:
     ColorInterpolation colorInterpolation() const;
 
     // These are needed for the RenderTree, animation and DOM.
-    AtomString className() const { return AtomString { m_className->currentValue() }; }
+    inline AtomString className() const; // Defined in SVGElementInlines.h
     SVGAnimatedString& classNameAnimated() { return m_className; }
 
     SVGConditionalProcessingAttributes& conditionalProcessingAttributes();
@@ -219,7 +234,7 @@ private:
     std::unique_ptr<SVGPropertyAnimatorFactory> m_propertyAnimatorFactory;
 
     UniqueRef<SVGPropertyRegistry> m_propertyRegistry;
-    Ref<SVGAnimatedString> m_className { SVGAnimatedString::create(this) };
+    Ref<SVGAnimatedString> m_className;
 };
 
 class SVGElement::InstanceInvalidationGuard {

--- a/Source/WebCore/svg/SVGElementInlines.h
+++ b/Source/WebCore/svg/SVGElementInlines.h
@@ -26,9 +26,16 @@
 #pragma once
 
 #include "ElementInlines.h"
+#include "SVGAnimatedString.h"
 #include "SVGElement.h"
+#include "SVGPropertyRegistry.h"
 
 namespace WebCore {
+
+inline void SVGElement::detachAllProperties()
+{
+    propertyRegistry().detachAllProperties();
+}
 
 inline void SVGElement::setAnimatedSVGAttributesAreDirty()
 {
@@ -39,6 +46,11 @@ inline void SVGElement::setPresentationalHintStyleIsDirty()
 {
     ensureUniqueElementData().setPresentationalHintStyleIsDirty(true);
     invalidateStyle();
+}
+
+inline AtomString SVGElement::className() const
+{
+    return AtomString { m_className->currentValue() };
 }
 
 inline bool Element::hasTagName(const SVGQualifiedName& tagName) const

--- a/Source/WebCore/svg/SVGEllipseElement.cpp
+++ b/Source/WebCore/svg/SVGEllipseElement.cpp
@@ -27,6 +27,7 @@
 #include "NodeName.h"
 #include "RenderSVGEllipse.h"
 #include "SVGElementInlines.h"
+#include "SVGParsingError.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -54,7 +55,7 @@ Ref<SVGEllipseElement> SVGEllipseElement::create(const QualifiedName& tagName, D
 
 void SVGEllipseElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGParsingError parseError = NoError;
+    auto parseError = SVGParsingError::None;
 
     switch (name.nodeName()) {
     case AttributeNames::cxAttr:

--- a/Source/WebCore/svg/SVGFECompositeElement.cpp
+++ b/Source/WebCore/svg/SVGFECompositeElement.cpp
@@ -25,6 +25,7 @@
 #include "FEComposite.h"
 #include "NodeName.h"
 #include "SVGNames.h"
+#include "SVGPropertyOwnerRegistry.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/svg/SVGFECompositeElement.h
+++ b/Source/WebCore/svg/SVGFECompositeElement.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "FEComposite.h"
+#include "SVGAnimatedPropertyImpl.h"
 #include "SVGFilterPrimitiveStandardAttributes.h"
 #include <wtf/SortedArrayMap.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
@@ -29,6 +29,7 @@
 #include "SVGFilter.h"
 #include "SVGNames.h"
 #include "SVGParserUtilities.h"
+#include "SVGPropertyOwnerRegistry.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 

--- a/Source/WebCore/svg/SVGFELightElement.h
+++ b/Source/WebCore/svg/SVGFELightElement.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "LightSource.h"
+#include "SVGAnimatedPropertyImpl.h"
 #include "SVGElement.h"
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/svg/SVGFEMorphologyElement.cpp
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.cpp
@@ -27,6 +27,7 @@
 #include "SVGFilter.h"
 #include "SVGNames.h"
 #include "SVGParserUtilities.h"
+#include "SVGPropertyOwnerRegistry.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/svg/SVGFilterElement.cpp
+++ b/Source/WebCore/svg/SVGFilterElement.cpp
@@ -33,6 +33,7 @@
 #include "SVGFilterPrimitiveStandardAttributes.h"
 #include "SVGNames.h"
 #include "SVGParserUtilities.h"
+#include "SVGParsingError.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -66,7 +67,7 @@ Ref<SVGFilterElement> SVGFilterElement::create(const QualifiedName& tagName, Doc
 
 void SVGFilterElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGParsingError parseError = NoError;
+    auto parseError = SVGParsingError::None;
 
     switch (name.nodeName()) {
     case AttributeNames::filterUnitsAttr: {

--- a/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp
+++ b/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp
@@ -29,6 +29,8 @@
 #include "NodeName.h"
 #include "RenderSVGResourceFilterPrimitive.h"
 #include "SVGElementInlines.h"
+#include "SVGParsingError.h"
+#include "SVGPropertyOwnerRegistry.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -51,7 +53,7 @@ SVGFilterPrimitiveStandardAttributes::SVGFilterPrimitiveStandardAttributes(const
 
 void SVGFilterPrimitiveStandardAttributes::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGParsingError parseError = NoError;
+    auto parseError = SVGParsingError::None;
 
     switch (name.nodeName()) {
     case AttributeNames::xAttr:

--- a/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h
+++ b/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h
@@ -23,8 +23,10 @@
 
 #include "FilterEffectGeometry.h"
 #include "FilterEffectVector.h"
+#include "SVGAnimatedPropertyImpl.h"
 #include "SVGElement.h"
 #include "SVGNames.h"
+#include "SVGUnitTypes.h"
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/svg/SVGForeignObjectElement.cpp
+++ b/Source/WebCore/svg/SVGForeignObjectElement.cpp
@@ -31,6 +31,7 @@
 #include "SVGElementInlines.h"
 #include "SVGLengthValue.h"
 #include "SVGNames.h"
+#include "SVGParsingError.h"
 #include <wtf/Assertions.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -59,7 +60,7 @@ Ref<SVGForeignObjectElement> SVGForeignObjectElement::create(const QualifiedName
 
 void SVGForeignObjectElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGParsingError parseError = NoError;
+    auto parseError = SVGParsingError::None;
 
     switch (name.nodeName()) {
     case AttributeNames::xAttr:

--- a/Source/WebCore/svg/SVGGraphicsElement.cpp
+++ b/Source/WebCore/svg/SVGGraphicsElement.cpp
@@ -51,6 +51,7 @@ SVGGraphicsElement::SVGGraphicsElement(const QualifiedName& tagName, Document& d
     : SVGElement(tagName, document, WTFMove(propertyRegistry), typeFlags)
     , SVGTests(this)
     , m_shouldIsolateBlending(false)
+    , m_transform(SVGAnimatedTransformList::create(this))
 {
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
@@ -67,7 +68,7 @@ Ref<SVGMatrix> SVGGraphicsElement::getCTMForBindings()
 
 AffineTransform SVGGraphicsElement::getCTM(StyleUpdateStrategy styleUpdateStrategy)
 {
-    return SVGLocatable::computeCTM(this, SVGLocatable::NearestViewportScope, styleUpdateStrategy);
+    return SVGLocatable::computeCTM(this, CTMScope::NearestViewportScope, styleUpdateStrategy);
 }
 
 Ref<SVGMatrix> SVGGraphicsElement::getScreenCTMForBindings()
@@ -77,7 +78,7 @@ Ref<SVGMatrix> SVGGraphicsElement::getScreenCTMForBindings()
 
 AffineTransform SVGGraphicsElement::getScreenCTM(StyleUpdateStrategy styleUpdateStrategy)
 {
-    return SVGLocatable::computeCTM(this, SVGLocatable::ScreenScope, styleUpdateStrategy);
+    return SVGLocatable::computeCTM(this, CTMScope::ScreenScope, styleUpdateStrategy);
 }
 
 Ref<const SVGTransformList> SVGGraphicsElement::protectedTransform() const

--- a/Source/WebCore/svg/SVGGraphicsElement.h
+++ b/Source/WebCore/svg/SVGGraphicsElement.h
@@ -21,8 +21,10 @@
 
 #pragma once
 
+#include "SVGAnimatedPropertyImpl.h"
 #include "SVGElement.h"
 #include "SVGTests.h"
+#include "SVGTransformList.h"
 #include "SVGTransformable.h"
 #include <wtf/TZoneMalloc.h>
 
@@ -48,7 +50,7 @@ public:
     SVGElement* nearestViewportElement() const override;
     SVGElement* farthestViewportElement() const override;
 
-    AffineTransform localCoordinateSpaceTransform(SVGLocatable::CTMScope mode) const override { return SVGTransformable::localCoordinateSpaceTransform(mode); }
+    AffineTransform localCoordinateSpaceTransform(CTMScope mode) const override { return SVGTransformable::localCoordinateSpaceTransform(mode); }
     AffineTransform animatedLocalTransform() const override;
     AffineTransform* ensureSupplementalTransform() override;
     AffineTransform* supplementalTransform() const override { return m_supplementalTransform.get(); }
@@ -89,9 +91,9 @@ private:
     std::unique_ptr<AffineTransform> m_supplementalTransform;
 
     // Used to isolate blend operations caused by masking.
-    bool m_shouldIsolateBlending;
+    bool m_shouldIsolateBlending { false };
 
-    Ref<SVGAnimatedTransformList> m_transform { SVGAnimatedTransformList::create(this) };
+    Ref<SVGAnimatedTransformList> m_transform;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -35,6 +35,7 @@
 #include "RenderSVGImage.h"
 #include "SVGElementInlines.h"
 #include "SVGNames.h"
+#include "SVGParsingError.h"
 #include "XLinkNames.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -91,7 +92,7 @@ bool SVGImageElement::renderingTaintsOrigin() const
 
 void SVGImageElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGParsingError parseError = NoError;
+    auto parseError = SVGParsingError::None;
     switch (name.nodeName()) {
     case AttributeNames::preserveAspectRatioAttr:
         Ref { m_preserveAspectRatio }->setBaseValInternal(SVGPreserveAspectRatioValue { newValue });

--- a/Source/WebCore/svg/SVGLengthValue.cpp
+++ b/Source/WebCore/svg/SVGLengthValue.cpp
@@ -26,6 +26,7 @@
 #include "SVGElement.h"
 #include "SVGLengthContext.h"
 #include "SVGParserUtilities.h"
+#include "SVGParsingError.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/FastCharacterComparison.h>
 #include <wtf/text/MakeString.h>
@@ -215,9 +216,9 @@ SVGLengthValue SVGLengthValue::construct(SVGLengthMode lengthMode, StringView va
     SVGLengthValue length(lengthMode);
 
     if (length.setValueAsString(valueAsString).hasException())
-        parseError = ParsingAttributeFailedError;
+        parseError = SVGParsingError::ParsingFailed;
     else if (negativeValuesMode == SVGLengthNegativeValuesMode::Forbid && length.valueInSpecifiedUnits() < 0)
-        parseError = NegativeValueForbiddenError;
+        parseError = SVGParsingError::ForbiddenNegativeValue;
 
     return length;
 }

--- a/Source/WebCore/svg/SVGLineElement.cpp
+++ b/Source/WebCore/svg/SVGLineElement.cpp
@@ -27,6 +27,7 @@
 #include "NodeName.h"
 #include "RenderSVGShape.h"
 #include "SVGLengthValue.h"
+#include "SVGParsingError.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -54,7 +55,7 @@ Ref<SVGLineElement> SVGLineElement::create(const QualifiedName& tagName, Documen
 
 void SVGLineElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGParsingError parseError = NoError;
+    auto parseError = SVGParsingError::None;
 
     switch (name.nodeName()) {
     case AttributeNames::x1Attr:

--- a/Source/WebCore/svg/SVGLinearGradientElement.cpp
+++ b/Source/WebCore/svg/SVGLinearGradientElement.cpp
@@ -34,6 +34,7 @@
 #include "SVGElementTypeHelpers.h"
 #include "SVGLengthValue.h"
 #include "SVGNames.h"
+#include "SVGParsingError.h"
 #include "SVGUnitTypes.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -64,7 +65,7 @@ Ref<SVGLinearGradientElement> SVGLinearGradientElement::create(const QualifiedNa
 
 void SVGLinearGradientElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGParsingError parseError = NoError;
+    auto parseError = SVGParsingError::None;
 
     switch (name.nodeName()) {
     case AttributeNames::x1Attr:

--- a/Source/WebCore/svg/SVGLocatable.cpp
+++ b/Source/WebCore/svg/SVGLocatable.cpp
@@ -91,7 +91,7 @@ AffineTransform SVGLocatable::computeCTM(SVGElement* element, CTMScope mode, Sty
     if (styleUpdateStrategy == AllowStyleUpdate)
         element->protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, element);
 
-    RefPtr stopAtElement = mode == NearestViewportScope ? nearestViewportElement(element) : nullptr;
+    RefPtr stopAtElement = mode == CTMScope::NearestViewportScope ? nearestViewportElement(element) : nullptr;
 
     if (element->document().settings().layerBasedSVGEngineEnabled()) {
         // Rudimentary support for operations on "detached" elements.
@@ -99,7 +99,7 @@ AffineTransform SVGLocatable::computeCTM(SVGElement* element, CTMScope mode, Sty
         if (!renderer)
             return element->localCoordinateSpaceTransform(mode);
 
-        auto trackingMode { mode == SVGLocatable::ScreenScope ? TransformState::TrackSVGScreenCTMMatrix : TransformState::TrackSVGCTMMatrix };
+        auto trackingMode { mode == CTMScope::ScreenScope ? TransformState::TrackSVGScreenCTMMatrix : TransformState::TrackSVGCTMMatrix };
         CheckedPtr stopAtRenderer = dynamicDowncast<RenderLayerModelObject>(stopAtElement ? stopAtElement->renderer() : nullptr);
         return SVGLayerTransformComputation(*renderer).computeAccumulatedTransform(stopAtRenderer.get(), trackingMode);
     }

--- a/Source/WebCore/svg/SVGLocatable.h
+++ b/Source/WebCore/svg/SVGLocatable.h
@@ -30,6 +30,11 @@ class FloatRect;
 class SVGElement;
 class SVGMatrix;
 
+enum class CTMScope : bool {
+    NearestViewportScope, // Used for getCTM()
+    ScreenScope // Used for getScreenCTM()
+};
+
 class SVGLocatable {
 public:
     virtual ~SVGLocatable() = default;
@@ -47,13 +52,8 @@ public:
     static SVGElement* nearestViewportElement(const SVGElement*);
     static SVGElement* farthestViewportElement(const SVGElement*);
 
-    enum CTMScope {
-        NearestViewportScope, // Used for getCTM()
-        ScreenScope // Used for getScreenCTM()
-    };
-
 protected:
-    virtual AffineTransform localCoordinateSpaceTransform(SVGLocatable::CTMScope) const { return AffineTransform(); }
+    virtual AffineTransform localCoordinateSpaceTransform(CTMScope) const { return AffineTransform(); }
 
     static FloatRect getBBox(SVGElement*, StyleUpdateStrategy);
     static AffineTransform computeCTM(SVGElement*, CTMScope, StyleUpdateStrategy);

--- a/Source/WebCore/svg/SVGMarkerElement.cpp
+++ b/Source/WebCore/svg/SVGMarkerElement.cpp
@@ -28,6 +28,7 @@
 #include "NodeName.h"
 #include "RenderSVGResourceMarker.h"
 #include "SVGNames.h"
+#include "SVGParsingError.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -64,11 +65,11 @@ AffineTransform SVGMarkerElement::viewBoxToViewTransform(float viewWidth, float 
 
 void SVGMarkerElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGParsingError parseError = NoError;
+    auto parseError = SVGParsingError::None;
     switch (name.nodeName()) {
     case AttributeNames::markerUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGMarkerUnitsType>::fromString(newValue);
-        if (propertyValue > 0)
+        if (propertyValue != SVGMarkerUnitsType::Unknown)
             Ref { m_markerUnits }->setBaseValInternal<SVGMarkerUnitsType>(propertyValue);
         return;
     }

--- a/Source/WebCore/svg/SVGMarkerElement.h
+++ b/Source/WebCore/svg/SVGMarkerElement.h
@@ -34,9 +34,9 @@ class SVGMarkerElement final : public SVGElement, public SVGFitToViewBox {
 public:
     // Forward declare enumerations in the W3C naming scheme, for IDL generation.
     enum {
-        SVG_MARKERUNITS_UNKNOWN = SVGMarkerUnitsUnknown,
-        SVG_MARKERUNITS_USERSPACEONUSE = SVGMarkerUnitsUserSpaceOnUse,
-        SVG_MARKERUNITS_STROKEWIDTH = SVGMarkerUnitsStrokeWidth
+        SVG_MARKERUNITS_UNKNOWN = std::underlying_type_t<SVGMarkerUnitsType>(SVGMarkerUnitsType::Unknown),
+        SVG_MARKERUNITS_USERSPACEONUSE = std::underlying_type_t<SVGMarkerUnitsType>(SVGMarkerUnitsType::UserSpaceOnUse),
+        SVG_MARKERUNITS_STROKEWIDTH = std::underlying_type_t<SVGMarkerUnitsType>(SVGMarkerUnitsType::StrokeWidth)
     };
 
     enum {
@@ -95,7 +95,7 @@ private:
     Ref<SVGAnimatedLength> m_refY { SVGAnimatedLength::create(this, SVGLengthMode::Height) };
     Ref<SVGAnimatedLength> m_markerWidth { SVGAnimatedLength::create(this, SVGLengthMode::Width, "3"_s) };
     Ref<SVGAnimatedLength> m_markerHeight { SVGAnimatedLength::create(this, SVGLengthMode::Height, "3"_s) };
-    Ref<SVGAnimatedEnumeration> m_markerUnits { SVGAnimatedEnumeration::create(this, SVGMarkerUnitsStrokeWidth) };
+    Ref<SVGAnimatedEnumeration> m_markerUnits { SVGAnimatedEnumeration::create(this, SVGMarkerUnitsType::StrokeWidth) };
     Ref<SVGAnimatedAngle> m_orientAngle { SVGAnimatedAngle::create(this) };
     Ref<SVGAnimatedOrientType> m_orientType { SVGAnimatedOrientType::create(this, SVGMarkerOrientAngle) };
 };

--- a/Source/WebCore/svg/SVGMarkerTypes.h
+++ b/Source/WebCore/svg/SVGMarkerTypes.h
@@ -31,10 +31,10 @@
 
 namespace WebCore {
 
-enum SVGMarkerUnitsType {
-    SVGMarkerUnitsUnknown = 0,
-    SVGMarkerUnitsUserSpaceOnUse,
-    SVGMarkerUnitsStrokeWidth
+enum class SVGMarkerUnitsType : uint8_t {
+    Unknown = 0,
+    UserSpaceOnUse,
+    StrokeWidth,
 };
 
 enum SVGMarkerOrientType {
@@ -49,15 +49,15 @@ enum SVGMarkerOrientType {
     
 template<>
 struct SVGPropertyTraits<SVGMarkerUnitsType> {
-    static unsigned highestEnumValue() { return SVGMarkerUnitsStrokeWidth; }
+    static unsigned highestEnumValue() { return std::underlying_type_t<SVGMarkerUnitsType>(SVGMarkerUnitsType::StrokeWidth); }
     static String toString(SVGMarkerUnitsType type)
     {
         switch (type) {
-        case SVGMarkerUnitsUnknown:
+        case SVGMarkerUnitsType::Unknown:
             return emptyString();
-        case SVGMarkerUnitsUserSpaceOnUse:
+        case SVGMarkerUnitsType::UserSpaceOnUse:
             return "userSpaceOnUse"_s;
-        case SVGMarkerUnitsStrokeWidth:
+        case SVGMarkerUnitsType::StrokeWidth:
             return "strokeWidth"_s;
         }
         
@@ -67,10 +67,10 @@ struct SVGPropertyTraits<SVGMarkerUnitsType> {
     static SVGMarkerUnitsType fromString(const String& value)
     {
         if (value == "userSpaceOnUse"_s)
-            return SVGMarkerUnitsUserSpaceOnUse;
+            return SVGMarkerUnitsType::UserSpaceOnUse;
         if (value == "strokeWidth"_s)
-            return SVGMarkerUnitsStrokeWidth;
-        return SVGMarkerUnitsUnknown;
+            return SVGMarkerUnitsType::StrokeWidth;
+        return SVGMarkerUnitsType::Unknown;
     }
 };
 

--- a/Source/WebCore/svg/SVGMaskElement.cpp
+++ b/Source/WebCore/svg/SVGMaskElement.cpp
@@ -33,6 +33,7 @@
 #include "SVGElementInlines.h"
 #include "SVGLayerTransformComputation.h"
 #include "SVGNames.h"
+#include "SVGParsingError.h"
 #include "SVGRenderSupport.h"
 #include "SVGStringList.h"
 #include "SVGUnitTypes.h"
@@ -70,7 +71,7 @@ Ref<SVGMaskElement> SVGMaskElement::create(const QualifiedName& tagName, Documen
 
 void SVGMaskElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGParsingError parseError = NoError;
+    auto parseError = SVGParsingError::None;
     switch (name.nodeName()) {
     case AttributeNames::maskUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);

--- a/Source/WebCore/svg/SVGMaskElement.h
+++ b/Source/WebCore/svg/SVGMaskElement.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "SVGAnimatedPropertyImpl.h"
 #include "SVGElement.h"
 #include "SVGNames.h"
 #include "SVGTests.h"

--- a/Source/WebCore/svg/SVGParsingError.h
+++ b/Source/WebCore/svg/SVGParsingError.h
@@ -28,10 +28,10 @@
 
 namespace WebCore {
 
-enum SVGParsingError {
-    NoError,
-    ParsingAttributeFailedError,
-    NegativeValueForbiddenError
+enum class SVGParsingError : uint8_t {
+    None,
+    ParsingFailed,
+    ForbiddenNegativeValue,
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGPathSegImpl.h
+++ b/Source/WebCore/svg/SVGPathSegImpl.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "SVGPathSeg.h"
+#include "SVGPathSegList.h"
 #include "SVGPathSegValue.h"
 
 namespace WebCore {

--- a/Source/WebCore/svg/SVGPatternElement.cpp
+++ b/Source/WebCore/svg/SVGPatternElement.cpp
@@ -38,6 +38,7 @@
 #include "SVGFitToViewBox.h"
 #include "SVGGraphicsElement.h"
 #include "SVGNames.h"
+#include "SVGParsingError.h"
 #include "SVGRenderSupport.h"
 #include "SVGStringList.h"
 #include "SVGTransformable.h"
@@ -75,7 +76,7 @@ Ref<SVGPatternElement> SVGPatternElement::create(const QualifiedName& tagName, D
 
 void SVGPatternElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGParsingError parseError = NoError;
+    auto parseError = SVGParsingError::None;
     switch (name.nodeName()) {
     case AttributeNames::patternUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
@@ -195,7 +196,7 @@ Ref<const SVGTransformList> SVGPatternElement::protectedPatternTransform() const
     return m_patternTransform->currentValue();
 }
 
-AffineTransform SVGPatternElement::localCoordinateSpaceTransform(SVGLocatable::CTMScope) const
+AffineTransform SVGPatternElement::localCoordinateSpaceTransform(CTMScope) const
 {
     return protectedPatternTransform()->concatenate();
 }

--- a/Source/WebCore/svg/SVGPatternElement.h
+++ b/Source/WebCore/svg/SVGPatternElement.h
@@ -41,7 +41,7 @@ public:
 
     void collectPatternAttributes(PatternAttributes&) const;
 
-    AffineTransform localCoordinateSpaceTransform(SVGLocatable::CTMScope) const final;
+    AffineTransform localCoordinateSpaceTransform(CTMScope) const final;
 
     const SVGLengthValue& x() const { return m_x->currentValue(); }
     const SVGLengthValue& y() const { return m_y->currentValue(); }

--- a/Source/WebCore/svg/SVGRadialGradientElement.cpp
+++ b/Source/WebCore/svg/SVGRadialGradientElement.cpp
@@ -34,6 +34,7 @@
 #include "RenderSVGResourceRadialGradient.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGNames.h"
+#include "SVGParsingError.h"
 #include "SVGStopElement.h"
 #include "SVGUnitTypes.h"
 #include <wtf/NeverDestroyed.h>
@@ -67,7 +68,7 @@ Ref<SVGRadialGradientElement> SVGRadialGradientElement::create(const QualifiedNa
 
 void SVGRadialGradientElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGParsingError parseError = NoError;
+    auto parseError = SVGParsingError::None;
 
     switch (name.nodeName()) {
     case AttributeNames::cxAttr:

--- a/Source/WebCore/svg/SVGRectElement.cpp
+++ b/Source/WebCore/svg/SVGRectElement.cpp
@@ -29,6 +29,7 @@
 #include "RenderSVGRect.h"
 #include "SVGElementInlines.h"
 #include "SVGNames.h"
+#include "SVGParsingError.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -75,7 +76,7 @@ SVGAnimatedProperty* SVGRectElement::propertyForAttribute(const QualifiedName& n
 
 void SVGRectElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGParsingError parseError = NoError;
+    auto parseError = SVGParsingError::None;
 
     switch (name.nodeName()) {
     case AttributeNames::xAttr:

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -48,6 +48,7 @@
 #include "SVGLength.h"
 #include "SVGMatrix.h"
 #include "SVGNumber.h"
+#include "SVGParsingError.h"
 #include "SVGPoint.h"
 #include "SVGRect.h"
 #include "SVGTransform.h"
@@ -196,7 +197,7 @@ void SVGSVGElement::attributeChanged(const QualifiedName& name, const AtomString
         }
     }
 
-    SVGParsingError parseError = NoError;
+    auto parseError = SVGParsingError::None;
 
     switch (name.nodeName()) {
     case AttributeNames::xAttr:
@@ -207,7 +208,7 @@ void SVGSVGElement::attributeChanged(const QualifiedName& name, const AtomString
         break;
     case AttributeNames::widthAttr: {
         auto length = SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Forbid);
-        if (parseError != NoError || newValue.isEmpty()) {
+        if (parseError != SVGParsingError::None || newValue.isEmpty()) {
             // FIXME: This is definitely the correct behavior for a missing/removed attribute.
             // Not sure it's correct for the empty string or for something that can't be parsed.
             length = SVGLengthValue(SVGLengthMode::Width, "100%"_s);
@@ -217,7 +218,7 @@ void SVGSVGElement::attributeChanged(const QualifiedName& name, const AtomString
     }
     case AttributeNames::heightAttr: {
         auto length = SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Forbid);
-        if (parseError != NoError || newValue.isEmpty()) {
+        if (parseError != SVGParsingError::None || newValue.isEmpty()) {
             // FIXME: This is definitely the correct behavior for a removed attribute.
             // Not sure it's correct for the empty string or for something that can't be parsed.
             length = SVGLengthValue(SVGLengthMode::Height, "100%"_s);
@@ -394,7 +395,7 @@ Ref<SVGTransform> SVGSVGElement::createSVGTransformFromMatrix(DOMMatrix2DInit&& 
     return SVGTransform::create(transform);
 }
 
-AffineTransform SVGSVGElement::localCoordinateSpaceTransform(SVGLocatable::CTMScope mode) const
+AffineTransform SVGSVGElement::localCoordinateSpaceTransform(CTMScope mode) const
 {
     AffineTransform viewBoxTransform;
     if (!hasEmptyViewBox()) {
@@ -419,7 +420,7 @@ AffineTransform SVGSVGElement::localCoordinateSpaceTransform(SVGLocatable::CTMSc
     if (!isOutermostSVGSVGElement()) {
         SVGLengthContext lengthContext(this);
         transform.translate(x().value(lengthContext), y().value(lengthContext));
-    } else if (mode == SVGLocatable::ScreenScope) {
+    } else if (mode == CTMScope::ScreenScope) {
         if (CheckedPtr renderer = this->renderer()) {
             FloatPoint location;
             float zoomFactor = 1;

--- a/Source/WebCore/svg/SVGSVGElement.h
+++ b/Source/WebCore/svg/SVGSVGElement.h
@@ -141,7 +141,7 @@ private:
     void resumeFromDocumentSuspension() override;
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) override;
 
-    AffineTransform localCoordinateSpaceTransform(SVGLocatable::CTMScope) const override;
+    AffineTransform localCoordinateSpaceTransform(CTMScope) const override;
     RefPtr<LocalFrame> frameForCurrentScale() const;
     Ref<NodeList> collectIntersectionOrEnclosureList(SVGRect&, SVGElement*, bool (*checkFunction)(SVGElement&, SVGRect&));
 

--- a/Source/WebCore/svg/SVGStopElement.cpp
+++ b/Source/WebCore/svg/SVGStopElement.cpp
@@ -37,6 +37,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(SVGStopElement);
 
 inline SVGStopElement::SVGStopElement(const QualifiedName& tagName, Document& document)
     : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+    , m_offset { SVGAnimatedNumber::create(this, 0) }
 {
     ASSERT(hasTagName(SVGNames::stopTag));
 

--- a/Source/WebCore/svg/SVGStopElement.h
+++ b/Source/WebCore/svg/SVGStopElement.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "SVGAnimatedPropertyImpl.h"
 #include "SVGElement.h"
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/svg/SVGTests.cpp
+++ b/Source/WebCore/svg/SVGTests.cpp
@@ -27,6 +27,7 @@
 #include "NodeName.h"
 #include "SVGElement.h"
 #include "SVGNames.h"
+#include "SVGPropertyOwnerRegistry.h"
 #include "SVGStringList.h"
 #include <wtf/Language.h>
 #include <wtf/SortedArrayMap.h>

--- a/Source/WebCore/svg/SVGTextContentElement.cpp
+++ b/Source/WebCore/svg/SVGTextContentElement.cpp
@@ -35,6 +35,7 @@
 #include "RenderSVGText.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGNames.h"
+#include "SVGParsingError.h"
 #include "SVGPoint.h"
 #include "SVGRect.h"
 #include "SVGTextQuery.h"
@@ -167,7 +168,7 @@ void SVGTextContentElement::collectPresentationalHintsForAttribute(const Qualifi
 
 void SVGTextContentElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGParsingError parseError = NoError;
+    auto parseError = SVGParsingError::None;
 
     if (name == SVGNames::lengthAdjustAttr) {
         auto propertyValue = SVGPropertyTraits<SVGLengthAdjustType>::fromString(newValue);

--- a/Source/WebCore/svg/SVGTextPathElement.cpp
+++ b/Source/WebCore/svg/SVGTextPathElement.cpp
@@ -30,6 +30,7 @@
 #include "SVGElementInlines.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGNames.h"
+#include "SVGParsingError.h"
 #include "SVGPathElement.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -69,7 +70,7 @@ void SVGTextPathElement::clearResourceReferences()
 
 void SVGTextPathElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGParsingError parseError = NoError;
+    auto parseError = SVGParsingError::None;
 
     switch (name.nodeName()) {
     case AttributeNames::startOffsetAttr:

--- a/Source/WebCore/svg/SVGTransformable.h
+++ b/Source/WebCore/svg/SVGTransformable.h
@@ -42,7 +42,7 @@ public:
     static std::optional<SVGTransformValue::SVGTransformType> parseTransformType(StringParsingBuffer<LChar>&);
     static std::optional<SVGTransformValue::SVGTransformType> parseTransformType(StringParsingBuffer<UChar>&);
 
-    AffineTransform localCoordinateSpaceTransform(SVGLocatable::CTMScope) const override { return animatedLocalTransform(); }
+    AffineTransform localCoordinateSpaceTransform(CTMScope) const override { return animatedLocalTransform(); }
     virtual AffineTransform animatedLocalTransform() const = 0;
 };
 

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -42,6 +42,7 @@
 #include "SVGDocumentExtensions.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGGElement.h"
+#include "SVGParsingError.h"
 #include "SVGSVGElement.h"
 #include "SVGSymbolElement.h"
 #include "ScriptDisallowedScope.h"
@@ -85,7 +86,7 @@ SVGUseElement::~SVGUseElement()
 
 void SVGUseElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGParsingError parseError = NoError;
+    auto parseError = SVGParsingError::None;
 
     switch (name.nodeName()) {
     case AttributeNames::xAttr:

--- a/Source/WebCore/svg/properties/SVGPropertyRegistry.h
+++ b/Source/WebCore/svg/properties/SVGPropertyRegistry.h
@@ -25,11 +25,10 @@
 
 #pragma once
 
-#include "SVGAttributeAnimator.h"
-
 namespace WebCore {
 
 class SVGAnimatedProperty;
+class SVGAttributeAnimator;
 
 class SVGPropertyRegistry {
 public:


### PR DESCRIPTION
#### 9e08044604db3666fd14b94af81a46f91623e74e
<pre>
Reduce header includes in SVGElement.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=292567">https://bugs.webkit.org/show_bug.cgi?id=292567</a>

Reviewed by Anne van Kesteren.

Reduced #include in SVGElement.h to reduce WebKit&apos;s build time.

Also convert SVGParsingError, SVGMarkerUnitsType, and CTMScope to enum classes.

* Source/WebCore/dom/Node.cpp:
* Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp:
(WebCore::RenderSVGResourceMarker::markerTransformation const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.cpp:
(WebCore::LegacyRenderSVGResourceMarker::markerTransformation const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.h:
* Source/WebCore/svg/SVGAnimationElement.h:
* Source/WebCore/svg/SVGCircleElement.cpp:
(WebCore::SVGCircleElement::attributeChanged):
* Source/WebCore/svg/SVGComponentTransferFunctionElement.h:
* Source/WebCore/svg/SVGCursorElement.cpp:
(WebCore::SVGCursorElement::attributeChanged):
* Source/WebCore/svg/SVGDescElement.cpp:
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::SVGElement):
(WebCore::SVGElement::reportAttributeParsingError):
(WebCore::SVGElement::localCoordinateSpaceTransform const):
* Source/WebCore/svg/SVGElement.h:
(WebCore::SVGElement::detachAllProperties): Deleted.
(WebCore::SVGElement::className const): Deleted.
* Source/WebCore/svg/SVGElementInlines.h:
(WebCore::SVGElement::detachAllProperties):
(WebCore::SVGElement::className const):
* Source/WebCore/svg/SVGEllipseElement.cpp:
(WebCore::SVGEllipseElement::attributeChanged):
* Source/WebCore/svg/SVGFECompositeElement.cpp:
* Source/WebCore/svg/SVGFECompositeElement.h:
* Source/WebCore/svg/SVGFEGaussianBlurElement.cpp:
* Source/WebCore/svg/SVGFELightElement.h:
* Source/WebCore/svg/SVGFEMorphologyElement.cpp:
* Source/WebCore/svg/SVGFilterElement.cpp:
(WebCore::SVGFilterElement::attributeChanged):
* Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp:
(WebCore::SVGFilterPrimitiveStandardAttributes::attributeChanged):
* Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h:
* Source/WebCore/svg/SVGForeignObjectElement.cpp:
(WebCore::SVGForeignObjectElement::attributeChanged):
* Source/WebCore/svg/SVGGraphicsElement.cpp:
(WebCore::SVGGraphicsElement::SVGGraphicsElement):
(WebCore::SVGGraphicsElement::getCTM):
(WebCore::SVGGraphicsElement::getScreenCTM):
* Source/WebCore/svg/SVGGraphicsElement.h:
* Source/WebCore/svg/SVGImageElement.cpp:
(WebCore::SVGImageElement::attributeChanged):
* Source/WebCore/svg/SVGLengthValue.cpp:
(WebCore::SVGLengthValue::construct):
* Source/WebCore/svg/SVGLineElement.cpp:
(WebCore::SVGLineElement::attributeChanged):
* Source/WebCore/svg/SVGLinearGradientElement.cpp:
(WebCore::SVGLinearGradientElement::attributeChanged):
* Source/WebCore/svg/SVGLocatable.cpp:
(WebCore::SVGLocatable::computeCTM):
* Source/WebCore/svg/SVGLocatable.h:
(WebCore::SVGLocatable::localCoordinateSpaceTransform const):
* Source/WebCore/svg/SVGMarkerElement.cpp:
(WebCore::SVGMarkerElement::attributeChanged):
* Source/WebCore/svg/SVGMarkerElement.h:
* Source/WebCore/svg/SVGMarkerTypes.h:
(WebCore::SVGPropertyTraits&lt;SVGMarkerUnitsType&gt;::highestEnumValue):
(WebCore::SVGPropertyTraits&lt;SVGMarkerUnitsType&gt;::toString):
(WebCore::SVGPropertyTraits&lt;SVGMarkerUnitsType&gt;::fromString):
* Source/WebCore/svg/SVGMaskElement.cpp:
(WebCore::SVGMaskElement::attributeChanged):
* Source/WebCore/svg/SVGMaskElement.h:
* Source/WebCore/svg/SVGParsingError.h:
(): Deleted.
* Source/WebCore/svg/SVGPathSegImpl.h:
* Source/WebCore/svg/SVGPatternElement.cpp:
(WebCore::SVGPatternElement::attributeChanged):
(WebCore::SVGPatternElement::localCoordinateSpaceTransform const):
* Source/WebCore/svg/SVGPatternElement.h:
* Source/WebCore/svg/SVGRadialGradientElement.cpp:
(WebCore::SVGRadialGradientElement::attributeChanged):
* Source/WebCore/svg/SVGRectElement.cpp:
(WebCore::SVGRectElement::attributeChanged):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::attributeChanged):
(WebCore::SVGSVGElement::localCoordinateSpaceTransform const):
* Source/WebCore/svg/SVGSVGElement.h:
* Source/WebCore/svg/SVGStopElement.cpp:
(WebCore::SVGStopElement::SVGStopElement):
* Source/WebCore/svg/SVGStopElement.h:
* Source/WebCore/svg/SVGTests.cpp:
* Source/WebCore/svg/SVGTextContentElement.cpp:
(WebCore::SVGTextContentElement::attributeChanged):
* Source/WebCore/svg/SVGTextPathElement.cpp:
(WebCore::SVGTextPathElement::attributeChanged):
* Source/WebCore/svg/SVGTransformable.h:
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::attributeChanged):
* Source/WebCore/svg/properties/SVGPropertyRegistry.h:

Canonical link: <a href="https://commits.webkit.org/294576@main">https://commits.webkit.org/294576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3023f5e57153954ecea7fecb77449befce63d100

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12255 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107432 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52908 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104311 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77820 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34806 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105278 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17220 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92321 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58158 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17053 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10349 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52266 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86880 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10419 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109807 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29404 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21676 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86801 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29768 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86389 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21994 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31198 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8916 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23646 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29332 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34627 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29143 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32466 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30702 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->