### PR TITLE
[GTK] Remove initialGamepadsConnectedTimer from ManetteGamepadProvider

### DIFF
--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.cpp
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.cpp
@@ -58,7 +58,6 @@ static void onDeviceDisconnected(ManetteMonitor*, ManetteDevice* device, Manette
 
 ManetteGamepadProvider::ManetteGamepadProvider()
     : m_monitor(adoptGRef(manette_monitor_new()))
-    , m_initialGamepadsConnectedTimer(RunLoop::currentSingleton(), this, &ManetteGamepadProvider::initialGamepadsConnectedTimerFired)
     , m_inputNotificationTimer(RunLoop::currentSingleton(), this, &ManetteGamepadProvider::inputNotificationTimerFired)
 {
     g_signal_connect(m_monitor.get(), "device-connected", G_CALLBACK(onDeviceConnected), this);
@@ -85,16 +84,12 @@ void ManetteGamepadProvider::startMonitoringGamepads(GamepadProviderClient& clie
 
     m_initialGamepadsConnected = false;
 
-    // Any connections we are notified of within the connectionDelayInterval of listening likely represent
-    // devices that were already connected, so we suppress notifying clients of these.
-    m_initialGamepadsConnectedTimer.startOneShot(connectionDelayInterval);
+    ManetteDevice* device;
+    GUniquePtr<ManetteMonitorIter> iter(manette_monitor_iterate(m_monitor.get()));
+    while (manette_monitor_iter_next(iter.get(), &device))
+        deviceConnected(device);
 
-    RunLoop::currentSingleton().dispatch([this] {
-        ManetteDevice* device;
-        GUniquePtr<ManetteMonitorIter> iter(manette_monitor_iterate(m_monitor.get()));
-        while (manette_monitor_iter_next(iter.get(), &device))
-            deviceConnected(device);
-    });
+    m_initialGamepadsConnected = true;
 }
 
 void ManetteGamepadProvider::stopMonitoringGamepads(GamepadProviderClient& client)
@@ -105,7 +100,6 @@ void ManetteGamepadProvider::stopMonitoringGamepads(GamepadProviderClient& clien
     if (shouldCloseAndUnscheduleManager) {
         m_gamepadVector.clear();
         m_gamepadMap.clear();
-        m_initialGamepadsConnectedTimer.stop();
     }
 }
 
@@ -132,16 +126,6 @@ void ManetteGamepadProvider::deviceConnected(ManetteDevice* device)
 
     m_gamepadVector[index] = gamepad.get();
     m_gamepadMap.set(device, WTFMove(gamepad));
-
-    if (!m_initialGamepadsConnected) {
-        // This added device is the result of us starting to monitor gamepads.
-        // We'll get notified of all connected devices during this current spin of the runloop
-        // and the client should be told they were already connected.
-        // The m_initialGamepadsConnectedTimer fires in a subsequent spin of the runloop after which
-        // any connection events are actual new devices and can trigger gamepad visibility.
-        if (!m_initialGamepadsConnectedTimer.isActive())
-            m_initialGamepadsConnectedTimer.startOneShot(0_s);
-    }
 
     auto eventVisibility = m_initialGamepadsConnected ? EventMakesGamepadsVisible::Yes : EventMakesGamepadsVisible::No;
     for (auto& client : m_clients)

--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.h
@@ -76,7 +76,6 @@ private:
     bool m_initialGamepadsConnected { false };
 
     GRefPtr<ManetteMonitor> m_monitor;
-    RunLoop::Timer m_initialGamepadsConnectedTimer;
     RunLoop::Timer m_inputNotificationTimer;
 };
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1776,12 +1776,13 @@ void WebProcessPool::startedUsingGamepads(IPC::Connection& connection)
         return;
 
     bool wereAnyProcessesUsingGamepads = !m_processesUsingGamepads.isEmptyIgnoringNullReferences();
-
-    ASSERT(!m_processesUsingGamepads.contains(*proxy));
-    m_processesUsingGamepads.add(*proxy);
-
     if (!wereAnyProcessesUsingGamepads)
         UIGamepadProvider::singleton().processPoolStartedUsingGamepads(*this);
+
+    // Add the process proxy after notifying the UIGamepadProvider so that any gamepad connected while starting
+    // to monitor gamepads doesn't produce a GamepadConnected message, and it's only sent as initial gamepad.
+    ASSERT(!m_processesUsingGamepads.contains(*proxy));
+    m_processesUsingGamepads.add(*proxy);
 
     proxy->send(Messages::WebProcess::SetInitialGamepads(UIGamepadProvider::singleton().snapshotGamepads()), 0);
 }


### PR DESCRIPTION
#### 0d28061c864c03f4c33b490ce3ba7e6928a74f30
<pre>
[GTK] Remove initialGamepadsConnectedTimer from ManetteGamepadProvider
<a href="https://bugs.webkit.org/show_bug.cgi?id=292661">https://bugs.webkit.org/show_bug.cgi?id=292661</a>

Reviewed by Adrian Perez de Castro.

We don&apos;t really need a timer because ManetteMonitor already collects
devices on construction, so we can immediately iterate the devices to be
sent as initial devices to the web process.

* Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.cpp:
(WebCore::ManetteGamepadProvider::ManetteGamepadProvider):
(WebCore::ManetteGamepadProvider::startMonitoringGamepads):
(WebCore::ManetteGamepadProvider::stopMonitoringGamepads):
(WebCore::ManetteGamepadProvider::deviceConnected):
* Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::startedUsingGamepads): Add the process proxy
after notifying the UIGamepadProvider so that any gamepad connected
while starting to monitor gamepads doesn&apos;t produce a GamepadConnected
message, and it&apos;s only sent as initial gamepad.

Canonical link: <a href="https://commits.webkit.org/294657@main">https://commits.webkit.org/294657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56389318517bf8e45d1950b608a25db2dacac477

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102454 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12437 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107615 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53091 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30629 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77944 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34939 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105460 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17379 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92479 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58281 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17216 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10507 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52448 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87033 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10578 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109990 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29586 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21818 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86927 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29950 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88675 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86520 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22045 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31347 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9067 "Found 2 new test failures: pageoverlay/overlay-small-frame-mouse-events.html pageoverlay/overlay-small-frame-paints.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23831 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29514 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34817 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29325 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32648 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30884 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->