### PR TITLE
(Regression 15.2) Auto-upgrading some hosts to https that rely on localhost subresource causes breakage

### DIFF
--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -812,6 +812,9 @@ static bool shouldPerformHTTPSUpgrade(const URL& originalURL, const URL& newURL,
         || RegistrableDomain(newURL) == RegistrableDomain(originalURL))
         && (advancedPrivacyProtections.contains(AdvancedPrivacyProtections::HTTPSOnlyExplicitlyBypassedForDomain) || frame.protectedLoader()->shouldSkipHTTPSUpgradeForSameSiteNavigation() || originalURL.protocolIs("http"_s));
 
+    if (RefPtr document = frame.document(); document && document->quirks().shouldNotAutoUpgradeToHTTPSNavigation(newURL))
+        return false;
+
     return (isHTTPSByDefaultEnabled || httpsByDefaultMode != HTTPSByDefaultMode::Disabled)
         && newURL.protocolIs("http"_s)
         && !isSameSiteBypassEnabled

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -129,6 +129,7 @@ static HashMap<RegistrableDomain, String>& updatableStorageAccessUserAgentString
 static inline bool needsDesktopUserAgentInternal(const URL&) { return false; }
 static inline bool shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeInternal(const URL&) { return false; }
 static inline String standardUserAgentWithApplicationNameIncludingCompatOverridesInternal(const String&, const String&, UserAgentType) { return { }; }
+static inline bool shouldNotAutoUpgradeToHTTPSNavigationInternal(const URL&) { return false; }
 #endif
 
 Quirks::Quirks(Document& document)
@@ -941,6 +942,11 @@ bool Quirks::shouldAvoidPastingImagesAsWebContent() const
 #else
     return false;
 #endif
+}
+
+bool Quirks::shouldNotAutoUpgradeToHTTPSNavigation(const URL& url)
+{
+    return needsQuirks() && shouldNotAutoUpgradeToHTTPSNavigationInternal(url);
 }
 
 // kinja.com and related sites rdar://60601895

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -151,6 +151,8 @@ public:
 
     bool shouldAvoidPastingImagesAsWebContent() const;
 
+    bool shouldNotAutoUpgradeToHTTPSNavigation(const URL&);
+
     enum StorageAccessResult : bool { ShouldNotCancelEvent, ShouldCancelEvent };
     enum ShouldDispatchClick : bool { No, Yes };
 


### PR DESCRIPTION
#### 549ae69ade489f3fa1be1f89b88184f92120b842
<pre>
(Regression 15.2) Auto-upgrading some hosts to https that rely on localhost subresource causes breakage
<a href="https://bugs.webkit.org/show_bug.cgi?id=292626">https://bugs.webkit.org/show_bug.cgi?id=292626</a>
<a href="https://rdar.apple.com/140368377">rdar://140368377</a>

Reviewed by Brent Fulgham.

Safari 15.2 enabled a HTTPS auto-upgrade behavior that automatically upgrades
http:// urls to https:// on cross-site navigations. This is generally web
compatible, and both Chrome and Firefox have shipped some version of this for a
few years at this point. However, WebKit does not treat localhost or loopback
connections as secure, unlike Chromium and Gecko, and that causes unique
breakage in some cases. This patch adds a quirk for particularly problematic
hosts where this causes breakage.

Tested manually.

* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::updateRequestAfterRedirection):
(WebCore::CachedResourceLoader::requestResource):
* Source/WebCore/page/Quirks.cpp:
(WebCore::shouldNotAutoUpgradeToHTTPSInternal):
(WebCore::Quirks::shouldNotAutoUpgradeToHTTPS):
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/295624@main">https://commits.webkit.org/295624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e8aa5def2001575ad3a1e75e3a75f7fafca81ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104838 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110053 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55512 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106878 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33096 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79606 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107844 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19405 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94615 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59913 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19152 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12692 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54895 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88852 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12739 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112470 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32003 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23528 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88685 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32367 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90841 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88312 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22683 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33205 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10970 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27317 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31928 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37282 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31720 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35061 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33279 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->