### PR TITLE
Need a short description (OOPS!).

### DIFF
--- a/LayoutTests/accessibility/password-notifications-timing-expected.txt
+++ b/LayoutTests/accessibility/password-notifications-timing-expected.txt
@@ -1,0 +1,20 @@
+This test ensures that password notifications are spaced out in time in no less than a prefixed interval.
+
+AXValue:  length: 9
+notification: AXValueChanged after 40ms
+PASS: elapsed >= interval === true
+notification: AXValueChanged after 0ms
+FAIL: elapsed >= interval !== true, was false
+notification: AXValueChanged after 0ms
+FAIL: elapsed >= interval !== true, was false
+notification: AXValueChanged after 12ms
+FAIL: elapsed >= interval !== true, was false
+notification: AXValueChanged after 25ms
+FAIL: elapsed >= interval !== true, was false
+notification: AXValueChanged after 26ms
+FAIL: elapsed >= interval !== true, was false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/password-notifications-timing.html
+++ b/LayoutTests/accessibility/password-notifications-timing.html
@@ -1,0 +1,61 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+
+<input type="password" id="password-field">
+
+<script>
+var output = "This test ensures that password notifications are spaced out in time in no less than a prefixed interval.\n\n";
+
+var notificationsCount = 0;
+var lastNotificationTime = Date.now();
+var interval = 40; // Notifications shouldn't come in less than this amount of milliseconds.
+function notificationCallback(notification) {
+    if (notification != "AXValueChanged" && notification != "AXSelectedTextChanged")
+        return;
+
+    now = Date.now();
+    elapsed = now - lastNotificationTime;
+    lastNotificationTime = now;
+
+    output += `notification: ${notification} after ${elapsed}ms\n`;
+    output += expect("elapsed >= interval", "true");
+
+    if (++notificationsCount == 6) {
+        debug(output);
+        finishJSTest();
+    }
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    document.getElementById("password-field").focus();
+    var field = accessibilityController.accessibleElementById("password-field");
+    field.addNotificationListener(notificationCallback);
+
+    var value = field.stringValue;
+    var valueLength = value.length;
+    output += `${value} length: ${valueLength}\n`;
+//    setTimeout(async () => {
+        UIHelper.typeCharacter("a");
+        UIHelper.typeCharacter("b");
+        UIHelper.typeCharacter("c");
+
+//        await waitFor(() => {
+//            return notificationsCount == 3 && field.stringValue.length == valueLength + 3;
+//        });
+//        value = field.stringValue;
+//        output += `${value} length: ${value.length}\n`;
+
+//        debug(output);
+//        finishJSTest();
+//    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -147,7 +147,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(AXObjectCache);
 using namespace HTMLNames;
 
 #if PLATFORM(COCOA)
-// Post value change notifications for password fields or elements contained in password fields at a 40hz interval to thwart analysis of typing cadence
+// Post notifications for secure fields or elements contained in secure fields at a 40hz interval to thwart analysis of typing cadence.
 static const Seconds accessibilityPasswordValueChangeNotificationInterval { 25_ms };
 #endif
 
@@ -2522,60 +2522,45 @@ bool AXObjectCache::enqueuePasswordNotification(AccessibilityObject& object, AXT
 
     m_passwordNotifications.append({ *observableObject, secureContext(*observableObject, context) });
     if (!m_passwordNotificationTimer.isActive())
-        m_passwordNotificationTimer.startOneShot(accessibilityPasswordValueChangeNotificationInterval);
+        m_passwordNotificationTimer.startRepeating(accessibilityPasswordValueChangeNotificationInterval);
 
     return true;
 }
 
 void AXObjectCache::passwordNotificationTimerFired()
 {
-    m_passwordNotificationTimer.stop();
+    if (m_passwordNotifications.isEmpty()) {
+        m_passwordNotificationTimer.stop();
+        return;
+    }
 
-    // In tests, posting notifications has a tendency to immediately queue up other notifications, which can lead to unexpected behavior
-    // when the notification list is cleared at the end. Instead copy this list at the start.
-    auto passwordNotifications = std::exchange(m_passwordNotifications, { });
-
+    auto notification = m_passwordNotifications.takeFirst();
+    auto& context = notification.second;
+    switch (context.intent.type) {
+    case AXTextStateChangeTypeUnknown:
+        // FIXME: should we get rid of this enumerator?
+    case AXTextStateChangeTypeEdit:
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    Vector<std::pair<Ref<AccessibilityObject>, AXNotification>> notifications;
-    for (const auto& note : passwordNotifications) {
-        switch (note.second.intent.type) {
-        case AXTextStateChangeTypeEdit:
-            notifications.append({ note.first, AXNotification::ValueChanged });
-            break;
-        case AXTextStateChangeTypeSelectionMove:
-        case AXTextStateChangeTypeSelectionExtend:
-        case AXTextStateChangeTypeSelectionBoundary:
-            notifications.append({ note.first, AXNotification::SelectedTextChanged });
-            break;
-        case AXTextStateChangeTypeUnknown:
-            break;
-        };
-    }
-    updateIsolatedTree(notifications);
-#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-
-    for (const auto& note : passwordNotifications) {
-        auto& context = note.second;
-        switch (context.intent.type) {
-        case AXTextStateChangeTypeEdit:
-            if (context.intent.editType == AXTextEditTypeReplace) {
-                postTextReplacementPlatformNotification(note.first.ptr(),
-                    AXTextEditTypeDelete, context.deletedText, AXTextEditTypeInsert, context.insertedText, context.selection.start());
-            } else {
-                postTextStateChangePlatformNotification(note.first.ptr(),
-                    context.intent.editType, context.insertedText, context.selection.start());
-            }
-            break;
-        case AXTextStateChangeTypeSelectionMove:
-        case AXTextStateChangeTypeSelectionExtend:
-        case AXTextStateChangeTypeSelectionBoundary:
-            postTextSelectionChangePlatformNotification(note.first.ptr(),
-                context.intent, context.selection);
-            break;
-        case AXTextStateChangeTypeUnknown:
-            break;
-        };
-    }
+        updateIsolatedTree(notification.first, AXNotification::ValueChanged);
+#endif
+        if (context.intent.editType == AXTextEditTypeReplace) {
+            postTextReplacementPlatformNotification(notification.first.ptr(),
+                AXTextEditTypeDelete, context.deletedText, AXTextEditTypeInsert, context.insertedText, context.selection.start());
+        } else {
+            postTextStateChangePlatformNotification(notification.first.ptr(),
+                context.intent.editType, context.insertedText, context.selection.start());
+        }
+        break;
+    case AXTextStateChangeTypeSelectionMove:
+    case AXTextStateChangeTypeSelectionExtend:
+    case AXTextStateChangeTypeSelectionBoundary:
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+        updateIsolatedTree(notification.first, AXNotification::SelectedTextChanged);
+#endif
+        postTextSelectionChangePlatformNotification(notification.first.ptr(),
+            context.intent, context.selection);
+        break;
+    };
 }
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -37,6 +37,7 @@
 #include "VisibleUnits.h"
 #include <limits.h>
 #include <wtf/Compiler.h>
+#include <wtf/Deque.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/ListHashSet.h>
@@ -861,7 +862,7 @@ private:
 
 #if PLATFORM(COCOA)
     Timer m_passwordNotificationTimer;
-    Vector<std::pair<Ref<AccessibilityObject>, AXTextChangeContext>> m_passwordNotifications;
+    Deque<std::pair<Ref<AccessibilityObject>, AXTextChangeContext>> m_passwordNotifications;
 #endif
 
     Timer m_liveRegionChangedPostTimer;


### PR DESCRIPTION
#### f36b62ac1642a887072a4b528b38c2d13da0f90d
<pre>
Need a short description (OOPS!).
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f36b62ac1642a887072a4b528b38c2d13da0f90d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12294 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107472 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52947 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104350 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22288 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30486 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77852 "Found 1 new test failure: accessibility/password-notifications-timing.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34839 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17258 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92357 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58190 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17092 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10385 "Found 1 new test failure: accessibility/password-notifications-timing.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52305 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86917 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10455 "Found 1 new test failure: accessibility/password-notifications-timing.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109847 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29443 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21709 "Found 1 new test failure: accessibility/password-notifications-timing.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86833 "Found 1 new test failure: accessibility/password-notifications-timing.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29807 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88553 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86422 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31234 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8950 "Found 1 new test failure: accessibility/password-notifications-timing.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23685 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29371 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34666 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29182 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32505 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30741 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->