### PR TITLE
[JSC] Upstream partial ARMv7 port of InPlaceInterpreter 3/?

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -122,7 +122,7 @@ elsif ARMv7
 
     const sc0 = t4
     const sc1 = t5
-    const sc2 = t6
+    const sc2 = csr0
     const sc3 = t7
 else
     const PC = invalidGPR
@@ -612,7 +612,13 @@ macro ipintCatchCommon()
     loadp VM::targetInterpreterPCForThrow[t3], PC
     loadp VM::targetInterpreterMetadataPCForThrow[t3], MC
 
+if ARMv7
+    push MC
+end
     getIPIntCallee()
+if ARMv7
+    pop MC
+end
 
     loadp CodeBlock[cfr], wasmInstance
     if ARM64 or ARM64E
@@ -630,16 +636,21 @@ macro ipintCatchCommon()
         loadi Wasm::IPIntCallee::m_numRethrowSlotsToAlloc[ws0], t1
         loadi Wasm::IPIntCallee::m_localSizeToAlloc[ws0], t0
     end
-    addq t1, t0
-    mulq LocalSize, t0
-    addq IPIntCalleeSaveSpaceStackAligned, t0
-    subq cfr, t0, PL
+    addp t1, t0
+    mulp LocalSize, t0
+    addp IPIntCalleeSaveSpaceStackAligned, t0
+    subp cfr, t0, PL
 
     loadi [MC], t0
     addp t1, t0
-    lshiftq StackValueShift, t0
-    addq IPIntCalleeSaveSpaceStackAligned, t0
+    lshiftp StackValueShift, t0
+    addp IPIntCalleeSaveSpaceStackAligned, t0
+if ARMv7
+    move cfr, sp
+    subp sp, t0, sp
+else
     subp cfr, t0, sp
+end
 
 if X86_64
     loadp UnboxedWasmCalleeStackSlot[cfr], ws0
@@ -690,7 +701,7 @@ end
 
 global _ipint_table_catch_entry
 _ipint_table_catch_entry:
-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
+if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     ipintCatchCommon()
 if X86_64
     initPCRelative(ipint_table_catch_entry, IB)
@@ -713,7 +724,7 @@ end
 
 global _ipint_table_catch_ref_entry
 _ipint_table_catch_ref_entry:
-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
+if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     ipintCatchCommon()
 if X86_64
     initPCRelative(ipint_table_catch_ref_entry, IB)
@@ -736,7 +747,7 @@ end
 
 global _ipint_table_catch_all_entry
 _ipint_table_catch_all_entry:
-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
+if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     ipintCatchCommon()
 if X86_64
     initPCRelative(ipint_table_catch_all_entry, IB)
@@ -759,7 +770,7 @@ end
 
 global _ipint_table_catch_allref_entry
 _ipint_table_catch_allref_entry:
-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
+if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     ipintCatchCommon()
 if X86_64
     initPCRelative(ipint_table_catch_allref_entry, IB)

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm
@@ -4,13 +4,18 @@
 
 # Callee Save
 
+const IPIntCalleeSaveSpaceMCPC = -8
+const IPIntCalleeSaveSpaceWI = -12
+
 macro saveIPIntRegisters()
     subp IPIntCalleeSaveSpaceStackAligned, sp
-    store2ia MC, PC, -8[cfr]
+    store2ia MC, PC, IPIntCalleeSaveSpaceMCPC[cfr]
+    storep wasmInstance, IPIntCalleeSaveSpaceWI[cfr]
 end
 
 macro restoreIPIntRegisters()
-    load2ia -8[cfr], MC, PC
+    load2ia IPIntCalleeSaveSpaceMCPC[cfr], MC, PC
+    loadp IPIntCalleeSaveSpaceWI[cfr], wasmInstance
     addp IPIntCalleeSaveSpaceStackAligned, sp
 end
 
@@ -305,9 +310,40 @@ end)
 
 unimplementedInstruction(_try)
 unimplementedInstruction(_catch)
-unimplementedInstruction(_throw)
+
+ipintOp(_throw, macro()
+    saveCallSiteIndex()
+
+    loadp JSWebAssemblyInstance::m_vm[wasmInstance], t0
+    loadp VM::topEntryFrame[t0], t0
+    copyCalleeSavesToEntryFrameCalleeSavesBuffer(t0)
+
+    move cfr, a1
+    move sp, a2
+    loadi IPInt::ThrowMetadata::exceptionIndex[MC], a3
+    operationCall(macro() cCall4(_ipint_extern_throw_exception) end)
+    jumpToException()
+end)
+
 unimplementedInstruction(_rethrow)
-unimplementedInstruction(_throw_ref)
+
+ipintOp(_throw_ref, macro()
+    popQuad(a3, a2)
+    bieq a3, NullTag, .throw_null_ref
+
+    saveCallSiteIndex()
+
+    loadp JSWebAssemblyInstance::m_vm[wasmInstance], t0
+    loadp VM::topEntryFrame[t0], t0
+    copyCalleeSavesToEntryFrameCalleeSavesBuffer(t0)
+
+    move cfr, a1
+    operationCall(macro() cCall4(_ipint_extern_throw_ref) end)
+    jumpToException()
+
+.throw_null_ref:
+    throwException(NullExnReference)
+end)
 
 # MC = location in uINT bytecode
 # csr1, csr0 = tmp # clobbers PC, WI
@@ -476,10 +512,92 @@ ipintOp(_call_indirect, macro()
     jmp .ipint_call_common
 end)
 
-unimplementedInstruction(_return_call)
-unimplementedInstruction(_return_call_indirect)
-unimplementedInstruction(_call_ref)
-unimplementedInstruction(_return_call_ref)
+ipintOp(_return_call, macro()
+    saveCallSiteIndex()
+
+    loadb IPInt::TailCallMetadata::length[MC], t0
+    advancePCByReg(t0)
+
+    # get function index
+    loadi IPInt::TailCallMetadata::functionIndex[MC], a1
+
+    subp 16, sp
+    move sp, a2
+
+    # operation returns the entrypoint in r0 and the target instance in r1
+    # this operation stores the boxed Callee into *r2
+    operationCall(macro() cCall3(_ipint_extern_prepare_call) end)
+
+    loadp [sp], IPIntCallCallee
+    loadp 8[sp], IPIntCallFunctionSlot
+    addp 16, sp
+
+    loadi IPInt::TailCallMetadata::callerStackArgSize[MC], t3
+    advanceMC(IPInt::TailCallMetadata::argumentBytecode)
+    jmp .ipint_tail_call_common
+end)
+
+ipintOp(_return_call_indirect, macro()
+    saveCallSiteIndex()
+
+    loadb IPInt::TailCallIndirectMetadata::length[MC], t0
+    advancePCByReg(t0)
+
+    # Get function index by pointer, use it as a return for callee
+    move sp, a2
+
+    # Get callIndirectMetadata
+    move cfr, a1
+    move MC, a3
+    operationCallMayThrow(macro() cCall4(_ipint_extern_prepare_call_indirect) end)
+
+    loadp [sp], IPIntCallCallee
+    loadp 8[sp], IPIntCallFunctionSlot
+    addp 16, sp
+
+    loadi IPInt::TailCallIndirectMetadata::callerStackArgSize[MC], t3
+    advanceMC(IPInt::TailCallIndirectMetadata::argumentBytecode)
+    jmp .ipint_tail_call_common
+end)
+
+ipintOp(_call_ref, macro()
+    saveCallSiteIndex()
+
+    move cfr, a1
+    loadi IPInt::CallRefMetadata::typeIndex[MC], a2
+    move sp, a3
+
+    operationCallMayThrow(macro() cCall4(_ipint_extern_prepare_call_ref) end)
+    loadp [sp], IPIntCallCallee
+    loadp 8[sp], IPIntCallFunctionSlot
+    addp 16, sp
+    
+    loadb IPInt::CallRefMetadata::length[MC], t3
+    advanceMC(IPInt::CallRefMetadata::signature)
+    advancePCByReg(t3)
+
+    jmp .ipint_call_common
+end)
+
+ipintOp(_return_call_ref, macro()
+    saveCallSiteIndex()
+
+    loadb IPInt::TailCallRefMetadata::length[MC], t2
+    advancePCByReg(t2)
+
+    move cfr, a1
+    loadi IPInt::TailCallRefMetadata::typeIndex[MC], a2
+    move sp, a3
+    operationCallMayThrow(macro() cCall4(_ipint_extern_prepare_call_ref) end)
+    loadp [sp], IPIntCallCallee
+    loadp 8[sp], IPIntCallFunctionSlot
+    addp 16, sp
+
+    loadi IPInt::TailCallRefMetadata::callerStackArgSize[MC], t3
+    advanceMC(IPInt::TailCallRefMetadata::argumentBytecode)
+    jmp .ipint_tail_call_common
+end)
+
 reservedOpcode(0x16)
 reservedOpcode(0x17)
 unimplementedInstruction(_delegate)
@@ -527,7 +645,15 @@ end)
 
 reservedOpcode(0x1d)
 reservedOpcode(0x1e)
-unimplementedInstruction(_try_table)
+
+ipintOp(_try_table, macro()
+    # advance MC/PC
+    loadi IPInt::BlockMetadata::deltaPC[MC], t0
+    loadi IPInt::BlockMetadata::deltaMC[MC], t1
+    advancePCByReg(t0)
+    advanceMCByReg(t1)
+    nextIPIntInstruction()
+end)
 
     ###################################
     # 0x20 - 0x26: get and set values #
@@ -2979,7 +3105,7 @@ end)
 
 ipintOp(_br_on_null, macro()
     peekQuad(0, t1, t0)
-    bpeq t1, NullTag, .br_on_null_not_null
+    bineq t1, NullTag, .br_on_null_not_null
 
     # pop the null
     drop()
@@ -3908,6 +4034,7 @@ slowPathLabel(_local_tee)
 # sc0 = mINT shadow stack pointer (tracks the Wasm stack)
 
 const mintSS = sc1
+const mintDst = sc2
 
 macro mintPop(hi, lo)
     load2ia [mintSS], lo, hi
@@ -4029,9 +4156,110 @@ end
     storep IPIntCallFunctionSlot, CodeBlock - CallerFrameAndPCSize[sp]
 
     push targetEntrypoint, targetInstance
-    move t3, csr0
+    move t3, mintDst
 
     move t4, mintSS
+
+    mintArgDispatch()
+
+.ipint_tail_call_common:
+    # Free up r0 to be used as argument register
+
+    #  <caller frame>
+    #  return val
+    #  return val
+    #  argument
+    #  argument
+    #  argument
+    #  argument
+    #  call frame
+    #  call frame      <- cfr
+    #  (IPInt locals)
+    #  (IPInt stack)
+    #  argument 0
+    #  ...
+    #  argument n-1
+    #  argument n      <- sp
+
+    # store entrypoint and target instance on the stack for now
+    push r0, r1
+    push IPIntCallCallee, IPIntCallFunctionSlot
+
+    # keep the top of IPInt stack in mintSS as shadow stack
+    move sp, mintSS
+    # we pushed four values previously, so offset for this
+    addp 16, mintSS
+
+    #  <caller frame>
+    #  return val
+    #  return val
+    #  argument
+    #  argument
+    #  argument
+    #  argument
+    #  call frame
+    #  call frame                  <- cfr
+    #  (IPInt locals)
+    #  (IPInt stack)
+    #  argument 0
+    #  ...
+    #  argument n-1
+    #  argument n                  <- mintSS
+    #  entrypoint, targetInstance
+    #  callee, function info       <- sp
+
+    # determine the location to begin copying stack arguments, starting from the last
+    move cfr, mintDst
+    addp FirstArgumentOffset, mintDst
+    addp t3, mintDst
+
+    #  <caller frame>
+    #  return val                  <- mintDst
+    #  return val
+    #  argument
+    #  argument
+    #  argument
+    #  argument
+    #  call frame
+    #  call frame                  <- cfr
+    #  (IPInt locals)
+    #  (IPInt stack)
+    #  argument 0
+    #  ...
+    #  argument n-1
+    #  argument n                  <- mintSS
+    #  entrypoint, targetInstance
+    #  callee, function info       <- sp
+
+    # get saved MC and PC
+    load2ia IPIntCalleeSaveSpaceMCPC[cfr], t0, t1
+    push t0, t1
+
+    # store the return address and CFR on the stack so we don't lose it
+    loadp ReturnPC[cfr], t0
+    loadp [cfr], t1
+
+    push t0, t1
+
+    #  <caller frame>
+    #  return val                  <- mintDst
+    #  return val
+    #  argument
+    #  argument
+    #  argument
+    #  argument
+    #  call frame
+    #  call frame                  <- cfr
+    #  (IPInt locals)
+    #  (IPInt stack)
+    #  argument 0
+    #  ...
+    #  argument n-1
+    #  argument n                  <- mintSS
+    #  entrypoint, targetInstance
+    #  callee, function info
+    #  saved MC/PC
+    #  return address, saved CFR   <- sp
 
     mintArgDispatch()
 
@@ -4096,13 +4324,13 @@ mintAlign(_fa7)
 
 mintAlign(_stackzero)
     mintPop(t1, t0)
-    store2ia t0, t1, [csr0]
+    store2ia t0, t1, [mintDst]
     mintArgDispatch()
 
 mintAlign(_stackeight)
     mintPop(t1, t0)
-    subp 16, csr0
-    store2ia t0, t1, 8[csr0]
+    subp 16, mintDst
+    store2ia t0, t1, 8[mintDst]
     mintArgDispatch()
 
 mintAlign(_tail_stackzero)
@@ -4112,14 +4340,14 @@ mintAlign(_tail_stackeight)
     break
 
 mintAlign(_gap)
-    subp 16, csr0
+    subp 16, mintDst
     mintArgDispatch()
 
 mintAlign(_tail_gap)
     break
 
 mintAlign(_tail_call)
-    break
+    jmp .ipint_perform_tail_call
 
 mintAlign(_call)
     pop wasmInstance, sc3 # sc3 = targetEntrypoint
@@ -4143,7 +4371,7 @@ mintAlign(_call)
     # reserved
     # reserved
     # argSP, PC
-    # PL, wasmInstance  <- csr0
+    # PL, wasmInstance  <- sc2
     # call frame return
     # call frame return
     # call frame
@@ -4151,8 +4379,8 @@ mintAlign(_call)
     # call frame
     # call frame        <- sp
 
-    loadi IPInt::CallReturnMetadata::stackFrameSize[MC], csr0
-    leap [sp, csr0], csr0
+    loadi IPInt::CallReturnMetadata::stackFrameSize[MC], sc2
+    leap [sp, sc2], sc2
 
     const mintRetSrc = csr1
     const mintRetDst = sc1
@@ -4161,7 +4389,7 @@ mintAlign(_call)
     advanceMC(IPInt::CallReturnMetadata::resultBytecode)
     leap [sp, csr1], mintRetSrc
 
-    loadp 3*MachineRegisterSize[csr0], mintRetDst # load argSP
+    loadp 3*MachineRegisterSize[sc2], mintRetDst # load argSP
 
     mintRetDispatch()
 
@@ -4254,7 +4482,7 @@ mintAlign(_end)
     # return result
     # return result     <- mintRetDst => new SP
     # argSP, PC
-    # PL, wasmInstance  <- csr0
+    # PL, wasmInstance  <- sc2
     # call frame return <- sp
     # call frame return
     # call frame
@@ -4263,9 +4491,9 @@ mintAlign(_end)
     # call frame
 
     # Restore PC, WI, PL
-    loadp 2*MachineRegisterSize[csr0], PC
+    loadp 2*MachineRegisterSize[sc2], PC
     # note: we don't care about argSP anymore
-    load2ia [csr0], wasmInstance, PL
+    load2ia [sc2], wasmInstance, PL
     move mintRetDst, sp
 
     push MC
@@ -4277,6 +4505,104 @@ mintAlign(_end)
         pcrtoaddr _ipint_unreachable, IB
     end)
     nextIPIntInstruction()
+
+.ipint_perform_tail_call:
+
+    #  <caller frame>
+    #  return val                  <- sc2
+    #  return val
+    #  argument
+    #  argument
+    #  argument
+    #  argument
+    #  call frame
+    #  call frame                  <- cfr
+    #  (IPInt locals)
+    #  (IPInt stack)
+    #  argument 0
+    #  ...
+    #  argument n-1
+    #  argument n                  <- mintSS
+    #  entrypoint, targetInstance
+    #  callee, function info
+    #  saved MC/PC
+    #  return address, saved CFR
+    #  stack arguments
+    #  stack arguments
+    #  stack arguments
+    #  stack arguments             <- sp
+
+    # load the size of stack values in, and subtract that from sc2
+    loadi [MC], sc3
+    mulp -SlotSize, sc3
+
+    # copy from sc2 downwards
+.ipint_tail_call_copy_stackargs_loop:
+    btiz sc3, .ipint_tail_call_copy_stackargs_loop_end
+    load2ia [sp], sc0, sc1
+    store2ia sc0, sc1, [sc2, sc3]
+    load2ia 8[sp], sc0, sc1
+    store2ia sc0, sc1, 8[sc2, sc3]
+
+    addp 16, sc3
+    addp 16, sp
+    jmp .ipint_tail_call_copy_stackargs_loop
+
+.ipint_tail_call_copy_stackargs_loop_end:
+
+    # reload it here, which isn't optimal, but we don't really have registers
+    loadi [MC], sc3
+    mulp SlotSize, sc3
+    subp sc3, sc2
+
+    # re-setup the call frame, and load our return address in
+    subp FirstArgumentOffset, sc2
+    pop sc1, lr
+
+    pop PC, MC
+
+    # function info, callee
+    pop sc3, sc0
+
+    # save new Callee
+    store2ia sc0, (constexpr JSValue::NativeCalleeTag), Callee[sc2]
+    storep sc3, CodeBlock[sc2]
+
+    # take off the last two values we stored, and move SP down to make it look like a fresh frame
+    pop sc0, sc3  # sc0 = targetInstance
+
+    #  <caller frame>
+    #  return val
+    #  return val
+    #  ...
+    #  argument
+    #  argument
+    #  argument
+    #  argument
+    #  argument                    <- cfr
+    #  argument
+    #  argument
+    #  <to be frame>
+    #  <to be frame>               <- NEW SP
+    #  <to be frame>               <- sc2
+    #  argument 0
+    #  ...
+    #  argument n-1
+    #  argument n                  <- sc1
+
+    # on ARM: lr = return address
+
+    move sc2, sp
+
+    # saved cfr
+    move sc1, cfr
+
+    # swap instances
+    move sc0, wasmInstance
+
+    addp CallerFrameAndPCSize, sp
+
+    jmp sc3, WasmEntryPtrTag
 
 ###########################################
 # uINT: function return value interpreter #


### PR DESCRIPTION
#### 0cc84c157b37a8b8af8103a668e597a66ff60850
<pre>
[JSC] Upstream partial ARMv7 port of InPlaceInterpreter 3/?
<a href="https://bugs.webkit.org/show_bug.cgi?id=292600">https://bugs.webkit.org/show_bug.cgi?id=292600</a>

Reviewed by Justin Michaud.

Implement tail-call instructions, fix some ref bugs, minor cleanup.

* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm:

Canonical link: <a href="https://commits.webkit.org/294784@main">https://commits.webkit.org/294784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4892db4279ef1b18fb18aefd88719855d887cd9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107455 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52930 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22271 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30469 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77838 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34828 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105300 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17240 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92341 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58176 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17074 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10369 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52288 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94965 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86899 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10439 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109829 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100903 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29426 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21694 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86819 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29790 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88540 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86408 "Found 102 new API test failures: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/javascript-dialogs, /TestWebKit:WebKit.DOMWindowExtensionCrashOnReload, /TestWebKit:WebKit.PageLoadBasic, /TestWebKit:WebKit.NewFirstVisuallyNonEmptyLayoutFails, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /TestWebKit:WebKit.InjectedBundleBasic, /TestWebKit:WebKit.PreventEmptyUserAgent, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/select-all/non-editable ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22130 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31218 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8935 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23668 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29354 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34649 "Failed to build and analyze WebKit") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124537 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29165 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34574 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32488 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30724 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->