### PR TITLE
Stream IPC spends time constructing StreamConnectionEncoder

### DIFF
--- a/Source/WebKit/Platform/IPC/StreamConnectionEncoder.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionEncoder.h
@@ -48,7 +48,12 @@ public:
     StreamConnectionEncoder(MessageName messageName, std::span<uint8_t> stream)
         : m_buffer(stream)
     {
-        *this << messageName;
+        // Instead of using *this << messageName, manually encode the messageName since we
+        // know the stream buffer is bigger than needed as per API contract.
+        auto bytes = asBytes(singleElementSpan(messageName));
+        ASSERT(stream.size() > bytes.size()); // By API contract.
+        memcpySpan(m_buffer, bytes);
+        m_encodedSize = bytes.size();
     }
 
     ~StreamConnectionEncoder() = default;


### PR DESCRIPTION
#### 2a0d2fe32cf63983d2241a347a0adf5b4bece795
<pre>
Stream IPC spends time constructing StreamConnectionEncoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=292670">https://bugs.webkit.org/show_bug.cgi?id=292670</a>
<a href="https://rdar.apple.com/150858939">rdar://150858939</a>

Reviewed by Simon Fraser.

Manually encode the MessageName, so that
StreamConnectionEncoder::StreamConnectionEncoder inlines to
fewer instructions.

* Source/WebKit/Platform/IPC/StreamConnectionEncoder.h:

Canonical link: <a href="https://commits.webkit.org/294656@main">https://commits.webkit.org/294656@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12184800741136de156cbc52aaed6fc5fe9f1110

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102478 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22147 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107639 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53115 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30653 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77966 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34956 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17399 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92504 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58302 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17236 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52472 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87054 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10603 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110014 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29610 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21837 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86950 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29974 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88700 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86542 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22043 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31370 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9092 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23860 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29538 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34841 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29349 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32672 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30908 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->