### PR TITLE
[Model Element] Unload the model player (and its resources) when it's invisible

### DIFF
--- a/LayoutTests/model-element/model-element-on-hidden-page-expected.txt
+++ b/LayoutTests/model-element/model-element-on-hidden-page-expected.txt
@@ -1,0 +1,3 @@
+
+PASS <model> on hidden page should keep animation running
+

--- a/LayoutTests/model-element/model-element-on-hidden-page.html
+++ b/LayoutTests/model-element/model-element-on-hidden-page.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ModelElementEnabled=true ModelProcessEnabled=true ] -->
+<meta charset="utf-8">
+<title>&lt;model> state while page is hidden playback</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="resources/model-element-test-utils.js"></script>
+<script src="resources/model-utils.js"></script>
+<body>
+<script>
+internals.disableModelLoadDelaysForTesting();
+
+promise_test(async t => {
+    const [model, source] = createModelAndSource(t, "resources/stopwatch-60s.usdz");
+    const initialModelReadyPromise = model.ready;
+    await model.ready;
+    model.loop = true;
+    await model.play();
+
+    assert_false(document.hidden, "Page should be initially visible");
+
+    window.testRunner.setPageVisibility("hidden");
+    await sleepForSeconds(0.5);
+
+    assert_true(document.hidden, "Page should be hidden");
+    assert_false(model.paused, "Model animation is still playing after hiding page");
+    assert_true(model.currentTime >= 0.5, "Model animation is still progressing after page becomes hidden");
+
+    model.currentTime = model.duration - 1.0;
+    model.playbackRate = 4;
+    await sleepForSeconds(0.5);
+    assert_true(model.currentTime >= 1.0, "Model animation should continue to run with the last set playback rate and loop when page is hidden");
+    
+    window.testRunner.setPageVisibility("visible");
+    await sleepForSeconds(0.5);
+    assert_false(document.hidden, "Page should be visible");
+    assert_equals(model.ready, initialModelReadyPromise, "model.ready promise should not have been reset after hiding and re-showing");
+
+    assert_false(model.paused, "Model animation is still playing after re-showing page");
+    assert_true(model.currentTime >= 3.0, "Model animation is still progressing after page is shown again");
+}, `<model> on hidden page should keep animation running`);
+
+</script>
+</body>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -539,8 +539,10 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/model-element/HTMLModelElement.h
     Modules/model-element/HTMLModelElementCamera.h
     Modules/model-element/ModelPlayer.h
+    Modules/model-element/ModelPlayerAnimationState.h
     Modules/model-element/ModelPlayerClient.h
     Modules/model-element/ModelPlayerProvider.h
+    Modules/model-element/ModelPlayerTransformState.h
 
     Modules/model-element/dummy/DummyModelPlayer.h
     Modules/model-element/dummy/DummyModelPlayerProvider.h

--- a/Source/WebCore/Modules/model-element/ModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.cpp
@@ -43,6 +43,11 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ModelPlayer);
 
 ModelPlayer::~ModelPlayer() = default;
 
+bool ModelPlayer::isPlaceholder() const
+{
+    return false;
+}
+
 std::optional<ModelPlayerAnimationState> ModelPlayer::currentAnimationState() const
 {
     return std::nullopt;
@@ -51,6 +56,14 @@ std::optional<ModelPlayerAnimationState> ModelPlayer::currentAnimationState() co
 std::optional<std::unique_ptr<ModelPlayerTransformState>> ModelPlayer::currentTransformState() const
 {
     return std::nullopt;
+}
+
+void ModelPlayer::reload(Model&, LayoutSize, ModelPlayerAnimationState&, std::unique_ptr<ModelPlayerTransformState>&&)
+{
+}
+
+void ModelPlayer::visibilityStateDidChange()
+{
 }
 
 std::optional<FloatPoint3D> ModelPlayer::boundingBoxCenter() const
@@ -156,10 +169,6 @@ void ModelPlayer::updateStageModeTransform(const TransformationMatrix&)
 }
 
 void ModelPlayer::endStageModeInteraction()
-{
-}
-
-void ModelPlayer::renderingAbruptlyStopped()
 {
 }
 

--- a/Source/WebCore/Modules/model-element/ModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.h
@@ -60,10 +60,14 @@ public:
     virtual ModelPlayerIdentifier identifier() const = 0;
 #endif
 
+    virtual bool isPlaceholder() const;
     virtual std::optional<ModelPlayerAnimationState> currentAnimationState() const;
     virtual std::optional<std::unique_ptr<ModelPlayerTransformState>> currentTransformState() const;
 
     virtual void load(Model&, LayoutSize) = 0;
+    virtual void reload(Model&, LayoutSize, ModelPlayerAnimationState&, std::unique_ptr<ModelPlayerTransformState>&&);
+    virtual void visibilityStateDidChange();
+
     virtual void sizeDidChange(LayoutSize) = 0;
     virtual PlatformLayer* layer() = 0;
     virtual std::optional<LayerHostingContextIdentifier> layerHostingContextIdentifier() = 0;
@@ -110,7 +114,6 @@ public:
     virtual void beginStageModeTransform(const TransformationMatrix&);
     virtual void updateStageModeTransform(const TransformationMatrix&);
     virtual void endStageModeInteraction();
-    virtual void renderingAbruptlyStopped();
     virtual void animateModelToFitPortal(CompletionHandler<void(bool)>&&);
     virtual void resetModelTransformAfterDrag();
 #endif

--- a/Source/WebCore/Modules/model-element/ModelPlayerClient.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayerClient.h
@@ -57,9 +57,10 @@ public:
     virtual void didUpdateEntityTransform(ModelPlayer&, const TransformationMatrix&) = 0;
     virtual void didUpdateBoundingBox(ModelPlayer&, const FloatPoint3D&, const FloatPoint3D&) = 0;
     virtual void didFinishEnvironmentMapLoading(bool succeeded) = 0;
-    virtual void renderingAbruptlyStopped() = 0;
+    virtual void didUnload(ModelPlayer&) = 0;
 #endif
     virtual std::optional<PlatformLayerIdentifier> modelContentsLayerID() const = 0;
+    virtual bool isVisible() const = 0;
 };
 
 }

--- a/Source/WebCore/Modules/model-element/ModelPlayerTransformState.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayerTransformState.h
@@ -35,15 +35,16 @@ class TransformationMatrix;
 class WEBCORE_EXPORT ModelPlayerTransformState {
 public:
     virtual ~ModelPlayerTransformState() = default;
+    virtual std::unique_ptr<ModelPlayerTransformState> clone() const = 0;
 
     virtual std::optional<TransformationMatrix> entityTransform() const = 0;
     virtual void setEntityTransform(TransformationMatrix) = 0;
     virtual bool isEntityTransformSupported(const TransformationMatrix&) const = 0;
 
-#if ENABLE(MODEL_PROCESS)
     virtual std::optional<FloatPoint3D> boundingBoxCenter() const = 0;
     virtual std::optional<FloatPoint3D> boundingBoxExtents() const = 0;
 
+#if ENABLE(MODEL_PROCESS)
     virtual bool hasPortal() const = 0;
     virtual void setHasPortal(bool) = 0;
     virtual StageModeOperation stageMode() const = 0;

--- a/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp
@@ -1,0 +1,274 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PlaceholderModelPlayer.h"
+
+#include "FloatPoint3D.h"
+#include "Logging.h"
+#include "Model.h"
+#include "ModelPlayerTransformState.h"
+#include "TransformationMatrix.h"
+#include <wtf/CompletionHandler.h>
+
+namespace WebCore {
+
+Ref<PlaceholderModelPlayer> PlaceholderModelPlayer::create(bool suspended, const ModelPlayerAnimationState& animationState, std::unique_ptr<ModelPlayerTransformState>&& transformState)
+{
+    return adoptRef(*new PlaceholderModelPlayer(suspended, animationState, WTFMove(transformState)));
+}
+
+PlaceholderModelPlayer::PlaceholderModelPlayer(bool suspended, const ModelPlayerAnimationState& animationState, std::unique_ptr<ModelPlayerTransformState>&& transformState)
+    : m_animationState(animationState)
+    , m_transformState(WTFMove(transformState))
+#if ENABLE(MODEL_PROCESS)
+    , m_id(ModelPlayerIdentifier::generate())
+#endif
+{
+    ASSERT(m_transformState);
+
+    RELEASE_LOG(ModelElement, "%p - PlaceholderModelPlayer created when model was suspended: %d", this, suspended);
+    if (!suspended)
+        return;
+
+    m_lastPausedStateIfSuspended = m_animationState.paused();
+    if (m_animationState.paused())
+        return;
+
+    m_animationState.setCurrentTime(animationState.currentTime(), MonotonicTime::now());
+    m_animationState.setPaused(true);
+}
+
+PlaceholderModelPlayer::~PlaceholderModelPlayer() = default;
+
+std::optional<ModelPlayerAnimationState> PlaceholderModelPlayer::currentAnimationState() const
+{
+    if (!m_lastPausedStateIfSuspended || *m_lastPausedStateIfSuspended)
+        return m_animationState;
+
+    auto unsuspendedAnimationState = ModelPlayerAnimationState(m_animationState);
+    unsuspendedAnimationState.setCurrentTime(unsuspendedAnimationState.currentTime(), MonotonicTime::now());
+    unsuspendedAnimationState.setPaused(false);
+    return unsuspendedAnimationState;
+}
+
+std::optional<std::unique_ptr<ModelPlayerTransformState>> PlaceholderModelPlayer::currentTransformState() const
+{
+    return m_transformState->clone();
+}
+
+void PlaceholderModelPlayer::load(Model&, LayoutSize)
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+void PlaceholderModelPlayer::reload(Model&, LayoutSize, ModelPlayerAnimationState&, std::unique_ptr<ModelPlayerTransformState>&&)
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+std::optional<WebCore::FloatPoint3D> PlaceholderModelPlayer::boundingBoxCenter() const
+{
+    return m_transformState->boundingBoxCenter();
+}
+
+std::optional<WebCore::FloatPoint3D> PlaceholderModelPlayer::boundingBoxExtents() const
+{
+    return m_transformState->boundingBoxExtents();
+}
+
+std::optional<WebCore::TransformationMatrix> PlaceholderModelPlayer::entityTransform() const
+{
+    return m_transformState->entityTransform();
+}
+
+/// This comes from JS side, so we need to tell Model Process about it. Not to be confused with didUpdateEntityTransform().
+void PlaceholderModelPlayer::setEntityTransform(WebCore::TransformationMatrix transform)
+{
+#if ENABLE(MODEL_PROCESS)
+    ASSERT(m_transformState->stageMode() == StageModeOperation::None);
+#endif
+    m_transformState->setEntityTransform(transform);
+}
+
+bool PlaceholderModelPlayer::supportsTransform(WebCore::TransformationMatrix transform)
+{
+    return m_transformState->isEntityTransformSupported(transform);
+}
+
+#if ENABLE(MODEL_PROCESS)
+void PlaceholderModelPlayer::setAutoplay(bool autoplay)
+{
+    m_animationState.setAutoplay(autoplay);
+}
+
+void PlaceholderModelPlayer::setLoop(bool loop)
+{
+    m_animationState.setLoop(loop);
+}
+
+void PlaceholderModelPlayer::setPlaybackRate(double playbackRate, CompletionHandler<void(double effectivePlaybackRate)>&& completionHandler)
+{
+    if (m_animationState.effectivePlaybackRate() == playbackRate)
+        return;
+
+    m_animationState.setCurrentTime(m_animationState.currentTime(), MonotonicTime::now());
+    m_animationState.setPlaybackRate(playbackRate);
+    auto effectivePlaybackRate = m_animationState.effectivePlaybackRate();
+    completionHandler(effectivePlaybackRate ? *effectivePlaybackRate : 1.0);
+}
+
+double PlaceholderModelPlayer::duration() const
+{
+    return m_animationState.duration().seconds();
+}
+
+bool PlaceholderModelPlayer::paused() const
+{
+    return m_animationState.paused();
+}
+
+void PlaceholderModelPlayer::setPaused(bool paused, CompletionHandler<void(bool succeeded)>&& completionHandler)
+{
+    if (m_animationState.paused() == paused)
+        return;
+
+    m_animationState.setCurrentTime(m_animationState.currentTime(), MonotonicTime::now());
+    m_animationState.setPaused(paused);
+    completionHandler(true);
+}
+
+Seconds PlaceholderModelPlayer::currentTime() const
+{
+    return m_animationState.currentTime();
+}
+
+void PlaceholderModelPlayer::setCurrentTime(Seconds currentTime, CompletionHandler<void()>&& completionHandler)
+{
+    double durationSeconds = m_animationState.duration().seconds();
+    if (durationSeconds)
+        m_animationState.setCurrentTime(currentTime, MonotonicTime::now());
+
+    completionHandler();
+}
+
+void PlaceholderModelPlayer::setHasPortal(bool hasPortal)
+{
+    m_transformState->setHasPortal(hasPortal);
+}
+
+void PlaceholderModelPlayer::setStageMode(WebCore::StageModeOperation stageModeOperation)
+{
+    m_transformState->setStageMode(stageModeOperation);
+}
+#endif
+
+// Empty implementation
+PlatformLayer* PlaceholderModelPlayer::layer()
+{
+    return nullptr;
+}
+
+std::optional<LayerHostingContextIdentifier> PlaceholderModelPlayer::layerHostingContextIdentifier()
+{
+    return std::nullopt;
+}
+
+void PlaceholderModelPlayer::sizeDidChange(LayoutSize)
+{
+}
+
+void PlaceholderModelPlayer::enterFullscreen()
+{
+}
+
+void PlaceholderModelPlayer::handleMouseDown(const LayoutPoint&, MonotonicTime)
+{
+}
+
+void PlaceholderModelPlayer::handleMouseMove(const LayoutPoint&, MonotonicTime)
+{
+}
+
+void PlaceholderModelPlayer::handleMouseUp(const LayoutPoint&, MonotonicTime)
+{
+}
+
+void PlaceholderModelPlayer::getCamera(CompletionHandler<void(std::optional<WebCore::HTMLModelElementCamera>&&)>&&)
+{
+}
+
+void PlaceholderModelPlayer::setCamera(WebCore::HTMLModelElementCamera, CompletionHandler<void(bool success)>&&)
+{
+}
+
+void PlaceholderModelPlayer::isPlayingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&)
+{
+}
+
+void PlaceholderModelPlayer::setAnimationIsPlaying(bool, CompletionHandler<void(bool success)>&&)
+{
+}
+
+void PlaceholderModelPlayer::isLoopingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&)
+{
+}
+
+void PlaceholderModelPlayer::setIsLoopingAnimation(bool, CompletionHandler<void(bool success)>&&)
+{
+}
+
+void PlaceholderModelPlayer::animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&&)
+{
+}
+
+void PlaceholderModelPlayer::animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&&)
+{
+}
+
+void PlaceholderModelPlayer::setAnimationCurrentTime(Seconds, CompletionHandler<void(bool success)>&&)
+{
+}
+
+void PlaceholderModelPlayer::hasAudio(CompletionHandler<void(std::optional<bool>&&)>&&)
+{
+}
+
+void PlaceholderModelPlayer::isMuted(CompletionHandler<void(std::optional<bool>&&)>&&)
+{
+}
+
+void PlaceholderModelPlayer::setIsMuted(bool, CompletionHandler<void(bool success)>&&)
+{
+}
+
+#if PLATFORM(COCOA)
+Vector<RetainPtr<id>> PlaceholderModelPlayer::accessibilityChildren()
+{
+    return { };
+}
+#endif
+
+}

--- a/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ModelPlayer.h"
+#include "ModelPlayerAnimationState.h"
+
+namespace WebCore {
+
+class PlaceholderModelPlayer final : public ModelPlayer {
+public:
+    static Ref<PlaceholderModelPlayer> create(bool suspended, const ModelPlayerAnimationState&, std::unique_ptr<ModelPlayerTransformState>&&);
+    virtual ~PlaceholderModelPlayer();
+
+private:
+    PlaceholderModelPlayer(bool suspended, const ModelPlayerAnimationState&, std::unique_ptr<ModelPlayerTransformState>&&);
+
+    // ModelPlayer overrides.
+#if ENABLE(MODEL_PROCESS)
+    ModelPlayerIdentifier identifier() const final { return m_id; }
+#endif
+
+    bool isPlaceholder() const final { return true; }
+    std::optional<ModelPlayerAnimationState> currentAnimationState() const final;
+    std::optional<std::unique_ptr<ModelPlayerTransformState>> currentTransformState() const final;
+    void load(Model&, LayoutSize) final;
+    void reload(Model&, LayoutSize, ModelPlayerAnimationState&, std::unique_ptr<ModelPlayerTransformState>&&) final;
+
+    std::optional<FloatPoint3D> boundingBoxCenter() const final;
+    std::optional<FloatPoint3D> boundingBoxExtents() const final;
+    std::optional<TransformationMatrix> entityTransform() const final;
+    void setEntityTransform(TransformationMatrix) final;
+    bool supportsTransform(TransformationMatrix) final;
+#if ENABLE(MODEL_PROCESS)
+    void setAutoplay(bool) final;
+    void setLoop(bool) final;
+    void setPlaybackRate(double playbackRate, CompletionHandler<void(double effectivePlaybackRate)>&&) final;
+    double duration() const final;
+    bool paused() const final;
+    void setPaused(bool, CompletionHandler<void(bool succeeded)>&&) final;
+    Seconds currentTime() const final;
+    void setCurrentTime(Seconds, CompletionHandler<void()>&&) final;
+    void setHasPortal(bool) final;
+    void setStageMode(WebCore::StageModeOperation) final;
+#endif
+
+    // Empty implementation
+    void sizeDidChange(LayoutSize) final;
+    PlatformLayer* layer() final;
+    std::optional<LayerHostingContextIdentifier> layerHostingContextIdentifier() final;
+    void enterFullscreen() final;
+    void handleMouseDown(const LayoutPoint&, MonotonicTime) final;
+    void handleMouseMove(const LayoutPoint&, MonotonicTime) final;
+    void handleMouseUp(const LayoutPoint&, MonotonicTime) final;
+    void getCamera(CompletionHandler<void(std::optional<WebCore::HTMLModelElementCamera>&&)>&&) final;
+    void setCamera(WebCore::HTMLModelElementCamera, CompletionHandler<void(bool success)>&&) final;
+    void isPlayingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&) final;
+    void setAnimationIsPlaying(bool, CompletionHandler<void(bool success)>&&) final;
+    void isLoopingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&) final;
+    void setIsLoopingAnimation(bool, CompletionHandler<void(bool success)>&&) final;
+    void animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
+    void animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
+    void setAnimationCurrentTime(Seconds, CompletionHandler<void(bool success)>&&) final;
+    void hasAudio(CompletionHandler<void(std::optional<bool>&&)>&&) final;
+    void isMuted(CompletionHandler<void(std::optional<bool>&&)>&&) final;
+    void setIsMuted(bool, CompletionHandler<void(bool success)>&&) final;
+#if PLATFORM(COCOA)
+    Vector<RetainPtr<id>> accessibilityChildren() final;
+#endif
+
+    std::optional<bool> m_lastPausedStateIfSuspended;
+    ModelPlayerAnimationState m_animationState;
+    std::unique_ptr<ModelPlayerTransformState> m_transformState;
+#if ENABLE(MODEL_PROCESS)
+    ModelPlayerIdentifier m_id;
+#endif
+};
+
+}

--- a/Source/WebCore/Modules/speech/SpeechRecognition.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognition.cpp
@@ -28,6 +28,7 @@
 
 #include "ClientOrigin.h"
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "EventNames.h"
 #include "EventTargetInlines.h"
 #include "FrameDestructionObserverInlines.h"

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp
@@ -26,6 +26,7 @@
 #include "GStreamerAudioData.h"
 #include "GStreamerAudioStreamDescription.h"
 #include "Logging.h"
+#include <wtf/MediaTime.h>
 
 namespace WebCore {
 
@@ -36,7 +37,7 @@ void MediaStreamAudioSource::consumeAudio(AudioBus& bus, size_t numberOfFrames)
         return;
     }
 
-    MediaTime mediaTime((m_numberOfFrames * G_USEC_PER_SEC) / m_currentSettings.sampleRate(), G_USEC_PER_SEC);
+    WTF::MediaTime mediaTime((m_numberOfFrames * G_USEC_PER_SEC) / m_currentSettings.sampleRate(), G_USEC_PER_SEC);
     m_numberOfFrames += numberOfFrames;
 
     // Lazily initialize caps, the settings don't change so this is OK.

--- a/Source/WebCore/Modules/webdatabase/DatabaseTracker.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseTracker.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "DatabaseDetails.h"
+#include "DatabaseManagerClient.h"
 #include "ExceptionOr.h"
 #include "SQLiteDatabase.h"
 #include "SecurityOriginData.h"

--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -29,6 +29,7 @@
 
 #if ENABLE(WEBXR) && !PLATFORM(COCOA)
 
+#include "DocumentInlines.h"
 #include "IntSize.h"
 #include "WebGLFramebuffer.h"
 #include "WebGL2RenderingContext.h"

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -297,6 +297,7 @@ Modules/model-element/ModelPlayer.cpp
 Modules/model-element/ModelPlayerAnimationState.cpp
 Modules/model-element/ModelPlayerClient.cpp
 Modules/model-element/ModelPlayerProvider.cpp
+Modules/model-element/PlaceholderModelPlayer.cpp
 Modules/model-element/dummy/DummyModelPlayer.cpp
 Modules/model-element/dummy/DummyModelPlayerProvider.cpp
 Modules/notifications/Notification.cpp

--- a/Source/WebCore/dom/TaskSource.h
+++ b/Source/WebCore/dom/TaskSource.h
@@ -39,6 +39,7 @@ enum class TaskSource : uint8_t {
     IndexedDB,
     MediaElement,
     Microtask,
+    ModelElement,
     Networking,
     Payment,
     PerformanceTimeline,

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1306,6 +1306,11 @@ public:
     WEBCORE_EXPORT void setPresentingApplicationBundleIdentifier(String&&);
 #endif
 
+#if ENABLE(MODEL_ELEMENT)
+    bool shouldDisableModelLoadDelaysForTesting() const { return m_modelLoadDelaysDisabledForTesting; }
+    void disableModelLoadDelaysForTesting() { m_modelLoadDelaysDisabledForTesting = true; }
+#endif
+
 private:
     explicit Page(PageConfiguration&&);
 
@@ -1755,6 +1760,10 @@ private:
 
 #if PLATFORM(COCOA)
     String m_presentingApplicationBundleIdentifier;
+#endif
+
+#if ENABLE(MODEL_ELEMENT)
+    bool m_modelLoadDelaysDisabledForTesting { false };
 #endif
 }; // class Page
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7895,4 +7895,15 @@ ExceptionOr<Vector<Internals::FrameDamage>> Internals::getFrameDamageHistory() c
 }
 #endif
 
+#if ENABLE(MODEL_ELEMENT)
+void Internals::disableModelLoadDelaysForTesting()
+{
+    RefPtr document = contextDocument();
+    if (!document || !document->page())
+        return;
+
+    document->page()->disableModelLoadDelaysForTesting();
+}
+#endif
+
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1577,6 +1577,10 @@ public:
     ExceptionOr<Vector<FrameDamage>> getFrameDamageHistory() const;
 #endif // ENABLE(DAMAGE_TRACKING)
 
+#if ENABLE(MODEL_ELEMENT)
+    void disableModelLoadDelaysForTesting();
+#endif
+
 private:
     explicit Internals(Document&);
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1452,4 +1452,6 @@ enum ContentsFormat {
     undefined setResourceMonitorNetworkUsageThreshold(unsigned long threshold, double randomness);
     attribute boolean shouldSkipResourceMonitorThrottling;
 #endif
+
+    [Conditional=MODEL_ELEMENT] undefined disableModelLoadDelaysForTesting();
 };

--- a/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp
+++ b/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp
@@ -162,6 +162,11 @@ void ModelConnectionToWebProcess::configureLoggingChannel(const String& channelN
 #endif
 }
 
+void ModelConnectionToWebProcess::didUnloadModelPlayer(WebCore::ModelPlayerIdentifier modelPlayerIdentifier)
+{
+    m_connection->send(Messages::ModelProcessConnection::DidUnloadModelPlayer(modelPlayerIdentifier), 0);
+}
+
 bool ModelConnectionToWebProcess::allowsExitUnderMemoryPressure() const
 {
     // FIXME: Should allow exit if we have no models.

--- a/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
+++ b/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
@@ -34,6 +34,7 @@
 #include "ScopedActiveMessageReceiveQueue.h"
 #include "SharedPreferencesForWebProcess.h"
 #include "WebPageProxyIdentifier.h"
+#include <WebCore/ModelPlayerIdentifier.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/ProcessIdentifier.h>
 #include <WebCore/ProcessIdentity.h>
@@ -96,6 +97,7 @@ public:
 
     const WebCore::ProcessIdentity& webProcessIdentity() const { return m_webProcessIdentity; }
 
+    void didUnloadModelPlayer(WebCore::ModelPlayerIdentifier);
     bool allowsExitUnderMemoryPressure() const;
 
     void lowMemoryHandler(WTF::Critical, WTF::Synchronous);

--- a/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp
+++ b/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp
@@ -84,6 +84,14 @@ void ModelProcessModelPlayerManagerProxy::deleteModelPlayer(WebCore::ModelPlayer
         m_modelConnectionToWebProcess->modelProcess().tryExitIfUnusedAndUnderMemoryPressure();
 }
 
+void ModelProcessModelPlayerManagerProxy::unloadModelPlayer(WebCore::ModelPlayerIdentifier identifier)
+{
+    ASSERT(RunLoop::isMain());
+
+    deleteModelPlayer(identifier);
+    m_modelConnectionToWebProcess->didUnloadModelPlayer(identifier);
+}
+
 void ModelProcessModelPlayerManagerProxy::didReceivePlayerMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     ASSERT(RunLoop::isMain());

--- a/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.h
+++ b/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.h
@@ -62,6 +62,8 @@ public:
     void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
     void didReceivePlayerMessage(IPC::Connection&, IPC::Decoder&);
 
+    void unloadModelPlayer(WebCore::ModelPlayerIdentifier);
+
 private:
     explicit ModelProcessModelPlayerManagerProxy(ModelConnectionToWebProcess&);
 

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
@@ -26,6 +26,9 @@
 [EnabledBy=ModelElementEnabled && ModelProcessEnabled]
 messages -> ModelProcessModelPlayerProxy {
     CreateLayer()
+    ReloadModel(Ref<WebCore::Model> model, WebCore::LayoutSize layoutSize, std::optional<WebCore::TransformationMatrix> entityTransformToRestore, std::optional<WebCore::ModelPlayerAnimationState> animationStateToRestore)
+    ModelVisibilityDidChange(bool isVisible)
+    DisableUnloadDelayForTesting()
     
     # WebCore::ModelPlayer
     LoadModel(Ref<WebCore::Model> url, WebCore::LayoutSize layoutSize)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7155,6 +7155,16 @@ struct WebCore::CookieChangeSubscription {
     URL url()
 }
 
+class WebCore::ModelPlayerAnimationState {
+    bool autoplay()
+    bool loop()
+    bool paused()
+    Seconds duration()
+    std::optional<double> effectivePlaybackRate()
+    std::optional<Seconds> lastCachedCurrentTime()
+    std::optional<MonotonicTime> lastCachedClockTimestamp()
+}
+
 #if ENABLE(MODEL_PROCESS)
 enum class WebCore::ModelContextDisablePortal : bool
 

--- a/Source/WebKit/WebProcess/Model/ModelProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessConnection.cpp
@@ -135,6 +135,11 @@ void ModelProcessConnection::didInitialize(std::optional<ModelProcessConnectionI
     m_hasInitialized = true;
 }
 
+void ModelProcessConnection::didUnloadModelPlayer(WebCore::ModelPlayerIdentifier modelPlayerIdentifier)
+{
+    WebProcess::singleton().modelProcessModelPlayerManager().didUnloadModelProcessModelPlayer(modelPlayerIdentifier);
+}
+
 bool ModelProcessConnection::waitForDidInitialize()
 {
     if (!m_hasInitialized) {

--- a/Source/WebKit/WebProcess/Model/ModelProcessConnection.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessConnection.h
@@ -29,6 +29,7 @@
 
 #include "Connection.h"
 #include "MessageReceiverMap.h"
+#include <WebCore/ModelPlayerIdentifier.h>
 #include <wtf/AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RefCounted.h>
 #include <wtf/WeakHashSet.h>
@@ -94,6 +95,7 @@ private:
 
     // Messages.
     void didInitialize(std::optional<ModelProcessConnectionInfo>&&);
+    void didUnloadModelPlayer(WebCore::ModelPlayerIdentifier);
 
     // The connection from the web process to the model process.
     Ref<IPC::Connection> m_connection;

--- a/Source/WebKit/WebProcess/Model/ModelProcessConnection.messages.in
+++ b/Source/WebKit/WebProcess/Model/ModelProcessConnection.messages.in
@@ -29,6 +29,7 @@
 ]
 messages -> ModelProcessConnection WantsDispatchMessage {
     DidInitialize(struct std::optional<WebKit::ModelProcessConnectionInfo> info) CanDispatchOutOfOrder
+    DidUnloadModelPlayer(WebCore::ModelPlayerIdentifier identifier)
 }
 
 #endif // ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -51,9 +51,10 @@ public:
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
-    void renderingAbruptlyStopped() final;
-
     std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier() { return m_layerHostingContextIdentifier; };
+    void didUnload();
+
+    void disableUnloadDelayForTesting();
 
 private:
     explicit ModelProcessModelPlayer(WebCore::ModelPlayerIdentifier, WebPage&, WebCore::ModelPlayerClient&);
@@ -79,6 +80,8 @@ private:
     std::optional<WebCore::ModelPlayerAnimationState> currentAnimationState() const final;
     std::optional<std::unique_ptr<WebCore::ModelPlayerTransformState>> currentTransformState() const final;
     void load(WebCore::Model&, WebCore::LayoutSize) final;
+    void reload(WebCore::Model&, WebCore::LayoutSize, WebCore::ModelPlayerAnimationState&, std::unique_ptr<WebCore::ModelPlayerTransformState>&&) final;
+    void visibilityStateDidChange() final;
     void sizeDidChange(WebCore::LayoutSize) final;
     PlatformLayer* layer() final;
     void handleMouseDown(const WebCore::LayoutPoint&, MonotonicTime) final;

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in
@@ -34,6 +34,7 @@ messages -> ModelProcessModelPlayer {
     DidUpdateEntityTransform(WebCore::TransformationMatrix transform)
     DidUpdateAnimationPlaybackState(bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp)
     DidFinishEnvironmentMapLoading(bool succeeded)
+    DidUnload()
 }
 
 #endif // ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.h
@@ -55,6 +55,7 @@ public:
     void deleteModelProcessModelPlayer(WebCore::ModelPlayer&);
 
     void didReceivePlayerMessage(IPC::Connection&, IPC::Decoder&);
+    void didUnloadModelProcessModelPlayer(WebCore::ModelPlayerIdentifier);
 
     // ModelProcessConnection::Client
     void modelProcessConnectionDidClose(ModelProcessConnection&) override;

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.cpp
@@ -48,6 +48,11 @@ ModelProcessModelPlayerTransformState::ModelProcessModelPlayerTransformState(std
 {
 }
 
+std::unique_ptr<WebCore::ModelPlayerTransformState> ModelProcessModelPlayerTransformState::clone() const
+{
+    return makeUnique<ModelProcessModelPlayerTransformState>(m_entityTransform, m_boundingBoxCenter, m_boundingBoxExtents, m_hasPortal, m_stageModeOperation);
+}
+
 static bool areSameSignAndAlmostEqual(float a, float b, float tolerance)
 {
     if (a * b < 0)

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.h
@@ -44,6 +44,7 @@ public:
 
 private:
     // ModelPlayerTransformState overrides
+    std::unique_ptr<WebCore::ModelPlayerTransformState> clone() const final;
     std::optional<WebCore::TransformationMatrix> entityTransform() const final { return m_entityTransform; }
     void setEntityTransform(WebCore::TransformationMatrix) final;
     bool isEntityTransformSupported(const WebCore::TransformationMatrix&) const final;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -10375,6 +10375,13 @@ void WebPage::frameViewLayoutOrVisualViewportChanged(const LocalFrameView& frame
 #endif
 }
 
+#if ENABLE(MODEL_ELEMENT)
+bool WebPage::shouldDisableModelLoadDelaysForTesting() const
+{
+    return m_page && m_page->shouldDisableModelLoadDelaysForTesting();
+}
+#endif
+
 } // namespace WebKit
 
 #undef WEBPAGE_RELEASE_LOG

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1984,6 +1984,10 @@ public:
 
     void setNeedsFixedContainerEdgesUpdate() { m_needsFixedContainerEdgesUpdate = true; }
 
+#if ENABLE(MODEL_ELEMENT)
+    bool shouldDisableModelLoadDelaysForTesting() const;
+#endif
+
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
 

--- a/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
@@ -528,9 +528,12 @@ const char* TestController::platformLibraryPathForTesting()
     return [platformLibraryPath.get() UTF8String];
 }
 
-void TestController::setHidden(bool)
+void TestController::setHidden(bool hidden)
 {
-    // FIXME: implement for iOS
+    if (hidden)
+        mainWebView()->removeFromWindow();
+    else
+        mainWebView()->addToWindow();
 }
 
 static UIKeyboardInputMode *swizzleCurrentInputMode()


### PR DESCRIPTION
#### df1d0981bc3818eeb64d5369b4b30f7b834f976f
<pre>
[Model Element] Unload the model player (and its resources) when it&apos;s invisible
<a href="https://bugs.webkit.org/show_bug.cgi?id=292574">https://bugs.webkit.org/show_bug.cgi?id=292574</a>
<a href="https://rdar.apple.com/149972888">rdar://149972888</a>

Reviewed by Ryosuke Niwa and Mike Wyrzykowski.

When the model element&apos;s document has become hidden, unload its model player in
the model process to reduce its memory allocations. The unloading is done with
a delay in case the user quickly reactivates the page the model is in. The
unloading is handled by the model process, as the web content process will
likely get suspended when the page becomes hidden.

When the web content process is notified of the model player unloading, it
creates a PlaceholderModelPlayer with the current animation and transform
states. This way HTMLModelElement can continue to access/update that placeholder
model player. Any running animation timeline can keep running, and updates
can still be tracked by this placeholder model player.

When the page is shown again, HTMLModelElement gets the most current animation
and transform states from the placeholder model player, creates the &quot;real&quot;
model player, and restores it with those states. The reloading is also done
with a short delay in case the user quickly deactivates the page right after
activating it.

Unload the model player into a PlaceholderModelPlayer when the &lt;model&gt;
element is suspended when the page is added to the back/forward cache.
Any running animation is paused when the element is suspended, and
unpaused when the element is resumed.

* LayoutTests/model-element/model-element-on-hidden-page-expected.txt
* LayoutTests/model-element/model-element-on-hidden-page.html
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::visibilityStateChanged):
(WebCore::HTMLModelElement::unloadModelPlayer):
(WebCore::HTMLModelElement::reloadModelPlayer):
(WebCore::HTMLModelElement::reloadModelTimerFired):
(WebCore::HTMLModelElement::isVisible const):
(WebCore::HTMLModelElement::didUnload):
(WebCore::HTMLModelElement::renderingAbruptlyStopped): Deleted.
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/ModelPlayer.cpp:
(WebCore::ModelPlayer::isPlaceholder const):
(WebCore::ModelPlayer::reload):
(WebCore::ModelPlayer::visibilityStateDidChange):
(WebCore::ModelPlayer::renderingAbruptlyStopped): Deleted.
* Source/WebCore/Modules/model-element/ModelPlayer.h:
* Source/WebCore/Modules/model-element/ModelPlayerClient.h:
* Source/WebCore/Modules/model-element/ModelPlayerTransformState.h:
* Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp: Added.
(WebCore::PlaceholderModelPlayer::create):
(WebCore::PlaceholderModelPlayer::PlaceholderModelPlayer):
(WebCore::PlaceholderModelPlayer::currentAnimationState const):
(WebCore::PlaceholderModelPlayer::currentTransformState const):
(WebCore::PlaceholderModelPlayer::load):
(WebCore::PlaceholderModelPlayer::reload):
(WebCore::PlaceholderModelPlayer::boundingBoxCenter const):
(WebCore::PlaceholderModelPlayer::boundingBoxExtents const):
(WebCore::PlaceholderModelPlayer::entityTransform const):
(WebCore::PlaceholderModelPlayer::setEntityTransform):
(WebCore::PlaceholderModelPlayer::supportsTransform):
(WebCore::PlaceholderModelPlayer::setAutoplay):
(WebCore::PlaceholderModelPlayer::setLoop):
(WebCore::PlaceholderModelPlayer::setPlaybackRate):
(WebCore::PlaceholderModelPlayer::duration const):
(WebCore::PlaceholderModelPlayer::paused const):
(WebCore::PlaceholderModelPlayer::setPaused):
(WebCore::PlaceholderModelPlayer::currentTime const):
(WebCore::PlaceholderModelPlayer::setCurrentTime):
(WebCore::PlaceholderModelPlayer::setHasPortal):
(WebCore::PlaceholderModelPlayer::setStageMode):
(WebCore::PlaceholderModelPlayer::layer):
(WebCore::PlaceholderModelPlayer::layerHostingContextIdentifier):
(WebCore::PlaceholderModelPlayer::sizeDidChange):
(WebCore::PlaceholderModelPlayer::enterFullscreen):
(WebCore::PlaceholderModelPlayer::handleMouseDown):
(WebCore::PlaceholderModelPlayer::handleMouseMove):
(WebCore::PlaceholderModelPlayer::handleMouseUp):
(WebCore::PlaceholderModelPlayer::getCamera):
(WebCore::PlaceholderModelPlayer::setCamera):
(WebCore::PlaceholderModelPlayer::isPlayingAnimation):
(WebCore::PlaceholderModelPlayer::setAnimationIsPlaying):
(WebCore::PlaceholderModelPlayer::isLoopingAnimation):
(WebCore::PlaceholderModelPlayer::setIsLoopingAnimation):
(WebCore::PlaceholderModelPlayer::animationDuration):
(WebCore::PlaceholderModelPlayer::animationCurrentTime):
(WebCore::PlaceholderModelPlayer::setAnimationCurrentTime):
(WebCore::PlaceholderModelPlayer::hasAudio):
(WebCore::PlaceholderModelPlayer::isMuted):
(WebCore::PlaceholderModelPlayer::setIsMuted):
(WebCore::PlaceholderModelPlayer::accessibilityChildren):
* Source/WebCore/Modules/model-element/PlaceholderModelPlayer.h: Added.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp:
(WebKit::ModelConnectionToWebProcess::didUnloadModelPlayer):
* Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h:
* Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp:
(WebKit::ModelProcessModelPlayerManagerProxy::unloadModelPlayer):
* Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::ModelProcessModelPlayerProxy):
(WebKit::ModelProcessModelPlayerProxy::reloadModel):
(WebKit::ModelProcessModelPlayerProxy::modelVisibilityDidChange):
(WebKit::ModelProcessModelPlayerProxy::unloadModelTimerFired):
(WebKit::ModelProcessModelPlayerProxy::didFinishLoading):
(WebKit::ModelProcessModelPlayerProxy::sizeDidChange):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/Model/ModelProcessConnection.cpp:
(WebKit::ModelProcessConnection::didUnloadModelPlayer):
* Source/WebKit/WebProcess/Model/ModelProcessConnection.h:
* Source/WebKit/WebProcess/Model/ModelProcessConnection.messages.in:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::didUnload):
(WebKit::ModelProcessModelPlayer::reload):
(WebKit::ModelProcessModelPlayer::visibilityStateDidChange):
(WebKit::ModelProcessModelPlayer::sizeDidChange):
(WebKit::ModelProcessModelPlayer::renderingAbruptlyStopped): Deleted.
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.cpp:
(WebKit::ModelProcessModelPlayerManager::didUnloadModelProcessModelPlayer):
(WebKit::ModelProcessModelPlayerManager::modelProcessConnectionDidClose):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.h:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.cpp:
(WebKit::ModelProcessModelPlayerTransformState::clone const):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayerTransformState.h:

Canonical link: <a href="https://commits.webkit.org/294731@main">https://commits.webkit.org/294731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3fdc72eb5caaae2797a213c1ae449b69bf53301

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12766 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107938 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53414 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104812 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22763 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30948 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78154 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35119 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105779 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17630 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92750 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58486 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17519 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10785 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52771 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87287 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110314 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29910 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22041 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87146 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30274 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88946 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86748 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22102 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31583 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9306 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24166 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29837 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35158 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29645 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32972 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31207 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->