### PR TITLE
Sticky elements that are not currently sticking should not get OverlayRegions

### DIFF
--- a/LayoutTests/overlay-region/split-scrollers-expected.txt
+++ b/LayoutTests/overlay-region/split-scrollers-expected.txt
@@ -120,7 +120,6 @@
                                           (subviews
                                             (view [class: <class not in allowed list of classes>]
                                               (scrolling behavior 2)
-                                              (overlay region [x: 0 y: 0 width: 640 height: 50])
                                               (overlay region [x: 0 y: 550 width: 640 height: 50])
                                               (layer bounds [x: 0 y: 0 width: 640 height: 600])
                                               (layer position [x: 320 y: 320])

--- a/LayoutTests/overlay-region/sticky-expected.txt
+++ b/LayoutTests/overlay-region/sticky-expected.txt
@@ -1,0 +1,115 @@
+
+(UIView tree root view [class: <class not in allowed list of classes>]
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer position [x: 400 y: 400])
+  (subviews
+    (view [class: WKScrollView]
+      (scrolling behavior 2)
+      (overlay region [x: 0 y: 40 width: 800 height: 50])
+      (layer bounds [x: 0 y: 225 width: 800 height: 600])
+      (layer position [x: 400 y: 400])
+      (subviews
+        (view [class: WKContentView]
+          (layer bounds [x: 0 y: 0 width: 800 height: 1263])
+          (layer anchorPoint [x: 0 y: 0])
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 1263])
+              (layer anchorPoint [x: 0 y: 0])
+              (subviews
+                (view [class: UIView]
+                  (layer bounds [x: 0 y: 0 width: 800 height: 1263])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: WKCompositingView]
+                      (layer bounds [x: 0 y: 0 width: 800 height: 1263])
+                      (layer position [x: 400 y: 400])
+                      (subviews
+                        (view [class: WKCompositingView]
+                          (layer bounds [x: 0 y: 0 width: 800 height: 1263])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (subviews
+                            (view [class: WKCompositingView]
+                              (layer bounds [x: 0 y: 0 width: 800 height: 1263])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (subviews
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 800 height: 1263])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (subviews
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 0 y: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                          (layer position [x: 400 y: 400]))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 0 y: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                          (layer position [x: 400 y: 400]))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 0 y: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                          (layer position [x: 400 y: 400]))))))))))))))))
+            (view [class: _UILayerHostView]
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+        (view [class: UIView]
+          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+          (layer anchorPoint [x: 0 y: 0]))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 800 height: 12])
+          (layer position [x: 400 y: 400])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 116 height: 32])
+              (layer position [x: 400 y: 400]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+              (layer position [x: 400 y: 400])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                  (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                      (layer position [x: 48 y: 48]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 3))))))))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 12 height: 600])
+          (layer position [x: 791 y: 791])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 32 height: 116])
+              (layer position [x: 6 y: 6]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+              (layer position [x: 6 y: 6])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                  (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 43])
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 3))))))))))))

--- a/LayoutTests/overlay-region/sticky.html
+++ b/LayoutTests/overlay-region/sticky.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system; }
+        h1, h2 { margin: 0; padding: 0; line-height: 50px; }
+        h2 { font-size: 1.1em; }
+
+        .sticky {
+            position: sticky;
+            top: 40px;
+            height: 50px;
+            background: #6C5B7B;
+            z-index: 10;
+        }
+
+        .long {
+            position: relative;
+            height: 250px;
+            background: #355C7D;
+        }
+        .long::before {
+            content: "↓";
+            color: white;
+            font-size: 10em;
+            text-align: center;
+            position: absolute;
+            top: 40px;
+            left: 0;
+            right: 0;
+        }
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<section id="test">
+    <div class="long">
+        <h2 class="sticky">not sticking anymore</h2>
+    </div>
+    <div class="long">
+        <h2 class="sticky">currently sticking</h2>
+    </div>
+    <div class="long">
+        <h2 class="sticky">not sticking yet</h2>
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+    await UIHelper.animationFrame();
+    window.scrollTo(0, 225);
+
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getUIViewTree();
+    document.getElementById('test').remove();
+
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h
@@ -52,6 +52,7 @@ protected:
     bool commitStateBeforeChildren(const ScrollingStateNode&) override;
 
     FloatPoint computeClippingLayerPosition() const;
+    std::optional<FloatRect> findConstrainingRect() const;
     FloatPoint computeAnchorLayerPosition() const;
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
 

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h
@@ -39,6 +39,7 @@ class ScrollingTreeStickyNodeCocoa : public ScrollingTreeStickyNode {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ScrollingTreeStickyNodeCocoa, WEBCORE_EXPORT);
 public:
     WEBCORE_EXPORT static Ref<ScrollingTreeStickyNodeCocoa> create(ScrollingTree&, ScrollingNodeID);
+    WEBCORE_EXPORT bool isCurrentlySticking() const;
 
     virtual ~ScrollingTreeStickyNodeCocoa() = default;
 

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm
@@ -93,6 +93,20 @@ bool ScrollingTreeStickyNodeCocoa::hasViewportClippingLayer() const
     return m_viewportAnchorLayer && m_layer != m_viewportAnchorLayer;
 }
 
+bool ScrollingTreeStickyNodeCocoa::isCurrentlySticking() const
+{
+    if (auto constrainingRect = findConstrainingRect()) {
+        auto stickyOffset = m_constraints.computeStickyOffset(*constrainingRect);
+        auto stickyRect = m_constraints.stickyBoxRect();
+        auto containingRect = m_constraints.containingBlockRect();
+
+        return stickyOffset.height() > 0
+            && stickyOffset.height() < containingRect.height() - stickyRect.height();
+    }
+
+    return false;
+}
+
 FloatPoint ScrollingTreeStickyNodeCocoa::layerTopLeft() const
 {
     FloatRect layerBounds = [m_layer bounds];

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
@@ -64,10 +64,7 @@ public:
 
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
     void removeDestroyedLayerIDs(const Vector<WebCore::PlatformLayerIdentifier>&);
-    void updateOverlayRegionLayerIDs(const HashSet<WebCore::PlatformLayerIdentifier>& overlayRegionLayerIDs) { m_overlayRegionLayerIDs = overlayRegionLayerIDs; }
-
-    const HashSet<WebCore::PlatformLayerIdentifier>& fixedScrollingNodeLayerIDs() const { return m_fixedScrollingNodeLayerIDs; }
-    const HashSet<WebCore::PlatformLayerIdentifier>& overlayRegionLayerIDs() const { return m_overlayRegionLayerIDs; }
+    HashSet<WebCore::PlatformLayerIdentifier> fixedScrollingNodeLayerIDs() const;
     Vector<WKBaseScrollView*> overlayRegionScrollViewCandidates() const;
 #endif
 
@@ -97,8 +94,7 @@ private:
     HashMap<unsigned, OptionSet<WebCore::TouchAction>> m_touchActionsByTouchIdentifier;
 
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-    HashSet<WebCore::PlatformLayerIdentifier> m_fixedScrollingNodeLayerIDs;
-    HashSet<WebCore::PlatformLayerIdentifier> m_overlayRegionLayerIDs;
+    HashMap<WebCore::PlatformLayerIdentifier, WebCore::ScrollingNodeID> m_fixedScrollingNodesByLayerID;
     HashMap<WebCore::PlatformLayerIdentifier, WebCore::ScrollingNodeID> m_scrollingNodesByLayerID;
 #endif
 


### PR DESCRIPTION
#### 9db84d0aa73958ea6a2639a69849bd734c241352
<pre>
Sticky elements that are not currently sticking should not get OverlayRegions
<a href="https://bugs.webkit.org/show_bug.cgi?id=292685">https://bugs.webkit.org/show_bug.cgi?id=292685</a>
&lt;<a href="https://rdar.apple.com/141296473">rdar://141296473</a>&gt;

Reviewed by Mike Wyrzykowski.

First, fix an issue where an overlay region would never be removed
unless its corresponding layer was destroyed.
We now always start from the set of &quot;fixed layer IDs&quot; to build the
OverlayRegions. Ignoring previous layers with overlay regions.

Then filter out sticky layers that are note currently sticking from this
&quot;fixed layer IDs&quot; set.

* Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp:
(WebCore::ScrollingTreeStickyNode::findConstrainingRect const):
(WebCore::ScrollingTreeStickyNode::computeAnchorLayerPosition const):
Extract the code finding the constraining Rect to a new method for
reuse.

* Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm:
(WebCore::ScrollingTreeStickyNodeCocoa::isCurrentlySticking const):
Introduce a new method signaling if the ScrollingTreeNode is currently
sticking.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(addOverlayEventRegions):
(-[WKWebView _updateOverlayRegions:destroyedLayers:]):
Rework the overlay region code to better support updates.

* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::removeDestroyedLayerIDs):
(WebKit::RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers):
Remove the now unused `overlayRegionLayerIDs` set.
Turn the fixed layer IDs set into a map so we can keep track of the
ScrollingNode too.
(WebKit::RemoteScrollingCoordinatorProxyIOS::fixedScrollingNodeLayerIDs const):
Filter the exposed set of fixed scrolling node layer IDs to only contain
fixed layers and sticky layers _currently sticking_.

* LayoutTests/overlay-region/split-scrollers-expected.txt:
One sticky element in this test doesn&apos;t get an overlay region anymore.
* LayoutTests/overlay-region/sticky-expected.txt: Added.
* LayoutTests/overlay-region/sticky.html: Added.
Add a new test with:
- one element that is not sticking anymore
- one elements that is sticking
- one element that is not sticking yet

Canonical link: <a href="https://commits.webkit.org/294701@main">https://commits.webkit.org/294701@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67560039e27f2f1d233e1fd8713cf1fded6132bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102540 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107701 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53177 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104579 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30715 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78005 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34989 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17449 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92616 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58341 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17287 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10584 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52534 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87102 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110076 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29672 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86985 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30036 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88750 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86584 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22083 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31414 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9139 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23922 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29600 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34912 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29411 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32734 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30970 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->