### PR TITLE
Web Inspector: fix remaining sourcemap spec test failures

### DIFF
--- a/LayoutTests/imported/tc39-tg4/source-map-tests/source-map-spec-tests.json
+++ b/LayoutTests/imported/tc39-tg4/source-map-tests/source-map-spec-tests.json
@@ -101,7 +101,7 @@
     {
       "name": "sourcesContentNotStringOrNull",
       "description": "Test a source map with a sourcesContent list that has non-string and non-null items",
-      "baseFile": "sources-not-string-or-null.js",
+      "baseFile": "sources-content-not-string-or-null.js",
       "sourceMapFile": "sources-content-not-string-or-null.js.map",
       "sourceMapIsValid": false
     },

--- a/LayoutTests/inspector/model/source-map-spec-expected.txt
+++ b/LayoutTests/inspector/model/source-map-spec-expected.txt
@@ -100,10 +100,10 @@ PASS: Expected no source map resource loaded
 
 -- Running test case: sourcesContentNotStringOrNull
 expecting INVALID source map
-WARN: Source Map "sources-not-string-or-null.js.map" has invalid "sources"
-FAIL: Script resource should have loaded
-    Expected: truthy
-    Actual: undefined
+WARN: Source Map "sources-content-not-string-or-null.js.map" has invalid "sourcesContent"
+PASS: Script resource should have loaded
+PASS: Expected that there is an associated failed source map URL
+PASS: Expected no source map resource loaded
 
 -- Running test case: sourcesAndSourcesContentBothNull
 expecting VALID source map
@@ -177,7 +177,7 @@ expecting VALID source map
 PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
-PASS: Ignored sources should be in ignoreList
+PASS: Should have resource 'empty-original.js'.
 
 -- Running test case: ignoreListWrongType1
 expecting INVALID source map
@@ -549,304 +549,296 @@ expecting VALID source map
 PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
-PASS: Test location (0, 0) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 9) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 9, expected: 9
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 15) should be mapped
-PASS: Original line: 1, expected: 1
-PASS: Original column: 2, expected: 2
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 22) should be mapped
-PASS: Original line: 1, expected: 1
-PASS: Original column: 9, expected: 9
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 24) should be mapped
-PASS: Original line: 2, expected: 2
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 25) should be mapped
-PASS: Original line: 3, expected: 3
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 34) should be mapped
-PASS: Original line: 3, expected: 3
-PASS: Original column: 9, expected: 9
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 40) should be mapped
-PASS: Original line: 4, expected: 4
-PASS: Original column: 2, expected: 2
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 47) should be mapped
-PASS: Original line: 4, expected: 4
-PASS: Original column: 9, expected: 9
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 49) should be mapped
-PASS: Original line: 5, expected: 5
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 50) should be mapped
-PASS: Original line: 6, expected: 6
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 56) should be mapped
-PASS: Original line: 7, expected: 7
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
+PASS: Test location (0, 0) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 9) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 9.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 15) should be mapped.
+PASS: Mapped line should be 1.
+PASS: Mapped column should be 2.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 22) should be mapped.
+PASS: Mapped line should be 1.
+PASS: Mapped column should be 9.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 24) should be mapped.
+PASS: Mapped line should be 2.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 25) should be mapped.
+PASS: Mapped line should be 3.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 34) should be mapped.
+PASS: Mapped line should be 3.
+PASS: Mapped column should be 9.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 40) should be mapped.
+PASS: Mapped line should be 4.
+PASS: Mapped column should be 2.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 47) should be mapped.
+PASS: Mapped line should be 4.
+PASS: Mapped column should be 9.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 49) should be mapped.
+PASS: Mapped line should be 5.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 50) should be mapped.
+PASS: Mapped line should be 6.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 56) should be mapped.
+PASS: Mapped line should be 7.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
 
 -- Running test case: sourceRootResolution
 expecting VALID source map
 PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
-PASS: Test location (0, 0) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 0, expected: 0
-FAIL: Original source: basic-mapping-original.js, expected: theroot/basic-mapping-original.js
-    Expected: "theroot/basic-mapping-original.js"
-    Actual: "basic-mapping-original.js"
-PASS: Test location (0, 9) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 9, expected: 9
-FAIL: Original source: basic-mapping-original.js, expected: theroot/basic-mapping-original.js
-    Expected: "theroot/basic-mapping-original.js"
-    Actual: "basic-mapping-original.js"
+PASS: Test location (0, 0) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'theroot/basic-mapping-original.js'.
+PASS: Test location (0, 9) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 9.
+PASS: Mapped source should be 'theroot/basic-mapping-original.js'.
 
 -- Running test case: sourceResolutionAbsoluteURL
 expecting VALID source map
 PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
-PASS: Test location (0, 0) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 0, expected: 0
-FAIL: Original source: basic-mapping-original.js, expected: /baz/quux/basic-mapping-original.js
-    Expected: "/baz/quux/basic-mapping-original.js"
-    Actual: "basic-mapping-original.js"
-PASS: Test location (0, 9) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 9, expected: 9
-FAIL: Original source: basic-mapping-original.js, expected: /baz/quux/basic-mapping-original.js
-    Expected: "/baz/quux/basic-mapping-original.js"
-    Actual: "basic-mapping-original.js"
+PASS: Test location (0, 0) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be '/baz/quux/basic-mapping-original.js'.
+PASS: Test location (0, 9) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 9.
+PASS: Mapped source should be '/baz/quux/basic-mapping-original.js'.
 
 -- Running test case: basicMappingWithIndexMap
 expecting VALID source map
 PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
-PASS: Test location (0, 0) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 9) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 9, expected: 9
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 15) should be mapped
-PASS: Original line: 1, expected: 1
-PASS: Original column: 2, expected: 2
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 22) should be mapped
-PASS: Original line: 1, expected: 1
-PASS: Original column: 9, expected: 9
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 24) should be mapped
-PASS: Original line: 2, expected: 2
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 25) should be mapped
-PASS: Original line: 3, expected: 3
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 34) should be mapped
-PASS: Original line: 3, expected: 3
-PASS: Original column: 9, expected: 9
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 40) should be mapped
-PASS: Original line: 4, expected: 4
-PASS: Original column: 2, expected: 2
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 47) should be mapped
-PASS: Original line: 4, expected: 4
-PASS: Original column: 9, expected: 9
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 49) should be mapped
-PASS: Original line: 5, expected: 5
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 50) should be mapped
-PASS: Original line: 6, expected: 6
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 56) should be mapped
-PASS: Original line: 7, expected: 7
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
+PASS: Test location (0, 0) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 9) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 9.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 15) should be mapped.
+PASS: Mapped line should be 1.
+PASS: Mapped column should be 2.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 22) should be mapped.
+PASS: Mapped line should be 1.
+PASS: Mapped column should be 9.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 24) should be mapped.
+PASS: Mapped line should be 2.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 25) should be mapped.
+PASS: Mapped line should be 3.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 34) should be mapped.
+PASS: Mapped line should be 3.
+PASS: Mapped column should be 9.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 40) should be mapped.
+PASS: Mapped line should be 4.
+PASS: Mapped column should be 2.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 47) should be mapped.
+PASS: Mapped line should be 4.
+PASS: Mapped column should be 9.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 49) should be mapped.
+PASS: Mapped line should be 5.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 50) should be mapped.
+PASS: Mapped line should be 6.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 56) should be mapped.
+PASS: Mapped line should be 7.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
 
 -- Running test case: indexMapWithMissingFile
 expecting VALID source map
 PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
-PASS: Test location (0, 0) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 9) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 9, expected: 9
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 15) should be mapped
-PASS: Original line: 1, expected: 1
-PASS: Original column: 2, expected: 2
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 22) should be mapped
-PASS: Original line: 1, expected: 1
-PASS: Original column: 9, expected: 9
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 24) should be mapped
-PASS: Original line: 2, expected: 2
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 25) should be mapped
-PASS: Original line: 3, expected: 3
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 34) should be mapped
-PASS: Original line: 3, expected: 3
-PASS: Original column: 9, expected: 9
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 40) should be mapped
-PASS: Original line: 4, expected: 4
-PASS: Original column: 2, expected: 2
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 47) should be mapped
-PASS: Original line: 4, expected: 4
-PASS: Original column: 9, expected: 9
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 49) should be mapped
-PASS: Original line: 5, expected: 5
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 50) should be mapped
-PASS: Original line: 6, expected: 6
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 56) should be mapped
-PASS: Original line: 7, expected: 7
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
+PASS: Test location (0, 0) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 9) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 9.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 15) should be mapped.
+PASS: Mapped line should be 1.
+PASS: Mapped column should be 2.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 22) should be mapped.
+PASS: Mapped line should be 1.
+PASS: Mapped column should be 9.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 24) should be mapped.
+PASS: Mapped line should be 2.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 25) should be mapped.
+PASS: Mapped line should be 3.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 34) should be mapped.
+PASS: Mapped line should be 3.
+PASS: Mapped column should be 9.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 40) should be mapped.
+PASS: Mapped line should be 4.
+PASS: Mapped column should be 2.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 47) should be mapped.
+PASS: Mapped line should be 4.
+PASS: Mapped column should be 9.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 49) should be mapped.
+PASS: Mapped line should be 5.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 50) should be mapped.
+PASS: Mapped line should be 6.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 56) should be mapped.
+PASS: Mapped line should be 7.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
 
 -- Running test case: indexMapWithTwoConcatenatedSources
 expecting VALID source map
 PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
-PASS: Test location (0, 0) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 9) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 9, expected: 9
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 15) should be mapped
-PASS: Original line: 1, expected: 1
-PASS: Original column: 2, expected: 2
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 22) should be mapped
-PASS: Original line: 1, expected: 1
-PASS: Original column: 9, expected: 9
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 24) should be mapped
-PASS: Original line: 2, expected: 2
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 25) should be mapped
-PASS: Original line: 3, expected: 3
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 34) should be mapped
-PASS: Original line: 3, expected: 3
-PASS: Original column: 9, expected: 9
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 40) should be mapped
-PASS: Original line: 4, expected: 4
-PASS: Original column: 2, expected: 2
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 47) should be mapped
-PASS: Original line: 4, expected: 4
-PASS: Original column: 9, expected: 9
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 49) should be mapped
-PASS: Original line: 5, expected: 5
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 50) should be mapped
-PASS: Original line: 6, expected: 6
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 56) should be mapped
-PASS: Original line: 7, expected: 7
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 62) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 0, expected: 0
-PASS: Original source: second-source-original.js, expected: second-source-original.js
-PASS: Test location (0, 71) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 9, expected: 9
-PASS: Original source: second-source-original.js, expected: second-source-original.js
-PASS: Test location (0, 77) should be mapped
-PASS: Original line: 1, expected: 1
-PASS: Original column: 2, expected: 2
-PASS: Original source: second-source-original.js, expected: second-source-original.js
-PASS: Test location (0, 83) should be mapped
-PASS: Original line: 1, expected: 1
-PASS: Original column: 9, expected: 9
-PASS: Original source: second-source-original.js, expected: second-source-original.js
-PASS: Test location (0, 88) should be mapped
-PASS: Original line: 2, expected: 2
-PASS: Original column: 0, expected: 0
-PASS: Original source: second-source-original.js, expected: second-source-original.js
-PASS: Test location (0, 89) should be mapped
-PASS: Original line: 3, expected: 3
-PASS: Original column: 0, expected: 0
-PASS: Original source: second-source-original.js, expected: second-source-original.js
+PASS: Test location (0, 0) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 9) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 9.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 15) should be mapped.
+PASS: Mapped line should be 1.
+PASS: Mapped column should be 2.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 22) should be mapped.
+PASS: Mapped line should be 1.
+PASS: Mapped column should be 9.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 24) should be mapped.
+PASS: Mapped line should be 2.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 25) should be mapped.
+PASS: Mapped line should be 3.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 34) should be mapped.
+PASS: Mapped line should be 3.
+PASS: Mapped column should be 9.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 40) should be mapped.
+PASS: Mapped line should be 4.
+PASS: Mapped column should be 2.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 47) should be mapped.
+PASS: Mapped line should be 4.
+PASS: Mapped column should be 9.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 49) should be mapped.
+PASS: Mapped line should be 5.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 50) should be mapped.
+PASS: Mapped line should be 6.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 56) should be mapped.
+PASS: Mapped line should be 7.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 62) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'second-source-original.js'.
+PASS: Test location (0, 71) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 9.
+PASS: Mapped source should be 'second-source-original.js'.
+PASS: Test location (0, 77) should be mapped.
+PASS: Mapped line should be 1.
+PASS: Mapped column should be 2.
+PASS: Mapped source should be 'second-source-original.js'.
+PASS: Test location (0, 83) should be mapped.
+PASS: Mapped line should be 1.
+PASS: Mapped column should be 9.
+PASS: Mapped source should be 'second-source-original.js'.
+PASS: Test location (0, 88) should be mapped.
+PASS: Mapped line should be 2.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'second-source-original.js'.
+PASS: Test location (0, 89) should be mapped.
+PASS: Mapped line should be 3.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'second-source-original.js'.
 
 -- Running test case: sourcesNullSourcesContentNonNull
 expecting VALID source map
 PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
-PASS: Test location (0, 0) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 0, expected: 0
-PASS: Original source: null, expected: null
-PASS: Test location (0, 9) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 9, expected: 9
-PASS: Original source: null, expected: null
+PASS: Test location (0, 0) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'null'.
+PASS: Test location (0, 9) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 9.
+PASS: Mapped source should be 'null'.
 
 -- Running test case: sourcesNonNullSourcesContentNull
 expecting VALID source map
 PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
-PASS: Test location (0, 0) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 0, expected: 0
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
-PASS: Test location (0, 9) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 9, expected: 9
-PASS: Original source: basic-mapping-original.js, expected: basic-mapping-original.js
+PASS: Test location (0, 0) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'basic-mapping-original.js'.
+PASS: Test location (0, 9) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 9.
+PASS: Mapped source should be 'basic-mapping-original.js'.
 
 -- Running test case: transitiveMapping
 expecting VALID source map
@@ -881,126 +873,118 @@ expecting VALID source map
 PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
-PASS: Test location (0, 15) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 0, expected: 0
-PASS: Original source: vlq-valid-single-digit-original.js, expected: vlq-valid-single-digit-original.js
+PASS: Test location (0, 15) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'vlq-valid-single-digit-original.js'.
 
 -- Running test case: vlqValidNegativeDigit
 expecting VALID source map
 PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
-PASS: Test location (2, 15) should be mapped
-PASS: Original line: 1, expected: 1
-PASS: Original column: 3, expected: 3
-PASS: Original source: vlq-valid-negative-digit-original.js, expected: vlq-valid-negative-digit-original.js
-PASS: Test location (2, 2) should be mapped
-PASS: Original line: 1, expected: 1
-PASS: Original column: 1, expected: 1
-PASS: Original source: vlq-valid-negative-digit-original.js, expected: vlq-valid-negative-digit-original.js
+PASS: Test location (2, 15) should be mapped.
+PASS: Mapped line should be 1.
+PASS: Mapped column should be 3.
+PASS: Mapped source should be 'vlq-valid-negative-digit-original.js'.
+PASS: Test location (2, 2) should be mapped.
+PASS: Mapped line should be 1.
+PASS: Mapped column should be 1.
+PASS: Mapped source should be 'vlq-valid-negative-digit-original.js'.
 
 -- Running test case: vlqValidContinuationBitPresent1
 expecting VALID source map
 PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
-PASS: Test location (0, 15) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 1, expected: 1
-PASS: Original source: vlq-valid-continuation-bit-present-1-original.js, expected: vlq-valid-continuation-bit-present-1-original.js
+PASS: Test location (0, 15) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 1.
+PASS: Mapped source should be 'vlq-valid-continuation-bit-present-1-original.js'.
 
 -- Running test case: vlqValidContinuationBitPresent2
 expecting VALID source map
 PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
-PASS: Test location (2, 16) should be mapped
-PASS: Original line: 1, expected: 1
-PASS: Original column: 1, expected: 1
-PASS: Original source: vlq-valid-continuation-bit-present-2-original.js, expected: vlq-valid-continuation-bit-present-2-original.js
+PASS: Test location (2, 16) should be mapped.
+PASS: Mapped line should be 1.
+PASS: Mapped column should be 1.
+PASS: Mapped source should be 'vlq-valid-continuation-bit-present-2-original.js'.
 
 -- Running test case: mappingSemanticsSingleFieldSegment
 expecting VALID source map
 PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
-PASS: Test location (0, 0) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 1, expected: 1
-PASS: Original source: mapping-semantics-single-field-segment-original.js, expected: mapping-semantics-single-field-segment-original.js
-FAIL: Test location (0, 2) should be mapped
-    Expected: truthy
-    Actual: false
-FAIL: Original line: 0, expected: null
-    Expected: null
-    Actual: 0
-FAIL: Original column: 2, expected: null
-    Expected: null
-    Actual: 2
-FAIL: Original source: mapping-semantics-single-field-segment.js, expected: null
-    Expected: null
-    Actual: "mapping-semantics-single-field-segment.js"
+PASS: Test location (0, 0) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 1.
+PASS: Mapped source should be 'mapping-semantics-single-field-segment-original.js'.
+PASS: Test location (0, 2) should not be mapped.
+PASS: Generated line should be 0.
+PASS: Generated column should be 2.
+PASS: Generated path should be 'mapping-semantics-single-field-segment.js'.
 
 -- Running test case: mappingSemanticsFourFieldSegment
 expecting VALID source map
 PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
-PASS: Test location (0, 1) should be mapped
-PASS: Original line: 2, expected: 2
-PASS: Original column: 2, expected: 2
-PASS: Original source: mapping-semantics-four-field-segment-original.js, expected: mapping-semantics-four-field-segment-original.js
+PASS: Test location (0, 1) should be mapped.
+PASS: Mapped line should be 2.
+PASS: Mapped column should be 2.
+PASS: Mapped source should be 'mapping-semantics-four-field-segment-original.js'.
 
 -- Running test case: mappingSemanticsFiveFieldSegment
 expecting VALID source map
 PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
-PASS: Test location (0, 1) should be mapped
-PASS: Original line: 2, expected: 2
-PASS: Original column: 2, expected: 2
-PASS: Original source: mapping-semantics-five-field-segment-original.js, expected: mapping-semantics-five-field-segment-original.js
+PASS: Test location (0, 1) should be mapped.
+PASS: Mapped line should be 2.
+PASS: Mapped column should be 2.
+PASS: Mapped source should be 'mapping-semantics-five-field-segment-original.js'.
 
 -- Running test case: mappingSemanticsColumnReset
 expecting VALID source map
 PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
-PASS: Test location (0, 1) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 0, expected: 0
-PASS: Original source: mapping-semantics-column-reset-original.js, expected: mapping-semantics-column-reset-original.js
-PASS: Test location (1, 1) should be mapped
-PASS: Original line: 1, expected: 1
-PASS: Original column: 0, expected: 0
-PASS: Original source: mapping-semantics-column-reset-original.js, expected: mapping-semantics-column-reset-original.js
+PASS: Test location (0, 1) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'mapping-semantics-column-reset-original.js'.
+PASS: Test location (1, 1) should be mapped.
+PASS: Mapped line should be 1.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'mapping-semantics-column-reset-original.js'.
 
 -- Running test case: mappingSemanticsRelative1
 expecting VALID source map
 PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
-PASS: Test location (0, 1) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 0, expected: 0
-PASS: Original source: mapping-semantics-relative-1-original.js, expected: mapping-semantics-relative-1-original.js
-PASS: Test location (0, 5) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 4, expected: 4
-PASS: Original source: mapping-semantics-relative-1-original.js, expected: mapping-semantics-relative-1-original.js
+PASS: Test location (0, 1) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 0.
+PASS: Mapped source should be 'mapping-semantics-relative-1-original.js'.
+PASS: Test location (0, 5) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 4.
+PASS: Mapped source should be 'mapping-semantics-relative-1-original.js'.
 
 -- Running test case: mappingSemanticsRelative2
 expecting VALID source map
 PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
-PASS: Test location (0, 1) should be mapped
-PASS: Original line: 0, expected: 0
-PASS: Original column: 2, expected: 2
-PASS: Original source: mapping-semantics-relative-2-original.js, expected: mapping-semantics-relative-2-original.js
-PASS: Test location (1, 2) should be mapped
-PASS: Original line: 1, expected: 1
-PASS: Original column: 2, expected: 2
-PASS: Original source: mapping-semantics-relative-2-original.js, expected: mapping-semantics-relative-2-original.js
+PASS: Test location (0, 1) should be mapped.
+PASS: Mapped line should be 0.
+PASS: Mapped column should be 2.
+PASS: Mapped source should be 'mapping-semantics-relative-2-original.js'.
+PASS: Test location (1, 2) should be mapped.
+PASS: Mapped line should be 1.
+PASS: Mapped column should be 2.
+PASS: Mapped source should be 'mapping-semantics-relative-2-original.js'.
 

--- a/LayoutTests/inspector/model/source-map-spec.html
+++ b/LayoutTests/inspector/model/source-map-spec.html
@@ -24,22 +24,25 @@ function test()
     function checkMapping(resource, testCase, action)
     {
         const location = resource.createSourceCodeLocation(action.generatedLine, action.generatedColumn);
-        InspectorTest.expectThat(location.hasMappedLocation(), `Test location (${action.generatedLine}, ${action.generatedColumn}) should be mapped`);
-        InspectorTest.expectEqual(location.displayLineNumber, action.originalLine, `Original line: ${location.displayLineNumber}, expected: ${action.originalLine}`);
-        InspectorTest.expectEqual(location.displayColumnNumber, action.originalColumn, `Original column: ${location.displayColumnNumber}, expected: ${action.originalColumn}`);
-        InspectorTest.expectEqual(location.displaySourceCode.displayName, action.originalSource, `Original source: ${location.displaySourceCode.displayName}, expected: ${action.originalSource}`);
+        if (action.originalLine !== null && action.originalColumn !== null) {
+            InspectorTest.expectTrue(location.hasMappedLocation(), `Test location (${action.generatedLine}, ${action.generatedColumn}) should be mapped.`);
+            InspectorTest.expectEqual(location.displayLineNumber, action.originalLine, `Mapped line should be ${action.originalLine}.`);
+            InspectorTest.expectEqual(location.displayColumnNumber, action.originalColumn, `Mapped column should be ${action.originalColumn}.`);
+            InspectorTest.expectTrue((!action.originalSource && !location.displaySourceCode.urlComponents.path) || location.displaySourceCode.urlComponents.path.endsWith(action.originalSource), `Mapped source should be '${action.originalSource}'.`);
+        } else {
+            InspectorTest.expectFalse(location.hasMappedLocation(), `Test location (${action.generatedLine}, ${action.generatedColumn}) should not be mapped.`);
+            InspectorTest.expectEqual(location.displayLineNumber, action.generatedLine, `Generated line should be ${action.generatedLine}.`);
+            InspectorTest.expectEqual(location.displayColumnNumber, action.generatedColumn, `Generated column should be ${action.generatedColumn}.`);
+            InspectorTest.expectTrue(location.displaySourceCode.urlComponents.path.endsWith(testCase.baseFile), `Generated path should be '${testCase.baseFile}'.`);
+        }
     }
 
     function checkIgnoreList(resource, testCase, action)
     {
         const sourceMap = resource.sourceMaps[0];
         InspectorTest.assert(sourceMap);
-        const result = action.present.every((sourceName) => {
-            return sourceMap.resources.some((resource) => {
-                return resource.displayName.match(sourceName);
-            });
-        });
-        InspectorTest.expectThat(result, "Ignored sources should be in ignoreList");
+        for (let sourceName of action.present)
+            InspectorTest.expectThat(sourceMap.resources.some((resource) => resource.urlComponents.path.endsWith(sourceName)), `Should have resource '${sourceName}'.`);
     }
 
     function withTimeout(promise, seconds)

--- a/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
@@ -219,9 +219,11 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
             // COMPATIBILITY (iOS 18.0, macOS 15.0): `Console.ClearReason.Frontend` did not exist yet.
             // COMPATIBILITY (iOS 18.0, macOS 15.0): `Console.setConsoleClearAPIEnabled` did not exist yet.
             console.assert(InspectorBackend.hasCommand("Console.setConsoleClearAPIEnabled"));
-            console.assert(WI.settings.consoleClearAPIEnabled.value);
-            // fallthrough
+            this._clearMessages();
+            return;
+
         case WI.ConsoleManager.ClearReason.ConsoleAPI:
+            console.assert(WI.settings.consoleClearAPIEnabled.value);
             this._clearMessages();
             return;
 

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
@@ -285,7 +285,6 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
         let elementsSettingsView = new WI.SettingsView("elements", WI.UIString("Elements"));
 
         // COMPATIBILITY (macOS 13.0, iOS 16.0): CSS.LayoutFlag.Rendered did not exist yet.
-        console.log(InspectorBackend.Enum.CSS);
         if (InspectorBackend.Enum.CSS?.LayoutFlag?.Rendered) {
             elementsSettingsView.addSetting(WI.UIString("DOM Tree:"), WI.settings.domTreeDeemphasizesNodesThatAreNotRendered, WI.UIString("De-emphasize nodes that are not rendered"));
 


### PR DESCRIPTION
#### 3ca25a3db6437a2fd04194de172da05577d00e15
<pre>
Web Inspector: fix remaining sourcemap spec test failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=292583">https://bugs.webkit.org/show_bug.cgi?id=292583</a>

Reviewed by BJ Burg.

There were a few different things that needed to be fixed in the test harness:
- eagerly downstream a typo fix &lt;<a href="https://github.com/tc39/source-map-tests/pull/31">https://github.com/tc39/source-map-tests/pull/31</a>&gt;
- the spec does not govern how resources are displayed in the UI, so don&apos;t use `WI.SourceMapResource.prototype.get displayName` when comparing to the `originalSource`
- only log the expected values in the test output to avoid minor variances (e.g. whether a leading `/` is included in the `originalSource`)
- compare against the generated line/column if the mapping segment has no original line/column (i.e. there&apos;s no mapping)

* LayoutTests/imported/tc39-tg4/source-map-tests/source-map-spec-tests.json:
* LayoutTests/inspector/model/source-map-spec.html:
* LayoutTests/inspector/model/source-map-spec-expected.txt:

* Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js:
(WI.ConsoleManager.prototype.messagesCleared):
Drive-by: fix an incorrect `console.assert`.

* Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js:
(WI.SettingsTabContentView.prototype._createElementsSettingsView):

Drive-by: remove an errant `console.log`.
Canonical link: <a href="https://commits.webkit.org/294861@main">https://commits.webkit.org/294861@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95f3d177f98ddf4615d0dfe3298c4007a332b3a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107414 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52890 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30429 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77804 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34792 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17204 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92305 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58142 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17035 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10333 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52248 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86864 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10403 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109789 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29386 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21660 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86785 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29750 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88508 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86393 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22184 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31183 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8900 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23628 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29314 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34609 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29125 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32448 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30684 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->