### PR TITLE
Drawing paths spends time in Path::isEmpty()

### DIFF
--- a/Source/WebCore/platform/graphics/Path.h
+++ b/Source/WebCore/platform/graphics/Path.h
@@ -75,7 +75,7 @@ public:
 
     WEBCORE_EXPORT void closeSubpath();
 
-    void addPath(const Path&, const AffineTransform&);
+    WEBCORE_EXPORT void addPath(const Path&, const AffineTransform&);
 
     void applySegments(const PathSegmentApplier&) const;
     WEBCORE_EXPORT void applyElements(const PathElementApplier&) const;
@@ -89,7 +89,7 @@ public:
     WEBCORE_EXPORT std::optional<PathSegment> singleSegment() const;
     std::optional<PathDataLine> singleDataLine() const;
 
-    WEBCORE_EXPORT bool isEmpty() const;
+    bool isEmpty() const;
     bool definitelySingleLine() const;
     WEBCORE_EXPORT PlatformPathPtr platformPath() const;
 
@@ -104,8 +104,8 @@ public:
     PathTraversalState traversalStateAtLength(float length) const;
     FloatPoint pointAtLength(float length) const;
 
-    bool contains(const FloatPoint&, WindRule = WindRule::NonZero) const;
-    bool strokeContains(const FloatPoint&, NOESCAPE const Function<void(GraphicsContext&)>& strokeStyleApplier) const;
+    WEBCORE_EXPORT bool contains(const FloatPoint&, WindRule = WindRule::NonZero) const;
+    WEBCORE_EXPORT bool strokeContains(const FloatPoint&, NOESCAPE const Function<void(GraphicsContext&)>& strokeStyleApplier) const;
 
     WEBCORE_EXPORT FloatRect fastBoundingRect() const;
     WEBCORE_EXPORT FloatRect boundingRect() const;
@@ -135,6 +135,11 @@ WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const Path&);
 inline Path::Path(PathSegment&& segment)
     : m_data(WTFMove(segment))
 {
+}
+
+inline bool Path::isEmpty() const
+{
+    return std::holds_alternative<std::monostate>(m_data);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/PathImpl.h
+++ b/Source/WebCore/platform/graphics/PathImpl.h
@@ -77,8 +77,6 @@ public:
 
     virtual std::optional<PathSegment> singleSegment() const { return std::nullopt; }
 
-    virtual bool isEmpty() const = 0;
-
     virtual bool isClosed() const;
 
     virtual bool hasSubpaths() const;

--- a/Source/WebCore/platform/graphics/PathStream.cpp
+++ b/Source/WebCore/platform/graphics/PathStream.cpp
@@ -102,7 +102,7 @@ Ref<PathImpl> PathStream::copy() const
 
 const PathMoveTo* PathStream::lastIfMoveTo() const
 {
-    if (isEmpty())
+    if (m_segments.isEmpty())
         return nullptr;
 
     return std::get_if<PathMoveTo>(&m_segments.last().data());
@@ -228,7 +228,7 @@ std::optional<PathSegment> PathStream::singleSegment() const
 
 bool PathStream::isClosed() const
 {
-    if (isEmpty())
+    if (m_segments.isEmpty())
         return false;
 
     return m_segments.last().closesSubpath();

--- a/Source/WebCore/platform/graphics/PathStream.h
+++ b/Source/WebCore/platform/graphics/PathStream.h
@@ -89,8 +89,6 @@ private:
 
     std::optional<PathSegment> singleSegment() const final;
 
-    bool isEmpty() const final { return m_segments.isEmpty(); }
-
     bool isClosed() const final;
     FloatPoint currentPoint() const final;
 

--- a/Source/WebCore/platform/graphics/cairo/PathCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/PathCairo.h
@@ -41,6 +41,7 @@ class PathCairo final : public PathImpl {
 public:
     static Ref<PathCairo> create(std::span<const PathSegment> = { });
     static Ref<PathCairo> create(RefPtr<cairo_t>&&, RefPtr<PathStream>&& = nullptr);
+    static PlatformPathPtr emptyPlatformPath();
 
     PathCairo();
     PathCairo(RefPtr<cairo_t>&&, RefPtr<PathStream>&&);
@@ -75,8 +76,6 @@ public:
     FloatRect strokeBoundingRect(NOESCAPE const Function<void(GraphicsContext&)>& strokeStyleApplier) const;
 
 private:
-    bool isEmpty() const final;
-
     FloatPoint currentPoint() const final;
 
     FloatRect fastBoundingRect() const final;

--- a/Source/WebCore/platform/graphics/cg/PathCG.h
+++ b/Source/WebCore/platform/graphics/cg/PathCG.h
@@ -47,6 +47,8 @@ public:
     static Ref<PathCG> create(std::span<const PathSegment> = { });
     static Ref<PathCG> create(RetainPtr<CGMutablePathRef>&&);
 
+    static PlatformPathPtr emptyPlatformPath();
+
     PlatformPathPtr platformPath() const;
 
     void addPath(const PathCG&, const AffineTransform&);
@@ -80,8 +82,6 @@ private:
     PathCG(RetainPtr<CGMutablePathRef>&&);
 
     PlatformPathPtr ensureMutablePlatformPath();
-
-    bool isEmpty() const final;
 
     FloatPoint currentPoint() const final;
 

--- a/Source/WebCore/platform/graphics/skia/PathSkia.h
+++ b/Source/WebCore/platform/graphics/skia/PathSkia.h
@@ -43,6 +43,7 @@ class PathStream;
 class PathSkia final : public PathImpl {
 public:
     static Ref<PathSkia> create(std::span<const PathSegment> = { });
+    static PlatformPathPtr emptyPlatformPath();
 
     PlatformPathPtr platformPath() const;
 
@@ -76,8 +77,6 @@ public:
 private:
     PathSkia() = default;
     explicit PathSkia(const SkPath&);
-
-    bool isEmpty() const final;
 
     FloatPoint currentPoint() const final;
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/PathTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PathTests.cpp
@@ -25,7 +25,9 @@
 
 #include "config.h"
 
+#include <WebCore/AffineTransform.h>
 #include <WebCore/Path.h>
+
 namespace TestWebKitAPI {
 
 using namespace WebCore;
@@ -133,6 +135,44 @@ TEST(Path, CurveBoundingRect)
     auto boundingRect2 = path2.boundingRect();
 
     ASSERT_TRUE(areEssentiallyEqual(boundingRect1, boundingRect2));
+}
+
+TEST(Path, IsEmpty)
+{
+    Path a;
+    Path b;
+    ASSERT_TRUE(a.isEmpty());
+    ASSERT_TRUE(b.isEmpty());
+
+    // platformPath() does not allocate new instances.
+    ASSERT_EQ(a.platformPath(), a.platformPath());
+    ASSERT_EQ(b.platformPath(), b.platformPath());
+
+    // platformPath() does not change isEmpty().
+    ASSERT_TRUE(a.isEmpty());
+    ASSERT_TRUE(b.isEmpty());
+    ASSERT_TRUE(a.definitelyEqual(b));
+    ASSERT_TRUE(b.definitelyEqual(a));
+
+    // ensureImplForTesting works.
+    a.ensureImplForTesting();
+    ASSERT_TRUE(a.definitelyEqual(b));
+    ASSERT_TRUE(b.definitelyEqual(a));
+
+    // addPath() with empty paths works.
+    a.addPath(b, AffineTransform(1, 0, 0, 1, 0, 0));
+    ASSERT_TRUE(a.isEmpty());
+    ASSERT_TRUE(a.definitelyEqual(b));
+
+    bool r = a.strokeContains({ 0, 0 }, [](GraphicsContext&) { });
+    ASSERT_FALSE(r);
+    ASSERT_TRUE(a.isEmpty());
+    ASSERT_TRUE(a.definitelyEqual(b));
+    r = a.contains({ 0, 0 }, WindRule::EvenOdd);
+    ASSERT_FALSE(r);
+    ASSERT_TRUE(a.isEmpty());
+    ASSERT_TRUE(a.definitelyEqual(b));
+
 }
 
 }


### PR DESCRIPTION
#### 2f4a53dcf74f1f2e621ebc736c81902a827f3886
<pre>
Drawing paths spends time in Path::isEmpty()
<a href="https://bugs.webkit.org/show_bug.cgi?id=292659">https://bugs.webkit.org/show_bug.cgi?id=292659</a>
<a href="https://rdar.apple.com/150840520">rdar://150840520</a>

Reviewed by Simon Fraser.

Inline Path::isEmpty().

In order to make the inline simple, make sure only empty state is the
case when the Path is represented by the std::monostate. Ensure that
PathImpls are never empty.
Return a shared singleton platform path for empty Path instances.

* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::definitelyEqual const):
(WebCore::Path::ensurePlatformPathImpl):
(WebCore::Path::ensureImpl):
(WebCore::Path::ensureImplForTesting):
(WebCore::Path::platformPath const):
(WebCore::Path::isEmpty const): Deleted.
* Source/WebCore/platform/graphics/Path.h:
(WebCore::Path::isEmpty const):
* Source/WebCore/platform/graphics/PathImpl.h:
* Source/WebCore/platform/graphics/PathStream.cpp:
(WebCore::PathStream::lastIfMoveTo const):
(WebCore::PathStream::isClosed const):
* Source/WebCore/platform/graphics/PathStream.h:
* Source/WebCore/platform/graphics/cairo/PathCairo.cpp:
(WebCore::PathCairo::emptyPlatformPath):
(WebCore::PathCairo::add):
(WebCore::PathCairo::addPath):
(WebCore::PathCairo::contains const):
(WebCore::PathCairo::strokeContains const):
(WebCore::PathCairo::strokeBoundingRect const):
(WebCore::PathCairo::isEmpty const): Deleted.
* Source/WebCore/platform/graphics/cairo/PathCairo.h:
* Source/WebCore/platform/graphics/cg/PathCG.cpp:
(WebCore::PathCG::emptyPlatformPath):
(WebCore::PathCG::contains const):
(WebCore::PathCG::strokeContains const):
(WebCore::PathCG::strokeBoundingRect const):
(WebCore::PathCG::isEmpty const): Deleted.
* Source/WebCore/platform/graphics/cg/PathCG.h:
* Source/WebCore/platform/graphics/skia/PathSkia.cpp:
(WebCore::PathSkia::emptyPlatformPath):
(WebCore::PathSkia::contains const):
(WebCore::PathSkia::strokeContains const):
(WebCore::PathSkia::strokeBoundingRect const):
(WebCore::PathSkia::isEmpty const): Deleted.
* Source/WebCore/platform/graphics/skia/PathSkia.h:
* Tools/TestWebKitAPI/Tests/WebCore/PathTests.cpp:
(TestWebKitAPI::TEST(Path, IsEmpty)):

Canonical link: <a href="https://commits.webkit.org/294631@main">https://commits.webkit.org/294631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55e5b614f5cc7c0efde80c0e7140a3710c8dff40

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102476 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22145 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12459 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107637 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53113 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104515 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22453 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30651 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77963 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34954 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105482 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92500 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58299 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17234 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10528 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52470 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87052 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110012 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29608 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21838 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86948 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29972 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88696 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86540 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22023 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31368 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9088 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23858 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29536 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34839 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29347 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32670 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30906 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->