### PR TITLE
[JSC] Always use sub64 / add64 with FPR in 64bit JIT

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -7669,8 +7669,25 @@ public:
 
     void sub64(FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
-        ASSERT(supportsAVX());
-        m_assembler.vpsubq_rrr(right, left, dest);
+        if (supportsAVX()) {
+            m_assembler.vpsubq_rrr(right, left, dest);
+            return;
+        }
+
+        // SSE implementation uses macro assembler register.
+        if (dest == left) {
+            m_assembler.psubq_rr(right, dest);
+            return;
+        }
+
+        FPRegisterID safeRight = right;
+        if (dest == right) {
+            moveDouble(right, fpTempRegister);
+            safeRight = fpTempRegister;
+        }
+
+        moveDouble(left, dest);
+        m_assembler.psubq_rr(safeRight, dest);
     }
 
     void vectorAdd(SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)

--- a/Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp
@@ -73,9 +73,6 @@ private:
                     if constexpr (useKind != DoubleRepUse)
                         break;
 
-                    if (!isARM64() && !isX86_64_AVX())
-                        break;
-
                     switch (node->child1()->op()) {
                     case GetClosureVar:
                     case GetGlobalVar:
@@ -169,9 +166,6 @@ private:
                 case MultiGetByOffset:
                 case GetByOffset: {
                     if constexpr (useKind != DoubleRepUse)
-                        break;
-
-                    if (!isARM64() && !isX86_64_AVX())
                         break;
 
                     if (candidates.contains(node))
@@ -297,12 +291,6 @@ private:
                         case GetGlobalLexicalVariable:
                         case MultiGetByOffset:
                         case GetByOffset: {
-                            if (!isARM64() && !isX86_64_AVX()) {
-                                ok = false;
-                                dumpEscape("Unsupported incoming value to Phi: ", node);
-                                break;
-                            }
-
                             if constexpr (useKind != DoubleRepUse) {
                                 ok = false;
                                 dumpEscape("Phi Incoming Get is escaped: ", node);
@@ -416,12 +404,6 @@ private:
                             dumpEscape("Normal escape: ", user);
                             break;
                         }
-
-                        if (!isARM64() && !isX86_64_AVX()) {
-                            dumpEscape("Normal escape: ", user);
-                            ok = false;
-                            break;
-                        }
                         break;
 
                     case Upsilon: {
@@ -502,8 +484,6 @@ private:
                     case GetGlobalLexicalVariable:
                     case MultiGetByOffset:
                     case GetByOffset: {
-                        if (!isARM64() && !isX86_64_AVX())
-                            RELEASE_ASSERT_NOT_REACHED();
                         newChild = incomingValue;
                         break;
                     }
@@ -538,8 +518,6 @@ private:
             case GetGlobalLexicalVariable:
             case MultiGetByOffset:
             case GetByOffset: {
-                if (!isARM64() && !isX86_64_AVX())
-                    RELEASE_ASSERT_NOT_REACHED();
                 candidate->setResult(NodeResultDouble);
                 resultNode = candidate;
                 break;
@@ -581,26 +559,18 @@ private:
                     break;
 
                 case PutByOffset:
-                    if (!isARM64() && !isX86_64_AVX())
-                        RELEASE_ASSERT_NOT_REACHED();
                     user->child3() = Edge(resultNode, useKind);
                     break;
 
                 case MultiPutByOffset:
-                    if (!isARM64() && !isX86_64_AVX())
-                        RELEASE_ASSERT_NOT_REACHED();
                     user->child2() = Edge(resultNode, useKind);
                     break;
 
                 case PutClosureVar:
-                    if (!isARM64() && !isX86_64_AVX())
-                        RELEASE_ASSERT_NOT_REACHED();
                     user->child2() = Edge(resultNode, useKind);
                     break;
 
                 case PutGlobalVariable:
-                    if (!isARM64() && !isX86_64_AVX())
-                        RELEASE_ASSERT_NOT_REACHED();
                     user->child2() = Edge(resultNode, useKind);
                     break;
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -2171,8 +2171,11 @@ private:
         PatchpointValue* result = m_out.patchpoint(Double);
         result->append(value, ValueRep::SomeRegister);
         result->append(m_out.doubleEncodeOffsetAsDouble, ValueRep::SomeRegister);
+        if (isX86_64() && !isX86_64_AVX())
+            result->clobber(RegisterSetBuilder::macroClobberedFPRs());
         result->setGenerator(
             [](CCallHelpers& jit, const StackmapGenerationParams& params) {
+                AllowMacroScratchRegisterUsageIf allowScratchIf(jit, isX86_64() && !isX86_64_AVX());
                 jit.sub64(params[1].fpr(), params[2].fpr(), params[0].fpr());
             });
         result->effects = Effects::none();


### PR DESCRIPTION
#### 3ceb0bbb219d9b6952d2ddc24c0a5c7b35c6c531
<pre>
[JSC] Always use sub64 / add64 with FPR in 64bit JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=292587">https://bugs.webkit.org/show_bug.cgi?id=292587</a>
<a href="https://rdar.apple.com/150737978">rdar://150737978</a>

Reviewed by Yijia Huang.

This patch adds sub64 implementation for x86_64 SSE so that we do not
need to have some guard in DFGValueRepReductionPhase.

* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::sub64):
* Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp:
(JSC::DFG::ValueRepReductionPhase::convertValueRepsToUnboxed):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::unboxDoubleAsDouble):

Canonical link: <a href="https://commits.webkit.org/294583@main">https://commits.webkit.org/294583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c277ec8f192a89d211184d40449c5e46ebd41ed8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102346 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12329 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107507 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52982 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22323 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30521 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77876 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34868 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17289 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92389 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58214 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17124 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10417 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52340 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/95017 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86949 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10488 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109882 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100955 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29478 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21737 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86860 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29842 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88585 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86450 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31265 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8980 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23720 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16624 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29406 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34702 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124589 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29217 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34584 "Failed to compile JSC") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32540 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30776 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->