### PR TITLE
Do not IPC encode calculated fields of ShareableBitmapConfiguration

### DIFF
--- a/Source/WebCore/platform/graphics/ShareableBitmap.cpp
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.cpp
@@ -51,27 +51,6 @@ ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, 
     ASSERT(!m_size.isEmpty());
 }
 
-ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, std::optional<DestinationColorSpace> colorSpace, bool isOpaque, unsigned bytesPerPixel, unsigned bytesPerRow
-#if USE(CG)
-    , CGBitmapInfo bitmapInfo
-#endif
-)
-    : m_size(size)
-    , m_colorSpace(colorSpace)
-    , m_isOpaque(isOpaque)
-    , m_bytesPerPixel(bytesPerPixel)
-    , m_bytesPerRow(bytesPerRow)
-#if USE(CG)
-    , m_bitmapInfo(bitmapInfo)
-#endif
-#if USE(SKIA)
-    , m_imageInfo(SkImageInfo::MakeN32Premul(size.width(), size.height(), this->colorSpace().platformColorSpace()))
-#endif
-{
-    // This constructor is called when decoding ShareableBitmapConfiguration. So this constructor
-    // will behave like the default constructor if a null ShareableBitmapHandle was encoded.
-}
-
 CheckedUint32 ShareableBitmapConfiguration::calculateSizeInBytes(const IntSize& size, const DestinationColorSpace& colorSpace)
 {
     return calculateBytesPerRow(size, colorSpace) * size.height();

--- a/Source/WebCore/platform/graphics/ShareableBitmap.h
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.h
@@ -51,11 +51,6 @@ public:
     ShareableBitmapConfiguration() = default;
 
     WEBCORE_EXPORT ShareableBitmapConfiguration(const IntSize&, std::optional<DestinationColorSpace> = std::nullopt, bool isOpaque = false);
-    WEBCORE_EXPORT ShareableBitmapConfiguration(const IntSize&, std::optional<DestinationColorSpace>, bool isOpaque, unsigned bytesPerPixel, unsigned bytesPerRow
-#if USE(CG)
-        , CGBitmapInfo
-#endif
-    );
 #if USE(CG)
     ShareableBitmapConfiguration(NativeImage&);
 #endif

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8438,15 +8438,10 @@ header: <WebCore/VideoTrackPrivate.h>
 #endif
 
 header: <WebCore/ShareableBitmap.h>
-[CustomHeader] class WebCore::ShareableBitmapConfiguration {
+[CustomHeader, DisableMissingMemberCheck] class WebCore::ShareableBitmapConfiguration {
     [Validator='m_size->width() >= 0 && m_size->height() >= 0'] WebCore::IntSize m_size;
     std::optional<WebCore::DestinationColorSpace> m_colorSpace;
     bool m_isOpaque;
-    unsigned bytesPerPixel();
-    unsigned bytesPerRow();
-#if USE(CG)
-    CGBitmapInfo m_bitmapInfo;
-#endif
 }
 
 [CustomHeader, RValue] class WebCore::ShareableBitmapHandle {


### PR DESCRIPTION
#### d583497392cebd89f6fb32336cc9823c9cd2c125
<pre>
Do not IPC encode calculated fields of ShareableBitmapConfiguration
<a href="https://bugs.webkit.org/show_bug.cgi?id=292648">https://bugs.webkit.org/show_bug.cgi?id=292648</a>

Reviewed by NOBODY (OOPS!).

There is no need to encode the bytesPerPixel, bytesPerRow or bitmapInfo of
ShareableBitmapConfiguration. They can all be calculated from the size and
the color space of the image.

* Source/WebCore/platform/graphics/ShareableBitmap.cpp:
* Source/WebCore/platform/graphics/ShareableBitmap.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d583497392cebd89f6fb32336cc9823c9cd2c125

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102419 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107580 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53056 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104458 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30594 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77924 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34912 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105425 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17347 "Found 60 new test failures: accessibility/smart-invert.html animations/cross-fade-list-style-image.html animations/duplicated-keyframes-name.html compositing/animation/keyframe-order.html compositing/background-color/background-color-alpha-with-opacity.html compositing/backing/solid-color-with-paints-into-ancestor.html compositing/contents-opaque/negative-z-before-html.html compositing/document-background-color.html compositing/filters/backdrop-filter-rect-border-radius.html compositing/iframes/content-visibility-with-clipping.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92449 "Found 17 new API test failures: TestWebKitAPI.DragAndDropTests.DataTransferTypesOnDragStartForLink, TestWebKitAPI.DragAndDropTests.ProvideImageDataAsTypeIdentifiers, TestWebKitAPI.DragAndDropTests.ReadURLWhenDroppingPromisedWebLoc, TestWebKitAPI.WebKit.ScrollByLineCommands, TestWebKitAPI.DragAndDropTests.DataTransferTypesOnDragStartForTextSelection, TestWebKitAPI.WebKit.ScrollPinningBehaviors, TestWebKitAPI.ContextMenuTests.ContextMenuElementInfoContainsQRCodePayloadStringCanvas, TestWebKitAPI.MediaSessionTest.MinimalCommands, TestWebKitAPI.ContextMenuTests.ContextMenuElementInfoContainsQRCodePayloadString, TestWebKitAPI.ImageAnalysisTests.AnalyzeDynamicallyLoadedImages ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58261 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17183 "Found 60 new test failures: imported/w3c/web-platform-tests/clipboard-apis/feature-policy/clipboard-write/clipboard-write-enabled-by-feature-policy-attribute-cross-origin-tentative.https.sub.html imported/w3c/web-platform-tests/content-security-policy/generic/no-default-src.sub.html imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-to-overrides-report-uri-2.https.sub.html imported/w3c/web-platform-tests/content-security-policy/reporting/report-frame-ancestors-no-parent-cookies.sub.html imported/w3c/web-platform-tests/content-security-policy/reporting/report-only-cross-origin-frame.sub.html imported/w3c/web-platform-tests/content-security-policy/reporting/report-only-in-meta.sub.html imported/w3c/web-platform-tests/content-security-policy/style-src/style-src-multiple-policies-multiple-hashing-algorithms.html imported/w3c/web-platform-tests/cookies/attributes/invalid.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-color-animation-with-mask.html imported/w3c/web-platform-tests/css/css-backgrounds/background-334.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10477 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52413 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/87057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10548 "Found 60 new test failures: accessibility/mac/dynamic-drag.html accessibility/mac/nested-modal.html accessibility/mac/scrolling-in-pdf-crash.html accessibility/mac/selection-boundary-userinfo.html accessibility/mac/text-operation/text-operation-replace-slotted-shadow.html accessibility/smart-invert.html accessibility/tree-update-with-dirty-layout.html animations/cross-fade-list-style-image.html animations/duplicate-keys.html compositing/animation/keyframe-order.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109955 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29551 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21787 "Found 60 new test failures: accessibility/canvas-fallback-content.html accessibility/crash-when-render-tree-is-not-clean.html accessibility/disabled-controls-not-focusable.html accessibility/dynamically-changing-iframe-remains-accessible.html accessibility/mac/attributed-string/attributed-string-for-range-with-options.html accessibility/mac/basic-embed-pdf-accessibility.html accessibility/mac/checkbox-posts-value-change-notification-after-activation-with-space.html accessibility/mac/iframe-relative-frame.html accessibility/mac/text-operation/text-operation-replace-across-multiple-fields.html accessibility/text-marker/text-marker-range-stale-node-crash.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86902 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29915 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88645 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86494 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31318 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9037 "Found 60 new test failures: accessibility/mac/dynamic-drag.html accessibility/mac/nested-modal.html accessibility/mac/text-operation/text-operation-replace-slotted-shadow.html accessibility/smart-invert.html accessibility/tree-update-with-dirty-layout.html animations/cross-fade-list-style-image.html animations/duplicate-keys.html compositing/animation/keyframe-order.html compositing/backing/non-composited-visibility-change.html compositing/backing/solid-color-with-paints-into-ancestor.html ... (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23793 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29479 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34781 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29290 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32613 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30849 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->