### PR TITLE
VideoMediaSampleRenderer doesn't handle going from clear to protected content

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8350,6 +8350,24 @@ VideoQualityIncludesDisplayCompositingEnabled:
     WebCore:
       default: false
 
+VideoRendererProtectedFallbackDisabled:
+  type: bool
+  status: stable
+  category: media
+  humanReadableName: "VideoMediaSampleRenderer fallback to AVSBDL for protected content disabled"
+  humanReadableDescription: "VideoMediaSampleRenderer fallback to AVSBDL for protected content disabled"
+  condition: USE(AVFOUNDATION)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      "USE(MODERN_AVCONTENTKEYSESSION)": true
+      default: false
+    WebCore:
+      "USE(MODERN_AVCONTENTKEYSESSION)": true
+      default: false
+  sharedPreferenceForWebProcess: true
+
 ViewGestureDebuggingEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8019,7 +8019,7 @@ void HTMLMediaElement::createMediaPlayer() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     player->setInFullscreenOrPictureInPicture(isFullscreen());
 
 #if USE(AVFOUNDATION) && ENABLE(MEDIA_SOURCE)
-    player->setDecompressionSessionPreferences(document().settings().mediaSourcePrefersDecompressionSession(), document().settings().mediaSourceCanFallbackToDecompressionSession());
+    player->setDecompressionSessionPreferences(document().settings().mediaSourcePrefersDecompressionSession(), document().settings().mediaSourceCanFallbackToDecompressionSession(), document().settings().videoRendererProtectedFallbackDisabled());
 #endif
     schedulePlaybackControlsManagerUpdate();
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA) && ENABLE(ENCRYPTED_MEDIA)

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -545,11 +545,12 @@ bool MediaPlayer::load(const URL& url, const LoadOptions& options, MediaSourcePr
 }
 
 #if USE(AVFOUNDATION)
-void MediaPlayer::setDecompressionSessionPreferences(bool preferDecompressionSession, bool canFallbackToDecompressionSession)
+void MediaPlayer::setDecompressionSessionPreferences(bool preferDecompressionSession, bool canFallbackToDecompressionSession, bool videoRendererProtectedFallbackDisabled)
 {
     m_preferDecompressionSession = preferDecompressionSession;
     m_canFallbackToDecompressionSession = canFallbackToDecompressionSession;
-    m_private->setDecompressionSessionPreferences(preferDecompressionSession, canFallbackToDecompressionSession);
+    m_videoRendererProtectedFallbackDisabled = videoRendererProtectedFallbackDisabled;
+    m_private->setDecompressionSessionPreferences(preferDecompressionSession, canFallbackToDecompressionSession, videoRendererProtectedFallbackDisabled);
 }
 #endif
 
@@ -645,7 +646,7 @@ void MediaPlayer::loadWithNextMediaEngine(const MediaPlayerFactory* current)
         if (playerPrivate) {
             client().mediaPlayerEngineUpdated();
 #if USE(AVFOUNDATION)
-            playerPrivate->setDecompressionSessionPreferences(m_preferDecompressionSession, m_canFallbackToDecompressionSession);
+            playerPrivate->setDecompressionSessionPreferences(m_preferDecompressionSession, m_canFallbackToDecompressionSession, m_videoRendererProtectedFallbackDisabled);
 #endif
             if (m_pageIsVisible)
                 playerPrivate->setPageIsVisible(m_pageIsVisible);

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -719,7 +719,7 @@ public:
 
 #if USE(AVFOUNDATION)
     AVPlayer *objCAVFoundationAVPlayer() const;
-    void setDecompressionSessionPreferences(bool, bool);
+    void setDecompressionSessionPreferences(bool, bool, bool);
 #endif
 
     bool performTaskAtTime(Function<void()>&&, const MediaTime&);
@@ -877,6 +877,7 @@ private:
 #if USE(AVFOUNDATION)
     bool m_preferDecompressionSession { false };
     bool m_canFallbackToDecompressionSession { false };
+    bool m_videoRendererProtectedFallbackDisabled { true };
 #endif
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -315,7 +315,7 @@ public:
 
 #if USE(AVFOUNDATION)
     virtual AVPlayer *objCAVFoundationAVPlayer() const { return nullptr; }
-    virtual void setDecompressionSessionPreferences(bool, bool) { }
+    virtual void setDecompressionSessionPreferences(bool, bool, bool) { }
 #endif
 
     virtual bool performTaskAtTime(Function<void()>&&, const MediaTime&) { return false; }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -341,10 +341,11 @@ private:
 
     void isInFullscreenOrPictureInPictureChanged(bool) final;
 
-    void setDecompressionSessionPreferences(bool preferDecompressionSession, bool canFallbackToDecompressionSession) final
+    void setDecompressionSessionPreferences(bool preferDecompressionSession, bool canFallbackToDecompressionSession, bool videoRendererProtectedFallbackDisabled) final
     {
         m_preferDecompressionSession = preferDecompressionSession;
         m_canFallbackToDecompressionSession = canFallbackToDecompressionSession;
+        m_videoRendererProtectedFallbackDisabled = videoRendererProtectedFallbackDisabled;
     }
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
@@ -430,6 +431,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     bool m_needsPlaceholderImage { false };
     bool m_preferDecompressionSession { false };
     bool m_canFallbackToDecompressionSession { false };
+    bool m_videoRendererProtectedFallbackDisabled { true };
     LoadOptions m_loadOptions;
 #if HAVE(SPATIAL_TRACKING_LABEL)
     String m_defaultSpatialTrackingLabel;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1115,6 +1115,7 @@ Ref<VideoMediaSampleRenderer> MediaPlayerPrivateMediaSourceAVFObjC::createVideoM
     });
     videoRenderer->setResourceOwner(m_resourceOwner);
     videoRenderer->setPrefersDecompressionSession(m_preferDecompressionSession);
+    videoRenderer->setUseDecompressionSessionForProtectedFallback(m_videoRendererProtectedFallbackDisabled);
     return videoRenderer;
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -64,6 +64,7 @@ public:
     bool prefersDecompressionSession() const;
     void setPrefersDecompressionSession(bool);
     bool isUsingDecompressionSession() const { return m_isUsingDecompressionSession; }
+    void setUseDecompressionSessionForProtectedFallback(bool);
 
     void setTimebase(RetainPtr<CMTimebaseRef>&&);
     RetainPtr<CMTimebaseRef> timebase() const;
@@ -108,6 +109,7 @@ private:
     void clearTimebase();
     using TimebaseAndTimerSource = std::pair<RetainPtr<CMTimebaseRef>, OSObjectPtr<dispatch_source_t>>;
     TimebaseAndTimerSource timebaseAndTimerSource() const;
+    MediaTime currentTime() const;
 
     WebSampleBufferVideoRendering *rendererOrDisplayLayer() const;
 
@@ -134,14 +136,14 @@ private:
     size_t decodedSamplesCount() const;
     RetainPtr<CMSampleBufferRef> nextDecodedSample() const;
     CMTime nextDecodedSampleEndTime() const;
-    CMTime lastDecodedSampleTime() const;
-    bool hasIncomingOutOfOrderFrame(const CMTime&) const;
-    CMTime minimumUpcomingSampleTime(CMSampleBufferRef) const;
+    MediaTime lastDecodedSampleTime() const;
+    bool hasIncomingOutOfOrderFrame(const MediaTime&) const;
+    MediaTime minimumUpcomingSampleTime(const MediaTime&) const;
 
     void assignResourceOwner(CMSampleBufferRef);
     bool areSamplesQueuesReadyForMoreMediaData(size_t waterMark) const;
     void maybeBecomeReadyForMoreMediaData();
-    bool shouldDecodeSample(CMSampleBufferRef, bool displaying);
+    bool shouldDecodeSample(const MediaSample&);
 
     void notifyHasAvailableVideoFrame(const MediaTime&, double, FlushId);
     void notifyErrorHasOccurred(OSStatus);
@@ -162,7 +164,7 @@ private:
     TimebaseAndTimerSource m_timebaseAndTimerSource WTF_GUARDED_BY_LOCK(m_lock);
     RefPtr<EffectiveRateChangedListener> m_effectiveRateChangedListener;
     std::atomic<FlushId> m_flushId { 0 };
-    Deque<std::pair<RetainPtr<CMSampleBufferRef>, FlushId>> m_compressedSampleQueue WTF_GUARDED_BY_CAPABILITY(dispatcher().get());
+    Deque<std::pair<Ref<const MediaSample>, FlushId>> m_compressedSampleQueue WTF_GUARDED_BY_CAPABILITY(dispatcher().get());
     std::atomic<uint32_t> m_compressedSampleQueueSize { 0 };
     static constexpr MediaTime s_decodeAhead { 133, 1000 };
     RetainPtr<CMBufferQueueRef> m_decodedSampleQueue; // created on the main thread, immutable after creation.
@@ -180,6 +182,7 @@ private:
     std::optional<uint32_t> m_currentCodec;
     std::atomic<bool> m_gotDecodingError { false };
     bool m_needsFlushing WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
+    bool m_useDecompressionSessionForProtectedFallback { true };
 
     // B-Frame tracker.
     MediaTime m_highestPresentationTime WTF_GUARDED_BY_CAPABILITY(mainThread) { MediaTime::invalidTime() };
@@ -188,9 +191,14 @@ private:
     // Playback Statistics
     std::atomic<unsigned> m_totalVideoFrames { 0 };
     std::atomic<unsigned> m_droppedVideoFrames { 0 };
+    unsigned m_droppedVideoFramesOffset WTF_GUARDED_BY_CAPABILITY(mainThread) { 0 };
     std::atomic<unsigned> m_corruptedVideoFrames { 0 };
     std::atomic<unsigned> m_presentedVideoFrames { 0 };
     MediaTime m_totalFrameDelay { MediaTime::zeroTime() };
+
+    // Protected samples
+    bool m_protectedContentEncountered { false };
+    bool m_wasProtected { false };
 
     Function<void(const MediaTime&, double)> m_hasAvailableFrameCallback WTF_GUARDED_BY_CAPABILITY(mainThread);
     Function<void(OSStatus)> m_errorOccurredFunction WTF_GUARDED_BY_CAPABILITY(mainThread);

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -204,7 +204,7 @@ void RemoteMediaPlayerProxy::loadMediaSource(URL&& url, const MediaPlayer::LoadO
     RefPtr player = m_player;
 #if USE(AVFOUNDATION) && ENABLE(MEDIA_SOURCE)
     if (auto preferences = sharedPreferencesForWebProcess())
-        player->setDecompressionSessionPreferences(preferences->mediaSourcePrefersDecompressionSession, preferences->mediaSourceCanFallbackToDecompressionSession);
+        player->setDecompressionSessionPreferences(preferences->mediaSourcePrefersDecompressionSession, preferences->mediaSourceCanFallbackToDecompressionSession, preferences->videoRendererProtectedFallbackDisabled);
 #endif
     player->load(url, options, *protectedMediaSourceProxy());
 


### PR DESCRIPTION
#### ac41e368867cf70d4326463900b9e5013ce51ede
<pre>
VideoMediaSampleRenderer doesn&apos;t handle going from clear to protected content
<a href="https://bugs.webkit.org/show_bug.cgi?id=292646">https://bugs.webkit.org/show_bug.cgi?id=292646</a>
<a href="https://rdar.apple.com/150809466">rdar://150809466</a>

Reviewed by Jer Noble.

Some content provider (Netflix) can stream non-protected content and later
switch to protected using the same HTMLVideoElement. If the WebCoreDecompressionSession
codepath was enabled, we would continue to decrypt and decode the video
content using that same VTDecompressionSession. This wasn&apos;t expected to work.
This change add the originally intended way of dealing with protected
content: enqueue the compressed sample to the AVSBDL. This behaviour
is placed behind a new preferences, disabled by default as code had been
in used for several months without anyone noticing.
This will allow to more easily revert back to the original codepath should
the need arise.

Also, use MediaTime and MediaSample in place of CoreMedia objects
(CMTime and CMSampleBuffer respectively) in several methods as it reduces
complexity and improve readability.

* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::lastDecodedSampleTime const): Make it use and return a MediaTime
(WebCore::VideoMediaSampleRenderer::hasIncomingOutOfOrderFrame const): Make it use and return a MediaTime
(WebCore::VideoMediaSampleRenderer::minimumUpcomingSampleTime const): Make it use and return a MediaTime
(WebCore::VideoMediaSampleRenderer::setUseDecompressionSessionForProtectedFallback): Added
(WebCore::VideoMediaSampleRenderer::currentTime const): Add convenience method.
(WebCore::VideoMediaSampleRenderer::enqueueSample): Fly-by: m_hasOutOfOrderFrames was incorrectly cleared. It should only ever be set once.
(WebCore::VideoMediaSampleRenderer::decodeNextSampleIfNeeded): Make it us a MediaSample
(WebCore::VideoMediaSampleRenderer::shouldDecodeSample): Make it use a MediaSample.
(WebCore::VideoMediaSampleRenderer::totalVideoFrames const): We need to use the AVSBDL videoPerformanceMetrics when it&apos;s used to do decoding
(WebCore::VideoMediaSampleRenderer::droppedVideoFrames const): Ditto
(WebCore::VideoMediaSampleRenderer::corruptedVideoFrames const): Ditto
(WebCore::VideoMediaSampleRenderer::totalFrameDelay const): Ditto

Canonical link: <a href="https://commits.webkit.org/294669@main">https://commits.webkit.org/294669@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d16c7efa2ee4ea846a56af582cb7b4f5bcfa2de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102631 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12614 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107792 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53268 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104670 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30806 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78071 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35048 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105637 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17520 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92627 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58406 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/17360 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10658 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52625 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/95302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/87188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10726 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110167 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/101240 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29763 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/21945 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87052 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30127 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88823 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86659 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22056 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31481 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9208 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24018 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29691 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35003 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124874 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29502 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34664 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32825 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31061 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->