### PR TITLE
Use a strong type for weekday in GregorianDateTime

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -5028,7 +5028,7 @@ JSC_DEFINE_JIT_OPERATION(operationDateGetDay, EncodedJSValue, (VM* vmPointer, Da
     const GregorianDateTime* gregorianDateTime = date->gregorianDateTime(vm.dateCache);
     if (!gregorianDateTime)
         OPERATION_RETURN(scope, JSValue::encode(jsNaN()));
-    OPERATION_RETURN(scope, JSValue::encode(jsNumber(gregorianDateTime->weekDay())));
+    OPERATION_RETURN(scope, JSValue::encode(jsNumber(gregorianDateTime->weekDay().c_encoding())));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationDateGetUTCDay, EncodedJSValue, (VM* vmPointer, DateInstance* date))
@@ -5041,7 +5041,7 @@ JSC_DEFINE_JIT_OPERATION(operationDateGetUTCDay, EncodedJSValue, (VM* vmPointer,
     const GregorianDateTime* gregorianDateTime = date->gregorianDateTimeUTC(vm.dateCache);
     if (!gregorianDateTime)
         OPERATION_RETURN(scope, JSValue::encode(jsNaN()));
-    OPERATION_RETURN(scope, JSValue::encode(jsNumber(gregorianDateTime->weekDay())));
+    OPERATION_RETURN(scope, JSValue::encode(jsNumber(gregorianDateTime->weekDay().c_encoding())));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationDateGetHours, EncodedJSValue, (VM* vmPointer, DateInstance* date))

--- a/Source/JavaScriptCore/runtime/DateConversion.cpp
+++ b/Source/JavaScriptCore/runtime/DateConversion.cpp
@@ -65,7 +65,7 @@ String formatDateTime(const GregorianDateTime& t, DateTimeFormat format, bool as
     StringBuilder builder;
 
     if (appendDate) {
-        builder.append(WTF::weekdayName[(t.weekDay() + 6) % 7]);
+        builder.append(WTF::weekdayName(t.weekDay()));
 
         if (asUTCVariant) {
             builder.append(", "_s);

--- a/Source/JavaScriptCore/runtime/DatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/DatePrototype.cpp
@@ -500,7 +500,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetDay, (JSGlobalObject* globalObject, Cal
     const GregorianDateTime* gregorianDateTime = thisDateObj->gregorianDateTime(vm.dateCache);
     if (!gregorianDateTime)
         return JSValue::encode(jsNaN());
-    return JSValue::encode(jsNumber(gregorianDateTime->weekDay()));
+    return JSValue::encode(jsNumber(gregorianDateTime->weekDay().c_encoding()));
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetUTCDay, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -515,7 +515,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetUTCDay, (JSGlobalObject* globalObject, 
     const GregorianDateTime* gregorianDateTime = thisDateObj->gregorianDateTimeUTC(vm.dateCache);
     if (!gregorianDateTime)
         return JSValue::encode(jsNaN());
-    return JSValue::encode(jsNumber(gregorianDateTime->weekDay()));
+    return JSValue::encode(jsNumber(gregorianDateTime->weekDay().c_encoding()));
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetHours, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/WTF/wtf/DateMath.cpp
+++ b/Source/WTF/wtf/DateMath.cpp
@@ -81,7 +81,6 @@
 #include <wtf/ASCIICType.h>
 #include <wtf/Language.h>
 #include <wtf/NeverDestroyed.h>
-#include <wtf/StdLibExtras.h>
 #include <wtf/ThreadSpecific.h>
 #include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilder.h>
@@ -103,9 +102,15 @@ static Vector<UChar>& innerTimeZoneOverride() WTF_REQUIRES_LOCK(innerTimeZoneOve
 
 /* Constants */
 
-const std::array<ASCIILiteral, 7> weekdayName { "Mon"_s, "Tue"_s, "Wed"_s, "Thu"_s, "Fri"_s, "Sat"_s, "Sun"_s };
 const std::array<ASCIILiteral, 12> monthName { "Jan"_s, "Feb"_s, "Mar"_s, "Apr"_s, "May"_s, "Jun"_s, "Jul"_s, "Aug"_s, "Sep"_s, "Oct"_s, "Nov"_s, "Dec"_s };
 const std::array<ASCIILiteral, 12> monthFullName { "January"_s, "February"_s, "March"_s, "April"_s, "May"_s, "June"_s, "July"_s, "August"_s, "September"_s, "October"_s, "November"_s, "December"_s };
+
+
+ASCIILiteral weekdayName(Weekday weekday)
+{
+    static constexpr std::array<ASCIILiteral, 7> weekdayName { "Sun"_s, "Mon"_s, "Tue"_s, "Wed"_s, "Thu"_s, "Fri"_s, "Sat"_s };
+    return weekdayName[weekday.c_encoding()];
+}
 
 // Day of year for the first day of each month, where index 0 is January, and day 0 is January 1.
 // First for non-leap years, then for leap years.
@@ -972,10 +977,10 @@ double parseDate(std::span<const LChar> dateString)
 }
 
 // See http://tools.ietf.org/html/rfc2822#section-3.3 for more information.
-String makeRFC2822DateString(unsigned dayOfWeek, unsigned day, unsigned month, unsigned year, unsigned hours, unsigned minutes, unsigned seconds, int utcOffset)
+String makeRFC2822DateString(Weekday dayOfWeek, unsigned day, unsigned month, unsigned year, unsigned hours, unsigned minutes, unsigned seconds, int utcOffset)
 {
     StringBuilder stringBuilder;
-    stringBuilder.append(weekdayName[dayOfWeek], ", "_s, day, ' ', monthName[month], ' ', year, ' ');
+    stringBuilder.append(weekdayName(dayOfWeek), ", "_s, day, ' ', monthName[month], ' ', year, ' ');
 
     appendTwoDigitNumber(stringBuilder, hours);
     stringBuilder.append(':');

--- a/Source/WTF/wtf/DateMath.h
+++ b/Source/WTF/wtf/DateMath.h
@@ -47,6 +47,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <time.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/WallTime.h>
 #include <wtf/text/WTFString.h>
 
@@ -55,6 +56,19 @@ namespace WTF {
 enum TimeType {
     UTCTime = 0,
     LocalTime
+};
+
+// FIXME: Replace with std::chrono::weekday once supported by the Playstation port.
+// The API matches std::chrono::weekday to facilitate transition.
+// 0 is Sunday, 1 is Monday, 2 is Tuesday, ...
+class Weekday {
+public:
+    explicit Weekday(unsigned weekday)
+        : m_weekday(static_cast<uint8_t>(weekday == 7 ? 0 : weekday))
+    { }
+    unsigned c_encoding() const { return m_weekday; }
+private:
+    uint8_t m_weekday;
 };
 
 struct LocalTimeOffset {
@@ -81,7 +95,7 @@ WTF_EXPORT_PRIVATE double parseES5Date(std::span<const LChar> dateString, bool& 
 WTF_EXPORT_PRIVATE double parseDate(std::span<const LChar> dateString);
 WTF_EXPORT_PRIVATE double parseDate(std::span<const LChar> dateString, bool& isLocalTime);
 // dayOfWeek: [0, 6] 0 being Monday, day: [1, 31], month: [0, 11], year: ex: 2011, hours: [0, 23], minutes: [0, 59], seconds: [0, 59], utcOffset: [-720,720]. 
-WTF_EXPORT_PRIVATE String makeRFC2822DateString(unsigned dayOfWeek, unsigned day, unsigned month, unsigned year, unsigned hours, unsigned minutes, unsigned seconds, int utcOffset);
+WTF_EXPORT_PRIVATE String makeRFC2822DateString(Weekday dayOfWeek, unsigned day, unsigned month, unsigned year, unsigned hours, unsigned minutes, unsigned seconds, int utcOffset);
 
 inline double jsCurrentTime()
 {
@@ -89,11 +103,12 @@ inline double jsCurrentTime()
     return floor(WallTime::now().secondsSinceEpoch().milliseconds());
 }
 
-extern WTF_EXPORT_PRIVATE const std::array<ASCIILiteral, 7> weekdayName;
 extern WTF_EXPORT_PRIVATE const std::array<ASCIILiteral, 12> monthName;
 extern WTF_EXPORT_PRIVATE const std::array<ASCIILiteral, 12> monthFullName;
 extern WTF_EXPORT_PRIVATE const std::array<std::array<int, 12>, 2> firstDayOfMonth;
 extern WTF_EXPORT_PRIVATE const std::array<int8_t, 12> daysInMonths;
+
+WTF_EXPORT_PRIVATE ASCIILiteral weekdayName(Weekday);
 
 static constexpr double hoursPerDay = 24.0;
 static constexpr double minutesPerHour = 60.0;
@@ -373,18 +388,18 @@ inline int msToSeconds(double ms)
 }
 
 // 0: Sunday, 1: Monday, etc.
-inline int msToWeekDay(double ms)
+inline Weekday msToWeekDay(double ms)
 {
     int wd = (static_cast<int>(msToDays(ms)) + 4) % 7;
     if (wd < 0)
         wd += 7;
-    return wd;
+    return Weekday { unsignedCast(wd) };
 }
 
-inline int32_t weekDay(int32_t days)
+inline Weekday weekDay(int32_t days)
 {
     int32_t result = (days + 4) % 7;
-    return result >= 0 ? result : result + 7;
+    return Weekday { unsignedCast(result >= 0 ? result : result + 7) };
 }
 
 inline int monthFromDayInYear(int dayInYear, bool leapYear)
@@ -468,8 +483,8 @@ inline double timeToMS(double hour, double min, double sec, double ms)
 // ECMA 262 - 15.9.1.9.
 inline int32_t equivalentYear(int32_t year)
 {
-    int weekDay = WTF::weekDay(daysFromYearMonth(year, 0));
-    int recentYear = (isLeapYear(year) ? 1956 : 1967) + (weekDay * 12) % 28;
+    auto weekDay = WTF::weekDay(daysFromYearMonth(year, 0));
+    int recentYear = (isLeapYear(year) ? 1956 : 1967) + (weekDay.c_encoding() * 12) % 28;
     // Find the year in the range 2008..2037 that is equivalent mod 28.
     // Add 3*28 to give a positive argument to the modulus operator.
     return 2008 + (recentYear + 3 * 28 - 2008) % 28;

--- a/Source/WTF/wtf/GregorianDateTime.cpp
+++ b/Source/WTF/wtf/GregorianDateTime.cpp
@@ -82,7 +82,7 @@ void GregorianDateTime::setToCurrentLocalTime()
     m_month = systemTime.wMonth - 1;
     m_monthDay = systemTime.wDay;
     m_yearDay = dayInYear(m_year, m_month, m_monthDay);
-    m_weekDay = systemTime.wDayOfWeek;
+    m_weekDay = Weekday { systemTime.wDayOfWeek };
     m_hour = systemTime.wHour;
     m_minute = systemTime.wMinute;
     m_second = systemTime.wSecond;
@@ -101,7 +101,7 @@ void GregorianDateTime::setToCurrentLocalTime()
     m_month = localTM.tm_mon;
     m_monthDay = localTM.tm_mday;
     m_yearDay = localTM.tm_yday;
-    m_weekDay = localTM.tm_wday;
+    m_weekDay = Weekday { unsignedCast(localTM.tm_wday) };
     m_hour = localTM.tm_hour;
     m_minute = localTM.tm_min;
     m_second = localTM.tm_sec;

--- a/Source/WTF/wtf/GregorianDateTime.h
+++ b/Source/WTF/wtf/GregorianDateTime.h
@@ -37,7 +37,7 @@ class GregorianDateTime final {
 public:
     GregorianDateTime() = default;
     WTF_EXPORT_PRIVATE explicit GregorianDateTime(double ms, LocalTimeOffset);
-    explicit GregorianDateTime(int year, int month, int yearDay, int monthDay, int weekDay, int hour, int minute, int second, int utcOffsetInMinute, bool isDST)
+    explicit GregorianDateTime(int year, int month, int yearDay, int monthDay, Weekday weekDay, int hour, int minute, int second, int utcOffsetInMinute, bool isDST)
         : m_year(year)
         , m_month(month)
         , m_yearDay(yearDay)
@@ -55,7 +55,7 @@ public:
     inline int month() const { return m_month; }
     inline int yearDay() const { return m_yearDay; }
     inline int monthDay() const { return m_monthDay; }
-    inline int weekDay() const { return m_weekDay; }
+    inline Weekday weekDay() const { return m_weekDay; }
     inline int hour() const { return m_hour; }
     inline int minute() const { return m_minute; }
     inline int second() const { return m_second; }
@@ -66,7 +66,7 @@ public:
     inline void setMonth(int month) { m_month = month; }
     inline void setYearDay(int yearDay) { m_yearDay = yearDay; }
     inline void setMonthDay(int monthDay) { m_monthDay = monthDay; }
-    inline void setWeekDay(int weekDay) { m_weekDay = weekDay; }
+    inline void setWeekDay(Weekday weekDay) { m_weekDay = weekDay; }
     inline void setHour(int hour) { m_hour = hour; }
     inline void setMinute(int minute) { m_minute = minute; }
     inline void setSecond(int second) { m_second = second; }
@@ -95,7 +95,7 @@ public:
         ret.tm_mon = m_month;
         ret.tm_yday = m_yearDay;
         ret.tm_mday = m_monthDay;
-        ret.tm_wday = m_weekDay;
+        ret.tm_wday = m_weekDay.c_encoding();
         ret.tm_hour = m_hour;
         ret.tm_min = m_minute;
         ret.tm_sec = m_second;
@@ -113,7 +113,7 @@ private:
     int m_month { 0 };
     int m_yearDay { 0 };
     int m_monthDay { 0 };
-    int m_weekDay { 0 };
+    Weekday m_weekDay { 0 };
     int m_hour { 0 };
     int m_minute { 0 };
     int m_second { 0 };


### PR DESCRIPTION
#### 61c45636fa179d656ac263df70a9ba9d1580d698
<pre>
Use a strong type for weekday in GregorianDateTime
<a href="https://bugs.webkit.org/show_bug.cgi?id=292682">https://bugs.webkit.org/show_bug.cgi?id=292682</a>

Reviewed by Darin Adler and Geoffrey Garen.

Use a strong type for weekday in GregorianDateTime instead of an int. It is
less error-prone and it removes ambiguity over whether 0 represents Monday
or Sunday. I wanted to use std::chrono::weekday but it is not yet available
in the playstation port&apos;s SDK. As a result, I am using an API-compatible
WTF::Weekday instead for now.

* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/runtime/DateConversion.cpp:
(JSC::formatDateTime):
* Source/JavaScriptCore/runtime/DatePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/WTF/wtf/DateMath.cpp:
(WTF::weekdayName):
(WTF::makeRFC2822DateString):
* Source/WTF/wtf/DateMath.h:
(WTF::msToWeekDay):
(WTF::weekDay):
(WTF::equivalentYear):
* Source/WTF/wtf/GregorianDateTime.cpp:
(WTF::GregorianDateTime::setToCurrentLocalTime):
* Source/WTF/wtf/GregorianDateTime.h:

Canonical link: <a href="https://commits.webkit.org/294709@main">https://commits.webkit.org/294709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/199e43a1a681bc9e28d2b550494827b6f0a48233

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102769 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107934 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53410 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30944 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78156 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35116 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105775 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92747 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58488 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10782 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52767 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/95444 "Built successfully and passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110310 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/101379 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29906 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22037 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30270 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88943 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86746 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22085 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31580 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9303 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24162 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29833 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35154 "Failed to build and analyze WebKit") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/125012 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29641 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34690 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32968 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31203 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->