### PR TITLE
AX: Text descendants of links can incorrectly return InsideLink::InsideVisited or InsideLink::InsideUnvisited despite not being links, in turn causing AXProperty::InsideLink to be cached for them, wasting memory

### DIFF
--- a/LayoutTests/accessibility/link-becomes-visited.html
+++ b/LayoutTests/accessibility/link-becomes-visited.html
@@ -19,11 +19,18 @@ if (window.accessibilityController) {
     window.testRunner.keepWebHistory();
 
     var webArea = accessibilityController.rootElement.childAtIndex(0);
+    var link = webArea.childAtIndex(0);
+    var linkText = link.childAtIndex(0);
 
-    output += expect("webArea.childAtIndex(0).boolAttributeValue('AXVisited')", "false");
+    output += expect("link.boolAttributeValue('AXVisited')", "false");
     document.getElementById("link").click();
     setTimeout(async function() {
-        output += await expectAsync("webArea.childAtIndex(0).boolAttributeValue('AXVisited')", "true");
+        output += await expectAsync("link.boolAttributeValue('AXVisited')", "true");
+        output += expect("linkText.role.toLowerCase().includes('statictext')", "true");
+        // On non-iOS platforms, text inside a link should not report it's visited (because it's not a link), even if
+        // its parent link is visited. This is different on iOS because only leaf nodes are exposed, thus the text must
+        // be able to report itself as visited.
+        output += expect("linkText.boolAttributeValue('AXVisited')", accessibilityController.platformName === "ios" ? "true" : "false");
 
         debug(output);
         finishJSTest();

--- a/LayoutTests/platform/ios/accessibility/link-becomes-visited-expected.txt
+++ b/LayoutTests/platform/ios/accessibility/link-becomes-visited-expected.txt
@@ -3,7 +3,7 @@ This test ensures that we properly report AXVisited after dynamic page changes.
 PASS: link.boolAttributeValue('AXVisited') === false
 PASS: link.boolAttributeValue('AXVisited') === true
 PASS: linkText.role.toLowerCase().includes('statictext') === true
-PASS: linkText.boolAttributeValue('AXVisited') === false
+PASS: linkText.boolAttributeValue('AXVisited') === true
 
 PASS successfullyParsed is true
 

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -966,9 +966,9 @@ public:
     virtual bool isOnScreen() const = 0;
     virtual bool isOffScreen() const = 0;
     virtual bool isPressed() const = 0;
-    virtual InsideLink insideLink() const = 0;
-    bool isUnvisited() const { return insideLink() == InsideLink::InsideUnvisited; }
-    bool isVisited() const { return insideLink() == InsideLink::InsideVisited; }
+    bool isUnvisitedLink() const { return isLink() && !isVisited(); }
+    bool isVisitedLink() const { return isLink() && isVisited(); }
+    virtual bool isVisited() const = 0;
     virtual bool isRequired() const = 0;
     bool supportsRequiredAttribute() const;
     virtual bool isExpanded() const = 0;

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -834,9 +834,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::InternalLinkElement:
         stream << "InternalLinkElement";
         break;
-    case AXProperty::InsideLink:
-        stream << "InsideLink";
-        break;
     case AXProperty::IsGrabbed:
         stream << "IsGrabbed";
         break;
@@ -977,6 +974,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
         break;
     case AXProperty::IsVisible:
         stream << "IsVisible";
+        break;
+    case AXProperty::IsVisited:
+        stream << "IsVisited";
         break;
     case AXProperty::IsWidget:
         stream << "IsWidget";

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -4991,7 +4991,7 @@ void AXObjectCache::updateIsolatedTree(const Vector<std::pair<Ref<AccessibilityO
             tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::IsVisible });
             break;
         case AXNotification::VisitedStateChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::InsideLink });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::IsVisited });
             break;
         case AXNotification::ActiveDescendantChanged:
         case AXNotification::RoleChanged:

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -154,9 +154,9 @@ bool AXSearchManager::matchForSearchKeyAtIndex(Ref<AXCoreObject> axObject, const
     case AccessibilitySearchKey::Underline:
         return axObject->hasUnderline();
     case AccessibilitySearchKey::UnvisitedLink:
-        return axObject->isUnvisited();
+        return axObject->isUnvisitedLink();
     case AccessibilitySearchKey::VisitedLink:
-        return axObject->isVisited();
+        return axObject->isVisitedLink();
     default:
         return false;
     }

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1893,12 +1893,18 @@ bool AccessibilityObject::hasRowGroupTag() const
     return tag == theadTag || tag == tbodyTag || tag == tfootTag;
 }
 
-InsideLink AccessibilityObject::insideLink() const
+bool AccessibilityObject::isVisited() const
 {
+    if (!isLink()) {
+        // Note that this isLink() check is necessary in addition to the RenderStyle::isLink() check below, as multiple
+        // renderers can share the same style, e.g. RenderTexts within a link take their parent's (the link) style.
+        return false;
+    }
+
     auto* style = this->style();
     if (!style || !style->isLink())
-        return InsideLink::NotInside;
-    return style->insideLink();
+        return false;
+    return style->insideLink() == InsideLink::InsideVisited;
 }
 
 // If you call node->hasEditableStyle() since that will return true if an ancestor is editable.

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -202,7 +202,7 @@ public:
     bool isMultiSelectable() const override { return false; }
     bool isOffScreen() const override { return false; }
     bool isPressed() const override { return false; }
-    InsideLink insideLink() const final;
+    bool isVisited() const final;
     bool isRequired() const override { return false; }
     bool isExpanded() const final;
     bool isVisible() const override { return !isHidden(); }

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -672,7 +672,7 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
         case AccessibilityRole::Link:
         case AccessibilityRole::WebCoreLink:
             traits |= [self _axLinkTrait];
-            if (parent->isVisited())
+            if (parent->isVisitedLink())
                 traits |= [self _axVisitedTrait];
             break;
         case AccessibilityRole::Heading:
@@ -784,7 +784,7 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
     case AccessibilityRole::Link:
     case AccessibilityRole::WebCoreLink:
         traits |= [self _axLinkTrait];
-        if (self.axBackingObject->isVisited())
+        if (self.axBackingObject->isVisitedLink())
             traits |= [self _axVisitedTrait];
         break;
     case AccessibilityRole::ComboBox: {

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -175,7 +175,7 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
     setProperty(AXProperty::IsMultiSelectable, object.isMultiSelectable());
     setProperty(AXProperty::IsRequired, object.isRequired());
     setProperty(AXProperty::IsSelected, object.isSelected());
-    setProperty(AXProperty::InsideLink, object.insideLink());
+    setProperty(AXProperty::IsVisited, object.isVisited());
     setProperty(AXProperty::IsValueAutofillAvailable, object.isValueAutofillAvailable());
     setProperty(AXProperty::RoleDescription, object.roleDescription().isolatedCopy());
     setProperty(AXProperty::SubrolePlatformString, object.subrolePlatformString().isolatedCopy());
@@ -570,6 +570,9 @@ void AXIsolatedObject::setProperty(AXProperty property, AXPropertyValueVariant&&
         case AXProperty::IsTableRow:
             setPropertyFlag(AXPropertyFlag::IsTableRow, std::get<bool>(value));
             return;
+        case AXProperty::IsVisited:
+            setPropertyFlag(AXPropertyFlag::IsVisited, std::get<bool>(value));
+            return;
         case AXProperty::SupportsCheckedState:
             setPropertyFlag(AXPropertyFlag::SupportsCheckedState, std::get<bool>(value));
             return;
@@ -636,7 +639,6 @@ void AXIsolatedObject::setProperty(AXProperty property, AXPropertyValueVariant&&
         [](RetainPtr<NSAttributedString>& typedValue) { return !typedValue; },
         [](RetainPtr<id>& typedValue) { return !typedValue; },
 #endif
-        [](InsideLink& typedValue) { return typedValue == InsideLink(); },
         [](Vector<Vector<Markable<AXID>>>& typedValue) { return typedValue.isEmpty(); },
         [](CharacterRange& typedValue) { return !typedValue.location && !typedValue.length; },
         [](std::shared_ptr<AXIDAndCharacterRange>& typedValue) {
@@ -1207,6 +1209,8 @@ bool AXIsolatedObject::boolAttributeValue(AXProperty property) const
         return hasPropertyFlag(AXPropertyFlag::IsNonLayerSVGObject);
     case AXProperty::IsTableRow:
         return hasPropertyFlag(AXPropertyFlag::IsTableRow);
+    case AXProperty::IsVisited:
+        return hasPropertyFlag(AXPropertyFlag::IsVisited);
     case AXProperty::SupportsCheckedState:
         return hasPropertyFlag(AXPropertyFlag::SupportsCheckedState);
     case AXProperty::SupportsDragging:

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -253,7 +253,7 @@ private:
     bool isSelected() const final { return boolAttributeValue(AXProperty::IsSelected); }
     bool isFocused() const final { return tree()->focusedNodeID() == objectID(); }
     bool isMultiSelectable() const final { return boolAttributeValue(AXProperty::IsMultiSelectable); }
-    InsideLink insideLink() const final { return propertyValue<InsideLink>(AXProperty::InsideLink); }
+    bool isVisited() const final { return boolAttributeValue(AXProperty::IsVisited); }
     bool isRequired() const final { return boolAttributeValue(AXProperty::IsRequired); }
     bool isExpanded() const final { return boolAttributeValue(AXProperty::IsExpanded); }
     bool isFileUploadButton() const final { return boolAttributeValue(AXProperty::IsFileUploadButton); }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -673,9 +673,6 @@ void AXIsolatedTree::updateNodeProperties(AccessibilityObject& axObject, const A
         case AXProperty::IdentifierAttribute:
             properties.append({ AXProperty::IdentifierAttribute, axObject.identifierAttribute().isolatedCopy() });
             break;
-        case AXProperty::InsideLink:
-            properties.append({ AXProperty::InsideLink, axObject.insideLink() });
-            break;
         case AXProperty::InternalLinkElement: {
             auto* linkElement = axObject.internalLinkElement();
             properties.append({ AXProperty::InternalLinkElement, linkElement ? std::optional { linkElement->objectID() } : std::nullopt });
@@ -709,6 +706,9 @@ void AXIsolatedTree::updateNodeProperties(AccessibilityObject& axObject, const A
             break;
         case AXProperty::IsVisible:
             properties.append({ AXProperty::IsVisible, axObject.isVisible() });
+            break;
+        case AXProperty::IsVisited:
+            properties.append({ AXProperty::IsVisited, axObject.isVisited() });
             break;
         case AXProperty::MaxValueForRange:
             properties.append({ AXProperty::MaxValueForRange, axObject.maxValueForRange() });

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -74,12 +74,13 @@ enum class AXPropertyFlag : uint32_t {
     IsKeyboardFocusable                           = 1 << 12,
     IsNonLayerSVGObject                           = 1 << 13,
     IsTableRow                                    = 1 << 14,
-    SupportsCheckedState                          = 1 << 15,
-    SupportsDragging                              = 1 << 16,
-    SupportsExpanded                              = 1 << 17,
-    SupportsPath                                  = 1 << 18,
-    SupportsPosInSet                              = 1 << 19,
-    SupportsSetSize                               = 1 << 20
+    IsVisited                                     = 1 << 15,
+    SupportsCheckedState                          = 1 << 16,
+    SupportsDragging                              = 1 << 17,
+    SupportsExpanded                              = 1 << 18,
+    SupportsPath                                  = 1 << 19,
+    SupportsPosInSet                              = 1 << 20,
+    SupportsSetSize                               = 1 << 21
 };
 
 enum class AXProperty : uint16_t {
@@ -157,7 +158,6 @@ enum class AXProperty : uint16_t {
     InitialFrameRect,
     InnerHTML,
     InternalLinkElement,
-    InsideLink,
     IsGrabbed,
     IsARIATreeGridRow,
     IsAnonymousMathOperator,
@@ -205,6 +205,7 @@ enum class AXProperty : uint16_t {
     IsTreeItem,
     IsValueAutofillAvailable,
     IsVisible,
+    IsVisited,
     IsWidget,
     KeyShortcuts,
     Language,
@@ -297,7 +298,7 @@ using AXPropertySet = HashSet<AXProperty, IntHash<AXProperty>, WTF::StrongEnumHa
 using AXIDAndCharacterRange = std::pair<Markable<AXID>, CharacterRange>;
 
 // If this type is modified, the switchOn statment in AXIsolatedObject::setProperty must be updated as well.
-using AXPropertyValueVariant = Variant<std::nullptr_t, Markable<AXID>, String, bool, int, unsigned, double, float, uint64_t, WallTime, DateComponentsType, AccessibilityButtonState, Color, std::shared_ptr<URL>, LayoutRect, FloatPoint, FloatRect, IntPoint, IntRect, std::pair<unsigned, unsigned>, std::optional<unsigned>, Vector<AccessibilityText>, Vector<AXID>, Vector<std::pair<Markable<AXID>, Markable<AXID>>>, Vector<String>, std::shared_ptr<Path>, OptionSet<AXAncestorFlag>, InsideLink, Vector<Vector<Markable<AXID>>>, CharacterRange, std::shared_ptr<AXIDAndCharacterRange>, TagName, std::optional<AccessibilityOrientation>
+using AXPropertyValueVariant = Variant<std::nullptr_t, Markable<AXID>, String, bool, int, unsigned, double, float, uint64_t, WallTime, DateComponentsType, AccessibilityButtonState, Color, std::shared_ptr<URL>, LayoutRect, FloatPoint, FloatRect, IntPoint, IntRect, std::pair<unsigned, unsigned>, std::optional<unsigned>, Vector<AccessibilityText>, Vector<AXID>, Vector<std::pair<Markable<AXID>, Markable<AXID>>>, Vector<String>, std::shared_ptr<Path>, OptionSet<AXAncestorFlag>, Vector<Vector<Markable<AXID>>>, CharacterRange, std::shared_ptr<AXIDAndCharacterRange>, TagName, std::optional<AccessibilityOrientation>
 #if PLATFORM(COCOA)
     , RetainPtr<NSAttributedString>
     , RetainPtr<id>

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -1298,7 +1298,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     }
 
     if ([attributeName isEqualToString: NSAccessibilityVisitedAttribute])
-        return [NSNumber numberWithBool: backingObject->isVisited()];
+        return [NSNumber numberWithBool: backingObject->isVisitedLink()];
 
     if ([attributeName isEqualToString: NSAccessibilityTitleAttribute]) {
         if (backingObject->isAttachment()) {


### PR DESCRIPTION
#### e5a92c63a66a763a8b1bfdf6b872d4aa19e22920
<pre>
AX: Text descendants of links can incorrectly return InsideLink::InsideVisited or InsideLink::InsideUnvisited despite not being links, in turn causing AXProperty::InsideLink to be cached for them, wasting memory
<a href="https://bugs.webkit.org/show_bug.cgi?id=292622">https://bugs.webkit.org/show_bug.cgi?id=292622</a>
<a href="https://rdar.apple.com/150779990">rdar://150779990</a>

Reviewed by Joshua Hoffman.

RenderTexts take their parent&apos;s style, which is a problem for the implementation of AccessibilityObject::insideLink
prior to this commit, as RenderStyle::isLink would return true for these RenderTexts, despite them not actually being
links. This is confusing and wrong from a behavioral standpoint, and also caused AXProperty::InsideLink to be cached
for objects associated with these RenderTexts, wasting memory.

Fix this by adding an AXCoreObject::isLink check. Also replace AXProperty::InsideLink with AXProperty::IsVisited,
meaning we only ever cache a value for visited links. Some webpages have tens of thousands of links, so this can
make quite a significant difference.

* LayoutTests/accessibility/link-becomes-visited-expected.txt:
* LayoutTests/accessibility/link-becomes-visited.html:
New testcase added ensuring static text doesn&apos;t think it is ever `isVisited`.
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::isUnvisitedLink const):
(WebCore::AXCoreObject::isVisitedLink const):
(WebCore::AXCoreObject::isUnvisited const): Deleted.
(WebCore::AXCoreObject::isVisited const): Deleted.
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::updateIsolatedTree):
* Source/WebCore/accessibility/AXSearchManager.cpp:
(WebCore::AXSearchManager::matchForSearchKeyAtIndex):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::isVisited const):
(WebCore::AccessibilityObject::insideLink const): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper _accessibilityTraitsFromAncestors]):
(-[WebAccessibilityObjectWrapper accessibilityTraits]):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
(WebCore::AXIsolatedObject::setProperty):
(WebCore::AXIsolatedObject::boolAttributeValue const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateNodeProperties):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:]):

Canonical link: <a href="https://commits.webkit.org/294598@main">https://commits.webkit.org/294598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69cb5779d022ef538b831b254508c4b4d0a27cab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107570 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53046 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104448 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30584 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77912 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34911 "Failed to checkout and rebase branch from PR 45015") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92436 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58249 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17173 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10464 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52403 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/86994 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109945 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29541 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21780 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86896 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29905 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88632 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86487 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22003 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31310 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9025 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23783 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29469 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34771 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29280 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32603 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30839 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->