### PR TITLE
[macOS] Content inset fill backdrop layer sometimes ends up on top of the root layer

### DIFF
--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -536,7 +536,7 @@ public:
 
 #if PLATFORM(COCOA)
     virtual void didCommitLayerTree(const RemoteLayerTreeTransaction&) = 0;
-    virtual void layerTreeCommitComplete() = 0;
+    virtual void layerTreeCommitComplete() { }
 
     virtual void scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID) = 0;
 

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -204,8 +204,6 @@ private:
 
     void setEditableElementIsFocused(bool) override;
 
-    void layerTreeCommitComplete() override;
-
     void scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID) override;
 
     void registerInsertionUndoGrouping() override;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -771,11 +771,6 @@ void PageClientImpl::setEditableElementIsFocused(bool editableElementIsFocused)
     m_impl->setEditableElementIsFocused(editableElementIsFocused);
 }
 
-void PageClientImpl::layerTreeCommitComplete()
-{
-    m_impl->layerTreeCommitComplete();
-}
-
 void PageClientImpl::scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID)
 {
     m_impl->suppressContentRelativeChildViews(WebViewImpl::ContentRelativeChildViewsSuppressionType::TemporarilyRemove);

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -276,8 +276,6 @@ public:
     void updateLayer();
     static bool wantsUpdateLayer() { return true; }
 
-    void layerTreeCommitComplete();
-
     void drawRect(CGRect);
     bool canChangeFrameLayout(WebFrameProxy&);
     RetainPtr<NSPrintOperation> printOperationWithPrintInfo(NSPrintInfo *, WebFrameProxy&);
@@ -815,10 +813,6 @@ private:
 
     void suppressContentRelativeChildViews();
     void restoreContentRelativeChildViews();
-
-#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-    void updateContentInsetFillBackdropLayerParentIfNeeded();
-#endif
 
     bool m_clientWantsMediaPlaybackControlsView { false };
     bool m_canCreateTouchBars { false };

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2383,13 +2383,6 @@ void WebViewImpl::pageDidScroll(const IntPoint& scrollPosition)
 #endif // HAVE(NSSCROLLVIEW_SEPARATOR_TRACKING_ADAPTER)
 }
 
-void WebViewImpl::layerTreeCommitComplete()
-{
-#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-    updateContentInsetFillBackdropLayerParentIfNeeded();
-#endif
-}
-
 #if HAVE(NSSCROLLVIEW_SEPARATOR_TRACKING_ADAPTER)
 
 NSRect WebViewImpl::scrollViewFrame()


### PR DESCRIPTION
#### c6928763a16810d8e4caf686044eab1b04627391
<pre>
[macOS] Content inset fill backdrop layer sometimes ends up on top of the root layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=292668">https://bugs.webkit.org/show_bug.cgi?id=292668</a>
<a href="https://rdar.apple.com/148840316">rdar://148840316</a>

Reviewed by Abrar Rahman Protyasha and Richard Robinson.

Currently, the backdrop layer for the content inset fill view sometimes gets unparented and
reinserted in the web view, from underneath WebKit (i.e. AppKit). This happens because the `NSView`
corresponding to the backdrop layer is underneath the `WKWebView` right now, but the backdrop layer
actually needs to be inserted before the `m_rootLayer`, under the `WKFlippedView`&apos;s layer. This
reinsertion happens in `updateContentInsetFillBackdropLayerParentIfNeeded()`, and runs (only if
necessary) after each rendering update, which might&apos;ve changed the compositing layer hierarchy.

This mostly works, but there are still cases where AppKit ends up switching the sublayer hierarchy
out from under us (for example, when hovering over items in the sidebar). To mitigate this, we
change up our approach entirely, by:

1.  Inserting the backdrop layer&apos;s view under `WKFlippedView` (such that the backdrop layer parent
    is consistent with its view&apos;s parent in the view hierarchy).

2.  Setting a large negative `zPosition` on the backdrop layer instead, to force the layer to be
    beneath `m_rootLayer` in compositing order (even if it&apos;s in front of it in sublayer order).

This alternative approach avoids the need for shuffling around any layers, and ensures that the
view hierarchy is consistent with the backing layer hierarchy.

* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::layerTreeCommitComplete):
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::layerTreeCommitComplete): Deleted.

Delete this now-unused codepath.

* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::layerTreeCommitComplete): Deleted.

Canonical link: <a href="https://commits.webkit.org/294632@main">https://commits.webkit.org/294632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/342b4061c7e2e23b1c2dd1ef4db5a21d1cc605c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107638 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53114 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30652 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77965 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34955 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17398 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92502 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58301 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17235 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52471 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87053 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10601 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110013 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29609 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21836 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86946 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29973 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88698 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86538 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22024 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31369 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9090 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23859 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29537 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34840 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29348 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32671 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30907 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->