### PR TITLE
Have isPowerOfTwo() call std::has_single_bit() and move it to MathExtras.h

### DIFF
--- a/Source/JavaScriptCore/heap/FreeList.h
+++ b/Source/JavaScriptCore/heap/FreeList.h
@@ -44,7 +44,7 @@ struct FreeCell {
 
     static ALWAYS_INLINE std::tuple<int32_t, uint32_t> descramble(uint64_t scrambledBits, uint64_t secret)
     {
-        static_assert(WTF::isPowerOfTwo(sizeof(FreeCell))); // Make sure this division isn't super costly.
+        static_assert(isPowerOfTwo(sizeof(FreeCell))); // Make sure this division isn't super costly.
         uint64_t descrambledBits = scrambledBits ^ secret;
         return { static_cast<int32_t>(static_cast<uint32_t>(descrambledBits)), static_cast<uint32_t>(descrambledBits >> 32u) };
     }

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
@@ -281,7 +281,7 @@ void BBQJIT::emitModOrDiv(Value& lhs, Location lhsLocation, Value& rhs, Location
             }
 
             // Fall through to general case.
-        } else if (isPowerOfTwo(divisor)) {
+        } else if (isPowerOfTwo<size_t>(divisor)) {
             if constexpr (IsMod) {
                 if constexpr (isSigned) {
                     // This constructs an extra operand with log2(divisor) bits equal to the sign bit of the dividend. If the dividend

--- a/Source/WTF/wtf/PageBlock.h
+++ b/Source/WTF/wtf/PageBlock.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <wtf/FastMalloc.h>
-#include <wtf/StdLibExtras.h>
+#include <wtf/MathExtras.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -106,6 +106,5 @@ inline PageBlock::PageBlock(void* base, size_t size, bool hasGuardPages)
 using WTF::CeilingOnPageSize;
 using WTF::pageSize;
 using WTF::isPageAligned;
-using WTF::isPowerOfTwo;
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -210,8 +210,6 @@ inline size_t bitCount(uint64_t bits)
     return bitCount(static_cast<unsigned>(bits)) + bitCount(static_cast<unsigned>(bits >> 32));
 }
 
-inline constexpr bool isPowerOfTwo(size_t size) { return !(size & (size - 1)); }
-
 template<typename T> constexpr T mask(T value, uintptr_t mask)
 {
     static_assert(sizeof(T) == sizeof(uintptr_t), "sizeof(T) must be equal to sizeof(uintptr_t).");
@@ -221,73 +219,6 @@ template<typename T> constexpr T mask(T value, uintptr_t mask)
 template<typename T> inline T* mask(T* value, uintptr_t mask)
 {
     return reinterpret_cast<T*>(reinterpret_cast<uintptr_t>(value) & mask);
-}
-
-template<typename T, typename U>
-ALWAYS_INLINE constexpr T roundUpToMultipleOfImpl(U divisor, T x)
-{
-    T remainderMask = static_cast<T>(divisor) - 1;
-    return (x + remainderMask) & ~remainderMask;
-}
-
-// Efficient implementation that takes advantage of powers of two.
-template<typename T, typename U>
-inline constexpr T roundUpToMultipleOf(U divisor, T x)
-{
-    ASSERT_UNDER_CONSTEXPR_CONTEXT(divisor && isPowerOfTwo(divisor));
-    return roundUpToMultipleOfImpl<T, U>(divisor, x);
-}
-
-template<size_t divisor> constexpr size_t roundUpToMultipleOf(size_t x)
-{
-    static_assert(divisor && isPowerOfTwo(divisor));
-    return roundUpToMultipleOfImpl(divisor, x);
-}
-
-template<size_t divisor, typename T> inline constexpr T* roundUpToMultipleOf(T* x)
-{
-    static_assert(sizeof(T*) == sizeof(size_t));
-    return reinterpret_cast<T*>(roundUpToMultipleOf<divisor>(reinterpret_cast<size_t>(x)));
-}
-
-template<typename T, typename U>
-inline constexpr T roundUpToMultipleOfNonPowerOfTwo(U divisor, T x)
-{
-    T remainder = x % divisor;
-    if (!remainder)
-        return x;
-    return x + static_cast<T>(divisor - remainder);
-}
-
-template<typename T, typename C>
-inline constexpr Checked<T, C> roundUpToMultipleOfNonPowerOfTwo(Checked<T, C> divisor, Checked<T, C> x)
-{
-    if (x.hasOverflowed() || divisor.hasOverflowed())
-        return ResultOverflowed;
-    T remainder = x % divisor;
-    if (!remainder)
-        return x;
-    return x + static_cast<T>(divisor.value() - remainder);
-}
-
-template<typename T, typename U>
-inline constexpr T roundDownToMultipleOf(U divisor, T x)
-{
-    ASSERT_UNDER_CONSTEXPR_CONTEXT(divisor && isPowerOfTwo(divisor));
-    static_assert(sizeof(T) == sizeof(uintptr_t), "sizeof(T) must be equal to sizeof(uintptr_t).");
-    return static_cast<T>(mask(static_cast<uintptr_t>(x), ~(divisor - 1ul)));
-}
-
-template<typename T> inline constexpr T* roundDownToMultipleOf(size_t divisor, T* x)
-{
-    ASSERT_UNDER_CONSTEXPR_CONTEXT(isPowerOfTwo(divisor));
-    return reinterpret_cast<T*>(mask(reinterpret_cast<uintptr_t>(x), ~(divisor - 1ul)));
-}
-
-template<size_t divisor, typename T> constexpr T roundDownToMultipleOf(T x)
-{
-    static_assert(isPowerOfTwo(divisor), "'divisor' must be a power of two.");
-    return roundDownToMultipleOf(divisor, x);
 }
 
 template<typename IntType>
@@ -1619,9 +1550,6 @@ using WTF::memmoveSpan;
 using WTF::memsetSpan;
 using WTF::mergeDeduplicatedSorted;
 using WTF::reinterpretCastSpanStartTo;
-using WTF::roundUpToMultipleOf;
-using WTF::roundUpToMultipleOfNonPowerOfTwo;
-using WTF::roundDownToMultipleOf;
 using WTF::safeCast;
 using WTF::secureMemsetSpan;
 using WTF::singleElementSpan;

--- a/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
+++ b/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
@@ -52,7 +52,7 @@ CARingBuffer::CARingBuffer(size_t bytesPerFrame, size_t frameCount, uint32_t num
     , m_frameCount(frameCount)
     , m_capacityBytes(computeCapacityBytes(bytesPerFrame, frameCount))
 {
-    ASSERT(WTF::isPowerOfTwo(frameCount));
+    ASSERT(isPowerOfTwo(frameCount));
 }
 
 CARingBuffer::~CARingBuffer() = default;


### PR DESCRIPTION
#### 209ba9726d1063586de06057455d882efa0d3480
<pre>
Have isPowerOfTwo() call std::has_single_bit() and move it to MathExtras.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=292572">https://bugs.webkit.org/show_bug.cgi?id=292572</a>

Reviewed by Ryosuke Niwa.

* Source/JavaScriptCore/heap/FreeList.h:
(JSC::FreeCell::descramble):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.h:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitModOrDiv):
* Source/WTF/wtf/MathExtras.h:
(WTF::isPowerOfTwo):
(WTF::roundUpToMultipleOfImpl):
(WTF::roundUpToMultipleOf):
(WTF::roundUpToMultipleOfNonPowerOfTwo):
(WTF::roundDownToMultipleOf):
* Source/WTF/wtf/PageBlock.h:
* Source/WTF/wtf/StdLibExtras.h:
(WTF::isPowerOfTwo): Deleted.
(WTF::roundUpToMultipleOfImpl): Deleted.
(WTF::roundUpToMultipleOf): Deleted.
(WTF::roundUpToMultipleOfNonPowerOfTwo): Deleted.
(WTF::roundDownToMultipleOf): Deleted.
* Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp:
(WebCore::CARingBuffer::CARingBuffer):

Canonical link: <a href="https://commits.webkit.org/294562@main">https://commits.webkit.org/294562@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1828d1e0480f0d6e5ccc8ed1152ac54a82ffea8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107382 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52859 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104262 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30398 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77796 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34781 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105229 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17177 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92277 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58132 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17007 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10305 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52217 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94894 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86846 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10375 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109758 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100832 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29355 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21640 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86774 "Found 1 new test failure: http/tests/inspector/network/har/har-page.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88480 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86365 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21980 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31167 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8878 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23597 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29283 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34578 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124458 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29094 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34559 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32417 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30653 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->