### PR TITLE
[Content Filtering] Make ParentalControlsContentFilter::finishedAddingData wait for decision before returning

### DIFF
--- a/Source/WebCore/loader/ContentFilter.h
+++ b/Source/WebCore/loader/ContentFilter.h
@@ -90,12 +90,12 @@ private:
     using State = PlatformContentFilter::State;
 
     struct Type {
-        Function<UniqueRef<PlatformContentFilter>(const PlatformContentFilter::FilterParameters&)> create;
+        Function<Ref<PlatformContentFilter>(const PlatformContentFilter::FilterParameters&)> create;
     };
     template <typename T> static Type type();
     WEBCORE_EXPORT static Vector<Type>& types();
 
-    using Container = Vector<UniqueRef<PlatformContentFilter>>;
+    using Container = Vector<Ref<PlatformContentFilter>>;
     friend std::unique_ptr<ContentFilter> std::make_unique<ContentFilter>(Container&&, ContentFilterClient&);
     ContentFilter(Container&&, ContentFilterClient&);
 
@@ -116,7 +116,7 @@ private:
     };
     Vector<ResourceDataItem> m_buffers;
     CachedResourceHandle<CachedRawResource> m_mainResource;
-    WeakPtr<const PlatformContentFilter> m_blockingContentFilter;
+    ThreadSafeWeakPtr<const PlatformContentFilter> m_blockingContentFilter;
     State m_state { State::Stopped };
     ResourceError m_blockedError;
     bool m_isLoadingBlockedPage { false };

--- a/Source/WebCore/platform/PlatformContentFilter.h
+++ b/Source/WebCore/platform/PlatformContentFilter.h
@@ -30,6 +30,7 @@
 #include <wtf/CheckedPtr.h>
 #include <wtf/Ref.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -50,9 +51,8 @@ class ResourceRequest;
 class ResourceResponse;
 class SharedBuffer;
 
-class PlatformContentFilter : public CanMakeWeakPtr<PlatformContentFilter>, public CanMakeCheckedPtr<PlatformContentFilter> {
+class PlatformContentFilter : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PlatformContentFilter> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(PlatformContentFilter);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlatformContentFilter);
     WTF_MAKE_NONCOPYABLE(PlatformContentFilter);
 
 public:

--- a/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.h
+++ b/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.h
@@ -44,10 +44,9 @@ namespace WebCore {
 
 class NetworkExtensionContentFilter final : public PlatformContentFilter {
     WTF_MAKE_TZONE_ALLOCATED(NetworkExtensionContentFilter);
-    friend UniqueRef<NetworkExtensionContentFilter> WTF::makeUniqueRefWithoutFastMallocCheck<NetworkExtensionContentFilter>();
 
 public:
-    static UniqueRef<NetworkExtensionContentFilter> create(const PlatformContentFilter::FilterParameters&);
+    static Ref<NetworkExtensionContentFilter> create(const PlatformContentFilter::FilterParameters&);
 
     void willSendRequest(ResourceRequest&, const ResourceResponse&) override;
     void responseReceived(const ResourceResponse&) override;

--- a/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.mm
+++ b/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.mm
@@ -56,9 +56,9 @@ bool NetworkExtensionContentFilter::enabled()
     return isRequired();
 }
 
-UniqueRef<NetworkExtensionContentFilter> NetworkExtensionContentFilter::create(const PlatformContentFilter::FilterParameters&)
+Ref<NetworkExtensionContentFilter> NetworkExtensionContentFilter::create(const PlatformContentFilter::FilterParameters&)
 {
-    return makeUniqueRef<NetworkExtensionContentFilter>();
+    return adoptRef(*new NetworkExtensionContentFilter);
 }
 
 void NetworkExtensionContentFilter::initialize(const URL* url)

--- a/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
@@ -40,10 +40,9 @@ class ParentalControlsURLFilter;
 
 class ParentalControlsContentFilter final : public PlatformContentFilter {
     WTF_MAKE_TZONE_ALLOCATED(ParentalControlsContentFilter);
-    friend UniqueRef<ParentalControlsContentFilter> WTF::makeUniqueRefWithoutFastMallocCheck<ParentalControlsContentFilter>(const PlatformContentFilter::FilterParameters&);
 
 public:
-    static UniqueRef<ParentalControlsContentFilter> create(const PlatformContentFilter::FilterParameters&);
+    static Ref<ParentalControlsContentFilter> create(const PlatformContentFilter::FilterParameters&);
 
     void willSendRequest(ResourceRequest&, const ResourceResponse&) override { }
     void responseReceived(const ResourceResponse&) override;
@@ -60,7 +59,8 @@ private:
 
     void updateFilterState();
 #if HAVE(WEBCONTENTRESTRICTIONS)
-    void updateFilterState(PlatformContentFilter::State, NSData *);
+    void didReceiveAllowDecisionOnQueue(bool isAllowed, NSData *);
+    void updateFilterStateOnMain();
     void enableURLFilter();
 #endif
 
@@ -70,6 +70,10 @@ private:
 #if HAVE(WEBCONTENTRESTRICTIONS)
     bool m_usesWebContentRestrictions { false };
     std::optional<URL> m_evaluatedURL;
+    Lock m_resultLock;
+    Condition m_resultCondition;
+    std::optional<bool> m_isAllowdByWebContentRestrictions WTF_GUARDED_BY_LOCK(m_resultLock);
+    RetainPtr<NSData> m_webContentRestrictionsReplacementData WTF_GUARDED_BY_LOCK(m_resultLock);
 #endif
 #if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
     String m_webContentRestrictionsConfigurationPath;

--- a/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm
+++ b/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm
@@ -36,6 +36,7 @@
 #import <pal/spi/cocoa/WebFilterEvaluatorSPI.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/TZoneMallocInlines.h>
+#import <wtf/WorkQueue.h>
 #import <wtf/cocoa/SpanCocoa.h>
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
@@ -53,6 +54,16 @@ SOFT_LINK_CLASS_OPTIONAL(WebContentAnalysis, WebFilterEvaluator);
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ParentalControlsContentFilter);
+
+#if HAVE(WEBCONTENTRESTRICTIONS)
+
+static WorkQueue& globalQueue()
+{
+    static MainThreadNeverDestroyed<Ref<WorkQueue>> queue = WorkQueue::create("ParentalControlsContentFilter queue"_s);
+    return queue.get();
+}
+
+#endif
 
 bool ParentalControlsContentFilter::enabled() const
 {
@@ -76,9 +87,9 @@ bool ParentalControlsContentFilter::enabled() const
 #endif
 }
 
-UniqueRef<ParentalControlsContentFilter> ParentalControlsContentFilter::create(const PlatformContentFilter::FilterParameters& params)
+Ref<ParentalControlsContentFilter> ParentalControlsContentFilter::create(const PlatformContentFilter::FilterParameters& params)
 {
-    return makeUniqueRef<ParentalControlsContentFilter>(params);
+    return adoptRef(*new ParentalControlsContentFilter(params));
 }
 
 ParentalControlsContentFilter::ParentalControlsContentFilter(const PlatformContentFilter::FilterParameters& params)
@@ -117,10 +128,10 @@ void ParentalControlsContentFilter::responseReceived(const ResourceResponse& res
 #else
         auto& filter = ParentalControlsURLFilter::singleton();
 #endif
-        filter.isURLAllowed(*m_evaluatedURL, [weakThis = WeakPtr { *this }](bool isAllowed, auto replacementData) {
-            if (CheckedPtr checkedThis = weakThis.get())
-                checkedThis->updateFilterState(isAllowed ? State::Allowed : State::Blocked, replacementData);
-        });
+        filter.isURLAllowed(*m_evaluatedURL, [weakThis = ThreadSafeWeakPtr { *this }](bool isAllowed, auto replacementData) {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->didReceiveAllowDecisionOnQueue(isAllowed, replacementData);
+        }, globalQueue());
         return;
     }
 #endif
@@ -158,8 +169,18 @@ void ParentalControlsContentFilter::addData(const SharedBuffer& data)
 void ParentalControlsContentFilter::finishedAddingData()
 {
 #if HAVE(WEBCONTENTRESTRICTIONS)
-    if (m_usesWebContentRestrictions)
+    if (m_usesWebContentRestrictions) {
+        if (m_state != State::Filtering)
+            return;
+
+        // Callers expect state is ready after finishing adding data.
+        Locker resultLocker { m_resultLock };
+        while (!m_isAllowdByWebContentRestrictions)
+            m_resultCondition.wait(m_resultLock);
+        m_state = *m_isAllowdByWebContentRestrictions ? State::Allowed : State::Blocked;
+        m_replacementData = std::exchange(m_webContentRestrictionsReplacementData, nullptr);
         return;
+    }
 #endif
 
 #if HAVE(WEBCONTENTANALYSIS_FRAMEWORK)
@@ -216,10 +237,32 @@ void ParentalControlsContentFilter::updateFilterState()
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
 
-void ParentalControlsContentFilter::updateFilterState(State state, NSData *replacementData)
+void ParentalControlsContentFilter::didReceiveAllowDecisionOnQueue(bool isAllowed, NSData *replacementData)
 {
-    m_state = state;
-    m_replacementData = replacementData;
+    ASSERT(!isMainThread());
+
+    Locker resultLocker { m_resultLock };
+    ASSERT(!m_isAllowdByWebContentRestrictions);
+    m_isAllowdByWebContentRestrictions = isAllowed;
+    m_webContentRestrictionsReplacementData = replacementData;
+
+    callOnMainRunLoop([weakThis = ThreadSafeWeakPtr { *this }]() {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->updateFilterStateOnMain();
+    });
+}
+
+void ParentalControlsContentFilter::updateFilterStateOnMain()
+{
+    ASSERT(isMainThread());
+
+    if (m_state != State::Filtering)
+        return;
+
+    Locker resultLocker { m_resultLock };
+    ASSERT(m_isAllowdByWebContentRestrictions);
+    m_state = *m_isAllowdByWebContentRestrictions ? State::Allowed : State::Blocked;
+    m_replacementData = std::exchange(m_webContentRestrictionsReplacementData, nullptr);
 }
 
 #endif

--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
@@ -29,6 +29,10 @@
 
 OBJC_CLASS WCRBrowserEngineClient;
 
+namespace WTF {
+class WorkQueue;
+}
+
 namespace WebCore {
 
 class ParentalControlsURLFilter {
@@ -41,7 +45,7 @@ public:
 #endif
 
     bool isEnabled() const;
-    void isURLAllowed(const URL&, CompletionHandler<void(bool, NSData *)>&&);
+    void isURLAllowed(const URL&, CompletionHandler<void(bool, NSData *)>&&, const WTF::WorkQueue& completionHandlerQueue);
     void allowURL(const URL&, CompletionHandler<void(bool)>&&);
 
 private:

--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm
@@ -97,7 +97,7 @@ bool ParentalControlsURLFilter::isEnabled() const
     return !!m_wcrBrowserEngineClient;
 }
 
-void ParentalControlsURLFilter::isURLAllowed(const URL& url, CompletionHandler<void(bool, NSData *)>&& completionHandler)
+void ParentalControlsURLFilter::isURLAllowed(const URL& url, CompletionHandler<void(bool, NSData *)>&& completionHandler, const WorkQueue& completionHandlerQueue)
 {
     ASSERT(isMainThread());
 
@@ -108,7 +108,7 @@ void ParentalControlsURLFilter::isURLAllowed(const URL& url, CompletionHandler<v
         ASSERT(isMainThread());
 
         completionHandler(!shouldBlock, replacementData);
-    }).get()];
+    }).get() onCompletionQueue:completionHandlerQueue.dispatchQueue()];
 }
 
 void ParentalControlsURLFilter::allowURL(const URL& url, CompletionHandler<void(bool)>&& completionHandler)

--- a/Source/WebCore/testing/MockContentFilter.cpp
+++ b/Source/WebCore/testing/MockContentFilter.cpp
@@ -61,9 +61,9 @@ bool MockContentFilter::enabled()
     return enabled;
 }
 
-UniqueRef<MockContentFilter> MockContentFilter::create(const PlatformContentFilter::FilterParameters&)
+Ref<MockContentFilter> MockContentFilter::create(const PlatformContentFilter::FilterParameters&)
 {
-    return makeUniqueRef<MockContentFilter>();
+    return adoptRef(*new MockContentFilter);
 }
 
 void MockContentFilter::willSendRequest(ResourceRequest& request, const ResourceResponse& redirectResponse)

--- a/Source/WebCore/testing/MockContentFilter.h
+++ b/Source/WebCore/testing/MockContentFilter.h
@@ -34,11 +34,10 @@ namespace WebCore {
 
 class MockContentFilter final : public PlatformContentFilter {
     WTF_MAKE_TZONE_ALLOCATED(MockContentFilter);
-    friend UniqueRef<MockContentFilter> WTF::makeUniqueRefWithoutFastMallocCheck<MockContentFilter>();
 
 public:
     static void ensureInstalled();
-    static UniqueRef<MockContentFilter> create(const PlatformContentFilter::FilterParameters&);
+    static Ref<MockContentFilter> create(const PlatformContentFilter::FilterParameters&);
 
     void willSendRequest(ResourceRequest&, const ResourceResponse&) override;
     void responseReceived(const ResourceResponse&) override;


### PR DESCRIPTION
#### 26b4f3b13848a3be71a83cc3212e84a1c26ff61d
<pre>
[Content Filtering] Make ParentalControlsContentFilter::finishedAddingData wait for decision before returning
<a href="https://bugs.webkit.org/show_bug.cgi?id=292566">https://bugs.webkit.org/show_bug.cgi?id=292566</a>
<a href="https://rdar.apple.com/145777952">rdar://145777952</a>

Reviewed by Per Arne Vollan.

Clients expect that filtering result is immediately available after finishedAddingData is called, see
ContentFilter::continueAfterNotifyFinished for an example. In existing implementation, there is no guarantee for that
when using WebContentRestrictions framework for filtering, since the WCRBrowserEngineClient SPI is async. To implement
that, this patches adopts the SPI that takes a queue parameter, so that the result can be set on background queue and
ParentalControlsContentFilter::finishedAddingData can be blocked waiting for the result on the main thread.

* Source/WebCore/loader/ContentFilter.cpp:
(WebCore::ContentFilter::forEachContentFilterUntilBlocked):
(WebCore::ContentFilter::didDecide):
(WebCore::ContentFilter::handleProvisionalLoadFailure):
* Source/WebCore/loader/ContentFilter.h:
* Source/WebCore/platform/PlatformContentFilter.h:
* Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.h:
* Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.mm:
(WebCore::NetworkExtensionContentFilter::create):
* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h:
* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm:
(WebCore::globalQueue):
(WebCore::ParentalControlsContentFilter::create):
(WebCore::ParentalControlsContentFilter::responseReceived):
(WebCore::ParentalControlsContentFilter::finishedAddingData):
(WebCore::ParentalControlsContentFilter::didReceiveAllowDecisionOnQueue):
(WebCore::ParentalControlsContentFilter::updateFilterStateOnMain):
* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h:
* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm:
(WebCore::ParentalControlsURLFilter::isURLAllowed):
* Source/WebCore/testing/MockContentFilter.cpp:
(WebCore::MockContentFilter::create):
* Source/WebCore/testing/MockContentFilter.h:

Canonical link: <a href="https://commits.webkit.org/294563@main">https://commits.webkit.org/294563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a936974070270478b39017c862d72015e034e069

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12242 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107419 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52895 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104298 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30434 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77806 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34797 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105265 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17208 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58144 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17039 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10337 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52253 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86868 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10407 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109794 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29391 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21664 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86786 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29755 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86374 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21981 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31185 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8904 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23633 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29319 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34614 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29130 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32453 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30689 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->