### PR TITLE
[Page color sampling] Fixed element background color extension views should animate

### DIFF
--- a/LayoutTests/compositing/cocoa/clip-sticky-element-to-viewport-expected.html
+++ b/LayoutTests/compositing/cocoa/clip-sticky-element-to-viewport-expected.html
@@ -39,6 +39,7 @@ addEventListener("load", async () => {
     await UIHelper.renderingUpdate();
     scrollTo(0, 400);
     await UIHelper.ensurePresentationUpdate();
+    await UIHelper.cancelFixedColorExtensionFadeAnimations();
     window.testRunner?.notifyDone();
 });
 </script>

--- a/LayoutTests/compositing/cocoa/clip-sticky-element-to-viewport.html
+++ b/LayoutTests/compositing/cocoa/clip-sticky-element-to-viewport.html
@@ -39,6 +39,7 @@ addEventListener("load", async () => {
     await UIHelper.renderingUpdate();
     scrollTo(0, 350);
     await UIHelper.ensurePresentationUpdate();
+    await UIHelper.cancelFixedColorExtensionFadeAnimations();
     window.testRunner?.notifyDone();
 });
 </script>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2272,6 +2272,15 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static cancelFixedColorExtensionFadeAnimations()
+    {
+        if (!this.isWebKit2())
+            return Promise.resolve();
+
+        const script = "uiController.cancelFixedColorExtensionFadeAnimations()";
+        return new Promise(resolve => testRunner.runUIScript(script, resolve));
+    }
+
     static fixedContainerEdgeColors()
     {
         if (!this.isWebKit2())

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -448,6 +448,7 @@ UIProcess/Cocoa/WebProcessCacheCocoa.mm
 UIProcess/Cocoa/WebProcessPoolCocoa.mm
 UIProcess/Cocoa/WebProcessProxyCocoa.mm
 UIProcess/Cocoa/WebURLSchemeHandlerCocoa.mm
+UIProcess/Cocoa/WKColorExtensionView.mm
 UIProcess/Cocoa/WKContactPicker.mm
 UIProcess/Cocoa/WKEditCommand.mm
 UIProcess/Cocoa/WKFullKeyboardAccessWatcher.mm

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -107,6 +107,7 @@ struct AppHighlight;
 struct ExceptionDetails;
 struct DigitalCredentialsRequestData;
 struct TextAnimationData;
+enum class BoxSide : uint8_t;
 enum class WheelScrollGestureState : uint8_t;
 namespace WritingTools {
 enum class TextSuggestionState : uint8_t;
@@ -132,6 +133,7 @@ class ViewGestureController;
 #endif
 }
 
+@class WKColorExtensionView;
 @class WKContentView;
 @class WKPasswordView;
 @class WKScrollGeometry;
@@ -447,7 +449,7 @@ struct PerWebProcessState {
 #endif
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-    WebCore::RectEdges<RetainPtr<CocoaView>> _fixedColorExtensionViews;
+    WebCore::RectEdges<RetainPtr<WKColorExtensionView>> _fixedColorExtensionViews;
 #endif
 }
 
@@ -519,6 +521,7 @@ struct PerWebProcessState {
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
 - (void)_updateFixedColorExtensionViewFrames;
+- (BOOL)_hasVisibleColorExtensionView:(WebCore::BoxSide)side;
 #endif
 
 #if ENABLE(GAMEPAD)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -166,6 +166,7 @@ struct WKAppPrivacyReportTestingData {
 @property (nonatomic, readonly) NSColor *_sampledBottomFixedPositionContentColor;
 @property (nonatomic, readonly) NSColor *_sampledRightFixedPositionContentColor;
 #endif
+- (void)_cancelFixedColorExtensionFadeAnimationsForTesting;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -37,8 +37,10 @@
 #import "UserMediaProcessManager.h"
 #import "ViewGestureController.h"
 #import "ViewSnapshotStore.h"
+#import "WKColorExtensionView.h"
 #import "WKContentViewInteraction.h"
 #import "WKPreferencesInternal.h"
+#import "WKWebViewInternal.h"
 #import "WebPageProxy.h"
 #import "WebPageProxyTesting.h"
 #import "WebProcessPool.h"
@@ -47,6 +49,7 @@
 #import "WebsiteDataStore.h"
 #import "_WKFrameHandleInternal.h"
 #import "_WKInspectorInternal.h"
+#import <WebCore/BoxSides.h>
 #import <WebCore/NowPlayingInfo.h>
 #import <WebCore/ScrollingNodeID.h>
 #import <WebCore/ValidationBubble.h>
@@ -998,6 +1001,14 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
         @"opaque" : @(layer.get().opaque),
         @"opacity" : @(layer.get().opacity),
     };
+}
+
+- (void)_cancelFixedColorExtensionFadeAnimationsForTesting
+{
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    for (auto side : WebCore::allBoxSides)
+        [_fixedColorExtensionViews.at(side) cancelFadeAnimation];
+#endif
 }
 
 @end

--- a/Source/WebKit/UIProcess/Cocoa/WKColorExtensionView.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKColorExtensionView.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import <WebCore/CocoaView.h>
+#import <WebCore/ColorCocoa.h>
+
+#if PLATFORM(IOS_FAMILY)
+#import <UIKit/UIKit.h>
+#else
+#import <AppKit/AppKit.h>
+#endif
+
+@protocol WKColorExtensionViewDelegate <NSObject>
+- (void)colorExtensionViewWillFadeOut:(WKColorExtensionView *)view;
+- (void)colorExtensionViewDidFadeIn:(WKColorExtensionView *)view;
+@end
+
+@interface WKColorExtensionView : CocoaView
+
+- (instancetype)initWithFrame:(CGRect)frame delegate:(id<WKColorExtensionViewDelegate>)delegate;
+- (void)fadeToColor:(WebCore::CocoaColor *)color;
+- (void)fadeOut;
+- (void)cancelFadeAnimation;
+
+@property (nonatomic, readonly, getter=isHiddenOrFadingOut) BOOL hiddenOrFadingOut;
+
+@end

--- a/Source/WebKit/UIProcess/Cocoa/WKColorExtensionView.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKColorExtensionView.mm
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "WKColorExtensionView.h"
+
+@interface WKColorExtensionView () <CAAnimationDelegate>
+@end
+
+@implementation WKColorExtensionView {
+    BOOL _isVisible;
+    BOOL _isDoneFadingIn;
+    __weak id<WKColorExtensionViewDelegate> _delegate;
+    RetainPtr<WebCore::CocoaColor> _targetColor;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame delegate:(id<WKColorExtensionViewDelegate>)delegate
+{
+    if (!(self = [super initWithFrame:frame]))
+        return nil;
+
+    _delegate = delegate;
+    return self;
+}
+
+- (void)fadeToColor:(WebCore::CocoaColor *)color
+{
+    [self _fadeToColor:color visible:YES];
+}
+
+- (void)fadeOut
+{
+    [self _fadeToColor:[WebCore::CocoaColor clearColor] visible:NO];
+}
+
+- (void)_fadeToColor:(WebCore::CocoaColor *)color visible:(BOOL)visible
+{
+    if (!visible && !_isVisible)
+        return;
+
+    BOOL wasVisible = std::exchange(_isVisible, visible);
+    if (wasVisible && !visible) {
+        [_delegate colorExtensionViewWillFadeOut:self];
+        _isDoneFadingIn = NO;
+    }
+
+    if (visible)
+        self.hidden = NO;
+
+    static constexpr auto animationDuration = 0.1;
+
+    RetainPtr fromColor = [self.layer backgroundColor];
+    RetainPtr toColor = [color CGColor];
+    _targetColor = color;
+    self.layer.backgroundColor = toColor.get();
+
+    RetainPtr animation = [CABasicAnimation animationWithKeyPath:@"backgroundColor"];
+    [animation setFromValue:(__bridge id)fromColor.get()];
+    [animation setToValue:(__bridge id)toColor.get()];
+    [animation setDuration:animationDuration];
+    [animation setFillMode:kCAFillModeForwards];
+    [animation setRemovedOnCompletion:NO];
+    [animation setDelegate:self];
+
+    [self.layer addAnimation:animation.get() forKey:@"WKColorExtensionViewFade"];
+}
+
+- (void)animationDidStop:(CAAnimation *)animation finished:(BOOL)finished
+{
+    if (!finished)
+        return;
+
+    if (!_isVisible) {
+        self.hidden = YES;
+        return;
+    }
+
+    if (!std::exchange(_isDoneFadingIn, YES))
+        [_delegate colorExtensionViewDidFadeIn:self];
+}
+
+- (BOOL)isHiddenOrFadingOut
+{
+    return self.hidden || !_isVisible;
+}
+
+- (void)cancelFadeAnimation
+{
+    if (!_targetColor)
+        return;
+
+    [self.layer removeAnimationForKey:@"WKColorExtensionViewFade"];
+    self.layer.backgroundColor = [_targetColor CGColor];
+    self.hidden = !_isVisible;
+}
+
+@end

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2492,6 +2492,7 @@
 		F42A04712CA1B328000D3118 /* _WKTextRunInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = F42A04702CA1B328000D3118 /* _WKTextRunInternal.h */; };
 		F42A04722CA1B3FC000D3118 /* _WKTextRun.h in Headers */ = {isa = PBXBuildFile; fileRef = F42A046C2CA1B2A4000D3118 /* _WKTextRun.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F42D634122A0EFDF00D2FB3A /* WebAutocorrectionData.h in Headers */ = {isa = PBXBuildFile; fileRef = F42D633F22A0EFD300D2FB3A /* WebAutocorrectionData.h */; };
+		F43019682DC97B10006522E0 /* WKColorExtensionView.h in Headers */ = {isa = PBXBuildFile; fileRef = F43019662DC97AAE006522E0 /* WKColorExtensionView.h */; };
 		F430E9422247335F005FE053 /* WebsiteMetaViewportPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = F430E941224732A9005FE053 /* WebsiteMetaViewportPolicy.h */; };
 		F430E94422473DFF005FE053 /* WebContentMode.h in Headers */ = {isa = PBXBuildFile; fileRef = F430E94322473DB8005FE053 /* WebContentMode.h */; };
 		F433C0A72958C22F00E771C2 /* NetworkIssueReporter.h in Headers */ = {isa = PBXBuildFile; fileRef = F433C0A52958C22F00E771C2 /* NetworkIssueReporter.h */; };
@@ -8383,6 +8384,8 @@
 		F42A04702CA1B328000D3118 /* _WKTextRunInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKTextRunInternal.h; sourceTree = "<group>"; };
 		F42D633F22A0EFD300D2FB3A /* WebAutocorrectionData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebAutocorrectionData.h; path = ios/WebAutocorrectionData.h; sourceTree = "<group>"; };
 		F42FC8702B7ADA5800BAF8D6 /* CoreIPCNSURLProtectionSpace.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreIPCNSURLProtectionSpace.serialization.in; sourceTree = "<group>"; };
+		F43019662DC97AAE006522E0 /* WKColorExtensionView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKColorExtensionView.h; sourceTree = "<group>"; };
+		F43019672DC97AAE006522E0 /* WKColorExtensionView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKColorExtensionView.mm; sourceTree = "<group>"; };
 		F430E941224732A9005FE053 /* WebsiteMetaViewportPolicy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebsiteMetaViewportPolicy.h; sourceTree = "<group>"; };
 		F430E94322473DB8005FE053 /* WebContentMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebContentMode.h; sourceTree = "<group>"; };
 		F433C0A52958C22F00E771C2 /* NetworkIssueReporter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkIssueReporter.h; sourceTree = "<group>"; };
@@ -10083,6 +10086,8 @@
 				1A04F6171A4A3A7A00A21B6E /* WebProcessProxyCocoa.mm */,
 				51D124311E6DE521002B2820 /* WebURLSchemeHandlerCocoa.h */,
 				51D124321E6DE521002B2820 /* WebURLSchemeHandlerCocoa.mm */,
+				F43019662DC97AAE006522E0 /* WKColorExtensionView.h */,
+				F43019672DC97AAE006522E0 /* WKColorExtensionView.mm */,
 				E596DD68251E71D300C275A7 /* WKContactPicker.h */,
 				E596DD69251E71D400C275A7 /* WKContactPicker.mm */,
 				2ECF66CC21D6B77E009E5C3F /* WKEditCommand.h */,
@@ -18044,6 +18049,7 @@
 				BC14DF9F120B635F00826C0C /* WKBundleScriptWorld.h in Headers */,
 				BC4075F6124FF0270068F20A /* WKCertificateInfo.h in Headers */,
 				BC407627124FF0400068F20A /* WKCertificateInfoMac.h in Headers */,
+				F43019682DC97B10006522E0 /* WKColorExtensionView.h in Headers */,
 				E596DD6A251E71D400C275A7 /* WKContactPicker.h in Headers */,
 				5CD286541E7235B10094FDC8 /* WKContentRuleList.h in Headers */,
 				5CD286551E7235B80094FDC8 /* WKContentRuleListInternal.h in Headers */,

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -401,6 +401,7 @@ interface UIScriptController {
     undefined setWebViewEditable(boolean editable);
 
     readonly attribute object fixedContainerEdgeColors;
+    undefined cancelFixedColorExtensionFadeAnimations();
 
     undefined cookiesForDomain(DOMString domain, object callback);
 

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -121,6 +121,7 @@ public:
     virtual void setObscuredInsets(double, double, double, double) { notImplemented(); }
 
     virtual JSObjectRef fixedContainerEdgeColors() const { return nullptr; }
+    virtual void cancelFixedColorExtensionFadeAnimations() const { notImplemented(); }
 
     virtual void cookiesForDomain(JSStringRef, JSValueRef) { notImplemented(); }
 

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
@@ -98,6 +98,7 @@ private:
     void cookiesForDomain(JSStringRef, JSValueRef callback) final;
 
     JSObjectRef fixedContainerEdgeColors() const final;
+    void cancelFixedColorExtensionFadeAnimations() const final;
 };
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -446,4 +446,9 @@ void UIScriptControllerCocoa::cookiesForDomain(JSStringRef jsDomain, JSValueRef 
     }];
 }
 
+void UIScriptControllerCocoa::cancelFixedColorExtensionFadeAnimations() const
+{
+    [webView() _cancelFixedColorExtensionFadeAnimationsForTesting];
+}
+
 } // namespace WTR


### PR DESCRIPTION
#### 7f4fa54b63f297c3eaf011a2e59d275a1af8fed1
<pre>
[Page color sampling] Fixed element background color extension views should animate
<a href="https://bugs.webkit.org/show_bug.cgi?id=292623">https://bugs.webkit.org/show_bug.cgi?id=292623</a>
<a href="https://rdar.apple.com/150400616">rdar://150400616</a>

Reviewed by Abrar Rahman Protyasha.

This patch refactors background color extension views for fixed-position elements docked to edges of
the viewport, such that they update background colors with a short (100 ms) animation. This helps to
smooth out transitions and prevent flickering in cases where the background color thrashes.

See below for more details.

* LayoutTests/compositing/cocoa/clip-sticky-element-to-viewport-expected.html:
* LayoutTests/compositing/cocoa/clip-sticky-element-to-viewport.html:
* LayoutTests/resources/ui-helper.js:

Adjust an existing layout test to force color extension views to finish animating instantly before
ending the test, using the new testing helper method below.

(window.UIHelper.cancelFixedColorExtensionFadeAnimations):
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _updateFixedColorExtensionViews]):

Pull out logic to update which edges of the viewport have color extension views into a separate
helper method. We no longer update this state immediately after updating `_fixedContainerEdges`,
since we now need to wait for the fixed color extension views to either finish animating in to
prevent a flicker due to `m_topContentInsetFillView` otherwise disappearing without animation.

(-[WKWebView _updateFixedColorExtensionEdges]):
(-[WKWebView _hasVisibleColorExtensionView:]):
(-[WKWebView colorExtensionViewWillFadeOut:]):
(-[WKWebView colorExtensionViewDidFadeIn:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _cancelFixedColorExtensionFadeAnimationsForTesting]):
* Source/WebKit/UIProcess/Cocoa/WKColorExtensionView.h: Added.
* Source/WebKit/UIProcess/Cocoa/WKColorExtensionView.mm: Added.
(-[WKColorExtensionView initWithFrame:delegate:]):

Add a new helper class to help facilitate animated transitions between targeted background colors,
in such a way that:

- Animations are reversible and cancelable.
- The view is hidden after animating to `+clearColor`.
- The view can notify its delegate when it&apos;s about to begin fading out, or when it&apos;s done fading in.

(-[WKColorExtensionView fadeToColor:]):
(-[WKColorExtensionView fadeOut]):
(-[WKColorExtensionView _fadeToColor:visible:]):

Add support for methods to fade to a target color, fade out entirely (setting `-isHidden` when
finished), and also cancel any pending fade animation.

(-[WKColorExtensionView animationDidStop:finished:]):
(-[WKColorExtensionView isHiddenOrFadingOut]):
(-[WKColorExtensionView cancelFadeAnimation]):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::cancelFixedColorExtensionFadeAnimations const):

Add a testing hook to immediately fast-forward ongoing fade animations in all of the color extension
views. This is used to ensure that `clip-sticky-element-to-viewport.html` above doesn&apos;t fail due to
taking a snapshot that includes the color extension view, while the color extension view is still in
the middle of its animation.

* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::cancelFixedColorExtensionFadeAnimations const):

Canonical link: <a href="https://commits.webkit.org/294575@main">https://commits.webkit.org/294575@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4260de4ce08111bae1d2eda8eff9f7cffce85a14

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102342 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22011 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12325 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107503 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52978 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104381 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22319 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77872 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34861 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105348 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17285 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92383 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58210 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17120 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10411 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52336 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86945 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109878 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29474 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21734 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86853 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29838 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88579 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86443 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21992 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31259 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8974 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23716 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29402 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34698 "Found 3 new failures in UIProcess/Cocoa/WKColorExtensionView.mm") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29213 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32536 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30772 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->