### PR TITLE
Remove CSSScopeAtRuleEnabled preference

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1456,20 +1456,6 @@ CSSRubyOverhangEnabled:
     WebCore:
       default: true
 
-CSSScopeAtRuleEnabled:
-  type: bool
-  status: stable
-  category: css
-  humanReadableName: "CSS Scoping (@scope)"
-  humanReadableDescription: "Enable the CSS Scoping feature with @scope rule"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 CSSScrollAnchoringEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/css/CSSScopeRule.idl
+++ b/Source/WebCore/css/CSSScopeRule.idl
@@ -28,7 +28,6 @@
 typedef USVString CSSOMString;
 
 [
-    EnabledBySetting=CSSScopeAtRuleEnabled,
     Exposed=Window
 ] interface CSSScopeRule : CSSGroupingRule {
     readonly attribute CSSOMString? start;

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -1077,9 +1077,6 @@ RefPtr<StyleRulePositionTry> CSSParser::consumePositionTryRule(CSSParserTokenRan
 
 RefPtr<StyleRuleScope> CSSParser::consumeScopeRule(CSSParserTokenRange prelude, CSSParserTokenRange block)
 {
-    if (!m_context.cssScopeAtRuleEnabled)
-        return nullptr;
-
     auto preludeRangeCopy = prelude;
     CSSSelectorList scopeStart;
     CSSSelectorList scopeEnd;

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -90,7 +90,6 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , masonryEnabled { document.settings().masonryEnabled() }
     , cssAppearanceBaseEnabled { document.settings().cssAppearanceBaseEnabled() }
     , cssPaintingAPIEnabled { document.settings().cssPaintingAPIEnabled() }
-    , cssScopeAtRuleEnabled { document.settings().cssScopeAtRuleEnabled() }
     , cssShapeFunctionEnabled { document.settings().cssShapeFunctionEnabled() }
     , cssStyleQueriesEnabled { document.settings().cssStyleQueriesEnabled() }
     , cssTextUnderlinePositionLeftRightEnabled { document.settings().cssTextUnderlinePositionLeftRightEnabled() }
@@ -132,29 +131,28 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.masonryEnabled                            << 6
         | context.cssAppearanceBaseEnabled                  << 7
         | context.cssPaintingAPIEnabled                     << 8
-        | context.cssScopeAtRuleEnabled                     << 9
-        | context.cssShapeFunctionEnabled                   << 10
-        | context.cssTextUnderlinePositionLeftRightEnabled  << 11
-        | context.cssBackgroundClipBorderAreaEnabled        << 12
-        | context.cssWordBreakAutoPhraseEnabled             << 13
-        | context.popoverAttributeEnabled                   << 14
-        | context.sidewaysWritingModesEnabled               << 15
-        | context.cssTextWrapPrettyEnabled                  << 16
-        | context.thumbAndTrackPseudoElementsEnabled        << 17
+        | context.cssShapeFunctionEnabled                   << 9
+        | context.cssTextUnderlinePositionLeftRightEnabled  << 10
+        | context.cssBackgroundClipBorderAreaEnabled        << 11
+        | context.cssWordBreakAutoPhraseEnabled             << 12
+        | context.popoverAttributeEnabled                   << 13
+        | context.sidewaysWritingModesEnabled               << 14
+        | context.cssTextWrapPrettyEnabled                  << 15
+        | context.thumbAndTrackPseudoElementsEnabled        << 16
 #if ENABLE(SERVICE_CONTROLS)
-        | context.imageControlsEnabled                      << 18
+        | context.imageControlsEnabled                      << 17
 #endif
-        | context.colorLayersEnabled                        << 19
-        | context.contrastColorEnabled                      << 20
-        | context.targetTextPseudoElementEnabled            << 21
-        | context.viewTransitionTypesEnabled                << 22
-        | context.cssProgressFunctionEnabled                << 23
-        | context.cssMediaProgressFunctionEnabled           << 24
-        | context.cssContainerProgressFunctionEnabled       << 25
-        | context.cssRandomFunctionEnabled                  << 26
-        | context.cssTreeCountingFunctionsEnabled           << 27
-        | context.cssURLModifiersEnabled                    << 28
-        | context.cssAxisRelativePositionKeywordsEnabled    << 29;
+        | context.colorLayersEnabled                        << 18
+        | context.contrastColorEnabled                      << 19
+        | context.targetTextPseudoElementEnabled            << 20
+        | context.viewTransitionTypesEnabled                << 21
+        | context.cssProgressFunctionEnabled                << 22
+        | context.cssMediaProgressFunctionEnabled           << 23
+        | context.cssContainerProgressFunctionEnabled       << 24
+        | context.cssRandomFunctionEnabled                  << 25
+        | context.cssTreeCountingFunctionsEnabled           << 26
+        | context.cssURLModifiersEnabled                    << 27
+        | context.cssAxisRelativePositionKeywordsEnabled    << 28;
     add(hasher, context.baseURL, context.charset, context.propertySettings, context.mode, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -63,7 +63,6 @@ struct CSSParserContext {
     bool masonryEnabled : 1 { false };
     bool cssAppearanceBaseEnabled : 1 { false };
     bool cssPaintingAPIEnabled : 1 { false };
-    bool cssScopeAtRuleEnabled : 1 { false };
     bool cssShapeFunctionEnabled : 1 { false };
     bool cssStyleQueriesEnabled : 1 { false };
     bool cssTextUnderlinePositionLeftRightEnabled : 1 { false };


### PR DESCRIPTION
#### 6ada4d70726aa068d9db49b501cc006ed3d048c7
<pre>
Remove CSSScopeAtRuleEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=292589">https://bugs.webkit.org/show_bug.cgi?id=292589</a>

Reviewed by Antti Koivisto.

It&apos;s been enabled on main for a year and a half.

Canonical link: <a href="https://commits.webkit.org/294612@main">https://commits.webkit.org/294612@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/039c872c8c916dbefbe38bf1a14af7b5ab956370

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102271 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12254 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107431 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52907 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104310 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22248 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30446 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77819 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34805 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17218 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92319 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58157 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17051 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10347 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52265 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94942 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86878 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10417 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109806 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100880 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29403 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21675 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86803 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29767 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88522 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86391 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31197 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8914 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23645 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16640 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29331 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34626 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124514 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29142 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34567 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/cc-int-to-int-no-jit.js.default-wasm (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32465 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30701 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->