### PR TITLE
Leverage C++20's std::midpoint() where appropriate

### DIFF
--- a/Source/JavaScriptCore/b3/B3LowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerMacros.cpp
@@ -48,6 +48,7 @@
 #include "CCallHelpers.h"
 #include "LinkBuffer.h"
 #include <cmath>
+#include <numeric>
 #include <wtf/BitVector.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -862,7 +863,7 @@ private:
             return;
         }
 
-        unsigned medianIndex = (start + end) / 2;
+        unsigned medianIndex = std::midpoint(start, end);
 
         BasicBlock* left = m_blockInsertionSet.insertAfter(m_block);
         BasicBlock* right = m_blockInsertionSet.insertAfter(m_block);

--- a/Source/JavaScriptCore/bytecode/ExpressionInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/ExpressionInfo.cpp
@@ -27,6 +27,7 @@
 #include "ExpressionInfo.h"
 
 #include "VM.h"
+#include <numeric>
 #include <wtf/DataLog.h>
 #include <wtf/StringPrintStream.h>
 #include <wtf/UniqueRef.h>
@@ -931,7 +932,7 @@ auto ExpressionInfo::findChapterEncodedInfoJustBelow(InstPC instPC) const -> Enc
     unsigned low = 0;
     unsigned high = m_numberOfChapters;
     while (low < high) {
-        unsigned mid = (low + high) / 2;
+        unsigned mid = std::midpoint(low, high);
         if (chapters[mid].startInstPC <= instPC)
             low = mid + 1;
         else

--- a/Source/JavaScriptCore/heap/HeapSnapshot.cpp
+++ b/Source/JavaScriptCore/heap/HeapSnapshot.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "HeapSnapshot.h"
 
+#include <numeric>
 #include <wtf/DataLog.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -58,7 +59,7 @@ void HeapSnapshot::sweepCell(JSCell* cell)
         unsigned start = 0;
         unsigned end = m_nodes.size();
         while (start != end) {
-            unsigned middle = start + ((end - start) / 2);
+            unsigned middle = std::midpoint(start, end);
             HeapSnapshotNode& node = m_nodes[middle];
             if (cell == node.cell) {
                 // Cells should always have 0 as low bits.
@@ -140,7 +141,7 @@ std::optional<HeapSnapshotNode> HeapSnapshot::nodeForCell(JSCell* cell)
         unsigned start = 0;
         unsigned end = m_nodes.size();
         while (start != end) {
-            unsigned middle = start + ((end - start) / 2);
+            unsigned middle = std::midpoint(start, end);
             HeapSnapshotNode& node = m_nodes[middle];
             if (cell == node.cell)
                 return std::optional<HeapSnapshotNode>(node);

--- a/Source/JavaScriptCore/jit/BinarySwitch.cpp
+++ b/Source/JavaScriptCore/jit/BinarySwitch.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(JIT)
 
+#include <numeric>
 #include <wtf/ListDump.h>
 
 namespace JSC {
@@ -330,7 +331,7 @@ void BinarySwitch::build(unsigned start, bool hardStart, unsigned end)
     // are more likely to take one of the cases than the default, so we use leafThreshold = 3
     // and get a 1/6 speed-up on average for taking an explicit case.
         
-    unsigned medianIndex = (start + end) / 2;
+    unsigned medianIndex = std::midpoint(start, end);
 
     if (BinarySwitchInternal::verbose)
         dataLog("medianIndex = ", medianIndex, "\n");

--- a/Source/JavaScriptCore/runtime/StableSort.h
+++ b/Source/JavaScriptCore/runtime/StableSort.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ArgList.h"
+#include <numeric>
 #include <wtf/Int128.h>
 #include <wtf/StdLibExtras.h>
 
@@ -59,7 +60,7 @@ static ALWAYS_INLINE void arrayInsertionSort(VM& vm, std::span<ElementType> span
         size_t left = 0;
         size_t right = i;
         for (; left < right;) {
-            size_t m = left + (right - left) / 2;
+            size_t m = std::midpoint(left, right);
             auto target = array[m];
             bool result = comparator(value, target);
             RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, void());

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -32,6 +32,7 @@
 #include "SuperSampler.h"
 #include "Yarr.h"
 #include "YarrCanonicalize.h"
+#include <numeric>
 #include <wtf/BitVector.h>
 #include <wtf/BumpPointerAllocator.h>
 #include <wtf/CheckedArithmetic.h>
@@ -499,7 +500,7 @@ public:
             size_t high = matches.size() - 1;
 
             while (low <= high) {
-                size_t mid = low + (high - low) / 2;
+                size_t mid = std::midpoint(low, high);
                 int diff = ch - matches[mid];
                 if (!diff)
                     return true;
@@ -528,7 +529,7 @@ public:
             size_t high = ranges.size() - 1;
 
             while (low <= high) {
-                size_t mid = low + (high - low) / 2;
+                size_t mid = std::midpoint(low, high);
                 int rangeBeginDiff = ch - ranges[mid].begin;
                 if (rangeBeginDiff >= 0 && ch <= ranges[mid].end)
                     return true;

--- a/Source/WTF/wtf/HashTable.h
+++ b/Source/WTF/wtf/HashTable.h
@@ -24,6 +24,7 @@
 #include <atomic>
 #include <iterator>
 #include <mutex>
+#include <numeric>
 #include <string.h>
 #include <type_traits>
 #include <utility>
@@ -1236,8 +1237,8 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
             // give us a load in the bounds [9/24, 15/24).
             double maxLoadRatio = loadFactor;
             double minLoadRatio = 1.0 / minLoad;
-            double averageLoadRatio = (maxLoadRatio + minLoadRatio) / 2;
-            double halfWayBetweenAverageAndMaxLoadRatio = (averageLoadRatio + maxLoadRatio) / 2;
+            double averageLoadRatio = std::midpoint(minLoadRatio, maxLoadRatio);
+            double halfWayBetweenAverageAndMaxLoadRatio = std::midpoint(averageLoadRatio, maxLoadRatio);
             return keyCount >= tableSize * halfWayBetweenAverageAndMaxLoadRatio;
         };
 

--- a/Source/WTF/wtf/RobinHoodHashTable.h
+++ b/Source/WTF/wtf/RobinHoodHashTable.h
@@ -51,6 +51,7 @@
 
 #pragma once
 
+#include <numeric>
 #include <wtf/AlignedStorage.h>
 #include <wtf/HashTable.h>
 #include <wtf/text/StringHash.h>
@@ -740,8 +741,8 @@ constexpr unsigned RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Trai
         // give us a load in the bounds [9/24, 15/24).
         double maxLoadRatio = loadFactor;
         double minLoadRatio = 1.0 / minLoad;
-        double averageLoadRatio = (maxLoadRatio + minLoadRatio) / 2;
-        double halfWayBetweenAverageAndMaxLoadRatio = (averageLoadRatio + maxLoadRatio) / 2;
+        double averageLoadRatio = std::midpoint(minLoadRatio, maxLoadRatio);
+        double halfWayBetweenAverageAndMaxLoadRatio = std::midpoint(averageLoadRatio, maxLoadRatio);
         return keyCount >= tableSize * halfWayBetweenAverageAndMaxLoadRatio;
     };
 

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -90,6 +90,7 @@
 #include "TypedElementDescendantIteratorInlines.h"
 #include "UserGestureIndicator.h"
 #include "VisibleUnits.h"
+#include <numeric>
 #include <wtf/Scope.h>
 #include <wtf/SetForScope.h>
 #include <wtf/StdLibExtras.h>
@@ -1024,7 +1025,7 @@ float AccessibilityNodeObject::valueForRange() const
     if (!value.isEmpty())
         return value.toFloat();
 
-    return isSpinButton() ? 0 : (minValueForRange() + maxValueForRange()) / 2;
+    return isSpinButton() ? 0 : std::midpoint(minValueForRange(), maxValueForRange());
 }
 
 float AccessibilityNodeObject::maxValueForRange() const

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -102,6 +102,7 @@
 #include "TextIterator.h"
 #include "UserGestureIndicator.h"
 #include "VisibleUnits.h"
+#include <numeric>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/MakeString.h>
@@ -821,7 +822,7 @@ std::optional<BoundaryPoint> AccessibilityObject::lastBoundaryPointContainedInRe
         return boundaryPointsContainedInRect(startBoundary, boundary, rect, isFlippedWritingMode);
     };
 
-    int midIndex = leftIndex + (rightIndex - leftIndex) / 2;
+    int midIndex = std::midpoint(leftIndex, rightIndex);
     if (boundaryPointContainedInRect(boundaryPoints.at(midIndex))) {
         // We have a match if `midIndex` boundary point is contained in the rect, but the one at `midIndex - 1` isn't.
         if (indexIsValid(midIndex - 1) && !boundaryPointContainedInRect(boundaryPoints.at(midIndex - 1)))

--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -62,6 +62,7 @@
 #include "TreeScopeInlines.h"
 #include "UserAgentStyleSheets.h"
 #include "VisibleSelection.h"
+#include <numeric>
 #include <wtf/Range.h>
 #include <wtf/Scope.h>
 #include <wtf/WeakPtr.h>
@@ -675,7 +676,7 @@ void updateWithTextRecognitionResult(HTMLElement& element, const TextRecognition
                 continue;
             }
 
-            state.scale = (state.minScale + state.maxScale) / 2;
+            state.scale = std::midpoint(state.minScale, state.maxScale);
             setInlineStylesForBlock(state.container.get(), state.scale, targetHeight);
         }
 

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -62,6 +62,7 @@
 #include "TypedElementDescendantIteratorInlines.h"
 #include "UserGestureIndicator.h"
 #include <limits>
+#include <numeric>
 #include <wtf/Ref.h>
 #include <wtf/SetForScope.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -516,7 +517,7 @@ unsigned HTMLFormElement::formElementIndexWithFormAttribute(Element* element, un
 
     // Does binary search on m_listedElements in order to find the index to be inserted.
     while (left != right) {
-        unsigned middle = left + ((right - left) / 2);
+        unsigned middle = std::midpoint(left, right);
         ASSERT(middle < m_listedElementsBeforeIndex || middle >= m_listedElementsAfterIndex);
         position = element->compareDocumentPosition(*m_listedElements[middle]);
         if (position & DOCUMENT_POSITION_FOLLOWING)

--- a/Source/WebCore/html/HTMLMeterElement.cpp
+++ b/Source/WebCore/html/HTMLMeterElement.cpp
@@ -145,8 +145,8 @@ void HTMLMeterElement::setHigh(double high)
 
 double HTMLMeterElement::optimum() const
 {
-    double optimum = parseHTMLFloatingPointNumberValue(attributeWithoutSynchronization(optimumAttr), (max() + min()) / 2);
-    return std::min(std::max(optimum, min()), max());
+    double optimum = parseHTMLFloatingPointNumberValue(attributeWithoutSynchronization(optimumAttr), std::midpoint(min(), max()));
+    return std::clamp(optimum, min(), max());
 }
 
 void HTMLMeterElement::setOptimum(double optimum)

--- a/Source/WebCore/html/RangeInputType.cpp
+++ b/Source/WebCore/html/RangeInputType.cpp
@@ -57,6 +57,7 @@
 #include "StepRange.h"
 #include "UserAgentParts.h"
 #include <limits>
+#include <numeric>
 #include <ranges>
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -417,7 +418,7 @@ std::optional<Decimal> RangeInputType::findClosestTickMarkValue(const Decimal& v
     size_t middle;
     while (true) {
         ASSERT(left <= right);
-        middle = left + (right - left) / 2;
+        middle = std::midpoint(left, right);
         if (!middle)
             break;
         if (middle == m_tickMarkValues.size() - 1 && m_tickMarkValues[middle] < value) {

--- a/Source/WebCore/html/parser/HTMLEntitySearch.cpp
+++ b/Source/WebCore/html/parser/HTMLEntitySearch.cpp
@@ -28,6 +28,7 @@
 #include "HTMLEntitySearch.h"
 
 #include "HTMLEntityTable.h"
+#include <numeric>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -35,7 +36,7 @@ namespace WebCore {
 
 static const HTMLEntityTableEntry* midpoint(const HTMLEntityTableEntry* left, const HTMLEntityTableEntry* right)
 {
-    return &left[(right - left) / 2];
+    return std::midpoint(left, right);
 }
 
 HTMLEntitySearch::HTMLEntitySearch()

--- a/Source/WebCore/html/track/TextTrack.cpp
+++ b/Source/WebCore/html/track/TextTrack.cpp
@@ -43,6 +43,7 @@
 #include "TextTrackList.h"
 #include "VTTRegion.h"
 #include "VTTRegionList.h"
+#include <numeric>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -564,7 +565,7 @@ RefPtr<TextTrackCue> TextTrack::matchCue(TextTrackCue& cue, TextTrackCue::CueMat
             }
         }
         
-        size_t index = (searchStart + searchEnd) / 2;
+        size_t index = std::midpoint(searchStart, searchEnd);
         existingCue = m_cues->item(index);
         if ((cue.startMediaTime() + startTimeVariance()) < existingCue->startMediaTime() || (match != TextTrackCue::IgnoreDuration && cue.hasEquivalentStartTime(*existingCue) && cue.endMediaTime() > existingCue->endMediaTime()))
             searchEnd = index;

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -41,6 +41,7 @@
 #include "TextSpacing.h"
 #include "UnicodeHelpers.h"
 #include "WidthIterator.h"
+#include <numeric>
 #include <wtf/text/CharacterProperties.h>
 #include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/TextBreakIterator.h>
@@ -334,7 +335,7 @@ TextUtil::WordBreakLeft TextUtil::breakWord(const InlineTextBox& inlineTextBox, 
             // Preserve the left width for the final split position so that we don't need to remeasure the left side again.
             auto leftSideWidth = InlineLayoutUnit { 0 };
             while (left < right) {
-                auto middle = userPerceivedCharacterBoundaryAlignedIndex((left + right) / 2);
+                auto middle = userPerceivedCharacterBoundaryAlignedIndex(std::midpoint(left, right));
                 ASSERT(middle >= left && middle < right);
                 auto endOfMiddleCharacter = nextUserPerceivedCharacterIndex(middle);
                 auto width = TextUtil::width(inlineTextBox, fontCascade, startPosition, endOfMiddleCharacter, contentLogicalLeft);

--- a/Source/WebCore/platform/graphics/ColorConversion.cpp
+++ b/Source/WebCore/platform/graphics/ColorConversion.cpp
@@ -30,6 +30,7 @@
 #include "ColorNormalization.h"
 #include "ColorSpace.h"
 #include "DestinationColorSpace.h"
+#include <numeric>
 #include <wtf/MathExtras.h>
 
 namespace WebCore {
@@ -83,7 +84,7 @@ HSLA<float> ColorConversion<HSLA<float>, ExtendedSRGBA<float>>::convert(const Ex
     auto d = max - min;
 
     float hue = std::numeric_limits<float>::quiet_NaN();
-    float lightness = (min + max) / 2.0f;
+    float lightness = std::midpoint(min, max);
     float saturation;
 
     if (d != 0.0f) {

--- a/Source/WebCore/platform/graphics/ColorConversion.h
+++ b/Source/WebCore/platform/graphics/ColorConversion.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ColorTypes.h"
+#include <numeric>
 #include <wtf/MathExtras.h>
 
 namespace WebCore {
@@ -318,7 +319,7 @@ struct CSSGamutMapping {
         float max = colorInOKLCHColorSpace.chroma;
 
         while (true) {
-            auto chroma = (min + max) / 2.0f;
+            auto chroma = std::midpoint(min, max);
 
             auto current = colorInOKLCHColorSpace;
             current.chroma = chroma;

--- a/Source/WebCore/platform/graphics/GeometryUtilities.cpp
+++ b/Source/WebCore/platform/graphics/GeometryUtilities.cpp
@@ -29,6 +29,7 @@
 
 #include "FloatQuad.h"
 #include <numbers>
+#include <numeric>
 #include <wtf/MathExtras.h>
 #include <wtf/Vector.h>
 
@@ -198,7 +199,7 @@ bool ellipseContainsPoint(const FloatPoint& center, const FloatSize& radii, cons
 
 FloatPoint midPoint(const FloatPoint& first, const FloatPoint& second)
 {
-    return { (first.x() + second.x()) / 2, (first.y() + second.y()) / 2 };
+    return { std::midpoint(first.x(), second.x()), std::midpoint(first.y(), second.y()) };
 }
 
 static float dotProduct(const FloatSize& u, const FloatSize& v)

--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
@@ -27,6 +27,7 @@
 #include "PlatformTimeRanges.h"
 
 #include <math.h>
+#include <numeric>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/PrintStream.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -376,7 +377,7 @@ size_t PlatformTimeRanges::findLastRangeIndexBefore(const MediaTime& start, cons
 
     first = 0;
     last = m_ranges.size() - 1;
-    middle = first + ((last - first) / 2);
+    middle = std::midpoint(first, last);
 
     while (first < last && middle > 0) {
         if (m_ranges[middle].isBeforeRange(range)) {
@@ -385,7 +386,7 @@ size_t PlatformTimeRanges::findLastRangeIndexBefore(const MediaTime& start, cons
         } else
             last = middle - 1;
 
-        middle = first + ((last - first) / 2);
+        middle = std::midpoint(first, last);
     }
     return index;
 }

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm
@@ -32,6 +32,7 @@
 #import "IOSurface.h"
 #import "IntRect.h"
 #import <CoreText/CoreText.h>
+#import <numeric>
 #import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <pal/spi/cocoa/FeatureFlagsSPI.h>
 #import <pal/spi/mac/NSGraphicsSPI.h>
@@ -195,7 +196,7 @@ static inline void drawRoundedRectForDocumentMarker(CGContextRef context, const 
     auto maxX = rect.maxX();
     auto minY = rect.y();
     auto maxY = rect.maxY();
-    auto midY = (minY + maxY) / 2.0;
+    auto midY = std::midpoint(minY, maxY);
 
     CGContextMoveToPoint(context, minX + radius, maxY);
     CGContextAddArc(context, minX + radius, midY, radius, piOverTwoDouble, 3 * piOverTwoDouble, 0);

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -39,6 +39,7 @@
 #include "RenderBox.h"
 #include "RenderStyleInlines.h"
 #include "RenderTheme.h"
+#include <numeric>
 
 namespace WebCore {
 
@@ -1209,8 +1210,8 @@ void BorderPainter::drawLineForBoxSide(GraphicsContext& graphicsContext, const D
         if (((side == BoxSide::Top || side == BoxSide::Left) && adjacentWidth2 > 0) || ((side == BoxSide::Bottom || side == BoxSide::Right) && adjacentWidth2 < 0))
             offset4 = ceilToDevicePixel(adjacentWidth2 / 2, deviceScaleFactor);
 
-        float adjustedX = ceilToDevicePixel((x1 + x2) / 2, deviceScaleFactor);
-        float adjustedY = ceilToDevicePixel((y1 + y2) / 2, deviceScaleFactor);
+        float adjustedX = ceilToDevicePixel(std::midpoint(x1, x2), deviceScaleFactor);
+        float adjustedY = ceilToDevicePixel(std::midpoint(y1, y2), deviceScaleFactor);
         // Quads can't use the default snapping rect functions.
         x1 = roundToDevicePixel(x1, deviceScaleFactor);
         x2 = roundToDevicePixel(x2, deviceScaleFactor);

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -34,6 +34,7 @@
 #import <WebCore/DNS.h>
 #import <WebCore/LinkDecorationFilteringData.h>
 #import <WebCore/OrganizationStorageAccessPromptQuirk.h>
+#import <numeric>
 #import <pal/spi/cf/CFNetworkSPI.h>
 #import <pal/spi/cocoa/NetworkSPI.h>
 #import <time.h>
@@ -568,7 +569,7 @@ public:
             lower = upper;
         else {
             while (upper - lower > 1) {
-                auto middle = (lower + upper) / 2;
+                auto middle = std::midpoint(lower, upper);
                 auto compareResult = address <=> list[middle].m_network;
                 if (is_eq(compareResult))
                     return &list[middle];

--- a/Source/WebKitLegacy/mac/History/WebHistory.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistory.mm
@@ -34,6 +34,7 @@
 #import "WebNSURLExtras.h"
 #import "WebVisitedLinkStore.h"
 #import <WebCore/HistoryItem.h>
+#import <numeric>
 #import <pal/spi/cocoa/NSCalendarDateSPI.h>
 #import <ranges>
 
@@ -207,7 +208,7 @@ static inline WebHistoryDateKey dateKey(NSTimeInterval date)
     unsigned low = 0;
     unsigned high = count;
     while (low < high) {
-        unsigned mid = low + (high - low) / 2;
+        unsigned mid = std::midpoint(low, high);
         if ([[entriesForDate objectAtIndex:mid] lastVisitedTimeInterval] >= entryDate)
             low = mid + 1;
         else


### PR DESCRIPTION
#### a75e58cbe8e17b31a2a900fa435f9485248051aa
<pre>
Leverage C++20&apos;s std::midpoint() where appropriate
<a href="https://bugs.webkit.org/show_bug.cgi?id=292585">https://bugs.webkit.org/show_bug.cgi?id=292585</a>

Reviewed by Keith Miller.

Leverage C++20&apos;s std::midpoint() [1] where appropriate. It computes
the midpoint of 2 integers, floating points or pointers, while avoiding
overflows.

[1] <a href="https://en.cppreference.com/w/cpp/numeric/midpoint">https://en.cppreference.com/w/cpp/numeric/midpoint</a>

* Source/JavaScriptCore/b3/B3LowerMacros.cpp:
* Source/JavaScriptCore/bytecode/ExpressionInfo.cpp:
(JSC::ExpressionInfo::findChapterEncodedInfoJustBelow const):
* Source/JavaScriptCore/heap/HeapSnapshot.cpp:
(JSC::HeapSnapshot::sweepCell):
(JSC::HeapSnapshot::nodeForCell):
* Source/JavaScriptCore/jit/BinarySwitch.cpp:
(JSC::BinarySwitch::build):
* Source/JavaScriptCore/runtime/StableSort.h:
(JSC::arrayInsertionSort):
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::testCharacterClass):
* Source/WTF/wtf/HashTable.h:
(WTF::Malloc&gt;::computeBestTableSize):
* Source/WTF/wtf/RobinHoodHashTable.h:
(WTF::Malloc&gt;::computeBestTableSize):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::valueForRange const):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::lastBoundaryPointContainedInRect const):
* Source/WebCore/dom/ImageOverlay.cpp:
(WebCore::ImageOverlay::updateWithTextRecognitionResult):
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::formElementIndexWithFormAttribute):
* Source/WebCore/html/HTMLMeterElement.cpp:
(WebCore::HTMLMeterElement::optimum const):
* Source/WebCore/html/RangeInputType.cpp:
(WebCore::RangeInputType::findClosestTickMarkValue):
* Source/WebCore/html/parser/HTMLEntitySearch.cpp:
(WebCore::midpoint):
* Source/WebCore/html/track/TextTrack.cpp:
(WebCore::TextTrack::matchCue):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::breakWord):
* Source/WebCore/platform/graphics/ColorConversion.cpp:
(WebCore::ExtendedSRGBA&lt;float&gt;&gt;::convert):
* Source/WebCore/platform/graphics/ColorConversion.h:
(WebCore::CSSGamutMapping::mapToBoundedGamut):
* Source/WebCore/platform/graphics/GeometryUtilities.cpp:
(WebCore::midPoint):
* Source/WebCore/platform/graphics/PlatformTimeRanges.cpp:
(WebCore::PlatformTimeRanges::findLastRangeIndexBefore const):
* Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm:
(WebCore::drawRoundedRectForDocumentMarker):
* Source/WebCore/rendering/BorderPainter.cpp:
(WebCore::BorderPainter::drawLineForBoxSide):
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::TrackerAddressLookupInfo::find):
* Source/WebKitLegacy/mac/History/WebHistory.mm:
(-[WebHistoryPrivate insertItem:forDateKey:]):

Canonical link: <a href="https://commits.webkit.org/294561@main">https://commits.webkit.org/294561@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/351a2178ea57415045e3d9833c86ded6471dea56

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102261 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21929 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107421 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52897 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30436 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77822 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34798 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92315 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58160 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17045 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10343 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52255 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94932 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86874 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10413 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109796 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100870 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29393 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21668 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86793 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29757 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86381 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21979 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31191 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8910 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23635 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29321 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34616 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124496 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29132 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34565 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32455 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30691 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->