### PR TITLE
Reduce header includes in FrameSelection.h

### DIFF
--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2539,6 +2539,16 @@ RefPtr<MutableStyleProperties> FrameSelection::copyTypingStyle() const
     return m_typingStyle->style()->mutableCopy();
 }
 
+void FrameSelection::setTypingStyle(RefPtr<EditingStyle>&& style)
+{
+    m_typingStyle = WTFMove(style);
+}
+
+void FrameSelection::clearTypingStyle()
+{
+    m_typingStyle = nullptr;
+}
+
 bool FrameSelection::shouldDeleteSelection(const VisibleSelection& selection) const
 {
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -28,13 +28,11 @@
 #include "AXTextStateChangeIntent.h"
 #include "CaretAnimator.h"
 #include "Color.h"
-#include "EditingStyle.h"
-#include "Element.h"
 #include "IntRect.h"
 #include "LayoutRect.h"
-#include "Range.h"
 #include "ScrollAlignment.h"
 #include "ScrollBehavior.h"
+#include "ScrollTypes.h"
 #include "VisibleSelection.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/Noncopyable.h>
@@ -43,10 +41,13 @@
 namespace WebCore {
 
 class CharacterData;
+class Element;
 class GraphicsContext;
+class EditingStyle;
 class HTMLFormElement;
 class LocalFrame;
 class MutableStyleProperties;
+class Range;
 class RenderBlock;
 class RenderObject;
 class RenderView;
@@ -262,8 +263,8 @@ public:
 
     EditingStyle* typingStyle() const;
     WEBCORE_EXPORT RefPtr<MutableStyleProperties> copyTypingStyle() const;
-    void setTypingStyle(RefPtr<EditingStyle>&& style) { m_typingStyle = WTFMove(style); }
-    void clearTypingStyle();
+    WEBCORE_EXPORT void setTypingStyle(RefPtr<EditingStyle>&&);
+    WEBCORE_EXPORT void clearTypingStyle();
 
     enum class ClipToVisibleContent : bool { No, Yes };
     WEBCORE_EXPORT FloatRect selectionBounds(ClipToVisibleContent = ClipToVisibleContent::Yes);
@@ -402,11 +403,6 @@ constexpr auto FrameSelection::defaultSetSelectionOptions(UserTriggered userTrig
 inline EditingStyle* FrameSelection::typingStyle() const
 {
     return m_typingStyle.get();
-}
-
-inline void FrameSelection::clearTypingStyle()
-{
-    m_typingStyle = nullptr;
 }
 
 #if !(PLATFORM(COCOA) || USE(ATSPI))


### PR DESCRIPTION
#### 79f89ce73252d538ce6f0b968d0a7c1eabf37cc2
<pre>
Reduce header includes in FrameSelection.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=292654">https://bugs.webkit.org/show_bug.cgi?id=292654</a>

Reviewed by Wenson Hsieh.

Reduced #include in FrameSelection.h to improve the build time.

* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::setTypingStyle):
(WebCore::FrameSelection::clearTypingStyle):
* Source/WebCore/editing/FrameSelection.h:
(WebCore::FrameSelection::clearTypingStyle): Deleted.

Canonical link: <a href="https://commits.webkit.org/294630@main">https://commits.webkit.org/294630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d63275e5974dd9a9053765722910f67002cda12a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102441 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107602 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53078 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104480 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30616 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77939 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34928 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105447 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17368 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92468 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58276 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17205 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10496 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52435 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87022 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109977 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21806 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86922 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29937 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88664 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86515 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31338 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9056 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23818 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16653 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29501 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34804 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29312 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32635 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30871 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->