### PR TITLE
[JSC] Remove `NO_RETURN` macro

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -199,7 +199,7 @@ namespace {
 
 #define EXIT_EXCEPTION 3
 
-NO_RETURN_WITH_VALUE static void jscExit(int status)
+[[noreturn]] static void jscExit(int status)
 {
     waitForAsynchronousDisassembly();
     
@@ -352,7 +352,7 @@ static JSC_DECLARE_HOST_FUNCTION(functionJSCOptions);
 static JSC_DECLARE_HOST_FUNCTION(functionReoptimizationRetryCount);
 static JSC_DECLARE_HOST_FUNCTION(functionTransferArrayBuffer);
 static JSC_DECLARE_HOST_FUNCTION(functionFailNextNewCodeBlock);
-static NO_RETURN_WITH_VALUE JSC_DECLARE_HOST_FUNCTION(functionQuit);
+[[noreturn]] static JSC_DECLARE_HOST_FUNCTION(functionQuit);
 static JSC_DECLARE_HOST_FUNCTION(functionFalse);
 static JSC_DECLARE_HOST_FUNCTION(functionUndefined1);
 static JSC_DECLARE_HOST_FUNCTION(functionUndefined2);

--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -129,6 +129,14 @@
 extern "C" {
 #endif
 
+/*
+   This header file needs to be compatible with C code, [noreturn]] cannot be used here.
+   Use [[noreturn]] in WebKit except this header file.
+*/
+#if !defined(NO_RETURN_FOR_C)
+#define NO_RETURN_FOR_C __attribute((__noreturn__))
+#endif
+
 /* CRASH() - Raises a fatal error resulting in program termination and triggering either the debugger or the crash reporter.
 
    Use CRASH() in response to known, unrecoverable errors like out-of-memory.
@@ -137,7 +145,7 @@ extern "C" {
 
    Signals are ignored by the crash reporter on OS X so we must do better.
 */
-#define NO_RETURN_DUE_TO_CRASH NO_RETURN
+#define NO_RETURN_DUE_TO_CRASH NO_RETURN_FOR_C
 
 #ifdef __cplusplus
 enum class WTFLogChannelState : uint8_t { Off, On, OnWithAccumulation };

--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -260,12 +260,6 @@
 #define NEVER_INLINE __attribute__((__noinline__))
 #endif
 
-/* NO_RETURN */
-
-#if !defined(NO_RETURN)
-#define NO_RETURN __attribute((__noreturn__))
-#endif
-
 /* NOT_TAIL_CALLED */
 
 #if !defined(NOT_TAIL_CALLED)
@@ -303,12 +297,6 @@
 /* RETURNS_NONNULL */
 #if !defined(RETURNS_NONNULL)
 #define RETURNS_NONNULL __attribute__((returns_nonnull))
-#endif
-
-/* NO_RETURN_WITH_VALUE */
-
-#if !defined(NO_RETURN_WITH_VALUE)
-#define NO_RETURN_WITH_VALUE NO_RETURN
 #endif
 
 /* OBJC_CLASS */


### PR DESCRIPTION
#### 0a0b2ce91423846c5a3ec6eed4da46aed1132871
<pre>
[JSC] Remove `NO_RETURN` macro
<a href="https://bugs.webkit.org/show_bug.cgi?id=292658">https://bugs.webkit.org/show_bug.cgi?id=292658</a>

Reviewed by Sosuke Suzuki and Yusuke Suzuki.

Remove NO_RETURN macro

* Source/JavaScriptCore/jsc.cpp:
(JSC::jscExit):
* Source/WTF/wtf/Assertions.h:
* Source/WTF/wtf/Compiler.h:

Canonical link: <a href="https://commits.webkit.org/294652@main">https://commits.webkit.org/294652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1668bfd6b6b78d2de85e7ebc3cae50a664767db4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22118 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107610 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53086 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30624 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77945 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34937 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17375 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58282 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17212 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10506 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52443 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/95120 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87029 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10577 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109985 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/101058 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29581 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21815 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86928 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29945 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88674 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86521 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22041 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31346 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9066 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/23826 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29509 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34812 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124692 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29320 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34600 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32643 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30879 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->