### PR TITLE
WebCore::Path has unused single segment accessors

### DIFF
--- a/Source/WebCore/platform/graphics/Path.cpp
+++ b/Source/WebCore/platform/graphics/Path.cpp
@@ -390,105 +390,10 @@ std::optional<PathSegment> Path::singleSegment() const
 
 std::optional<PathDataLine> Path::singleDataLine() const
 {
-    if (auto segment = asSingle()) {
-        if (auto data = std::get_if<PathDataLine>(&segment->data()))
-            return *data;
+    if (auto segment = singleSegment()) {
+        if (auto* line = std::get_if<PathDataLine>(&segment->data()))
+            return *line;
     }
-
-    if (auto impl = asImpl())
-        return impl->singleDataLine();
-
-    return std::nullopt;
-}
-
-std::optional<PathRect> Path::singleRect() const
-{
-    if (auto segment = asSingle()) {
-        if (auto data = std::get_if<PathRect>(&segment->data()))
-            return *data;
-    }
-
-    if (auto impl = asImpl())
-        return impl->singleRect();
-
-    return std::nullopt;
-}
-
-std::optional<PathRoundedRect> Path::singleRoundedRect() const
-{
-    if (auto segment = asSingle()) {
-        if (auto data = std::get_if<PathRoundedRect>(&segment->data()))
-            return *data;
-    }
-
-    if (auto impl = asImpl())
-        return impl->singleRoundedRect();
-
-    return std::nullopt;
-}
-
-std::optional<PathContinuousRoundedRect> Path::singleContinuousRoundedRect() const
-{
-    if (auto segment = asSingle()) {
-        if (auto data = std::get_if<PathContinuousRoundedRect>(&segment->data()))
-            return *data;
-    }
-
-    if (auto impl = asImpl())
-        return impl->singleContinuousRoundedRect();
-
-    return std::nullopt;
-}
-
-std::optional<PathArc> Path::singleArc() const
-{
-    if (auto segment = asSingle()) {
-        if (auto data = std::get_if<PathArc>(&segment->data()))
-            return *data;
-    }
-
-    if (auto impl = asImpl())
-        return impl->singleArc();
-
-    return std::nullopt;
-}
-
-std::optional<PathClosedArc> Path::singleClosedArc() const
-{
-    if (auto segment = asSingle()) {
-        if (auto data = std::get_if<PathClosedArc>(&segment->data()))
-            return *data;
-    }
-
-    if (auto impl = asImpl())
-        return impl->singleClosedArc();
-
-    return std::nullopt;
-}
-
-std::optional<PathDataQuadCurve> Path::singleQuadCurve() const
-{
-    if (auto segment = asSingle()) {
-        if (auto data = std::get_if<PathDataQuadCurve>(&segment->data()))
-            return *data;
-    }
-
-    if (auto impl = asImpl())
-        return impl->singleQuadCurve();
-
-    return std::nullopt;
-}
-
-std::optional<PathDataBezierCurve> Path::singleBezierCurve() const
-{
-    if (auto segment = asSingle()) {
-        if (auto data = std::get_if<PathDataBezierCurve>(&segment->data()))
-            return *data;
-    }
-
-    if (auto impl = asImpl())
-        return impl->singleBezierCurve();
-
     return std::nullopt;
 }
 

--- a/Source/WebCore/platform/graphics/Path.h
+++ b/Source/WebCore/platform/graphics/Path.h
@@ -88,13 +88,6 @@ public:
 
     WEBCORE_EXPORT std::optional<PathSegment> singleSegment() const;
     std::optional<PathDataLine> singleDataLine() const;
-    std::optional<PathRect> singleRect() const;
-    std::optional<PathRoundedRect> singleRoundedRect() const;
-    std::optional<PathContinuousRoundedRect> singleContinuousRoundedRect() const;
-    std::optional<PathArc> singleArc() const;
-    std::optional<PathClosedArc> singleClosedArc() const;
-    std::optional<PathDataQuadCurve> singleQuadCurve() const;
-    std::optional<PathDataBezierCurve> singleBezierCurve() const;
 
     WEBCORE_EXPORT bool isEmpty() const;
     bool definitelySingleLine() const;

--- a/Source/WebCore/platform/graphics/PathImpl.h
+++ b/Source/WebCore/platform/graphics/PathImpl.h
@@ -76,14 +76,6 @@ public:
     virtual bool transform(const AffineTransform&) = 0;
 
     virtual std::optional<PathSegment> singleSegment() const { return std::nullopt; }
-    virtual std::optional<PathDataLine> singleDataLine() const { return std::nullopt; }
-    virtual std::optional<PathRect> singleRect() const { return std::nullopt; }
-    virtual std::optional<PathRoundedRect> singleRoundedRect() const { return std::nullopt; }
-    virtual std::optional<PathContinuousRoundedRect> singleContinuousRoundedRect() const { return std::nullopt; }
-    virtual std::optional<PathArc> singleArc() const { return std::nullopt; }
-    virtual std::optional<PathClosedArc> singleClosedArc() const { return std::nullopt; }
-    virtual std::optional<PathDataQuadCurve> singleQuadCurve() const { return std::nullopt; }
-    virtual std::optional<PathDataBezierCurve> singleBezierCurve() const { return std::nullopt; }
 
     virtual bool isEmpty() const = 0;
 

--- a/Source/WebCore/platform/graphics/PathStream.cpp
+++ b/Source/WebCore/platform/graphics/PathStream.cpp
@@ -225,57 +225,6 @@ std::optional<PathSegment> PathStream::singleSegment() const
     return m_segments.first();
 }
 
-template<class DataType>
-std::optional<DataType> PathStream::singleDataType() const
-{
-    const auto segment = singleSegment();
-    if (!segment)
-        return std::nullopt;
-    const auto data = std::get_if<DataType>(&segment->data());
-    if (!data)
-        return std::nullopt;
-    return *data;
-}
-
-std::optional<PathDataLine> PathStream::singleDataLine() const
-{
-    return singleDataType<PathDataLine>();
-}
-
-std::optional<PathRect> PathStream::singleRect() const
-{
-    return singleDataType<PathRect>();
-}
-
-std::optional<PathRoundedRect> PathStream::singleRoundedRect() const
-{
-    return singleDataType<PathRoundedRect>();
-}
-
-std::optional<PathContinuousRoundedRect> PathStream::singleContinuousRoundedRect() const
-{
-    return singleDataType<PathContinuousRoundedRect>();
-}
-
-std::optional<PathArc> PathStream::singleArc() const
-{
-    return singleDataType<PathArc>();
-}
-
-std::optional<PathClosedArc> PathStream::singleClosedArc() const
-{
-    return singleDataType<PathClosedArc>();
-}
-
-std::optional<PathDataQuadCurve> PathStream::singleQuadCurve() const
-{
-    return singleDataType<PathDataQuadCurve>();
-}
-
-std::optional<PathDataBezierCurve> PathStream::singleBezierCurve() const
-{
-    return singleDataType<PathDataBezierCurve>();
-}
 
 bool PathStream::isClosed() const
 {

--- a/Source/WebCore/platform/graphics/PathStream.h
+++ b/Source/WebCore/platform/graphics/PathStream.h
@@ -87,18 +87,7 @@ private:
 
     bool isPathStream() const final { return true; }
 
-    template<typename DataType>
-    std::optional<DataType> singleDataType() const;
-
     std::optional<PathSegment> singleSegment() const final;
-    std::optional<PathDataLine> singleDataLine() const final;
-    std::optional<PathRect> singleRect() const final;
-    std::optional<PathRoundedRect> singleRoundedRect() const final;
-    std::optional<PathContinuousRoundedRect> singleContinuousRoundedRect() const final;
-    std::optional<PathArc> singleArc() const final;
-    std::optional<PathClosedArc> singleClosedArc() const final;
-    std::optional<PathDataQuadCurve> singleQuadCurve() const final;
-    std::optional<PathDataBezierCurve> singleBezierCurve() const final;
 
     bool isEmpty() const final { return m_segments.isEmpty(); }
 


### PR DESCRIPTION
#### 65a3cb0ce3177821ec9ab4b00e4000894093151b
<pre>
WebCore::Path has unused single segment accessors
<a href="https://bugs.webkit.org/show_bug.cgi?id=292601">https://bugs.webkit.org/show_bug.cgi?id=292601</a>
<a href="https://rdar.apple.com/150753635">rdar://150753635</a>

Reviewed by Simon Fraser.

Remove the unused functions.

* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::singleDataLine const):
(WebCore::Path::singleRect const): Deleted.
(WebCore::Path::singleRoundedRect const): Deleted.
(WebCore::Path::singleContinuousRoundedRect const): Deleted.
(WebCore::Path::singleArc const): Deleted.
(WebCore::Path::singleClosedArc const): Deleted.
(WebCore::Path::singleQuadCurve const): Deleted.
(WebCore::Path::singleBezierCurve const): Deleted.
* Source/WebCore/platform/graphics/Path.h:
* Source/WebCore/platform/graphics/PathImpl.h:
(WebCore::PathImpl::singleSegment const):
(WebCore::PathImpl::singleDataLine const): Deleted.
(WebCore::PathImpl::singleRect const): Deleted.
(WebCore::PathImpl::singleRoundedRect const): Deleted.
(WebCore::PathImpl::singleContinuousRoundedRect const): Deleted.
(WebCore::PathImpl::singleArc const): Deleted.
(WebCore::PathImpl::singleClosedArc const): Deleted.
(WebCore::PathImpl::singleQuadCurve const): Deleted.
(WebCore::PathImpl::singleBezierCurve const): Deleted.
* Source/WebCore/platform/graphics/PathStream.cpp:
(WebCore::PathStream::singleDataType const): Deleted.
(WebCore::PathStream::singleDataLine const): Deleted.
(WebCore::PathStream::singleRect const): Deleted.
(WebCore::PathStream::singleRoundedRect const): Deleted.
(WebCore::PathStream::singleContinuousRoundedRect const): Deleted.
(WebCore::PathStream::singleArc const): Deleted.
(WebCore::PathStream::singleClosedArc const): Deleted.
(WebCore::PathStream::singleQuadCurve const): Deleted.
(WebCore::PathStream::singleBezierCurve const): Deleted.
* Source/WebCore/platform/graphics/PathStream.h:

Canonical link: <a href="https://commits.webkit.org/294606@main">https://commits.webkit.org/294606@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68d1ac7ef1dcb3a87aefc99c4afb7d1e6a6c8e81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107515 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52990 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104393 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22331 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30529 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77878 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34871 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105360 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92396 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58216 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17128 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10424 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52348 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86953 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10495 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109890 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29486 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86861 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29850 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88592 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86451 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22007 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31271 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8987 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23728 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29414 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34710 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29225 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32548 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30784 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->