### PR TITLE
Don't update floating object set during an internal reshuffle.

### DIFF
--- a/LayoutTests/fast/block/float/skipped-content-with-intrusive-floats-crash-001-expected.txt
+++ b/LayoutTests/fast/block/float/skipped-content-with-intrusive-floats-crash-001-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/block/float/skipped-content-with-intrusive-floats-crash-001.html
+++ b/LayoutTests/fast/block/float/skipped-content-with-intrusive-floats-crash-001.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<style>
+  html {
+    text-indent: 50000vmin hanging;
+    padding-left: 1vh;
+  }
+  #span1, #span2, #span3, #span4 {
+    margin: 100%;
+    padding-left: 100%;
+  }
+  .floatLeft {
+    float: left;
+  }
+</style>
+<script>
+  window.addEventListener("load", () => {
+    window.testRunner?.dumpAsText();
+    window.testRunner?.waitUntilDone();
+
+    marquee.appendChild(span2);
+    document.body.scrollTop;
+
+    span4.appendChild(span2);
+    let range = document.createRange();
+    range.selectNodeContents(span1);
+    range.insertNode(span4);
+    document.body.scrollTop;
+
+    details.open = false;
+    span4.remove();
+    document.body.scrollTop;
+    container.remove();
+
+    document.body.innerHTML = "PASS if no crash.";
+    window.testRunner?.notifyDone();
+  });
+</script>
+<div id="container">
+  <table>
+    <li></li>
+    <marquee id="marquee">
+      <div></div>
+      <span id="span1"></span>
+      <span id="span2"><span id="span3" class="floatLeft"></span>A</span>
+    </marquee>
+    <span><span class="floatLeft">B</span></span>
+    <details id="details" open>
+      <embed><span><div><span id="span4"></span></div></span></embed>
+    </details>
+  </table>
+</div>

--- a/LayoutTests/fast/block/float/skipped-content-with-intrusive-floats-crash-002-expected.txt
+++ b/LayoutTests/fast/block/float/skipped-content-with-intrusive-floats-crash-002-expected.txt
@@ -1,0 +1,5 @@
+PASS if no crash.
+
+ 
+
+

--- a/LayoutTests/fast/block/float/skipped-content-with-intrusive-floats-crash-002.html
+++ b/LayoutTests/fast/block/float/skipped-content-with-intrusive-floats-crash-002.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<style>
+  html {
+    text-indent: 50000vmin hanging;
+    padding-left: 1vh;
+    margin-right: 100%;
+  }
+  #span1, #span2, #span3 {
+      margin-right: 100%;
+      padding: 100%;
+  }
+  .floatLeft {
+    float: left;
+  }
+  #div1, #div2 {
+    padding: 1em;
+  }
+</style>
+<p>PASS if no crash.</p>
+<div id="container">
+  &nbsp;
+  <table>
+    <li></li>
+    <marquee id="marquee">
+      <div></div>
+      <span id="span1"></span>
+      <span id="span2"><span id="span3" class="floatLeft"></span>&nbsp;</span>
+    </marquee>
+    <output id="output">
+      <div id="div1" class="floatLeft class1">
+        <template class="floatLeft"></template>
+      </div>&nbsp;
+    </output>
+    <details id="details" open>
+      <embed id="embed">
+        <div id="div2">
+          <data id="data" contenteditable="true"><span></span></data>
+        </div>
+      </embed>
+    </details>
+  </table>
+</div>
+<script>
+  window.addEventListener("load", _ => {
+    window.testRunner?.dumpAsText();
+    window.testRunner?.waitUntilDone();
+
+    marquee.appendChild(span2);
+    document.body.scrollTop;
+
+    span1.remove();
+    document.body.scrollTop;
+
+    let range = document.createRange();
+    range.selectNodeContents(span2);
+    range.surroundContents(data);
+    document.body.scrollTop;
+
+    details.open = false;
+    document.execCommand("selectAll",false,null);
+    data.remove();
+    embed.type = "video/mp4";
+    output.value = "";
+    document.body.scrollTop;
+
+    window.testRunner?.notifyDone();
+  });
+</script>

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -2413,6 +2413,9 @@ void RenderBlockFlow::addFloatsToNewParent(RenderBlockFlow& toBlockFlow) const
     if (!m_floatingObjects)
         return;
 
+    if (layoutContext().isSkippedContentForLayout(toBlockFlow))
+        return;
+
     if (!toBlockFlow.m_floatingObjects)
         toBlockFlow.createFloatingObjects();
 
@@ -2569,6 +2572,7 @@ void RenderBlockFlow::insertFloatingBoxAndMarkForLayout(RenderBox& floatBox)
 FloatingObject& RenderBlockFlow::insertFloatingBox(RenderBox& floatBox)
 {
     ASSERT(floatBox.isFloating());
+    ASSERT(!layoutContext().isSkippedContentForLayout(*this));
 
     if (!m_floatingObjects)
         createFloatingObjects();
@@ -2901,6 +2905,7 @@ std::optional<LayoutUnit> RenderBlockFlow::lowestInitialLetterLogicalBottom() co
 
 LayoutUnit RenderBlockFlow::addOverhangingFloats(RenderBlockFlow& child, bool makeChildPaintOtherFloats)
 {
+    ASSERT(!layoutContext().isSkippedContentForLayout(*this));
     // Prevent floats from being added to the canvas by the root element, e.g., <html>.
     if (!child.containsFloats() || child.createsNewFormattingContext())
         return 0;
@@ -2975,6 +2980,7 @@ bool RenderBlockFlow::hasOverhangingFloat(RenderBox& renderer)
 void RenderBlockFlow::addIntrudingFloats(RenderBlockFlow* prev, RenderBlockFlow* container, LayoutUnit logicalLeftOffset, LayoutUnit logicalTopOffset)
 {
     ASSERT(!avoidsFloats());
+    ASSERT(!layoutContext().isSkippedContentForLayout(*this));
 
     // If we create our own block formatting context then our contents don't interact with floats outside it, even those from our parent.
     if (createsNewFormattingContext())


### PR DESCRIPTION
#### dd5fe1011df7e3438ac4889356abcab7681df46d
<pre>
Don&apos;t update floating object set during an internal reshuffle.
<a href="https://bugs.webkit.org/show_bug.cgi?id=292606">https://bugs.webkit.org/show_bug.cgi?id=292606</a>

Reviewed by Alan Baradlay.

* LayoutTests/fast/block/float/skipped-content-with-intrusive-floats-crash-001-expected.txt: Added.
* LayoutTests/fast/block/float/skipped-content-with-intrusive-floats-crash-001.html: Added.
* LayoutTests/fast/block/float/skipped-content-with-intrusive-floats-crash-002-expected.txt: Added.
* LayoutTests/fast/block/float/skipped-content-with-intrusive-floats-crash-002.html: Added.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::addFloatsToNewParent const): Don&apos;t add the floats if the parent is skipped content.
(WebCore::RenderBlockFlow::insertFloatingBox): ASSERT this is not skipped subtree.
(WebCore::RenderBlockFlow::addOverhangingFloats): Ditto.
(WebCore::RenderBlockFlow::addIntrudingFloats): Ditto.

Canonical link: <a href="https://commits.webkit.org/294605@main">https://commits.webkit.org/294605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c46e575b508c522b90348b98575ddcd868d8552

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107467 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52942 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104345 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22283 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30481 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77847 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34835 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105312 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17249 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92350 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58185 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17083 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10378 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52300 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86908 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10448 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109842 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29438 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21704 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86829 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29802 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88548 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86440 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22005 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31229 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8944 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23680 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29366 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34661 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29177 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32500 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30736 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->