### PR TITLE
Invisible <audio> controls when transformed.

### DIFF
--- a/LayoutTests/compositing/transforms/transformed-replaced-with-shadow-children-expected.html
+++ b/LayoutTests/compositing/transforms/transformed-replaced-with-shadow-children-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+ <script src="../../resources/ui-helper.js"></script>
+  <script>
+    if (window.testRunner)
+       testRunner.waitUntilDone();
+
+    async function doTest()
+    {
+      await UIHelper.renderingUpdate();
+      await UIHelper.renderingUpdate();
+      if (window.testRunner)
+        testRunner.notifyDone();
+    }
+    window.addEventListener('load', doTest, false);
+  </script>
+</head>
+<body>
+  <audio controls style="width: 400px">
+</body>
+</html>

--- a/LayoutTests/compositing/transforms/transformed-replaced-with-shadow-children.html
+++ b/LayoutTests/compositing/transforms/transformed-replaced-with-shadow-children.html
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+ <script src="../../resources/ui-helper.js"></script>
+  <script>
+    if (window.testRunner)
+       testRunner.waitUntilDone();
+
+    async function doTest()
+    {
+      await UIHelper.renderingUpdate();
+      await UIHelper.renderingUpdate();
+      if (window.testRunner)
+        testRunner.notifyDone();
+    }
+    window.addEventListener('load', doTest, false);
+  </script>
+</head>
+<body style="overflow:hidden">
+  <audio controls style="margin-left: 100vw; transform: translateX(-100vw); width: 400px;">
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1333,8 +1333,9 @@ void RenderLayer::recursiveUpdateLayerPositions(OptionSet<UpdateLayerPositionsFl
 
     }
 
-    if (!isRenderViewLayer() && renderer().canContainFixedPositionObjects()) {
-        flags.add(SeenFixedContainingBlockLayer);
+    if (!isRenderViewLayer()) {
+        if (renderer().canContainFixedPositionObjects())
+            flags.add(SeenFixedContainingBlockLayer);
 
         if (transform()) {
             flags.add(SeenTransformedLayer);


### PR DESCRIPTION
#### cbcf12b76b17023f2a38b026fae975e1c1ff9075
<pre>
Invisible &lt;audio&gt; controls when transformed.
<a href="https://bugs.webkit.org/show_bug.cgi?id=292425">https://bugs.webkit.org/show_bug.cgi?id=292425</a>
&lt;<a href="https://rdar.apple.com/150526971">rdar://150526971</a>&gt;

Reviewed by Simon Fraser.

Replaced elements aren&apos;t fixed position containing blocks, but they can still
have (shadow-tree) children and we need to set the flag so that clips on
children get computed in the correct coordinate space.

This was causing the clipped overlap bounds of the backdrop-filter layer to be
incorrect and empty, and causing foreground content to be painted into
background layers.

* LayoutTests/compositing/transforms/transformed-replaced-with-shadow-children-expected.html: Added.
* LayoutTests/compositing/transforms/transformed-replaced-with-shadow-children.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::recursiveUpdateLayerPositions):

Canonical link: <a href="https://commits.webkit.org/294694@main">https://commits.webkit.org/294694@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bff104a61636667e679115b053b994290078e5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22236 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12550 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107728 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53204 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104606 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30742 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78021 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35002 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17470 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92579 "Found 1 new API test failure: TestWebKitAPI.WebKit.PrintFrame (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58356 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17309 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10608 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52561 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87119 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10677 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110103 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29699 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21900 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86999 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30063 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88774 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86603 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22077 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31432 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9160 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23949 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29627 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34939 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29438 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32761 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30997 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->