### PR TITLE
Followup to 294575@main — fix Safer C++ warnings in WKColorExtensionView.mm

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WKColorExtensionView.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKColorExtensionView.mm
@@ -26,6 +26,8 @@
 #import "config.h"
 #import "WKColorExtensionView.h"
 
+#import <wtf/RetainPtr.h>
+
 @interface WKColorExtensionView () <CAAnimationDelegate>
 @end
 
@@ -62,7 +64,7 @@
 
     BOOL wasVisible = std::exchange(_isVisible, visible);
     if (wasVisible && !visible) {
-        [_delegate colorExtensionViewWillFadeOut:self];
+        [retainPtr(_delegate) colorExtensionViewWillFadeOut:self];
         _isDoneFadingIn = NO;
     }
 
@@ -98,7 +100,7 @@
     }
 
     if (!std::exchange(_isDoneFadingIn, YES))
-        [_delegate colorExtensionViewDidFadeIn:self];
+        [retainPtr(_delegate) colorExtensionViewDidFadeIn:self];
 }
 
 - (BOOL)isHiddenOrFadingOut
@@ -111,8 +113,9 @@
     if (!_targetColor)
         return;
 
-    [self.layer removeAnimationForKey:@"WKColorExtensionViewFade"];
-    self.layer.backgroundColor = [_targetColor CGColor];
+    RetainPtr layer = [self layer];
+    [layer removeAnimationForKey:@"WKColorExtensionViewFade"];
+    [layer setBackgroundColor:RetainPtr { [_targetColor CGColor] }.get()];
     self.hidden = !_isVisible;
 }
 


### PR DESCRIPTION
#### df7b170217e90aefa518dedc829a1ad38638a5d9
<pre>
Followup to 294575@main — fix Safer C++ warnings in WKColorExtensionView.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=292623">https://bugs.webkit.org/show_bug.cgi?id=292623</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

Fixes a few (unretained) method calls to `_delegate`, as well passing an unretained reference to
`[_targetColor CGColor]` when setting the background color.

* Source/WebKit/UIProcess/Cocoa/WKColorExtensionView.mm:
(-[WKColorExtensionView _fadeToColor:visible:]):
(-[WKColorExtensionView animationDidStop:finished:]):
(-[WKColorExtensionView cancelFadeAnimation]):

Also wrap `self.layer` in a `RetainPtr` for good measure.

Canonical link: <a href="https://commits.webkit.org/294590@main">https://commits.webkit.org/294590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af88f92311265c8de4e65adb6b38ddc07cff341d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107543 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53018 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30557 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77896 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34886 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17316 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92417 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58233 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17151 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52376 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86974 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10516 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109918 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29514 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21757 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86877 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29878 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88613 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86468 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21997 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31288 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23756 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29442 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34744 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29253 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32576 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30812 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->