### PR TITLE
SimpleFontDataCoreText: Avoid leak of CT object

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
@@ -13,7 +13,6 @@ platform/graphics/cg/ImageDecoderCG.cpp
 platform/graphics/cg/PatternCG.cpp
 platform/graphics/cocoa/VideoMediaSampleRenderer.mm
 platform/graphics/coretext/ComplexTextControllerCoreText.mm
-platform/graphics/coretext/SimpleFontDataCoreText.cpp
 platform/graphics/cv/PixelBufferConformerCV.cpp
 platform/graphics/mac/GraphicsChecksMac.cpp
 platform/mac/CursorMac.mm

--- a/Source/WebCore/platform/graphics/coretext/SimpleFontDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/SimpleFontDataCoreText.cpp
@@ -37,7 +37,7 @@ static CTParagraphStyleRef paragraphStyleWithCompositionLanguageNone()
     static LazyNeverDestroyed<RetainPtr<CTParagraphStyleRef>> paragraphStyle;
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [&] {
-        paragraphStyle.construct(CTParagraphStyleCreate(nullptr, 0));
+        paragraphStyle.construct(adoptCF(CTParagraphStyleCreate(nullptr, 0)));
         CTParagraphStyleSetCompositionLanguage(paragraphStyle.get().get(), kCTCompositionLanguageNone);
     });
     return paragraphStyle.get().get();


### PR DESCRIPTION
#### 9069eed1d3392a322c9904b4fb9233cde599ad38
<pre>
SimpleFontDataCoreText: Avoid leak of CT object
<a href="https://bugs.webkit.org/show_bug.cgi?id=292620">https://bugs.webkit.org/show_bug.cgi?id=292620</a>
<a href="https://rdar.apple.com/150776106">rdar://150776106</a>

Reviewed by Aditya Keerthi.

* Source/WebCore/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations:
* Source/WebCore/platform/graphics/coretext/SimpleFontDataCoreText.cpp:
(WebCore::paragraphStyleWithCompositionLanguageNone):

Canonical link: <a href="https://commits.webkit.org/294574@main">https://commits.webkit.org/294574@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9446de050660426643b24454ad857a091bc835f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102337 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22006 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12320 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107498 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52973 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22314 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77867 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34860 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17276 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58205 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17110 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10408 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52331 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86936 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10479 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109873 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29469 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21729 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86849 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29833 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88576 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86438 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21990 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31256 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8971 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23711 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29397 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34693 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29208 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32531 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30767 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->