### PR TITLE
Add FrameMemoryMonitor for LocalFrame GPU memory tracking during media loading

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7920,3 +7920,5 @@ imported/w3c/web-platform-tests/css/cssom/adoptedstylesheets-adopt-style.tentati
 
 imported/w3c/web-platform-tests/wasm/jsapi/jspi/js-promise-integration.any.html [ Pass Failure ]
 imported/w3c/web-platform-tests/wasm/webapi/esm-integration/script-src-blocks-wasm.tentative.sub.html [ Pass Failure ]
+
+http/tests/iframe-memory-monitor/video-iframe.html [ Skip ]

--- a/LayoutTests/http/tests/iframe-memory-monitor/media-video-autoplay-in-frames-expected.txt
+++ b/LayoutTests/http/tests/iframe-memory-monitor/media-video-autoplay-in-frames-expected.txt
@@ -1,0 +1,5 @@
+PASS document.querySelector('iframe[name=frame1]').srcdoc is not ""
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/iframe-memory-monitor/media-video-autoplay-in-frames.html
+++ b/LayoutTests/http/tests/iframe-memory-monitor/media-video-autoplay-in-frames.html
@@ -1,0 +1,44 @@
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<div id="stage"></div>
+</body>
+<script>
+
+window.jsTestIsAsync = true;
+
+onload = async () => {
+    stage.innerHTML = `
+        <iframe allow="autoplay; encrypted-media" name="frame1" src="http://localhost:8080/iframe-memory-monitor/video-iframe.html"></iframe>
+    `;
+
+    await waitUntilUnload('frame1');
+
+    shouldNotBe(`document.querySelector('iframe[name=frame1]').srcdoc`, '""');
+
+    finishJSTest();
+}
+
+async function pause(ms) {
+    return new Promise((resolve) => {
+        setTimeout(() => resolve(), ms);
+    });
+}
+
+async function waitUntilUnload(name) {
+    const iframe = document.querySelector(`iframe[name=${name}]`);
+    if (!iframe)
+        throw new Error("iframe dosn't exist");
+
+    while (!iframe.srcdoc) {
+        await pause(10);
+    }
+
+    // extra wait time
+    await pause(100);
+    return iframe;
+}
+</script>
+</html>

--- a/LayoutTests/http/tests/iframe-memory-monitor/video-iframe.html
+++ b/LayoutTests/http/tests/iframe-memory-monitor/video-iframe.html
@@ -1,0 +1,16 @@
+<style>
+    body { margin: 0; padding: 0; overflow: hidden; }
+    video { width: 100%; height: 100%; object-fit: cover; }
+</style>
+<script>
+    window.internals?.setTopDocumentURLForQuirks("https://dailymail.co.uk");
+    window.internals?.lowerAllFrameMemoryMonitorLimits();
+
+    window.unload = () => {
+        console.log('Should not be run');
+        window.parent.postMessage({ message: 'Bye from iframe' }, '*');
+    };
+</script>
+<body>
+    <video id="vid" src="http://127.0.0.1:8000/media/resources/serve_video.py?name=test.mp4&type=video&chunkSize=8" controls autoplay muted loop playsinline></video>
+</body>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1997,3 +1997,5 @@ webkit.org/b/290449 imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adj
 webkit.org/b/291636 svg/text/timeout-long-text-content.html [ Skip ]
 
 webkit.org/b/286580 http/tests/media/clearkey/clear-key-session-id.html [ Skip ]
+
+http/tests/iframe-memory-monitor/media-video-autoplay-in-frames.html [ Skip ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -3113,3 +3113,5 @@ imported/w3c/web-platform-tests/svg/painting/marker-006.svg [ ImageOnlyFailure ]
 webkit.org/b/292218 [ Sonoma Release ] media/media-source/media-source-video-renders.html [ Pass ImageOnlyFailure Timeout ]
 
 webkit.org/b/292395 [ Debug ] fast/picture/viewport-resize.html [ Pass Crash ]
+
+http/tests/iframe-memory-monitor/media-video-autoplay-in-frames.html [ Skip ]

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -4447,3 +4447,5 @@ imported/w3c/web-platform-tests/wasm/core/simd/simd_f32x4_pmin_pmax.wast.js.html
 imported/w3c/web-platform-tests/wasm/core/simd/simd_f64x2_arith.wast.js.html [ Timeout Pass ]
 imported/w3c/web-platform-tests/wasm/core/simd/simd_f64x2_cmp.wast.js.html [ Timeout Pass ]
 imported/w3c/web-platform-tests/wasm/core/simd/simd_f64x2_pmin_pmax.wast.js.html [ Timeout Pass ]
+
+http/tests/iframe-memory-monitor/media-video-autoplay-in-frames.html [ Skip ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1745,3 +1745,5 @@ webkit.org/b/291636 svg/text/timeout-long-text-content.html [ Skip ]
 webkit.org/b/286580 http/tests/media/clearkey/clear-key-session-id.html [ Skip ]
 
 webkit.org/b/292841 fullscreen/exit-full-screen-video-crash.html [ Timeout ]
+
+http/tests/iframe-memory-monitor/media-video-autoplay-in-frames.html [ Skip ]

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1578,6 +1578,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     loader/FrameLoaderClient.h
     loader/FrameLoaderStateMachine.h
     loader/FrameLoaderTypes.h
+    loader/FrameMemoryMonitor.h
     loader/FrameNetworkingContext.h
     loader/HTTPHeaderField.h
     loader/HistoryController.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2017,6 +2017,7 @@ loader/ResourceLoadObserver.cpp
 loader/ResourceLoadStatistics.cpp
 loader/ResourceLoader.cpp
 loader/ResourceMonitor.cpp
+loader/FrameMemoryMonitor.cpp
 loader/ResourceMonitorChecker.cpp
 loader/ResourceMonitorPersistence.cpp
 loader/ResourceMonitorThrottler.cpp

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -102,6 +102,7 @@
 #include "FormController.h"
 #include "FragmentDirective.h"
 #include "FrameLoader.h"
+#include "FrameMemoryMonitor.h"
 #include "GCReachableRef.h"
 #include "GPUCanvasContext.h"
 #include "GenericCachedHTMLCollection.h"
@@ -946,6 +947,7 @@ void Document::commonTeardown()
     clearScriptedAnimationController();
 
     m_documentFragmentForInnerOuterHTML = nullptr;
+    m_frameMemoryMonitor = nullptr;
 
     auto intersectionObservers = m_intersectionObservers;
     for (auto& weakIntersectionObserver : intersectionObservers) {
@@ -11595,6 +11597,21 @@ void Document::elementDisconnectedFromDocument(const Element& element)
 {
     if (m_cachedFirstElementWithAttribute && m_cachedFirstElementWithAttribute->second == &element)
         m_cachedFirstElementWithAttribute = std::nullopt;
+}
+
+FrameMemoryMonitor& Document::frameMemoryMonitor()
+{
+    ASSERT(!frame()->isMainFrame());
+
+    if (!m_frameMemoryMonitor)
+        m_frameMemoryMonitor = FrameMemoryMonitor::create(*frame());
+
+    return *m_frameMemoryMonitor;
+}
+
+Ref<FrameMemoryMonitor> Document::protectedFrameMemoryMonitor()
+{
+    return frameMemoryMonitor();
 }
 
 #if ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -221,6 +221,7 @@ class ReportingScope;
 class RequestAnimationFrameCallback;
 class ResizeObserver;
 class ResourceMonitor;
+class FrameMemoryMonitor;
 class SVGDocumentExtensions;
 class SVGElement;
 class SVGSVGElement;
@@ -1981,6 +1982,9 @@ public:
 
     unsigned unloadCounter() const { return m_unloadCounter; }
 
+    WEBCORE_EXPORT FrameMemoryMonitor& frameMemoryMonitor();
+    Ref<FrameMemoryMonitor> protectedFrameMemoryMonitor();
+
 #if ENABLE(CONTENT_EXTENSIONS)
     ResourceMonitor* resourceMonitorIfExists();
     ResourceMonitor& resourceMonitor();
@@ -2723,6 +2727,8 @@ private:
 
     mutable std::unique_ptr<CSSParserContext> m_cachedCSSParserContext;
     mutable std::unique_ptr<PermissionsPolicy> m_permissionsPolicy;
+
+    RefPtr<FrameMemoryMonitor> m_frameMemoryMonitor;
 
 #if ENABLE(CONTENT_EXTENSIONS)
     RefPtr<ResourceMonitor> m_resourceMonitor;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -63,6 +63,7 @@
 #include "EventTargetInlines.h"
 #include "FourCC.h"
 #include "FrameLoader.h"
+#include "FrameMemoryMonitor.h"
 #include "HTMLAudioElement.h"
 #include "HTMLParserIdioms.h"
 #include "HTMLSourceElement.h"
@@ -5018,6 +5019,15 @@ void HTMLMediaElement::mediaPlayerDidRemoveTextTrack(InbandTextTrackPrivate& tra
 void HTMLMediaElement::mediaPlayerDidRemoveVideoTrack(VideoTrackPrivate& track)
 {
     track.willBeRemoved();
+}
+
+void HTMLMediaElement::mediaPlayerDidReportGPUMemoryFootprint(size_t footPrint)
+{
+
+    RefPtr frame = document().frame();
+
+    if (frame && !frame->isMainFrame())
+        document().protectedFrameMemoryMonitor()->setUsage(footPrint);
 }
 
 void HTMLMediaElement::addAudioTrack(Ref<AudioTrack>&& track)

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -431,6 +431,7 @@ public:
     void mediaPlayerDidRemoveAudioTrack(AudioTrackPrivate&) final;
     void mediaPlayerDidRemoveTextTrack(InbandTextTrackPrivate&) final;
     void mediaPlayerDidRemoveVideoTrack(VideoTrackPrivate&) final;
+    void mediaPlayerDidReportGPUMemoryFootprint(size_t) final;
 
     Vector<RefPtr<PlatformTextTrack>> outOfBandTrackSources() final;
 

--- a/Source/WebCore/loader/FrameMemoryMonitor.cpp
+++ b/Source/WebCore/loader/FrameMemoryMonitor.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FrameMemoryMonitor.h"
+
+#include "Document.h"
+#include "LocalFrame.h"
+#include "LocalFrameLoaderClient.h"
+#include "Quirks.h"
+namespace WebCore {
+
+Ref<FrameMemoryMonitor> FrameMemoryMonitor::create(const LocalFrame& frame)
+{
+    return adoptRef(*new FrameMemoryMonitor(frame));
+}
+
+FrameMemoryMonitor::FrameMemoryMonitor(const LocalFrame& frame)
+    : m_frame(frame)
+{
+}
+
+void FrameMemoryMonitor::setUsage(size_t bytes)
+{
+    if (m_usageHasExceeded)
+        return;
+
+    // FIXME: Add support for memory usage deltas
+    m_currentMemoryUsage = bytes;
+
+    checkMemoryPressureAndUnloadFrameIfNeeded();
+}
+
+void FrameMemoryMonitor::checkMemoryPressureAndUnloadFrameIfNeeded()
+{
+    if (m_usageHasExceeded)
+        return;
+
+    if (m_currentMemoryUsage.hasOverflowed() || m_currentMemoryUsage > m_maxMemoryAllowedPerFrame) {
+        m_exceedCount++;
+
+        if (m_exceedCount >= m_memoryPressureConsecutiveLimit) {
+            m_usageHasExceeded = true;
+            unloadFrameAndShowMemoryMonitorError();
+        }
+    } else
+        m_exceedCount = 0;
+}
+
+void FrameMemoryMonitor::unloadFrameAndShowMemoryMonitorError()
+{
+    if (RefPtr frame = m_frame.get()) {
+        if (RefPtr document = m_frame->document()) {
+            if (document->quirks().shouldUnloadHeavyFrame()) {
+                // FIXME: Prevent any navigations of an unloaded frame
+                frame->showMemoryMonitorError();
+            }
+        }
+    }
+}
+
+void FrameMemoryMonitor::lowerAllMemoryLimitsForTesting()
+{
+    m_maxMemoryAllowedPerFrame = 1;
+    m_memoryPressureConsecutiveLimit = 0;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/loader/FrameMemoryMonitor.h
+++ b/Source/WebCore/loader/FrameMemoryMonitor.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/CheckedArithmetic.h>
+#include <wtf/WeakPtr.h>
+namespace WebCore {
+
+class LocalFrame;
+
+class FrameMemoryMonitor final : public RefCounted<FrameMemoryMonitor> {
+public:
+    static Ref<FrameMemoryMonitor> create(const LocalFrame&);
+    WEBCORE_EXPORT ~FrameMemoryMonitor() = default;
+
+    WEBCORE_EXPORT void setUsage(size_t);
+    WEBCORE_EXPORT void lowerAllMemoryLimitsForTesting();
+
+private:
+    explicit FrameMemoryMonitor(const LocalFrame&);
+
+    void checkMemoryPressureAndUnloadFrameIfNeeded();
+    void unloadFrameAndShowMemoryMonitorError();
+
+    WeakPtr<LocalFrame> m_frame;
+    CheckedSize m_currentMemoryUsage;
+    bool m_usageHasExceeded { false };
+
+    // FIXME: Add platform specific memory limits
+    size_t m_maxMemoryAllowedPerFrame = { 1 * GB };
+    unsigned m_exceedCount = { 0 };
+    unsigned m_memoryPressureConsecutiveLimit = { 3 };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -337,6 +337,7 @@ public:
     ScrollbarMode scrollingMode() const { return m_scrollingMode; }
     WEBCORE_EXPORT void updateScrollingMode() final;
     WEBCORE_EXPORT void setScrollingMode(ScrollbarMode);
+    WEBCORE_EXPORT void showMemoryMonitorError();
 
 #if ENABLE(CONTENT_EXTENSIONS)
     WEBCORE_EXPORT void showResourceMonitoringError();

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -913,6 +913,11 @@ bool Quirks::shouldEnableEnumerateDeviceQuirk() const
 }
 #endif
 
+bool Quirks::shouldUnloadHeavyFrame() const
+{
+    return needsQuirks() && m_quirksData.shouldUnloadHeavyFrames;
+}
+
 // hulu.com rdar://55041979
 bool Quirks::needsCanPlayAfterSeekedQuirk() const
 {
@@ -2203,6 +2208,17 @@ static void handleWarbyParkerQuirks(QuirksData& quirksData, const URL& quirksURL
 }
 #endif
 
+static void handleDailyMailCoUkQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "dailymail.co.uk"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+
+    quirksData.shouldUnloadHeavyFrames = true;
+}
+
 #if ENABLE(TEXT_AUTOSIZING)
 static void handleYCombinatorQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
 {
@@ -2919,6 +2935,7 @@ void Quirks::determineRelevantQuirks()
         { "zomato"_s, &handleZomatoQuirks },
 #endif
         { "zoom"_s, &handleZoomQuirks },
+        { "dailymail"_s, &handleDailyMailCoUkQuirks }
     });
 
     auto findResult = dispatchMap->find(quirkDomainWithoutPSL);

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -145,6 +145,7 @@ public:
     bool shouldEnableSpeakerSelectionPermissionsPolicyQuirk() const;
     bool shouldEnableEnumerateDeviceQuirk() const;
 #endif
+    bool shouldUnloadHeavyFrame() const;
 
     bool needsCanPlayAfterSeekedQuirk() const;
 

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -80,6 +80,7 @@ struct WEBCORE_EXPORT QuirksData {
     bool shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeQuirk : 1 { false };
     bool shouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk : 1 { false };
     bool shouldDispatchPlayPauseEventsOnResume : 1 { false };
+    bool shouldUnloadHeavyFrames : 1 { false };
 
     // Requires check at moment of use
     std::optional<bool> needsDisableDOMPasteAccessQuirk;

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -1721,6 +1721,11 @@ size_t MediaPlayer::extraMemoryCost() const
     return playerPrivate ? playerPrivate->extraMemoryCost() : 0;
 }
 
+void MediaPlayer::reportGPUMemoryFootprint(uint64_t footPrint) const
+{
+    client().mediaPlayerDidReportGPUMemoryFootprint(footPrint);
+}
+
 unsigned long long MediaPlayer::fileSize() const
 {
     if (!m_private)

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -287,6 +287,7 @@ public:
     virtual void mediaPlayerDidRemoveAudioTrack(AudioTrackPrivate&) { }
     virtual void mediaPlayerDidRemoveTextTrack(InbandTextTrackPrivate&) { }
     virtual void mediaPlayerDidRemoveVideoTrack(VideoTrackPrivate&) { }
+    virtual void mediaPlayerDidReportGPUMemoryFootprint(size_t) { }
 
     virtual void mediaPlayerReloadAndResumePlaybackIfNeeded() { }
 
@@ -681,6 +682,8 @@ public:
     String languageOfPrimaryAudioTrack() const;
 
     size_t extraMemoryCost() const;
+
+    void reportGPUMemoryFootprint(uint64_t) const;
 
     unsigned long long fileSize() const;
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -95,6 +95,7 @@
 #include "FormController.h"
 #include "FragmentDirectiveGenerator.h"
 #include "FrameLoader.h"
+#include "FrameMemoryMonitor.h"
 #include "GCObservation.h"
 #include "GridPosition.h"
 #include "HEVCUtilities.h"
@@ -7814,6 +7815,18 @@ void Internals::setResourceCachingDisabledByWebInspector(bool disabled)
         return;
 
     document->page()->setResourceCachingDisabledByWebInspector(disabled);
+}
+
+ExceptionOr<void> Internals::lowerAllFrameMemoryMonitorLimits()
+{
+    RefPtr document = contextDocument();
+
+    if (!document || !document->frame())
+        return Exception { ExceptionCode::InvalidAccessError };
+
+
+    document->frameMemoryMonitor().lowerAllMemoryLimitsForTesting();
+    return { };
 }
 
 void Internals::setTopDocumentURLForQuirks(const String& urlString)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1559,6 +1559,7 @@ public:
     void getImageBufferResourceLimits(ImageBufferResourceLimitsPromise&&);
 
     void setResourceCachingDisabledByWebInspector(bool);
+    ExceptionOr<void> lowerAllFrameMemoryMonitorLimits();
 
 #if ENABLE(CONTENT_EXTENSIONS)
     void setResourceMonitorNetworkUsageThreshold(size_t threshold, double randomness = ResourceMonitorChecker::defaultNetworkUsageThresholdRandomness);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -756,6 +756,7 @@ enum ContentsFormat {
     boolean testProcessIncomingSyncMessagesWhenWaitingForSyncReply();
 
     undefined setResourceCachingDisabledByWebInspector(boolean disabled);
+    undefined lowerAllFrameMemoryMonitorLimits();
 
     [Conditional=DAMAGE_TRACKING] DamagePropagation? getCurrentDamagePropagation();
     [Conditional=DAMAGE_TRACKING] sequence<FrameDamage> getFrameDamageHistory();

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -58,6 +58,7 @@
 #include <WebCore/ResourceError.h>
 #include <WebCore/SecurityOrigin.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/MemoryFootprint.h>
 
 #if ENABLE(ENCRYPTED_MEDIA)
 #include "RemoteCDMFactoryProxy.h"
@@ -343,6 +344,8 @@ void RemoteMediaPlayerProxy::setRate(double rate)
 void RemoteMediaPlayerProxy::didLoadingProgress(CompletionHandler<void(bool)>&& completionHandler)
 {
     protectedPlayer()->didLoadingProgress(WTFMove(completionHandler));
+
+    protectedConnection()->send(Messages::MediaPlayerPrivateRemote::ReportGPUMemoryFootprint(WTF::memoryFootprint()), m_id);
 }
 
 void RemoteMediaPlayerProxy::setPresentationSize(const WebCore::IntSize& size)

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -1530,6 +1530,12 @@ size_t MediaPlayerPrivateRemote::extraMemoryCost() const
     return 0;
 }
 
+void MediaPlayerPrivateRemote::reportGPUMemoryFootprint(uint64_t footPrint)
+{
+    if (auto player = m_player.get())
+        player->reportGPUMemoryFootprint(footPrint);
+}
+
 void MediaPlayerPrivateRemote::updateVideoPlaybackMetricsUpdateInterval(const Seconds& interval)
 {
     m_videoPlaybackMetricsUpdateInterval = interval;

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -114,6 +114,7 @@ public:
     void setReadyState(WebCore::MediaPlayer::ReadyState);
 
     void commitAllTransactions(CompletionHandler<void()>&&);
+    void reportGPUMemoryFootprint(uint64_t);
     void networkStateChanged(RemoteMediaPlayerState&&);
     void readyStateChanged(RemoteMediaPlayerState&&, WebCore::MediaPlayer::ReadyState);
     void volumeChanged(double);

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in
@@ -105,6 +105,7 @@ messages -> MediaPlayerPrivateRemote {
 #endif
 
     CommitAllTransactions() -> ()
+    ReportGPUMemoryFootprint(uint64_t memoryFootPrint)
 }
 
 #endif


### PR DESCRIPTION
#### fd514e08ad086282a0fcb6076116d62664bc92d3
<pre>
Add FrameMemoryMonitor for LocalFrame GPU memory tracking during media loading
<a href="https://rdar.apple.com/150463891">rdar://150463891</a>

Reviewed by Brent Fulgham.

Introduce FrameMemoryMonitor to track LocalFrame GPU memory usage during media
loading. Reports memoryFootprint from RemoteMediaPlayerProxy to HTMLMediaElement
periodically via the progress timer. Enables unloading autoplay frames when
excessive GPU memory is detected.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::commonTeardown):
(WebCore::Document::frameMemoryMonitor):
(WebCore::Document::protectedFrameMemoryMonitor):
(WebCore::Document::parentFrameMemoryMonitorIfExists):
* Source/WebCore/dom/Document.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaPlayerDidReportGPUMemoryFootprint):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/loader/FrameMemoryMonitor.cpp: Added.
(WebCore::FrameMemoryMonitor::create):
(WebCore::FrameMemoryMonitor::FrameMemoryMonitor):
(WebCore::FrameMemoryMonitor::~FrameMemoryMonitor):
(WebCore::FrameMemoryMonitor::addUsage):
(WebCore::FrameMemoryMonitor::setMaxMemoryAllowedPerFrameForTesting):
(WebCore::FrameMemoryMonitor::checkMemoryPressureAndUnloadFrameIfNeeded):
(WebCore::FrameMemoryMonitor::parentFrameMemoryMonitorIfExists const):
* Source/WebCore/loader/FrameMemoryMonitor.h: Added.
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::reportGPUMemoryFootprint const):
* Source/WebCore/platform/graphics/MediaPlayer.h:
(WebCore::MediaPlayerClient::mediaPlayerDidReportGPUMemoryFootprint):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::didLoadingProgress):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::reportGPUMemoryFootprint):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in:

Canonical link: <a href="https://commits.webkit.org/294877@main">https://commits.webkit.org/294877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a9d29359c84c3944e7f56185c5051e8eff61153

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103337 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108510 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53980 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31564 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78534 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35486 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18107 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58867 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17944 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11264 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53337 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87745 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11326 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110885 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30475 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22502 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87534 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30840 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89420 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87171 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22196 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32028 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9747 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/24809 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30404 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35723 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30210 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33537 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31772 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->