### PR TITLE
Move Frame::ownerElement() and Frame::protectedOwnerElement() to FrameInlines.h

### DIFF
--- a/Source/WebCore/html/HTMLFrameOwnerElement.h
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.h
@@ -109,16 +109,6 @@ private:
     WeakPtr<ContainerNode, WeakPtrImplWithEventTargetData> m_root;
 };
 
-inline HTMLFrameOwnerElement* Frame::ownerElement() const
-{
-    return m_ownerElement.get();
-}
-
-inline RefPtr<HTMLFrameOwnerElement> Frame::protectedOwnerElement() const
-{
-    return m_ownerElement.get();
-}
-
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::HTMLFrameOwnerElement)

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -96,8 +96,8 @@ public:
     WEBCORE_EXPORT void detachFromPage();
 
     WEBCORE_EXPORT void setOwnerElement(HTMLFrameOwnerElement*);
-    inline HTMLFrameOwnerElement* ownerElement() const; // Defined in HTMLFrameOwnerElement.h.
-    inline RefPtr<HTMLFrameOwnerElement> protectedOwnerElement() const; // Defined in HTMLFrameOwnerElement.h.
+    inline HTMLFrameOwnerElement* ownerElement() const; // Defined in FrameInlines.h.
+    inline RefPtr<HTMLFrameOwnerElement> protectedOwnerElement() const; // Defined in FrameInlines.h.
 
     WEBCORE_EXPORT void disconnectOwnerElement();
     NavigationScheduler& navigationScheduler() const { return m_navigationScheduler.get(); }

--- a/Source/WebCore/page/FrameInlines.h
+++ b/Source/WebCore/page/FrameInlines.h
@@ -26,9 +26,20 @@
 #pragma once
 
 #include "Frame.h"
+#include "HTMLFrameOwnerElement.h"
 #include "Page.h"
 
 namespace WebCore {
+
+inline HTMLFrameOwnerElement* Frame::ownerElement() const
+{
+    return m_ownerElement.get();
+}
+
+inline RefPtr<HTMLFrameOwnerElement> Frame::protectedOwnerElement() const
+{
+    return m_ownerElement.get();
+}
 
 inline Page* Frame::page() const
 {


### PR DESCRIPTION
#### 3017a7db3731e0bd7d2163bf35749be4efc45258
<pre>
Move Frame::ownerElement() and Frame::protectedOwnerElement() to FrameInlines.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=292652">https://bugs.webkit.org/show_bug.cgi?id=292652</a>

Reviewed by Anne van Kesteren.

Moved the functions from HTMLFrameOwnerElement.h to FrameInlines.h for consistency.

* Source/WebCore/html/HTMLFrameOwnerElement.h:
(WebCore::Frame::ownerElement const): Moved to FrameInlines.h
(WebCore::Frame::protectedOwnerElement const): Ditto.
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/FrameInlines.h:
(WebCore::Frame::ownerElement const): Moved from HTMLFrameOwnerElement.h
(WebCore::Frame::protectedOwnerElement const): Ditto.

Canonical link: <a href="https://commits.webkit.org/294608@main">https://commits.webkit.org/294608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bc597e3a033b5026e46ba79caa5dc465ba1f7b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12416 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107594 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53070 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104472 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30608 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77934 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34922 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92462 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58271 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17197 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10490 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52427 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/87014 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109969 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21799 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86915 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29929 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88658 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86508 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31332 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9050 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23808 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16637 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29493 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34795 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29304 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32627 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30863 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->