### PR TITLE
configurationchange event should fire if the microphone audio unit is changing of echo cancellation mode

### DIFF
--- a/LayoutTests/fast/mediastream/mediastreamtrack-configurationchange-2-expected.txt
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-configurationchange-2-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Trigger configurationchange event in case echo cancellation changes
+

--- a/LayoutTests/fast/mediastream/mediastreamtrack-configurationchange-2.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-configurationchange-2.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+promise_test(async (t) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const track = stream.getAudioTracks()[0];
+    t.add_cleanup(() => track.stop());
+
+    assert_true(track.getSettings().echoCancellation);
+
+    let promise = new Promise((resolve, reject) => {
+        track.onconfigurationchange = resolve;
+        setTimeout(()=> reject("waited too long for configurationchange"), 5000);
+    });
+
+    const stream2 = await navigator.mediaDevices.getUserMedia({ audio: { echoCancellation: false } });
+    const track2 = stream2.getAudioTracks()[0];
+    t.add_cleanup(() => track2.stop());
+
+    assert_false(track2.getSettings().echoCancellation, "track2");
+
+    await promise;
+    assert_false(track.getSettings().echoCancellation, "track");
+
+     promise = new Promise((resolve, reject) => {
+        track2.onconfigurationchange = resolve;
+        setTimeout(()=> reject("waited too long for configurationchange2"), 5000);
+    });
+
+    // Currently, cocoa platforms do not support capturing audio with and without echo cancellation.
+    track.applyConstraints({echoCancellation: true});
+
+    await promise;
+    assert_true(track2.getSettings().echoCancellation, "track2");
+}, "Trigger configurationchange event in case echo cancellation changes");
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/fast/mediastream/mediastreamtrack-configurationchange-2-expected.txt
+++ b/LayoutTests/platform/glib/fast/mediastream/mediastreamtrack-configurationchange-2-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Trigger configurationchange event in case echo cancellation changes promise_test: Unhandled rejection with value: "waited too long for configurationchange"
+

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -303,7 +303,7 @@ const RealtimeMediaSourceSettings& CoreAudioCaptureSource::settings()
 
 void CoreAudioCaptureSource::settingsDidChange(OptionSet<RealtimeMediaSourceSettings::Flag> settings)
 {
-    if (!m_isReadyToStart) {
+    if (!m_isReadyToStart || m_echoCancellationChanging) {
         m_currentSettings = std::nullopt;
         return;
     }
@@ -365,6 +365,18 @@ void CoreAudioCaptureSource::handleNewCurrentMicrophoneDevice(const CaptureDevic
     forEachObserver([](auto& observer) {
         observer.sourceConfigurationChanged();
     });
+}
+
+void CoreAudioCaptureSource::echoCancellationChanged()
+{
+    if (!isProducingData() || echoCancellation() == CoreAudioSharedUnit::singleton().enableEchoCancellation())
+        return;
+
+    m_echoCancellationChanging = true;
+    setEchoCancellation(CoreAudioSharedUnit::singleton().enableEchoCancellation());
+    m_echoCancellationChanging = false;
+
+    configurationChanged();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -61,6 +61,7 @@ public:
     CMClockRef timebaseClock();
 
     void handleNewCurrentMicrophoneDevice(const CaptureDevice&);
+    void echoCancellationChanged();
 
     WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
     virtual ~CoreAudioCaptureSource();
@@ -109,6 +110,7 @@ private:
 
     bool m_canResumeAfterInterruption { true };
     bool m_isReadyToStart { false };
+    bool m_echoCancellationChanging { false };
 
     std::optional<bool> m_echoCancellationCapability;
     BaseAudioSharedUnit* m_overrideUnit { nullptr };


### PR DESCRIPTION
#### 0936c5cbe1fe4856241174b741059960db92b419
<pre>
configurationchange event should fire if the microphone audio unit is changing of echo cancellation mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=292615">https://bugs.webkit.org/show_bug.cgi?id=292615</a>
<a href="https://rdar.apple.com/problem/150770940">rdar://problem/150770940</a>

Reviewed by Eric Carlson.

Currently, when a new microphone track is created from getUserMedia, it shares its audio unit with previously created microphone tracks.
If a page asks for a microphone track with echo cancellation, and then for a microphone track without echo cancellation, the end result is
that both tracks have no echo cancellation.

But the web page is not notified that the first track has no echo cancellation.
To make sure the web page knows about this, we fire the configurationchange event and the new echoCancellation value can be read from the track settings.

To implement this, we notify all CoreAudioCaptureSources of potential changes of echo cancellation at audio unit setup time.

Covered by LayoutTests/fast/mediastream/mediastreamtrack-configurationchange-2.html.

* LayoutTests/fast/mediastream/mediastreamtrack-configurationchange-2-expected.txt: Added.
* LayoutTests/fast/mediastream/mediastreamtrack-configurationchange-2.html: Added.
* LayoutTests/platform/glib/fast/mediastream/mediastreamtrack-configurationchange-2-expected.txt: Added.
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp:
(WebCore::CoreAudioCaptureSource::settingsDidChange):
(WebCore::CoreAudioCaptureSource::echoCancellationChanged):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::setupAudioUnit):

Canonical link: <a href="https://commits.webkit.org/294839@main">https://commits.webkit.org/294839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1a9a219534c1e9509738f44ce79e80076758423

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108310 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53785 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105181 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31317 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78411 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35354 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106148 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17946 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93062 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58744 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17792 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11103 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53140 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87599 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11166 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110687 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30279 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22325 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87403 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30644 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89260 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87032 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22162 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31884 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9597 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24603 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30206 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35528 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30014 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33341 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31576 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->