### PR TITLE
[Flex][Cleanup] Rename OverridingSizesScope width/height

### DIFF
--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -209,28 +209,28 @@ public:
     {
         ASSERT(!size || (axis != Axis::Both));
         if (axis == Axis::Both || axis == Axis::Inline) {
-            m_overridingWidth = box.overridingBorderBoxLogicalWidth();
+            m_previousOverridingBorderBoxLogicalWidth = box.overridingBorderBoxLogicalWidth();
             SET_OR_CLEAR_OVERRIDING_SIZE(m_box, Width, size);
         }
         if (axis == Axis::Both || axis == Axis::Block) {
-            m_overridingHeight = box.overridingBorderBoxLogicalHeight();
+            m_previousOverridingBorderBoxLogicalHeight = box.overridingBorderBoxLogicalHeight();
             SET_OR_CLEAR_OVERRIDING_SIZE(m_box, Height, size);
         }
     }
     ~OverridingSizesScope()
     {
         if (m_axis == Axis::Inline || m_axis == Axis::Both)
-            SET_OR_CLEAR_OVERRIDING_SIZE(m_box, Width, m_overridingWidth);
+            SET_OR_CLEAR_OVERRIDING_SIZE(m_box, Width, m_previousOverridingBorderBoxLogicalWidth);
 
         if (m_axis == Axis::Block || m_axis == Axis::Both)
-            SET_OR_CLEAR_OVERRIDING_SIZE(m_box, Height, m_overridingHeight);
+            SET_OR_CLEAR_OVERRIDING_SIZE(m_box, Height, m_previousOverridingBorderBoxLogicalHeight);
     }
 
 private:
     RenderBox& m_box;
     Axis m_axis;
-    std::optional<LayoutUnit> m_overridingWidth;
-    std::optional<LayoutUnit> m_overridingHeight;
+    std::optional<LayoutUnit> m_previousOverridingBorderBoxLogicalWidth;
+    std::optional<LayoutUnit> m_previousOverridingBorderBoxLogicalHeight;
 };
 
 static void updateFlexItemDirtyBitsBeforeLayout(bool relayoutFlexItem, RenderBox& flexItem)


### PR DESCRIPTION
#### 78a98f5478f81a0c31101697e65bcffb5168ae88
<pre>
[Flex][Cleanup] Rename OverridingSizesScope width/height
<a href="https://bugs.webkit.org/show_bug.cgi?id=292632">https://bugs.webkit.org/show_bug.cgi?id=292632</a>
<a href="https://rdar.apple.com/150799110">rdar://150799110</a>

Reviewed by Vitor Roriz.

OverridingSizesScope holds onto the previous values of the renderer&apos;s
overriding border box logical width/height. Rename them to reflect that
they hold onto the previous values and that they are the logical sizes
not the physical ones.

* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::OverridingSizesScope::OverridingSizesScope):
(WebCore::OverridingSizesScope::~OverridingSizesScope):

Canonical link: <a href="https://commits.webkit.org/294587@main">https://commits.webkit.org/294587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/debf8954380b419c4b655f0e5b6a752d50d96d43

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22046 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107538 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53013 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104416 "Build is in progress. Recent messages:OS: Sequoia (15.3), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed bindings tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22354 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30552 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77892 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34884 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105383 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17314 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92412 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58229 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17149 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10440 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52371 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86972 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109913 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29509 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21754 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86880 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29873 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88608 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86471 "Found 102 new API test failures: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/javascript-dialogs, /TestWebKit:WebKit.DOMWindowExtensionCrashOnReload, /TestWebKit:WebKit.PageLoadBasic, /TestWebKit:WebKit.NewFirstVisuallyNonEmptyLayoutFails, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /TestWebKit:WebKit.InjectedBundleBasic, /TestWebKit:WebKit.PreventEmptyUserAgent, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/select-all/non-editable ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21996 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31284 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9002 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23751 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29437 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34737 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29248 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32571 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30807 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->