### PR TITLE
[macOS] Improve support for textarea and textfields when vector-based controls are enabled

### DIFF
--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -788,8 +788,6 @@ void TextFieldInputType::createContainer(PreserveSelectionRange preserveSelectio
     ASSERT(!m_container);
     ASSERT(element());
 
-    static MainThreadNeverDestroyed<const AtomString> webkitTextfieldDecorationContainerName("-webkit-textfield-decoration-container"_s);
-
     Ref shadowRoot = *element()->userAgentShadowRoot();
     ScriptDisallowedScope::EventAllowedScope allowedScope(shadowRoot);
 

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -95,7 +95,7 @@ static inline bool isNumberInput(const Element* element)
 }
 #endif
 
-std::optional<Style::UnadjustedStyle> TextControlInnerContainer::resolveCustomStyle(const Style::ResolutionContext& resolutionContext, const RenderStyle*)
+std::optional<Style::UnadjustedStyle> TextControlInnerContainer::resolveCustomStyle(const Style::ResolutionContext& resolutionContext, const RenderStyle* shadowHostStyle)
 {
     auto elementStyle = resolveStyle(resolutionContext);
     if (isStrongPasswordTextField(shadowHost())) {
@@ -103,6 +103,9 @@ std::optional<Style::UnadjustedStyle> TextControlInnerContainer::resolveCustomSt
         elementStyle.style->setOverflowX(Overflow::Hidden);
         elementStyle.style->setOverflowY(Overflow::Hidden);
     }
+
+    if (shadowHostStyle)
+        RenderTheme::singleton().adjustTextControlInnerContainerStyle(*elementStyle.style, *shadowHostStyle, shadowHost());
 
     return elementStyle;
 }
@@ -208,6 +211,10 @@ RenderTextControlInnerBlock* TextControlInnerTextElement::renderer() const
 std::optional<Style::UnadjustedStyle> TextControlInnerTextElement::resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle)
 {
     auto style = downcast<HTMLTextFormControlElement>(*shadowHost()).createInnerTextStyle(*shadowHostStyle);
+
+    if (shadowHostStyle)
+        RenderTheme::singleton().adjustTextControlInnerTextStyle(style, *shadowHostStyle, shadowHost());
+
     return Style::UnadjustedStyle { makeUnique<RenderStyle>(WTFMove(style)) };
 }
 
@@ -238,6 +245,10 @@ std::optional<Style::UnadjustedStyle> TextControlPlaceholderElement::resolveCust
         style.style->setPaddingTop(Length { 0, LengthType::Fixed });
         style.style->setPaddingBottom(Length { 0, LengthType::Fixed });
     }
+
+    if (shadowHostStyle)
+        RenderTheme::singleton().adjustTextControlInnerPlaceholderStyle(*style.style, *shadowHostStyle, shadowHost());
+
     return style;
 }
 

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1754,7 +1754,7 @@ void RenderBox::paintBoxDecorations(PaintInfo& paintInfo, const LayoutPoint& pai
             if (auto* control = ensureControlPartForBorderOnly())
                 paintCSSBorder = theme().paint(*this, *control, paintInfo, paintRect);
             else
-                paintCSSBorder = theme().paintBorderOnly(*this, paintInfo, paintRect);
+                paintCSSBorder = theme().paintBorderOnly(*this, paintInfo);
         }
 
         if (paintCSSBorder && style().hasVisibleBorderDecoration())

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -912,7 +912,9 @@ bool RenderTheme::paint(const RenderBox& box, const PaintInfo& paintInfo, const 
     case StyleAppearance::SliderThumbVertical:
         return paintSliderThumb(box, paintInfo, devicePixelSnappedRect);
     case StyleAppearance::TextField:
+        return paintTextField(box, paintInfo, devicePixelSnappedRect);
     case StyleAppearance::TextArea:
+        return paintTextArea(box, paintInfo, devicePixelSnappedRect);
     case StyleAppearance::Listbox:
         return true;
     case StyleAppearance::InnerSpinButton:
@@ -951,23 +953,19 @@ bool RenderTheme::paint(const RenderBox& box, const PaintInfo& paintInfo, const 
     return true; // We don't support the appearance, so let the normal background/border paint.
 }
 
-bool RenderTheme::paintBorderOnly(const RenderBox& box, const PaintInfo& paintInfo, const LayoutRect& rect)
+bool RenderTheme::paintBorderOnly(const RenderBox& box, const PaintInfo& paintInfo)
 {
     if (paintInfo.context().paintingDisabled())
         return false;
 
 #if PLATFORM(IOS_FAMILY)
-    UNUSED_PARAM(rect);
     return box.style().usedAppearance() != StyleAppearance::None && box.style().usedAppearance() != StyleAppearance::Base;
 #else
-    FloatRect devicePixelSnappedRect = snapRectToDevicePixels(rect, box.document().deviceScaleFactor());
     // Call the appropriate paint method based off the appearance value.
     switch (box.style().usedAppearance()) {
     case StyleAppearance::TextField:
-        return paintTextField(box, paintInfo, devicePixelSnappedRect);
     case StyleAppearance::Listbox:
     case StyleAppearance::TextArea:
-        return paintTextArea(box, paintInfo, devicePixelSnappedRect);
     case StyleAppearance::MenulistButton:
     case StyleAppearance::SearchField:
         return true;

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -83,7 +83,7 @@ public:
     bool paint(const RenderBox&, ControlPart&, const PaintInfo&, const LayoutRect&);
     bool paint(const RenderBox&, const PaintInfo&, const LayoutRect&);
     
-    bool paintBorderOnly(const RenderBox&, const PaintInfo&, const LayoutRect&);
+    bool paintBorderOnly(const RenderBox&, const PaintInfo&);
     void paintDecorations(const RenderBox&, const PaintInfo&, const LayoutRect&);
 
     // The remaining methods should be implemented by the platform-specific portion of the theme, e.g.,
@@ -248,6 +248,10 @@ public:
     virtual void paintPlatformResizerFrame(const RenderLayerModelObject&, GraphicsContext&, const LayoutRect&);
 
     static bool hasAppearanceForElementTypeFromUAStyle(const Element&);
+
+    virtual void adjustTextControlInnerContainerStyle(RenderStyle&, const RenderStyle&, const Element*) const { }
+    virtual void adjustTextControlInnerPlaceholderStyle(RenderStyle&, const RenderStyle&, const Element*) const { }
+    virtual void adjustTextControlInnerTextStyle(RenderStyle&, const RenderStyle&, const Element*) const { }
 
 protected:
     ControlStyle extractControlStyleForRenderer(const RenderObject&) const;

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
@@ -76,6 +76,10 @@ protected:
     bool paintTextField(const RenderObject&, const PaintInfo&, const FloatRect&) override;
     void paintTextFieldDecorations(const RenderBox&, const PaintInfo&, const FloatRect&) override;
 
+    void adjustTextControlInnerContainerStyle(RenderStyle&, const RenderStyle&, const Element*) const override;
+    void adjustTextControlInnerPlaceholderStyle(RenderStyle&, const RenderStyle&, const Element*) const override;
+    void adjustTextControlInnerTextStyle(RenderStyle&, const RenderStyle&, const Element*) const override;
+
     void adjustTextAreaStyle(RenderStyle&, const Element*) const override;
     bool paintTextArea(const RenderObject&, const PaintInfo&, const FloatRect&) override;
     void paintTextAreaDecorations(const RenderBox&, const PaintInfo&, const FloatRect&) override;

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -939,4 +939,34 @@ bool RenderThemeCocoa::supportsFocusRing(const RenderObject& renderer, const Ren
     return RenderTheme::supportsFocusRing(renderer, style);
 }
 
+void RenderThemeCocoa::adjustTextControlInnerContainerStyle(RenderStyle& style, const RenderStyle& shadowHostStyle, const Element* shadowHost) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustTextControlInnerContainerStyleForVectorBasedControls(style, shadowHostStyle, shadowHost))
+        return;
+#endif
+
+    RenderTheme::adjustTextControlInnerContainerStyle(style, shadowHostStyle, shadowHost);
+}
+
+void RenderThemeCocoa::adjustTextControlInnerPlaceholderStyle(RenderStyle& style, const RenderStyle& shadowHostStyle, const Element* shadowHost) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustTextControlInnerPlaceholderStyleForVectorBasedControls(style, shadowHostStyle, shadowHost))
+        return;
+#endif
+
+    RenderTheme::adjustTextControlInnerPlaceholderStyle(style, shadowHostStyle, shadowHost);
+}
+
+void RenderThemeCocoa::adjustTextControlInnerTextStyle(RenderStyle& style, const RenderStyle& shadowHostStyle, const Element* shadowHost) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustTextControlInnerTextStyleForVectorBasedControls(style, shadowHostStyle, shadowHost))
+        return;
+#endif
+
+    RenderTheme::adjustTextControlInnerTextStyle(style, shadowHostStyle, shadowHost);
+}
+
 }


### PR DESCRIPTION
#### 7cfd2e7510a4db713120cefaf757ea3f8a249f2e
<pre>
[macOS] Improve support for textarea and textfields when vector-based controls are enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=292627">https://bugs.webkit.org/show_bug.cgi?id=292627</a>
<a href="https://rdar.apple.com/150787309">rdar://150787309</a>

Reviewed by Megan Gardner, Aditya Keerthi, and Wenson Hsieh.

Added paint methods for textareas and textfields. Added method to adjust styles
for the inner elements of text-based controls.

Removed unused variable &apos;webkitTextfieldDecorationContainerName&apos;.

Calls to `paintTextArea` and `paintTextField` have been moved from
`RenderTheme::paintBorderOnly` to `RenderTheme::paint`, and
`RenderTheme::paintBorderOnly` now simply returns true for
textareas and textfields. When `RenderTheme::paintBorderOnly`
returns true, the CSS background is painted for a control. The
method is only called when `RenderTheme::paint` returns true.
Since neither `paintTextArea` nor `paintTextField` do any
painting and simply return true in the cases where the base
implementation is used or the Cocoa implementation is used
&amp; vector-based controls for Mac/Mac Catalyst are disabled,
there is no change in behavior in these two cases.

The purpose of moving these calls is that, if the controls
end up being painted using the vector-based implementations
for Mac/Mac Catalyst, the background can just be painted there
instead of having to paint the CSS background since we know
what color the background will be. We know the background color
will be the same as the UA style because if any other background
style was applied, the control would have devolved and theme
painting for the control would have been skipped entirely.

* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::createContainer):
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
(WebCore::TextControlInnerContainer::resolveCustomStyle):
(WebCore::TextControlInnerTextElement::resolveCustomStyle):
(WebCore::TextControlPlaceholderElement::resolveCustomStyle):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::paint):
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::adjustTextControlInnerContainerStyle const):
(WebCore::RenderTheme::adjustTextControlInnerPlaceholderStyle const):
(WebCore::RenderTheme::adjustTextControlInnerTextStyle const):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.h:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::adjustTextControlInnerContainerStyle const):
(WebCore::RenderThemeCocoa::adjustTextControlInnerPlaceholderStyle const):
(WebCore::RenderThemeCocoa::adjustTextControlInnerTextStyle const):

Canonical link: <a href="https://commits.webkit.org/294757@main">https://commits.webkit.org/294757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/785235882704e02e684d74be987db06ee55d3592

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108145 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53618 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105016 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22978 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31152 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/78285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/35235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105983 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/17794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/92914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/58620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/17629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/10957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52975 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/87442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/11024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110518 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30114 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30478 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/89117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/86896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/31745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/9456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24388 "Failed to checkout and rebase branch from PR 45022") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16705 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30041 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35363 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29849 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33176 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31411 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->