### PR TITLE
[WPE][GStreamer] Support for client-side audio rendering

### DIFF
--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -62,6 +62,9 @@ SpeechSynthesis::SpeechSynthesis(ScriptExecutionContext& context)
     , m_isPaused(false)
     , m_restrictions({ })
     , m_speechSynthesisClient(nullptr)
+#if USE(GSTREAMER) && ENABLE(WPE_PLATFORM)
+    , m_context(context)
+#endif
 {
     if (auto* document = dynamicDowncast<Document>(context)) {
 #if PLATFORM(IOS_FAMILY)
@@ -311,6 +314,38 @@ void SpeechSynthesis::boundaryEventOccurred(bool wordBoundary, unsigned charInde
         return;
     boundaryEventOccurred(currentSpeechUtterance()->platformUtterance(), wordBoundary ? SpeechBoundary::SpeechWordBoundary : SpeechBoundary::SpeechSentenceBoundary, charIndex, charLength);
 }
+
+#if USE(GSTREAMER) && ENABLE(WPE_PLATFORM)
+String SpeechSynthesis::requestAudioSinkSocket()
+{
+    Ref protectedContext = { *m_context };
+    RefPtr document = dynamicDowncast<Document>(protectedContext);
+    if (!document)
+        return emptyString();
+
+    return document->frame()->page()->requestAudioSinkSocket();
+}
+
+void SpeechSynthesis::audioSinkStarted(const String& path)
+{
+    Ref protectedContext = { *m_context };
+    RefPtr document = dynamicDowncast<Document>(protectedContext);
+    if (!document)
+        return;
+
+    document->frame()->page()->audioSinkStarted(path);
+}
+
+void SpeechSynthesis::audioSinkStopped(const String& path)
+{
+    Ref protectedContext = { *m_context };
+    RefPtr document = dynamicDowncast<Document>(protectedContext);
+    if (!document)
+        return;
+
+    document->frame()->page()->audioSinkStopped(path);
+}
+#endif
 
 void SpeechSynthesis::voicesChanged()
 {

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.h
@@ -89,6 +89,11 @@ private:
     void didFinishSpeaking(PlatformSpeechSynthesisUtterance&) override;
     void speakingErrorOccurred(PlatformSpeechSynthesisUtterance&) override;
     void boundaryEventOccurred(PlatformSpeechSynthesisUtterance&, SpeechBoundary, unsigned charIndex, unsigned charLength) override;
+#if USE(GSTREAMER) && ENABLE(WPE_PLATFORM)
+    String requestAudioSinkSocket() override;
+    void audioSinkStarted(const String&) override;
+    void audioSinkStopped(const String&) override;
+#endif
 
     // SpeechSynthesisClientObserver
     void didStartSpeaking() override;
@@ -126,6 +131,10 @@ private:
     BehaviorRestrictions m_restrictions;
     WeakPtr<SpeechSynthesisClient> m_speechSynthesisClient;
     bool m_hasEventListener { false };
+
+#if USE(GSTREAMER) && ENABLE(WPE_PLATFORM)
+    WeakPtr<ScriptExecutionContext> m_context;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp
@@ -40,6 +40,7 @@
 #include "AudioWorkletMessagingProxy.h"
 #include "AudioWorkletThread.h"
 #include "DenormalDisabler.h"
+#include "Page.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -125,6 +126,47 @@ void AudioDestinationNode::deref() const
 {
     context().deref();
 }
+
+#if USE(GSTREAMER) && ENABLE(WPE_PLATFORM)
+String AudioDestinationNode::requestAudioSinkSocket()
+{
+    auto document = context().document();
+    if (!document)
+        return emptyString();
+
+    RefPtr page = protect(document->page());
+    if (!page)
+        return emptyString();
+
+    return page->requestAudioSinkSocket();
+}
+
+void AudioDestinationNode::audioSinkStarted(const String& path)
+{
+    auto document = context().document();
+    if (!document)
+        return;
+
+    RefPtr page = protect(document->page());
+    if (!page)
+        return;
+
+    page->audioSinkStarted(path);
+}
+
+void AudioDestinationNode::audioSinkStopped(const String& path)
+{
+    auto document = context().document();
+    if (!document)
+        return;
+
+    RefPtr page = protect(document->page());
+    if (!page)
+        return;
+
+    page->audioSinkStopped(path);
+}
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/webaudio/AudioDestinationNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioDestinationNode.h
@@ -64,6 +64,12 @@ public:
     virtual void setSceneIdentifier(const String&) { }
 #endif
 
+#if USE(GSTREAMER) && ENABLE(WPE_PLATFORM)
+    String requestAudioSinkSocket();
+    void audioSinkStarted(const String&);
+    void audioSinkStopped(const String&);
+#endif
+
 protected:
     AudioDestinationNode(BaseAudioContext&, float sampleRate);
 

--- a/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp
@@ -119,11 +119,22 @@ void DefaultAudioDestinationNode::createDestination()
 {
     ALWAYS_LOG(LOGIDENTIFIER, "contextSampleRate = ", sampleRate(), ", hardwareSampleRate = ", AudioDestination::hardwareSampleRate());
     ASSERT(!m_destination);
+#if USE(GSTREAMER) && ENABLE(WPE_PLATFORM)
+    AudioSinkStartedCallback audioSinkStartedCallback = [&](const auto& path) {
+        audioSinkStarted(path);
+    };
+    AudioSinkDisposedCallback audioSinkStoppedCallback = [&](const auto& path) {
+        audioSinkStopped(path);
+    };
+#endif
     m_destination = platformStrategies()->mediaStrategy()->createAudioDestination({ *this, m_inputDeviceId, m_numberOfInputChannels, channelCount(), sampleRate()
 #if PLATFORM(IOS_FAMILY)
         , context().sceneIdentifier()
 #endif
-        });
+#if USE(GSTREAMER) && ENABLE(WPE_PLATFORM)
+        , requestAudioSinkSocket(), audioSinkStartedCallback, audioSinkStoppedCallback
+#endif
+    });
 }
 
 void DefaultAudioDestinationNode::recreateDestination()

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -10515,6 +10515,35 @@ void HTMLMediaElement::setScreenReserved(bool reserved)
 }
 #endif
 
+#if USE(GSTREAMER) && ENABLE(WPE_PLATFORM)
+String HTMLMediaElement::requestAudioSinkSocket()
+{
+    auto page = protect(document().page());
+    if (!page)
+        return emptyString();
+
+    return page->requestAudioSinkSocket();
+}
+
+void HTMLMediaElement::audioSinkStarted(const String& path)
+{
+    auto page = protect(document().page());
+    if (!page)
+        return;
+
+    page->audioSinkStarted(path);
+}
+
+void HTMLMediaElement::audioSinkStopped(const String& path)
+{
+    auto page = protect(document().page());
+    if (!page)
+        return;
+
+    page->audioSinkStopped(path);
+}
+#endif // USE(GSTREAMER) && ENABLE(WPE_PLATFORM)
+
 } // namespace WebCore
 
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1195,6 +1195,12 @@ private:
     void setScreenReserved(bool);
 #endif
 
+#if USE(GSTREAMER) && ENABLE(WPE_PLATFORM)
+    String requestAudioSinkSocket() final;
+    void audioSinkStarted(const String&) final;
+    void audioSinkStopped(const String&) final;
+#endif
+
     Timer m_progressEventTimer;
     Timer m_playbackProgressTimer;
     Timer m_scanTimer;

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -801,6 +801,12 @@ public:
     virtual void foreachRegionInDamageHistoryForTesting(Function<void(const Region&)>&&) const { }
 #endif
 
+#if ENABLE(WPE_PLATFORM)
+    virtual String requestAudioSinkSocket() { return emptyString(); }
+    virtual void audioSinkStarted(const String &) { }
+    virtual void audioSinkStopped(const String &) { }
+#endif
+
     virtual bool usePluginRendererScrollableArea(LocalFrame&) const { return true; }
 
 #if ENABLE(VIDEO)

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -6006,6 +6006,23 @@ void Page::clearIsShowingInputView()
 }
 #endif
 
+#if ENABLE(WPE_PLATFORM)
+String Page::requestAudioSinkSocket()
+{
+    return m_chrome->client().requestAudioSinkSocket();
+}
+
+void Page::audioSinkStarted(const String& path)
+{
+    m_chrome->client().audioSinkStarted(path);
+}
+
+void Page::audioSinkStopped(const String& path)
+{
+    m_chrome->client().audioSinkStopped(path);
+}
+#endif
+
 #if HAVE(SUPPORT_HDR_DISPLAY)
 bool Page::drawsHDRContent() const
 {

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1372,6 +1372,12 @@ public:
     bool requiresUserGestureForAudioPlayback() const;
     bool requiresUserGestureForVideoPlayback() const;
 
+#if ENABLE(WPE_PLATFORM)
+    String requestAudioSinkSocket();
+    void audioSinkStarted(const String&);
+    void audioSinkStopped(const String&);
+#endif
+
 #if HAVE(SUPPORT_HDR_DISPLAY)
     WEBCORE_EXPORT bool drawsHDRContent() const;
     Headroom displayEDRHeadroom() const { return m_displayEDRHeadroom; }

--- a/Source/WebCore/platform/PlatformSpeechSynthesizer.h
+++ b/Source/WebCore/platform/PlatformSpeechSynthesizer.h
@@ -65,6 +65,11 @@ public:
     virtual void speakingErrorOccurred(PlatformSpeechSynthesisUtterance&) = 0;
     virtual void boundaryEventOccurred(PlatformSpeechSynthesisUtterance&, SpeechBoundary, unsigned charIndex, unsigned charLength) = 0;
     virtual void voicesDidChange() = 0;
+#if USE(GSTREAMER) && ENABLE(WPE_PLATFORM)
+    virtual String requestAudioSinkSocket() = 0;
+    virtual void audioSinkStarted(const String&) = 0;
+    virtual void audioSinkStopped(const String&) = 0;
+#endif
 protected:
     virtual ~PlatformSpeechSynthesizerClient() = default;
 };

--- a/Source/WebCore/platform/audio/AudioDestination.h
+++ b/Source/WebCore/platform/audio/AudioDestination.h
@@ -46,6 +46,11 @@ namespace WebCore {
 // The audio hardware periodically calls the AudioIOCallback render() method asking it to render/output the next render quantum of audio.
 // It optionally will pass in local/live audio input when it calls render().
 
+#if USE(GSTREAMER) && ENABLE(WPE_PLATFORM)
+using AudioSinkStartedCallback = Function<void(const String&)>;
+using AudioSinkDisposedCallback = Function<void(const String&)>;
+#endif
+
 struct AudioDestinationCreationOptions {
     AudioIOCallback& callback;
     const String& inputDeviceId;
@@ -54,6 +59,11 @@ struct AudioDestinationCreationOptions {
     float sampleRate;
 #if PLATFORM(IOS_FAMILY)
     const String& sceneIdentifier;
+#endif
+#if USE(GSTREAMER) && ENABLE(WPE_PLATFORM)
+    const String& audioSinkSocketPath;
+    AudioSinkStartedCallback& audioSinkStarted;
+    AudioSinkDisposedCallback& audioSinkStopped;
 #endif
 };
 

--- a/Source/WebCore/platform/audio/SharedAudioDestination.cpp
+++ b/Source/WebCore/platform/audio/SharedAudioDestination.cpp
@@ -137,6 +137,11 @@ SharedAudioDestinationAdapter::SharedAudioDestinationAdapter(const CreationOptio
 #if PLATFORM(IOS_FAMILY)
         , options.sceneIdentifier.isNull() ? emptyString() : options.sceneIdentifier
 #endif
+#if USE(GSTREAMER) && ENABLE(WPE_PLATFORM)
+        , options.audioSinkSocketPath
+        , options.audioSinkStarted
+        , options.audioSinkStopped
+#endif
         }) }
     , m_workBus { AudioBus::create(options.numberOfOutputChannels, AudioUtilities::renderQuantumSize) }
     , m_ensureFunction { WTF::move(ensureFunction) }

--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
@@ -27,6 +27,7 @@
 #include "AudioUtilities.h"
 #include "GStreamerCommon.h"
 #include "GStreamerQuirks.h"
+#include "WebKitAudioSinkGStreamer.h"
 #include "WebKitWebAudioSourceGStreamer.h"
 #include <gst/audio/gstaudiobasesink.h>
 #include <gst/gst.h>
@@ -119,6 +120,11 @@ unsigned long AudioDestination::maxChannelCount()
 AudioDestinationGStreamer::AudioDestinationGStreamer(const CreationOptions& options)
     : AudioDestination(options)
     , m_renderBus(AudioBus::create(options.numberOfOutputChannels, AudioUtilities::renderQuantumSize, false))
+#if ENABLE(WPE_PLATFORM)
+    , m_audioSinkStartedCallback(WTF::move(options.audioSinkStarted))
+    , m_audioSinkStoppedCallback(WTF::move(options.audioSinkStopped))
+    , m_audioSinkSocketPath(options.audioSinkSocketPath)
+#endif
 {
 }
 
@@ -156,7 +162,24 @@ void AudioDestinationGStreamer::initializePipeline()
     webkitWebAudioSourceSetDestination(WEBKIT_WEB_AUDIO_SRC(m_src.get()), this);
 
     auto& quirksManager = GStreamerQuirksManager::singleton();
-    GRefPtr<GstElement> audioSink = quirksManager.createWebAudioSink();
+    GRefPtr<GstElement> audioSink;
+#if ENABLE(WPE_PLATFORM)
+    if (!m_audioSinkSocketPath.isEmpty())
+        audioSink = createPlatformAudioSink("music"_s, { }, nullptr, m_audioSinkSocketPath.isolatedCopy());
+    if (WEBKIT_IS_AUDIO_SINK(audioSink.get()) && !m_audioSinkSocketPath.isEmpty()) {
+        webkitAudioSinkSetStartedCallback(WEBKIT_AUDIO_SINK(audioSink.get()), [&](const auto& path) {
+            m_audioSinkStartedCallback(path);
+        });
+        webkitAudioSinkSetStoppedCallback(WEBKIT_AUDIO_SINK(audioSink.get()), [&](const auto& path) {
+            m_audioSinkStoppedCallback(path);
+        });
+    }
+#endif
+    if (!audioSink)
+        audioSink = quirksManager.createWebAudioSink();
+    if (!audioSink)
+        audioSink = createPlatformAudioSink("music"_s);
+
     m_audioSinkAvailable = audioSink;
     if (!audioSink) {
         GST_ERROR("Failed to create GStreamer audio sink element");

--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.h
@@ -62,6 +62,11 @@ private:
     GRefPtr<GstElement> m_src;
     CompletionHandler<void(bool)> m_startupCompletionHandler;
     CompletionHandler<void(bool)> m_stopCompletionHandler;
+#if ENABLE(WPE_PLATFORM)
+    AudioSinkStartedCallback m_audioSinkStartedCallback;
+    AudioSinkDisposedCallback m_audioSinkStoppedCallback;
+    String m_audioSinkSocketPath;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -1829,6 +1829,23 @@ bool MediaPlayer::isGStreamerHolePunchingEnabled()
 }
 #endif
 
+#if USE(GSTREAMER) && ENABLE(WPE_PLATFORM)
+String MediaPlayer::requestAudioSinkSocket()
+{
+    return client().requestAudioSinkSocket();
+}
+
+void MediaPlayer::audioSinkStarted(const String& path)
+{
+    client().audioSinkStarted(path);
+}
+
+void MediaPlayer::audioSinkStopped(const String& path)
+{
+    client().audioSinkStopped(path);
+}
+#endif
+
 String MediaPlayer::languageOfPrimaryAudioTrack() const
 {
     RefPtr playerPrivate = m_private;

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -359,8 +359,15 @@ public:
     virtual bool canShowWhileLocked() const { return false; }
 #endif
 
+
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     virtual MediaPlaybackTargetType playbackTargetType() const { return MediaPlaybackTargetType::None; }
+#endif
+
+#if USE(GSTREAMER) && ENABLE(WPE_PLATFORM)
+    virtual String requestAudioSinkSocket() { return emptyString(); }
+    virtual void audioSinkStarted(const String &) { }
+    virtual void audioSinkStopped(const String &) { }
 #endif
 };
 
@@ -680,6 +687,12 @@ public:
 #if USE(GSTREAMER)
     void simulateAudioInterruption();
     bool isGStreamerHolePunchingEnabled();
+#endif
+
+#if USE(GSTREAMER) && ENABLE(WPE_PLATFORM)
+    String requestAudioSinkSocket();
+    void audioSinkStarted(const String&);
+    void audioSinkStopped(const String &);
 #endif
 
     String languageOfPrimaryAudioTrack() const;

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1188,9 +1188,10 @@ IGNORE_WARNINGS_END
     return audioSink;
 }
 
-GstElement* /* (transfer floating) */ createPlatformAudioSink(const String& role, const String& deviceId, const GRefPtr<GstDevice>& device)
+GstElement* /* (transfer floating) */ createPlatformAudioSink(const String& role, const String& deviceId, const GRefPtr<GstDevice>& device, String&& sharedMemory)
 {
-    GstElement* audioSink = webkitAudioSinkNew(role, deviceId, device);
+    GstElement* audioSink = webkitAudioSinkNew(role, deviceId, device, WTF::move(sharedMemory));
+
     if (!audioSink) {
         // This means the WebKit audio sink configuration failed. It can happen for the following reasons:
         // - audio mixing was not requested using the WEBKIT_GST_ENABLE_AUDIO_MIXER

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -293,7 +293,8 @@ bool isGStreamerPluginAvailable(ASCIILiteral name);
 bool gstElementFactoryEquals(GstElement*, ASCIILiteral name);
 
 GstElement* createAutoAudioSink(const String& role);
-GstElement* createPlatformAudioSink(const String& role, const String& deviceId = { }, const GRefPtr<GstDevice>& = { });
+
+GstElement* createPlatformAudioSink(const String& role, const String& deviceId = { }, const GRefPtr<GstDevice>& = { }, String&& sharedMemory = { });
 
 bool webkitGstSetElementStateSynchronously(GstElement*, GstState, Function<bool(GstMessage*)>&& = [](GstMessage*) -> bool {
     return true;

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1604,20 +1604,44 @@ GstElement* MediaPlayerPrivateGStreamer::createAudioSink()
     auto role = player->isVideoPlayer() ? "video"_s : "music"_s;
     GstElement* audioSink = nullptr;
 
+    String socketPath;
+#if ENABLE(WPE_PLATFORM)
+    socketPath = player->requestAudioSinkSocket();
+    bool hasSocketPath = !socketPath.isEmpty();
+#endif
+
 #if ENABLE(MEDIA_STREAM)
     auto deviceId = player->audioOutputDeviceId();
     if (!deviceId.isEmpty()) {
         auto [resolvedId, device] = resolveAudioOutputDevice(deviceId);
         if (device)
-            audioSink = createPlatformAudioSink(role, resolvedId, device);
+            audioSink = createPlatformAudioSink(role, resolvedId, device, WTF::move(socketPath));
     }
 #endif
 
     if (!audioSink)
-        audioSink = createPlatformAudioSink(role);
+        audioSink = createPlatformAudioSink(role, { }, nullptr, WTF::move(socketPath));
     RELEASE_ASSERT(audioSink);
     if (!audioSink)
         return nullptr;
+
+
+#if ENABLE(WPE_PLATFORM)
+    if (WEBKIT_IS_AUDIO_SINK(audioSink) && hasSocketPath) {
+        webkitAudioSinkSetStartedCallback(WEBKIT_AUDIO_SINK(audioSink), [&](const auto& path) {
+            callOnMainThreadAndWait([&] {
+                if (RefPtr player = m_player.get())
+                    player->audioSinkStarted(path);
+            });
+        });
+        webkitAudioSinkSetStoppedCallback(WEBKIT_AUDIO_SINK(audioSink), [&](const auto& path) {
+            callOnMainThreadAndWait([&] {
+                if (RefPtr player = m_player.get())
+                    player->audioSinkStopped(path);
+            });
+        });
+    }
+#endif
 
 #if ENABLE(WEB_AUDIO)
     GstElement* audioSinkBin = gst_bin_new("audio-sink");
@@ -2253,13 +2277,13 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
         GstState newState;
         gst_message_parse_state_changed(message, &currentState, &newState, nullptr);
 
+        auto element = GST_ELEMENT_CAST(GST_MESSAGE_SRC(message));
         if (isHolePunchRenderingEnabled() && currentState <= GST_STATE_READY && newState >= GST_STATE_READY) {
             // If we didn't create a video sink, store a reference to the created one.
             if (!m_videoSink) {
                 // Detect the videoSink element. Getting the video-sink property of the pipeline requires
                 // locking some elements, which may lead to deadlocks during playback. Instead, identify
                 // the videoSink based on its metadata.
-                GstElement* element = GST_ELEMENT(GST_MESSAGE_SRC(message));
                 if (GST_OBJECT_FLAG_IS_SET(element, GST_ELEMENT_FLAG_SINK)) {
                     auto klassStr = CStringView::unsafeFromUTF8(gst_element_get_metadata(element, "klass"));
                     if (contains(klassStr.span(), "Sink"_s)  && contains(klassStr.span(), "Video"_s)) {
@@ -2275,7 +2299,6 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
         auto& quirksManager = GStreamerQuirksManager::singleton();
         if (quirksManager.isEnabled() && currentState <= GST_STATE_READY && newState >= GST_STATE_READY) {
             // Detect an audio sink element and store reference to it if it supersedes what we currently have.
-            GstElement* element = GST_ELEMENT(GST_MESSAGE_SRC(message));
             if (GST_OBJECT_FLAG_IS_SET(element, GST_ELEMENT_FLAG_SINK)) {
                 auto klassStr = CStringView::unsafeFromUTF8(gst_element_get_metadata(element, "klass"));
                 if (contains(klassStr.span(), "Sink"_s) && contains(klassStr.span(), "Audio"_s)

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp
@@ -25,6 +25,8 @@
 #include "AudioUtilities.h"
 #include "GStreamerAudioMixer.h"
 #include "GStreamerCommon.h"
+#include <wtf/FileSystem.h>
+#include <wtf/Scope.h>
 #include <wtf/glib/WTFGType.h>
 
 #if ENABLE(WEB_AUDIO)
@@ -39,6 +41,11 @@ struct _WebKitAudioSinkPrivate {
     String role;
     String deviceId;
     GRefPtr<GstDevice> device;
+    GRefPtr<GstElement> volumeElement;
+    GRefPtr<GstElement> unixfdsink;
+    String socketPath;
+    AudioSinkStartedCallback audioSinkStartedCallback;
+    AudioSinkStoppedCallback audioSinkStoppedCallback;
 };
 
 enum {
@@ -58,8 +65,37 @@ WEBKIT_DEFINE_TYPE_WITH_CODE(WebKitAudioSink, webkit_audio_sink, GST_TYPE_BIN,
     GST_DEBUG_CATEGORY_INIT(webkit_audio_sink_debug, "webkitaudiosink", 0, "webkit audio sink element")
 )
 
-static bool webKitAudioSinkConfigure(WebKitAudioSink* sink)
+static bool webKitAudioSinkConfigure(WebKitAudioSink* sink, String&& socketPath)
 {
+    if (!socketPath.isEmpty()) {
+        FileSystem::makeAllDirectories(FileSystem::parentPath(socketPath));
+
+        if (!gst_check_version(1, 28, 0)) {
+            gst_printerrln("GStreamer 1.28 with unixfd plugin is required");
+            return false;
+        }
+
+        sink->priv->unixfdsink = makeGStreamerElement("unixfdsink"_s);
+        if (!sink->priv->unixfdsink) {
+            gst_printerrln("Unable to find unixfdsink element, please install gst-plugins-bad.");
+            return false;
+        }
+
+        sink->priv->volumeElement = gst_element_factory_make("volume", nullptr);
+        auto queue = gst_element_factory_make("queue", nullptr);
+
+        g_object_set(sink->priv->unixfdsink.get(), "socket-path", socketPath.utf8().data(), "wait-for-connection", TRUE, nullptr);
+        sink->priv->socketPath = WTF::move(socketPath);
+        gst_bin_add_many(GST_BIN_CAST(sink), sink->priv->volumeElement.get(), queue, sink->priv->unixfdsink.get(), nullptr);
+        gst_element_link_many(sink->priv->volumeElement.get(), queue, sink->priv->unixfdsink.get(), nullptr);
+
+        auto targetPad = adoptGRef(gst_element_get_static_pad(sink->priv->volumeElement.get(), "sink"));
+        auto sinkPad = webkitGstGhostPadFromStaticTemplate(&audioSinkTemplate, "sink"_s, targetPad.get());
+        gst_element_add_pad(GST_ELEMENT_CAST(sink), sinkPad);
+        GST_OBJECT_FLAG_SET(sinkPad, GST_PAD_FLAG_NEED_PARENT);
+        return true;
+    }
+
     auto enableAudioMixer = CStringView::unsafeFromUTF8(g_getenv("WEBKIT_GST_ENABLE_AUDIO_MIXER"));
     if (!enableAudioMixer || enableAudioMixer != "1"_s)
         return false;
@@ -108,17 +144,28 @@ static bool webKitAudioSinkConfigure(WebKitAudioSink* sink)
     return true;
 }
 
+static GstObject* getInternalVolumeObject(WebKitAudioSink* sink)
+{
+    if (sink->priv->volumeElement)
+        return GST_OBJECT_CAST(sink->priv->volumeElement.get());
+
+    RELEASE_ASSERT(sink->priv->mixerPad);
+    return GST_OBJECT_CAST(sink->priv->mixerPad.get());
+}
+
 static void webKitAudioSinkSetProperty(GObject* object, guint propID, const GValue* value, GParamSpec* pspec)
 {
     WebKitAudioSink* sink = WEBKIT_AUDIO_SINK(object);
 
     switch (propID) {
     case WEBKIT_AUDIO_SINK_PROP_VOLUME: {
-        g_object_set_property(G_OBJECT(sink->priv->mixerPad.get()), "volume", value);
+        GstObject* internalObject = getInternalVolumeObject(sink);
+        g_object_set_property(G_OBJECT(internalObject), "volume", value);
         break;
     }
     case WEBKIT_AUDIO_SINK_PROP_MUTE: {
-        g_object_set_property(G_OBJECT(sink->priv->mixerPad.get()), "mute", value);
+        GstObject* internalObject = getInternalVolumeObject(sink);
+        g_object_set_property(G_OBJECT(internalObject), "mute", value);
         break;
     }
     default:
@@ -133,11 +180,13 @@ static void webKitAudioSinkGetProperty(GObject* object, guint propID, GValue* va
 
     switch (propID) {
     case WEBKIT_AUDIO_SINK_PROP_VOLUME: {
-        g_object_get_property(G_OBJECT(sink->priv->mixerPad.get()), "volume", value);
+        GstObject* internalObject = getInternalVolumeObject(sink);
+        g_object_get_property(G_OBJECT(internalObject), "volume", value);
         break;
     }
     case WEBKIT_AUDIO_SINK_PROP_MUTE: {
-        g_object_get_property(G_OBJECT(sink->priv->mixerPad.get()), "mute", value);
+        GstObject* internalObject = getInternalVolumeObject(sink);
+        g_object_get_property(G_OBJECT(internalObject), "mute", value);
         break;
     }
     default:
@@ -168,12 +217,49 @@ static GstStateChangeReturn webKitAudioSinkChangeState(GstElement* element, GstS
 
     GstStateChangeReturn result = GST_ELEMENT_CLASS(webkit_audio_sink_parent_class)->change_state(element, stateChange);
 
-    if (priv->mixerPad && stateChange == GST_STATE_CHANGE_READY_TO_NULL && result > GST_STATE_CHANGE_FAILURE) {
-        mixer.unregisterProducer(priv->mixerPad);
-        priv->mixerPad = nullptr;
-    }
+    if (result <= GST_STATE_CHANGE_FAILURE)
+        return result;
+
+    switch (stateChange) {
+    case GST_STATE_CHANGE_READY_TO_NULL:
+        if (priv->mixerPad) {
+            mixer.unregisterProducer(priv->mixerPad);
+            priv->mixerPad = nullptr;
+        }
+        break;
+    default:
+        break;
+    };
 
     return result;
+}
+
+static void webKitAudioSinkHandleMessage(GstBin* bin, GstMessage* message)
+{
+    auto self = WEBKIT_AUDIO_SINK(bin);
+    auto scopeExit = makeScopeExit([&] {
+        GST_BIN_CLASS(webkit_audio_sink_parent_class)->handle_message(bin, message);
+    });
+
+    if (self->priv->socketPath.isEmpty())
+        return;
+
+    if (GST_MESSAGE_TYPE(message) != GST_MESSAGE_STATE_CHANGED)
+        return;
+
+    if (GST_MESSAGE_SRC(message) != GST_OBJECT_CAST(self->priv->unixfdsink.get()))
+        return;
+
+    GstState currentState, newState;
+    gst_message_parse_state_changed(message, &currentState, &newState, nullptr);
+
+    if (currentState < GST_STATE_READY && newState == GST_STATE_READY && self->priv->audioSinkStartedCallback) {
+        self->priv->audioSinkStartedCallback(self->priv->socketPath);
+        return;
+    }
+
+    if (currentState == GST_STATE_READY && newState == GST_STATE_NULL && self->priv->audioSinkStoppedCallback)
+        self->priv->audioSinkStoppedCallback(self->priv->socketPath);
 }
 
 static void webKitAudioSinkConstructed(GObject* object)
@@ -202,13 +288,26 @@ static void webkit_audio_sink_class_init(WebKitAudioSinkClass* klass)
     GstElementClass* eklass = GST_ELEMENT_CLASS(klass);
     gst_element_class_add_static_pad_template(eklass, &audioSinkTemplate);
     gst_element_class_set_metadata(eklass, "WebKit Audio sink element", "Sink/Audio",
-        "Proxies audio data to WebKit's audio mixer",
+        "Proxies audio data to WebKit's audio mixer or to a WPE external audio handler",
         "Philippe Normand <philn@igalia.com>");
 
     eklass->change_state = GST_DEBUG_FUNCPTR(webKitAudioSinkChangeState);
+
+    auto binClass = GST_BIN_CLASS(klass);
+    binClass->handle_message = webKitAudioSinkHandleMessage;
 }
 
-GstElement* /* (transfer floating) */ webkitAudioSinkNew(const String& role, const String& deviceId, const GRefPtr<GstDevice>& device)
+void webkitAudioSinkSetStartedCallback(WebKitAudioSink* sink, AudioSinkStartedCallback&& callback)
+{
+    sink->priv->audioSinkStartedCallback = WTF::move(callback);
+}
+
+void webkitAudioSinkSetStoppedCallback(WebKitAudioSink* sink, AudioSinkStoppedCallback&& callback)
+{
+    sink->priv->audioSinkStoppedCallback = WTF::move(callback);
+}
+
+GstElement* /* (transfer floating) */ webkitAudioSinkNew(const String& role, const String& deviceId, const GRefPtr<GstDevice>& device, String&& socketPath)
 {
     auto element = GST_ELEMENT_CAST(g_object_new(WEBKIT_TYPE_AUDIO_SINK, nullptr));
     auto audioSink = WEBKIT_AUDIO_SINK(element);
@@ -217,7 +316,7 @@ GstElement* /* (transfer floating) */ webkitAudioSinkNew(const String& role, con
     audioSink->priv->deviceId = deviceId;
     if (device)
         audioSink->priv->device = device;
-    if (!webKitAudioSinkConfigure(audioSink)) {
+    if (!webKitAudioSinkConfigure(audioSink, WTF::move(socketPath))) {
         gst_object_unref(element);
         return nullptr;
     }

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.h
@@ -22,6 +22,7 @@
 
 #include "GRefPtrGStreamer.h"
 #include <gst/gst.h>
+#include <wtf/Forward.h>
 #include <wtf/text/WTFString.h>
 
 G_BEGIN_DECLS
@@ -39,7 +40,7 @@ typedef struct _WebKitAudioSinkPrivate WebKitAudioSinkPrivate;
 struct _WebKitAudioSink {
     GstBin parent;
 
-    WebKitAudioSinkPrivate *priv;
+    WebKitAudioSinkPrivate* priv;
 };
 
 struct _WebKitAudioSinkClass {
@@ -50,7 +51,13 @@ GType webkit_audio_sink_get_type(void);
 
 G_END_DECLS
 
-GstElement* webkitAudioSinkNew(const String& role, const String& deviceId = { }, const GRefPtr<GstDevice>& = { });
+using AudioSinkStartedCallback = Function<void(const String&)>;
+void webkitAudioSinkSetStartedCallback(WebKitAudioSink*, AudioSinkStartedCallback&&);
+
+using AudioSinkStoppedCallback = Function<void(const String&)>;
+void webkitAudioSinkSetStoppedCallback(WebKitAudioSink*, AudioSinkStoppedCallback&&);
+
+GstElement* webkitAudioSinkNew(const String& role, const String& deviceId = { }, const GRefPtr<GstDevice>& = { }, String&& socketPath = { });
 bool webkitAudioSinkSetDevice(GstElement*, const String& deviceId = { }, const GRefPtr<GstDevice>& = { });
 
 #endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
@@ -196,8 +196,8 @@ GstElement* GStreamerQuirksManager::createWebAudioSink()
         return sink;
     }
 
-    GST_DEBUG("Quirks didn't specify a WebAudioSink, falling back to default sink");
-    return createPlatformAudioSink("webaudio"_s);
+    GST_DEBUG("Quirks didn't specify a WebAudioSink, letting the client create a default sink");
+    return nullptr;
 }
 
 GstElement* GStreamerQuirksManager::createHolePunchVideoSink(bool isLegacyPlaybin, const MediaPlayer* player)

--- a/Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp
@@ -62,6 +62,7 @@ private:
     GRefPtr<GstElement> m_src;
     GRefPtr<GstElement> m_volumeElement;
     GRefPtr<GstElement> m_pitchElement;
+    GRefPtr<GstElement> m_sink;
 };
 
 GstSpeechSynthesisWrapper::GstSpeechSynthesisWrapper(const PlatformSpeechSynthesizer& synthesizer)
@@ -78,14 +79,20 @@ GstSpeechSynthesisWrapper::GstSpeechSynthesisWrapper(const PlatformSpeechSynthes
     });
 
     m_src = GST_ELEMENT_CAST(g_object_new(WEBKIT_TYPE_FLITE_SRC, nullptr));
-    GRefPtr<GstElement> audioSink = createPlatformAudioSink("speech"_s);
-    if (!audioSink) {
+
+    String socketPath;
+#if ENABLE(WPE_PLATFORM)
+    socketPath = m_platformSynthesizer.client().requestAudioSinkSocket();
+#endif
+
+    m_sink = createPlatformAudioSink("speech"_s, { }, nullptr, WTF::move(socketPath));
+    if (!m_sink) {
         GST_ERROR("Failed to create GStreamer audio sink element");
         return;
     }
 
-    if (!WEBKIT_IS_AUDIO_SINK(audioSink.get())) {
-        g_signal_connect(audioSink.get(), "child-added", G_CALLBACK(+[](GstChildProxy*, GObject* object, gchar*, gpointer) {
+    if (!WEBKIT_IS_AUDIO_SINK(m_sink.get())) {
+        g_signal_connect(m_sink.get(), "child-added", G_CALLBACK(+[](GstChildProxy*, GObject* object, gchar*, gpointer) {
             if (GST_IS_AUDIO_BASE_SINK(object))
                 g_object_set(GST_AUDIO_BASE_SINK(object), "buffer-time", static_cast<gint64>(100000), nullptr);
         }), nullptr);
@@ -93,12 +100,21 @@ GstSpeechSynthesisWrapper::GstSpeechSynthesisWrapper(const PlatformSpeechSynthes
         // Autoaudiosink does the real sink detection in the GST_STATE_NULL->READY transition
         // so it's best to roll it to READY as soon as possible to ensure the underlying platform
         // audiosink was loaded correctly.
-        GstStateChangeReturn stateChangeReturn = gst_element_set_state(audioSink.get(), GST_STATE_READY);
+        GstStateChangeReturn stateChangeReturn = gst_element_set_state(m_sink.get(), GST_STATE_READY);
         if (stateChangeReturn == GST_STATE_CHANGE_FAILURE) {
             GST_ERROR("Failed to change autoaudiosink element state");
-            gst_element_set_state(audioSink.get(), GST_STATE_NULL);
+            gst_element_set_state(m_sink.get(), GST_STATE_NULL);
             return;
         }
+#if ENABLE(WPE_PLATFORM)
+    } else if (!socketPath.isEmpty()) {
+        webkitAudioSinkSetStartedCallback(WEBKIT_AUDIO_SINK(m_sink.get()), [&](const auto& path) {
+            m_platformSynthesizer.client().audioSinkStarted(path);
+        });
+        webkitAudioSinkSetStoppedCallback(WEBKIT_AUDIO_SINK(m_sink.get()), [&](const auto& path) {
+            m_platformSynthesizer.client().audioSinkStopped(path);
+        });
+#endif
     }
 
     m_volumeElement = makeGStreamerElement("volume"_s);
@@ -109,18 +125,18 @@ GstSpeechSynthesisWrapper::GstSpeechSynthesisWrapper(const PlatformSpeechSynthes
     GRefPtr<GstElement> audioConvert = makeGStreamerElement("audioconvert"_s);
     GRefPtr<GstElement> audioResample = makeGStreamerElement("audioresample"_s);
     if (m_pitchElement)
-        gst_bin_add_many(GST_BIN_CAST(m_pipeline.get()), m_src.get(), m_volumeElement.get(), audioConvert.get(), audioResample.get(), m_pitchElement.get(), audioSink.get(), nullptr);
+        gst_bin_add_many(GST_BIN_CAST(m_pipeline.get()), m_src.get(), m_volumeElement.get(), audioConvert.get(), audioResample.get(), m_pitchElement.get(), m_sink.get(), nullptr);
     else
-        gst_bin_add_many(GST_BIN_CAST(m_pipeline.get()), m_src.get(), m_volumeElement.get(), audioConvert.get(), audioResample.get(), audioSink.get(), nullptr);
+        gst_bin_add_many(GST_BIN_CAST(m_pipeline.get()), m_src.get(), m_volumeElement.get(), audioConvert.get(), audioResample.get(), m_sink.get(), nullptr);
 
     gst_element_link_pads_full(m_src.get(), "src", m_volumeElement.get(), "sink", GST_PAD_LINK_CHECK_NOTHING);
     gst_element_link_pads_full(m_volumeElement.get(), "src", audioConvert.get(), "sink", GST_PAD_LINK_CHECK_NOTHING);
     gst_element_link_pads_full(audioConvert.get(), "src", audioResample.get(), "sink", GST_PAD_LINK_CHECK_NOTHING);
     if (m_pitchElement) {
         gst_element_link_pads_full(audioResample.get(), "src", m_pitchElement.get(), "sink", GST_PAD_LINK_CHECK_NOTHING);
-        gst_element_link_pads_full(m_pitchElement.get(), "src", audioSink.get(), "sink", GST_PAD_LINK_CHECK_NOTHING);
+        gst_element_link_pads_full(m_pitchElement.get(), "src", m_sink.get(), "sink", GST_PAD_LINK_CHECK_NOTHING);
     } else
-        gst_element_link_pads_full(audioResample.get(), "src", audioSink.get(), "sink", GST_PAD_LINK_CHECK_NOTHING);
+        gst_element_link_pads_full(audioResample.get(), "src", m_sink.get(), "sink", GST_PAD_LINK_CHECK_NOTHING);
 }
 
 GstSpeechSynthesisWrapper::~GstSpeechSynthesisWrapper()

--- a/Source/WebCore/platform/spiel/PlatformSpeechSynthesizerSpiel.cpp
+++ b/Source/WebCore/platform/spiel/PlatformSpeechSynthesizerSpiel.cpp
@@ -84,10 +84,24 @@ SpielSpeechWrapper::SpielSpeechWrapper(const PlatformSpeechSynthesizer& synthesi
         GST_DEBUG_CATEGORY_INIT(webkit_spiel_debug, "webkitspiel", 0, "WebKit Spiel");
     });
 
-    m_sink = createPlatformAudioSink("speech"_s);
+    String socketPath;
+#if ENABLE(WPE_PLATFORM)
+    socketPath = m_platformSynthesizer.client().requestAudioSinkSocket();
+#endif
+
+    bool hasSocketPath = !socketPath.isEmpty();
+    m_sink = createPlatformAudioSink("speech"_s, { }, nullptr, WTF::move(socketPath));
     if (!m_sink) {
         GST_ERROR("Failed to create GStreamer audio sink element");
         return;
+    }
+    if (WEBKIT_IS_AUDIO_SINK(m_sink.get()) && hasSocketPath) {
+        webkitAudioSinkSetStartedCallback(WEBKIT_AUDIO_SINK(m_sink.get()), [&](const auto& path) {
+            m_platformSynthesizer.client().audioSinkStarted(path);
+        });
+        webkitAudioSinkSetStoppedCallback(WEBKIT_AUDIO_SINK(m_sink.get()), [&](const auto& path) {
+            m_platformSynthesizer.client().audioSinkStopped(path);
+        });
     }
 
     spiel_speaker_new(nullptr, [](GObject*, GAsyncResult* result, gpointer userData) {

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -600,4 +600,26 @@ RefPtr<ViewSnapshot> PageClientImpl::takeViewSnapshot(std::optional<WebCore::Int
     return nullptr;
 }
 
+void PageClientImpl::requestAudioSinkSocket(CompletionHandler<void(String)>&& completionHandler)
+{
+    auto view = m_view.wpeView();
+    if (!view) {
+        completionHandler({ });
+        return;
+    }
+
+    GUniquePtr<char> path(wpe_view_request_audio_sink_socket(view));
+    completionHandler(String::fromUTF8(path.get()));
+}
+
+void PageClientImpl::audioSinkStarted(const String& path)
+{
+    wpe_view_audio_sink_started(m_view.wpeView(), path.utf8().data());
+}
+
+void PageClientImpl::audioSinkStopped(const String& path)
+{
+    wpe_view_audio_sink_stopped(m_view.wpeView(), path.utf8().data());
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
@@ -165,6 +165,10 @@ private:
 
     void didRestoreScrollPosition() override;
 
+    void requestAudioSinkSocket(CompletionHandler<void(String)>&&) final;
+    void audioSinkStarted(const String&) final;
+    void audioSinkStopped(const String&) final;
+
 #if ENABLE(FULLSCREEN_API)
     WebFullScreenManagerProxyClient& NODELETE fullScreenManagerProxyClient() final;
     void setFullScreenClientForTesting(std::unique_ptr<WebFullScreenManagerProxyClient>&&) final;

--- a/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
@@ -468,6 +468,15 @@ static void bindGStreamerData(Vector<CString>& args)
     args.appendList({ "--dev-bind-try", "/dev/udmabuf", "/dev/udmabuf" });
 }
 
+#if USE(GSTREAMER) && ENABLE(WPE_PLATFORM)
+static void bindClientSideAudioSockets(Vector<CString>& args)
+{
+    GUniquePtr<char> audioSocketsDir(g_build_filename(g_get_user_runtime_dir(), "wpe-audio", nullptr));
+    FileSystem::makeAllDirectories(String::fromUTF8(audioSocketsDir.get()));
+    bindIfExists(args, audioSocketsDir.get(), BindFlags::ReadWrite);
+}
+#endif
+
 static void bindOpenGL(Vector<CString>& args)
 {
     args.appendList({
@@ -966,6 +975,9 @@ GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher* launcher, const Proces
 #endif
 #if PLATFORM(GTK)
         bindGtkData(sandboxArgs);
+#endif
+#if USE(GSTREAMER) && ENABLE(WPE_PLATFORM)
+        bindClientSideAudioSockets(sandboxArgs);
 #endif
         dbusProxy.launch(launchOptions);
     } else {

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -894,6 +894,12 @@ public:
     virtual void presentImmersiveElement(const WebCore::LayerHostingContextIdentifier, Ref<API::FrameInfo>&&, CompletionHandler<void(bool)>&& completion) const { completion(false); }
     virtual void dismissImmersiveElement(CompletionHandler<void()>&& completion) const { completion(); }
 #endif
+
+#if ENABLE(WPE_PLATFORM)
+    virtual void requestAudioSinkSocket(CompletionHandler<void(String)> &&) = 0;
+    virtual void audioSinkStarted(const String &) = 0;
+    virtual void audioSinkStopped(const String &) = 0;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2725,6 +2725,12 @@ public:
 
     WebPageProxyMessageReceiverRegistration& NODELETE messageReceiverRegistration() LIFETIME_BOUND;
 
+#if ENABLE(WPE_PLATFORM)
+    void requestAudioSinkSocket(CompletionHandler<void(String)>&&);
+    void audioSinkStarted(const String&);
+    void audioSinkStopped(const String&);
+#endif
+
 #if HAVE(ESIM_AUTOFILL_SYSTEM_SUPPORT)
     bool shouldAllowAutoFillForCellularIdentifiers() const;
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -615,6 +615,12 @@ messages -> WebPageProxy {
     SendMessageToWebViewWithReply(struct WebKit::UserMessage userMessage) -> (struct WebKit::UserMessage replyMessage)
 #endif
 
+#if ENABLE(WPE_PLATFORM)
+    RequestAudioSinkSocket() -> (String result) Synchronous
+    AudioSinkStarted(String path)
+    AudioSinkStopped(String path)
+#endif
+
     DidFindTextManipulationItems(Vector<WebCore::TextManipulationItem> items)
 
 #if ENABLE(MEDIA_USAGE)

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -468,6 +468,12 @@ public:
 
     // PlatformSpeechSynthesizerClient
     void voicesDidChange() final;
+#if USE(GSTREAMER) && ENABLE(WPE_PLATFORM)
+    String requestAudioSinkSocket() final;
+    void audioSinkStarted(const String&) final;
+    void audioSinkStopped(const String&) final;
+#endif
+
 #endif
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET) && !PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/gstreamer/WebPageProxyGStreamer.cpp
+++ b/Source/WebKit/UIProcess/gstreamer/WebPageProxyGStreamer.cpp
@@ -77,6 +77,27 @@ void WebPageProxy::Internals::voicesDidChange()
     protect(protectedPage->legacyMainFrameProcess())->send(Messages::WebPage::VoicesDidChange(), protectedPage->webPageIDInMainFrameProcess());
 }
 
+#if ENABLE(WPE_PLATFORM)
+String WebPageProxy::Internals::requestAudioSinkSocket()
+{
+    // Not needed because our UIProcess doesn't act as a Synthesys client. The SpeechSynthesys does
+    // the IPC directly through its context/page.
+    return { };
+}
+
+void WebPageProxy::Internals::audioSinkStarted(const String& path)
+{
+    // Not needed because our UIProcess doesn't act as a Synthesys client. The SpeechSynthesys does
+    // the IPC directly through its context/page.
+}
+
+void WebPageProxy::Internals::audioSinkStopped(const String& path)
+{
+    // Not needed because our UIProcess doesn't act as a Synthesys client. The SpeechSynthesys does
+    // the IPC directly through its context/page.
+}
+#endif
+
 } // namespace WebKit
 
 #endif // ENABLE(VIDEO) && USE(GSTREAMER) && ENABLE(SPEECH_SYNTHESIS)

--- a/Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp
@@ -33,6 +33,7 @@
 #include "PageClientImpl.h"
 #include "UserMessage.h"
 #include "WebProcessProxy.h"
+#include "wpe/WPEViewPrivate.h"
 #include <WebCore/PlatformEvent.h>
 #include <wtf/CallbackAggregator.h>
 #include <wtf/glib/GSpanExtras.h>
@@ -248,5 +249,36 @@ void WebPageProxy::callAfterNextPresentationUpdate(CompletionHandler<void()>&& c
     callback();
 #endif
 }
+
+#if ENABLE(WPE_PLATFORM)
+void WebPageProxy::requestAudioSinkSocket(CompletionHandler<void(String)>&& completionHandler)
+{
+    RefPtr pageClient = this->pageClient();
+    if (!pageClient) {
+        completionHandler({ });
+        return;
+    }
+
+    pageClient->requestAudioSinkSocket(WTF::move(completionHandler));
+}
+
+void WebPageProxy::audioSinkStarted(const String& path)
+{
+    RefPtr pageClient = this->pageClient();
+    if (!pageClient)
+        return;
+
+    pageClient->audioSinkStarted(path);
+}
+
+void WebPageProxy::audioSinkStopped(const String& path)
+{
+    RefPtr pageClient = this->pageClient();
+    if (!pageClient)
+        return;
+
+    pageClient->audioSinkStopped(path);
+}
+#endif
 
 } // namespace WebKit

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -125,6 +125,9 @@ enum {
     EVENT,
     TOPLEVEL_STATE_CHANGED,
     PREFERRED_BUFFER_FORMATS_CHANGED,
+    REQUEST_AUDIO_SINK_SOCKET,
+    AUDIO_SINK_STARTED,
+    AUDIO_SINK_STOPPED,
 
     LAST_SIGNAL
 };
@@ -501,6 +504,50 @@ static void wpe_view_class_init(WPEViewClass* viewClass)
         0, nullptr, nullptr,
         g_cclosure_marshal_generic,
         G_TYPE_NONE, 0);
+
+    /**
+     * WPEView::request-audio-sink-socket:
+     * @view: a #WPEView
+     *
+     * Since: 2.52
+     */
+    signals[REQUEST_AUDIO_SINK_SOCKET] = g_signal_new(
+        "request-audio-sink-socket",
+        G_TYPE_FROM_CLASS(viewClass),
+        G_SIGNAL_RUN_LAST,
+        0, nullptr, nullptr,
+        g_cclosure_marshal_generic,
+        G_TYPE_STRING, 0);
+
+    /**
+     * WPEView::audio-sink-started:
+     * @view: a #WPEView
+     * @path: a socket path
+     *
+     * Since: 2.52
+     */
+    signals[AUDIO_SINK_STARTED] = g_signal_new(
+        "audio-sink-started",
+        G_TYPE_FROM_CLASS(viewClass),
+        G_SIGNAL_RUN_LAST,
+        0, nullptr, nullptr,
+        g_cclosure_marshal_generic,
+        G_TYPE_NONE, 1, G_TYPE_STRING);
+
+    /**
+     * WPEView::audio-sink-stopped:
+     * @view: a #WPEView
+     * @path: a socket path
+     *
+     * Since: 2.52
+     */
+    signals[AUDIO_SINK_STOPPED] = g_signal_new(
+        "audio-sink-stopped",
+        G_TYPE_FROM_CLASS(viewClass),
+        G_SIGNAL_RUN_LAST,
+        0, nullptr, nullptr,
+        g_cclosure_marshal_generic,
+        G_TYPE_NONE, 1, G_TYPE_STRING);
 }
 
 void wpeViewToplevelStateChanged(WPEView* view, WPEToplevelState state)
@@ -531,6 +578,72 @@ void wpeViewScreenChanged(WPEView* view)
 void wpeViewPreferredBufferFormatsChanged(WPEView* view)
 {
     g_signal_emit(view, signals[PREFERRED_BUFFER_FORMATS_CHANGED], 0);
+}
+
+/**
+ * wpe_view_audio_request_audio_sink_socket:
+ * @view: A #WPEView
+ *
+ * Returns: (transfer full) (nullable): A filesystem path to the Unix socket file, or %NULL
+ *
+ * Since: 2.52
+ */
+gchar* wpe_view_request_audio_sink_socket(WPEView* view)
+{
+    GValue args[1] = { G_VALUE_INIT };
+    GValue ret = G_VALUE_INIT;
+    gchar* path = nullptr;
+
+    g_value_init(&args[0], WPE_TYPE_VIEW);
+    g_value_set_object(&args[0], view);
+
+    g_value_init(&ret, G_TYPE_STRING);
+
+    g_signal_emitv(args, signals[REQUEST_AUDIO_SINK_SOCKET], 0, &ret);
+    g_value_unset(&args[0]);
+
+    path = g_value_dup_string(&ret);
+    g_value_unset(&ret);
+
+    return path;
+}
+
+/**
+ * wpe_view_audio_sink_started:
+ * @view: A #WPEView
+ * @path: Path of the Unix socket file
+ *
+ * Since: 2.52
+ */
+void wpe_view_audio_sink_started(WPEView* view, const gchar* path)
+{
+    GValue args[2] = { G_VALUE_INIT, G_VALUE_INIT };
+    g_value_init(&args[0], WPE_TYPE_VIEW);
+    g_value_set_object(&args[0], view);
+    g_value_init(&args[1], G_TYPE_STRING);
+    g_value_set_string(&args[1], path);
+    g_signal_emitv(args, signals[AUDIO_SINK_STARTED], 0, nullptr);
+    g_value_unset(&args[0]);
+    g_value_unset(&args[1]);
+}
+
+/**
+ * wpe_view_audio_sink_stopped:
+ * @view: A #WPEView
+ * @path: Path of the Unix socket file
+ *
+ * Since: 2.52
+ */
+void wpe_view_audio_sink_stopped(WPEView* view, const gchar* path)
+{
+    GValue args[2] = { G_VALUE_INIT, G_VALUE_INIT };
+    g_value_init(&args[0], WPE_TYPE_VIEW);
+    g_value_set_object(&args[0], view);
+    g_value_init(&args[1], G_TYPE_STRING);
+    g_value_set_string(&args[1], path);
+    g_signal_emitv(args, signals[AUDIO_SINK_STOPPED], 0, nullptr);
+    g_value_unset(&args[0]);
+    g_value_unset(&args[1]);
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.h
@@ -77,7 +77,10 @@ struct _WPEViewClass
     gboolean           (* can_be_mapped)         (WPEView            *view);
     WPEViewAccessible *(* get_accessible)        (WPEView            *view);
 
-    gpointer padding[32];
+    gchar             *(* request_audio_sink_socket) (WPEView *view);
+    void              *(* audio_sink_started)        (WPEView *view);
+
+    gpointer padding[30];
 };
 
 #define WPE_VIEW_ERROR (wpe_view_error_quark())
@@ -155,6 +158,12 @@ WPE_API void                  wpe_view_set_gesture_controller       (WPEView    
                                                                      WPEGestureController *controller);
 WPE_API WPEGestureController *wpe_view_get_gesture_controller       (WPEView            *view);
 WPE_API WPEViewAccessible    *wpe_view_get_accessible               (WPEView            *view);
+
+WPE_API gchar                  *wpe_view_request_audio_sink_socket     (WPEView            *view);
+WPE_API void                    wpe_view_audio_sink_started            (WPEView            *view,
+                                                                        const gchar        *path);
+WPE_API void                    wpe_view_audio_sink_stopped            (WPEView            *view,
+                                                                        const gchar        *path);
 
 G_END_DECLS
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -2509,6 +2509,23 @@ void WebChromeClient::setNeedsFixedContainerEdgesUpdate()
     m_page->setNeedsFixedContainerEdgesUpdate();
 }
 
+#if ENABLE(WPE_PLATFORM)
+String WebChromeClient::requestAudioSinkSocket()
+{
+    return m_page->requestAudioSinkSocket();
+}
+
+void WebChromeClient::audioSinkStarted(const String& path)
+{
+    m_page->audioSinkStarted(path);
+}
+
+void WebChromeClient::audioSinkStopped(const String& path)
+{
+    m_page->audioSinkStopped(path);
+}
+#endif
+
 bool WebChromeClient::usePluginRendererScrollableArea(LocalFrame& frame) const
 {
 #if ENABLE(PDF_PLUGIN)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -593,6 +593,12 @@ private:
 
     void setNeedsFixedContainerEdgesUpdate() final;
 
+#if ENABLE(WPE_PLATFORM)
+    String requestAudioSinkSocket() final;
+    void audioSinkStarted(const String&) final;
+    void audioSinkStopped(const String&) final;
+#endif
+
     bool usePluginRendererScrollableArea(WebCore::LocalFrame&) const final;
 
 #if ENABLE(VIDEO)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2180,6 +2180,12 @@ public:
     bool NODELETE shouldDisableModelLoadDelaysForTesting() const;
 #endif
 
+#if ENABLE(WPE_PLATFORM)
+    String requestAudioSinkSocket();
+    void audioSinkStarted(const String&);
+    void audioSinkStopped(const String&);
+#endif
+
     std::unique_ptr<FrameInfoData> takeMainFrameNavigationInitiator();
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/WebPage/wpe/WebPageWPE.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wpe/WebPageWPE.cpp
@@ -52,4 +52,23 @@ void WebPage::preferredBufferFormatsDidChange(Vector<RendererBufferFormat>&& pre
 }
 #endif
 
+#if ENABLE(WPE_PLATFORM)
+String WebPage::requestAudioSinkSocket()
+{
+    auto sendResult = sendSync(Messages::WebPageProxy::RequestAudioSinkSocket());
+    auto [result] = sendResult.takeReplyOr(String { });
+    return result;
+}
+
+void WebPage::audioSinkStarted(const String& path)
+{
+    send(Messages::WebPageProxy::AudioSinkStarted(path));
+}
+
+void WebPage::audioSinkStopped(const String& path)
+{
+    send(Messages::WebPageProxy::AudioSinkStopped(path));
+}
+#endif
+
 } // namespace WebKit


### PR DESCRIPTION
#### 6a292cf507e03b62c25037eac7d4fbe2d2a13789
<pre>
[WPE][GStreamer] Support for client-side audio rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=292605">https://bugs.webkit.org/show_bug.cgi?id=292605</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/WebCore/Modules/speech/SpeechSynthesis.cpp:
(WebCore::SpeechSynthesis::SpeechSynthesis):
(WebCore::SpeechSynthesis::requestAudioSinkSocket):
(WebCore::SpeechSynthesis::audioSinkStarted):
* Source/WebCore/Modules/speech/SpeechSynthesis.h:
* Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp:
(WebCore::AudioDestinationNode::requestAudioSinkSocket):
(WebCore::AudioDestinationNode::audioSinkStarted):
* Source/WebCore/Modules/webaudio/AudioDestinationNode.h:
* Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp:
(WebCore::DefaultAudioDestinationNode::createDestination):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::requestAudioSinkSocket):
(WebCore::HTMLMediaElement::audioSinkStarted):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::requestAudioSinkSocket):
(WebCore::ChromeClient::audioSinkStarted):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::requestAudioSinkSocket):
(WebCore::Page::audioSinkStarted):
* Source/WebCore/page/Page.h:
* Source/WebCore/platform/PlatformSpeechSynthesizer.h:
* Source/WebCore/platform/audio/AudioDestination.h:
* Source/WebCore/platform/audio/SharedAudioDestination.cpp:
* Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp:
(WebCore::AudioDestinationGStreamer::AudioDestinationGStreamer):
* Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.h:
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::requestAudioSinkSocket):
(WebCore::MediaPlayer::audioSinkStarted):
* Source/WebCore/platform/graphics/MediaPlayer.h:
(WebCore::MediaPlayerClient::requestAudioSinkSocket):
(WebCore::MediaPlayerClient::audioSinkStarted):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::createPlatformAudioSink):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
(WebCore::createPlatformAudioSink):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::createAudioSink):
(WebCore::MediaPlayerPrivateGStreamer::handleMessage):
* Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp:
(webKitAudioSinkConfigure):
(getInternalVolumeObject):
(webKitAudioSinkSetProperty):
(webKitAudioSinkGetProperty):
(webKitAudioSinkChangeState):
(webKitAudioSinkHandleMessage):
(webKitAudioSinkConstructed):
(webKitAudioSinkDispose):
(webkit_audio_sink_class_init):
(webkitAudioSinkSetStartedCallback):
(webkitAudioSinkSetDisposedCallback):
(webkitAudioSinkNew):
* Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.h:
(webkitAudioSinkNew):
* Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp:
(WebCore::GStreamerQuirksManager::createWebAudioSink):
* Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp:
(WebCore::GstSpeechSynthesisWrapper::GstSpeechSynthesisWrapper):
* Source/WebCore/platform/spiel/PlatformSpeechSynthesizerSpiel.cpp:
(WebCore::SpielSpeechWrapper::SpielSpeechWrapper):
* Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp:
(WebKit::PageClientImpl::requestAudioSinkSocket):
(WebKit::PageClientImpl::audioSinkStarted):
* Source/WebKit/UIProcess/API/wpe/PageClientImpl.h:
* Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp:
(WebKit::bindClientSideAudioSockets):
(WebKit::bubblewrapSpawn):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/gstreamer/WebPageProxyGStreamer.cpp:
(WebKit::WebPageProxy::Internals::requestAudioSinkSocket):
(WebKit::WebPageProxy::Internals::audioSinkStarted):
* Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp:
(WebKit::WebPageProxy::requestAudioSinkSocket):
(WebKit::WebPageProxy::audioSinkStarted):
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpe_view_class_init):
(wpe_view_request_audio_sink_socket):
(wpe_view_audio_sink_started):
* Source/WebKit/WPEPlatform/wpe/WPEView.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::requestAudioSinkSocket):
(WebKit::WebChromeClient::audioSinkStarted):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/wpe/WebPageWPE.cpp:
(WebKit::WebPage::requestAudioSinkSocket):
(WebKit::WebPage::audioSinkStarted):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c345156a5cc55e239f16e8a2a66f14ad657fabca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169323 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36511 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178679 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127035 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171189 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43413 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42873 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131893 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92828 "3 flakes 12 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172282 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34478 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152183 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112397 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33461 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32032 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27379 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143451 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181279 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33989 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36202 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140349 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42901 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140187 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43590 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28558 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107567 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35455 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115355 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42100 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6648 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41493 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41748 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41636 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->