### PR TITLE
Canvas with relative width not re-drawn correctly on parent resize (follow-up)

### DIFF
--- a/LayoutTests/compositing/tiling/huge-layer-canvas-resize.html
+++ b/LayoutTests/compositing/tiling/huge-layer-canvas-resize.html
@@ -43,7 +43,7 @@ function testOnLoad()
     context.strokeStyle = "red";
     context.stroke();
 
-    setTimeout(() => {
+    requestAnimationFrame(() => requestAnimationFrame(() => {
         if (window.internals)
             window.internals.startTrackingRepaints();
         document.getElementById('container').style.width = "3400px";
@@ -53,7 +53,7 @@ function testOnLoad()
         }
         if (window.testRunner)
             testRunner.notifyDone();
-    }, 1000);
+    }));
 }
 
 window.addEventListener('load', testOnLoad, false);

--- a/LayoutTests/compositing/tiling/huge-layer-img-resize.html
+++ b/LayoutTests/compositing/tiling/huge-layer-img-resize.html
@@ -49,9 +49,9 @@ function testOnLoad()
     img.src = canvas.toDataURL();
 }
 
-async function onImageLoad()
+function onImageLoad()
 {
-    setTimeout(() => {
+    requestAnimationFrame(() => requestAnimationFrame(() => {
         if (window.internals)
             window.internals.startTrackingRepaints();
         document.getElementById('container').style.width = "3400px";
@@ -61,7 +61,7 @@ async function onImageLoad()
         }
         if (window.testRunner)
             testRunner.notifyDone();
-    }, 1000);
+    }));
 }
 
 window.addEventListener('load', testOnLoad, false);

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -116,17 +116,13 @@ void RenderReplaced::styleDidChange(StyleDifference diff, const RenderStyle* old
         intrinsicSizeChanged();
 }
 
-static void issueFullRepaintOnSizeChangeIfNeeded(RenderReplaced& renderer)
+static bool shouldRepaintOnSizeChange(RenderReplaced& renderer)
 {
-    auto shouldRepaintOnSizeChange = [&] {
-        if (is<RenderHTMLCanvas>(renderer))
-            return true;
-        if (auto* renderImage = dynamicDowncast<RenderImage>(renderer); renderImage && !is<RenderMedia>(*renderImage) && !renderImage->isShowingMissingOrImageError())
-            return true;
-        return false;
-    };
-    if (shouldRepaintOnSizeChange())
-        renderer.repaint();
+    if (is<RenderHTMLCanvas>(renderer))
+        return true;
+    if (auto* renderImage = dynamicDowncast<RenderImage>(renderer); renderImage && !is<RenderMedia>(*renderImage) && !renderImage->isShowingMissingOrImageError())
+        return true;
+    return false;
 }
 
 void RenderReplaced::layout()
@@ -152,7 +148,8 @@ void RenderReplaced::layout()
 
     if (replacedContentRect() != oldContentRect) {
         setPreferredLogicalWidthsDirty(true);
-        issueFullRepaintOnSizeChangeIfNeeded(*this);
+        if (shouldRepaintOnSizeChange(*this))
+            repaint();
     }
 }
 


### PR DESCRIPTION
#### 795f60a234a0376d5a5aaf2b05feb91928c1d50b
<pre>
Canvas with relative width not re-drawn correctly on parent resize (follow-up)
<a href="https://bugs.webkit.org/show_bug.cgi?id=292644">https://bugs.webkit.org/show_bug.cgi?id=292644</a>

Reviewed by Alan Baradlay.

Address code review comments from <a href="https://bugs.webkit.org/show_bug.cgi?id=267986">https://bugs.webkit.org/show_bug.cgi?id=267986</a>

* LayoutTests/compositing/tiling/huge-layer-canvas-resize.html:
* LayoutTests/compositing/tiling/huge-layer-img-resize.html:
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::shouldRepaintOnSizeChange):
(WebCore::RenderReplaced::layout):
(WebCore::issueFullRepaintOnSizeChangeIfNeeded): Deleted.

Canonical link: <a href="https://commits.webkit.org/294647@main">https://commits.webkit.org/294647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd847ab7fe11c397f32e46c7089b8de58ec1a7b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107572 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53048 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104450 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30586 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77917 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34906 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105417 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17342 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92441 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58254 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17178 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10469 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52405 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86998 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10540 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109947 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29543 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21782 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86899 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29907 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88637 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86490 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22038 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31314 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9030 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23785 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29471 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34773 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29282 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32605 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30841 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->