### PR TITLE
Reduce use of strchr() in linux/ResourceUsageThreadLinux

### DIFF
--- a/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
+++ b/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
@@ -167,33 +167,38 @@ static bool threadCPUUsage(pid_t id, float period, ThreadInfo& info)
 
     // Skip tid and name.
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-    // FIXME: Use `find(std::span { buffer }, ')')` instead of `strchr()`.
-    char* position = strchr(buffer, ')');
-    if (!position)
+    auto bufferSpan = std::span { buffer, static_cast<size_t>(totalBytesRead + 1) };
+    auto position = WTF::find(bufferSpan, [](char c) { return c == ')';
+    }, 0);
+    if (position == bufferSpan.size())
         return false;
 
     if (!info.name) {
-        char* name = strchr(buffer, '(');
-        if (!name)
+        auto namePos = WTF::find(bufferSpan, [](char c) {
+            return c == '(';
+        }, 0);
+        if (namePos == bufferSpan.size())
             return false;
-        name++;
-        info.name = String::fromUTF8({ name, position });
+        namePos++;
+        info.name = String::fromUTF8({ buffer + namePos, buffer + position });
     }
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
+    char* positionPtr = buffer + position;
+
     // Move after state.
-    position += 4;
+    positionPtr += 4;
 
     // Skip ppid, pgrp, sid, tty_nr, tty_pgrp, flags, min_flt, cmin_flt, maj_flt, cmaj_flt.
     unsigned tokensToSkip = 10;
     while (tokensToSkip--) {
-        while (!isUnicodeCompatibleASCIIWhitespace(position[0]))
-            position++;
-        position++;
+        while (!isUnicodeCompatibleASCIIWhitespace(positionPtr[0]))
+            positionPtr++;
+        positionPtr++;
     }
 
-    unsigned long long utime = strtoull(position, &position, 10);
-    unsigned long long stime = strtoull(position, &position, 10);
+    unsigned long long utime = strtoull(positionPtr, &positionPtr, 10);
+    unsigned long long stime = strtoull(positionPtr, &positionPtr, 10);
     float usage = (utime + stime - (info.previousUtime + info.previousStime)) / period * 100.0;
     info.previousUtime = utime;
     info.previousStime = stime;


### PR DESCRIPTION
#### 9c48c52a53379624993ecef589afbde85c001b8f
<pre>
Reduce use of strchr() in linux/ResourceUsageThreadLinux
<a href="https://bugs.webkit.org/show_bug.cgi?id=292579">https://bugs.webkit.org/show_bug.cgi?id=292579</a>

Reviewed by NOBODY (OOPS!).

Use more type-safe and modern C++ features to replace C-style string searching.
After finding the positions, the code converts back to
raw pointers for compatibility with the remaining parsing logic that
uses pointer arithmetic and C functions like strtoull().

* Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp:
(WebCore::threadCPUUsage):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c48c52a53379624993ecef589afbde85c001b8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102241 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12224 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107400 "Hash 9c48c52a for PR 44974 does not build (failure)") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/52877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104280 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30416 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/107400 "Hash 9c48c52a for PR 44974 does not build (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/52877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105247 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17191 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/92293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/107400 "Hash 9c48c52a for PR 44974 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17021 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/10321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52235 "Hash 9c48c52a for PR 44974 does not build (failure)") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/10391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109776 "Hash 9c48c52a for PR 44974 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29373 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/21651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/109776 "Hash 9c48c52a for PR 44974 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29736 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/88496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/109776 "Hash 9c48c52a for PR 44974 does not build (failure)") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/31175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/8889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/23615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29301 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34596 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29112 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/32435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30671 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->