### PR TITLE
REGRESSION (283464@main): Several ResourceLoadStatistics API tests crash under `ListDataController<…>::setCachedListDataForTesting`

### DIFF
--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -87,6 +87,7 @@ public:
 
 protected:
     virtual bool hasCachedListData() const = 0;
+    virtual void didUpdateCachedListData() { }
     virtual void updateList(CompletionHandler<void()>&&) = 0;
 #ifdef __OBJC__
     virtual WPResourceType resourceType() const = 0;
@@ -126,7 +127,6 @@ protected:
         didUpdateCachedListData();
     }
 
-    virtual void didUpdateCachedListData() { }
     bool hasCachedListData() const final { return !m_cachedListData.isEmpty(); }
 
     BackingDataType m_cachedListData;


### PR DESCRIPTION
#### 8dd5078272deab17b0ff30a912ce2dcd15bd294a
<pre>
REGRESSION (283464@main): Several ResourceLoadStatistics API tests crash under `ListDataController&lt;…&gt;::setCachedListDataForTesting`
<a href="https://bugs.webkit.org/show_bug.cgi?id=292680">https://bugs.webkit.org/show_bug.cgi?id=292680</a>
<a href="https://rdar.apple.com/150609463">rdar://150609463</a>

Reviewed by Abrar Rahman Protyasha.

When running the following API tests:

• ResourceLoadStatistics.StorageAccessPromptSiteWithQuirk
• ResourceLoadStatistics.StorageAccessPromptSiteWithTrigger
• ResourceLoadStatistics.StorageAccessSupportMultipleSubFrameDomains

…we crash under `StorageAccessPromptQuirkController::setCachedListDataForTesting`. For reasons still
unknown, this:

-   Only occurs when the definition of `ListDataController::setCachedListData` is inlined.

-   Crashes when attempting to invoke the virtual method `didUpdateCachedListData()` on
    `StorageAccessPromptQuirkController`.

Additionally, the implementation of `setCachedListData` seems to only be inlined in local
engineering builds, as opposed to production builds (based on `nm` output).

To sidestep this issue, move the virtual method `didUpdateCachedListData()` into the concrete base
class on `ListDataControllerBase`, instead of the templated `ListDataController`.

* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h:
(WebKit::ListDataControllerBase::didUpdateCachedListData):
(WebKit::ListDataController::didUpdateCachedListData): Deleted.

Canonical link: <a href="https://commits.webkit.org/294651@main">https://commits.webkit.org/294651@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a6cf2b178dc34a577709cae97c1367c95c76a60

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102534 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107695 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53171 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30709 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78001 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34986 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105540 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17443 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92552 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58337 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17281 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52528 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87096 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10649 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110070 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29666 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21877 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86981 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30030 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88746 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86579 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22040 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31406 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9136 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23916 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29594 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34906 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29405 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32728 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30964 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->