### PR TITLE
2D context stroke, fill color parsing spends time resolving script execution context

### DIFF
--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp
@@ -889,7 +889,7 @@ Color consumeColorRaw(CSSParserTokenRange& range, CSS::PropertyParserState& prop
 
 // MARK: - Raw parsing entry points
 
-Color parseColorRawSlow(const String& string, const CSSParserContext& context, ScriptExecutionContext& scriptExecutionContext, const CSSColorParsingOptions& options, CSS::PlatformColorResolutionState& eagerResolutionState)
+Color parseColorRawGeneral(const String& string, const CSSParserContext& context, ScriptExecutionContext& scriptExecutionContext, const CSSColorParsingOptions& options, CSS::PlatformColorResolutionState& eagerResolutionState)
 {
     CSSTokenizer tokenizer(string);
     CSSParserTokenRange range(tokenizer.tokenRange());

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.h
@@ -66,10 +66,18 @@ RefPtr<CSSValue> consumeColor(CSSParserTokenRange&, CSS::PropertyParserState&, c
 WebCore::Color consumeColorRaw(CSSParserTokenRange&, CSS::PropertyParserState&, const CSSColorParsingOptions&, CSS::PlatformColorResolutionState&);
 
 // MARK: <color> parsing (raw)
-WEBCORE_EXPORT WebCore::Color parseColorRawSlow(const String&, const CSSParserContext&, ScriptExecutionContext&, const CSSColorParsingOptions&, CSS::PlatformColorResolutionState&);
 
+// Parse with default options.
 // NOTE: Callers must include CSSPropertyParserConsumer+ColorInlines.h to use this.
-template<typename F> WebCore::Color parseColorRaw(const String&, const CSSParserContext&, ScriptExecutionContext&, NOESCAPE const F& lazySlowPathOptionsFunctor);
+WebCore::Color parseColorRaw(const String&, const CSSParserContext&, ScriptExecutionContext&);
+
+// Fast variant to be used when ScriptExecutionContext is expensive to obtain or when need to pass parsing options.
+// If the result is invalid, callers should call parseColorRawGeneral().
+// NOTE: Callers must include CSSPropertyParserConsumer+ColorInlines.h to use this.
+WebCore::Color parseColorRawSimple(const String&, const CSSParserContext&);
+
+// Parse with specific options.
+WEBCORE_EXPORT WebCore::Color parseColorRawGeneral(const String&, const CSSParserContext&, ScriptExecutionContext&, const CSSColorParsingOptions&, CSS::PlatformColorResolutionState&);
 
 // FIXME: All callers are not getting the right Settings, keyword resolution and calc resolution
 // when using this function and should switch to parseColorRaw().

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorInlines.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorInlines.h
@@ -33,21 +33,18 @@ namespace CSSPropertyParserHelpers {
 
 // MARK: <color> parsing (raw)
 
-template<typename F> WebCore::Color parseColorRaw(const String& string, const CSSParserContext& context, ScriptExecutionContext& scriptExecutionContext, NOESCAPE const F& lazySlowPathOptionsFunctor)
+inline WebCore::Color parseColorRawSimple(const String& string, const CSSParserContext& context)
 {
-    if (auto color = CSSParserFastPaths::parseSimpleColor(string, context))
-        return *color;
+    return CSSParserFastPaths::parseSimpleColor(string, context);
+}
 
-    // To avoid doing anything unnecessary before the fast path can run, callers bundle up
-    // a functor to generate the slow path parameters.
-    auto [options, eagerResolutionState, eagerResolutionDelegate] = lazySlowPathOptionsFunctor();
-
-    // If a delegate is provided, hook it up to the context here. By having it live on the stack,
-    // we avoid allocating it.
-    if (eagerResolutionDelegate)
-        eagerResolutionState.delegate = &eagerResolutionDelegate.value();
-
-    return parseColorRawSlow(string, context, scriptExecutionContext, options, eagerResolutionState);
+inline WebCore::Color parseColorRaw(const String& string, const CSSParserContext& context, ScriptExecutionContext& scriptExecutionContext)
+{
+    auto color = parseColorRawSimple(string, context);
+    if (color.isValid())
+        return color;
+    CSS::PlatformColorResolutionState state;
+    return parseColorRawGeneral(string, context, scriptExecutionContext, { }, state);
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2295,21 +2295,14 @@ ExceptionOr<void> Internals::setViewBaseBackgroundColor(const String& colorValue
     return Exception { ExceptionCode::SyntaxError };
 }
 
-using LazySlowPathColorParsingParameters = std::tuple<
-    CSSPropertyParserHelpers::CSSColorParsingOptions,
-    CSS::PlatformColorResolutionState,
-    std::optional<CSS::PlatformColorResolutionDelegate>
->;
-
 ExceptionOr<void> Internals::setUnderPageBackgroundColorOverride(const String& colorValue)
 {
     Document* document = contextDocument();
     if (!document || !document->page())
         return Exception { ExceptionCode::InvalidAccessError };
 
-    auto color = CSSPropertyParserHelpers::parseColorRaw(colorValue, document->cssParserContext(), *document, [] {
-        return LazySlowPathColorParsingParameters { { }, { }, std::nullopt };
-    });
+    auto cssParserContext = document->cssParserContext();
+    auto color = CSSPropertyParserHelpers::parseColorRaw(colorValue, cssParserContext, *document);
     if (!color.isValid())
         return Exception { ExceptionCode::SyntaxError };
 


### PR DESCRIPTION
#### 48f94876ce2f2aa91bdbc15afbd8672bbfd509b4
<pre>
2D context stroke, fill color parsing spends time resolving script execution context
<a href="https://bugs.webkit.org/show_bug.cgi?id=292604">https://bugs.webkit.org/show_bug.cgi?id=292604</a>
<a href="https://rdar.apple.com/150757978">rdar://150757978</a>

Reviewed by Simon Fraser.

General parsing CSS colors needs the CSS value pool from script
execution context. The fast path does not need this, but 2D context
code would resolve the context anyway. For significant number of
strokeStyle/fillStyle assignments, this would result in significant
amount of work.

Simplify the fast/slow path invocation by exposing the specific fast
path function. There&apos;s only few call sites and the previous functor
based approach resulted in more complex and less efficient code.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp:
(WebCore::CSSPropertyParserHelpers::parseColorRaw):
(WebCore::CSSPropertyParserHelpers::parseColorRawSlow): Deleted.
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorInlines.h:
(WebCore::CSSPropertyParserHelpers::parseColorRawFast):
(WebCore::CSSPropertyParserHelpers::parseColorRaw):
* Source/WebCore/html/ColorInputType.cpp:
(WebCore::parseColorValue):
(WebCore::colorParsingParameters): Deleted.
* Source/WebCore/html/canvas/CanvasStyle.cpp:
(WebCore::CanvasStyleColorResolutionDelegate::currentColor const):
(WebCore::parseColor):
(WebCore::elementlessColorParsingParameters): Deleted.
(WebCore::colorParsingParameters): Deleted.
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setUnderPageBackgroundColorOverride):

Canonical link: <a href="https://commits.webkit.org/294607@main">https://commits.webkit.org/294607@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ad7efa3d8f96d7e2f4829fdbbfc5d7023630d13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102358 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22027 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107519 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52994 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104397 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30533 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77883 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34873 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105364 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17296 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92399 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58221 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17131 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10427 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52352 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86955 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10498 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109894 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29490 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21743 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86870 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29854 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86461 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22006 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31273 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8989 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23732 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29418 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34721 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29229 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32552 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30788 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->