### PR TITLE
Use [[noreturn]] in C++

### DIFF
--- a/Source/WTF/benchmarks/ConditionSpeedTest.cpp
+++ b/Source/WTF/benchmarks/ConditionSpeedTest.cpp
@@ -54,7 +54,7 @@ unsigned numConsumers;
 unsigned maxQueueSize;
 unsigned numMessagesPerProducer;
     
-NO_RETURN void usage()
+[[noreturn]] void usage()
 {
     printf("Usage: ConditionSpeedTest lock|mutex|all <num producers> <num consumers> <max queue size> <num messages per producer>\n");
     exit(1);

--- a/Source/WTF/benchmarks/LockFairnessTest.cpp
+++ b/Source/WTF/benchmarks/LockFairnessTest.cpp
@@ -46,7 +46,7 @@
 
 namespace {
 
-NO_RETURN void usage()
+[[noreturn]] void usage()
 {
     printf("Usage: LockFairnessTest yieldspinlock|pausespinlock|wordlock|lock|barginglock|bargingwordlock|thunderlock|thunderwordlock|cascadelock|cascadewordlockhandofflock|unfairlock|mutex|all <num threads> <seconds per test> <microseconds in critical section>\n");
     exit(1);

--- a/Source/WTF/benchmarks/LockSpeedTest.cpp
+++ b/Source/WTF/benchmarks/LockSpeedTest.cpp
@@ -50,7 +50,7 @@ unsigned workPerCriticalSection;
 unsigned workBetweenCriticalSections;
 double secondsPerTest;
     
-NO_RETURN void usage()
+[[noreturn]] void usage()
 {
     printf("Usage: LockSpeedTest yieldspinlock|pausespinlock|wordlock|lock|barginglock|bargingwordlock|thunderlock|thunderwordlock|cascadelock|cascadewordlock|handofflock|unfairlock|mutex|all <num thread groups> <num threads per group> <work per critical section> <work between critical sections> <spin limit> <seconds per test>\n");
     exit(1);

--- a/Source/WTF/wtf/StackShotProfiler.h
+++ b/Source/WTF/wtf/StackShotProfiler.h
@@ -58,7 +58,7 @@ public:
     }
     
 private:
-    NO_RETURN void run()
+    [[noreturn]] void run()
     {
         for (;;) {
             sleep(1_s);

--- a/Source/WTF/wtf/WTFProcess.h
+++ b/Source/WTF/wtf/WTFProcess.h
@@ -28,9 +28,9 @@
 namespace WTF {
 
 // Expect exit call on UNIX platforms.
-WTF_EXPORT_PRIVATE NO_RETURN void exitProcess(int status);
+[[noreturn]] WTF_EXPORT_PRIVATE void exitProcess(int status);
 // Expect _exit call on UNIX platforms.
-WTF_EXPORT_PRIVATE NO_RETURN void terminateProcess(int status);
+[[noreturn]] WTF_EXPORT_PRIVATE void terminateProcess(int status);
 
 } // namespace WTF
 

--- a/Source/WTF/wtf/WorkQueue.cpp
+++ b/Source/WTF/wtf/WorkQueue.cpp
@@ -108,7 +108,7 @@ void ConcurrentWorkQueue::apply(size_t iterations, WTF::Function<void(size_t ind
         }
 
     private:
-        NO_RETURN void threadBody()
+        [[noreturn]] void threadBody()
         {
             while (true) {
                 const WTF::Function<void ()>* function;

--- a/Source/WebCore/page/ResourceUsageThread.cpp
+++ b/Source/WebCore/page/ResourceUsageThread.cpp
@@ -122,7 +122,7 @@ void ResourceUsageThread::createThreadIfNeeded()
     });
 }
 
-NO_RETURN void ResourceUsageThread::threadBody()
+[[noreturn]] void ResourceUsageThread::threadBody()
 {
     // Wait a bit after waking up for the first time.
     sleep(10_ms);

--- a/Source/WebCore/page/ResourceUsageThread.h
+++ b/Source/WebCore/page/ResourceUsageThread.h
@@ -72,7 +72,7 @@ private:
     void recomputeCollectionMode() WTF_REQUIRES_LOCK(m_observersLock);
 
     void createThreadIfNeeded();
-    NO_RETURN void threadBody();
+    [[noreturn]] void threadBody();
 
     void platformSaveStateBeforeStarting();
     void platformCollectCPUData(JSC::VM*, ResourceUsageData&);

--- a/Source/WebGPU/WGSL/wgslc.cpp
+++ b/Source/WebGPU/WGSL/wgslc.cpp
@@ -32,7 +32,7 @@
 #include <wtf/FileSystem.h>
 #include <wtf/WTFProcess.h>
 
-static NO_RETURN void printUsageStatement(bool help = false)
+[[noreturn]] static void printUsageStatement(bool help = false)
 {
     fprintf(stderr, "Usage: wgsl [options] <file> [entrypoint]\n");
     fprintf(stderr, "  -h|--help  Prints this help message\n");

--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
@@ -813,7 +813,7 @@ static const HashSet<CFTypeRef> alwaysAllowedClasses()
 }
 
 template<typename CharacterType>
-NO_RETURN static void crashWithClassName(std::span<const CharacterType> className) requires(sizeof(CharacterType) == 1)
+[[noreturn]] static void crashWithClassName(std::span<const CharacterType> className) requires(sizeof(CharacterType) == 1)
 {
     std::array<uint64_t, 6> values { 0, 0, 0, 0, 0, 0 };
     auto valuesAsBytes  = asMutableByteSpan(std::span { values });
@@ -821,7 +821,7 @@ NO_RETURN static void crashWithClassName(std::span<const CharacterType> classNam
     CRASH_WITH_INFO(values[0], values[1], values[2], values[3], values[4], values[5]);
 }
 
-NO_RETURN static void crashWithClassName(Class objectClass)
+[[noreturn]] static void crashWithClassName(Class objectClass)
 {
     crashWithClassName(span(NSStringFromClass(objectClass)));
 }

--- a/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm
@@ -93,7 +93,7 @@ bool conformsToWebKitSecureCoding(id object)
 }
 
 #if !HAVE(WK_SECURE_CODING_NSURLREQUEST)
-NO_RETURN static void crashWithClassName(Class objectClass)
+[[noreturn]] static void crashWithClassName(Class objectClass)
 {
     WebKit::logAndSetCrashLogMessage("NSSecureCoding path used for unexpected object"_s);
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -280,7 +280,7 @@ using namespace WebCore;
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebProcess);
 
 #if !PLATFORM(GTK) && !PLATFORM(WPE)
-NO_RETURN static void callExit(IPC::Connection*)
+[[noreturn]] static void callExit(IPC::Connection*)
 {
     terminateProcess(EXIT_SUCCESS);
 }
@@ -1231,7 +1231,7 @@ void WebProcess::setInjectedBundleParameters(std::span<const uint8_t> value)
     injectedBundle->setBundleParameters(value);
 }
 
-NO_RETURN inline void failedToGetNetworkProcessConnection()
+[[noreturn]] inline void failedToGetNetworkProcessConnection()
 {
 #if PLATFORM(GTK) || PLATFORM(WPE)
     // GTK and WPE ports don't exit on send sync message failure.

--- a/Source/WebKitLegacy/mac/DOM/ExceptionHandlers.h
+++ b/Source/WebKitLegacy/mac/DOM/ExceptionHandlers.h
@@ -27,10 +27,10 @@
 
 #include <WebCore/ExceptionOr.h>
 
-NO_RETURN void raiseTypeErrorException();
-NO_RETURN void raiseNotSupportedErrorException();
+[[noreturn]] void raiseTypeErrorException();
+[[noreturn]] void raiseNotSupportedErrorException();
 
-NO_RETURN void raiseDOMErrorException(WebCore::Exception&&);
+[[noreturn]] void raiseDOMErrorException(WebCore::Exception&&);
 template<typename T> T raiseOnDOMError(WebCore::ExceptionOr<T>&&);
 void raiseOnDOMError(WebCore::ExceptionOr<void>&&);
 

--- a/Source/WebKitLegacy/mac/DOM/ExceptionHandlers.mm
+++ b/Source/WebKitLegacy/mac/DOM/ExceptionHandlers.mm
@@ -36,7 +36,7 @@ NSString * const DOMRangeException = @"DOMRangeException";
 NSString * const DOMEventException = @"DOMEventException";
 NSString * const DOMXPathException = @"DOMXPathException";
 
-static NO_RETURN void raiseDOMErrorException(WebCore::ExceptionCode ec)
+[[noreturn]] static void raiseDOMErrorException(WebCore::ExceptionCode ec)
 {
     ASSERT(static_cast<bool>(ec));
 

--- a/Tools/TestRunnerShared/TestCommand.cpp
+++ b/Tools/TestRunnerShared/TestCommand.cpp
@@ -76,7 +76,7 @@ bool CommandTokenizer::hasNext() const
     return !m_next.empty();
 }
 
-NO_RETURN static void die(const std::string& inputLine)
+[[noreturn]] static void die(const std::string& inputLine)
 {
     fprintf(stderr, "Unexpected input line: %s\n", inputLine.c_str());
     exit(1);


### PR DESCRIPTION
#### 76d8319c5509840b7eed9f0a119e66be63f79715
<pre>
Use [[noreturn]] in C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=292590">https://bugs.webkit.org/show_bug.cgi?id=292590</a>

Reviewed by Yusuke Suzuki.

Use [[noreturn]] in C++

* Source/WTF/benchmarks/ConditionSpeedTest.cpp:
* Source/WTF/benchmarks/LockFairnessTest.cpp:
* Source/WTF/benchmarks/LockSpeedTest.cpp:
* Source/WTF/wtf/StackShotProfiler.h:
(WTF::StackShotProfiler::run):
* Source/WTF/wtf/WTFProcess.h:
* Source/WTF/wtf/WorkQueue.cpp:
(WTF::ConcurrentWorkQueue::apply):
* Source/WebCore/page/ResourceUsageThread.cpp:
(WebCore::ResourceUsageThread::threadBody):
* Source/WebCore/page/ResourceUsageThread.h:
* Source/WebGPU/WGSL/wgslc.cpp:
(printUsageStatement):
* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm:
(requires):
(crashWithClassName):
* Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm:
(WebKit::crashWithClassName):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::callExit):
(WebKit::failedToGetNetworkProcessConnection):
* Source/WebKitLegacy/mac/DOM/ExceptionHandlers.h:
* Source/WebKitLegacy/mac/DOM/ExceptionHandlers.mm:
(raiseDOMErrorException):
* Tools/TestRunnerShared/TestCommand.cpp:
(WTR::die):

Canonical link: <a href="https://commits.webkit.org/294589@main">https://commits.webkit.org/294589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71b0b44faf087e0f01241fbf0e419264a5fe107d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12257 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107434 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52910 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104313 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30449 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77823 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34807 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17222 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92323 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58161 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17055 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10351 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52268 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94945 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86882 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10421 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109809 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100883 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29406 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21678 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86804 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29770 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88526 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86392 "Found 101 new API test failures: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/javascript-dialogs, /TestWebKit:WebKit.DOMWindowExtensionCrashOnReload, /TestWebKit:WebKit.PageLoadBasic, /TestWebKit:WebKit.NewFirstVisuallyNonEmptyLayoutFails, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /TestWebKit:WebKit.InjectedBundleBasic, /TestWebKit:WebKit.PreventEmptyUserAgent, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/select-all/non-editable ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31200 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8918 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/23648 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16629 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29334 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34629 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124517 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29145 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34568 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32468 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30704 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->