### PR TITLE
GPUP: Drawing paths spends time in Path related constructors

### DIFF
--- a/Source/WebCore/platform/graphics/Path.cpp
+++ b/Source/WebCore/platform/graphics/Path.cpp
@@ -61,11 +61,6 @@ Path::Path(Ref<PathImpl>&& impl)
 {
 }
 
-Path::Path(const Path& other)
-{
-    *this = other;
-}
-
 bool Path::definitelyEqual(const Path& other) const
 {
     if (&other == this)
@@ -90,11 +85,6 @@ bool Path::definitelyEqual(const Path& other) const
 
             return impl.ptr() && other.asImpl() && impl->definitelyEqual(*other.asImpl());
         });
-}
-
-Path::Path(PathSegment&& segment)
-{
-    m_data = WTFMove(segment);
 }
 
 PathImpl& Path::setImpl(Ref<PathImpl>&& impl)

--- a/Source/WebCore/platform/graphics/Path.h
+++ b/Source/WebCore/platform/graphics/Path.h
@@ -45,12 +45,12 @@ class Path {
     WTF_MAKE_TZONE_ALLOCATED(Path);
 public:
     Path() = default;
-    WEBCORE_EXPORT Path(PathSegment&&);
+    Path(PathSegment&&);
     WEBCORE_EXPORT Path(Vector<PathSegment>&&);
     explicit Path(const Vector<FloatPoint>& points);
     Path(Ref<PathImpl>&&);
 
-    WEBCORE_EXPORT Path(const Path&);
+    Path(const Path&) = default;
     Path(Path&&) = default;
     Path& operator=(const Path&) = default;
     Path& operator=(Path&&) = default;
@@ -138,5 +138,10 @@ private:
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const Path&);
+
+inline Path::Path(PathSegment&& segment)
+    : m_data(WTFMove(segment))
+{
+}
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/PathSegment.cpp
+++ b/Source/WebCore/platform/graphics/PathSegment.cpp
@@ -32,11 +32,6 @@
 
 namespace WebCore {
 
-PathSegment::PathSegment(Data&& data)
-    : m_data(WTFMove(data))
-{
-}
-
 FloatPoint PathSegment::calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const
 {
     return WTF::switchOn(m_data, [&](auto& data) {

--- a/Source/WebCore/platform/graphics/PathSegment.h
+++ b/Source/WebCore/platform/graphics/PathSegment.h
@@ -56,7 +56,7 @@ public:
         PathCloseSubpath
     >;
 
-    WEBCORE_EXPORT PathSegment(Data&&);
+    PathSegment(Data&&);
 
     bool operator==(const PathSegment&) const = default;
 
@@ -85,4 +85,9 @@ using PathSegmentApplier = Function<void(const PathSegment&)>;
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathSegment&);
 
+
+inline PathSegment::PathSegment(Data&& data)
+    : m_data(WTFMove(data))
+{
+}
 } // namespace WebCore


### PR DESCRIPTION
#### d8a5885accdfcfab160da1dada50396d51a076e8
<pre>
GPUP: Drawing paths spends time in Path related constructors
<a href="https://bugs.webkit.org/show_bug.cgi?id=292594">https://bugs.webkit.org/show_bug.cgi?id=292594</a>
<a href="https://rdar.apple.com/150749584">rdar://150749584</a>

Reviewed by Simon Fraser.

Inline Path(PathSegment) and PathSegment constructors. They only invoke
variant construction, likely resulting in equal code size as calling
the function.

Inline and default Path(const Path&amp;), to be consistent with move
construction and copy and move assignments.

* Source/WebCore/platform/graphics/Path.cpp:
* Source/WebCore/platform/graphics/Path.h:
(WebCore::Path::Path):
* Source/WebCore/platform/graphics/PathSegment.cpp:
(WebCore::PathSegment::PathSegment): Deleted.
* Source/WebCore/platform/graphics/PathSegment.h:
(WebCore::PathSegment::PathSegment):

Canonical link: <a href="https://commits.webkit.org/294569@main">https://commits.webkit.org/294569@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49a6350f966a7184331b68c38bc7d553a16b7776

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12269 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107446 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52922 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104325 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22263 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30461 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77833 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34819 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17234 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92336 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58171 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17068 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10364 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52280 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86893 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10434 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109821 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29418 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21689 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86816 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29782 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88536 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86405 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21987 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31213 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8930 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23660 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29346 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34641 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29157 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32480 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30716 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->