### PR TITLE
[iOS] Use SF symbols instead of text in the form accessory view

### DIFF
--- a/Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.mm
@@ -61,6 +61,11 @@ inline static UIImage *downArrow()
     return [UIImage systemImageNamed:@"chevron.down"];
 }
 
+inline static UIImage *checkmark()
+{
+    return [UIImage systemImageNamed:@"checkmark"];
+}
+
 inline static RetainPtr<UIToolbar> createToolbarWithItems(NSArray<UIBarButtonItem *> *items)
 {
     auto bar = adoptNS([[UIToolbar alloc] init]);
@@ -97,6 +102,15 @@ inline static RetainPtr<UIToolbar> createToolbarWithItems(NSArray<UIBarButtonIte
 - (CGFloat)_toolbarMargin
 {
     return 0;
+}
+
+- (BOOL)_useCheckmarkForDone
+{
+    return NO;
+}
+
+- (void)_adjustFlexibleSpaceItem:(UIBarButtonItem *)item
+{
 }
 #endif
 
@@ -174,11 +188,17 @@ inline static RetainPtr<UIToolbar> createToolbarWithItems(NSArray<UIBarButtonIte
     [items addObject:_nextItem.get()];
 
     _flexibleSpaceItem = adoptNS([[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil]);
+    if (self._useCheckmarkForDone)
+        [self _adjustFlexibleSpaceItem:_flexibleSpaceItem.get()];
+
     _autoFillButtonItemSpacer = adoptNS([[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil]);
     [_autoFillButtonItemSpacer setWidth:WebKit::fixedSpaceBetweenButtonItems];
 
     // iPad doesn't show the "Done" button since the keyboard has its own dismiss key.
-    _doneButton = adoptNS([[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(_done)]);
+    if (self._useCheckmarkForDone)
+        _doneButton = adoptNS([[UIBarButtonItem alloc] initWithImage:WebKit::checkmark() style:UIBarButtonItemStylePlain target:self action:@selector(_done)]);
+    else
+        _doneButton = adoptNS([[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(_done)]);
     [items addObject:_flexibleSpaceItem.get()];
     [items addObject:_doneButton.get()];
 


### PR DESCRIPTION
#### 945701dc1d291ef7864370f7814e4bd998b7bee1
<pre>
[iOS] Use SF symbols instead of text in the form accessory view
<a href="https://bugs.webkit.org/show_bug.cgi?id=292634">https://bugs.webkit.org/show_bug.cgi?id=292634</a>
<a href="https://rdar.apple.com/149810250">rdar://149810250</a>

Reviewed by Abrar Rahman Protyasha and Wenson Hsieh.

* Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.mm:
(WebKit::checkmark):
(-[WKFormAccessoryView _useCheckmarkForDone]):
(-[WKFormAccessoryView _adjustFlexibleSpaceItem:]):
(-[WKFormAccessoryView initWithInputAssistantItem:delegate:]):

Use the &quot;checkmark&quot; SF symbol instead of the system&apos;s &quot;Done&quot; bar button item.

Canonical link: <a href="https://commits.webkit.org/294618@main">https://commits.webkit.org/294618@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1592acec6014bf3f1b74cc1dee18240ab42a1b32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12366 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107544 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53019 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30558 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77895 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34888 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105389 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92414 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58232 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17153 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52377 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86976 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10513 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109919 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29515 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21758 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86878 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86469 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31289 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9004 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23757 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16645 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29443 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34745 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29254 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32577 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30813 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->