### PR TITLE
Remove DeclarativeShadowRootsSerializerAPIsEnabled preference

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2509,20 +2509,6 @@ DateTimeInputsEditableComponentsEnabled:
     WebCore:
       default: false
 
-DeclarativeShadowRootsSerializerAPIsEnabled:
-  type: bool
-  status: stable
-  category: dom
-  humanReadableName: "Declarative Shadow Roots Serializer APIs"
-  humanReadableDescription: "Declarative Shadow Roots Serializer APIs (Element/ShadowRoot's getHTML() and ShadowRoot's serializable)"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 DeclarativeWebPush:
   type: bool
   status: stable

--- a/Source/WebCore/dom/InnerHTML.idl
+++ b/Source/WebCore/dom/InnerHTML.idl
@@ -27,6 +27,6 @@
 
 interface mixin InnerHTML {
     [CEReactions=Needed] undefined setHTMLUnsafe((TrustedHTML or DOMString) html);
-    [CEReactions=NotNeeded, EnabledBySetting=DeclarativeShadowRootsSerializerAPIsEnabled] DOMString getHTML(optional GetHTMLOptions options = {});
+    [CEReactions=NotNeeded] DOMString getHTML(optional GetHTMLOptions options = {});
     [CEReactions=Needed] attribute (TrustedHTML or [LegacyNullToEmptyString] DOMString) innerHTML;
 };

--- a/Source/WebCore/dom/ShadowRoot.idl
+++ b/Source/WebCore/dom/ShadowRoot.idl
@@ -34,7 +34,7 @@
     readonly attribute boolean delegatesFocus;
     [ImplementedAs=slotAssignmentMode] readonly attribute SlotAssignmentMode slotAssignment;
     [ImplementedAs=isClonable] readonly attribute boolean clonable;
-    [EnabledBySetting=DeclarativeShadowRootsSerializerAPIsEnabled] readonly attribute boolean serializable;
+    readonly attribute boolean serializable;
     readonly attribute Element host;
     [EnabledBySetting=ScopedCustomElementRegistryEnabled, ImplementedAs=registryForBindings] readonly attribute CustomElementRegistry? customElementRegistry;
     [EnabledBySetting=ShadowRootReferenceTargetEnabled] attribute [AtomString] DOMString referenceTarget;

--- a/Source/WebCore/dom/ShadowRootInit.idl
+++ b/Source/WebCore/dom/ShadowRootInit.idl
@@ -29,7 +29,7 @@ dictionary ShadowRootInit {
     required ShadowRootMode mode;
     boolean delegatesFocus = false;
     boolean clonable = false;
-    [EnabledBySetting=DeclarativeShadowRootsSerializerAPIsEnabled] boolean serializable = false;
+    boolean serializable = false;
     SlotAssignmentMode slotAssignment = "named";
     [EnabledBySetting=ScopedCustomElementRegistryEnabled] CustomElementRegistry customElementRegistry;
     [EnabledBySetting=ShadowRootReferenceTargetEnabled] DOMString referenceTarget;

--- a/Source/WebCore/html/HTMLTemplateElement.idl
+++ b/Source/WebCore/html/HTMLTemplateElement.idl
@@ -37,7 +37,7 @@
     [CEReactions=NotNeeded] attribute [AtomString] DOMString shadowRootMode;
     [CEReactions=NotNeeded, Reflect=shadowrootdelegatesfocus] attribute boolean shadowRootDelegatesFocus;
     [CEReactions=NotNeeded, Reflect=shadowrootclonable] attribute boolean shadowRootClonable;
-    [EnabledBySetting=DeclarativeShadowRootsSerializerAPIsEnabled, CEReactions=NotNeeded, Reflect=shadowrootserializable] attribute boolean shadowRootSerializable;
+    [CEReactions=NotNeeded, Reflect=shadowrootserializable] attribute boolean shadowRootSerializable;
     [EnabledBySetting=ScopedCustomElementRegistryEnabled, CEReactions=NotNeeded, Reflect=shadowrootcustomelementregistry] attribute DOMString shadowRootCustomElementRegistry;
     [EnabledBySetting=ShadowRootReferenceTargetEnabled, CEReactions=NotNeeded, Reflect=shadowrootreferencetarget] attribute DOMString shadowRootReferenceTarget;
 };


### PR DESCRIPTION
#### 71968c5d539d2b1e331b1a111e11ae3007416dd9
<pre>
Remove DeclarativeShadowRootsSerializerAPIsEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=292597">https://bugs.webkit.org/show_bug.cgi?id=292597</a>

Reviewed by Ryosuke Niwa.

It&apos;s been enabled for a year on main.

Canonical link: <a href="https://commits.webkit.org/294603@main">https://commits.webkit.org/294603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2271b0df1b23d67b2682e2137c2dfd83fe611be6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12272 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107450 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52925 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104328 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77839 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34823 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105295 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17238 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92338 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58177 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17072 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10366 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52283 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94960 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86897 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10436 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109824 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100898 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29421 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21691 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86818 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88538 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86407 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31215 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8932 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23663 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16636 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29349 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34644 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124532 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29160 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34573 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32483 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30719 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->