### PR TITLE
 Fix percent/calculated logical widths for RenderReplaced items with fixed logical heights and intrinsic aspect ratio.

### DIFF
--- a/LayoutTests/fast/css/max-content-img-sizing-1-expected.html
+++ b/LayoutTests/fast/css/max-content-img-sizing-1-expected.html
@@ -1,0 +1,56 @@
+<style>
+   div {
+      width: max-content;
+   }
+   #greenbox-icon-1 {
+      width: 25px;
+      height: 25px;
+   }
+   #greenbox-icon-2 {
+      width: 50px;
+      height: 50px;
+   }
+   #greenbox-icon-3 {
+      width: 5px;
+      height: 5px;
+   }
+   #greenbox-icon-4 {
+      width: 12.5px;
+      height: 12.5px;
+   }
+   #greenbox-icon-5 {
+      width: 50px;
+      height: 50px;
+   }
+   #circles-landscape-1 {
+      width: 100px;
+      height: 50px;
+   }
+   #circles-landscape-2 {
+      width: 288px;
+      height: 144px;
+   }
+   #circles-landscape-3 {
+      width: 50px;
+      height: 25px;
+   }
+   #circles-landscape-4 {
+      width: 144px;
+      height: 72px;
+   }
+   #circles-landscape-5 {
+      width: 100px;
+      height: 50px;
+   }
+</style>
+
+<div><img id="greenbox-icon-1" src="resources/greenbox.png"></div>
+<div><img id="greenbox-icon-2" src="resources/greenbox.png"></div>
+<div><img id="greenbox-icon-3" src="resources/greenbox.png"></div>
+<div><img id="greenbox-icon-4" src="resources/greenbox.png"></div>
+<div><img id="greenbox-icon-5" src="resources/greenbox.png"></div>
+<div><img id="circles-landscape-1" src="resources/circles-landscape.png"></div>
+<div><img id="circles-landscape-2" src="resources/circles-landscape.png"></div>
+<div><img id="circles-landscape-3" src="resources/circles-landscape.png"></div>
+<div><img id="circles-landscape-4" src="resources/circles-landscape.png"></div>
+<div><img id="circles-landscape-5" src="resources/circles-landscape.png"></div>

--- a/LayoutTests/fast/css/max-content-img-sizing-1.html
+++ b/LayoutTests/fast/css/max-content-img-sizing-1.html
@@ -1,0 +1,58 @@
+<style>
+   div {
+      width: max-content;
+   }
+   #greenbox-icon-1 {
+      width: 100%;
+      max-height: 50px;
+   }
+   #greenbox-icon-2 {
+      width: 100%;
+      min-height: 50px;
+   }
+   #greenbox-icon-3 {
+      width: 50%;
+      max-height: 10px;
+   }
+   #greenbox-icon-4 {
+      width: 50%;
+      min-height: 10px;
+   }
+   #greenbox-icon-5 {
+      width: 100%;
+      min-height: 50px;
+      max-height: 20px;
+   }
+   #circles-landscape-1 {
+      width: 100%;
+      max-height: 50px;
+   }
+   #circles-landscape-2 {
+      width: 100%;
+      min-height: 50px;
+   }
+   #circles-landscape-3 {
+      width: 50%;
+      max-height: 50px;
+   }
+   #circles-landscape-4 {
+      width: 50%;
+      min-height: 50px;
+   }
+   #circles-landscape-5 {
+      width: 100%;
+      min-height: 50px;
+      max-height: 20px;
+   }
+</style>
+
+<div><img id="greenbox-icon-1" src="resources/greenbox.png"></div>
+<div><img id="greenbox-icon-2" src="resources/greenbox.png"></div>
+<div><img id="greenbox-icon-3" src="resources/greenbox.png"></div>
+<div><img id="greenbox-icon-4" src="resources/greenbox.png"></div>
+<div><img id="greenbox-icon-5" src="resources/greenbox.png"></div>
+<div><img id="circles-landscape-1" src="resources/circles-landscape.png"></div>
+<div><img id="circles-landscape-2" src="resources/circles-landscape.png"></div>
+<div><img id="circles-landscape-3" src="resources/circles-landscape.png"></div>
+<div><img id="circles-landscape-4" src="resources/circles-landscape.png"></div>
+<div><img id="circles-landscape-5" src="resources/circles-landscape.png"></div>

--- a/LayoutTests/fast/css/max-content-img-sizing-2-expected.html
+++ b/LayoutTests/fast/css/max-content-img-sizing-2-expected.html
@@ -1,0 +1,31 @@
+<style>
+   div {
+      width: max-content;
+   }
+   #circles-portrait-1 {
+      width: 25px;
+      height: 50px;
+   }
+   #circles-portrait-2 {
+      width: 144px;
+      height: 288px;
+   }
+   #circles-portrait-3 {
+      width: 12.5px;
+      height: 25px;
+   }
+   #circles-portrait-4 {
+      width: 72px;
+      height: 144px;
+   }
+   #circles-portrait-5 {
+      width: 25px;
+      height: 50px;
+   }
+</style>
+
+<div><img id="circles-portrait-1" src="resources/circles-portrait.png"></div>
+<div><img id="circles-portrait-2" src="resources/circles-portrait.png"></div>
+<div><img id="circles-portrait-3" src="resources/circles-portrait.png"></div>
+<div><img id="circles-portrait-4" src="resources/circles-portrait.png"></div>
+<div><img id="circles-portrait-5" src="resources/circles-portrait.png"></div>

--- a/LayoutTests/fast/css/max-content-img-sizing-2.html
+++ b/LayoutTests/fast/css/max-content-img-sizing-2.html
@@ -1,0 +1,32 @@
+<style>
+   div {
+      width: max-content;
+   }
+   #circles-portrait-1 {
+      width: 100%;
+      max-height: 50px;
+   }
+   #circles-portrait-2 {
+      width: 100%;
+      min-height: 50px;
+   }
+   #circles-portrait-3 {
+      width: 50%;
+      max-height: 50px;
+   }
+   #circles-portrait-4 {
+      width: 50%;
+      min-height: 50px;
+}
+   #circles-portrait-5 {
+      width: 100%;
+      min-height: 50px;
+      max-height: 20px;
+   }
+</style>
+
+<div><img id="circles-portrait-1" src="resources/circles-portrait.png"></div>
+<div><img id="circles-portrait-2" src="resources/circles-portrait.png"></div>
+<div><img id="circles-portrait-3" src="resources/circles-portrait.png"></div>
+<div><img id="circles-portrait-4" src="resources/circles-portrait.png"></div>
+<div><img id="circles-portrait-5" src="resources/circles-portrait.png"></div>

--- a/Source/WebCore/rendering/RenderReplaced.h
+++ b/Source/WebCore/rendering/RenderReplaced.h
@@ -81,6 +81,8 @@ protected:
 private:
     LayoutUnit computeConstrainedLogicalWidth() const;
 
+    void computeAspectRatioAdjustedIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const;
+
     virtual RenderBox* embeddedContentBox() const { return 0; }
     ASCIILiteral renderName() const override { return "RenderReplaced"_s; }
 


### PR DESCRIPTION
#### bd8721b5d09d4fb5f600b4adb81c7ac6e1240591
<pre>
 Fix percent/calculated logical widths for RenderReplaced items with fixed logical heights and intrinsic aspect ratio.
<a href="https://bugs.webkit.org/show_bug.cgi?id=292568">https://bugs.webkit.org/show_bug.cgi?id=292568</a>
&lt;<a href="https://rdar.apple.com/146172341">rdar://146172341</a>&gt;

Reviewed by Alan Baradlay.

RenderReplaced::computePreferredLogicalWidths() now uses aspect ratio adjusted widths
when fixed height/min-height/max-height is specified. This ensures that intrinsic width
calculations keep the aspect ratio of RenderReplaced elements when vertical constraints
are present.

Combined changes:
* LayoutTests/fast/css/max-content-max-height-img-sizing-expected.html: Added.
* LayoutTests/fast/css/max-content-max-height-img-sizing.html: Added.
* Source/WebCore/rendering/RenderReplaced.cpp:
* Source/WebCore/rendering/RenderReplaced.h:

Canonical link: <a href="https://commits.webkit.org/294735@main">https://commits.webkit.org/294735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5b2e4e50ff4a4e673c716bac86a7dcd60e4caa2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108064 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/53539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104937 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22892 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31073 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/78232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/53539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105904 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17728 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/92857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/58566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/17567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10893 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52896 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/87376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10960 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110439 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30035 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87218 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30399 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89053 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86837 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22104 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31683 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/9400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/24297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29962 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/35284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29770 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33097 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/31332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->