### PR TITLE
Remove GraphicsContextFiltersEnabled preference

### DIFF
--- a/LayoutTests/css3/filters/drop-shadow-child-clipped.html
+++ b/LayoutTests/css3/filters/drop-shadow-child-clipped.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ GraphicsContextFiltersEnabled=true ] -->
 <style>
     .container {
         width: 135px;

--- a/LayoutTests/css3/filters/drop-shadow-target-clipped.html
+++ b/LayoutTests/css3/filters/drop-shadow-target-clipped.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ GraphicsContextFiltersEnabled=true ] -->
 <style>
     .box {
         width: 300px;

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3327,22 +3327,6 @@ GoogleAntiFlickerOptimizationQuirkEnabled:
     WebCore:
       default: true
 
-GraphicsContextFiltersEnabled:
-   type: bool
-   status: stable
-   category: media
-   webcoreOnChange: setNeedsRelayoutAllFrames
-   humanReadableName: "GraphicsContext Filter Rendering"
-   humanReadableDescription: "GraphicsContext Filter Rendering"
-   condition: USE(GRAPHICS_CONTEXT_FILTERS)
-   defaultValue:
-     WebKitLegacy:
-       default: true
-     WebKit:
-       default: true
-     WebCore:
-       default: true
-
 HTTPEquivEnabled:
   type: bool
   status: mature

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4719,8 +4719,7 @@ OptionSet<FilterRenderingMode> Page::preferredFilterRenderingModes() const
         modes.add(FilterRenderingMode::Accelerated);
 #endif
 #if USE(GRAPHICS_CONTEXT_FILTERS)
-    if (settings().graphicsContextFiltersEnabled())
-        modes.add(FilterRenderingMode::GraphicsContext);
+    modes.add(FilterRenderingMode::GraphicsContext);
 #endif
     return modes;
 }


### PR DESCRIPTION
#### 6af6814a19e8bb9ebce6453af4a8c76f6d5447c2
<pre>
Remove GraphicsContextFiltersEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=292602">https://bugs.webkit.org/show_bug.cgi?id=292602</a>

Reviewed by Said Abou-Hallawa.

It&apos;s been enabled for a year and a half on main.

Canonical link: <a href="https://commits.webkit.org/294623@main">https://commits.webkit.org/294623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6753cbc1b28bc40a1aa9fa3ca9fc5efc008fe10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12281 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107459 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52934 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104337 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22275 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30473 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77846 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34831 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105304 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17245 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92346 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58184 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17079 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10374 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52292 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/94969 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86904 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10444 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109833 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/100907 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29430 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21698 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86825 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29794 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88545 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86414 "Found 102 new API test failures: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/javascript-dialogs, /TestWebKit:WebKit.DOMWindowExtensionCrashOnReload, /TestWebKit:WebKit.PageLoadBasic, /TestWebKit:WebKit.NewFirstVisuallyNonEmptyLayoutFails, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /TestWebKit:WebKit.InjectedBundleBasic, /TestWebKit:WebKit.PreventEmptyUserAgent, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/select-all/non-editable ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31222 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8940 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23672 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16647 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29358 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34653 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124541 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29169 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34575 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32492 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30728 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->