### PR TITLE
AX: Store AXIsolatedObject::{m_platformWidget, m_remoteParent} as properties to avoid paying the memory cost for them on every single object

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1106,7 +1106,7 @@ public:
     virtual AXCoreObject* focusedUIElement() const = 0;
 
 #if PLATFORM(COCOA)
-    virtual RemoteAXObjectRef remoteParentObject() const = 0;
+    virtual RetainPtr<RemoteAXObjectRef> remoteParent() const = 0;
 #endif
     virtual AXCoreObject* parentObject() const = 0;
     virtual AXCoreObject* parentObjectUnignored() const;

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -1064,6 +1064,11 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::PlaceholderValue:
         stream << "PlaceholderValue";
         break;
+#if PLATFORM(COCOA)
+    case AXProperty::PlatformWidget:
+        stream << "PlatformWidget";
+        break;
+#endif
     case AXProperty::PosInSet:
         stream << "PosInSet";
         break;
@@ -1082,6 +1087,11 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::RemoteFramePlatformElement:
         stream << "RemoteFramePlatformElement";
         break;
+#if PLATFORM(COCOA)
+    case AXProperty::RemoteParent:
+        stream << "RemoteParent";
+        break;
+#endif
     case AXProperty::RolePlatformString:
         stream << "RolePlatformString";
         break;

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -2110,7 +2110,7 @@ const AccessibilityScrollView* AccessibilityObject::ancestorAccessibilityScrollV
 }
 
 #if PLATFORM(COCOA)
-RemoteAXObjectRef AccessibilityObject::remoteParentObject() const
+RetainPtr<RemoteAXObjectRef> AccessibilityObject::remoteParent() const
 {
     auto* document = this->document();
     auto* frame = document ? document->frame() : nullptr;

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -476,7 +476,7 @@ public:
 
     IntPoint remoteFrameOffset() const final;
 #if PLATFORM(COCOA)
-    RemoteAXObjectRef remoteParentObject() const final;
+    RetainPtr<RemoteAXObjectRef> remoteParent() const final;
     FloatRect convertRectToPlatformSpace(const FloatRect&, AccessibilityConversionSpace) const final;
     RetainPtr<id> remoteFramePlatformElement() const override { return nil; }
 #endif

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -643,6 +643,7 @@ void AXIsolatedObject::setProperty(AXProperty property, AXPropertyValueVariant&&
         [](OptionSet<AXAncestorFlag>& typedValue) { return typedValue.isEmpty(); },
 #if PLATFORM(COCOA)
         [](RetainPtr<NSAttributedString>& typedValue) { return !typedValue; },
+        [](RetainPtr<NSView>& typedValue) { return !typedValue; },
         [](RetainPtr<id>& typedValue) { return !typedValue; },
 #endif
         [](Vector<Vector<Markable<AXID>>>& typedValue) { return typedValue.isEmpty(); },
@@ -2159,7 +2160,7 @@ Widget* AXIsolatedObject::widget() const
 PlatformWidget AXIsolatedObject::platformWidget() const
 {
 #if PLATFORM(COCOA)
-    return m_platformWidget.get();
+    return propertyValue<RetainPtr<NSView>>(AXProperty::PlatformWidget).get();
 #else
     return m_platformWidget;
 #endif

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -547,7 +547,7 @@ private:
     bool isPlugin() const final { return boolAttributeValue(AXProperty::IsPlugin); }
 
 #if PLATFORM(COCOA)
-    RemoteAXObjectRef remoteParentObject() const final;
+    RetainPtr<RemoteAXObjectRef> remoteParent() const final;
     FloatRect convertRectToPlatformSpace(const FloatRect&, AccessibilityConversionSpace) const final;
 #endif
     Page* page() const final;
@@ -574,21 +574,20 @@ private:
     String innerHTML() const final;
     String outerHTML() const final;
 
-    // FIXME: Make this a ThreadSafeWeakPtr<AXIsolatedTree>.
-    RefPtr<AXIsolatedTree> m_cachedTree;
-    Markable<AXID> m_parentID;
-    bool m_childrenDirty { true };
     Vector<AXID> m_childrenIDs;
     Vector<Ref<AXCoreObject>> m_children;
     AXPropertyVector m_properties;
+
+    // FIXME: Make this a ThreadSafeWeakPtr<AXIsolatedTree>.
+    RefPtr<AXIsolatedTree> m_cachedTree;
+    Markable<AXID> m_parentID;
+
     OptionSet<AXPropertyFlag> m_propertyFlags;
     // Some objects (e.g. display:contents) form their geometry through their children.
     bool m_getsGeometryFromChildren { false };
+    bool m_childrenDirty { true };
 
-#if PLATFORM(COCOA)
-    RetainPtr<NSView> m_platformWidget;
-    RetainPtr<RemoteAXObjectRef> m_remoteParent;
-#else
+#if !PLATFORM(COCOA)
     PlatformWidget m_platformWidget;
 #endif
 };

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -236,12 +236,18 @@ enum class AXProperty : uint16_t {
     OuterHTML,
     Path,
     PlaceholderValue,
+#if PLATFORM(COCOA)
+    PlatformWidget,
+#endif
     PosInSet,
     PreventKeyboardDOMEventDispatch,
     RadioButtonGroup,
     RelativeFrame,
     RemoteFrameOffset,
     RemoteFramePlatformElement,
+#if PLATFORM(COCOA)
+    RemoteParent,
+#endif
     RolePlatformString,
     RoleDescription,
     Rows,
@@ -301,6 +307,7 @@ using AXIDAndCharacterRange = std::pair<Markable<AXID>, CharacterRange>;
 using AXPropertyValueVariant = Variant<std::nullptr_t, Markable<AXID>, String, bool, int, unsigned, double, float, uint64_t, WallTime, DateComponentsType, AccessibilityButtonState, Color, std::shared_ptr<URL>, LayoutRect, FloatPoint, FloatRect, IntPoint, IntRect, std::pair<unsigned, unsigned>, std::optional<unsigned>, Vector<AccessibilityText>, Vector<AXID>, Vector<std::pair<Markable<AXID>, Markable<AXID>>>, Vector<String>, std::shared_ptr<Path>, OptionSet<AXAncestorFlag>, Vector<Vector<Markable<AXID>>>, CharacterRange, std::shared_ptr<AXIDAndCharacterRange>, TagName, std::optional<AccessibilityOrientation>
 #if PLATFORM(COCOA)
     , RetainPtr<NSAttributedString>
+    , RetainPtr<NSView>
     , RetainPtr<id>
     , OptionSet<SpeakAs>
 #endif // PLATFORM(COCOA)

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -112,8 +112,8 @@ void AXIsolatedObject::initializePlatformProperties(const Ref<const Accessibilit
     }
 
     if (object->isScrollView()) {
-        m_platformWidget = object->platformWidget();
-        m_remoteParent = object->remoteParentObject();
+        setProperty(AXProperty::PlatformWidget, RetainPtr(object->platformWidget()));
+        setProperty(AXProperty::RemoteParent, object->remoteParent());
     }
 }
 
@@ -135,13 +135,13 @@ AttributedStringStyle AXIsolatedObject::stylesForAttributedString() const
     };
 }
 
-RemoteAXObjectRef AXIsolatedObject::remoteParentObject() const
+RetainPtr<RemoteAXObjectRef> AXIsolatedObject::remoteParent() const
 {
     auto* scrollView = Accessibility::findAncestor<AXCoreObject>(*this, true, [] (const AXCoreObject& object) {
         return object.isScrollView();
     });
     auto* isolatedObject = dynamicDowncast<AXIsolatedObject>(scrollView);
-    return isolatedObject ? isolatedObject->m_remoteParent.get() : nil;
+    return isolatedObject ? isolatedObject->propertyValue<RetainPtr<id>>(AXProperty::RemoteParent) : nil;
 }
 
 FloatRect AXIsolatedObject::primaryScreenRect() const

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -964,7 +964,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 - (id)remoteAccessibilityParentObject
 {
     RefPtr<AXCoreObject> backingObject = self.axBackingObject;
-    return backingObject ? backingObject->remoteParentObject() : nil;
+    return backingObject ? backingObject->remoteParent().get() : nil;
 }
 
 static void convertToVector(NSArray* array, AccessibilityObject::AccessibilityChildrenVector& vector)
@@ -1144,7 +1144,7 @@ static id scrollViewParent(AXCoreObject& axObject)
     if (auto platformWidget = axObject.platformWidget())
         return NSAccessibilityUnignoredAncestor(platformWidget);
 
-    return axObject.remoteParentObject();
+    return axObject.remoteParent().get();
 }
 
 - (id)windowElement:(NSString *)attributeName


### PR DESCRIPTION
#### 0378dfedf7b50590fa8309aef54da27002e6bb9f
<pre>
AX: Store AXIsolatedObject::{m_platformWidget, m_remoteParent} as properties to avoid paying the memory cost for them on every single object
<a href="https://bugs.webkit.org/show_bug.cgi?id=292689">https://bugs.webkit.org/show_bug.cgi?id=292689</a>
<a href="https://rdar.apple.com/150887081">rdar://150887081</a>

Reviewed by Joshua Hoffman.

Only scroll views and attachments ever set AXIsolatedObject::{m_platformWidget, m_remoteParent}, but because they are
member variables, we pay the cost for them on every single object. We can have hundreds of thousands of instances of
this class, so that&apos;s a major cost.

This commit turns these fields into AXProperty::PlatformWidget and AXProperty::RemoteParent. This commit also rearranges
AXIsolatedObject&apos;s fields to be more compact, avoiding unnecessary padding.

Prior to this commit, AXIsolatedObject was 136 bytes. Now it&apos;s 112 bytes. This saves 13.84mb on <a href="https://html.spec.whatwg.org">https://html.spec.whatwg.org</a>,
which has 567769 objects.

* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::remoteParentObject const): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::setProperty):
(WebCore::AXIsolatedObject::platformWidget const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::initializePlatformProperties):
(WebCore::AXIsolatedObject::remoteParent const):
(WebCore::AXIsolatedObject::remoteParentObject const): Deleted.
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper remoteAccessibilityParentObject]):
(scrollViewParent):

Canonical link: <a href="https://commits.webkit.org/294666@main">https://commits.webkit.org/294666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a807f6d51ad08974f1f01857a8b3bbcd50118e3d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107743 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53219 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104621 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30757 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78033 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35011 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105588 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17477 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92588 "Found 1 new API test failure: TestWebKitAPI.WebKit.PrintFrame (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58368 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17316 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10617 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52576 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87126 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10686 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110118 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29714 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21910 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87010 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30078 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88783 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86616 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22053 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31439 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9169 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23964 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29642 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34954 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29453 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32776 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31012 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->