### PR TITLE
ServiceWorkerContainer needs to queue a task to settle promises

### DIFF
--- a/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
@@ -260,8 +260,10 @@ void ServiceWorkerContainer::unregisterRegistration(ServiceWorkerRegistrationIde
     }
 
     CONTAINER_RELEASE_LOG("unregisterRegistration: Unregistering service worker.");
-    m_swConnection->scheduleUnregisterJobInServer(registrationIdentifier, contextIdentifier(), [promise = WTFMove(promise)](auto&& result) mutable {
-        promise.settle(WTFMove(result));
+    m_swConnection->scheduleUnregisterJobInServer(registrationIdentifier, contextIdentifier(), [protectedThis = Ref { *this }, promise = WTFMove(promise)](auto&& result) mutable {
+        queueTaskKeepingObjectAlive(protectedThis.get(), TaskSource::DOMManipulation, [promise = WTFMove(promise), result = WTFMove(result)](auto&) mutable {
+            promise.settle(WTFMove(result));
+        });
     });
 }
 
@@ -629,45 +631,53 @@ void ServiceWorkerContainer::removeRegistration(ServiceWorkerRegistration& regis
 
 void ServiceWorkerContainer::subscribeToPushService(ServiceWorkerRegistration& registration, const Vector<uint8_t>& applicationServerKey, DOMPromiseDeferred<IDLInterface<PushSubscription>>&& promise)
 {
-    ensureSWClientConnection().subscribeToPushService(registration.identifier(), applicationServerKey, [protectedRegistration = Ref { registration }, promise = WTFMove(promise)](auto&& result) mutable {
-        if (result.hasException()) {
-            promise.reject(result.releaseException());
-            return;
-        }
-        
-        promise.resolve(PushSubscription::create(result.releaseReturnValue(), WTFMove(protectedRegistration)));
+    ensureSWClientConnection().subscribeToPushService(registration.identifier(), applicationServerKey, [protectedThis = Ref { *this }, protectedRegistration = Ref { registration }, promise = WTFMove(promise)](auto&& result) mutable {
+        queueTaskKeepingObjectAlive(protectedThis.get(), TaskSource::DOMManipulation, [promise = WTFMove(promise), result = WTFMove(result), protectedRegistration = WTFMove(protectedRegistration)](auto&) mutable {
+            if (result.hasException()) {
+                promise.reject(result.releaseException());
+                return;
+            }
+
+            promise.resolve(PushSubscription::create(result.releaseReturnValue(), WTFMove(protectedRegistration)));
+        });
     });
 }
 
 void ServiceWorkerContainer::unsubscribeFromPushService(ServiceWorkerRegistrationIdentifier identifier, PushSubscriptionIdentifier subscriptionIdentifier, DOMPromiseDeferred<IDLBoolean>&& promise)
 {
-    ensureSWClientConnection().unsubscribeFromPushService(identifier, subscriptionIdentifier, [promise = WTFMove(promise)](auto&& result) mutable {
-        promise.settle(WTFMove(result));
+    ensureSWClientConnection().unsubscribeFromPushService(identifier, subscriptionIdentifier, [protectedThis = Ref { *this }, promise = WTFMove(promise)](auto&& result) mutable {
+        queueTaskKeepingObjectAlive(protectedThis.get(), TaskSource::DOMManipulation, [promise = WTFMove(promise), result = WTFMove(result)](auto&) mutable {
+            promise.settle(WTFMove(result));
+        });
     });
 }
 
 void ServiceWorkerContainer::getPushSubscription(ServiceWorkerRegistration& registration, DOMPromiseDeferred<IDLNullable<IDLInterface<PushSubscription>>>&& promise)
 {
-    ensureSWClientConnection().getPushSubscription(registration.identifier(), [protectedRegistration = Ref { registration }, promise = WTFMove(promise)](auto&& result) mutable {
-        if (result.hasException()) {
-            promise.reject(result.releaseException());
-            return;
-        }
+    ensureSWClientConnection().getPushSubscription(registration.identifier(), [protectedThis = Ref { *this }, protectedRegistration = Ref { registration }, promise = WTFMove(promise)](auto&& result) mutable {
+        queueTaskKeepingObjectAlive(protectedThis.get(), TaskSource::DOMManipulation, [promise = WTFMove(promise), result = WTFMove(result), protectedRegistration = WTFMove(protectedRegistration)](auto&) mutable {
+            if (result.hasException()) {
+                promise.reject(result.releaseException());
+                return;
+            }
 
-        auto optionalPushSubscriptionData = result.releaseReturnValue();
-        if (!optionalPushSubscriptionData) {
-            promise.resolve(nullptr);
-            return;
-        }
+            auto optionalPushSubscriptionData = result.releaseReturnValue();
+            if (!optionalPushSubscriptionData) {
+                promise.resolve(nullptr);
+                return;
+            }
 
-        promise.resolve(PushSubscription::create(WTFMove(*optionalPushSubscriptionData), WTFMove(protectedRegistration)).ptr());
+            promise.resolve(PushSubscription::create(WTFMove(*optionalPushSubscriptionData), WTFMove(protectedRegistration)).ptr());
+        });
     });
 }
 
 void ServiceWorkerContainer::getPushPermissionState(ServiceWorkerRegistrationIdentifier identifier, DOMPromiseDeferred<IDLEnumeration<PushPermissionState>>&& promise)
 {
-    ensureSWClientConnection().getPushPermissionState(identifier, [promise = WTFMove(promise)](auto&& result) mutable {
-        promise.settle(WTFMove(result));
+    ensureSWClientConnection().getPushPermissionState(identifier, [protectedThis = Ref { *this }, promise = WTFMove(promise)](auto&& result) mutable {
+        queueTaskKeepingObjectAlive(protectedThis.get(), TaskSource::DOMManipulation, [promise = WTFMove(promise), result = WTFMove(result)](auto&) mutable {
+            promise.settle(WTFMove(result));
+        });
     });
 }
 
@@ -675,21 +685,23 @@ void ServiceWorkerContainer::getPushPermissionState(ServiceWorkerRegistrationIde
 void ServiceWorkerContainer::getNotifications(const URL& serviceWorkerRegistrationURL, const String& tag, DOMPromiseDeferred<IDLSequence<IDLInterface<Notification>>>&& promise)
 {
     ensureSWClientConnection().getNotifications(serviceWorkerRegistrationURL, tag, [promise = WTFMove(promise), protectedThis = Ref { *this }](auto&& result) mutable {
-        auto* context = protectedThis->scriptExecutionContext();
-        if (!context)
-            return;
+        queueTaskKeepingObjectAlive(protectedThis.get(), TaskSource::DOMManipulation, [promise = WTFMove(promise), result = WTFMove(result), protectedThis](auto&) mutable {
+            RefPtr context = protectedThis->scriptExecutionContext();
+            if (!context)
+                return;
 
-        if (result.hasException()) {
-            promise.reject(result.releaseException());
-            return;
-        }
+            if (result.hasException()) {
+                promise.reject(result.releaseException());
+                return;
+            }
 
-        auto notifications = map(result.releaseReturnValue(), [context](NotificationData&& data) {
-            auto notification = Notification::create(*context, WTFMove(data));
-            notification->markAsShown();
-            return notification;
+            auto notifications = map(result.releaseReturnValue(), [context](NotificationData&& data) {
+                auto notification = Notification::create(*context, WTFMove(data));
+                notification->markAsShown();
+                return notification;
+            });
+            promise.resolve(WTFMove(notifications));
         });
-        promise.resolve(WTFMove(notifications));
     });
 }
 #endif
@@ -746,62 +758,70 @@ bool ServiceWorkerContainer::addEventListener(const AtomString& eventType, Ref<E
 
 void ServiceWorkerContainer::enableNavigationPreload(ServiceWorkerRegistrationIdentifier identifier, VoidPromise&& promise)
 {
-    ensureSWClientConnection().enableNavigationPreload(identifier, [promise = WTFMove(promise)](auto&& result) mutable {
-        promise.settle(WTFMove(result));
+    ensureSWClientConnection().enableNavigationPreload(identifier, [protectedThis = Ref { *this }, promise = WTFMove(promise)](auto&& result) mutable {
+        queueTaskKeepingObjectAlive(protectedThis.get(), TaskSource::DOMManipulation, [promise = WTFMove(promise), result = WTFMove(result)](auto&) mutable {
+            promise.settle(WTFMove(result));
+        });
     });
 }
 
 void ServiceWorkerContainer::disableNavigationPreload(ServiceWorkerRegistrationIdentifier identifier, VoidPromise&& promise)
 {
-    ensureSWClientConnection().disableNavigationPreload(identifier, [promise = WTFMove(promise)](auto&& result) mutable {
-        promise.settle(WTFMove(result));
+    ensureSWClientConnection().disableNavigationPreload(identifier, [protectedThis = Ref { *this }, promise = WTFMove(promise)](auto&& result) mutable {
+        queueTaskKeepingObjectAlive(protectedThis.get(), TaskSource::DOMManipulation, [promise = WTFMove(promise), result = WTFMove(result)](auto&) mutable {
+            promise.settle(WTFMove(result));
+        });
     });
 }
 
 void ServiceWorkerContainer::setNavigationPreloadHeaderValue(ServiceWorkerRegistrationIdentifier identifier, String&& headerValue, VoidPromise&& promise)
 {
-    ensureSWClientConnection().setNavigationPreloadHeaderValue(identifier, WTFMove(headerValue), [promise = WTFMove(promise)](auto&& result) mutable {
-        promise.settle(WTFMove(result));
+    ensureSWClientConnection().setNavigationPreloadHeaderValue(identifier, WTFMove(headerValue), [protectedThis = Ref { *this }, promise = WTFMove(promise)](auto&& result) mutable {
+        queueTaskKeepingObjectAlive(protectedThis.get(), TaskSource::DOMManipulation, [promise = WTFMove(promise), result = WTFMove(result)](auto&) mutable {
+            promise.settle(WTFMove(result));
+        });
     });
 }
 
 void ServiceWorkerContainer::getNavigationPreloadState(ServiceWorkerRegistrationIdentifier identifier, NavigationPreloadStatePromise&& promise)
 {
-    ensureSWClientConnection().getNavigationPreloadState(identifier, [promise = WTFMove(promise)](auto&& result) mutable {
-        promise.settle(WTFMove(result));
+    ensureSWClientConnection().getNavigationPreloadState(identifier, [protectedThis = Ref { *this }, promise = WTFMove(promise)](auto&& result) mutable {
+        queueTaskKeepingObjectAlive(protectedThis.get(), TaskSource::DOMManipulation, [promise = WTFMove(promise), result = WTFMove(result)](auto&) mutable {
+            promise.settle(WTFMove(result));
+        });
     });
 }
 
 void ServiceWorkerContainer::addCookieChangeSubscriptions(ServiceWorkerRegistrationIdentifier identifier, Vector<CookieChangeSubscription>&& subscriptions, Ref<DeferredPromise>&& promise)
 {
-    ensureProtectedSWClientConnection()->addCookieChangeSubscriptions(identifier, WTFMove(subscriptions), [promise = WTFMove(promise)](auto&& result) mutable {
-        if (result.hasException())
-            promise->reject(Exception { result.releaseException() });
-        else
-            promise->resolve();
+    ensureProtectedSWClientConnection()->addCookieChangeSubscriptions(identifier, WTFMove(subscriptions), [protectedThis = Ref { *this }, promise = VoidPromise { WTFMove(promise) }](auto&& result) mutable {
+        queueTaskKeepingObjectAlive(protectedThis.get(), TaskSource::DOMManipulation, [promise = WTFMove(promise), result = WTFMove(result)](auto&) mutable {
+            promise.settle(WTFMove(result));
+        });
     });
 }
 
 void ServiceWorkerContainer::removeCookieChangeSubscriptions(ServiceWorkerRegistrationIdentifier identifier, Vector<CookieChangeSubscription>&& subscriptions, Ref<DeferredPromise>&& promise)
 {
-    ensureProtectedSWClientConnection()->removeCookieChangeSubscriptions(identifier, WTFMove(subscriptions), [promise = WTFMove(promise)](auto&& result) mutable {
-        if (result.hasException())
-            promise->reject(Exception { result.releaseException() });
-        else
-            promise->resolve();
+    ensureProtectedSWClientConnection()->removeCookieChangeSubscriptions(identifier, WTFMove(subscriptions), [protectedThis = Ref { *this }, promise = VoidPromise { WTFMove(promise) }](auto&& result) mutable {
+        queueTaskKeepingObjectAlive(protectedThis.get(), TaskSource::DOMManipulation, [promise = WTFMove(promise), result = WTFMove(result)](auto&) mutable {
+            promise.settle(WTFMove(result));
+        });
     });
 }
 
 void ServiceWorkerContainer::cookieChangeSubscriptions(ServiceWorkerRegistrationIdentifier identifier, Ref<DeferredPromise>&& promise)
 {
-    ensureProtectedSWClientConnection()->cookieChangeSubscriptions(identifier, [promise = WTFMove(promise)](auto&& result) mutable {
-        if (result.hasException())
-            promise->reject(Exception { result.releaseException() });
-        else {
-            promise->resolve<IDLSequence<IDLDictionary<CookieStoreGetOptions>>>(WTF::map(result.releaseReturnValue(), [](CookieChangeSubscription&& subscription) {
-                return CookieStoreGetOptions { WTFMove(subscription.name), WTFMove(subscription.url) };
-            }));
-        }
+    ensureProtectedSWClientConnection()->cookieChangeSubscriptions(identifier, [protectedThis = Ref { *this }, promise = WTFMove(promise)](auto&& result) mutable {
+        queueTaskKeepingObjectAlive(protectedThis.get(), TaskSource::DOMManipulation, [promise = WTFMove(promise), result = WTFMove(result)](auto&) mutable {
+            if (result.hasException())
+                promise->reject(Exception { result.releaseException() });
+            else {
+                promise->resolve<IDLSequence<IDLDictionary<CookieStoreGetOptions>>>(WTF::map(result.releaseReturnValue(), [](CookieChangeSubscription&& subscription) {
+                    return CookieStoreGetOptions { WTFMove(subscription.name), WTFMove(subscription.url) };
+                }));
+            }
+        });
     });
 }
 


### PR DESCRIPTION
#### 10964ec0fcc4875a5fc068b24c53700892f10848
<pre>
ServiceWorkerContainer needs to queue a task to settle promises
<a href="https://rdar.apple.com/150751742">rdar://150751742</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292598">https://bugs.webkit.org/show_bug.cgi?id=292598</a>

Reviewed by NOBODY (OOPS!).

Mae sure to queue a task before resolving/rejecting a promise so that JS is not executed in suspended documents.
Covered by existing tests, like http/tests/workers/service/page-caching.html

* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::unregisterRegistration):
(WebCore::ServiceWorkerContainer::subscribeToPushService):
(WebCore::ServiceWorkerContainer::unsubscribeFromPushService):
(WebCore::ServiceWorkerContainer::getPushSubscription):
(WebCore::ServiceWorkerContainer::getPushPermissionState):
(WebCore::ServiceWorkerContainer::getNotifications):
(WebCore::ServiceWorkerContainer::enableNavigationPreload):
(WebCore::ServiceWorkerContainer::disableNavigationPreload):
(WebCore::ServiceWorkerContainer::setNavigationPreloadHeaderValue):
(WebCore::ServiceWorkerContainer::getNavigationPreloadState):
(WebCore::ServiceWorkerContainer::addCookieChangeSubscriptions):
(WebCore::ServiceWorkerContainer::removeCookieChangeSubscriptions):
(WebCore::ServiceWorkerContainer::cookieChangeSubscriptions):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10964ec0fcc4875a5fc068b24c53700892f10848

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102292 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12275 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107453 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52928 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104331 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30467 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77837 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34826 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105298 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17239 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92340 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58175 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17073 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10368 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52286 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86898 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10438 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109827 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29424 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21693 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86815 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29788 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88539 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86404 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31217 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8934 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23666 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29352 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34647 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29163 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32486 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30722 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->